### PR TITLE
Bumped sinon from 4.4.6 to 7.3.2

### DIFF
--- a/core/test/functional/api/v0.1/db_spec.js
+++ b/core/test/functional/api/v0.1/db_spec.js
@@ -13,7 +13,6 @@ const localUtils = require('./utils');
 
 let ghost = testUtils.startGhost;
 let request;
-let sandbox = sinon.sandbox.create();
 let eventsTriggered;
 
 describe('DB API', function () {
@@ -42,7 +41,7 @@ describe('DB API', function () {
     beforeEach(function () {
         eventsTriggered = {};
 
-        sandbox.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
+        sinon.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
             if (!eventsTriggered[eventName]) {
                 eventsTriggered[eventName] = [];
             }
@@ -52,7 +51,7 @@ describe('DB API', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('attaches the Content-Disposition header on export', function (done) {
@@ -144,7 +143,7 @@ describe('DB API', function () {
 
     it('export can be triggered by backup client', function (done) {
         backupQuery = '?client_id=' + backupClient.slug + '&client_secret=' + backupClient.secret;
-        fsStub = sandbox.stub(fs, 'writeFile').resolves();
+        fsStub = sinon.stub(fs, 'writeFile').resolves();
         request.post(localUtils.API.getApiQuery('db/backup' + backupQuery))
             .expect('Content-Type', /json/)
             .expect(200)
@@ -163,7 +162,7 @@ describe('DB API', function () {
 
     it('export can be triggered and named by backup client', function (done) {
         backupQuery = '?client_id=' + backupClient.slug + '&client_secret=' + backupClient.secret + '&filename=test';
-        fsStub = sandbox.stub(fs, 'writeFile').resolves();
+        fsStub = sinon.stub(fs, 'writeFile').resolves();
         request.post(localUtils.API.getApiQuery('db/backup' + backupQuery))
             .expect('Content-Type', /json/)
             .expect(200)
@@ -182,7 +181,7 @@ describe('DB API', function () {
 
     it('export can not be triggered by client other than backup', function (done) {
         schedulerQuery = '?client_id=' + schedulerClient.slug + '&client_secret=' + schedulerClient.secret;
-        fsStub = sandbox.stub(fs, 'writeFile').resolves();
+        fsStub = sinon.stub(fs, 'writeFile').resolves();
         request.post(localUtils.API.getApiQuery('db/backup' + schedulerQuery))
             .expect('Content-Type', /json/)
             .expect(403)

--- a/core/test/functional/api/v0.1/invites_spec.js
+++ b/core/test/functional/api/v0.1/invites_spec.js
@@ -6,7 +6,7 @@ const localUtils = require('./utils');
 const config = require('../../../../../core/server/config');
 const mailService = require('../../../../../core/server/services/mail');
 const ghost = testUtils.startGhost;
-const sandbox = sinon.sandbox.create();
+
 let request;
 
 describe('Invites API', function () {
@@ -27,11 +27,11 @@ describe('Invites API', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail is disabled');
+        sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail is disabled');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('browse', function () {

--- a/core/test/functional/api/v0.1/schedules_spec.js
+++ b/core/test/functional/api/v0.1/schedules_spec.js
@@ -10,7 +10,6 @@ const models = require('../../../../../core/server/models');
 const config = require('../../../../../core/server/config');
 const ghost = testUtils.startGhost;
 
-
 describe('Schedules API', function () {
     const posts = [];
     let request;

--- a/core/test/functional/api/v0.1/schedules_spec.js
+++ b/core/test/functional/api/v0.1/schedules_spec.js
@@ -9,7 +9,7 @@ const SchedulingDefault = require('../../../../../core/server/adapters/schedulin
 const models = require('../../../../../core/server/models');
 const config = require('../../../../../core/server/config');
 const ghost = testUtils.startGhost;
-const sandbox = sinon.sandbox.create();
+
 
 describe('Schedules API', function () {
     const posts = [];
@@ -21,11 +21,11 @@ describe('Schedules API', function () {
         models.init();
 
         // @NOTE: mock the post scheduler, otherwise it will auto publish the post
-        sandbox.stub(SchedulingDefault.prototype, '_pingUrl').resolves();
+        sinon.stub(SchedulingDefault.prototype, '_pingUrl').resolves();
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     before(function () {

--- a/core/test/functional/api/v0.1/subscribers_spec.js
+++ b/core/test/functional/api/v0.1/subscribers_spec.js
@@ -8,18 +8,18 @@ const config = require('../../../../../core/server/config');
 const labs = require('../../../../../core/server/services/labs');
 
 const ghost = testUtils.startGhost;
-const sandbox = sinon.sandbox.create();
+
 let request;
 
 describe('Subscribers API', function () {
     let accesstoken = '', ghostServer;
 
     before(function () {
-        sandbox.stub(labs, 'isSet').withArgs('subscribers').returns(true);
+        sinon.stub(labs, 'isSet').withArgs('subscribers').returns(true);
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     before(function () {

--- a/core/test/functional/api/v2/admin/db_spec.js
+++ b/core/test/functional/api/v2/admin/db_spec.js
@@ -12,7 +12,6 @@ const localUtils = require('./utils');
 
 let ghost = testUtils.startGhost;
 let request;
-let sandbox = sinon.sandbox.create();
 let eventsTriggered;
 
 describe('DB API', () => {
@@ -40,7 +39,7 @@ describe('DB API', () => {
     beforeEach(() => {
         eventsTriggered = {};
 
-        sandbox.stub(common.events, 'emit').callsFake((eventName, eventObj) => {
+        sinon.stub(common.events, 'emit').callsFake((eventName, eventObj) => {
             if (!eventsTriggered[eventName]) {
                 eventsTriggered[eventName] = [];
             }
@@ -50,7 +49,7 @@ describe('DB API', () => {
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should export data', () => {
@@ -139,7 +138,7 @@ describe('DB API', () => {
 
     it('export can be triggered by backup client', () => {
         const backupQuery = `?client_id=${backupClient.slug}&client_secret=${backupClient.secret}`;
-        const fsStub = sandbox.stub(fs, 'writeFile').resolves();
+        const fsStub = sinon.stub(fs, 'writeFile').resolves();
 
         return request.post(localUtils.API.getApiQuery(`db/backup${backupQuery}`))
             .expect('Content-Type', /json/)
@@ -153,7 +152,7 @@ describe('DB API', () => {
 
     it('export can be triggered and named by backup client', () => {
         const backupQuery = `?client_id=${backupClient.slug}&client_secret=${backupClient.secret}&filename=test`;
-        const fsStub = sandbox.stub(fs, 'writeFile').resolves();
+        const fsStub = sinon.stub(fs, 'writeFile').resolves();
 
         return request.post(localUtils.API.getApiQuery(`db/backup${backupQuery}`))
             .expect('Content-Type', /json/)
@@ -167,7 +166,7 @@ describe('DB API', () => {
 
     it('export can not be triggered by client other than backup', () => {
         const schedulerQuery = `?client_id=${schedulerClient.slug}&client_secret=${schedulerClient.secret}`;
-        const fsStub = sandbox.stub(fs, 'writeFile').resolves();
+        const fsStub = sinon.stub(fs, 'writeFile').resolves();
 
         return request.post(localUtils.API.getApiQuery(`db/backup${schedulerQuery}`))
             .expect('Content-Type', /json/)
@@ -180,7 +179,7 @@ describe('DB API', () => {
     });
 
     it('export can not be triggered by regular authentication', () => {
-        const fsStub = sandbox.stub(fs, 'writeFile').resolves();
+        const fsStub = sinon.stub(fs, 'writeFile').resolves();
 
         return request.post(localUtils.API.getApiQuery(`db/backup`))
             .set('Origin', config.get('url'))

--- a/core/test/functional/api/v2/admin/invites_spec.js
+++ b/core/test/functional/api/v2/admin/invites_spec.js
@@ -6,7 +6,7 @@ const localUtils = require('./utils');
 const config = require('../../../../../../core/server/config');
 const mailService = require('../../../../../../core/server/services/mail');
 const ghost = testUtils.startGhost;
-const sandbox = sinon.sandbox.create();
+
 let request;
 
 describe('Invites API V2', function () {
@@ -27,11 +27,11 @@ describe('Invites API V2', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail is disabled');
+        sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail is disabled');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('browse', function () {

--- a/core/test/functional/api/v2/admin/mail_spec.js
+++ b/core/test/functional/api/v2/admin/mail_spec.js
@@ -6,7 +6,7 @@ const localUtils = require('./utils');
 const config = require('../../../../../../core/server/config');
 const mailService = require('../../../../../../core/server/services/mail');
 const ghost = testUtils.startGhost;
-const sandbox = sinon.sandbox.create();
+
 let request;
 
 describe('Mail API V2', function () {
@@ -27,11 +27,11 @@ describe('Mail API V2', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(mailService.GhostMailer.prototype, 'send').resolves({message: 'sent'});
+        sinon.stub(mailService.GhostMailer.prototype, 'send').resolves({message: 'sent'});
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('default', function () {

--- a/core/test/functional/api/v2/admin/slack_spec.js
+++ b/core/test/functional/api/v2/admin/slack_spec.js
@@ -11,10 +11,8 @@ let request;
 
 describe('Slack API', function () {
     let ghostServer;
-    let sandbox;
-    before(function () {
-        sandbox = sinon.sandbox.create();
 
+    before(function () {
         return ghost()
             .then(function (_ghostServer) {
                 ghostServer = _ghostServer;
@@ -25,11 +23,11 @@ describe('Slack API', function () {
             });
     });
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should be able to post slack test', function (done) {
-        const eventSpy = sandbox.spy(common.events, 'emit');
+        const eventSpy = sinon.spy(common.events, 'emit');
         request.post(localUtils.API.getApiQuery('slack/test/'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)

--- a/core/test/functional/api/v2/admin/subscribers_spec.js
+++ b/core/test/functional/api/v2/admin/subscribers_spec.js
@@ -8,16 +8,16 @@ const config = require('../../../../../../core/server/config');
 const labs = require('../../../../../../core/server/services/labs');
 
 const ghost = testUtils.startGhost;
-const sandbox = sinon.sandbox.create();
+
 let request;
 
 describe('Subscribers API', function () {
     before(function () {
-        sandbox.stub(labs, 'isSet').withArgs('subscribers').returns(true);
+        sinon.stub(labs, 'isSet').withArgs('subscribers').returns(true);
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     before(function () {

--- a/core/test/functional/apps/subscribers/routing_spec.js
+++ b/core/test/functional/apps/subscribers/routing_spec.js
@@ -4,8 +4,7 @@ var supertest = require('supertest'),
     testUtils = require('../../../utils'),
     labs = require('../../../../server/services/labs'),
     config = require('../../../../server/config'),
-    ghost = testUtils.startGhost,
-    sandbox = sinon.sandbox.create();
+    ghost = testUtils.startGhost;
 
 describe('Subscriber: Routing', function () {
     var request;
@@ -18,7 +17,7 @@ describe('Subscriber: Routing', function () {
     });
 
     before(function () {
-        sandbox.stub(labs, 'isSet').callsFake(function (key) {
+        sinon.stub(labs, 'isSet').callsFake(function (key) {
             if (key === 'subscribers') {
                 return true;
             }
@@ -26,7 +25,7 @@ describe('Subscriber: Routing', function () {
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('GET', function () {

--- a/core/test/functional/dynamic_routing_spec.js
+++ b/core/test/functional/dynamic_routing_spec.js
@@ -12,8 +12,7 @@ const should = require('should'),
     config = require('../../server/config'),
     api = require('../../server/api'),
     settingsCache = require('../../server/services/settings/cache'),
-    ghost = testUtils.startGhost,
-    sandbox = sinon.sandbox.create();
+    ghost = testUtils.startGhost;
 
 let request;
 
@@ -38,7 +37,7 @@ describe('Dynamic Routing', function () {
     before(function () {
         // Default is always casper. We use the old compatible 1.4 casper theme for these tests. Available in the test content folder.
         var originalSettingsCacheGetFn = settingsCache.get;
-        sandbox.stub(settingsCache, 'get').callsFake(function (key, options) {
+        sinon.stub(settingsCache, 'get').callsFake(function (key, options) {
             if (key === 'active_theme') {
                 return 'casper-1.4';
             }
@@ -54,7 +53,7 @@ describe('Dynamic Routing', function () {
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Collection Index', function () {

--- a/core/test/functional/frontend_spec.js
+++ b/core/test/functional/frontend_spec.js
@@ -14,9 +14,7 @@ var should = require('should'),
     settingsCache = require('../../server/services/settings/cache'),
     origCache = _.cloneDeep(settingsCache),
     ghost = testUtils.startGhost,
-    request,
-
-    sandbox = sinon.sandbox.create();
+    request;
 
 describe('Frontend Routing', function () {
     function doEnd(done) {
@@ -45,7 +43,7 @@ describe('Frontend Routing', function () {
     }
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     before(function () {
@@ -251,7 +249,7 @@ describe('Frontend Routing', function () {
             });
 
             it('should redirect to regular post when AMP is disabled', function (done) {
-                sandbox.stub(settingsCache, 'get').callsFake(function (key, options) {
+                sinon.stub(settingsCache, 'get').callsFake(function (key, options) {
                     if (key === 'amp' && !options) {
                         return false;
                     }

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -17,8 +17,7 @@ var should = require('should'),
         returnImportedData: true
     },
 
-    knex = db.knex,
-    sandbox = sinon.sandbox.create();
+    knex = db.knex();
 
 const exportedLatestBody = () => {
     return _.clone({
@@ -116,12 +115,12 @@ describe('Integration: Importer', function () {
     before(testUtils.teardown);
 
     beforeEach(function () {
-        sandbox.stub(importer, 'cleanUp');
+        sinon.stub(importer, 'cleanUp');
     });
 
     afterEach(testUtils.teardown);
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     should.exist(importer);

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -17,7 +17,7 @@ var should = require('should'),
         returnImportedData: true
     },
 
-    knex = db.knex();
+    knex = db.knex;
 
 const exportedLatestBody = () => {
     return _.clone({

--- a/core/test/integration/export_spec.js
+++ b/core/test/integration/export_spec.js
@@ -5,15 +5,13 @@ var should = require('should'),
 
     // Stuff we are testing
     exporter = require('../../server/data/exporter'),
-    ghostVersion = require('../../server/lib/ghost-version'),
-
-    sandbox = sinon.sandbox.create();
+    ghostVersion = require('../../server/lib/ghost-version');
 
 describe('Exporter', function () {
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
     beforeEach(testUtils.setup('default', 'settings'));
 

--- a/core/test/integration/migration_spec.js
+++ b/core/test/integration/migration_spec.js
@@ -3,14 +3,13 @@ var should = require('should'),
     testUtils = require('../utils'),
     _ = require('lodash'),
     Promise = require('bluebird'),
-    Models = require('../../server/models'),
-    sandbox = sinon.sandbox.create();
+    Models = require('../../server/models');
 
 describe('Database Migration (special functions)', function () {
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Fixtures', function () {

--- a/core/test/integration/model/base/listeners_spec.js
+++ b/core/test/integration/model/base/listeners_spec.js
@@ -7,8 +7,7 @@ var should = require('should'),
     common = require('../../../../server/lib/common'),
     models = require('../../../../server/models'),
     testUtils = require('../../../../test/utils'),
-    sequence = require('../../../../server/lib/promise/sequence'),
-    sandbox = sinon.sandbox.create();
+    sequence = require('../../../../server/lib/promise/sequence');
 
 describe('Models: listeners', function () {
     var eventsToRemember = {},
@@ -25,7 +24,7 @@ describe('Models: listeners', function () {
     beforeEach(testUtils.setup('owner', 'user-token:0', 'settings'));
 
     beforeEach(function () {
-        sandbox.stub(common.events, 'on').callsFake(function (eventName, callback) {
+        sinon.stub(common.events, 'on').callsFake(function (eventName, callback) {
             eventsToRemember[eventName] = callback;
         });
 
@@ -34,7 +33,7 @@ describe('Models: listeners', function () {
 
     afterEach(function () {
         common.events.on.restore();
-        sandbox.restore();
+        sinon.restore();
         scope.posts = [];
         return testUtils.teardown();
     });
@@ -254,8 +253,8 @@ describe('Models: listeners', function () {
                     post1 = posts[0],
                     listenerHasFinished = false;
 
-                sandbox.spy(common.logging, 'error');
-                sandbox.spy(models.Post, 'findAll');
+                sinon.spy(common.logging, 'error');
+                sinon.spy(models.Post, 'findAll');
 
                 // simulate a delay, so that the edit operation from the test here interrupts
                 // the goal here is to force that the listener has old post data, updated_at is then too old

--- a/core/test/integration/model/model_accesstoken_spec.js
+++ b/core/test/integration/model/model_accesstoken_spec.js
@@ -3,9 +3,7 @@ var should = require('should'),
     testUtils = require('../../utils'),
     common = require('../../../server/lib/common'),
     constants = require('../../../server/lib/constants'),
-
-    // Stuff we are testing
-    AccesstokenModel = require('../../../server/models/accesstoken').Accesstoken();
+    AccesstokenModel = require('../../../server/models/accesstoken').Accesstoken;
 
 describe('Accesstoken Model', function () {
     // Keep the DB clean
@@ -20,7 +18,7 @@ describe('Accesstoken Model', function () {
 
     it('on creation emits token.added event', function (done) {
         // Setup
-        var eventSpy = sinon.spy(common.events, 'emit');
+        const eventSpy = sinon.spy(common.events, 'emit');
 
         // Test
         // Stub refreshtoken

--- a/core/test/integration/model/model_accesstoken_spec.js
+++ b/core/test/integration/model/model_accesstoken_spec.js
@@ -5,9 +5,7 @@ var should = require('should'),
     constants = require('../../../server/lib/constants'),
 
     // Stuff we are testing
-    AccesstokenModel = require('../../../server/models/accesstoken').Accesstoken,
-
-    sandbox = sinon.sandbox.create();
+    AccesstokenModel = require('../../../server/models/accesstoken').Accesstoken();
 
 describe('Accesstoken Model', function () {
     // Keep the DB clean
@@ -15,14 +13,14 @@ describe('Accesstoken Model', function () {
     afterEach(testUtils.teardown);
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     beforeEach(testUtils.setup('owner', 'clients'));
 
     it('on creation emits token.added event', function (done) {
         // Setup
-        var eventSpy = sandbox.spy(common.events, 'emit');
+        var eventSpy = sinon.spy(common.events, 'emit');
 
         // Test
         // Stub refreshtoken

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -11,8 +11,7 @@ var should = require('should'),
     common = require('../../../server/lib/common'),
     configUtils = require('../../utils/configUtils'),
     DataGenerator = testUtils.DataGenerator,
-    context = testUtils.context.owner,
-    sandbox = sinon.sandbox.create(),
+    context = testUtils.context.owner(),
     markdownToMobiledoc = testUtils.DataGenerator.markdownToMobiledoc;
 
 /**
@@ -31,11 +30,11 @@ describe('Post Model', function () {
     before(testUtils.setup('users:roles'));
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     beforeEach(function () {
-        sandbox.stub(urlService, 'getUrlByResourceId').withArgs(testUtils.DataGenerator.Content.posts[0].id).returns('/html-ipsum/');
+        sinon.stub(urlService, 'getUrlByResourceId').withArgs(testUtils.DataGenerator.Content.posts[0].id).returns('/html-ipsum/');
     });
 
     function checkFirstPostData(firstPost, options) {
@@ -401,7 +400,7 @@ describe('Post Model', function () {
             beforeEach(function () {
                 eventsTriggered = {};
 
-                sandbox.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
+                sinon.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
                     if (!eventsTriggered[eventName]) {
                         eventsTriggered[eventName] = [];
                     }
@@ -1025,7 +1024,7 @@ describe('Post Model', function () {
             beforeEach(function () {
                 eventsTriggered = {};
 
-                sandbox.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
+                sinon.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
                     if (!eventsTriggered[eventName]) {
                         eventsTriggered[eventName] = [];
                     }
@@ -1462,7 +1461,7 @@ describe('Post Model', function () {
 
             beforeEach(function () {
                 eventsTriggered = {};
-                sandbox.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
+                sinon.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
                     if (!eventsTriggered[eventName]) {
                         eventsTriggered[eventName] = [];
                     }
@@ -1907,7 +1906,7 @@ describe('Post Model', function () {
                 editOptions = _.extend({}, context, {id: postJSON.id, withRelated: ['tags']});
 
                 // reset the eventSpy here
-                sandbox.restore();
+                sinon.restore();
             });
         });
 

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -11,7 +11,7 @@ var should = require('should'),
     common = require('../../../server/lib/common'),
     configUtils = require('../../utils/configUtils'),
     DataGenerator = testUtils.DataGenerator,
-    context = testUtils.context.owner(),
+    context = testUtils.context.owner,
     markdownToMobiledoc = testUtils.DataGenerator.markdownToMobiledoc;
 
 /**

--- a/core/test/integration/model/model_settings_spec.js
+++ b/core/test/integration/model/model_settings_spec.js
@@ -7,8 +7,7 @@ var should = require('should'),
     SettingsModel = require('../../../server/models/settings').Settings,
     db = require('../../../server/data/db'),
     common = require('../../../server/lib/common'),
-    context = testUtils.context.admin,
-    sandbox = sinon.sandbox.create();
+    context = testUtils.context.admin();
 
 describe('Settings Model', function () {
     var eventSpy;
@@ -23,11 +22,11 @@ describe('Settings Model', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     beforeEach(function () {
-        eventSpy = sandbox.spy(common.events, 'emit');
+        eventSpy = sinon.spy(common.events, 'emit');
     });
 
     describe('API', function () {

--- a/core/test/integration/model/model_settings_spec.js
+++ b/core/test/integration/model/model_settings_spec.js
@@ -2,12 +2,10 @@ var should = require('should'),
     _ = require('lodash'),
     sinon = require('sinon'),
     testUtils = require('../../utils'),
-
-    // Stuff we are testing
     SettingsModel = require('../../../server/models/settings').Settings,
     db = require('../../../server/data/db'),
     common = require('../../../server/lib/common'),
-    context = testUtils.context.admin();
+    context = testUtils.context.admin;
 
 describe('Settings Model', function () {
     var eventSpy;

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -7,8 +7,7 @@ var should = require('should'),
     db = require('../../../server/data/db'),
     models = require('../../../server/models'),
     common = require('../../../server/lib/common'),
-    context = testUtils.context.admin,
-    sandbox = sinon.sandbox.create();
+    context = testUtils.context.admin();
 
 describe('Tag Model', function () {
     var eventSpy;
@@ -19,11 +18,11 @@ describe('Tag Model', function () {
     before(testUtils.setup('users:roles', 'posts'));
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     beforeEach(function () {
-        eventSpy = sandbox.spy(common.events, 'emit');
+        eventSpy = sinon.spy(common.events, 'emit');
     });
 
     describe('findPage', function () {

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -7,7 +7,7 @@ var should = require('should'),
     db = require('../../../server/data/db'),
     models = require('../../../server/models'),
     common = require('../../../server/lib/common'),
-    context = testUtils.context.admin();
+    context = testUtils.context.admin;
 
 describe('Tag Model', function () {
     var eventSpy;

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -9,8 +9,7 @@ var should = require('should'),
     imageLib = require('../../../server/lib/image'),
     UserModel = require('../../../server/models/user').User,
     RoleModel = require('../../../server/models/role').Role,
-    context = testUtils.context.admin,
-    sandbox = sinon.sandbox.create();
+    context = testUtils.context.admin();
 
 describe('User Model', function run() {
     var eventsTriggered = {};
@@ -18,7 +17,7 @@ describe('User Model', function run() {
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     before(function () {
@@ -89,7 +88,7 @@ describe('User Model', function run() {
         it('can find gravatar', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[4];
 
-            sandbox.stub(imageLib.gravatar, 'lookup').callsFake(function (userData) {
+            sinon.stub(imageLib.gravatar, 'lookup').callsFake(function (userData) {
                 userData.image = 'http://www.gravatar.com/avatar/2fab21a4c4ed88e76add10650c73bae1?d=404';
                 return Promise.resolve(userData);
             });
@@ -106,7 +105,7 @@ describe('User Model', function run() {
         it('can handle no gravatar', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[0];
 
-            sandbox.stub(imageLib.gravatar, 'lookup').callsFake(function (userData) {
+            sinon.stub(imageLib.gravatar, 'lookup').callsFake(function (userData) {
                 return Promise.resolve(userData);
             });
 
@@ -156,7 +155,7 @@ describe('User Model', function run() {
 
         beforeEach(function () {
             eventsTriggered = {};
-            sandbox.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
+            sinon.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
                 if (!eventsTriggered[eventName]) {
                     eventsTriggered[eventName] = [];
                 }

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -9,7 +9,7 @@ var should = require('should'),
     imageLib = require('../../../server/lib/image'),
     UserModel = require('../../../server/models/user').User,
     RoleModel = require('../../../server/models/role').Role,
-    context = testUtils.context.admin();
+    context = testUtils.context.admin;
 
 describe('User Model', function run() {
     var eventsTriggered = {};

--- a/core/test/integration/services/url/UrlService_spec.js
+++ b/core/test/integration/services/url/UrlService_spec.js
@@ -9,7 +9,7 @@ const common = require('../../../../server/lib/common');
 const themes = require('../../../../server/services/themes');
 const UrlService = rewire('../../../../server/services/url/UrlService');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Integration: services/url/UrlService', function () {
     let urlService;
@@ -17,7 +17,7 @@ describe('Integration: services/url/UrlService', function () {
     before(function () {
         models.init();
 
-        sandbox.stub(themes, 'getActive').returns({
+        sinon.stub(themes, 'getActive').returns({
             engine: () => 'v0.1'
         });
     });
@@ -27,7 +27,7 @@ describe('Integration: services/url/UrlService', function () {
     after(testUtils.teardown);
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('functional: default routing set', function () {
@@ -37,40 +37,40 @@ describe('Integration: services/url/UrlService', function () {
             urlService = new UrlService();
 
             router1 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'post collection';
                 }
             };
 
             router2 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'authors';
                 }
             };
 
             router3 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'tags';
                 }
             };
 
             router4 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'static pages';
                 }
@@ -221,50 +221,50 @@ describe('Integration: services/url/UrlService', function () {
             urlService = new UrlService();
 
             router1 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'post collection 1';
                 }
             };
 
             router2 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'post collection 2';
                 }
             };
 
             router3 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'authors';
                 }
             };
 
             router4 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'tags';
                 }
             };
 
             router5 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'static pages';
                 }
@@ -417,50 +417,50 @@ describe('Integration: services/url/UrlService', function () {
             urlService = new UrlService();
 
             router1 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'post collection 1';
                 }
             };
 
             router2 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'post collection 2';
                 }
             };
 
             router3 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'authors';
                 }
             };
 
             router4 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'tags';
                 }
             };
 
             router5 = {
-                getFilter: sandbox.stub(),
-                addListener: sandbox.stub(),
-                getResourceType: sandbox.stub(),
-                getPermalinks: sandbox.stub(),
+                getFilter: sinon.stub(),
+                addListener: sinon.stub(),
+                getResourceType: sinon.stub(),
+                getPermalinks: sinon.stub(),
                 toString: function () {
                     return 'static pages';
                 }

--- a/core/test/integration/services/url/UrlService_spec.js
+++ b/core/test/integration/services/url/UrlService_spec.js
@@ -9,8 +9,6 @@ const common = require('../../../../server/lib/common');
 const themes = require('../../../../server/services/themes');
 const UrlService = rewire('../../../../server/services/url/UrlService');
 
-
-
 describe('Integration: services/url/UrlService', function () {
     let urlService;
 

--- a/core/test/integration/update_check_spec.js
+++ b/core/test/integration/update_check_spec.js
@@ -10,8 +10,6 @@ const configUtils = require('../utils/configUtils');
 const packageInfo = require('../../../package');
 const api = require('../../server/api').v2;
 
-
-
 let updateCheck = rewire('../../server/update-check');
 let NotificationsAPI = rewire('../../server/api/v2/notifications');
 

--- a/core/test/integration/update_check_spec.js
+++ b/core/test/integration/update_check_spec.js
@@ -10,7 +10,7 @@ const configUtils = require('../utils/configUtils');
 const packageInfo = require('../../../package');
 const api = require('../../server/api').v2;
 
-const sandbox = sinon.sandbox.create();
+
 
 let updateCheck = rewire('../../server/update-check');
 let NotificationsAPI = rewire('../../server/api/v2/notifications');
@@ -22,7 +22,7 @@ describe('Update Check', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 
@@ -37,9 +37,9 @@ describe('Update Check', function () {
         beforeEach(testUtils.setup('roles', 'owner'));
 
         beforeEach(function () {
-            updateCheckRequestSpy = sandbox.stub().returns(Promise.resolve());
-            updateCheckResponseSpy = sandbox.stub().returns(Promise.resolve());
-            updateCheckErrorSpy = sandbox.stub();
+            updateCheckRequestSpy = sinon.stub().returns(Promise.resolve());
+            updateCheckResponseSpy = sinon.stub().returns(Promise.resolve());
+            updateCheckErrorSpy = sinon.stub();
 
             updateCheck.__set__('updateCheckRequest', updateCheckRequestSpy);
             updateCheck.__set__('updateCheckResponse', updateCheckResponseSpy);
@@ -48,12 +48,12 @@ describe('Update Check', function () {
         });
 
         it('update check was never executed', function (done) {
-            const readStub = sandbox.stub().resolves({
+            const readStub = sinon.stub().resolves({
                 settings: [{
                     value: null
                 }]
             });
-            sandbox.stub(api, 'settings').get(() => ({
+            sinon.stub(api, 'settings').get(() => ({
                 read: readStub
             }));
 
@@ -68,12 +68,12 @@ describe('Update Check', function () {
         });
 
         it('update check won\'t happen if it\'s too early', function (done) {
-            const readStub = sandbox.stub().resolves({
+            const readStub = sinon.stub().resolves({
                 settings: [{
                     value: moment().add('10', 'minutes').unix()
                 }]
             });
-            sandbox.stub(api, 'settings').get(() => ({
+            sinon.stub(api, 'settings').get(() => ({
                 read: readStub
             }));
 
@@ -88,12 +88,12 @@ describe('Update Check', function () {
         });
 
         it('update check will happen if it\'s time to check', function (done) {
-            const readStub = sandbox.stub().resolves({
+            const readStub = sinon.stub().resolves({
                 settings: [{
                     value: moment().subtract('10', 'minutes').unix()
                 }]
             });
-            sandbox.stub(api, 'settings').get(() => ({
+            sinon.stub(api, 'settings').get(() => ({
                 read: readStub
             }));
 
@@ -330,7 +330,7 @@ describe('Update Check', function () {
 
         it('receives a notifications with messages', function (done) {
             var updateCheckResponse = updateCheck.__get__('updateCheckResponse'),
-                createNotificationSpy = sandbox.spy(),
+                createNotificationSpy = sinon.spy(),
                 message = {
                     id: uuid.v4(),
                     version: '^0.11.11',
@@ -351,7 +351,7 @@ describe('Update Check', function () {
 
         it('receives multiple notifications', function (done) {
             var updateCheckResponse = updateCheck.__get__('updateCheckResponse'),
-                createNotificationSpy = sandbox.spy(),
+                createNotificationSpy = sinon.spy(),
                 message1 = {
                     id: uuid.v4(),
                     version: '^0.11.11',
@@ -383,7 +383,7 @@ describe('Update Check', function () {
 
         it('ignores some custom notifications which are not marked as group', function (done) {
             var updateCheckResponse = updateCheck.__get__('updateCheckResponse'),
-                createNotificationSpy = sandbox.spy(),
+                createNotificationSpy = sinon.spy(),
                 message1 = {
                     id: uuid.v4(),
                     version: '^0.11.11',
@@ -423,7 +423,7 @@ describe('Update Check', function () {
 
         it('group matches', function (done) {
             var updateCheckResponse = updateCheck.__get__('updateCheckResponse'),
-                createNotificationSpy = sandbox.spy(),
+                createNotificationSpy = sinon.spy(),
                 message1 = {
                     id: uuid.v4(),
                     version: '^0.11.11',
@@ -465,7 +465,7 @@ describe('Update Check', function () {
 
         it('single custom notification received, group matches', function (done) {
             var updateCheckResponse = updateCheck.__get__('updateCheckResponse'),
-                createNotificationSpy = sandbox.spy(),
+                createNotificationSpy = sinon.spy(),
                 message1 = {
                     id: uuid.v4(),
                     version: '^0.11.11',
@@ -491,7 +491,7 @@ describe('Update Check', function () {
 
         it('single custom notification received, group does not match', function (done) {
             var updateCheckResponse = updateCheck.__get__('updateCheckResponse'),
-                createNotificationSpy = sandbox.spy(),
+                createNotificationSpy = sinon.spy(),
                 message1 = {
                     id: uuid.v4(),
                     version: '^0.11.11',
@@ -527,7 +527,7 @@ describe('Update Check', function () {
 
         it('[default]', function () {
             var updateCheckRequest = updateCheck.__get__('updateCheckRequest'),
-                updateCheckDataSpy = sandbox.stub(),
+                updateCheckDataSpy = sinon.stub(),
                 hostname,
                 reqObj,
                 data = {
@@ -561,7 +561,7 @@ describe('Update Check', function () {
 
         it('privacy flag is used', function () {
             var updateCheckRequest = updateCheck.__get__('updateCheckRequest'),
-                updateCheckDataSpy = sandbox.stub(),
+                updateCheckDataSpy = sinon.stub(),
                 reqObj,
                 hostname;
 
@@ -604,7 +604,7 @@ describe('Update Check', function () {
 
         it('received 500 from the service', function () {
             var updateCheckRequest = updateCheck.__get__('updateCheckRequest'),
-                updateCheckDataSpy = sandbox.stub(),
+                updateCheckDataSpy = sinon.stub(),
                 reqObj,
                 hostname;
 
@@ -637,7 +637,7 @@ describe('Update Check', function () {
 
         it('received 404 from the service', function () {
             var updateCheckRequest = updateCheck.__get__('updateCheckRequest'),
-                updateCheckDataSpy = sandbox.stub(),
+                updateCheckDataSpy = sinon.stub(),
                 reqObj,
                 hostname;
 
@@ -671,7 +671,7 @@ describe('Update Check', function () {
 
         it('custom url', function () {
             var updateCheckRequest = updateCheck.__get__('updateCheckRequest'),
-                updateCheckDataSpy = sandbox.stub(),
+                updateCheckDataSpy = sinon.stub(),
                 reqObj,
                 hostname;
 

--- a/core/test/integration/web/site_spec.js
+++ b/core/test/integration/web/site_spec.js
@@ -6,8 +6,7 @@ const should = require('should'),
     configUtils = require('../../utils/configUtils'),
     settingsService = require('../../../server/services/settings'),
     themeService = require('../../../server/services/themes'),
-    siteApp = require('../../../server/web/parent-app'),
-    sandbox = sinon.sandbox.create();
+    siteApp = require('../../../server/web/parent-app');
 
 describe('Integration - Web - Site', function () {
     let app;
@@ -21,13 +20,13 @@ describe('Integration - Web - Site', function () {
 
         describe('default routes.yaml', function () {
             before(function () {
-                testUtils.integrationTesting.defaultMocks(sandbox);
+                testUtils.integrationTesting.defaultMocks(sinon);
                 testUtils.integrationTesting.overrideGhostConfig(configUtils);
 
                 return testUtils.integrationTesting.initGhost()
                     .then(function () {
-                        sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                        sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                        sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                        sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                         app = siteApp({start: true});
                         return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -37,7 +36,7 @@ describe('Integration - Web - Site', function () {
             beforeEach(function () {
                 configUtils.set('url', 'http://example.com');
 
-                sandbox.spy(api.posts, 'browse');
+                sinon.spy(api.posts, 'browse');
             });
 
             afterEach(function () {
@@ -46,7 +45,7 @@ describe('Integration - Web - Site', function () {
 
             after(function () {
                 configUtils.restore();
-                sandbox.restore();
+                sinon.restore();
             });
 
             describe('behaviour: default cases', function () {
@@ -429,7 +428,7 @@ describe('Integration - Web - Site', function () {
         describe('extended routes.yaml: collections', function () {
             describe('2 collections', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {
                             '/': 'home'
                         },
@@ -453,12 +452,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -474,7 +473,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve static route', function () {
@@ -562,7 +561,7 @@ describe('Integration - Web - Site', function () {
 
             describe('no collections', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {
                             '/test/': 'test'
                         },
@@ -571,12 +570,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -592,7 +591,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve route', function () {
@@ -613,7 +612,7 @@ describe('Integration - Web - Site', function () {
 
             describe('static permalink route', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -631,12 +630,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -652,7 +651,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve post', function () {
@@ -719,7 +718,7 @@ describe('Integration - Web - Site', function () {
 
             describe('primary author permalink', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -732,12 +731,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -753,7 +752,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve post', function () {
@@ -804,7 +803,7 @@ describe('Integration - Web - Site', function () {
 
             describe('primary tag permalink', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -817,12 +816,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -838,7 +837,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve post', function () {
@@ -904,7 +903,7 @@ describe('Integration - Web - Site', function () {
 
             describe('collection with data key', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -955,12 +954,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -976,7 +975,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve /food/', function () {
@@ -1042,7 +1041,7 @@ describe('Integration - Web - Site', function () {
         describe('extended routes.yaml: templates', function () {
             describe('default template, no template', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -1057,12 +1056,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -1078,7 +1077,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve collection', function () {
@@ -1114,7 +1113,7 @@ describe('Integration - Web - Site', function () {
 
             describe('two templates', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -1126,12 +1125,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -1147,7 +1146,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve collection', function () {
@@ -1168,7 +1167,7 @@ describe('Integration - Web - Site', function () {
 
             describe('home.hbs priority', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -1184,12 +1183,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme'});
+                    testUtils.integrationTesting.defaultMocks(sinon, {theme: 'test-theme'});
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -1205,7 +1204,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve collection', function () {
@@ -1247,9 +1246,9 @@ describe('Integration - Web - Site', function () {
                 before(testUtils.setup('users:roles', 'posts'));
 
                 before(function () {
-                    testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme-channels'});
+                    testUtils.integrationTesting.defaultMocks(sinon, {theme: 'test-theme-channels'});
 
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {
                             '/channel1/': {
                                 controller: 'channel',
@@ -1393,8 +1392,8 @@ describe('Integration - Web - Site', function () {
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(10);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(10);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -1410,7 +1409,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve channel 1', function () {
@@ -1637,7 +1636,7 @@ describe('Integration - Web - Site', function () {
 
         describe('extended routes.yaml (5): rss override', function () {
             before(function () {
-                sandbox.stub(settingsService, 'get').returns({
+                sinon.stub(settingsService, 'get').returns({
                     routes: {
                         '/about/': 'about',
                         '/podcast/rss/': {
@@ -1673,12 +1672,12 @@ describe('Integration - Web - Site', function () {
                 });
 
                 testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme'});
+                testUtils.integrationTesting.defaultMocks(sinon, {theme: 'test-theme'});
 
                 return testUtils.integrationTesting.initGhost()
                     .then(function () {
-                        sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
-                        sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                        sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                        sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                         app = siteApp({start: true});
                         return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -1694,7 +1693,7 @@ describe('Integration - Web - Site', function () {
             });
 
             after(function () {
-                sandbox.restore();
+                sinon.restore();
             });
 
             it('serve /rss/', function () {
@@ -1794,13 +1793,13 @@ describe('Integration - Web - Site', function () {
         describe('default routes.yaml', function () {
             before(function () {
                 testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox);
+                testUtils.integrationTesting.defaultMocks(sinon);
                 testUtils.integrationTesting.overrideGhostConfig(configUtils);
 
                 return testUtils.integrationTesting.initGhost()
                     .then(function () {
-                        sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                        sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                        sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                        sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                         app = siteApp({start: true});
                         return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -1810,7 +1809,7 @@ describe('Integration - Web - Site', function () {
             beforeEach(function () {
                 const postsAPI = require('../../../server/api/v2/posts');
                 configUtils.set('url', 'http://example.com');
-                postSpy = sandbox.spy(postsAPI.browse, 'query');
+                postSpy = sinon.spy(postsAPI.browse, 'query');
             });
 
             afterEach(function () {
@@ -1819,7 +1818,7 @@ describe('Integration - Web - Site', function () {
 
             after(function () {
                 configUtils.restore();
-                sandbox.restore();
+                sinon.restore();
             });
 
             describe('behaviour: default cases', function () {
@@ -2202,7 +2201,7 @@ describe('Integration - Web - Site', function () {
         describe('extended routes.yaml: collections', function () {
             describe('2 collections', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {
                             '/': 'home'
                         },
@@ -2226,12 +2225,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -2247,7 +2246,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve static route', function () {
@@ -2335,7 +2334,7 @@ describe('Integration - Web - Site', function () {
 
             describe('no collections', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {
                             '/test/': 'test'
                         },
@@ -2344,12 +2343,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -2365,7 +2364,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve route', function () {
@@ -2386,7 +2385,7 @@ describe('Integration - Web - Site', function () {
 
             describe('static permalink route', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -2404,12 +2403,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -2425,7 +2424,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve post', function () {
@@ -2492,7 +2491,7 @@ describe('Integration - Web - Site', function () {
 
             describe('primary author permalink', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -2505,12 +2504,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -2526,7 +2525,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve post', function () {
@@ -2577,7 +2576,7 @@ describe('Integration - Web - Site', function () {
 
             describe('primary tag permalink', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -2590,12 +2589,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -2611,7 +2610,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve post', function () {
@@ -2677,7 +2676,7 @@ describe('Integration - Web - Site', function () {
 
             describe('collection with data key', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -2728,12 +2727,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -2749,7 +2748,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve /food/', function () {
@@ -2815,7 +2814,7 @@ describe('Integration - Web - Site', function () {
         describe('extended routes.yaml: templates', function () {
             describe('default template, no template', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -2830,12 +2829,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -2851,7 +2850,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve collection', function () {
@@ -2887,7 +2886,7 @@ describe('Integration - Web - Site', function () {
 
             describe('two templates', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -2899,12 +2898,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox);
+                    testUtils.integrationTesting.defaultMocks(sinon);
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -2920,7 +2919,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve collection', function () {
@@ -2941,7 +2940,7 @@ describe('Integration - Web - Site', function () {
 
             describe('home.hbs priority', function () {
                 before(function () {
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {},
 
                         collections: {
@@ -2957,12 +2956,12 @@ describe('Integration - Web - Site', function () {
                     });
 
                     testUtils.integrationTesting.urlService.resetGenerators();
-                    testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme'});
+                    testUtils.integrationTesting.defaultMocks(sinon, {theme: 'test-theme'});
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -2978,7 +2977,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve collection', function () {
@@ -3020,9 +3019,9 @@ describe('Integration - Web - Site', function () {
                 before(testUtils.setup('users:roles', 'posts'));
 
                 before(function () {
-                    testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme-channels'});
+                    testUtils.integrationTesting.defaultMocks(sinon, {theme: 'test-theme-channels'});
 
-                    sandbox.stub(settingsService, 'get').returns({
+                    sinon.stub(settingsService, 'get').returns({
                         routes: {
                             '/channel1/': {
                                 controller: 'channel',
@@ -3146,8 +3145,8 @@ describe('Integration - Web - Site', function () {
 
                     return testUtils.integrationTesting.initGhost()
                         .then(function () {
-                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(10);
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(10);
 
                             app = siteApp({start: true});
                             return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -3163,7 +3162,7 @@ describe('Integration - Web - Site', function () {
                 });
 
                 after(function () {
-                    sandbox.restore();
+                    sinon.restore();
                 });
 
                 it('serve channel 1', function () {
@@ -3356,7 +3355,7 @@ describe('Integration - Web - Site', function () {
 
         describe('extended routes.yaml (5): rss override', function () {
             before(function () {
-                sandbox.stub(settingsService, 'get').returns({
+                sinon.stub(settingsService, 'get').returns({
                     routes: {
                         '/about/': 'about',
                         '/podcast/rss/': {
@@ -3392,12 +3391,12 @@ describe('Integration - Web - Site', function () {
                 });
 
                 testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme'});
+                testUtils.integrationTesting.defaultMocks(sinon, {theme: 'test-theme'});
 
                 return testUtils.integrationTesting.initGhost()
                     .then(function () {
-                        sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
-                        sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+                        sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                        sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
                         app = siteApp({start: true});
                         return testUtils.integrationTesting.urlService.waitTillFinished();
@@ -3413,7 +3412,7 @@ describe('Integration - Web - Site', function () {
             });
 
             after(function () {
-                sandbox.restore();
+                sinon.restore();
             });
 
             it('serve /rss/', function () {

--- a/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
+++ b/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
@@ -6,9 +6,7 @@ var should = require('should'),
     express = require('express'),
     bodyParser = require('body-parser'),
     http = require('http'),
-    SchedulingDefault = require(config.get('paths').corePath + '/server/adapters/scheduling/SchedulingDefault'),
-
-    sandbox = sinon.sandbox.create();
+    SchedulingDefault = require(config.get('paths').corePath + '/server/adapters/scheduling/SchedulingDefault');
 
 describe('Scheduling Default Adapter', function () {
     var scope = {};
@@ -18,13 +16,13 @@ describe('Scheduling Default Adapter', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('success', function () {
         it('addJob (schedule)', function () {
-            sandbox.stub(scope.adapter, 'run');
-            sandbox.stub(scope.adapter, '_execute');
+            sinon.stub(scope.adapter, 'run');
+            sinon.stub(scope.adapter, '_execute');
 
             var dates = [
                 moment().add(1, 'day').subtract(30, 'seconds').toDate(),
@@ -69,7 +67,7 @@ describe('Scheduling Default Adapter', function () {
                 }),
                 allJobs = {};
 
-            sandbox.stub(scope.adapter, '_execute').callsFake(function (nextJobs) {
+            sinon.stub(scope.adapter, '_execute').callsFake(function (nextJobs) {
                 Object.keys(nextJobs).length.should.eql(121);
                 Object.keys(scope.adapter.allJobs).length.should.eql(1000 - 121);
                 done();
@@ -86,7 +84,7 @@ describe('Scheduling Default Adapter', function () {
         });
 
         it('ensure recursive run works', function (done) {
-            sandbox.spy(scope.adapter, '_execute');
+            sinon.spy(scope.adapter, '_execute');
 
             scope.adapter.allJobs = {};
             scope.adapter.runTimeoutInMs = 10;
@@ -107,8 +105,8 @@ describe('Scheduling Default Adapter', function () {
                 }),
                 nextJobs = {};
 
-            sandbox.stub(scope.adapter, 'run');
-            sandbox.stub(scope.adapter, '_pingUrl').callsFake(function () {
+            sinon.stub(scope.adapter, 'run');
+            sinon.stub(scope.adapter, '_pingUrl').callsFake(function () {
                 pinged = pinged + 1;
             });
 
@@ -132,8 +130,8 @@ describe('Scheduling Default Adapter', function () {
                 jobsToDelete = {},
                 jobsToExecute = {};
 
-            sandbox.stub(scope.adapter, 'run');
-            sandbox.stub(scope.adapter, '_pingUrl').callsFake(function () {
+            sinon.stub(scope.adapter, 'run');
+            sinon.stub(scope.adapter, '_pingUrl').callsFake(function () {
                 pinged = pinged + 1;
             });
 

--- a/core/test/unit/adapters/scheduling/index_spec.js
+++ b/core/test/unit/adapters/scheduling/index_spec.js
@@ -3,20 +3,18 @@ var should = require('should'),
     rewire = require('rewire'),
     Promise = require('bluebird'),
     config = require(__dirname + '/../../../../server/config'),
-    postScheduling = require(__dirname + '/../../../../server/adapters/scheduling/post-scheduling'),
-
-    sandbox = sinon.sandbox.create();
+    postScheduling = require(__dirname + '/../../../../server/adapters/scheduling/post-scheduling');
 
 describe('Scheduling', function () {
     var scope = {};
 
     before(function () {
-        sandbox.stub(postScheduling, 'init').returns(Promise.resolve());
+        sinon.stub(postScheduling, 'init').returns(Promise.resolve());
         scope.scheduling = rewire(config.get('paths').corePath + '/server/adapters/scheduling');
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('success', function () {

--- a/core/test/unit/adapters/scheduling/post-scheduling/index_spec.js
+++ b/core/test/unit/adapters/scheduling/post-scheduling/index_spec.js
@@ -9,9 +9,7 @@ var should = require('should'),
     schedulingUtils = require('../../../../../server/adapters/scheduling/utils'),
     SchedulingDefault = require('../../../../../server/adapters/scheduling/SchedulingDefault'),
     postScheduling = require('../../../../../server/adapters/scheduling/post-scheduling'),
-    urlService = require('../../../../../server/services/url'),
-
-    sandbox = sinon.sandbox.create();
+    urlService = require('../../../../../server/services/url');
 
 describe('Scheduling: Post Scheduling', function () {
     var scope = {
@@ -35,28 +33,28 @@ describe('Scheduling: Post Scheduling', function () {
 
         scope.adapter = new SchedulingDefault();
 
-        sandbox.stub(api.schedules, 'getScheduledPosts').callsFake(function () {
+        sinon.stub(api.schedules, 'getScheduledPosts').callsFake(function () {
             return Promise.resolve({posts: scope.scheduledPosts});
         });
 
-        sandbox.stub(common.events, 'onMany').callsFake(function (events, stubDone) {
+        sinon.stub(common.events, 'onMany').callsFake(function (events, stubDone) {
             events.forEach(function (event) {
                 scope.events[event] = stubDone;
             });
         });
 
-        sandbox.stub(schedulingUtils, 'createAdapter').returns(Promise.resolve(scope.adapter));
+        sinon.stub(schedulingUtils, 'createAdapter').returns(Promise.resolve(scope.adapter));
 
-        sandbox.stub(models.Client, 'findOne').callsFake(function () {
+        sinon.stub(models.Client, 'findOne').callsFake(function () {
             return Promise.resolve(scope.client);
         });
 
-        sandbox.spy(scope.adapter, 'schedule');
-        sandbox.spy(scope.adapter, 'reschedule');
+        sinon.spy(scope.adapter, 'schedule');
+        sinon.spy(scope.adapter, 'reschedule');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         return testUtils.teardown();
     });
 

--- a/core/test/unit/adapters/storage/LocalFileStorage_spec.js
+++ b/core/test/unit/adapters/storage/LocalFileStorage_spec.js
@@ -7,10 +7,7 @@ var should = require('should'),
     common = require('../../../../server/lib/common'),
     LocalFileStore = require('../../../../server/adapters/storage/LocalFileStorage'),
     localFileStore,
-
-    configUtils = require('../../../utils/configUtils'),
-
-    sandbox = sinon.sandbox.create();
+    configUtils = require('../../../utils/configUtils');
 
 describe('Local File System Storage', function () {
     var image,
@@ -24,26 +21,21 @@ describe('Local File System Storage', function () {
         momentStub.withArgs('MM').returns(month < 10 ? '0' + month.toString() : month.toString());
     }
 
-    before(function () {
+    beforeEach(function () {
         // Fake a date, do this once for all tests in this file
         momentStub = sinon.stub(moment.fn, 'format');
     });
 
-    after(function () {
-        // Moment stub requires it's own restore after all the tests
-        momentStub.restore();
-    });
-
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 
     beforeEach(function () {
-        sandbox.stub(fs, 'mkdirs').resolves();
-        sandbox.stub(fs, 'copy').resolves();
-        sandbox.stub(fs, 'stat').rejects();
-        sandbox.stub(fs, 'unlink').resolves();
+        sinon.stub(fs, 'mkdirs').resolves();
+        sinon.stub(fs, 'copy').resolves();
+        sinon.stub(fs, 'stat').rejects();
+        sinon.stub(fs, 'unlink').resolves();
 
         image = {
             path: 'tmp/123456.jpg',
@@ -232,8 +224,8 @@ describe('Local File System Storage', function () {
         var truePathSep = path.sep;
 
         beforeEach(function () {
-            sandbox.stub(path, 'join');
-            sandbox.stub(configUtils.config, 'getContentPath').returns('content/images/');
+            sinon.stub(path, 'join');
+            sinon.stub(configUtils.config, 'getContentPath').returns('content/images/');
         });
 
         afterEach(function () {

--- a/core/test/unit/adapters/storage/utils_spec.js
+++ b/core/test/unit/adapters/storage/utils_spec.js
@@ -3,20 +3,18 @@ var should = require('should'),
     urlService = require('../../../../server/services/url'),
 
     // Stuff we are testing
-    storageUtils = require('../../../../server/adapters/storage/utils'),
-
-    sandbox = sinon.sandbox.create();
+    storageUtils = require('../../../../server/adapters/storage/utils');
 
 describe('storage utils', function () {
     var urlForStub,
         urlGetSubdirStub;
 
     beforeEach(function () {
-        urlForStub = sandbox.stub();
+        urlForStub = sinon.stub();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('fn: getLocalFileStoragePath', function () {
@@ -24,9 +22,9 @@ describe('storage utils', function () {
             var url = 'http://myblog.com/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalFileStoragePath(url);
@@ -41,9 +39,9 @@ describe('storage utils', function () {
             var url = 'https://myblog.com/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalFileStoragePath(url);
@@ -55,9 +53,9 @@ describe('storage utils', function () {
             var url = 'http://myblog.com/blog/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.getLocalFileStoragePath(url);
@@ -69,9 +67,9 @@ describe('storage utils', function () {
             var filePath = '/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalFileStoragePath(filePath);
@@ -83,9 +81,9 @@ describe('storage utils', function () {
             var filePath = '/blog/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.getLocalFileStoragePath(filePath);
@@ -97,9 +95,9 @@ describe('storage utils', function () {
             var url = 'http://example-blog.com/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalFileStoragePath(url);
@@ -113,9 +111,9 @@ describe('storage utils', function () {
             var url = 'http://myblog.com/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);
@@ -130,9 +128,9 @@ describe('storage utils', function () {
             var url = 'https://myblog.com/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);
@@ -144,9 +142,9 @@ describe('storage utils', function () {
             var url = 'http://myblog.com/blog/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.isLocalImage(url);
@@ -158,9 +156,9 @@ describe('storage utils', function () {
             var url = '/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);
@@ -172,9 +170,9 @@ describe('storage utils', function () {
             var url = '/blog/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.isLocalImage(url);
@@ -186,9 +184,9 @@ describe('storage utils', function () {
             var url = 'http://somewebsite.com/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);

--- a/core/test/unit/api/shared/http_spec.js
+++ b/core/test/unit/api/shared/http_spec.js
@@ -1,7 +1,6 @@
 const should = require('should');
 const sinon = require('sinon');
 const shared = require('../../../../server/api/shared');
-const sandbox = sinon.sandbox.create();
 
 describe('Unit: api/shared/http', function () {
     let req;
@@ -9,28 +8,28 @@ describe('Unit: api/shared/http', function () {
     let next;
 
     beforeEach(function () {
-        req = sandbox.stub();
-        res = sandbox.stub();
-        next = sandbox.stub();
+        req = sinon.stub();
+        res = sinon.stub();
+        next = sinon.stub();
 
         req.body = {
             a: 'a'
         };
 
-        res.status = sandbox.stub();
-        res.json = sandbox.stub();
-        res.set = sandbox.stub();
-        res.send = sandbox.stub();
+        res.status = sinon.stub();
+        res.json = sinon.stub();
+        res.set = sinon.stub();
+        res.send = sinon.stub();
 
-        sandbox.stub(shared.headers, 'get').resolves();
+        sinon.stub(shared.headers, 'get').resolves();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('check options', function () {
-        const apiImpl = sandbox.stub().resolves();
+        const apiImpl = sinon.stub().resolves();
         shared.http(apiImpl)(req, res, next);
 
         Object.keys(apiImpl.args[0][0]).should.eql([
@@ -53,7 +52,7 @@ describe('Unit: api/shared/http', function () {
     });
 
     it('api response is fn', function (done) {
-        const response = sandbox.stub().callsFake(function (req, res, next) {
+        const response = sinon.stub().callsFake(function (req, res, next) {
             should.exist(req);
             should.exist(res);
             should.exist(next);
@@ -62,12 +61,12 @@ describe('Unit: api/shared/http', function () {
             done();
         });
 
-        const apiImpl = sandbox.stub().resolves(response);
+        const apiImpl = sinon.stub().resolves(response);
         shared.http(apiImpl)(req, res, next);
     });
 
     it('api response is fn', function (done) {
-        const apiImpl = sandbox.stub().resolves('data');
+        const apiImpl = sinon.stub().resolves('data');
 
         next.callsFake(done);
 

--- a/core/test/unit/api/shared/pipeline_spec.js
+++ b/core/test/unit/api/shared/pipeline_spec.js
@@ -1,27 +1,26 @@
 const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
-const sandbox = sinon.sandbox.create();
 const common = require('../../../../server/lib/common');
 const shared = require('../../../../server/api/shared');
 
 describe('Unit: api/shared/pipeline', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('stages', function () {
         describe('validation', function () {
             describe('input', function () {
                 beforeEach(function () {
-                    sandbox.stub(shared.validators.handle, 'input').resolves();
+                    sinon.stub(shared.validators.handle, 'input').resolves();
                 });
 
                 it('do it yourself', function () {
                     const apiUtils = {};
                     const apiConfig = {};
                     const apiImpl = {
-                        validation: sandbox.stub().resolves('response')
+                        validation: sinon.stub().resolves('response')
                     };
                     const frame = {};
 
@@ -88,7 +87,7 @@ describe('Unit: api/shared/pipeline', function () {
             beforeEach(function () {
                 apiUtils = {
                     permissions: {
-                        handle: sandbox.stub().resolves()
+                        handle: sinon.stub().resolves()
                     }
                 };
             });
@@ -109,7 +108,7 @@ describe('Unit: api/shared/pipeline', function () {
             it('do it yourself', function () {
                 const apiConfig = {};
                 const apiImpl = {
-                    permissions: sandbox.stub().resolves('lol')
+                    permissions: sinon.stub().resolves('lol')
                 };
                 const frame = {};
 
@@ -178,11 +177,11 @@ describe('Unit: api/shared/pipeline', function () {
 
     describe('pipeline', function () {
         beforeEach(function () {
-            sandbox.stub(shared.pipeline.STAGES.validation, 'input');
-            sandbox.stub(shared.pipeline.STAGES.serialisation, 'input');
-            sandbox.stub(shared.pipeline.STAGES.serialisation, 'output');
-            sandbox.stub(shared.pipeline.STAGES, 'permissions');
-            sandbox.stub(shared.pipeline.STAGES, 'query');
+            sinon.stub(shared.pipeline.STAGES.validation, 'input');
+            sinon.stub(shared.pipeline.STAGES.serialisation, 'input');
+            sinon.stub(shared.pipeline.STAGES.serialisation, 'output');
+            sinon.stub(shared.pipeline.STAGES, 'permissions');
+            sinon.stub(shared.pipeline.STAGES, 'query');
         });
 
         it('ensure we receive a callable api controller fn', function () {

--- a/core/test/unit/api/shared/serializers/handle_spec.js
+++ b/core/test/unit/api/shared/serializers/handle_spec.js
@@ -3,11 +3,10 @@ const Promise = require('bluebird');
 const sinon = require('sinon');
 const common = require('../../../../../server/lib/common');
 const shared = require('../../../../../server/api/shared');
-const sandbox = sinon.sandbox.create();
 
 describe('Unit: api/shared/serializers/handle', function () {
     beforeEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('input', function () {
@@ -28,16 +27,16 @@ describe('Unit: api/shared/serializers/handle', function () {
         });
 
         it('ensure serializers are called with apiConfig and frame', function () {
-            const allStub = sandbox.stub();
-            const addStub = sandbox.stub();
-            sandbox.stub(shared.serializers.input.all, 'all').get(() => allStub);
-            sandbox.stub(shared.serializers.input.all, 'add').get(() => addStub);
+            const allStub = sinon.stub();
+            const addStub = sinon.stub();
+            sinon.stub(shared.serializers.input.all, 'all').get(() => allStub);
+            sinon.stub(shared.serializers.input.all, 'add').get(() => addStub);
 
             const apiSerializers = {
-                all: sandbox.stub().resolves(),
+                all: sinon.stub().resolves(),
                 posts: {
-                    all: sandbox.stub().resolves(),
-                    add: sandbox.stub().resolves()
+                    all: sinon.stub().resolves(),
+                    add: sinon.stub().resolves()
                 }
             };
 
@@ -87,10 +86,10 @@ describe('Unit: api/shared/serializers/handle', function () {
         it('ensure serializers are called', function () {
             const apiSerializers = {
                 posts: {
-                    add: sandbox.stub().resolves()
+                    add: sinon.stub().resolves()
                 },
                 users: {
-                    add: sandbox.stub().resolves()
+                    add: sinon.stub().resolves()
                 }
             };
 

--- a/core/test/unit/api/shared/validators/handle_spec.js
+++ b/core/test/unit/api/shared/validators/handle_spec.js
@@ -3,11 +3,10 @@ const Promise = require('bluebird');
 const sinon = require('sinon');
 const common = require('../../../../../server/lib/common');
 const shared = require('../../../../../server/api/shared');
-const sandbox = sinon.sandbox.create();
 
 describe('Unit: api/shared/validators/handle', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('input', function () {
@@ -28,20 +27,20 @@ describe('Unit: api/shared/validators/handle', function () {
         });
 
         it('ensure validators are called', function () {
-            const getStub = sandbox.stub();
-            const addStub = sandbox.stub();
-            sandbox.stub(shared.validators.input.all, 'all').get(() => {return getStub;});
-            sandbox.stub(shared.validators.input.all, 'add').get(() => {return addStub;});
+            const getStub = sinon.stub();
+            const addStub = sinon.stub();
+            sinon.stub(shared.validators.input.all, 'all').get(() => {return getStub;});
+            sinon.stub(shared.validators.input.all, 'add').get(() => {return addStub;});
 
             const apiValidators = {
                 all: {
-                    add: sandbox.stub().resolves()
+                    add: sinon.stub().resolves()
                 },
                 posts: {
-                    add: sandbox.stub().resolves()
+                    add: sinon.stub().resolves()
                 },
                 users: {
-                    add: sandbox.stub().resolves()
+                    add: sinon.stub().resolves()
                 }
             };
 

--- a/core/test/unit/api/shared/validators/input/all_spec.js
+++ b/core/test/unit/api/shared/validators/input/all_spec.js
@@ -3,11 +3,10 @@ const sinon = require('sinon');
 const Promise = require('bluebird');
 const common = require('../../../../../../server/lib/common');
 const shared = require('../../../../../../server/api/shared');
-const sandbox = sinon.sandbox.create();
 
 describe('Unit: api/shared/validators/input/all', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('all', function () {
@@ -256,7 +255,7 @@ describe('Unit: api/shared/validators/input/all', function () {
 
     describe('read', function () {
         it('default', function () {
-            sandbox.stub(shared.validators.input.all, 'browse');
+            sinon.stub(shared.validators.input.all, 'browse');
 
             const frame = {
                 options: {

--- a/core/test/unit/api/v0.1/decorators/urls_spec.js
+++ b/core/test/unit/api/v0.1/decorators/urls_spec.js
@@ -5,15 +5,13 @@ const testUtils = require('../../../../utils');
 const urlService = require('../../../../../server/services/url');
 const urls = require('../../../../../server/api/v0.1/decorators/urls');
 
-const sandbox = sinon.sandbox.create();
-
 describe('Unit: api:v0.1:decorators:urls', function () {
     beforeEach(function () {
-        sandbox.stub(urlService, 'getUrlByResourceId');
+        sinon.stub(urlService, 'getUrlByResourceId');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('urlsForPost', function () {

--- a/core/test/unit/api/v0.1/utils_spec.js
+++ b/core/test/unit/api/v0.1/utils_spec.js
@@ -5,13 +5,11 @@ var should = require('should'),
     ObjectId = require('bson-objectid'),
     permissions = require('../../../../server/services/permissions'),
     common = require('../../../../server/lib/common'),
-    apiUtils = require('../../../../server/api/v0.1/utils'),
-
-    sandbox = sinon.sandbox.create();
+    apiUtils = require('../../../../server/api/v0.1/utils');
 
 describe('API Utils', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('exports', function () {
@@ -91,7 +89,7 @@ describe('API Utils', function () {
 
         it('should check data if an object is passed', function (done) {
             var object = {test: [{id: 1}]},
-                checkObjectStub = sandbox.stub(apiUtils, 'checkObject').returns(Promise.resolve(object));
+                checkObjectStub = sinon.stub(apiUtils, 'checkObject').returns(Promise.resolve(object));
 
             apiUtils.validate('test')(object, {}).then(function (options) {
                 checkObjectStub.calledOnce.should.be.true();
@@ -111,7 +109,7 @@ describe('API Utils', function () {
 
         it('should handle options being undefined when provided with object', function (done) {
             var object = {test: [{id: 1}]},
-                checkObjectStub = sandbox.stub(apiUtils, 'checkObject').returns(Promise.resolve(object));
+                checkObjectStub = sinon.stub(apiUtils, 'checkObject').returns(Promise.resolve(object));
 
             apiUtils.validate('test')(object, undefined).then(function (options) {
                 checkObjectStub.calledOnce.should.be.true();
@@ -287,14 +285,14 @@ describe('API Utils', function () {
 
     describe('convertOptions', function () {
         it('should not call prepareInclude if there is no include option', function () {
-            var prepareIncludeStub = sandbox.stub(apiUtils, 'prepareInclude');
+            var prepareIncludeStub = sinon.stub(apiUtils, 'prepareInclude');
             apiUtils.convertOptions(['a', 'b', 'c'])({}).should.eql({});
             prepareIncludeStub.called.should.be.false();
         });
 
         it('should pass options.include to prepareInclude if provided', function () {
             var expectedResult = ['a', 'b'],
-                prepareIncludeStub = sandbox.stub(apiUtils, 'prepareInclude').returns(expectedResult),
+                prepareIncludeStub = sinon.stub(apiUtils, 'prepareInclude').returns(expectedResult),
                 allowed = ['a', 'b', 'c'],
                 options = {include: 'a,b'},
                 actualResult;
@@ -589,7 +587,7 @@ describe('API Utils', function () {
 
     describe('isPublicContext', function () {
         it('should call out to permissions', function () {
-            var permsStub = sandbox.stub(permissions, 'parseContext').returns({public: true});
+            var permsStub = sinon.stub(permissions, 'parseContext').returns({public: true});
             apiUtils.detectPublicContext({context: 'test'}).should.be.true();
             permsStub.called.should.be.true();
             permsStub.calledWith('test').should.be.true();
@@ -598,7 +596,7 @@ describe('API Utils', function () {
 
     describe('applyPublicPermissions', function () {
         it('should call out to permissions', function () {
-            var permsStub = sandbox.stub(permissions, 'applyPublicRules');
+            var permsStub = sinon.stub(permissions, 'applyPublicRules');
             apiUtils.applyPublicPermissions('test', {});
             permsStub.called.should.be.true();
             permsStub.calledWith('test', {}).should.be.true();
@@ -614,7 +612,7 @@ describe('API Utils', function () {
         });
 
         it('should treat no context as public', function (done) {
-            var aPPStub = sandbox.stub(apiUtils, 'applyPublicPermissions').returns(Promise.resolve({}));
+            var aPPStub = sinon.stub(apiUtils, 'applyPublicPermissions').returns(Promise.resolve({}));
             apiUtils.handlePublicPermissions('tests', 'test')({}).then(function (options) {
                 aPPStub.calledOnce.should.eql(true);
                 options.should.eql({context: {app: null, external: false, internal: false, public: true, user: null, api_key_id: null}});
@@ -625,10 +623,10 @@ describe('API Utils', function () {
         it('should treat user context as NOT public', function (done) {
             var cTMethodStub = {
                     test: {
-                        test: sandbox.stub().returns(Promise.resolve())
+                        test: sinon.stub().returns(Promise.resolve())
                     }
                 },
-                cTStub = sandbox.stub(permissions, 'canThis').returns(cTMethodStub);
+                cTStub = sinon.stub(permissions, 'canThis').returns(cTMethodStub);
 
             apiUtils.handlePublicPermissions('tests', 'test')({context: {user: 1}}).then(function (options) {
                 cTStub.calledOnce.should.eql(true);
@@ -641,10 +639,10 @@ describe('API Utils', function () {
         it('should throw a permissions error if permission is not granted', function (done) {
             var cTMethodStub = {
                     test: {
-                        test: sandbox.stub().returns(Promise.reject(new common.errors.NoPermissionError()))
+                        test: sinon.stub().returns(Promise.reject(new common.errors.NoPermissionError()))
                     }
                 },
-                cTStub = sandbox.stub(permissions, 'canThis').returns(cTMethodStub);
+                cTStub = sinon.stub(permissions, 'canThis').returns(cTMethodStub);
 
             apiUtils.handlePublicPermissions('tests', 'test')({context: {user: 1}}).then(function () {
                 done(new Error('should throw error when no permissions'));
@@ -667,8 +665,8 @@ describe('API Utils', function () {
         });
 
         it('should handle an unknown rejection', function (done) {
-            var testStub = sandbox.stub().returns(new Promise.reject(new Error('not found'))),
-                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
+            var testStub = sinon.stub().returns(new Promise.reject(new Error('not found'))),
+                permsStub = sinon.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -691,8 +689,8 @@ describe('API Utils', function () {
         });
 
         it('should handle a NoPermissions rejection', function (done) {
-            var testStub = sandbox.stub().returns(Promise.reject(new common.errors.NoPermissionError())),
-                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
+            var testStub = sinon.stub().returns(Promise.reject(new common.errors.NoPermissionError())),
+                permsStub = sinon.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -717,8 +715,8 @@ describe('API Utils', function () {
         });
 
         it('should handle success', function (done) {
-            var testStub = sandbox.stub().returns(new Promise.resolve()),
-                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
+            var testStub = sinon.stub().returns(new Promise.resolve()),
+                permsStub = sinon.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -744,8 +742,8 @@ describe('API Utils', function () {
         });
 
         it('should ignore unsafe attrs if none are provided', function (done) {
-            var testStub = sandbox.stub().returns(new Promise.resolve()),
-                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
+            var testStub = sinon.stub().returns(new Promise.resolve()),
+                permsStub = sinon.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -771,8 +769,8 @@ describe('API Utils', function () {
         });
 
         it('should ignore unsafe attrs if they are provided but not present', function (done) {
-            var testStub = sandbox.stub().returns(new Promise.resolve()),
-                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
+            var testStub = sinon.stub().returns(new Promise.resolve()),
+                permsStub = sinon.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -798,8 +796,8 @@ describe('API Utils', function () {
         });
 
         it('should pass through unsafe attrs if they DO exist', function (done) {
-            var testStub = sandbox.stub().returns(new Promise.resolve()),
-                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
+            var testStub = sinon.stub().returns(new Promise.resolve()),
+                permsStub = sinon.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -825,8 +823,8 @@ describe('API Utils', function () {
         });
 
         it('should strip excludedAttrs from data if permissions function returns them', function () {
-            var testStub = sandbox.stub().resolves({excludedAttrs: ['foo']}),
-                permsStub = sandbox.stub(permissions, 'canThis').returns({
+            var testStub = sinon.stub().resolves({excludedAttrs: ['foo']}),
+                permsStub = sinon.stub(permissions, 'canThis').returns({
                     testing: {
                         test: testStub
                     }

--- a/core/test/unit/api/v2/index_spec.js
+++ b/core/test/unit/api/v2/index_spec.js
@@ -2,7 +2,6 @@ const should = require('should');
 const sinon = require('sinon');
 const utils = require('../../../../server/api/v2/utils');
 
-
 describe('Unit: v2/utils/index', function () {
     afterEach(function () {
         sinon.restore();

--- a/core/test/unit/api/v2/index_spec.js
+++ b/core/test/unit/api/v2/index_spec.js
@@ -1,11 +1,11 @@
 const should = require('should');
 const sinon = require('sinon');
 const utils = require('../../../../server/api/v2/utils');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: v2/utils/index', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
     describe('isContentAPI', function () {
         it('is truthy when having api key and no user', function () {

--- a/core/test/unit/api/v2/session_spec.js
+++ b/core/test/unit/api/v2/session_spec.js
@@ -8,15 +8,12 @@ const sessionController = require('../../../../server/api/v2/session');
 const sessionServiceMiddleware = require('../../../../server/services/auth/session/middleware');
 
 describe('Session controller', function () {
-    let sandbox;
-
     before(function () {
         models.init();
-        sandbox = sinon.sandbox.create();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('exports an add method', function () {
@@ -36,7 +33,7 @@ describe('Session controller', function () {
         });
 
         it('it checks the username and password and throws UnauthorizedError if it fails', function () {
-            const userCheckStub = sandbox.stub(models.User, 'check')
+            const userCheckStub = sinon.stub(models.User, 'check')
                 .rejects(new Error());
 
             return sessionController.add({
@@ -52,16 +49,16 @@ describe('Session controller', function () {
         it('it returns a function that calls req.brute.reset, sets req.user and calls createSession if the check works', function () {
             const fakeReq = {
                 brute: {
-                    reset: sandbox.stub().callsArg(0)
+                    reset: sinon.stub().callsArg(0)
                 }
             };
             const fakeRes = {};
             const fakeNext = () => {};
             const fakeUser = models.User.forge({});
-            sandbox.stub(models.User, 'check')
+            sinon.stub(models.User, 'check')
                 .resolves(fakeUser);
 
-            const createSessionStub = sandbox.stub(sessionServiceMiddleware, 'createSession');
+            const createSessionStub = sinon.stub(sessionServiceMiddleware, 'createSession');
 
             return sessionController.add({
                 username: 'freddy@vodafone.com',
@@ -83,16 +80,16 @@ describe('Session controller', function () {
             const resetError = new Error();
             const fakeReq = {
                 brute: {
-                    reset: sandbox.stub().callsArgWith(0, resetError)
+                    reset: sinon.stub().callsArgWith(0, resetError)
                 }
             };
             const fakeRes = {};
-            const fakeNext = sandbox.stub();
+            const fakeNext = sinon.stub();
             const fakeUser = models.User.forge({});
-            sandbox.stub(models.User, 'check')
+            sinon.stub(models.User, 'check')
                 .resolves(fakeUser);
 
-            const createSessionStub = sandbox.stub(sessionServiceMiddleware, 'createSession');
+            const createSessionStub = sinon.stub(sessionServiceMiddleware, 'createSession');
 
             return sessionController.add({
                 username: 'freddy@vodafone.com',
@@ -112,7 +109,7 @@ describe('Session controller', function () {
             const fakeReq = {};
             const fakeRes = {};
             const fakeNext = () => {};
-            const destroySessionStub = sandbox.stub(sessionServiceMiddleware, 'destroySession');
+            const destroySessionStub = sinon.stub(sessionServiceMiddleware, 'destroySession');
 
             return sessionController.delete().then((fn) => {
                 fn(fakeReq, fakeRes, fakeNext);
@@ -128,7 +125,7 @@ describe('Session controller', function () {
     describe('#get', function () {
         it('returns the result of User.findOne', function () {
             const findOneReturnVal = new Promise(() => {});
-            const findOneStub = sandbox.stub(models.User, 'findOne')
+            const findOneStub = sinon.stub(models.User, 'findOne')
                 .returns(findOneReturnVal);
 
             const result = sessionController.read({

--- a/core/test/unit/api/v2/utils/serializers/output/pages_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/pages_spec.js
@@ -4,21 +4,21 @@ const testUtils = require('../../../../../../utils');
 const mapper = require('../../../../../../../server/api/v2/utils/serializers/output/utils/mapper');
 const serializers = require('../../../../../../../server/api/v2/utils/serializers');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: v2/utils/serializers/output/pages', () => {
     let pageModel;
 
     beforeEach(() => {
         pageModel = (data) => {
-            return Object.assign(data, {toJSON: sandbox.stub().returns(data)});
+            return Object.assign(data, {toJSON: sinon.stub().returns(data)});
         };
 
-        sandbox.stub(mapper, 'mapPost').returns({});
+        sinon.stub(mapper, 'mapPost').returns({});
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('calls the mapper', () => {

--- a/core/test/unit/api/v2/utils/serializers/output/pages_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/pages_spec.js
@@ -4,8 +4,6 @@ const testUtils = require('../../../../../../utils');
 const mapper = require('../../../../../../../server/api/v2/utils/serializers/output/utils/mapper');
 const serializers = require('../../../../../../../server/api/v2/utils/serializers');
 
-
-
 describe('Unit: v2/utils/serializers/output/pages', () => {
     let pageModel;
 

--- a/core/test/unit/api/v2/utils/serializers/output/posts_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/posts_spec.js
@@ -4,21 +4,19 @@ const testUtils = require('../../../../../../utils');
 const mapper = require('../../../../../../../server/api/v2/utils/serializers/output/utils/mapper');
 const serializers = require('../../../../../../../server/api/v2/utils/serializers');
 
-const sandbox = sinon.sandbox.create();
-
 describe('Unit: v2/utils/serializers/output/posts', () => {
     let postModel;
 
     beforeEach(() => {
         postModel = (data) => {
-            return Object.assign(data, {toJSON: sandbox.stub().returns(data)});
+            return Object.assign(data, {toJSON: sinon.stub().returns(data)});
         };
 
-        sandbox.stub(mapper, 'mapPost').returns({});
+        sinon.stub(mapper, 'mapPost').returns({});
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('calls the mapper', () => {

--- a/core/test/unit/api/v2/utils/serializers/output/tags_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/tags_spec.js
@@ -4,21 +4,21 @@ const testUtils = require('../../../../../../utils');
 const mapper = require('../../../../../../../server/api/v2/utils/serializers/output/utils/mapper');
 const serializers = require('../../../../../../../server/api/v2/utils/serializers');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: v2/utils/serializers/output/tags', () => {
     let tagModel;
 
     beforeEach(() => {
         tagModel = (data) => {
-            return Object.assign(data, {toJSON: sandbox.stub().returns(data)});
+            return Object.assign(data, {toJSON: sinon.stub().returns(data)});
         };
 
-        sandbox.stub(mapper, 'mapTag').returns({});
+        sinon.stub(mapper, 'mapTag').returns({});
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('calls the mapper when single tag present', () => {

--- a/core/test/unit/api/v2/utils/serializers/output/tags_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/tags_spec.js
@@ -4,8 +4,6 @@ const testUtils = require('../../../../../../utils');
 const mapper = require('../../../../../../../server/api/v2/utils/serializers/output/utils/mapper');
 const serializers = require('../../../../../../../server/api/v2/utils/serializers');
 
-
-
 describe('Unit: v2/utils/serializers/output/tags', () => {
     let tagModel;
 

--- a/core/test/unit/api/v2/utils/serializers/output/utils/date_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/utils/date_spec.js
@@ -3,11 +3,11 @@ const sinon = require('sinon');
 const settingsCache = require('../../../../../../../../server/services/settings/cache');
 const dateUtil = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/date');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: v2/utils/serializers/output/utils/date', () => {
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('creates date strings in ISO 8601 format with UTC offset', () => {
@@ -17,7 +17,7 @@ describe('Unit: v2/utils/serializers/output/utils/date', () => {
             {in:'2014-12-31T23:28:58.123Z', out: '2015-01-01T00:28:58.123+01:00'},
             {in:'2014-03-01T01:28:58.593Z', out: '2014-03-01T02:28:58.593+01:00'}
         ];
-        sandbox.stub(settingsCache, 'get').returns(timezone);
+        sinon.stub(settingsCache, 'get').returns(timezone);
 
         testDates.forEach((date) => {
             dateUtil.format(date.in).should.equal(date.out);

--- a/core/test/unit/api/v2/utils/serializers/output/utils/date_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/utils/date_spec.js
@@ -3,8 +3,6 @@ const sinon = require('sinon');
 const settingsCache = require('../../../../../../../../server/services/settings/cache');
 const dateUtil = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/date');
 
-
-
 describe('Unit: v2/utils/serializers/output/utils/date', () => {
     afterEach(() => {
         sinon.restore();

--- a/core/test/unit/api/v2/utils/serializers/output/utils/extra-attrs.js
+++ b/core/test/unit/api/v2/utils/serializers/output/utils/extra-attrs.js
@@ -1,7 +1,7 @@
 const should = require('should');
 const sinon = require('sinon');
 const extraAttrsUtil = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/extra-attrs');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: v2/utils/serializers/output/utils/extra-attrs', () => {
     const frame = {
@@ -11,8 +11,8 @@ describe('Unit: v2/utils/serializers/output/utils/extra-attrs', () => {
     let model;
 
     beforeEach(function () {
-        model = sandbox.stub();
-        model.get = sandbox.stub();
+        model = sinon.stub();
+        model.get = sinon.stub();
         model.get.withArgs('plaintext').returns(new Array(5000).join('A'));
     });
 

--- a/core/test/unit/api/v2/utils/serializers/output/utils/extra-attrs_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/utils/extra-attrs_spec.js
@@ -2,7 +2,6 @@ const should = require('should');
 const sinon = require('sinon');
 const extraAttrsUtil = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/extra-attrs');
 
-
 describe('Unit: v2/utils/serializers/output/utils/extra-attrs', () => {
     const frame = {
         options: {}

--- a/core/test/unit/api/v2/utils/serializers/output/utils/mapper_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/utils/mapper_spec.js
@@ -7,25 +7,25 @@ const cleanUtil = require('../../../../../../../../server/api/v2/utils/serialize
 const extraAttrsUtils = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/extra-attrs');
 const mapper = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/mapper');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: v2/utils/serializers/output/utils/mapper', () => {
     beforeEach(() => {
-        sandbox.stub(dateUtil, 'forPost').returns({});
+        sinon.stub(dateUtil, 'forPost').returns({});
 
-        sandbox.stub(urlUtil, 'forPost').returns({});
-        sandbox.stub(urlUtil, 'forTag').returns({});
-        sandbox.stub(urlUtil, 'forUser').returns({});
+        sinon.stub(urlUtil, 'forPost').returns({});
+        sinon.stub(urlUtil, 'forTag').returns({});
+        sinon.stub(urlUtil, 'forUser').returns({});
 
-        sandbox.stub(extraAttrsUtils, 'forPost').returns({});
+        sinon.stub(extraAttrsUtils, 'forPost').returns({});
 
-        sandbox.stub(cleanUtil, 'post').returns({});
-        sandbox.stub(cleanUtil, 'tag').returns({});
-        sandbox.stub(cleanUtil, 'author').returns({});
+        sinon.stub(cleanUtil, 'post').returns({});
+        sinon.stub(cleanUtil, 'tag').returns({});
+        sinon.stub(cleanUtil, 'author').returns({});
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('mapPost', () => {
@@ -34,7 +34,7 @@ describe('Unit: v2/utils/serializers/output/utils/mapper', () => {
         beforeEach(() => {
             postModel = (data) => {
                 return Object.assign(data, {
-                    toJSON: sandbox.stub().returns(data)
+                    toJSON: sinon.stub().returns(data)
                 });
             };
         });
@@ -118,7 +118,7 @@ describe('Unit: v2/utils/serializers/output/utils/mapper', () => {
 
         beforeEach(() => {
             userModel = (data) => {
-                return Object.assign(data, {toJSON: sandbox.stub().returns(data)});
+                return Object.assign(data, {toJSON: sinon.stub().returns(data)});
             };
         });
 
@@ -146,7 +146,7 @@ describe('Unit: v2/utils/serializers/output/utils/mapper', () => {
 
         beforeEach(() => {
             tagModel = (data) => {
-                return Object.assign(data, {toJSON: sandbox.stub().returns(data)});
+                return Object.assign(data, {toJSON: sinon.stub().returns(data)});
             };
         });
 

--- a/core/test/unit/api/v2/utils/serializers/output/utils/mapper_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/utils/mapper_spec.js
@@ -7,8 +7,6 @@ const cleanUtil = require('../../../../../../../../server/api/v2/utils/serialize
 const extraAttrsUtils = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/extra-attrs');
 const mapper = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/mapper');
 
-
-
 describe('Unit: v2/utils/serializers/output/utils/mapper', () => {
     beforeEach(() => {
         sinon.stub(dateUtil, 'forPost').returns({});

--- a/core/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
@@ -4,8 +4,6 @@ const testUtils = require('../../../../../../../utils');
 const urlService = require('../../../../../../../../server/services/url');
 const urlUtil = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/url');
 
-
-
 describe('Unit: v2/utils/serializers/output/utils/url', () => {
     beforeEach(() => {
         sinon.stub(urlService, 'getUrlByResourceId').returns('getUrlByResourceId');

--- a/core/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
@@ -4,17 +4,17 @@ const testUtils = require('../../../../../../../utils');
 const urlService = require('../../../../../../../../server/services/url');
 const urlUtil = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/url');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: v2/utils/serializers/output/utils/url', () => {
     beforeEach(() => {
-        sandbox.stub(urlService, 'getUrlByResourceId').returns('getUrlByResourceId');
-        sandbox.stub(urlService.utils, 'urlFor').returns('urlFor');
-        sandbox.stub(urlService.utils, 'makeAbsoluteUrls').returns({html: sandbox.stub()});
+        sinon.stub(urlService, 'getUrlByResourceId').returns('getUrlByResourceId');
+        sinon.stub(urlService.utils, 'urlFor').returns('urlFor');
+        sinon.stub(urlService.utils, 'makeAbsoluteUrls').returns({html: sinon.stub()});
     });
 
     afterEach(() => {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Ensure calls url service', () => {
@@ -22,7 +22,7 @@ describe('Unit: v2/utils/serializers/output/utils/url', () => {
 
         beforeEach(() => {
             pageModel = (data) => {
-                return Object.assign(data, {toJSON: sandbox.stub().returns(data)});
+                return Object.assign(data, {toJSON: sinon.stub().returns(data)});
             };
         });
 

--- a/core/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -3,11 +3,10 @@ const sinon = require('sinon');
 const Promise = require('bluebird');
 const common = require('../../../../../../../server/lib/common');
 const validators = require('../../../../../../../server/api/v2/utils/validators');
-const sandbox = sinon.sandbox.create();
 
 describe('Unit: v2/utils/validators/input/posts', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('add', function () {
@@ -84,7 +83,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
 
     describe('edit', function () {
         it('default', function () {
-            sandbox.stub(validators.input.posts, 'add');
+            sinon.stub(validators.input.posts, 'add');
 
             const apiConfig = {};
             const frame = {};

--- a/core/test/unit/apps/amp/amp_content_spec.js
+++ b/core/test/unit/apps/amp/amp_content_spec.js
@@ -1,8 +1,6 @@
 var should = require('should'),
     rewire = require('rewire'),
     configUtils = require('../../../../test/utils/configUtils'),
-
-// Stuff we are testing
     ampContentHelper = rewire('../../../../server/apps/amp/lib/helpers/amp_content');
 
 // TODO: Amperize really needs to get stubbed, so we can test returning errors

--- a/core/test/unit/apps/amp/router_spec.js
+++ b/core/test/unit/apps/amp/router_spec.js
@@ -6,8 +6,7 @@ const should = require('should'),
     helpers = require('../../../../server/services/routing/helpers'),
     common = require('../../../../server/lib/common'),
     testUtils = require('../../../utils'),
-    configUtils = require('../../../utils/configUtils'),
-    sandbox = sinon.sandbox.create();
+    configUtils = require('../../../utils/configUtils');
 
 // Helper function to prevent unit tests
 // from failing via timeout when they
@@ -25,14 +24,14 @@ describe('Unit - apps/amp/lib/router', function () {
         rendererStub;
 
     beforeEach(function () {
-        rendererStub = sandbox.stub();
+        rendererStub = sinon.stub();
 
-        sandbox.stub(helpers, 'renderer').get(function () {
+        sinon.stub(helpers, 'renderer').get(function () {
             return rendererStub;
         });
 
         res = {
-            render: sandbox.spy(),
+            render: sinon.spy(),
             locals: {
                 context: ['amp', 'post']
             }
@@ -54,7 +53,7 @@ describe('Unit - apps/amp/lib/router', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('fn: renderer', function () {
@@ -105,17 +104,17 @@ describe('Unit - apps/amp/lib/router', function () {
 
             req = {};
 
-            entryLookupStub = sandbox.stub();
+            entryLookupStub = sinon.stub();
 
-            sandbox.stub(helpers, 'entryLookup').get(function () {
+            sinon.stub(helpers, 'entryLookup').get(function () {
                 return entryLookupStub;
             });
 
-            sandbox.stub(urlService, 'getPermalinkByUrl');
+            sinon.stub(urlService, 'getPermalinkByUrl');
         });
 
         afterEach(function () {
-            sandbox.restore();
+            sinon.restore();
         });
 
         it('should successfully get the post data from slug', function (done) {

--- a/core/test/unit/apps/private-blogging/controller_spec.js
+++ b/core/test/unit/apps/private-blogging/controller_spec.js
@@ -4,9 +4,7 @@ var should = require('should'),
     path = require('path'),
     configUtils = require('../../../utils/configUtils'),
     themes = require('../../../../server/services/themes'),
-    privateController = require('../../../../server/apps/private-blogging/lib/router'),
-
-    sandbox = sinon.sandbox.create();
+    privateController = require('../../../../server/apps/private-blogging/lib/router');
 
 describe('Private Controller', function () {
     var res, req, defaultPath, hasTemplateStub;
@@ -21,16 +19,16 @@ describe('Private Controller', function () {
     }
 
     beforeEach(function () {
-        hasTemplateStub = sandbox.stub().returns(false);
+        hasTemplateStub = sinon.stub().returns(false);
         hasTemplateStub.withArgs('index').returns(true);
 
-        sandbox.stub(themes, 'getActive').returns({
+        sinon.stub(themes, 'getActive').returns({
             hasTemplate: hasTemplateStub
         });
 
         res = {
             locals: {version: ''},
-            render: sandbox.spy()
+            render: sinon.spy()
         };
 
         req = {
@@ -49,7 +47,7 @@ describe('Private Controller', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 

--- a/core/test/unit/apps/private-blogging/middleware_spec.js
+++ b/core/test/unit/apps/private-blogging/middleware_spec.js
@@ -5,8 +5,7 @@ var should = require('should'),
     fs = require('fs-extra'),
     common = require('../../../../server/lib/common'),
     settingsCache = require('../../../../server/services/settings/cache'),
-    privateBlogging = require('../../../../server/apps/private-blogging/lib/middleware'),
-    sandbox = sinon.sandbox.create();
+    privateBlogging = require('../../../../server/apps/private-blogging/lib/middleware');
 
 function hash(password, salt) {
     var hasher = crypto.createHash('sha256');
@@ -18,7 +17,7 @@ describe('Private Blogging', function () {
     var settingsStub;
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('passProtect', function () {
@@ -29,8 +28,8 @@ describe('Private Blogging', function () {
                 query: {}
             };
             res = {};
-            settingsStub = sandbox.stub(settingsCache, 'get');
-            next = sandbox.spy();
+            settingsStub = sinon.stub(settingsCache, 'get');
+            next = sinon.spy();
         });
 
         it('checkIsPrivate should call next if not private', function () {
@@ -60,7 +59,7 @@ describe('Private Blogging', function () {
 
             it('isPrivateSessionAuth should redirect if blog is not private', function () {
                 res = {
-                    redirect: sandbox.spy(),
+                    redirect: sinon.spy(),
                     isPrivateBlog: false
                 };
                 privateBlogging.isPrivateSessionAuth(req, res, next);
@@ -78,7 +77,7 @@ describe('Private Blogging', function () {
                     },
                     set: function () {
                     },
-                    redirect: sandbox.spy(),
+                    redirect: sinon.spy(),
                     isPrivateBlog: true
                 };
 
@@ -136,9 +135,9 @@ describe('Private Blogging', function () {
 
             it('filterPrivateRoutes should render custom robots.txt', function () {
                 req.url = req.path = '/robots.txt';
-                res.writeHead = sandbox.spy();
-                res.end = sandbox.spy();
-                sandbox.stub(fs, 'readFile').callsFake(function (file, cb) {
+                res.writeHead = sinon.spy();
+                res.end = sinon.spy();
+                sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
                     cb(null, 'User-agent: * Disallow: /');
                 });
                 privateBlogging.filterPrivateRoutes(req, res, next);
@@ -175,7 +174,7 @@ describe('Private Blogging', function () {
                         token: 'wrongpassword',
                         salt: Date.now().toString()
                     };
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.authenticatePrivateSession(req, res, next);
                     res.redirect.called.should.be.true();
@@ -188,7 +187,7 @@ describe('Private Blogging', function () {
                         token: hash('rightpassword', salt),
                         salt: salt
                     };
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.isPrivateSessionAuth(req, res, next);
                     res.redirect.called.should.be.true();
@@ -215,7 +214,7 @@ describe('Private Blogging', function () {
                 it('authenticateProtection should redirect if password is correct', function () {
                     req.body = {password: 'rightpassword'};
                     req.session = {};
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.authenticateProtection(req, res, next);
                     res.redirect.called.should.be.true();
@@ -227,7 +226,7 @@ describe('Private Blogging', function () {
                     req.query = {
                         r: encodeURIComponent('http://britney.com')
                     };
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.authenticateProtection(req, res, next);
                     res.redirect.called.should.be.true();
@@ -244,7 +243,7 @@ describe('Private Blogging', function () {
                     };
 
                     res.isPrivateBlog = true;
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     next.called.should.be.true();
@@ -261,7 +260,7 @@ describe('Private Blogging', function () {
                     };
 
                     res.isPrivateBlog = true;
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     next.called.should.be.true();
@@ -278,7 +277,7 @@ describe('Private Blogging', function () {
                     };
 
                     res.isPrivateBlog = true;
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     next.called.should.be.true();
@@ -295,7 +294,7 @@ describe('Private Blogging', function () {
                     };
 
                     res.isPrivateBlog = true;
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     next.called.should.be.true();
@@ -312,7 +311,7 @@ describe('Private Blogging', function () {
                     };
 
                     res.isPrivateBlog = true;
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     next.called.should.be.true();
@@ -329,7 +328,7 @@ describe('Private Blogging', function () {
                     };
 
                     res.isPrivateBlog = true;
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     next.called.should.be.true();
@@ -346,7 +345,7 @@ describe('Private Blogging', function () {
                     };
 
                     res.isPrivateBlog = true;
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     next.called.should.be.true();
@@ -404,7 +403,7 @@ describe('Private Blogging', function () {
                     res.isPrivateBlog = true;
                     res.locals = {};
 
-                    res.redirect = sandbox.spy();
+                    res.redirect = sinon.spy();
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     res.redirect.called.should.be.true();

--- a/core/test/unit/data/db/backup_spec.js
+++ b/core/test/unit/data/db/backup_spec.js
@@ -5,8 +5,7 @@ var should = require('should'),
     fs = require('fs-extra'),
     models = require('../../../../server/models'),
     exporter = require('../../../../server/data/exporter'),
-    backupDatabase = rewire('../../../../server/data/db/backup'),
-    sandbox = sinon.sandbox.create();
+    backupDatabase = rewire('../../../../server/data/db/backup');
 
 describe('Backup', function () {
     var exportStub, filenameStub, fsStub;
@@ -16,13 +15,13 @@ describe('Backup', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     beforeEach(function () {
-        exportStub = sandbox.stub(exporter, 'doExport').resolves();
-        filenameStub = sandbox.stub(exporter, 'fileName').resolves('test');
-        fsStub = sandbox.stub(fs, 'writeFile').resolves();
+        exportStub = sinon.stub(exporter, 'doExport').resolves();
+        filenameStub = sinon.stub(exporter, 'fileName').resolves('test');
+        fsStub = sinon.stub(fs, 'writeFile').resolves();
     });
 
     it('should create a backup JSON file', function (done) {

--- a/core/test/unit/data/exporter/index_spec.js
+++ b/core/test/unit/data/exporter/index_spec.js
@@ -7,9 +7,7 @@ var should = require('should'),
     exporter = rewire('../../../../server/data/exporter'),
     schema = require('../../../../server/data/schema'),
     models = require('../../../../server/models'),
-    schemaTables = Object.keys(schema.tables),
-
-    sandbox = sinon.sandbox.create();
+    schemaTables = Object.keys(schema.tables);
 
 describe('Exporter', function () {
     var tablesStub, queryMock, knexMock;
@@ -19,7 +17,7 @@ describe('Exporter', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('doExport', function () {
@@ -28,16 +26,16 @@ describe('Exporter', function () {
                 full: '2.0.0'
             });
 
-            tablesStub = sandbox.stub(schema.commands, 'getTables').returns(schemaTables);
+            tablesStub = sinon.stub(schema.commands, 'getTables').returns(schemaTables);
 
             queryMock = {
-                whereNot: sandbox.stub(),
-                select: sandbox.stub()
+                whereNot: sinon.stub(),
+                select: sinon.stub()
             };
 
-            knexMock = sandbox.stub().returns(queryMock);
+            knexMock = sinon.stub().returns(queryMock);
 
-            sandbox.stub(db, 'knex').get(function () {
+            sinon.stub(db, 'knex').get(function () {
                 return knexMock;
             });
         });
@@ -151,7 +149,7 @@ describe('Exporter', function () {
 
     describe('exportFileName', function () {
         it('should return a correctly structured filename', function (done) {
-            var settingsStub = sandbox.stub(models.Settings, 'findOne').returns(
+            var settingsStub = sinon.stub(models.Settings, 'findOne').returns(
                 new Promise.resolve({
                     get: function () {
                         return 'testblog';
@@ -169,7 +167,7 @@ describe('Exporter', function () {
         });
 
         it('should return a correctly structured filename if settings is empty', function (done) {
-            var settingsStub = sandbox.stub(models.Settings, 'findOne').returns(
+            var settingsStub = sinon.stub(models.Settings, 'findOne').returns(
                 new Promise.resolve()
             );
 
@@ -183,7 +181,7 @@ describe('Exporter', function () {
         });
 
         it('should return a correctly structured filename if settings errors', function (done) {
-            var settingsStub = sandbox.stub(models.Settings, 'findOne').returns(
+            var settingsStub = sinon.stub(models.Settings, 'findOne').returns(
                 new Promise.reject()
             );
 

--- a/core/test/unit/data/importer/index_spec.js
+++ b/core/test/unit/data/importer/index_spec.js
@@ -17,12 +17,11 @@ var should = require('should'),
 
     storage = require('../../../../server/adapters/storage'),
 
-    configUtils = require('../../../utils/configUtils'),
-    sandbox = sinon.sandbox.create();
+    configUtils = require('../../../utils/configUtils');
 
 describe('Importer', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 
@@ -90,8 +89,8 @@ describe('Importer', function () {
         describe('loadFile', function () {
             it('knows when to process a file', function (done) {
                 var testFile = {name: 'myFile.json', path: '/my/path/myFile.json'},
-                    zipSpy = sandbox.stub(ImportManager, 'processZip').returns(Promise.resolve()),
-                    fileSpy = sandbox.stub(ImportManager, 'processFile').returns(Promise.resolve());
+                    zipSpy = sinon.stub(ImportManager, 'processZip').returns(Promise.resolve()),
+                    fileSpy = sinon.stub(ImportManager, 'processFile').returns(Promise.resolve());
 
                 ImportManager.loadFile(testFile).then(function () {
                     zipSpy.calledOnce.should.be.false();
@@ -103,8 +102,8 @@ describe('Importer', function () {
             // We need to make sure we don't actually extract a zip and leave temporary files everywhere!
             it('knows when to process a zip', function (done) {
                 var testZip = {name: 'myFile.zip', path: '/my/path/myFile.zip'},
-                    zipSpy = sandbox.stub(ImportManager, 'processZip').returns(Promise.resolve()),
-                    fileSpy = sandbox.stub(ImportManager, 'processFile').returns(Promise.resolve());
+                    zipSpy = sinon.stub(ImportManager, 'processZip').returns(Promise.resolve()),
+                    fileSpy = sinon.stub(ImportManager, 'processFile').returns(Promise.resolve());
 
                 ImportManager.loadFile(testZip).then(function () {
                     zipSpy.calledOnce.should.be.true();
@@ -117,13 +116,13 @@ describe('Importer', function () {
                 var testFile = {name: 'myFile.json', path: '/my/path/myFile.json'},
                     testZip = {name: 'myFile.zip', path: '/my/path/myFile.zip'},
                     // need to stub out the extract and glob function for zip
-                    extractSpy = sandbox.stub(ImportManager, 'extractZip').returns(Promise.resolve('/tmp/dir/')),
-                    validSpy = sandbox.stub(ImportManager, 'isValidZip').returns(true),
-                    baseDirSpy = sandbox.stub(ImportManager, 'getBaseDirectory').returns(),
-                    getFileSpy = sandbox.stub(ImportManager, 'getFilesFromZip'),
-                    jsonSpy = sandbox.stub(JSONHandler, 'loadFile').returns(Promise.resolve({posts: []})),
-                    imageSpy = sandbox.stub(ImageHandler, 'loadFile'),
-                    mdSpy = sandbox.stub(MarkdownHandler, 'loadFile');
+                    extractSpy = sinon.stub(ImportManager, 'extractZip').returns(Promise.resolve('/tmp/dir/')),
+                    validSpy = sinon.stub(ImportManager, 'isValidZip').returns(true),
+                    baseDirSpy = sinon.stub(ImportManager, 'getBaseDirectory').returns(),
+                    getFileSpy = sinon.stub(ImportManager, 'getFilesFromZip'),
+                    jsonSpy = sinon.stub(JSONHandler, 'loadFile').returns(Promise.resolve({posts: []})),
+                    imageSpy = sinon.stub(ImageHandler, 'loadFile'),
+                    mdSpy = sinon.stub(MarkdownHandler, 'loadFile');
 
                 getFileSpy.withArgs(JSONHandler).returns(['/tmp/dir/myFile.json']);
                 getFileSpy.withArgs(ImageHandler).returns([]);
@@ -213,8 +212,8 @@ describe('Importer', function () {
                 var input = {data: {}, images: []},
                     // pass a copy so that input doesn't get modified
                     inputCopy = _.cloneDeep(input),
-                    dataSpy = sandbox.spy(DataImporter, 'preProcess'),
-                    imageSpy = sandbox.spy(ImageImporter, 'preProcess');
+                    dataSpy = sinon.spy(DataImporter, 'preProcess'),
+                    imageSpy = sinon.spy(ImageImporter, 'preProcess');
 
                 ImportManager.preProcess(inputCopy).then(function (output) {
                     dataSpy.calledOnce.should.be.true();
@@ -239,10 +238,10 @@ describe('Importer', function () {
                 var input = {data: {posts: []}, images: []},
                     // pass a copy so that input doesn't get modified
                     inputCopy = _.cloneDeep(input),
-                    dataSpy = sandbox.stub(DataImporter, 'doImport').callsFake(function (i) {
+                    dataSpy = sinon.stub(DataImporter, 'doImport').callsFake(function (i) {
                         return Promise.resolve(i);
                     }),
-                    imageSpy = sandbox.stub(ImageImporter, 'doImport').callsFake(function (i) {
+                    imageSpy = sinon.stub(ImageImporter, 'doImport').callsFake(function (i) {
                         return Promise.resolve(i);
                     }),
 
@@ -280,11 +279,11 @@ describe('Importer', function () {
 
         describe('importFromFile', function () {
             it('does the import steps in order', function (done) {
-                var loadFileSpy = sandbox.stub(ImportManager, 'loadFile').returns(Promise.resolve()),
-                    preProcessSpy = sandbox.stub(ImportManager, 'preProcess').returns(Promise.resolve()),
-                    doImportSpy = sandbox.stub(ImportManager, 'doImport').returns(Promise.resolve()),
-                    generateReportSpy = sandbox.stub(ImportManager, 'generateReport').returns(Promise.resolve()),
-                    cleanupSpy = sandbox.stub(ImportManager, 'cleanUp').returns({});
+                var loadFileSpy = sinon.stub(ImportManager, 'loadFile').returns(Promise.resolve()),
+                    preProcessSpy = sinon.stub(ImportManager, 'preProcess').returns(Promise.resolve()),
+                    doImportSpy = sinon.stub(ImportManager, 'doImport').returns(Promise.resolve()),
+                    generateReportSpy = sinon.stub(ImportManager, 'generateReport').returns(Promise.resolve()),
+                    cleanupSpy = sinon.stub(ImportManager, 'cleanUp').returns({});
 
                 ImportManager.importFromFile({}).then(function () {
                     loadFileSpy.calledOnce.should.be.true();
@@ -364,8 +363,8 @@ describe('Importer', function () {
                     path: '/my/test/' + filename,
                     name: filename
                 }],
-                storeSpy = sandbox.spy(store, 'getUniqueFileName'),
-                storageSpy = sandbox.spy(storage, 'getStorage');
+                storeSpy = sinon.spy(store, 'getUniqueFileName'),
+                storageSpy = sinon.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(file)).then(function () {
                 storageSpy.calledOnce.should.be.true();
@@ -384,8 +383,8 @@ describe('Importer', function () {
                     path: '/my/test/' + filename,
                     name: filename
                 }],
-                storeSpy = sandbox.spy(store, 'getUniqueFileName'),
-                storageSpy = sandbox.spy(storage, 'getStorage');
+                storeSpy = sinon.spy(store, 'getUniqueFileName'),
+                storageSpy = sinon.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(file)).then(function () {
                 storageSpy.calledOnce.should.be.true();
@@ -404,8 +403,8 @@ describe('Importer', function () {
                     path: '/my/test/content/images/' + filename,
                     name: filename
                 }],
-                storeSpy = sandbox.spy(store, 'getUniqueFileName'),
-                storageSpy = sandbox.spy(storage, 'getStorage');
+                storeSpy = sinon.spy(store, 'getUniqueFileName'),
+                storageSpy = sinon.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(file)).then(function () {
                 storageSpy.calledOnce.should.be.true();
@@ -426,8 +425,8 @@ describe('Importer', function () {
                     path: '/my/test/' + filename,
                     name: filename
                 }],
-                storeSpy = sandbox.spy(store, 'getUniqueFileName'),
-                storageSpy = sandbox.spy(storage, 'getStorage');
+                storeSpy = sinon.spy(store, 'getUniqueFileName'),
+                storageSpy = sinon.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(file)).then(function () {
                 storageSpy.calledOnce.should.be.true();
@@ -457,8 +456,8 @@ describe('Importer', function () {
                         path: '/my/test/images/puppy.jpg',
                         name: 'images/puppy.jpg'
                     }],
-                storeSpy = sandbox.spy(store, 'getUniqueFileName'),
-                storageSpy = sandbox.spy(storage, 'getStorage');
+                storeSpy = sinon.spy(store, 'getUniqueFileName'),
+                storageSpy = sinon.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(files)).then(function () {
                 storageSpy.calledOnce.should.be.true();
@@ -684,9 +683,9 @@ describe('Importer', function () {
         it('does import the images correctly', function () {
             var inputData = require('../../../utils/fixtures/import/import-data-1.json'),
                 storageApi = {
-                    save: sandbox.stub().returns(Promise.resolve())
+                    save: sinon.stub().returns(Promise.resolve())
                 },
-                storageSpy = sandbox.stub(storage, 'getStorage').callsFake(function () {
+                storageSpy = sinon.stub(storage, 'getStorage').callsFake(function () {
                     return storageApi;
                 });
 

--- a/core/test/unit/data/meta/amp_url_spec.js
+++ b/core/test/unit/data/meta/amp_url_spec.js
@@ -1,7 +1,6 @@
 const should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
-    sandbox = sinon.sandbox.create(),
     urlService = require('../../../../server/services/url'),
     testUtils = require('../../../utils');
 
@@ -11,17 +10,17 @@ describe('getAmpUrl', function () {
     let getUrlStub;
 
     beforeEach(function () {
-        getUrlStub = sandbox.stub();
+        getUrlStub = sinon.stub();
 
         getAmpUrl = rewire('../../../../server/data/meta/amp_url');
         getAmpUrl.__set__('getUrl', getUrlStub);
 
-        sandbox.stub(urlService.utils, 'urlJoin');
-        sandbox.stub(urlService.utils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
+        sinon.stub(urlService.utils, 'urlJoin');
+        sinon.stub(urlService.utils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
     });
 
     afterEach(function () {
-       sandbox.restore();
+       sinon.restore();
     });
 
     it('should return amp url for post', function () {

--- a/core/test/unit/data/meta/asset_url_spec.js
+++ b/core/test/unit/data/meta/asset_url_spec.js
@@ -3,14 +3,12 @@ var should = require('should'),
     getAssetUrl = require('../../../../server/data/meta/asset_url'),
     settingsCache = require('../../../../server/services/settings/cache'),
     configUtils = require('../../../utils/configUtils'),
-    config = configUtils.config,
-
-    sandbox = sinon.sandbox.create();
+    config = configUtils.config;
 
 describe('getAssetUrl', function () {
     afterEach(function () {
         configUtils.restore();
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return asset url with just context', function () {
@@ -45,7 +43,7 @@ describe('getAssetUrl', function () {
         });
 
         it('should correct favicon path for custom png', function () {
-            sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
+            sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
             var testUrl = getAssetUrl('favicon.ico');
             testUrl.should.equal('/favicon.png');
         });
@@ -114,7 +112,7 @@ describe('getAssetUrl', function () {
             });
 
             it('should return correct favicon path for custom png', function () {
-                sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
+                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
                 var testUrl = getAssetUrl('favicon.ico');
                 testUrl.should.equal('/blog/favicon.png');
             });

--- a/core/test/unit/data/meta/author_image_spec.js
+++ b/core/test/unit/data/meta/author_image_spec.js
@@ -1,11 +1,10 @@
 var should = require('should'),
     sinon = require('sinon'),
-    getAuthorImage = require('../../../../server/data/meta/author_image'),
-    sandbox = sinon.sandbox.create();
+    getAuthorImage = require('../../../../server/data/meta/author_image');
 
 describe('getAuthorImage', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return author image url if post and has url', function () {

--- a/core/test/unit/data/meta/author_url_spec.js
+++ b/core/test/unit/data/meta/author_url_spec.js
@@ -1,17 +1,16 @@
 const should = require('should'),
     sinon = require('sinon'),
     ObjectId = require('bson-objectid'),
-    sandbox = sinon.sandbox.create(),
     urlService = require('../../../../server/services/url'),
     getAuthorUrl = require('../../../../server/data/meta/author_url');
 
 describe('getAuthorUrl', function () {
     beforeEach(function () {
-        sandbox.stub(urlService, 'getUrlByResourceId');
+        sinon.stub(urlService, 'getUrlByResourceId');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return author url if context contains primary author', function () {

--- a/core/test/unit/data/meta/blog_logo_spec.js
+++ b/core/test/unit/data/meta/blog_logo_spec.js
@@ -1,19 +1,17 @@
 var should        = require('should'),
     getBlogLogo   = require('../../../../server/data/meta/blog_logo'),
     sinon         = require('sinon'),
-    settingsCache = require('../../../../server/services/settings/cache'),
-
-    sandbox       = sinon.sandbox.create();
+    settingsCache = require('../../../../server/services/settings/cache');
 
 describe('getBlogLogo', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return logo if uploaded', function () {
         var blogLogo;
 
-        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
+        sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return {
                 logo: '/content/images/logo.png',
                 icon: null
@@ -28,7 +26,7 @@ describe('getBlogLogo', function () {
     it('should return custom uploaded png icon if no logo given', function () {
         var blogLogo;
 
-        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
+        sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return {
                 logo: null,
                 icon: '/content/images/favicon.png'

--- a/core/test/unit/data/meta/canonical_url_spec.js
+++ b/core/test/unit/data/meta/canonical_url_spec.js
@@ -1,7 +1,6 @@
 const should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
-    sandbox = sinon.sandbox.create(),
     urlService = require('../../../../server/services/url'),
     testUtils = require('../../../utils');
 
@@ -11,17 +10,17 @@ describe('getCanonicalUrl', function () {
     let getUrlStub;
 
     beforeEach(function () {
-        getUrlStub = sandbox.stub();
+        getUrlStub = sinon.stub();
 
         getCanonicalUrl = rewire('../../../../server/data/meta/canonical_url');
         getCanonicalUrl.__set__('getUrl', getUrlStub);
 
-        sandbox.stub(urlService.utils, 'urlJoin');
-        sandbox.stub(urlService.utils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
+        sinon.stub(urlService.utils, 'urlJoin');
+        sinon.stub(urlService.utils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return canonical url', function () {

--- a/core/test/unit/data/meta/context_object_spec.js
+++ b/core/test/unit/data/meta/context_object_spec.js
@@ -1,8 +1,7 @@
 var should = require('should'),
     sinon = require('sinon'),
     getContextObject = require('../../../../server/data/meta/context_object.js'),
-    settingsCache = require('../../../../server/services/settings/cache'),
-    sandbox = sinon.sandbox.create();
+    settingsCache = require('../../../../server/services/settings/cache');
 
 describe('getContextObject', function () {
     var data, context, contextObject;
@@ -49,7 +48,7 @@ describe('getContextObject', function () {
 
     describe('override blog', function () {
         before(function () {
-            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return {
                     cover_image: 'test.png'
                 }[key];
@@ -57,7 +56,7 @@ describe('getContextObject', function () {
         });
 
         after(function () {
-            sandbox.restore();
+            sinon.restore();
         });
 
         it('should return blog context object for unknown context', function () {

--- a/core/test/unit/data/meta/image-dimensions_spec.js
+++ b/core/test/unit/data/meta/image-dimensions_spec.js
@@ -1,18 +1,17 @@
 var should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
-    getImageDimensions = rewire('../../../../server/data/meta/image-dimensions'),
-    sandbox = sinon.sandbox.create();
+    getImageDimensions = rewire('../../../../server/data/meta/image-dimensions');
 
 describe('getImageDimensions', function () {
     var sizeOfStub;
 
     beforeEach(function () {
-        sizeOfStub = sandbox.stub();
+        sizeOfStub = sinon.stub();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return dimension for images', function (done) {

--- a/core/test/unit/data/meta/keywords_spec.js
+++ b/core/test/unit/data/meta/keywords_spec.js
@@ -1,8 +1,7 @@
 var should = require('should'),
     sinon = require('sinon'),
     models = require('../../../../server/models'),
-    getKeywords = require('../../../../server/data/meta/keywords'),
-    sandbox = sinon.sandbox.create();
+    getKeywords = require('../../../../server/data/meta/keywords');
 
 describe('getKeywords', function () {
     before(function () {
@@ -10,7 +9,7 @@ describe('getKeywords', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return tags as keywords if post has tags', function () {

--- a/core/test/unit/data/meta/rss_url_spec.js
+++ b/core/test/unit/data/meta/rss_url_spec.js
@@ -1,16 +1,15 @@
 const should = require('should'),
     sinon = require('sinon'),
-    sandbox = sinon.sandbox.create(),
     routing = require('../../../../server/services/routing'),
     getRssUrl = require('../../../../server/data/meta/rss_url');
 
 describe('getRssUrl', function () {
     beforeEach(function () {
-        sandbox.stub(routing.registry, 'getRssUrl').returns('/rss/');
+        sinon.stub(routing.registry, 'getRssUrl').returns('/rss/');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return rss url', function () {

--- a/core/test/unit/data/meta/title_spec.js
+++ b/core/test/unit/data/meta/title_spec.js
@@ -1,20 +1,19 @@
 var should = require('should'),
     sinon = require('sinon'),
     getTitle = require('../../../../server/data/meta/title'),
-    settingsCache = require('../../../../server/services/settings/cache'),
-    sandbox = sinon.sandbox.create();
+    settingsCache = require('../../../../server/services/settings/cache');
 
 describe('getTitle', function () {
     var localSettingsCache = {};
 
     beforeEach(function () {
-        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
+        sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         localSettingsCache = {};
     });
 

--- a/core/test/unit/data/meta/url_spec.js
+++ b/core/test/unit/data/meta/url_spec.js
@@ -1,18 +1,17 @@
 const should = require('should'),
     sinon = require('sinon'),
-    sandbox = sinon.sandbox.create(),
     urlService = require('../../../../server/services/url'),
     getUrl = require('../../../../server/data/meta/url'),
     testUtils = require('../../../utils/');
 
 describe('getUrl', function () {
     beforeEach(function () {
-        sandbox.stub(urlService, 'getUrlByResourceId');
-        sandbox.stub(urlService.utils, 'urlFor');
+        sinon.stub(urlService, 'getUrlByResourceId');
+        sinon.stub(urlService.utils, 'urlFor');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return url for a post', function () {

--- a/core/test/unit/data/schema/fixtures/utils_spec.js
+++ b/core/test/unit/data/schema/fixtures/utils_spec.js
@@ -6,24 +6,22 @@ var should = require('should'),
     models = require('../../../../../server/models'),
     baseUtils = require('../../../../../server/models/base/utils'),
     fixtureUtils = rewire('../../../../../server/data/schema/fixtures/utils'),
-    fixtures = require('../../../../../server/data/schema/fixtures/fixtures'),
-
-    sandbox = sinon.sandbox.create();
+    fixtures = require('../../../../../server/data/schema/fixtures/fixtures');
 
 describe('Migration Fixture Utils', function () {
     var loggerStub;
 
     beforeEach(function () {
         loggerStub = {
-            info: sandbox.stub(),
-            warn: sandbox.stub()
+            info: sinon.stub(),
+            warn: sinon.stub()
         };
 
         models.init();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Match Func', function () {
@@ -31,7 +29,7 @@ describe('Migration Fixture Utils', function () {
             getStub;
 
         beforeEach(function () {
-            getStub = sandbox.stub();
+            getStub = sinon.stub();
             getStub.withArgs('foo').returns('bar');
             getStub.withArgs('fun').returns('baz');
         });
@@ -100,8 +98,8 @@ describe('Migration Fixture Utils', function () {
 
     describe('Add Fixtures For Model', function () {
         it('should call add for main post fixture', function (done) {
-            var postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve()),
-                postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve({}));
+            var postOneStub = sinon.stub(models.Post, 'findOne').returns(Promise.resolve()),
+                postAddStub = sinon.stub(models.Post, 'add').returns(Promise.resolve({}));
 
             fixtureUtils.addFixturesForModel(fixtures.models[5]).then(function (result) {
                 should.exist(result);
@@ -117,8 +115,8 @@ describe('Migration Fixture Utils', function () {
         });
 
         it('should not call add for main post fixture if it is already found', function (done) {
-            var postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve({})),
-                postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve({}));
+            var postOneStub = sinon.stub(models.Post, 'findOne').returns(Promise.resolve({})),
+                postAddStub = sinon.stub(models.Post, 'add').returns(Promise.resolve({}));
 
             fixtureUtils.addFixturesForModel(fixtures.models[5]).then(function (result) {
                 should.exist(result);
@@ -137,17 +135,17 @@ describe('Migration Fixture Utils', function () {
     describe('Add Fixtures For Relation', function () {
         it('should call attach for permissions-roles', function (done) {
             var fromItem = {
-                    related: sandbox.stub().returnsThis(),
-                    findWhere: sandbox.stub().returns()
+                    related: sinon.stub().returnsThis(),
+                    findWhere: sinon.stub().returns()
                 },
-                toItem = [{get: sandbox.stub()}],
+                toItem = [{get: sinon.stub()}],
                 dataMethodStub = {
-                    filter: sandbox.stub().returns(toItem),
-                    find: sandbox.stub().returns(fromItem)
+                    filter: sinon.stub().returns(toItem),
+                    find: sinon.stub().returns(fromItem)
                 },
-                baseUtilAttachStub = sandbox.stub(baseUtils, 'attach').returns(Promise.resolve([{}])),
-                permsAllStub = sandbox.stub(models.Permission, 'findAll').returns(Promise.resolve(dataMethodStub)),
-                rolesAllStub = sandbox.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
+                baseUtilAttachStub = sinon.stub(baseUtils, 'attach').returns(Promise.resolve([{}])),
+                permsAllStub = sinon.stub(models.Permission, 'findAll').returns(Promise.resolve(dataMethodStub)),
+                rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureUtils.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
@@ -172,17 +170,17 @@ describe('Migration Fixture Utils', function () {
 
         it('should call attach for posts-tags', function (done) {
             var fromItem = {
-                    related: sandbox.stub().returnsThis(),
-                    findWhere: sandbox.stub().returns()
+                    related: sinon.stub().returnsThis(),
+                    findWhere: sinon.stub().returns()
                 },
-                toItem = [{get: sandbox.stub()}],
+                toItem = [{get: sinon.stub()}],
                 dataMethodStub = {
-                    filter: sandbox.stub().returns(toItem),
-                    find: sandbox.stub().returns(fromItem)
+                    filter: sinon.stub().returns(toItem),
+                    find: sinon.stub().returns(fromItem)
                 },
-                baseUtilAttachStub = sandbox.stub(baseUtils, 'attach').returns(Promise.resolve([{}])),
-                postsAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(dataMethodStub)),
-                tagsAllStub = sandbox.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
+                baseUtilAttachStub = sinon.stub(baseUtils, 'attach').returns(Promise.resolve([{}])),
+                postsAllStub = sinon.stub(models.Post, 'findAll').returns(Promise.resolve(dataMethodStub)),
+                tagsAllStub = sinon.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureUtils.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
                 should.exist(result);
@@ -206,19 +204,19 @@ describe('Migration Fixture Utils', function () {
 
         it('will not call attach for posts-tags if already present', function (done) {
             var fromItem = {
-                    related: sandbox.stub().returnsThis(),
-                    findWhere: sandbox.stub().returns({}),
-                    tags: sandbox.stub().returnsThis(),
-                    attach: sandbox.stub().returns(Promise.resolve({}))
+                    related: sinon.stub().returnsThis(),
+                    findWhere: sinon.stub().returns({}),
+                    tags: sinon.stub().returnsThis(),
+                    attach: sinon.stub().returns(Promise.resolve({}))
                 },
-                toItem = [{get: sandbox.stub()}],
+                toItem = [{get: sinon.stub()}],
                 dataMethodStub = {
-                    filter: sandbox.stub().returns(toItem),
-                    find: sandbox.stub().returns(fromItem)
+                    filter: sinon.stub().returns(toItem),
+                    find: sinon.stub().returns(fromItem)
                 },
 
-                postsAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(dataMethodStub)),
-                tagsAllStub = sandbox.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
+                postsAllStub = sinon.stub(models.Post, 'findAll').returns(Promise.resolve(dataMethodStub)),
+                tagsAllStub = sinon.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureUtils.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
                 should.exist(result);

--- a/core/test/unit/data/xml/sitemap/generator_spec.js
+++ b/core/test/unit/data/xml/sitemap/generator_spec.js
@@ -8,8 +8,7 @@ const should = require('should'),
     PostGenerator = require('../../../../../server/data/xml/sitemap/post-generator'),
     PageGenerator = require('../../../../../server/data/xml/sitemap/page-generator'),
     TagGenerator = require('../../../../../server/data/xml/sitemap/tag-generator'),
-    UserGenerator = require('../../../../../server/data/xml/sitemap/user-generator'),
-    sandbox = sinon.sandbox.create();
+    UserGenerator = require('../../../../../server/data/xml/sitemap/user-generator');
 
 should.Assertion.add('ValidUrlNode', function (options) {
     // Check urlNode looks correct
@@ -50,7 +49,7 @@ describe('Generators', function () {
     let generator;
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('IndexGenerator', function () {
@@ -96,11 +95,11 @@ describe('Generators', function () {
 
         describe('fn: getXml', function () {
             beforeEach(function () {
-                sandbox.stub(urlService.utils, 'urlFor');
+                sinon.stub(urlService.utils, 'urlFor');
             });
 
             it('get cached xml', function () {
-                sandbox.spy(generator, 'generateXmlFromNodes');
+                sinon.spy(generator, 'generateXmlFromNodes');
                 generator.siteMapContent = 'something';
                 generator.getXml().should.eql('something');
                 generator.siteMapContent = null;

--- a/core/test/unit/data/xml/sitemap/manager_spec.js
+++ b/core/test/unit/data/xml/sitemap/manager_spec.js
@@ -8,9 +8,7 @@ const should = require('should'),
     PageGenerator = require('../../../../../server/data/xml/sitemap/page-generator'),
     TagGenerator = require('../../../../../server/data/xml/sitemap/tag-generator'),
     UserGenerator = require('../../../../../server/data/xml/sitemap/user-generator'),
-    IndexGenerator = require('../../../../../server/data/xml/sitemap/index-generator'),
-
-    sandbox = sinon.sandbox.create();
+    IndexGenerator = require('../../../../../server/data/xml/sitemap/index-generator');
 
 describe('Unit: sitemap/manager', function () {
     let eventsToRemember;
@@ -30,18 +28,18 @@ describe('Unit: sitemap/manager', function () {
     beforeEach(function () {
         eventsToRemember = {};
 
-        sandbox.stub(common.events, 'on').callsFake(function (eventName, callback) {
+        sinon.stub(common.events, 'on').callsFake(function (eventName, callback) {
             eventsToRemember[eventName] = callback;
         });
 
-        sandbox.stub(PostGenerator.prototype, 'getXml');
-        sandbox.stub(PostGenerator.prototype, 'addUrl');
-        sandbox.stub(PostGenerator.prototype, 'removeUrl');
-        sandbox.stub(IndexGenerator.prototype, 'getXml');
+        sinon.stub(PostGenerator.prototype, 'getXml');
+        sinon.stub(PostGenerator.prototype, 'addUrl');
+        sinon.stub(PostGenerator.prototype, 'removeUrl');
+        sinon.stub(IndexGenerator.prototype, 'getXml');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('SiteMapManager', function () {
@@ -49,7 +47,7 @@ describe('Unit: sitemap/manager', function () {
 
         beforeEach(function () {
             manager = makeStubManager();
-            fake = sandbox.stub();
+            fake = sinon.stub();
         });
 
         it('create SiteMapManager with defaults', function () {

--- a/core/test/unit/filters_spec.js
+++ b/core/test/unit/filters_spec.js
@@ -4,9 +4,7 @@ var should = require('should'),
     _ = require('lodash'),
 
     // Stuff we are testing
-    Filters = require('../../server/filters').Filters,
-
-    sandbox = sinon.sandbox.create();
+    Filters = require('../../server/filters').Filters
 
 describe('Filters', function () {
     var filters;
@@ -17,13 +15,13 @@ describe('Filters', function () {
 
     afterEach(function () {
         filters = null;
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('can register filters with specific priority', function () {
         var filterName = 'test',
             filterPriority = 9,
-            testFilterHandler = sandbox.spy();
+            testFilterHandler = sinon.spy();
 
         filters.registerFilter(filterName, filterPriority, testFilterHandler);
 
@@ -36,7 +34,7 @@ describe('Filters', function () {
     it('can register filters with default priority', function () {
         var filterName = 'test',
             defaultPriority = 5,
-            testFilterHandler = sandbox.spy();
+            testFilterHandler = sinon.spy();
 
         filters.registerFilter(filterName, testFilterHandler);
 
@@ -49,7 +47,7 @@ describe('Filters', function () {
     it('can register filters with priority null with default priority', function () {
         var filterName = 'test',
             defaultPriority = 5,
-            testFilterHandler = sandbox.spy();
+            testFilterHandler = sinon.spy();
 
         filters.registerFilter(filterName, null, testFilterHandler);
 
@@ -61,9 +59,9 @@ describe('Filters', function () {
 
     it('executes filters in priority order', function (done) {
         var filterName = 'testpriority',
-            testFilterHandler1 = sandbox.spy(),
-            testFilterHandler2 = sandbox.spy(),
-            testFilterHandler3 = sandbox.spy();
+            testFilterHandler1 = sinon.spy(),
+            testFilterHandler2 = sinon.spy(),
+            testFilterHandler3 = sinon.spy();
 
         filters.registerFilter(filterName, 0, testFilterHandler1);
         filters.registerFilter(filterName, 2, testFilterHandler2);

--- a/core/test/unit/filters_spec.js
+++ b/core/test/unit/filters_spec.js
@@ -4,7 +4,7 @@ var should = require('should'),
     _ = require('lodash'),
 
     // Stuff we are testing
-    Filters = require('../../server/filters').Filters
+    Filters = require('../../server/filters').Filters;
 
 describe('Filters', function () {
     var filters;

--- a/core/test/unit/helpers/asset_spec.js
+++ b/core/test/unit/helpers/asset_spec.js
@@ -2,9 +2,7 @@ var should = require('should'),
     sinon = require('sinon'),
     configUtils = require('../../utils/configUtils'),
     helpers = require('../../../server/helpers'),
-    settingsCache = require('../../../server/services/settings/cache'),
-
-    sandbox = sinon.sandbox.create();
+    settingsCache = require('../../../server/services/settings/cache');
 
 describe('{{asset}} helper', function () {
     var rendered, localSettingsCache = {};
@@ -13,14 +11,14 @@ describe('{{asset}} helper', function () {
         configUtils.set({assetHash: 'abc'});
         configUtils.set({useMinFiles: true});
 
-        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
+        sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
     });
 
     after(function () {
         configUtils.restore();
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('no subdirectory', function () {

--- a/core/test/unit/helpers/author_spec.js
+++ b/core/test/unit/helpers/author_spec.js
@@ -1,17 +1,16 @@
 const should = require('should'),
     sinon = require('sinon'),
-    sandbox = sinon.sandbox.create(),
     testUtils = require('../../utils'),
     urlService = require('../../../server/services/url'),
     helpers = require('../../../server/helpers');
 
 describe('{{author}} helper', function () {
     beforeEach(function () {
-        sandbox.stub(urlService, 'getUrlByResourceId');
+        sinon.stub(urlService, 'getUrlByResourceId');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('Returns the link to the author from the context', function () {

--- a/core/test/unit/helpers/authors_spec.js
+++ b/core/test/unit/helpers/authors_spec.js
@@ -3,8 +3,7 @@ const should = require('should'),
     urlService = require('../../../server/services/url'),
     helpers = require('../../../server/helpers'),
     models = require('../../../server/models'),
-    testUtils = require('../../utils'),
-    sandbox = sinon.sandbox.create();
+    testUtils = require('../../utils');
 
 describe('{{authors}} helper', function () {
     before(function () {
@@ -12,11 +11,11 @@ describe('{{authors}} helper', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(urlService, 'getUrlByResourceId');
+        sinon.stub(urlService, 'getUrlByResourceId');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('can return string with authors', function () {

--- a/core/test/unit/helpers/foreach_spec.js
+++ b/core/test/unit/helpers/foreach_spec.js
@@ -2,15 +2,13 @@ var should = require('should'),
     sinon = require('sinon'),
     _ = require('lodash'),
     helpers = require.main.require('core/server/helpers'),
-    handlebars = require.main.require('core/server/services/themes/engine').handlebars,
-
-    sandbox = sinon.sandbox.create();
+    handlebars = require.main.require('core/server/services/themes/engine').handlebars;
 
 describe('{{#foreach}} helper', function () {
     var options, context, _this, resultData;
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('(function call)', function () {
@@ -24,8 +22,8 @@ describe('{{#foreach}} helper', function () {
             }
 
             options = {
-                fn: sandbox.spy(fn),
-                inverse: sandbox.spy(),
+                fn: sinon.spy(fn),
+                inverse: sinon.spy(),
                 data: {}
             };
         });

--- a/core/test/unit/helpers/get_spec.js
+++ b/core/test/unit/helpers/get_spec.js
@@ -7,9 +7,7 @@ var should = require('should'),
     models = require('../../../server/models'),
     api = require('../../../server/api'),
 
-    labs = require('../../../server/services/labs'),
-
-    sandbox = sinon.sandbox.create();
+    labs = require('../../../server/services/labs');
 
 describe('{{#get}} helper', function () {
     var fn, inverse, labsStub;
@@ -20,15 +18,15 @@ describe('{{#get}} helper', function () {
     });
 
     beforeEach(function () {
-        fn = sandbox.spy();
-        inverse = sandbox.spy();
-        labsStub = sandbox.stub(labs, 'isSet').returns(true);
+        fn = sinon.spy();
+        inverse = sinon.spy();
+        labsStub = sinon.stub(labs, 'isSet').returns(true);
 
         locals = {root: {_locals: {apiVersion: 'v0.1'}}};
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('errors correctly if labs flag not set', function (done) {
@@ -66,10 +64,10 @@ describe('{{#get}} helper', function () {
             meta = {pagination: {}};
 
         beforeEach(function () {
-            browsePostsStub = sandbox.stub(api["v0.1"].posts, 'browse');
-            readPostsStub = sandbox.stub(api["v0.1"].posts, 'read');
-            readTagsStub = sandbox.stub(api["v0.1"].tags, 'read').returns(new Promise.resolve({tags: []}));
-            readUsersStub = sandbox.stub(api["v0.1"].users, 'read').returns(new Promise.resolve({users: []}));
+            browsePostsStub = sinon.stub(api["v0.1"].posts, 'browse');
+            readPostsStub = sinon.stub(api["v0.1"].posts, 'read');
+            readTagsStub = sinon.stub(api["v0.1"].tags, 'read').returns(new Promise.resolve({tags: []}));
+            readUsersStub = sinon.stub(api["v0.1"].users, 'read').returns(new Promise.resolve({users: []}));
 
             browsePostsStub.returns(new Promise.resolve({posts: testPostsArr, meta: meta}));
             browsePostsStub.withArgs({limit: '3'}).returns(new Promise.resolve({
@@ -261,7 +259,7 @@ describe('{{#get}} helper', function () {
         const meta = {pagination: {}};
 
         beforeEach(function () {
-            browseUsersStub = sandbox.stub(api["v0.1"].users, 'browse');
+            browseUsersStub = sinon.stub(api["v0.1"].users, 'browse');
             browseUsersStub.returns(new Promise.resolve({users: [], meta: meta}));
         });
 
@@ -288,7 +286,7 @@ describe('{{#get}} helper', function () {
         const meta = {pagination: {}};
 
         beforeEach(function () {
-            browseUsersStub = sandbox.stub(api["v0.1"].users, 'browse');
+            browseUsersStub = sinon.stub(api["v0.1"].users, 'browse');
             browseUsersStub.returns(new Promise.resolve({users: [], meta: meta}));
         });
 
@@ -313,9 +311,9 @@ describe('{{#get}} helper', function () {
         beforeEach(function () {
             locals = {root: {_locals: {apiVersion: 'v2'}}};
 
-            browseUsersStub = sandbox.stub(api["v2"], 'authors').get(() => {
+            browseUsersStub = sinon.stub(api["v2"], 'authors').get(() => {
                 return {
-                    browse: sandbox.stub().resolves({authors: [], meta: meta})
+                    browse: sinon.stub().resolves({authors: [], meta: meta})
                 };
             });
         });
@@ -346,9 +344,9 @@ describe('{{#get}} helper', function () {
         beforeEach(function () {
             locals = {root: {_locals: {apiVersion: 'v2'}}};
 
-            browseUsersStub = sandbox.stub(api["v2"], 'authors').get(() => {
+            browseUsersStub = sinon.stub(api["v2"], 'authors').get(() => {
                 return {
-                    browse: sandbox.stub().resolves({authors: [], meta: meta})
+                    browse: sinon.stub().resolves({authors: [], meta: meta})
                 };
             });
         });
@@ -427,8 +425,8 @@ describe('{{#get}} helper', function () {
             };
 
         beforeEach(function () {
-            browseStub = sandbox.stub(api["v0.1"].posts, 'browse').returns(new Promise.resolve());
-            readStub = sandbox.stub(api["v0.1"].posts, 'read').returns(new Promise.resolve());
+            browseStub = sinon.stub(api["v0.1"].posts, 'browse').returns(new Promise.resolve());
+            readStub = sinon.stub(api["v0.1"].posts, 'read').returns(new Promise.resolve());
         });
 
         it('should resolve post.tags alias', function (done) {

--- a/core/test/unit/helpers/ghost_foot_spec.js
+++ b/core/test/unit/helpers/ghost_foot_spec.js
@@ -1,22 +1,18 @@
 var should = require('should'),
     sinon = require('sinon'),
-
-// Stuff we are testing
     helpers = require('../../../server/helpers'),
     proxy = require('../../../server/helpers/proxy'),
-    settingsCache = proxy.settingsCache,
-
-    sandbox = sinon.sandbox.create();
+    settingsCache = proxy.settingsCache;
 
 describe('{{ghost_foot}} helper', function () {
     var settingsCacheStub;
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     beforeEach(function () {
-        settingsCacheStub = sandbox.stub(settingsCache, 'get');
+        settingsCacheStub = sinon.stub(settingsCache, 'get');
     });
 
     it('outputs global injected code', function (done) {

--- a/core/test/unit/helpers/ghost_head_spec.js
+++ b/core/test/unit/helpers/ghost_head_spec.js
@@ -11,8 +11,7 @@ const should = require('should'),
     urlService = require('../../../server/services/url'),
     helpers = require('../../../server/helpers'),
     proxy = require('../../../server/helpers/proxy'),
-    settingsCache = proxy.settingsCache,
-    sandbox = sinon.sandbox.create();
+    settingsCache = proxy.settingsCache;
 
 describe('{{ghost_head}} helper', function () {
     let posts = [], tags = [], authors = [], users = [];
@@ -273,16 +272,16 @@ describe('{{ghost_head}} helper', function () {
     before(function () {
         // @TODO: remove when visibility is refactored out of models
         models.init();
-        sandbox.stub(urlService, 'getUrlByResourceId').returns('https://mysite.com/fakeauthor/');
+        sinon.stub(urlService, 'getUrlByResourceId').returns('https://mysite.com/fakeauthor/');
 
         // @TODO: this is a LOT of mocking :/
-        sandbox.stub(routing.registry, 'getRssUrl').returns('http://localhost:65530/rss/');
-        sandbox.stub(imageLib.imageSize, 'getImageSizeFromUrl').resolves();
-        sandbox.stub(themes, 'getActive').returns({
+        sinon.stub(routing.registry, 'getRssUrl').returns('http://localhost:65530/rss/');
+        sinon.stub(imageLib.imageSize, 'getImageSizeFromUrl').resolves();
+        sinon.stub(themes, 'getActive').returns({
             engine: () => 'v0.1'
         });
 
-        sandbox.stub(settingsCache, 'get');
+        sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('title').returns('Ghost');
         settingsCache.get.withArgs('description').returns('blog description');
         settingsCache.get.withArgs('cover_image').returns('/content/images/blog-cover.png');
@@ -292,7 +291,7 @@ describe('{{ghost_head}} helper', function () {
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 

--- a/core/test/unit/helpers/has_spec.js
+++ b/core/test/unit/helpers/has_spec.js
@@ -2,20 +2,18 @@ var should = require('should'),
     sinon = require('sinon'),
 
 // Stuff we are testing
-    helpers = require('../../../server/helpers'),
-
-    sandbox = sinon.sandbox.create();
+    helpers = require('../../../server/helpers');
 
 describe('{{#has}} helper', function () {
     var fn, inverse, thisCtx, handlebarsOptions;
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     beforeEach(function () {
-        fn = sandbox.spy();
-        inverse = sandbox.spy();
+        fn = sinon.spy();
+        inverse = sinon.spy();
 
         thisCtx = {};
 

--- a/core/test/unit/helpers/img_url_spec.js
+++ b/core/test/unit/helpers/img_url_spec.js
@@ -4,9 +4,7 @@ var should = require('should'),
 
     // Stuff we are testing
     helpers = require('../../../server/helpers'),
-    common = require('../../../server/lib/common'),
-
-    sandbox = sinon.sandbox.create();
+    common = require('../../../server/lib/common');
 
 describe('{{image}} helper', function () {
     var logWarnStub;
@@ -16,11 +14,11 @@ describe('{{image}} helper', function () {
     });
 
     beforeEach(function () {
-        logWarnStub = sandbox.stub(common.logging, 'warn');
+        logWarnStub = sinon.stub(common.logging, 'warn');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     after(function () {

--- a/core/test/unit/helpers/is_spec.js
+++ b/core/test/unit/helpers/is_spec.js
@@ -1,19 +1,17 @@
 var should = require('should'),
     sinon = require('sinon'),
     helpers = require('../../../server/helpers'),
-    common = require('../../../server/lib/common'),
-
-    sandbox = sinon.sandbox.create();
+    common = require('../../../server/lib/common');
 
 describe('{{#is}} helper', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     // All positive tests
     it('should match single context "index"', function () {
-        var fn = sandbox.spy(),
-            inverse = sandbox.spy();
+        var fn = sinon.spy(),
+            inverse = sinon.spy();
 
         helpers.is.call(
             {},
@@ -26,8 +24,8 @@ describe('{{#is}} helper', function () {
     });
 
     it('should match OR context "index, paged"', function () {
-        var fn = sandbox.spy(),
-            inverse = sandbox.spy();
+        var fn = sinon.spy(),
+            inverse = sinon.spy();
 
         helpers.is.call(
             {},
@@ -40,8 +38,8 @@ describe('{{#is}} helper', function () {
     });
 
     it('should not match "paged"', function () {
-        var fn = sandbox.spy(),
-            inverse = sandbox.spy();
+        var fn = sinon.spy(),
+            inverse = sinon.spy();
 
         helpers.is.call(
             {},
@@ -54,9 +52,9 @@ describe('{{#is}} helper', function () {
     });
 
     it('should log warning with no args', function () {
-        var fn = sandbox.spy(),
-            inverse = sandbox.spy(),
-            logWarn = sandbox.stub(common.logging, 'warn');
+        var fn = sinon.spy(),
+            inverse = sinon.spy(),
+            logWarn = sinon.stub(common.logging, 'warn');
 
         helpers.is.call(
             {},

--- a/core/test/unit/helpers/meta_description_spec.js
+++ b/core/test/unit/helpers/meta_description_spec.js
@@ -2,18 +2,16 @@ var should = require('should'),
     sinon = require('sinon'),
     configUtils = require('../../utils/configUtils'),
     helpers = require('../../../server/helpers'),
-    settingsCache = require('../../../server/services/settings/cache'),
-
-    sandbox = sinon.sandbox.create();
+    settingsCache = require('../../../server/services/settings/cache');
 
 describe('{{meta_description}} helper', function () {
     before(function () {
-        sandbox.stub(settingsCache, 'get').returns('The professional publishing platform');
+        sinon.stub(settingsCache, 'get').returns('The professional publishing platform');
     });
 
     after(function () {
         configUtils.restore();
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('returns correct blog description', function () {

--- a/core/test/unit/helpers/meta_title_spec.js
+++ b/core/test/unit/helpers/meta_title_spec.js
@@ -2,13 +2,11 @@ var should = require('should'),
     sinon = require('sinon'),
     configUtils = require('../../utils/configUtils'),
     helpers = require('../../../server/helpers'),
-    settingsCache = require('../../../server/services/settings/cache'),
-
-    sandbox = sinon.sandbox.create();
+    settingsCache = require('../../../server/services/settings/cache');
 
 describe('{{meta_title}} helper', function () {
     before(function () {
-        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
+        sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return {
                 title: 'Ghost'
             }[key];
@@ -17,7 +15,7 @@ describe('{{meta_title}} helper', function () {
 
     after(function () {
         configUtils.restore();
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('returns correct title for homepage', function () {

--- a/core/test/unit/helpers/next_post_spec.js
+++ b/core/test/unit/helpers/next_post_spec.js
@@ -5,9 +5,7 @@ var should = require('should'),
 
     helpers = require('../../../server/helpers'),
     api = require('../../../server/api'),
-    common = require('../../../server/lib/common'),
-
-    sandbox = sinon.sandbox.create();
+    common = require('../../../server/lib/common');
 
 describe('{{next_post}} helper', function () {
     let locals;
@@ -25,12 +23,12 @@ describe('{{next_post}} helper', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('with valid post data - ', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({
                         posts: [{slug: '/next/', title: 'post 3'}]
@@ -72,7 +70,7 @@ describe('{{next_post}} helper', function () {
 
     describe('for valid post with no next post', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({posts: []});
                 }
@@ -110,7 +108,7 @@ describe('{{next_post}} helper', function () {
 
     describe('for invalid post data', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({});
                 }
@@ -146,7 +144,7 @@ describe('{{next_post}} helper', function () {
                 }
             };
 
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({posts: [{slug: '/previous/', title: 'post 1'}]});
                 }
@@ -190,7 +188,7 @@ describe('{{next_post}} helper', function () {
                 }
             };
 
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({posts: [{slug: '/next/', title: 'post 3'}]});
                 }
@@ -224,7 +222,7 @@ describe('{{next_post}} helper', function () {
 
     describe('with "in" option', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({
                         posts: [{slug: '/next/', title: 'post 1'}]
@@ -395,7 +393,7 @@ describe('{{next_post}} helper', function () {
 
     describe('general error handling', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function () {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function () {
                 return Promise.reject(new common.errors.NotFoundError({message: 'Something wasn\'t found'}));
             });
         });

--- a/core/test/unit/helpers/prev_post_spec.js
+++ b/core/test/unit/helpers/prev_post_spec.js
@@ -5,9 +5,7 @@ var should = require('should'),
 
     helpers = require('../../../server/helpers'),
     api = require('../../../server/api'),
-    common = require('../../../server/lib/common'),
-
-    sandbox = sinon.sandbox.create();
+    common = require('../../../server/lib/common');
 
 describe('{{prev_post}} helper', function () {
     var browsePostStub;
@@ -25,12 +23,12 @@ describe('{{prev_post}} helper', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('with valid post data - ', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({
                         posts: [{slug: '/previous/', title: 'post 1'}]
@@ -72,7 +70,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('for valid post with no previous post', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({posts: []});
                 }
@@ -110,7 +108,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('for invalid post data', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({});
                 }
@@ -146,7 +144,7 @@ describe('{{prev_post}} helper', function () {
                 }
             };
 
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({posts: [{slug: '/previous/', title: 'post 1'}]});
                 }
@@ -190,7 +188,7 @@ describe('{{prev_post}} helper', function () {
                 }
             };
 
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({posts: [{slug: '/previous/', title: 'post 1'}]});
                 }
@@ -224,7 +222,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('with "in" option', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({
                         posts: [{slug: '/previous/', title: 'post 1'}]
@@ -395,7 +393,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('general error handling', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api['v0.1'].posts, 'browse').callsFake(function () {
+            browsePostStub = sinon.stub(api['v0.1'].posts, 'browse').callsFake(function () {
                 return Promise.reject(new common.errors.NotFoundError({message: 'Something wasn\'t found'}));
             });
         });

--- a/core/test/unit/helpers/tags_spec.js
+++ b/core/test/unit/helpers/tags_spec.js
@@ -3,8 +3,7 @@ const should = require('should'),
     testUtils = require('../../utils'),
     urlService = require('../../../server/services/url'),
     models = require('../../../server/models'),
-    helpers = require('../../../server/helpers'),
-    sandbox = sinon.sandbox.create();
+    helpers = require('../../../server/helpers');
 
 describe('{{tags}} helper', function () {
     before(function () {
@@ -12,11 +11,11 @@ describe('{{tags}} helper', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(urlService, 'getUrlByResourceId');
+        sinon.stub(urlService, 'getUrlByResourceId');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('can return string with tags', function () {

--- a/core/test/unit/helpers/url_spec.js
+++ b/core/test/unit/helpers/url_spec.js
@@ -6,8 +6,7 @@ var should = require('should'),
     markdownToMobiledoc = require('../../utils/fixtures/data-generator').markdownToMobiledoc,
     helpers = require('../../../server/helpers'),
     urlService = require('../../../server/services/url'),
-    api = require('../../../server/api'),
-    sandbox = sinon.sandbox.create();
+    api = require('../../../server/api');
 
 describe('{{url}} helper', function () {
     var rendered;
@@ -19,15 +18,15 @@ describe('{{url}} helper', function () {
     beforeEach(function () {
         rendered = null;
 
-        sandbox.stub(urlService, 'getUrlByResourceId');
+        sinon.stub(urlService, 'getUrlByResourceId');
 
-        sandbox.stub(api.settings, 'read').callsFake(function () {
+        sinon.stub(api.settings, 'read').callsFake(function () {
             return Promise.resolve({settings: [{value: '/:slug/'}]});
         });
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     after(function () {

--- a/core/test/unit/lib/image/blog-icon_spec.js
+++ b/core/test/unit/lib/image/blog-icon_spec.js
@@ -9,9 +9,7 @@ var should = require('should'),
     config = configUtils.config,
 
     // stuff we are testing
-    blogIcon = rewire('../../../../server/lib/image/blog-icon'),
-
-    sandbox = sinon.sandbox.create();
+    blogIcon = rewire('../../../../server/lib/image/blog-icon');
 
 describe('lib/image: blog icon', function () {
     before(function () {
@@ -20,18 +18,18 @@ describe('lib/image: blog icon', function () {
 
     afterEach(function () {
         configUtils.restore();
-        sandbox.restore();
+        sinon.restore();
         rewire('../../../../server/lib/image/blog-icon');
     });
 
     describe('getIconUrl', function () {
         it('custom uploaded ico blog icon', function () {
-            sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
+            sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
             blogIcon.getIconUrl().should.eql('/favicon.ico');
         });
 
         it('custom uploaded png blog icon', function () {
-            sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
+            sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
             blogIcon.getIconUrl().should.eql('/favicon.png');
         });
 
@@ -41,13 +39,13 @@ describe('lib/image: blog icon', function () {
         describe('absolute URL', function () {
             it('custom uploaded ico blog icon', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com/'});
-                sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
+                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
                 blogIcon.getIconUrl(true).should.eql('http://my-ghost-blog.com/favicon.ico');
             });
 
             it('custom uploaded png blog icon', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com/'});
-                sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
+                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
                 blogIcon.getIconUrl(true).should.eql('http://my-ghost-blog.com/favicon.png');
             });
 
@@ -59,14 +57,14 @@ describe('lib/image: blog icon', function () {
 
         describe('with subdirectory', function () {
             it('custom uploaded ico blog icon', function () {
-                sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
+                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
 
                 blogIcon.getIconUrl().should.eql('/blog/favicon.ico');
             });
 
             it('custom uploaded png blog icon', function () {
-                sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
+                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
 
                 blogIcon.getIconUrl().should.eql('/blog/favicon.png');
@@ -81,12 +79,12 @@ describe('lib/image: blog icon', function () {
 
     describe('getIconPath', function () {
         it('custom uploaded ico blog icon', function () {
-            sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
+            sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
             blogIcon.getIconPath().should.eql('/2017/04/my-icon.ico');
         });
 
         it('custom uploaded png blog icon', function () {
-            sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
+            sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
             blogIcon.getIconPath().should.eql('/2017/04/my-icon.png');
         });
 
@@ -96,14 +94,14 @@ describe('lib/image: blog icon', function () {
 
         describe('with subdirectory', function () {
             it('custom uploaded ico blog icon', function () {
-                sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/blog/content/images/2017/04/my-icon.ico');
+                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/blog/content/images/2017/04/my-icon.ico');
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
 
                 blogIcon.getIconPath().should.eql('/2017/04/my-icon.ico');
             });
 
             it('custom uploaded png blog icon', function () {
-                sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/blog/content/images/2017/04/my-icon.png');
+                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/blog/content/images/2017/04/my-icon.png');
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
 
                 blogIcon.getIconPath().should.eql('/2017/04/my-icon.png');
@@ -174,7 +172,7 @@ describe('lib/image: blog icon', function () {
         });
 
         it('[failure] return error message', function (done) {
-            var sizeOfStub = sandbox.stub();
+            var sizeOfStub = sinon.stub();
 
             sizeOfStub.throws({error: 'image-size could not find dimensions'});
 

--- a/core/test/unit/lib/image/cached-image-size-from-url_spec.js
+++ b/core/test/unit/lib/image/cached-image-size-from-url_spec.js
@@ -4,20 +4,18 @@ var should = require('should'),
     rewire = require('rewire'),
 
     // Stuff we are testing
-    getCachedImageSizeFromUrl = rewire('../../../../server/lib/image/cached-image-size-from-url'),
-
-    sandbox = sinon.sandbox.create();
+    getCachedImageSizeFromUrl = rewire('../../../../server/lib/image/cached-image-size-from-url');
 
 describe('lib/image: image size cache', function () {
     var sizeOfStub,
         cachedImagedSize;
 
     beforeEach(function () {
-        sizeOfStub = sandbox.stub();
+        sizeOfStub = sinon.stub();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         getCachedImageSizeFromUrl.__set__('cache', {});
     });
 

--- a/core/test/unit/lib/image/image-size_spec.js
+++ b/core/test/unit/lib/image/image-size_spec.js
@@ -9,9 +9,7 @@ var should = require('should'),
     storage = require('../../../../server/adapters/storage'),
 
     // Stuff we are testing
-    imageSize = rewire('../../../../server/lib/image/image-size'),
-
-    sandbox = sinon.sandbox.create();
+    imageSize = rewire('../../../../server/lib/image/image-size');
 
 describe('lib/image: image size', function () {
     var sizeOfStub,
@@ -25,7 +23,7 @@ describe('lib/image: image size', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
         imageSize = rewire('../../../../server/lib/image/image-size');
         storage.getStorage().storagePath = originalStoragePath;
@@ -50,7 +48,7 @@ describe('lib/image: image size', function () {
                 .get('/files/f/feedough/x/11/1540353_20925115.jpg')
                 .reply(200);
 
-            sizeOfStub = sandbox.stub();
+            sizeOfStub = sinon.stub();
             sizeOfStub.returns({width: 50, height: 50, type: 'jpg'});
             imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -82,7 +80,7 @@ describe('lib/image: image size', function () {
                     body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
                 });
 
-            sizeOfStub = sandbox.stub();
+            sizeOfStub = sinon.stub();
             sizeOfStub.returns({width: 256, height: 256, type: 'png'});
             imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -117,7 +115,7 @@ describe('lib/image: image size', function () {
                     body: '<Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 00 68 00 00 00 0f 08 02 00 00 00 87 8f 1d 14 00 00 03 33 49 44 41 54 58 c3 ed 97 6b 48 93 51 18>'
                 });
 
-            sizeOfStub = sandbox.stub();
+            sizeOfStub = sinon.stub();
             sizeOfStub.returns({width: 104, height: 15, type: 'png'});
             imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -149,7 +147,7 @@ describe('lib/image: image size', function () {
                     body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
                 });
 
-            sizeOfStub = sandbox.stub();
+            sizeOfStub = sinon.stub();
             sizeOfStub.returns({
                 width: 32,
                 height: 32,
@@ -186,9 +184,9 @@ describe('lib/image: image size', function () {
                         width: 100
                     };
 
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             requestMock = nock('http://myblog.com')
@@ -197,7 +195,7 @@ describe('lib/image: image size', function () {
                     body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
                 });
 
-            sizeOfStub = sandbox.stub();
+            sizeOfStub = sinon.stub();
             sizeOfStub.returns({width: 100, height: 100, type: 'svg'});
             imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -229,7 +227,7 @@ describe('lib/image: image size', function () {
                     body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
                 });
 
-            sizeOfStub = sandbox.stub();
+            sizeOfStub = sinon.stub();
             sizeOfStub.returns({width: 250, height: 250, type: 'jpg'});
             imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -299,10 +297,10 @@ describe('lib/image: image size', function () {
                     };
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/favicon.png');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             requestMock = nock('http://myblog.com')
@@ -381,7 +379,7 @@ describe('lib/image: image size', function () {
                     body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
                 });
 
-            sizeOfStub = sandbox.stub();
+            sizeOfStub = sinon.stub();
             sizeOfStub.throws({error: 'image-size could not find dimensions'});
             imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -426,10 +424,10 @@ describe('lib/image: image size', function () {
                     };
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/ghost-logo.png');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = imageSize.getImageSizeFromStoragePath(url).then(function (res) {
@@ -456,10 +454,10 @@ describe('lib/image: image size', function () {
                     };
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/blog/content/images/favicon_too_large.png');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = imageSize.getImageSizeFromStoragePath(url).then(function (res) {
@@ -486,10 +484,10 @@ describe('lib/image: image size', function () {
                     };
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/favicon_multi_sizes.ico');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = imageSize.getImageSizeFromStoragePath(url).then(function (res) {
@@ -510,10 +508,10 @@ describe('lib/image: image size', function () {
                 urlGetSubdirStub;
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/not-existing-image.png');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = imageSize.getImageSizeFromStoragePath(url)
@@ -529,15 +527,15 @@ describe('lib/image: image size', function () {
                 urlForStub,
                 urlGetSubdirStub;
 
-            sizeOfStub = sandbox.stub();
+            sizeOfStub = sinon.stub();
             sizeOfStub.throws({error: 'image-size could not find dimensions'});
             imageSize.__set__('sizeOf', sizeOfStub);
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
+            urlForStub = sinon.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/ghost-logo.pngx');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
+            urlGetSubdirStub = sinon.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = imageSize.getImageSizeFromStoragePath(url)

--- a/core/test/unit/lib/image/manipulator_spec.js
+++ b/core/test/unit/lib/image/manipulator_spec.js
@@ -4,11 +4,10 @@ const fs = require('fs-extra');
 const common = require('../../../../server/lib/common');
 const manipulator = require('../../../../server/lib/image/manipulator');
 const testUtils = require('../../../utils');
-const sandbox = sinon.sandbox.create();
 
 describe('lib/image: manipulator', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         testUtils.unmockNotExistingModule();
     });
 
@@ -43,16 +42,16 @@ describe('lib/image: manipulator', function () {
         let sharp, sharpInstance;
 
         beforeEach(function () {
-            sandbox.stub(fs, 'readFile').resolves('original');
-            sandbox.stub(fs, 'writeFile').resolves();
+            sinon.stub(fs, 'readFile').resolves('original');
+            sinon.stub(fs, 'writeFile').resolves();
 
             sharpInstance = {
-                resize: sandbox.stub().returnsThis(),
-                rotate: sandbox.stub().returnsThis(),
-                toBuffer: sandbox.stub(),
+                resize: sinon.stub().returnsThis(),
+                rotate: sinon.stub().returnsThis(),
+                toBuffer: sinon.stub(),
             };
 
-            sharp = sandbox.stub().callsFake(() => {
+            sharp = sinon.stub().callsFake(() => {
                 return sharpInstance;
             });
 

--- a/core/test/unit/lib/promise/pipeline_spec.js
+++ b/core/test/unit/lib/promise/pipeline_spec.js
@@ -2,10 +2,8 @@ var should = require('should'),
     sinon = require('sinon'),
     Promise = require('bluebird'),
 
-// Stuff we are testing
-    pipeline = require('../../../../server/lib/promise/pipeline'),
-
-    sandbox = sinon.sandbox.create();
+    // Stuff we are testing
+    pipeline = require('../../../../server/lib/promise/pipeline');
 
 // These tests are based on the tests in https://github.com/cujojs/when/blob/3.7.4/test/pipeline-test.js
 function createTask(y) {
@@ -16,7 +14,7 @@ function createTask(y) {
 
 describe('Pipeline', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should execute tasks in order', function () {
@@ -39,7 +37,7 @@ describe('Pipeline', function () {
 
     it('should pass args to initial task', function () {
         var expected = [1, 2, 3],
-            tasks = [sandbox.spy()];
+            tasks = [sinon.spy()];
 
         return pipeline(tasks, 1, 2, 3).then(function () {
             tasks[0].calledOnce.should.be.true();
@@ -49,7 +47,7 @@ describe('Pipeline', function () {
 
     it('should allow initial args to be promises', function () {
         var expected = [1, 2, 3],
-            tasks = [sandbox.spy()],
+            tasks = [sinon.spy()],
             Resolver = Promise.resolve;
 
         return pipeline(tasks, new Resolver(1), new Resolver(2), new Resolver(3)).then(function () {
@@ -61,9 +59,9 @@ describe('Pipeline', function () {
     it('should allow tasks to be promises', function () {
         var expected = [1, 2, 3],
             tasks = [
-                sandbox.stub().returns(new Promise.resolve(4)),
-                sandbox.stub().returns(new Promise.resolve(5)),
-                sandbox.stub().returns(new Promise.resolve(6))
+                sinon.stub().returns(new Promise.resolve(4)),
+                sinon.stub().returns(new Promise.resolve(5)),
+                sinon.stub().returns(new Promise.resolve(6))
             ];
 
         return pipeline(tasks, 1, 2, 3).then(function (result) {
@@ -80,9 +78,9 @@ describe('Pipeline', function () {
     it('should allow tasks and args to be promises', function () {
         var expected = [1, 2, 3],
             tasks = [
-                sandbox.stub().returns(new Promise.resolve(4)),
-                sandbox.stub().returns(new Promise.resolve(5)),
-                sandbox.stub().returns(new Promise.resolve(6))
+                sinon.stub().returns(new Promise.resolve(4)),
+                sinon.stub().returns(new Promise.resolve(5)),
+                sinon.stub().returns(new Promise.resolve(6))
             ],
             Resolver = Promise.resolve;
 

--- a/core/test/unit/lib/promise/sequence_spec.js
+++ b/core/test/unit/lib/promise/sequence_spec.js
@@ -2,11 +2,10 @@ const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
 const sequence = require('../../../../server/lib/promise/sequence');
-const sandbox = sinon.sandbox.create();
 
 describe('Unit: lib/promise/sequence', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('mixed tasks: promise and none promise', function () {

--- a/core/test/unit/models/api-key_spec.js
+++ b/core/test/unit/models/api-key_spec.js
@@ -77,7 +77,6 @@ describe('Unit: models/api_key', function () {
 
     describe('refreshSecret', function () {
         it('returns a call to edit passing a new secret', function () {
-
             const editStub = sinon.stub(models.ApiKey, 'edit').resolves();
 
             const fakeData = {

--- a/core/test/unit/models/api-key_spec.js
+++ b/core/test/unit/models/api-key_spec.js
@@ -77,8 +77,8 @@ describe('Unit: models/api_key', function () {
 
     describe('refreshSecret', function () {
         it('returns a call to edit passing a new secret', function () {
-            const sandbox = sinon.sandbox.create();
-            const editStub = sandbox.stub(models.ApiKey, 'edit').resolves();
+
+            const editStub = sinon.stub(models.ApiKey, 'edit').resolves();
 
             const fakeData = {
                 id: 'TREVOR'
@@ -92,7 +92,7 @@ describe('Unit: models/api_key', function () {
             should.equal(editStub.args[0][0].secret.length, 128);
             should.equal(editStub.args[0][1], fakeOptions);
 
-            sandbox.restore();
+            sinon.restore();
         });
     });
 });

--- a/core/test/unit/models/base/index_spec.js
+++ b/core/test/unit/models/base/index_spec.js
@@ -6,8 +6,7 @@ var should = require('should'),
     models = require('../../../../server/models'),
     urlService = require('../../../../server/services/url'),
     filters = require('../../../../server/filters'),
-    testUtils = require('../../../utils'),
-    sandbox = sinon.sandbox.create();
+    testUtils = require('../../../utils');
 
 describe('Models: base', function () {
     before(function () {
@@ -15,7 +14,7 @@ describe('Models: base', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('generateSlug', function () {
@@ -23,15 +22,15 @@ describe('Models: base', function () {
         let options = {};
 
         beforeEach(function () {
-            sandbox.stub(security.string, 'safe');
-            sandbox.stub(filters, 'doFilter').resolves();
-            sandbox.stub(urlService.utils, 'getProtectedSlugs').returns(['upsi', 'schwupsi']);
+            sinon.stub(security.string, 'safe');
+            sinon.stub(filters, 'doFilter').resolves();
+            sinon.stub(urlService.utils, 'getProtectedSlugs').returns(['upsi', 'schwupsi']);
 
-            Model = sandbox.stub();
+            Model = sinon.stub();
             Model.prototype = {
                 tableName: 'tableName'
             };
-            Model.findOne = sandbox.stub();
+            Model.findOne = sinon.stub();
         });
 
         it('default', function () {
@@ -175,7 +174,7 @@ describe('Models: base', function () {
         it('resets given empty value to null', function () {
             const base = models.Base.Model.forge({a: '', b: ''});
 
-            base.emptyStringProperties = sandbox.stub();
+            base.emptyStringProperties = sinon.stub();
             base.emptyStringProperties.returns(['a']);
 
             base.get('a').should.eql('');
@@ -201,12 +200,12 @@ describe('Models: base', function () {
                 }
             };
             const model = models.Base.Model.forge({});
-            const filterOptionsSpy = sandbox.spy(models.Base.Model, 'filterOptions');
-            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
+            const forgeStub = sinon.stub(models.Base.Model, 'forge')
                 .returns(model);
-            const fetchStub = sandbox.stub(model, 'fetch')
+            const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(model);
-            const destroyStub = sandbox.stub(model, 'destroy');
+            const destroyStub = sinon.stub(model, 'destroy');
 
             return models.Base.Model.destroy(unfilteredOptions).then(() => {
                 should.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
@@ -228,12 +227,12 @@ describe('Models: base', function () {
                 id: 23
             };
             const model = models.Base.Model.forge({});
-            const filterOptionsSpy = sandbox.spy(models.Base.Model, 'filterOptions');
-            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
+            const forgeStub = sinon.stub(models.Base.Model, 'forge')
                 .returns(model);
-            const fetchStub = sandbox.stub(model, 'fetch')
+            const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(model);
-            const destroyStub = sandbox.stub(model, 'destroy');
+            const destroyStub = sinon.stub(model, 'destroy');
 
             return models.Base.Model.destroy(unfilteredOptions).then(() => {
                 should.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
@@ -261,11 +260,11 @@ describe('Models: base', function () {
             };
             const model = models.Base.Model.forge({});
             const fetchedModel = models.Base.Model.forge({});
-            const filterOptionsSpy = sandbox.spy(models.Base.Model, 'filterOptions');
-            const filterDataSpy = sandbox.spy(models.Base.Model, 'filterData');
-            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
+            const filterDataSpy = sinon.spy(models.Base.Model, 'filterData');
+            const forgeStub = sinon.stub(models.Base.Model, 'forge')
                 .returns(model);
-            const fetchStub = sandbox.stub(model, 'fetch')
+            const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(fetchedModel);
 
             const findOneReturnValue = models.Base.Model.findOne(data, unfilteredOptions);
@@ -299,13 +298,13 @@ describe('Models: base', function () {
             };
             const model = models.Base.Model.forge({});
             const savedModel = models.Base.Model.forge({});
-            const filterOptionsSpy = sandbox.spy(models.Base.Model, 'filterOptions');
-            const filterDataSpy = sandbox.spy(models.Base.Model, 'filterData');
-            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
+            const filterDataSpy = sinon.spy(models.Base.Model, 'filterData');
+            const forgeStub = sinon.stub(models.Base.Model, 'forge')
                 .returns(model);
-            const fetchStub = sandbox.stub(model, 'fetch')
+            const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(model);
-            const saveStub = sandbox.stub(model, 'save')
+            const saveStub = sinon.stub(model, 'save')
                 .resolves(savedModel);
 
             return models.Base.Model.edit(data, unfilteredOptions).then((result) => {
@@ -336,9 +335,9 @@ describe('Models: base', function () {
                 importing: true
             };
             const model = models.Base.Model.forge({});
-            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+            const forgeStub = sinon.stub(models.Base.Model, 'forge')
                 .returns(model);
-            const fetchStub = sandbox.stub(model, 'fetch')
+            const fetchStub = sinon.stub(model, 'fetch')
                 .resolves();
 
             return models.Base.Model.findOne(data, unfilteredOptions).then(() => {
@@ -354,13 +353,13 @@ describe('Models: base', function () {
                 id: 'something real special',
             };
             const model = models.Base.Model.forge({});
-            const filterOptionsSpy = sandbox.spy(models.Base.Model, 'filterOptions');
-            const filterDataSpy = sandbox.spy(models.Base.Model, 'filterData');
-            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
+            const filterDataSpy = sinon.spy(models.Base.Model, 'filterData');
+            const forgeStub = sinon.stub(models.Base.Model, 'forge')
                 .returns(model);
-            const fetchStub = sandbox.stub(model, 'fetch')
+            const fetchStub = sinon.stub(model, 'fetch')
                 .resolves();
-            const saveSpy = sandbox.stub(model, 'save');
+            const saveSpy = sinon.stub(model, 'save');
 
             return models.Base.Model.edit(data, unfilteredOptions).then((result) => {
                 should.equal(result, undefined);
@@ -377,11 +376,11 @@ describe('Models: base', function () {
             const unfilteredOptions = {};
             const model = models.Base.Model.forge({});
             const savedModel = models.Base.Model.forge({});
-            const filterOptionsSpy = sandbox.spy(models.Base.Model, 'filterOptions');
-            const filterDataSpy = sandbox.spy(models.Base.Model, 'filterData');
-            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
+            const filterDataSpy = sinon.spy(models.Base.Model, 'filterData');
+            const forgeStub = sinon.stub(models.Base.Model, 'forge')
                 .returns(model);
-            const saveStub = sandbox.stub(model, 'save')
+            const saveStub = sinon.stub(model, 'save')
                 .resolves(savedModel);
 
             return models.Base.Model.add(data, unfilteredOptions).then((result) => {
@@ -410,9 +409,9 @@ describe('Models: base', function () {
                 importing: true
             };
             const model = models.Base.Model.forge({});
-            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+            const forgeStub = sinon.stub(models.Base.Model, 'forge')
                 .returns(model);
-            const saveStub = sandbox.stub(model, 'save')
+            const saveStub = sinon.stub(model, 'save')
                 .resolves();
 
             return models.Base.Model.add(data, unfilteredOptions).then(() => {

--- a/core/test/unit/models/base/listeners_spec.js
+++ b/core/test/unit/models/base/listeners_spec.js
@@ -2,16 +2,14 @@ var should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
     common = require('../../../../server/lib/common'),
-    Models = require('../../../../server/models'),
-
-    sandbox = sinon.sandbox.create();
+    Models = require('../../../../server/models');
 
 describe('Models: listeners', function () {
     var eventsToRemember = {};
     const emit = (event, data) => eventsToRemember[event](data);
 
     before(function () {
-        sandbox.stub(common.events, 'on').callsFake(function (name, callback) {
+        sinon.stub(common.events, 'on').callsFake(function (name, callback) {
             eventsToRemember[name] = callback;
         });
 
@@ -20,21 +18,21 @@ describe('Models: listeners', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('on token added', function () {
         it('calls updateLastSeen on the user when the token.added event is emited', function (done) {
             const userId = 1;
             const user = Models.User.forge({id: 1});
-            sandbox.stub(Models.User, 'findOne').withArgs({id: userId}).resolves(user);
-            const updateLastSeenSpy = sandbox.stub(user, 'updateLastSeen').callsFake(function () {
+            sinon.stub(Models.User, 'findOne').withArgs({id: userId}).resolves(user);
+            const updateLastSeenSpy = sinon.stub(user, 'updateLastSeen').callsFake(function () {
                 updateLastSeenSpy.calledOnce.should.be.true();
                 done();
             });
 
             const fakeToken = {
-                get: sandbox.stub().withArgs('user_id').returns(userId)
+                get: sinon.stub().withArgs('user_id').returns(userId)
             };
 
             emit('token.added', fakeToken);

--- a/core/test/unit/models/invite_spec.js
+++ b/core/test/unit/models/invite_spec.js
@@ -4,8 +4,7 @@ const should = require('should'),
     common = require('../../../server/lib/common'),
     models = require('../../../server/models'),
     settingsCache = require('../../../server/services/settings/cache'),
-    testUtils = require('../../utils'),
-    sandbox = sinon.sandbox.create();
+    testUtils = require('../../utils');
 
 describe('Unit: models/invite', function () {
     before(function () {
@@ -13,11 +12,11 @@ describe('Unit: models/invite', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(settingsCache, 'get').withArgs('db_hash').returns('12345678');
+        sinon.stub(settingsCache, 'get').withArgs('db_hash').returns('12345678');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     before(testUtils.teardown);
@@ -85,8 +84,8 @@ describe('Unit: models/invite', function () {
                 inviteModel = {};
                 context = {};
                 unsafeAttrs = {role_id: 'role_id'};
-                roleModel = sandbox.stub();
-                roleModel.get = sandbox.stub();
+                roleModel = sinon.stub();
+                roleModel.get = sinon.stub();
                 loadedPermissions = {
                     user: {
                         roles: []
@@ -95,7 +94,7 @@ describe('Unit: models/invite', function () {
             });
 
             it('role does not exist', function () {
-                sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(null);
+                sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(null);
 
                 return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs)
                     .then(Promise.reject)
@@ -105,7 +104,7 @@ describe('Unit: models/invite', function () {
             });
 
             it('invite owner', function () {
-                sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                 roleModel.get.withArgs('name').returns('Owner');
 
                 return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs)
@@ -121,28 +120,28 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite editor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite author', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite contributor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
@@ -155,28 +154,28 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite editor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite author', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite contributor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
@@ -189,7 +188,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
@@ -200,7 +199,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite editor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
@@ -211,14 +210,14 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite author', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite contributor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
@@ -231,7 +230,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
@@ -242,7 +241,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite editor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
@@ -253,7 +252,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite author', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
@@ -264,7 +263,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite contributor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
@@ -281,7 +280,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
@@ -292,7 +291,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite editor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
@@ -303,7 +302,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite author', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
@@ -314,7 +313,7 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite contributor', function () {
-                    sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
                     return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)

--- a/core/test/unit/models/permission_spec.js
+++ b/core/test/unit/models/permission_spec.js
@@ -2,8 +2,7 @@ const should = require('should'),
     sinon = require('sinon'),
     models = require('../../../server/models'),
     testUtils = require('../../utils'),
-    configUtils = require('../../utils/configUtils'),
-    sandbox = sinon.sandbox.create();
+    configUtils = require('../../utils/configUtils');
 
 describe('Unit: models/permission', function () {
     before(function () {
@@ -11,7 +10,7 @@ describe('Unit: models/permission', function () {
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 

--- a/core/test/unit/models/plugins/pagination_spec.js
+++ b/core/test/unit/models/plugins/pagination_spec.js
@@ -2,14 +2,13 @@ var should = require('should'),
     sinon = require('sinon'),
     Promise = require('bluebird'),
     rewire = require('rewire'),
-    pagination = rewire('../../../../server/models/plugins/pagination'),
-    sandbox = sinon.sandbox.create();
+    pagination = rewire('../../../../server/models/plugins/pagination');
 
 describe('pagination', function () {
     var paginationUtils;
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('paginationUtils', function () {
@@ -144,7 +143,7 @@ describe('pagination', function () {
             });
 
             beforeEach(function () {
-                collection.query = sandbox.stub().returns(collection);
+                collection.query = sinon.stub().returns(collection);
             });
 
             it('should add query options if limit is set', function () {
@@ -172,15 +171,15 @@ describe('pagination', function () {
 
         beforeEach(function () {
             // Stub paginationUtils
-            paginationUtils.parseOptions = sandbox.stub();
-            paginationUtils.addLimitAndOffset = sandbox.stub();
-            paginationUtils.formatResponse = sandbox.stub().returns({});
+            paginationUtils.parseOptions = sinon.stub();
+            paginationUtils.addLimitAndOffset = sinon.stub();
+            paginationUtils.formatResponse = sinon.stub().returns({});
 
             // Mock out bookshelf model
             mockQuery = {
-                clone: sandbox.stub(),
-                select: sandbox.stub(),
-                toQuery: sandbox.stub()
+                clone: sinon.stub(),
+                select: sinon.stub(),
+                toQuery: sinon.stub()
             };
             mockQuery.clone.returns(mockQuery);
             mockQuery.select.returns(Promise.resolve([{aggregate: 1}]));
@@ -188,11 +187,11 @@ describe('pagination', function () {
             model = function () {
             };
 
-            model.prototype.fetchAll = sandbox.stub().returns(Promise.resolve({}));
-            model.prototype.query = sandbox.stub();
+            model.prototype.fetchAll = sinon.stub().returns(Promise.resolve({}));
+            model.prototype.query = sinon.stub();
             model.prototype.query.returns(mockQuery);
 
-            knex = {raw: sandbox.stub().returns(Promise.resolve())};
+            knex = {raw: sinon.stub().returns(Promise.resolve())};
 
             bookshelf = {Model: model, knex: knex};
 

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -10,7 +10,7 @@ const schema = require('../../../server/data/schema');
 const models = require('../../../server/models');
 const common = require('../../../server/lib/common');
 const security = require('../../../server/lib/security');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: models/post', function () {
     const mockDb = require('mock-knex');
@@ -23,7 +23,7 @@ describe('Unit: models/post', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     after(function () {
@@ -356,16 +356,16 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
     before(testUtils.setup('users:roles', 'posts'));
 
     beforeEach(function () {
-        sandbox.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
-        sandbox.stub(urlService, 'getUrlByResourceId');
+        sinon.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
+        sinon.stub(urlService, 'getUrlByResourceId');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('add', function () {
@@ -375,7 +375,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -424,7 +424,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -447,7 +447,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -481,7 +481,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -516,7 +516,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -562,7 +562,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -611,7 +611,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
             testUtils.DataGenerator.forKnex.posts[4].featured.should.eql(true);
 
             // @NOTE: simulate that the onSaving hook takes longer
-            sandbox.stub(models.Post.prototype, 'onSaving').callsFake(function () {
+            sinon.stub(models.Post.prototype, 'onSaving').callsFake(function () {
                 var self = this,
                     args = arguments;
 
@@ -650,11 +650,11 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 tag: []
             };
 
-            sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+            sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                 events.post.push(event);
             });
 
-            sandbox.stub(models.Tag.prototype, 'emitChange').callsFake(function (event) {
+            sinon.stub(models.Tag.prototype, 'emitChange').callsFake(function (event) {
                 events.tag.push(event);
             });
 
@@ -689,11 +689,11 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 tag: []
             };
 
-            sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+            sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                 events.post.push(event);
             });
 
-            sandbox.stub(models.Tag.prototype, 'emitChange').callsFake(function (event) {
+            sinon.stub(models.Tag.prototype, 'emitChange').callsFake(function (event) {
                 events.tag.push(event);
             });
 
@@ -723,11 +723,11 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 tag: []
             };
 
-            sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+            sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                 events.post.push(event);
             });
 
-            sandbox.stub(models.Tag.prototype, 'emitChange').callsFake(function (event) {
+            sinon.stub(models.Tag.prototype, 'emitChange').callsFake(function (event) {
                 events.tag.push(event);
             });
 
@@ -772,7 +772,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -810,7 +810,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -851,7 +851,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -892,7 +892,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -936,7 +936,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     post: []
                 };
 
-                sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+                sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                     events.post.push({event: event, data: this.toJSON()});
                 });
 
@@ -1517,8 +1517,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
             describe('Editing', function () {
                 it('rejects if changing status', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'published'};
@@ -1547,8 +1547,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if changing author id', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 2};
@@ -1576,8 +1576,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if changing authors.0', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', authors: [{id: 2}]};
@@ -1605,8 +1605,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('ignores if changes authors.1', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', authors: [{id: 1}, {id: 2}]};
@@ -1634,8 +1634,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if post is not draft', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'published', author_id: 1};
@@ -1665,8 +1665,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if contributor is not author of post', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 2};
@@ -1696,8 +1696,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('resolves if none of the above cases are true', function () {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 1};
@@ -1727,7 +1727,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
             describe('Adding', function () {
                 it('rejects if "published" status', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'published', author_id: 1};
@@ -1752,7 +1752,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if different author id', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 2};
@@ -1777,7 +1777,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if different logged in user and `authors.0`', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', authors: [{id: 2}]};
@@ -1802,7 +1802,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if same logged in user and `authors.0`, but different author_id', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 3, authors: [{id: 1}]};
@@ -1827,7 +1827,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if different logged in user and `authors.0`, but correct author_id', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 1, authors: [{id: 2}]};
@@ -1852,7 +1852,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('resolves if same logged in user and `authors.0`', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', authors: [{id: 1}]};
@@ -1876,7 +1876,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('resolves if none of the above cases are true', function () {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 1};
@@ -1901,8 +1901,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
             describe('Destroying', function () {
                 it('rejects if destroying another author\'s post', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1};
 
@@ -1929,8 +1929,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if destroying a published post', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1};
 
@@ -1958,8 +1958,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('resolves if none of the above cases are true', function () {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1};
 
@@ -1989,8 +1989,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
             describe('Editing', function () {
                 it('rejects if editing another\'s post', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {author_id: 2};
@@ -2019,8 +2019,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if editing another\'s post (using `authors`)', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {authors: [{id: 2}]};
@@ -2048,8 +2048,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if changing author', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {author_id: 2};
@@ -2078,8 +2078,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if changing authors', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {authors: [{id: 2}]};
@@ -2107,8 +2107,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if changing authors and author_id', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {authors: [{id: 1}], author_id: 2};
@@ -2137,8 +2137,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if changing authors and author_id', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {authors: [{id: 2}], author_id: 1};
@@ -2167,8 +2167,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('resolves if none of the above cases are true', function () {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {author_id: 1};
@@ -2195,7 +2195,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
             describe('Adding', function () {
                 it('rejects if different author id', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {author_id: 2};
@@ -2220,8 +2220,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('rejects if different authors', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub(),
-                            related: sandbox.stub()
+                            get: sinon.stub(),
+                            related: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {authors: [{id: 2}]};
@@ -2248,7 +2248,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                 it('resolves if none of the above cases are true', function () {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sinon.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {author_id: 1};
@@ -2272,8 +2272,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
         describe('Everyone Else', function () {
             it('rejects if hasUserPermissions is false and not current owner', function (done) {
                 var mockPostObj = {
-                        get: sandbox.stub(),
-                        related: sandbox.stub()
+                        get: sinon.stub(),
+                        related: sinon.stub()
                     },
                     context = {user: 1},
                     unsafeAttrs = {author_id: 2};
@@ -2302,7 +2302,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
             it('resolves if hasUserPermission is true', function () {
                 var mockPostObj = {
-                        get: sandbox.stub()
+                        get: sinon.stub()
                     },
                     context = {user: 1},
                     unsafeAttrs = {author_id: 2};
@@ -2335,7 +2335,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 post: []
             };
 
-            sandbox.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
+            sinon.stub(models.Post.prototype, 'emitChange').callsFake(function (event) {
                 events.post.push({event: event, data: this.toJSON()});
             });
         });

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -11,7 +11,6 @@ const models = require('../../../server/models');
 const common = require('../../../server/lib/common');
 const security = require('../../../server/lib/security');
 
-
 describe('Unit: models/post', function () {
     const mockDb = require('mock-knex');
     let tracker;

--- a/core/test/unit/models/session_spec.js
+++ b/core/test/unit/models/session_spec.js
@@ -2,18 +2,13 @@ const should = require('should');
 const sinon = require('sinon');
 const models = require('../../../server/models');
 
-const sandbox = sinon.sandbox.create();
-
 describe('Unit: models/session', function () {
-    let sandbox;
-
     before(function () {
         models.init();
-        sandbox = sinon.sandbox.create();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('parse', function () {
@@ -65,7 +60,7 @@ describe('Unit: models/session', function () {
     describe('user', function () {
         it('sets up the relation to the "User" model', function () {
             const model = models.Session.forge({});
-            const belongsToSpy = sandbox.spy(model, 'belongsTo');
+            const belongsToSpy = sinon.spy(model, 'belongsTo');
             model.user();
 
             should.equal(belongsToSpy.args[0][0], 'User');
@@ -78,7 +73,7 @@ describe('Unit: models/session', function () {
 
         beforeEach(function () {
             basePermittedOptionsReturnVal = ['super', 'doopa'];
-            basePermittedOptionsStub = sandbox.stub(models.Base.Model, 'permittedOptions')
+            basePermittedOptionsStub = sinon.stub(models.Base.Model, 'permittedOptions')
                 .returns(basePermittedOptionsReturnVal);
         });
 
@@ -112,7 +107,7 @@ describe('Unit: models/session', function () {
     describe('destroy', function () {
         it('calls and returns the Base Model destroy if an id is passed', function () {
             const baseDestroyReturnVal = {};
-            const baseDestroyStub = sandbox.stub(models.Base.Model, 'destroy')
+            const baseDestroyStub = sinon.stub(models.Base.Model, 'destroy')
                 .returns(baseDestroyReturnVal);
 
             const options = {id: 1};
@@ -128,13 +123,13 @@ describe('Unit: models/session', function () {
             const unfilteredOptions = {session_id};
             const filteredOptions = {session_id};
 
-            const filterOptionsStub = sandbox.stub(models.Session, 'filterOptions')
+            const filterOptionsStub = sinon.stub(models.Session, 'filterOptions')
                 .returns(filteredOptions);
-            const forgeStub = sandbox.stub(models.Session, 'forge')
+            const forgeStub = sinon.stub(models.Session, 'forge')
                 .returns(model);
-            const fetchStub = sandbox.stub(model, 'fetch')
+            const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(model);
-            const destroyStub = sandbox.stub(model, 'destroy')
+            const destroyStub = sinon.stub(model, 'destroy')
                 .resolves();
 
             models.Session.destroy(unfilteredOptions).then(() => {
@@ -162,13 +157,13 @@ describe('Unit: models/session', function () {
                 }
             };
 
-            const filterOptionsStub = sandbox.stub(models.Session, 'filterOptions')
+            const filterOptionsStub = sinon.stub(models.Session, 'filterOptions')
                 .returns(filteredOptions);
 
-            const findOneStub = sandbox.stub(models.Session, 'findOne')
+            const findOneStub = sinon.stub(models.Session, 'findOne')
                 .resolves();
 
-            const addStub = sandbox.stub(models.Session, 'add');
+            const addStub = sinon.stub(models.Session, 'add');
 
             models.Session.upsert(data, unfilteredOptions).then(() => {
                 should.equal(filterOptionsStub.args[0][0], unfilteredOptions);
@@ -201,13 +196,13 @@ describe('Unit: models/session', function () {
                 }
             };
 
-            const filterOptionsStub = sandbox.stub(models.Session, 'filterOptions')
+            const filterOptionsStub = sinon.stub(models.Session, 'filterOptions')
                 .returns(filteredOptions);
 
-            const findOneStub = sandbox.stub(models.Session, 'findOne')
+            const findOneStub = sinon.stub(models.Session, 'findOne')
                 .resolves(model);
 
-            const editStub = sandbox.stub(models.Session, 'edit');
+            const editStub = sinon.stub(models.Session, 'edit');
 
             models.Session.upsert(data, unfilteredOptions).then(() => {
                 should.equal(filterOptionsStub.args[0][0], unfilteredOptions);

--- a/core/test/unit/models/tag_spec.js
+++ b/core/test/unit/models/tag_spec.js
@@ -5,8 +5,6 @@ const models = require('../../../server/models');
 const testUtils = require('../../utils');
 const {knex} = require('../../../server/data/db');
 
-
-
 describe('Unit: models/tag', function () {
     before(function () {
         models.init();

--- a/core/test/unit/models/tag_spec.js
+++ b/core/test/unit/models/tag_spec.js
@@ -5,7 +5,7 @@ const models = require('../../../server/models');
 const testUtils = require('../../utils');
 const {knex} = require('../../../server/data/db');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: models/tag', function () {
     before(function () {
@@ -13,7 +13,7 @@ describe('Unit: models/tag', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('SQL', function () {
@@ -26,7 +26,7 @@ describe('Unit: models/tag', function () {
         });
 
         after(function () {
-            sandbox.restore();
+            sinon.restore();
         });
 
         after(function () {

--- a/core/test/unit/models/user_spec.js
+++ b/core/test/unit/models/user_spec.js
@@ -9,8 +9,7 @@ const should = require('should'),
     validation = require('../../../server/data/validation'),
     common = require('../../../server/lib/common'),
     security = require('../../../server/lib/security'),
-    testUtils = require('../../utils'),
-    sandbox = sinon.sandbox.create();
+    testUtils = require('../../utils');
 
 describe('Unit: models/user', function () {
     before(function () {
@@ -21,7 +20,7 @@ describe('Unit: models/user', function () {
     before(testUtils.setup('users:roles'));
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('updateLastSeen method', function () {
@@ -31,8 +30,8 @@ describe('Unit: models/user', function () {
 
         it('sets the last_seen property to new Date and returns a call to save', function () {
             const instance = {
-                set: sandbox.spy(),
-                save: sandbox.stub().resolves()
+                set: sinon.spy(),
+                save: sinon.stub().resolves()
             };
 
             const now = new Date();
@@ -52,7 +51,7 @@ describe('Unit: models/user', function () {
 
     describe('validation', function () {
         beforeEach(function () {
-            sandbox.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
+            sinon.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
         });
 
         describe('password', function () {
@@ -103,7 +102,7 @@ describe('Unit: models/user', function () {
 
             it('email cannot be blank', function () {
                 let data = {name: 'name'};
-                sandbox.stub(models.User, 'findOne').resolves(null);
+                sinon.stub(models.User, 'findOne').resolves(null);
 
                 return models.User.add(data)
                     .then(function () {
@@ -120,14 +119,14 @@ describe('Unit: models/user', function () {
 
     describe('fn: check', function () {
         beforeEach(function () {
-            sandbox.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
+            sinon.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
         });
 
         it('user status is warn', function () {
-            sandbox.stub(security.password, 'compare').resolves(true);
+            sinon.stub(security.password, 'compare').resolves(true);
 
             // NOTE: Add a user with a broken field to ensure we only validate changed fields on login
-            sandbox.stub(validation, 'validateSchema').resolves();
+            sinon.stub(validation, 'validateSchema').resolves();
 
             const user = testUtils.DataGenerator.forKnex.createUser({
                 status: 'warn-1',
@@ -144,13 +143,13 @@ describe('Unit: models/user', function () {
         });
 
         it('user status is active', function () {
-            sandbox.stub(security.password, 'compare').resolves(true);
+            sinon.stub(security.password, 'compare').resolves(true);
 
             return models.User.check({email: testUtils.DataGenerator.Content.users[1].email, password: 'test'});
         });
 
         it('password is incorrect', function () {
-            sandbox.stub(security.password, 'compare').resolves(false);
+            sinon.stub(security.password, 'compare').resolves(false);
 
             return models.User.check({email: testUtils.DataGenerator.Content.users[1].email, password: 'test'})
                 .catch(function (err) {
@@ -159,7 +158,7 @@ describe('Unit: models/user', function () {
         });
 
         it('user not found', function () {
-            sandbox.stub(security.password, 'compare').resolves(true);
+            sinon.stub(security.password, 'compare').resolves(true);
 
             return models.User.check({email: 'notfound@example.to', password: 'test'})
                 .catch(function (err) {
@@ -168,7 +167,7 @@ describe('Unit: models/user', function () {
         });
 
         it('user not found', function () {
-            sandbox.stub(security.password, 'compare').resolves(true);
+            sinon.stub(security.password, 'compare').resolves(true);
 
             return models.User.check({email: null, password: 'test'})
                 .catch(function (err) {
@@ -179,15 +178,15 @@ describe('Unit: models/user', function () {
 
     describe('permissible', function () {
         function getUserModel(id, role, roleId) {
-            var hasRole = sandbox.stub();
+            var hasRole = sinon.stub();
 
             hasRole.withArgs(role).returns(true);
 
             return {
                 id: id,
                 hasRole: hasRole,
-                related: sandbox.stub().returns([{name: role, id: roleId}]),
-                get: sandbox.stub().returns(id)
+                related: sinon.stub().returns([{name: role, id: roleId}]),
+                get: sinon.stub().returns(id)
             };
         }
 
@@ -225,12 +224,12 @@ describe('Unit: models/user', function () {
         });
 
         it('without related roles', function () {
-            sandbox.stub(models.User, 'findOne').withArgs({
+            sinon.stub(models.User, 'findOne').withArgs({
                 id: 3,
                 status: 'all'
             }, {withRelated: ['roles']}).resolves(getUserModel(3, 'Contributor'));
 
-            const mockUser = {id: 3, related: sandbox.stub().returns()};
+            const mockUser = {id: 3, related: sinon.stub().returns()};
             const context = {user: 3};
 
             return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true, true)
@@ -241,21 +240,21 @@ describe('Unit: models/user', function () {
 
         describe('change role', function () {
             function getUserToEdit(id, role) {
-                var hasRole = sandbox.stub();
+                var hasRole = sinon.stub();
 
                 hasRole.withArgs(role).returns(true);
 
                 return {
                     id: id,
                     hasRole: hasRole,
-                    related: sandbox.stub().returns([role]),
-                    get: sandbox.stub().returns(id)
+                    related: sinon.stub().returns([role]),
+                    get: sinon.stub().returns(id)
                 };
             }
 
             beforeEach(function () {
-                sandbox.stub(models.User, 'getOwnerUser');
-                sandbox.stub(permissions, 'canThis');
+                sinon.stub(models.User, 'getOwnerUser');
+                sinon.stub(permissions, 'canThis');
 
                 models.User.getOwnerUser.resolves({
                     id: testUtils.context.owner.context.user,
@@ -311,7 +310,7 @@ describe('Unit: models/user', function () {
 
                 permissions.canThis.returns({
                     assign: {
-                        role: sandbox.stub().resolves()
+                        role: sinon.stub().resolves()
                     }
                 });
 
@@ -329,7 +328,7 @@ describe('Unit: models/user', function () {
 
                 permissions.canThis.returns({
                     assign: {
-                        role: sandbox.stub().resolves()
+                        role: sinon.stub().resolves()
                     }
                 });
 
@@ -470,7 +469,7 @@ describe('Unit: models/user', function () {
         });
 
         after(function () {
-            sandbox.restore();
+            sinon.restore();
         });
 
         it('ensure data type', function () {
@@ -490,7 +489,7 @@ describe('Unit: models/user', function () {
         });
 
         after(function () {
-            sandbox.restore();
+            sinon.restore();
         });
 
         it('resets given empty value to null', function () {
@@ -517,13 +516,13 @@ describe('Unit: models/user', function () {
         before(function () {
             models.init();
 
-            sandbox.stub(models.User.prototype, 'emitChange').callsFake(function (event) {
+            sinon.stub(models.User.prototype, 'emitChange').callsFake(function (event) {
                 events.user.push({event: event, data: this.toJSON()});
             });
         });
 
         after(function () {
-            sandbox.restore();
+            sinon.restore();
         });
 
         it('defaults', function () {
@@ -550,9 +549,9 @@ describe('Unit: models/user', function () {
         let ownerRole;
 
         beforeEach(function () {
-            ownerRole = sandbox.stub();
+            ownerRole = sinon.stub();
 
-            sandbox.stub(models.Role, 'findOne');
+            sinon.stub(models.Role, 'findOne');
 
             models.Role.findOne
                 .withArgs({name: 'Owner'})
@@ -562,15 +561,15 @@ describe('Unit: models/user', function () {
                 .withArgs({name: 'Administrator'})
                 .resolves(testUtils.permissions.admin.user.roles[0]);
 
-            sandbox.stub(models.User, 'findOne');
+            sinon.stub(models.User, 'findOne');
         });
 
         it('Cannot transfer ownership if not owner', function () {
             const loggedInUser = testUtils.context.admin;
             const userToChange = loggedInUser;
-            const contextUser = sandbox.stub();
+            const contextUser = sinon.stub();
 
-            contextUser.toJSON = sandbox.stub().returns(testUtils.permissions.admin.user);
+            contextUser.toJSON = sinon.stub().returns(testUtils.permissions.admin.user);
 
             models.User
                 .findOne
@@ -587,9 +586,9 @@ describe('Unit: models/user', function () {
         it('Owner tries to transfer ownership to author', function () {
             const loggedInUser = testUtils.context.owner;
             const userToChange = testUtils.context.editor;
-            const contextUser = sandbox.stub();
+            const contextUser = sinon.stub();
 
-            contextUser.toJSON = sandbox.stub().returns(testUtils.permissions.owner.user);
+            contextUser.toJSON = sinon.stub().returns(testUtils.permissions.owner.user);
 
             models.User
                 .findOne
@@ -611,7 +610,7 @@ describe('Unit: models/user', function () {
 
     describe('isSetup', function () {
         it('active', function () {
-            sandbox.stub(models.User, 'getOwnerUser').resolves({get: sandbox.stub().returns('active')});
+            sinon.stub(models.User, 'getOwnerUser').resolves({get: sinon.stub().returns('active')});
 
             return models.User.isSetup()
                 .then((result) => {
@@ -620,7 +619,7 @@ describe('Unit: models/user', function () {
         });
 
         it('inactive', function () {
-            sandbox.stub(models.User, 'getOwnerUser').resolves({get: sandbox.stub().returns('inactive')});
+            sinon.stub(models.User, 'getOwnerUser').resolves({get: sinon.stub().returns('inactive')});
 
             return models.User.isSetup()
                 .then((result) => {

--- a/core/test/unit/models/webhook_spec.js
+++ b/core/test/unit/models/webhook_spec.js
@@ -5,14 +5,14 @@ const models = require('../../../server/models');
 const testUtils = require('../../utils');
 const {knex} = require('../../../server/data/db');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: models/webhooks', function () {
     before(function () {
         models.init();
     });
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     before(testUtils.teardown);

--- a/core/test/unit/models/webhook_spec.js
+++ b/core/test/unit/models/webhook_spec.js
@@ -5,8 +5,6 @@ const models = require('../../../server/models');
 const testUtils = require('../../utils');
 const {knex} = require('../../../server/data/db');
 
-
-
 describe('Unit: models/webhooks', function () {
     before(function () {
         models.init();

--- a/core/test/unit/services/apps/dependencies_spec.js
+++ b/core/test/unit/services/apps/dependencies_spec.js
@@ -4,13 +4,11 @@ var should = require('should'),
     _ = require('lodash'),
 
     // Stuff we are testing
-    AppDependencies = require('../../../../server/services/apps/dependencies'),
-
-    sandbox = sinon.sandbox.create();
+    AppDependencies = require('../../../../server/services/apps/dependencies');
 
 describe('Apps', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Dependencies', function () {
@@ -18,7 +16,7 @@ describe('Apps', function () {
             var deps = new AppDependencies(process.cwd()),
                 fakeEmitter = new EventEmitter();
 
-            deps.spawnCommand = sandbox.stub().returns(fakeEmitter);
+            deps.spawnCommand = sinon.stub().returns(fakeEmitter);
 
             deps.install().then(function () {
                 deps.spawnCommand.calledWith('npm').should.equal(true);
@@ -33,7 +31,7 @@ describe('Apps', function () {
             var deps = new AppDependencies(__dirname),
                 fakeEmitter = new EventEmitter();
 
-            deps.spawnCommand = sandbox.stub().returns(fakeEmitter);
+            deps.spawnCommand = sinon.stub().returns(fakeEmitter);
 
             deps.install().then(function () {
                 deps.spawnCommand.called.should.equal(false);

--- a/core/test/unit/services/apps/lifecycle_spec.js
+++ b/core/test/unit/services/apps/lifecycle_spec.js
@@ -7,9 +7,7 @@ var should = require('should'),
 
     // Stuff we are testing
     AppLoader = require('../../../../server/services/apps/loader'),
-    AppIndex = require('../../../../server/services/apps'),
-
-    sandbox = sinon.sandbox.create();
+    AppIndex = require('../../../../server/services/apps');
 
 describe('Apps', function () {
     var settingsCacheStub,
@@ -18,18 +16,18 @@ describe('Apps', function () {
         loaderInstallStub;
 
     beforeEach(function () {
-        settingsCacheStub = sandbox.stub(settingsCache, 'get');
-        settingsEditStub = sandbox.stub(api.settings, 'edit');
-        loaderActivateStub = sandbox.stub(AppLoader, 'activateAppByName').callsFake(function (appName) {
+        settingsCacheStub = sinon.stub(settingsCache, 'get');
+        settingsEditStub = sinon.stub(api.settings, 'edit');
+        loaderActivateStub = sinon.stub(AppLoader, 'activateAppByName').callsFake(function (appName) {
             return new Promise.resolve(appName);
         });
-        loaderInstallStub = sandbox.stub(AppLoader, 'installAppByName').callsFake(function (appName) {
+        loaderInstallStub = sinon.stub(AppLoader, 'installAppByName').callsFake(function (appName) {
             return new Promise.resolve(appName);
         });
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('will activate, but not install, internal apps', function (done) {

--- a/core/test/unit/services/apps/permissions_spec.js
+++ b/core/test/unit/services/apps/permissions_spec.js
@@ -4,13 +4,11 @@ var should = require('should'),
     Promise = require('bluebird'),
 
     // Stuff we are testing
-    AppPermissions = require('../../../../server/services/apps/permissions'),
-
-    sandbox = sinon.sandbox.create();
+    AppPermissions = require('../../../../server/services/apps/permissions');
 
 describe('Apps', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Permissions', function () {
@@ -65,7 +63,7 @@ describe('Apps', function () {
             var perms = new AppPermissions('test');
 
             // No package.json in this directory
-            sandbox.stub(perms, 'checkPackageContentsExists').returns(Promise.resolve(false));
+            sinon.stub(perms, 'checkPackageContentsExists').returns(Promise.resolve(false));
 
             perms.read().then(function (readPerms) {
                 should.exist(readPerms);
@@ -80,9 +78,9 @@ describe('Apps', function () {
                 noGhostPackageJsonContents = JSON.stringify(noGhostPackageJson, null, 2);
 
             // package.json IS in this directory
-            sandbox.stub(perms, 'checkPackageContentsExists').returns(Promise.resolve(true));
+            sinon.stub(perms, 'checkPackageContentsExists').returns(Promise.resolve(true));
             // no ghost property on package
-            sandbox.stub(perms, 'getPackageContents').returns(Promise.resolve(noGhostPackageJsonContents));
+            sinon.stub(perms, 'getPackageContents').returns(Promise.resolve(noGhostPackageJsonContents));
 
             perms.read().then(function (readPerms) {
                 should.exist(readPerms);
@@ -96,9 +94,9 @@ describe('Apps', function () {
             var perms = new AppPermissions('test');
 
             // package.json IS in this directory
-            sandbox.stub(perms, 'checkPackageContentsExists').returns(Promise.resolve(true));
+            sinon.stub(perms, 'checkPackageContentsExists').returns(Promise.resolve(true));
             // malformed JSON on package
-            sandbox.stub(perms, 'getPackageContents').returns(Promise.reject(new Error('package.json file is malformed')));
+            sinon.stub(perms, 'getPackageContents').returns(Promise.reject(new Error('package.json file is malformed')));
 
             perms.read().then(function (readPerms) {
                 done(new Error('should not resolve'));
@@ -112,9 +110,9 @@ describe('Apps', function () {
                 validGhostPackageJsonContents = validGhostPackageJson;
 
             // package.json IS in this directory
-            sandbox.stub(perms, 'checkPackageContentsExists').returns(Promise.resolve(true));
+            sinon.stub(perms, 'checkPackageContentsExists').returns(Promise.resolve(true));
             // valid ghost property on package
-            sandbox.stub(perms, 'getPackageContents').returns(Promise.resolve(validGhostPackageJsonContents));
+            sinon.stub(perms, 'getPackageContents').returns(Promise.resolve(validGhostPackageJsonContents));
 
             perms.read().then(function (readPerms) {
                 should.exist(readPerms);

--- a/core/test/unit/services/apps/proxy_spec.js
+++ b/core/test/unit/services/apps/proxy_spec.js
@@ -3,8 +3,7 @@ const should = require('should'),
     helpers = require('../../../../server/helpers/register'),
     filters = require('../../../../server/filters'),
     AppProxy = require('../../../../server/services/apps/proxy'),
-    routing = require('../../../../server/services/routing'),
-    sandbox = sinon.sandbox.create();
+    routing = require('../../../../server/services/routing');
 
 describe('Apps', function () {
     var fakeApi;
@@ -12,38 +11,38 @@ describe('Apps', function () {
     beforeEach(function () {
         fakeApi = {
             posts: {
-                browse: sandbox.stub(),
-                read: sandbox.stub(),
-                edit: sandbox.stub(),
-                add: sandbox.stub(),
-                destroy: sandbox.stub()
+                browse: sinon.stub(),
+                read: sinon.stub(),
+                edit: sinon.stub(),
+                add: sinon.stub(),
+                destroy: sinon.stub()
             },
             users: {
-                browse: sandbox.stub(),
-                read: sandbox.stub(),
-                edit: sandbox.stub()
+                browse: sinon.stub(),
+                read: sinon.stub(),
+                edit: sinon.stub()
             },
             tags: {
-                all: sandbox.stub()
+                all: sinon.stub()
             },
             notifications: {
-                destroy: sandbox.stub(),
-                add: sandbox.stub()
+                destroy: sinon.stub(),
+                add: sinon.stub()
             },
             settings: {
-                browse: sandbox.stub(),
-                read: sandbox.stub(),
-                add: sandbox.stub()
+                browse: sinon.stub(),
+                read: sinon.stub(),
+                add: sinon.stub()
             }
         };
 
-        sandbox.stub(routing.registry, 'getRouter').withArgs('appRouter').returns({
-            mountRouter: sandbox.stub()
+        sinon.stub(routing.registry, 'getRouter').withArgs('appRouter').returns({
+            mountRouter: sinon.stub()
         });
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Proxy', function () {
@@ -109,7 +108,7 @@ describe('Apps', function () {
         });
 
         it('allows filter registration with permission', function (done) {
-            var registerSpy = sandbox.spy(filters, 'registerFilter'),
+            var registerSpy = sinon.spy(filters, 'registerFilter'),
                 appProxy = new AppProxy({
                     name: 'TestApp',
                     permissions: {
@@ -119,7 +118,7 @@ describe('Apps', function () {
                     }
                 }),
                 fakePosts = [{id: 0}, {id: 1}],
-                filterStub = sandbox.spy(function (val) {
+                filterStub = sinon.spy(function (val) {
                     return val;
                 });
 
@@ -139,7 +138,7 @@ describe('Apps', function () {
         });
 
         it('does not allow filter registration without permission', function () {
-            var registerSpy = sandbox.spy(filters, 'registerFilter'),
+            var registerSpy = sinon.spy(filters, 'registerFilter'),
                 appProxy = new AppProxy({
                     name: 'TestApp',
                     permissions: {
@@ -148,7 +147,7 @@ describe('Apps', function () {
                         posts: ['browse', 'read', 'edit', 'add', 'delete']
                     }
                 }),
-                filterStub = sandbox.stub().returns('test result');
+                filterStub = sinon.stub().returns('test result');
 
             function registerFilterWithoutPermission() {
                 appProxy.filters.register('superSecretFilter', 5, filterStub);
@@ -161,7 +160,7 @@ describe('Apps', function () {
         });
 
         it('allows filter deregistration with permission', function (done) {
-            var registerSpy = sandbox.spy(filters, 'deregisterFilter'),
+            var registerSpy = sinon.spy(filters, 'deregisterFilter'),
                 appProxy = new AppProxy({
                     name: 'TestApp',
                     permissions: {
@@ -171,7 +170,7 @@ describe('Apps', function () {
                     }
                 }),
                 fakePosts = [{id: 0}, {id: 1}],
-                filterStub = sandbox.stub().returns(fakePosts);
+                filterStub = sinon.stub().returns(fakePosts);
 
             appProxy.filters.deregister('prePostsRender', 5, filterStub);
 
@@ -188,7 +187,7 @@ describe('Apps', function () {
         });
 
         it('does not allow filter deregistration without permission', function () {
-            var registerSpy = sandbox.spy(filters, 'deregisterFilter'),
+            var registerSpy = sinon.spy(filters, 'deregisterFilter'),
                 appProxy = new AppProxy({
                     name: 'TestApp',
                     permissions: {
@@ -197,7 +196,7 @@ describe('Apps', function () {
                         posts: ['browse', 'read', 'edit', 'add', 'delete']
                     }
                 }),
-                filterStub = sandbox.stub().returns('test result');
+                filterStub = sinon.stub().returns('test result');
 
             function deregisterFilterWithoutPermission() {
                 appProxy.filters.deregister('superSecretFilter', 5, filterStub);
@@ -210,7 +209,7 @@ describe('Apps', function () {
         });
 
         it('allows helper registration with permission', function () {
-            var registerSpy = sandbox.stub(helpers, 'registerThemeHelper'),
+            var registerSpy = sinon.stub(helpers, 'registerThemeHelper'),
                 appProxy = new AppProxy({
                     name: 'TestApp',
                     permissions: {
@@ -220,13 +219,13 @@ describe('Apps', function () {
                     }
                 });
 
-            appProxy.helpers.register('myTestHelper', sandbox.stub().returns('test result'));
+            appProxy.helpers.register('myTestHelper', sinon.stub().returns('test result'));
 
             registerSpy.called.should.equal(true);
         });
 
         it('does not allow helper registration without permission', function () {
-            var registerSpy = sandbox.stub(helpers, 'registerThemeHelper'),
+            var registerSpy = sinon.stub(helpers, 'registerThemeHelper'),
                 appProxy = new AppProxy({
                     name: 'TestApp',
                     permissions: {
@@ -237,7 +236,7 @@ describe('Apps', function () {
                 });
 
             function registerWithoutPermissions() {
-                appProxy.helpers.register('otherHelper', sandbox.stub().returns('test result'));
+                appProxy.helpers.register('otherHelper', sinon.stub().returns('test result'));
             }
 
             registerWithoutPermissions.should.throw('The App "TestApp" attempted to perform an action or access a ' +
@@ -247,7 +246,7 @@ describe('Apps', function () {
         });
 
         it('does allow INTERNAL app to register helper without permission', function () {
-            var registerSpy = sandbox.stub(helpers, 'registerThemeHelper'),
+            var registerSpy = sinon.stub(helpers, 'registerThemeHelper'),
                 appProxy = new AppProxy({
                     name: 'TestApp',
                     permissions: {},
@@ -255,7 +254,7 @@ describe('Apps', function () {
                 });
 
             function registerWithoutPermissions() {
-                appProxy.helpers.register('otherHelper', sandbox.stub().returns('test result'));
+                appProxy.helpers.register('otherHelper', sinon.stub().returns('test result'));
             }
 
             registerWithoutPermissions.should.not.throw('The App "TestApp" attempted to perform an action or access a ' +

--- a/core/test/unit/services/apps/sandbox_spec.js
+++ b/core/test/unit/services/apps/sandbox_spec.js
@@ -1,24 +1,23 @@
 const should = require('should'),
     sinon = require('sinon'),
     path = require('path'),
-    AppSandbox = require('../../../../server/services/apps/sandbox'),
-    sandbox = sinon.sandbox.create();
+    AppSandbox = require('../../../../server/services/apps/sandbox');
 
 describe('Apps', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
-    describe('Sandbox', function () {
+    describe('sinon', function () {
         function makeAppPath(fileName) {
             return path.resolve(__dirname, '..', '..', '..', 'utils', 'fixtures', 'app', fileName);
         }
 
-        it('loads apps in a sandbox', function () {
+        it('loads apps in a sinon', function () {
             var appBox = new AppSandbox(),
                 appPath = makeAppPath('good.js'),
                 GoodApp,
-                appProxy = sandbox.stub(),
+                appProxy = sinon.stub(),
                 app;
 
             GoodApp = appBox.loadApp(appPath);
@@ -49,7 +48,7 @@ describe('Apps', function () {
             var appBox = new AppSandbox(),
                 badAppPath = makeAppPath('badinstall.js'),
                 BadApp,
-                appProxy = sandbox.stub(),
+                appProxy = sinon.stub(),
                 app,
                 installApp = function () {
                     app.install(appProxy);

--- a/core/test/unit/services/auth/api-key/admin_spec.js
+++ b/core/test/unit/services/auth/api-key/admin_spec.js
@@ -7,7 +7,7 @@ const common = require('../../../../../server/lib/common');
 const models = require('../../../../../server/models');
 const testUtils = require('../../../../utils');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Admin API Key Auth', function () {
     before(models.init);
@@ -25,13 +25,13 @@ describe('Admin API Key Auth', function () {
         this.fakeApiKey = fakeApiKey;
         this.secret = Buffer.from(fakeApiKey.secret, 'hex');
 
-        this.apiKeyStub = sandbox.stub(models.ApiKey, 'findOne');
+        this.apiKeyStub = sinon.stub(models.ApiKey, 'findOne');
         this.apiKeyStub.resolves();
         this.apiKeyStub.withArgs({id: fakeApiKey.id}).resolves(fakeApiKey);
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should authenticate known+valid API key', function (done) {

--- a/core/test/unit/services/auth/api-key/admin_spec.js
+++ b/core/test/unit/services/auth/api-key/admin_spec.js
@@ -7,8 +7,6 @@ const common = require('../../../../../server/lib/common');
 const models = require('../../../../../server/models');
 const testUtils = require('../../../../utils');
 
-
-
 describe('Admin API Key Auth', function () {
     before(models.init);
     before(testUtils.teardown);

--- a/core/test/unit/services/auth/api-key/content_spec.js
+++ b/core/test/unit/services/auth/api-key/content_spec.js
@@ -5,8 +5,6 @@ const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
 
-
-
 describe('Content API Key Auth', function () {
     before(models.init);
     before(testUtils.teardown);

--- a/core/test/unit/services/auth/api-key/content_spec.js
+++ b/core/test/unit/services/auth/api-key/content_spec.js
@@ -5,7 +5,7 @@ const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Content API Key Auth', function () {
     before(models.init);
@@ -22,13 +22,13 @@ describe('Content API Key Auth', function () {
         };
         this.fakeApiKey = fakeApiKey;
 
-        this.apiKeyStub = sandbox.stub(models.ApiKey, 'findOne');
+        this.apiKeyStub = sinon.stub(models.ApiKey, 'findOne');
         this.apiKeyStub.returns(new Promise.resolve());
         this.apiKeyStub.withArgs({secret: fakeApiKey.secret}).returns(new Promise.resolve(fakeApiKey));
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should authenticate with known+valid key', function (done) {

--- a/core/test/unit/services/auth/auth-strategies_spec.js
+++ b/core/test/unit/services/auth/auth-strategies_spec.js
@@ -9,8 +9,6 @@ var should = require('should'),
     security = require('../../../../server/lib/security'),
     constants = require('../../../../server/lib/constants'),
 
-    sandbox = sinon.sandbox.create(),
-
     fakeClient = {
         slug: 'ghost-admin',
         secret: 'not_available',
@@ -39,18 +37,18 @@ describe('Auth Strategies', function () {
     });
 
     beforeEach(function () {
-        next = sandbox.spy();
+        next = sinon.spy();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Client Password Strategy', function () {
         var clientStub;
 
         beforeEach(function () {
-            clientStub = sandbox.stub(Models.Client, 'findOne');
+            clientStub = sinon.stub(Models.Client, 'findOne');
             clientStub.returns(new Promise.resolve());
             clientStub.withArgs({slug: fakeClient.slug}).returns(new Promise.resolve({
                 toJSON: function () {
@@ -118,7 +116,7 @@ describe('Auth Strategies', function () {
         var tokenStub, userStub, userIsActive;
 
         beforeEach(function () {
-            tokenStub = sandbox.stub(Models.Accesstoken, 'findOne');
+            tokenStub = sinon.stub(Models.Accesstoken, 'findOne');
             tokenStub.returns(new Promise.resolve());
             tokenStub.withArgs({token: fakeValidToken.token}).returns(new Promise.resolve({
                 toJSON: function () {
@@ -132,7 +130,7 @@ describe('Auth Strategies', function () {
                 }
             }));
 
-            userStub = sandbox.stub(Models.User, 'findOne');
+            userStub = sinon.stub(Models.User, 'findOne');
             userStub.returns(new Promise.resolve());
             userStub.withArgs({id: 3}).returns(new Promise.resolve({
                 toJSON: function () {
@@ -230,10 +228,10 @@ describe('Auth Strategies', function () {
         var inviteFindOneStub, userAddStub, userEditStub, userFindOneStub;
 
         beforeEach(function () {
-            userFindOneStub = sandbox.stub(Models.User, 'findOne');
-            userAddStub = sandbox.stub(Models.User, 'add');
-            userEditStub = sandbox.stub(Models.User, 'edit');
-            inviteFindOneStub = sandbox.stub(Models.Invite, 'findOne');
+            userFindOneStub = sinon.stub(Models.User, 'findOne');
+            userAddStub = sinon.stub(Models.User, 'add');
+            userEditStub = sinon.stub(Models.User, 'edit');
+            inviteFindOneStub = sinon.stub(Models.Invite, 'findOne');
         });
 
         it('with invite, but with wrong invite token', function (done) {
@@ -286,7 +284,7 @@ describe('Auth Strategies', function () {
                     role_id: '2'
                 });
 
-            sandbox.stub(security.identifier, 'uid').returns('12345678');
+            sinon.stub(security.identifier, 'uid').returns('12345678');
 
             userFindOneStub.returns(Promise.resolve(null));
 
@@ -303,7 +301,7 @@ describe('Auth Strategies', function () {
 
             userEditStub.returns(Promise.resolve(invitedUser));
             inviteFindOneStub.returns(Promise.resolve(inviteModel));
-            sandbox.stub(inviteModel, 'destroy').returns(Promise.resolve());
+            sinon.stub(inviteModel, 'destroy').returns(Promise.resolve());
 
             authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, invitedProfile, function (err, user, profile) {
                 should.not.exist(err);

--- a/core/test/unit/services/auth/authenticate_spec.js
+++ b/core/test/unit/services/auth/authenticate_spec.js
@@ -15,7 +15,7 @@ const client = {
     id: 2,
     type: 'ua'
 };
-const sandbox = sinon.sandbox.create();
+
 
 function registerSuccessfulBearerStrategy() {
     // register fake BearerStrategy which always authenticates
@@ -90,12 +90,12 @@ describe('Auth', function () {
     beforeEach(function () {
         req = {};
         res = {};
-        next = sandbox.spy();
-        loggingStub = sandbox.stub(common.logging, 'error');
+        next = sinon.spy();
+        loggingStub = sinon.stub(common.logging, 'error');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should require authorized user (user exists)', function (done) {

--- a/core/test/unit/services/auth/authenticate_spec.js
+++ b/core/test/unit/services/auth/authenticate_spec.js
@@ -16,7 +16,6 @@ const client = {
     type: 'ua'
 };
 
-
 function registerSuccessfulBearerStrategy() {
     // register fake BearerStrategy which always authenticates
     passport.use(new BearerStrategy(

--- a/core/test/unit/services/auth/oauth_spec.js
+++ b/core/test/unit/services/auth/oauth_spec.js
@@ -7,9 +7,7 @@ var should = require('should'),
     authUtils = require('../../../../server/services/auth/utils'),
     spamPrevention = require('../../../../server/web/shared/middlewares/api/spam-prevention'),
     common = require('../../../../server/lib/common'),
-    models = require('../../../../server/models'),
-
-    sandbox = sinon.sandbox.create();
+    models = require('../../../../server/models');
 
 describe('OAuth', function () {
     var next, req, res;
@@ -21,20 +19,20 @@ describe('OAuth', function () {
     beforeEach(function () {
         req = {};
         res = {};
-        next = sandbox.spy();
+        next = sinon.spy();
 
-        sandbox.stub(spamPrevention.userLogin(), 'reset');
+        sinon.stub(spamPrevention.userLogin(), 'reset');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Generate Token from Password', function () {
         beforeEach(function () {
-            sandbox.stub(models.Accesstoken, 'destroyAllExpired')
+            sinon.stub(models.Accesstoken, 'destroyAllExpired')
                 .returns(new Promise.resolve());
-            sandbox.stub(models.Refreshtoken, 'destroyAllExpired')
+            sinon.stub(models.Refreshtoken, 'destroyAllExpired')
                 .returns(new Promise.resolve());
             oAuth.init();
         });
@@ -59,22 +57,22 @@ describe('OAuth', function () {
             res.end = function () {
             };
 
-            sandbox.stub(models.User, 'check')
+            sinon.stub(models.User, 'check')
                 .withArgs({email: 'username', password: 'password'}).returns(Promise.resolve({
                 id: 1
             }));
 
-            sandbox.stub(authUtils, 'createTokens')
+            sinon.stub(authUtils, 'createTokens')
                 .returns(Promise.resolve({
                     access_token: 'AT',
                     refresh_token: 'RT',
                     expires_in: Date.now() + 1000
                 }));
 
-            sandbox.stub(res, 'setHeader').callsFake(function () {
+            sinon.stub(res, 'setHeader').callsFake(function () {
             });
 
-            sandbox.stub(res, 'end').callsFake(function (json) {
+            sinon.stub(res, 'end').callsFake(function (json) {
                 try {
                     should.exist(json);
                     json = JSON.parse(json);
@@ -160,12 +158,12 @@ describe('OAuth', function () {
             res.setHeader = {};
             res.end = {};
 
-            sandbox.stub(models.User, 'check')
+            sinon.stub(models.User, 'check')
                 .withArgs({email: 'username', password: 'password'}).returns(new Promise.resolve({
                 id: 1
             }));
 
-            sandbox.stub(authUtils, 'createTokens')
+            sinon.stub(authUtils, 'createTokens')
                 .returns(new Promise.reject({
                     message: 'DB error'
                 }));
@@ -179,9 +177,9 @@ describe('OAuth', function () {
 
     describe('Generate Token from Refreshtoken', function () {
         beforeEach(function () {
-            sandbox.stub(models.Accesstoken, 'destroyAllExpired')
+            sinon.stub(models.Accesstoken, 'destroyAllExpired')
                 .returns(new Promise.resolve());
-            sandbox.stub(models.Refreshtoken, 'destroyAllExpired')
+            sinon.stub(models.Refreshtoken, 'destroyAllExpired')
                 .returns(new Promise.resolve());
 
             oAuth.init();
@@ -201,7 +199,7 @@ describe('OAuth', function () {
             res.end = function () {
             };
 
-            sandbox.stub(models.Refreshtoken, 'findOne')
+            sinon.stub(models.Refreshtoken, 'findOne')
                 .withArgs({token: 'token'}).returns(new Promise.resolve({
                 toJSON: function () {
                     return {
@@ -210,17 +208,17 @@ describe('OAuth', function () {
                 }
             }));
 
-            sandbox.stub(authUtils, 'createTokens')
+            sinon.stub(authUtils, 'createTokens')
                 .returns(new Promise.resolve({
                     access_token: 'AT',
                     refresh_token: 'RT',
                     expires_in: Date.now() + 1000
                 }));
 
-            sandbox.stub(res, 'setHeader').callsFake(function () {
+            sinon.stub(res, 'setHeader').callsFake(function () {
             });
 
-            sandbox.stub(res, 'end').callsFake(function (json) {
+            sinon.stub(res, 'end').callsFake(function (json) {
                 try {
                     should.exist(json);
                     json = JSON.parse(json);
@@ -249,7 +247,7 @@ describe('OAuth', function () {
             res.setHeader = {};
             res.end = {};
 
-            sandbox.stub(models.Refreshtoken, 'findOne')
+            sinon.stub(models.Refreshtoken, 'findOne')
                 .withArgs({token: 'token'}).returns(new Promise.resolve());
 
             oAuth.generateAccessToken(req, res, function (err) {
@@ -270,7 +268,7 @@ describe('OAuth', function () {
             res.setHeader = {};
             res.end = {};
 
-            sandbox.stub(models.Refreshtoken, 'findOne')
+            sinon.stub(models.Refreshtoken, 'findOne')
                 .withArgs({token: 'token'}).returns(new Promise.resolve({
                 toJSON: function () {
                     return {
@@ -297,7 +295,7 @@ describe('OAuth', function () {
             res.setHeader = {};
             res.end = {};
 
-            sandbox.stub(models.Refreshtoken, 'findOne')
+            sinon.stub(models.Refreshtoken, 'findOne')
                 .withArgs({token: 'token'}).returns(new Promise.resolve({
                 toJSON: function () {
                     return {
@@ -306,7 +304,7 @@ describe('OAuth', function () {
                 }
             }));
 
-            sandbox.stub(authUtils, 'createTokens').callsFake(function () {
+            sinon.stub(authUtils, 'createTokens').callsFake(function () {
                 return Promise.reject(new Error('DB error'));
             });
 
@@ -319,10 +317,10 @@ describe('OAuth', function () {
 
     describe('Generate Token from Authorization Code', function () {
         beforeEach(function () {
-            sandbox.stub(models.Accesstoken, 'destroyAllExpired')
+            sinon.stub(models.Accesstoken, 'destroyAllExpired')
                 .returns(new Promise.resolve());
 
-            sandbox.stub(models.Refreshtoken, 'destroyAllExpired')
+            sinon.stub(models.Refreshtoken, 'destroyAllExpired')
                 .returns(new Promise.resolve());
 
             oAuth.init();
@@ -348,14 +346,14 @@ describe('OAuth', function () {
                 done();
             };
 
-            sandbox.stub(authUtils, 'createTokens')
+            sinon.stub(authUtils, 'createTokens')
                 .returns(new Promise.resolve({
                     access_token: 'access-token',
                     refresh_token: 'refresh-token',
                     expires_in: 10
                 }));
 
-            sandbox.stub(passport, 'authenticate').callsFake(function (name, options, onSuccess) {
+            sinon.stub(passport, 'authenticate').callsFake(function (name, options, onSuccess) {
                 return function () {
                     onSuccess(null, user);
                 };
@@ -376,7 +374,7 @@ describe('OAuth', function () {
             req.body.grant_type = 'authorization_code';
             req.body.authorizationCode = '1234';
 
-            sandbox.stub(passport, 'authenticate').callsFake(function (name, options, onSuccess) {
+            sinon.stub(passport, 'authenticate').callsFake(function (name, options, onSuccess) {
                 return function () {
                     onSuccess(new common.errors.UnauthorizedError());
                 };

--- a/core/test/unit/services/auth/passport_spec.js
+++ b/core/test/unit/services/auth/passport_spec.js
@@ -1,16 +1,15 @@
 var should = require('should'),
     sinon = require('sinon'),
     passport = require('passport'),
-    ghostPassport = require('../../../../server/services/auth/passport'),
-    sandbox = sinon.sandbox.create();
+    ghostPassport = require('../../../../server/services/auth/passport');
 
 describe('Ghost Passport', function () {
     beforeEach(function () {
-        sandbox.spy(passport, 'use');
+        sinon.spy(passport, 'use');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('[default] local auth', function () {

--- a/core/test/unit/services/auth/session/middleware_spec.js
+++ b/core/test/unit/services/auth/session/middleware_spec.js
@@ -9,14 +9,13 @@ const {
 } = require('../../../../../server/lib/common/errors');
 
 describe('Session Service', function () {
-    let sandbox;
+    
     before(function () {
         models.init();
-        sandbox = sinon.sandbox.create();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     const fakeReq = function fakeReq() {
@@ -38,7 +37,7 @@ describe('Session Service', function () {
     describe('createSession', function () {
         it('calls next with a BadRequestError if there is no Origin or Refferer', function (done) {
             const req = fakeReq();
-            sandbox.stub(req, 'get')
+            sinon.stub(req, 'get')
                 .withArgs('origin').returns('')
                 .withArgs('referrer').returns('');
 
@@ -52,7 +51,7 @@ describe('Session Service', function () {
             const req = fakeReq();
             const res = fakeRes();
 
-            sandbox.stub(req, 'get')
+            sinon.stub(req, 'get')
                 .withArgs('user-agent').returns('')
                 .withArgs('origin').returns('')
                 .withArgs('referrer').returns('http://ghost.org/path');
@@ -60,7 +59,7 @@ describe('Session Service', function () {
             req.ip = '127.0.0.1';
             req.user = models.User.forge({id: 23});
 
-            sandbox.stub(res, 'sendStatus')
+            sinon.stub(res, 'sendStatus')
                 .callsFake(function (statusCode) {
                     should.equal(req.session.origin, 'http://ghost.org');
                     done();
@@ -73,14 +72,14 @@ describe('Session Service', function () {
             const req = fakeReq();
             const res = fakeRes();
 
-            sandbox.stub(req, 'get')
+            sinon.stub(req, 'get')
                 .withArgs('origin').returns('http://host.tld')
                 .withArgs('user-agent').returns('bububang');
 
             req.ip = '127.0.0.1';
             req.user = models.User.forge({id: 23});
 
-            sandbox.stub(res, 'sendStatus')
+            sinon.stub(res, 'sendStatus')
                 .callsFake(function (statusCode) {
                     should.equal(req.session.user_id, 23);
                     should.equal(req.session.origin, 'http://host.tld');
@@ -98,7 +97,7 @@ describe('Session Service', function () {
         it('calls req.session.destroy', function () {
             const req = fakeReq();
             const res = fakeRes();
-            const destroyStub = sandbox.stub(req.session, 'destroy');
+            const destroyStub = sinon.stub(req.session, 'destroy');
 
             sessionMiddleware.destroySession(req, res);
 
@@ -108,7 +107,7 @@ describe('Session Service', function () {
         it('calls next with InternalServerError if destroy errors', function (done) {
             const req = fakeReq();
             const res = fakeRes();
-            sandbox.stub(req.session, 'destroy')
+            sinon.stub(req.session, 'destroy')
                 .callsFake(function (fn) {
                     fn(new Error('oops'));
                 });
@@ -122,11 +121,11 @@ describe('Session Service', function () {
         it('calls sendStatus with 204 if destroy does not error', function (done) {
             const req = fakeReq();
             const res = fakeRes();
-            sandbox.stub(req.session, 'destroy')
+            sinon.stub(req.session, 'destroy')
                 .callsFake(function (fn) {
                     fn();
                 });
-            sandbox.stub(res, 'sendStatus')
+            sinon.stub(res, 'sendStatus')
                 .callsFake(function (status) {
                     should.equal(status, 204);
                     done();
@@ -148,7 +147,7 @@ describe('Session Service', function () {
         it('calls next if req origin matches the session origin', function (done) {
             const req = fakeReq();
             const res = fakeRes();
-            sandbox.stub(req, 'get')
+            sinon.stub(req, 'get')
                 .withArgs('origin').returns('http://host.tld');
             req.session.origin = 'http://host.tld';
 
@@ -159,7 +158,7 @@ describe('Session Service', function () {
         it('calls next with BadRequestError if the origin of req does not match the session', function (done) {
             const req = fakeReq();
             const res = fakeRes();
-            sandbox.stub(req, 'get')
+            sinon.stub(req, 'get')
                 .withArgs('origin').returns('http://host.tld');
             req.session.origin = 'http://different-host.tld';
 

--- a/core/test/unit/services/auth/session/middleware_spec.js
+++ b/core/test/unit/services/auth/session/middleware_spec.js
@@ -9,7 +9,6 @@ const {
 } = require('../../../../../server/lib/common/errors');
 
 describe('Session Service', function () {
-    
     before(function () {
         models.init();
     });

--- a/core/test/unit/services/auth/session/store_spec.js
+++ b/core/test/unit/services/auth/session/store_spec.js
@@ -6,13 +6,11 @@ const sinon = require('sinon');
 const should = require('should');
 
 describe('Auth Service SessionStore', function () {
-    let sandbox;
     before(function () {
         models.init();
-        sandbox = sinon.sandbox.create();
     });
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('inheritance', function () {
@@ -29,7 +27,7 @@ describe('Auth Service SessionStore', function () {
 
     describe('SessionStore#destroy', function () {
         it('calls destroy on the model with the session_id `sid`', function (done) {
-            const destroyStub = sandbox.stub(models.Session, 'destroy')
+            const destroyStub = sinon.stub(models.Session, 'destroy')
                 .resolves();
 
             const store = new SessionStore(models.Session);
@@ -42,7 +40,7 @@ describe('Auth Service SessionStore', function () {
         });
 
         it('calls back with null if destroy resolve', function (done) {
-            sandbox.stub(models.Session, 'destroy')
+            sinon.stub(models.Session, 'destroy')
                 .resolves();
 
             const store = new SessionStore(models.Session);
@@ -55,7 +53,7 @@ describe('Auth Service SessionStore', function () {
 
         it('calls back with the error if destroy errors', function (done) {
             const error = new Error('beam me up scotty');
-            sandbox.stub(models.Session, 'destroy')
+            sinon.stub(models.Session, 'destroy')
                 .rejects(error);
 
             const store = new SessionStore(models.Session);
@@ -69,7 +67,7 @@ describe('Auth Service SessionStore', function () {
 
     describe('SessionStore#get', function () {
         it('calls findOne on the model with the session_id `sid`', function (done) {
-            const findOneStub = sandbox.stub(models.Session, 'findOne')
+            const findOneStub = sinon.stub(models.Session, 'findOne')
                 .resolves();
 
             const store = new SessionStore(models.Session);
@@ -82,7 +80,7 @@ describe('Auth Service SessionStore', function () {
         });
 
         it('callsback with null, null if findOne does not return a model', function (done) {
-            sandbox.stub(models.Session, 'findOne')
+            sinon.stub(models.Session, 'findOne')
                 .resolves(null);
 
             const store = new SessionStore(models.Session);
@@ -100,7 +98,7 @@ describe('Auth Service SessionStore', function () {
                     ice: 'cube'
                 }
             });
-            sandbox.stub(models.Session, 'findOne')
+            sinon.stub(models.Session, 'findOne')
                 .resolves(model);
 
             const store = new SessionStore(models.Session);
@@ -116,7 +114,7 @@ describe('Auth Service SessionStore', function () {
 
         it('callsback with an error if the findOne does error', function (done) {
             const error = new Error('hot damn');
-            sandbox.stub(models.Session, 'findOne')
+            sinon.stub(models.Session, 'findOne')
                 .rejects(error);
 
             const store = new SessionStore(models.Session);
@@ -140,7 +138,7 @@ describe('Auth Service SessionStore', function () {
         });
 
         it('calls upsert on the model with the session_id and the session_data', function (done) {
-            const upsertStub = sandbox.stub(models.Session, 'upsert')
+            const upsertStub = sinon.stub(models.Session, 'upsert')
                 .resolves();
 
             const store = new SessionStore(models.Session);
@@ -156,7 +154,7 @@ describe('Auth Service SessionStore', function () {
 
         it('calls back with an error if upsert errors', function (done) {
             const error = new Error('huuuuuurrr');
-            sandbox.stub(models.Session, 'upsert')
+            sinon.stub(models.Session, 'upsert')
                 .rejects(error);
 
             const store = new SessionStore(models.Session);
@@ -169,7 +167,7 @@ describe('Auth Service SessionStore', function () {
         });
 
         it('calls back with null, null if upsert succeed', function (done) {
-            sandbox.stub(models.Session, 'upsert')
+            sinon.stub(models.Session, 'upsert')
                 .resolves('success');
 
             const store = new SessionStore(models.Session);

--- a/core/test/unit/services/mail/GhostMailer_spec.js
+++ b/core/test/unit/services/mail/GhostMailer_spec.js
@@ -5,7 +5,6 @@ var should = require('should'),
     settingsCache = require('../../../../server/services/settings/cache'),
     configUtils = require('../../../utils/configUtils'),
     common = require('../../../../server/lib/common'),
-    sandbox = sinon.sandbox.create(),
     mailer,
 
     // Mock SMTP config
@@ -42,7 +41,7 @@ describe('Mail: Ghostmailer', function () {
     afterEach(function () {
         mailer = null;
         configUtils.restore();
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should attach mail provider to ghost instance', function () {
@@ -178,7 +177,7 @@ describe('Mail: Ghostmailer', function () {
         });
 
         it('should fall back to [blog.title] <ghost@[blog.url]>', function () {
-            sandbox.stub(settingsCache, 'get').returns('Test');
+            sinon.stub(settingsCache, 'get').returns('Test');
 
             // Standard domain
             configUtils.set({url: 'http://default.com', mail: {from: null}});
@@ -197,7 +196,7 @@ describe('Mail: Ghostmailer', function () {
             mailer.from().should.equal('"Test" <ghost@default.com>');
 
             settingsCache.get.restore();
-            sandbox.stub(settingsCache, 'get').returns('Test"');
+            sinon.stub(settingsCache, 'get').returns('Test"');
 
             // Escape title
             configUtils.set({url: 'http://default.com:2368/', mail: {from: null}});
@@ -214,7 +213,7 @@ describe('Mail: Ghostmailer', function () {
         });
 
         it('should attach blog title', function () {
-            sandbox.stub(settingsCache, 'get').returns('Test');
+            sinon.stub(settingsCache, 'get').returns('Test');
 
             configUtils.set({mail: {from: 'from@default.com'}});
 

--- a/core/test/unit/services/mail/utils_spec.js
+++ b/core/test/unit/services/mail/utils_spec.js
@@ -1,7 +1,6 @@
 var should = require('should'),
     sinon = require('sinon'),
-    mail = require('../../../../server/services/mail'),
-    sandbox = sinon.sandbox.create();
+    mail = require('../../../../server/services/mail');
 
 describe('Mail: Utils', function () {
     var scope = {ghostMailer: null};
@@ -9,7 +8,7 @@ describe('Mail: Utils', function () {
     beforeEach(function () {
         scope.ghostMailer = new mail.GhostMailer();
 
-        sandbox.stub(scope.ghostMailer.transport, 'sendMail').callsFake(function (message, sendMailDone) {
+        sinon.stub(scope.ghostMailer.transport, 'sendMail').callsFake(function (message, sendMailDone) {
             sendMailDone(null, {
                 statusHandler: {
                     once: function (eventName, eventDone) {
@@ -23,7 +22,7 @@ describe('Mail: Utils', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('generate welcome', function (done) {

--- a/core/test/unit/services/permissions/can-this_spec.js
+++ b/core/test/unit/services/permissions/can-this_spec.js
@@ -5,9 +5,7 @@ const should = require('should'),
     _ = require('lodash'),
     models = require('../../../../server/models'),
     permissions = require('../../../../server/services/permissions'),
-    providers = require('../../../../server/services/permissions/providers'),
-
-    sandbox = sinon.sandbox.create();
+    providers = require('../../../../server/services/permissions/providers');
 
 describe('Permissions', function () {
     var fakePermissions = [],
@@ -19,11 +17,11 @@ describe('Permissions', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(models.Permission, 'findAll').callsFake(function () {
+        sinon.stub(models.Permission, 'findAll').callsFake(function () {
             return Promise.resolve(models.Permissions.forge(fakePermissions));
         });
 
-        findPostSpy = sandbox.stub(models.Post, 'findOne').callsFake(function () {
+        findPostSpy = sinon.stub(models.Post, 'findOne').callsFake(function () {
             // @TODO: the test env has no concept of including relations
             let post = models.Post.forge(testUtils.DataGenerator.Content.posts[0]),
                 authors = [testUtils.DataGenerator.Content.users[0]];
@@ -32,13 +30,13 @@ describe('Permissions', function () {
             return Promise.resolve(post);
         });
 
-        findTagSpy = sandbox.stub(models.Tag, 'findOne').callsFake(function () {
+        findTagSpy = sinon.stub(models.Tag, 'findOne').callsFake(function () {
             return Promise.resolve({});
         });
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     /**
@@ -246,7 +244,7 @@ describe('Permissions', function () {
             // It can depend on bookshelf, but should NOT use hard coded model knowledge.
             // We use the tag model here because it doesn't have permissible, once that changes, these tests must also change
             it('No permissions: cannot edit tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                var userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: [],
@@ -269,7 +267,7 @@ describe('Permissions', function () {
             });
 
             it('With permissions: can edit specific tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                var userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -290,7 +288,7 @@ describe('Permissions', function () {
             });
 
             it('With permissions: can edit non-specific tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                var userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -311,7 +309,7 @@ describe('Permissions', function () {
             });
 
             it('Specific permissions: can edit correct specific tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                var userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge([
@@ -340,7 +338,7 @@ describe('Permissions', function () {
             });
 
             it('Specific permissions: cannot edit incorrect specific tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                var userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge([
@@ -372,7 +370,7 @@ describe('Permissions', function () {
 
             // @TODO fix this case - it makes no sense?!
             it('Specific permissions: CAN edit non-specific tag (no permissible function on model) @TODO fix this', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                var userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge([
@@ -401,7 +399,7 @@ describe('Permissions', function () {
             });
 
             it('With owner role: can edit tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                var userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: [],
@@ -429,7 +427,7 @@ describe('Permissions', function () {
             // It can depend on bookshelf, but should NOT use hard coded model knowledge.
             // We use the tag model here because it doesn't have permissible, once that changes, these tests must also change
             it('With permissions: can edit non-specific tag (no permissible function on model)', function (done) {
-                const apiKeyProviderStub = sandbox.stub(providers, 'apiKey').callsFake(() => {
+                const apiKeyProviderStub = sinon.stub(providers, 'apiKey').callsFake(() => {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -452,7 +450,7 @@ describe('Permissions', function () {
         describe('App-based permissions (requires user as well)', function () {
             // @TODO: revisit this - do we really need to have USER permissions AND app permissions?
             it('No permissions: cannot edit tag with app only (no permissible function on model)', function (done) {
-                var appProviderStub = sandbox.stub(providers, 'app').callsFake(function () {
+                var appProviderStub = sinon.stub(providers, 'app').callsFake(function () {
                     // Fake the response from providers.app, which contains an empty array for this case
                     return Promise.resolve([]);
                 });
@@ -472,11 +470,11 @@ describe('Permissions', function () {
             });
 
             it('No permissions: cannot edit tag (no permissible function on model)', function (done) {
-                var appProviderStub = sandbox.stub(providers, 'app').callsFake(function () {
+                var appProviderStub = sinon.stub(providers, 'app').callsFake(function () {
                         // Fake the response from providers.app, which contains an empty array for this case
                         return Promise.resolve([]);
                     }),
-                    userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                    userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                         // Fake the response from providers.user, which contains permissions and roles
                         return Promise.resolve({
                             permissions: [],
@@ -500,13 +498,13 @@ describe('Permissions', function () {
             });
 
             it('With permissions: can edit specific tag (no permissible function on model)', function (done) {
-                var appProviderStub = sandbox.stub(providers, 'app').callsFake(function () {
+                var appProviderStub = sinon.stub(providers, 'app').callsFake(function () {
                         // Fake the response from providers.app, which contains permissions only
                         return Promise.resolve({
                             permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models
                         });
                     }),
-                    userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                    userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                         // Fake the response from providers.user, which contains permissions and roles
                         return Promise.resolve({
                             permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -528,13 +526,13 @@ describe('Permissions', function () {
             });
 
             it('With permissions: can edit non-specific tag (no permissible function on model)', function (done) {
-                var appProviderStub = sandbox.stub(providers, 'app').callsFake(function () {
+                var appProviderStub = sinon.stub(providers, 'app').callsFake(function () {
                         // Fake the response from providers.app, which contains permissions only
                         return Promise.resolve({
                             permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models
                         });
                     }),
-                    userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+                    userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                         // Fake the response from providers.user, which contains permissions and roles
                         return Promise.resolve({
                             permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -559,14 +557,14 @@ describe('Permissions', function () {
 
     describe('permissible (overridden)', function () {
         it('can use permissible function on model to forbid something (post model)', function (done) {
-            var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+            var userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
                         roles: undefined
                     });
                 }),
-                permissibleStub = sandbox.stub(models.Post, 'permissible').callsFake(function () {
+                permissibleStub = sinon.stub(models.Post, 'permissible').callsFake(function () {
                     return Promise.reject({message: 'Hello World!'});
                 });
 
@@ -597,14 +595,14 @@ describe('Permissions', function () {
         });
 
         it('can use permissible function on model to allow something (post model)', function (done) {
-            var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
+            var userProviderStub = sinon.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
                         roles: undefined
                     });
                 }),
-                permissibleStub = sandbox.stub(models.Post, 'permissible').callsFake(function () {
+                permissibleStub = sinon.stub(models.Post, 'permissible').callsFake(function () {
                     return Promise.resolve();
                 });
 

--- a/core/test/unit/services/permissions/index_spec.js
+++ b/core/test/unit/services/permissions/index_spec.js
@@ -5,9 +5,7 @@ var should = require('should'),
     _ = require('lodash'),
     models = require('../../../../server/models'),
     actionsMap = require('../../../../server/services/permissions/actions-map-cache'),
-    permissions = require('../../../../server/services/permissions'),
-
-    sandbox = sinon.sandbox.create();
+    permissions = require('../../../../server/services/permissions');
 
 describe('Permissions', function () {
     var fakePermissions = [],
@@ -19,21 +17,21 @@ describe('Permissions', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(models.Permission, 'findAll').callsFake(function () {
+        sinon.stub(models.Permission, 'findAll').callsFake(function () {
             return Promise.resolve(models.Permissions.forge(fakePermissions));
         });
 
-        findPostSpy = sandbox.stub(models.Post, 'findOne').callsFake(function () {
+        findPostSpy = sinon.stub(models.Post, 'findOne').callsFake(function () {
             return Promise.resolve(models.Post.forge(testUtils.DataGenerator.Content.posts[0]));
         });
 
-        findTagSpy = sandbox.stub(models.Tag, 'findOne').callsFake(function () {
+        findTagSpy = sinon.stub(models.Tag, 'findOne').callsFake(function () {
             return Promise.resolve({});
         });
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     /**
@@ -69,7 +67,7 @@ describe('Permissions', function () {
 
     describe('No init (no action map)', function () {
         it('throws an error without actionMap', function () {
-            sandbox.stub(actionsMap, 'empty').returns(true);
+            sinon.stub(actionsMap, 'empty').returns(true);
 
             permissions.canThis.should.throw(/No actions map found/);
         });

--- a/core/test/unit/services/permissions/providers_spec.js
+++ b/core/test/unit/services/permissions/providers_spec.js
@@ -3,9 +3,7 @@ var should = require('should'),
     testUtils = require('../../../utils'),
     Promise = require('bluebird'),
     models = require('../../../../server/models'),
-    providers = require('../../../../server/services/permissions/providers'),
-
-    sandbox = sinon.sandbox.create();
+    providers = require('../../../../server/services/permissions/providers');
 
 describe('Permission Providers', function () {
     before(function () {
@@ -13,12 +11,12 @@ describe('Permission Providers', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('User', function () {
         it('errors if user cannot be found', function (done) {
-            var findUserSpy = sandbox.stub(models.User, 'findOne').callsFake(function () {
+            var findUserSpy = sinon.stub(models.User, 'findOne').callsFake(function () {
                 return Promise.resolve();
             });
 
@@ -35,7 +33,7 @@ describe('Permission Providers', function () {
 
         it('can load user with role, and permissions', function (done) {
             // This test requires quite a lot of unique setup work
-            var findUserSpy = sandbox.stub(models.User, 'findOne').callsFake(function () {
+            var findUserSpy = sinon.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
                 var fakeUser = models.User.forge(testUtils.DataGenerator.Content.users[0]),
                     // Roles & Permissions need to be collections
@@ -80,7 +78,7 @@ describe('Permission Providers', function () {
 
         it('can load user with role, and role.permissions', function (done) {
             // This test requires quite a lot of unique setup work
-            var findUserSpy = sandbox.stub(models.User, 'findOne').callsFake(function () {
+            var findUserSpy = sinon.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
                 var fakeUser = models.User.forge(testUtils.DataGenerator.Content.users[0]),
                     // Roles & Permissions need to be collections
@@ -127,7 +125,7 @@ describe('Permission Providers', function () {
 
         it('can load user with role, permissions and role.permissions and deduplicate them', function (done) {
             // This test requires quite a lot of unique setup work
-            var findUserSpy = sandbox.stub(models.User, 'findOne').callsFake(function () {
+            var findUserSpy = sinon.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
                 var fakeUser = models.User.forge(testUtils.DataGenerator.Content.users[0]),
                     // Roles & Permissions need to be collections
@@ -176,7 +174,7 @@ describe('Permission Providers', function () {
 
     describe('API Key', function () {
         it('errors if api_key cannot be found', function (done) {
-            let findApiKeySpy = sandbox.stub(models.ApiKey, 'findOne');
+            let findApiKeySpy = sinon.stub(models.ApiKey, 'findOne');
             findApiKeySpy.returns(new Promise.resolve());
             providers.apiKey(1)
                 .then(() => {
@@ -189,7 +187,7 @@ describe('Permission Providers', function () {
                 });
         });
         it('can load api_key with role, and role.permissions', function (done) {
-            const findApiKeySpy = sandbox.stub(models.ApiKey, 'findOne').callsFake(function () {
+            const findApiKeySpy = sinon.stub(models.ApiKey, 'findOne').callsFake(function () {
                 const fakeApiKey = models.ApiKey.forge(testUtils.DataGenerator.Content.api_keys[0]);
                 const fakeAdminRole = models.Role.forge(testUtils.DataGenerator.Content.roles[0]);
                 const fakeAdminRolePermissions = models.Permissions.forge(testUtils.DataGenerator.Content.permissions);
@@ -220,7 +218,7 @@ describe('Permission Providers', function () {
         // Why is this an empty array, when the success is an object?
         // Also why is this an empty array when for users we error?!
         it('returns empty array if app cannot be found!', function (done) {
-            var findAppSpy = sandbox.stub(models.App, 'findOne').callsFake(function () {
+            var findAppSpy = sinon.stub(models.App, 'findOne').callsFake(function () {
                 return Promise.resolve();
             });
 
@@ -235,7 +233,7 @@ describe('Permission Providers', function () {
 
         it('can load user with role, and permissions', function (done) {
             // This test requires quite a lot of unique setup work
-            var findAppSpy = sandbox.stub(models.App, 'findOne').callsFake(function () {
+            var findAppSpy = sinon.stub(models.App, 'findOne').callsFake(function () {
                 var fakeApp = models.App.forge(testUtils.DataGenerator.Content.apps[0]),
                     fakePermissions = models.Permissions.forge(testUtils.DataGenerator.Content.permissions);
 

--- a/core/test/unit/services/routing/CollectionRouter_spec.js
+++ b/core/test/unit/services/routing/CollectionRouter_spec.js
@@ -5,30 +5,29 @@ const should = require('should'),
     common = require('../../../../server/lib/common'),
     controllers = require('../../../../server/services/routing/controllers'),
     CollectionRouter = require('../../../../server/services/routing/CollectionRouter'),
-    sandbox = sinon.sandbox.create(),
     RESOURCE_CONFIG = {QUERY: {post: {controller: 'posts', resource: 'posts'}}};
 
 describe('UNIT - services/routing/CollectionRouter', function () {
     let req, res, next;
 
     beforeEach(function () {
-        sandbox.stub(common.events, 'emit');
-        sandbox.stub(common.events, 'on');
+        sinon.stub(common.events, 'emit');
+        sinon.stub(common.events, 'on');
 
-        sandbox.spy(CollectionRouter.prototype, 'mountRoute');
-        sandbox.spy(CollectionRouter.prototype, 'mountRouter');
-        sandbox.spy(CollectionRouter.prototype, 'unmountRoute');
-        sandbox.spy(express.Router, 'param');
+        sinon.spy(CollectionRouter.prototype, 'mountRoute');
+        sinon.spy(CollectionRouter.prototype, 'mountRouter');
+        sinon.spy(CollectionRouter.prototype, 'unmountRoute');
+        sinon.spy(express.Router, 'param');
 
-        req = sandbox.stub();
-        res = sandbox.stub();
-        next = sandbox.stub();
+        req = sinon.stub();
+        res = sinon.stub();
+        next = sinon.stub();
 
         res.locals = {};
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('instantiate', function () {
@@ -187,7 +186,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             it('default', function () {
                 const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/'}, RESOURCE_CONFIG);
 
-                sandbox.stub(collectionRouter, 'emit');
+                sinon.stub(collectionRouter, 'emit');
 
                 common.events.on.args[0][1]({
                     attributes: {value: 'America/Los_Angeles'},
@@ -200,7 +199,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             it('tz has not changed', function () {
                 const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/'}, RESOURCE_CONFIG);
 
-                sandbox.stub(collectionRouter, 'emit');
+                sinon.stub(collectionRouter, 'emit');
 
                 common.events.on.args[0][1]({
                     attributes: {value: 'America/Los_Angeles'},
@@ -215,7 +214,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             it('default', function () {
                 const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:year/:slug/'}, RESOURCE_CONFIG);
 
-                sandbox.stub(collectionRouter, 'emit');
+                sinon.stub(collectionRouter, 'emit');
 
                 common.events.on.args[0][1]({
                     attributes: {value: 'America/Los_Angeles'},
@@ -228,7 +227,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             it('tz has not changed', function () {
                 const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:year/:slug/'}, RESOURCE_CONFIG);
 
-                sandbox.stub(collectionRouter, 'emit');
+                sinon.stub(collectionRouter, 'emit');
 
                 common.events.on.args[0][1]({
                     attributes: {value: 'America/Los_Angeles'},

--- a/core/test/unit/services/routing/ParentRouter_spec.js
+++ b/core/test/unit/services/routing/ParentRouter_spec.js
@@ -3,33 +3,32 @@ const should = require('should'),
     configUtils = require('../../../utils/configUtils'),
     common = require('../../../../server/lib/common'),
     urlService = require('../../../../server/services/url'),
-    ParentRouter = require('../../../../server/services/routing/ParentRouter'),
-    sandbox = sinon.sandbox.create();
+    ParentRouter = require('../../../../server/services/routing/ParentRouter');
 
 describe('UNIT - services/routing/ParentRouter', function () {
     let req, res, next;
 
     beforeEach(function () {
-        sandbox.stub(common.events, 'emit');
-        sandbox.stub(common.events, 'on');
+        sinon.stub(common.events, 'emit');
+        sinon.stub(common.events, 'on');
 
-        sandbox.stub(urlService.utils, 'redirect301');
+        sinon.stub(urlService.utils, 'redirect301');
 
-        req = sandbox.stub();
+        req = sinon.stub();
         req.app = {
             _router: {
                 stack: []
             }
         };
 
-        res = sandbox.stub();
-        next = sandbox.stub();
+        res = sinon.stub();
+        next = sinon.stub();
 
         res.locals = {};
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 
@@ -52,9 +51,9 @@ describe('UNIT - services/routing/ParentRouter', function () {
     describe('fn: _respectDominantRouter', function () {
         it('redirect', function () {
             const parentRouter = new ParentRouter();
-            parentRouter.getResourceType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sinon.stub().returns('tags');
             parentRouter.permalinks = {
-                getValue: sandbox.stub().returns('/tag/:slug/')
+                getValue: sinon.stub().returns('/tag/:slug/')
             };
 
             req.url = '/tag/bacon/';
@@ -67,8 +66,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
                         name: 'StaticRoutesRouter',
                         handle: {
                             parent: {
-                                isRedirectEnabled: sandbox.stub().returns(true),
-                                getRoute: sandbox.stub().returns('/channel/')
+                                isRedirectEnabled: sinon.stub().returns(true),
+                                getRoute: sinon.stub().returns('/channel/')
                             }
                         }
                     }]
@@ -82,9 +81,9 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('redirect with query params', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getResourceType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sinon.stub().returns('tags');
             parentRouter.permalinks = {
-                getValue: sandbox.stub().returns('/tag/:slug/')
+                getValue: sinon.stub().returns('/tag/:slug/')
             };
 
             req.url = '/tag/bacon/';
@@ -97,8 +96,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
                         name: 'StaticRoutesRouter',
                         handle: {
                             parent: {
-                                isRedirectEnabled: sandbox.stub().returns(true),
-                                getRoute: sandbox.stub().returns('/channel/')
+                                isRedirectEnabled: sinon.stub().returns(true),
+                                getRoute: sinon.stub().returns('/channel/')
                             }
                         }
                     }]
@@ -112,9 +111,9 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('redirect rss', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getResourceType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sinon.stub().returns('tags');
             parentRouter.permalinks = {
-                getValue: sandbox.stub().returns('/tag/:slug/')
+                getValue: sinon.stub().returns('/tag/:slug/')
             };
 
             req.url = '/tag/bacon/rss/';
@@ -127,8 +126,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
                         name: 'StaticRoutesRouter',
                         handle: {
                             parent: {
-                                isRedirectEnabled: sandbox.stub().returns(true),
-                                getRoute: sandbox.stub().returns('/channel/')
+                                isRedirectEnabled: sinon.stub().returns(true),
+                                getRoute: sinon.stub().returns('/channel/')
                             }
                         }
                     }]
@@ -142,9 +141,9 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('redirect pagination', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getResourceType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sinon.stub().returns('tags');
             parentRouter.permalinks = {
-                getValue: sandbox.stub().returns('/tag/:slug/')
+                getValue: sinon.stub().returns('/tag/:slug/')
             };
 
             req.url = '/tag/bacon/page/2/';
@@ -157,8 +156,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
                         name: 'StaticRoutesRouter',
                         handle: {
                             parent: {
-                                isRedirectEnabled: sandbox.stub().returns(true),
-                                getRoute: sandbox.stub().returns('/channel/')
+                                isRedirectEnabled: sinon.stub().returns(true),
+                                getRoute: sinon.stub().returns('/channel/')
                             }
                         }
                     }]
@@ -174,9 +173,9 @@ describe('UNIT - services/routing/ParentRouter', function () {
             configUtils.set('url', 'http://localhost:7777/blog/');
 
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getResourceType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sinon.stub().returns('tags');
             parentRouter.permalinks = {
-                getValue: sandbox.stub().returns('/tag/:slug/')
+                getValue: sinon.stub().returns('/tag/:slug/')
             };
 
             req.url = '/tag/bacon/';
@@ -189,8 +188,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
                         name: 'StaticRoutesRouter',
                         handle: {
                             parent: {
-                                isRedirectEnabled: sandbox.stub().returns(true),
-                                getRoute: sandbox.stub().returns('/channel/')
+                                isRedirectEnabled: sinon.stub().returns(true),
+                                getRoute: sinon.stub().returns('/channel/')
                             }
                         }
                     }]
@@ -204,9 +203,9 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('no redirect: different data key', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getResourceType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sinon.stub().returns('tags');
             parentRouter.permalinks = {
-                getValue: sandbox.stub().returns('/tag/:slug/')
+                getValue: sinon.stub().returns('/tag/:slug/')
             };
 
             req.app._router.stack = [{
@@ -216,8 +215,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
                         name: 'StaticRoutesRouter',
                         handle: {
                             parent: {
-                                isRedirectEnabled: sandbox.stub().returns(false),
-                                getRoute: sandbox.stub().returns('/channel/')
+                                isRedirectEnabled: sinon.stub().returns(false),
+                                getRoute: sinon.stub().returns('/channel/')
                             }
                         }
                     }]
@@ -231,9 +230,9 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('no redirect: no channel defined', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getResourceType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sinon.stub().returns('tags');
             parentRouter.permalinks = {
-                getValue: sandbox.stub().returns('/tag/:slug/')
+                getValue: sinon.stub().returns('/tag/:slug/')
             };
 
             req.app._router.stack = [{
@@ -253,9 +252,9 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('redirect primary tag permalink', function () {
             const parentRouter = new ParentRouter('index');
-            parentRouter.getResourceType = sandbox.stub().returns('posts');
+            parentRouter.getResourceType = sinon.stub().returns('posts');
             parentRouter.permalinks = {
-                getValue: sandbox.stub().returns('/:primary_tag/:slug/')
+                getValue: sinon.stub().returns('/:primary_tag/:slug/')
             };
 
             req.url = '/bacon/welcome/';
@@ -268,8 +267,8 @@ describe('UNIT - services/routing/ParentRouter', function () {
                         name: 'StaticRoutesRouter',
                         handle: {
                             parent: {
-                                isRedirectEnabled: sandbox.stub().returns(true),
-                                getRoute: sandbox.stub().returns('/route/')
+                                isRedirectEnabled: sinon.stub().returns(true),
+                                getRoute: sinon.stub().returns('/route/')
                             }
                         }
                     }]

--- a/core/test/unit/services/routing/RSSRouter_spec.js
+++ b/core/test/unit/services/routing/RSSRouter_spec.js
@@ -4,23 +4,22 @@ const should = require('should'),
     common = require('../../../../server/lib/common'),
     controllers = require('../../../../server/services/routing/controllers'),
     RSSRouter = require('../../../../server/services/routing/RSSRouter'),
-    urlService = require('../../../../server/services/url'),
-    sandbox = sinon.sandbox.create();
+    urlService = require('../../../../server/services/url');
 
 describe('UNIT - services/routing/RSSRouter', function () {
     describe('instantiate', function () {
         beforeEach(function () {
-            sandbox.stub(common.events, 'emit');
-            sandbox.stub(common.events, 'on');
+            sinon.stub(common.events, 'emit');
+            sinon.stub(common.events, 'on');
 
-            sandbox.spy(RSSRouter.prototype, 'mountRoute');
-            sandbox.spy(RSSRouter.prototype, 'mountRouter');
+            sinon.spy(RSSRouter.prototype, 'mountRoute');
+            sinon.spy(RSSRouter.prototype, 'mountRouter');
 
-            sandbox.stub(urlService.utils, 'urlJoin');
+            sinon.stub(urlService.utils, 'urlJoin');
         });
 
         afterEach(function () {
-            sandbox.restore();
+            sinon.restore();
             configUtils.restore();
         });
 

--- a/core/test/unit/services/routing/StaticRoutesRouter_spec.js
+++ b/core/test/unit/services/routing/StaticRoutesRouter_spec.js
@@ -3,8 +3,7 @@ const should = require('should'),
     common = require('../../../../server/lib/common'),
     controllers = require('../../../../server/services/routing/controllers'),
     StaticRoutesRouter = require('../../../../server/services/routing/StaticRoutesRouter'),
-    configUtils = require('../../../utils/configUtils'),
-    sandbox = sinon.sandbox.create();
+    configUtils = require('../../../utils/configUtils');
 
 describe('UNIT - services/routing/StaticRoutesRouter', function () {
     let req, res, next;
@@ -14,21 +13,21 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(common.events, 'emit');
-        sandbox.stub(common.events, 'on');
+        sinon.stub(common.events, 'emit');
+        sinon.stub(common.events, 'on');
 
-        sandbox.spy(StaticRoutesRouter.prototype, 'mountRoute');
-        sandbox.spy(StaticRoutesRouter.prototype, 'mountRouter');
+        sinon.spy(StaticRoutesRouter.prototype, 'mountRoute');
+        sinon.spy(StaticRoutesRouter.prototype, 'mountRouter');
 
-        req = sandbox.stub();
-        res = sandbox.stub();
-        next = sandbox.stub();
+        req = sinon.stub();
+        res = sinon.stub();
+        next = sinon.stub();
 
         res.locals = {};
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('static routes', function () {

--- a/core/test/unit/services/routing/TaxonomyRouter_spec.js
+++ b/core/test/unit/services/routing/TaxonomyRouter_spec.js
@@ -5,30 +5,29 @@ const should = require('should'),
     common = require('../../../../server/lib/common'),
     controllers = require('../../../../server/services/routing/controllers'),
     TaxonomyRouter = require('../../../../server/services/routing/TaxonomyRouter'),
-    RESOURCE_CONFIG = require('../../../../server/services/routing/config/v2'),
-    sandbox = sinon.sandbox.create();
+    RESOURCE_CONFIG = require('../../../../server/services/routing/config/v2');
 
 describe('UNIT - services/routing/TaxonomyRouter', function () {
     let req, res, next;
 
     beforeEach(function () {
-        sandbox.stub(settingsCache, 'get').withArgs('permalinks').returns('/:slug/');
+        sinon.stub(settingsCache, 'get').withArgs('permalinks').returns('/:slug/');
 
-        sandbox.stub(common.events, 'emit');
-        sandbox.stub(common.events, 'on');
+        sinon.stub(common.events, 'emit');
+        sinon.stub(common.events, 'on');
 
-        sandbox.spy(TaxonomyRouter.prototype, 'mountRoute');
-        sandbox.spy(TaxonomyRouter.prototype, 'mountRouter');
+        sinon.spy(TaxonomyRouter.prototype, 'mountRoute');
+        sinon.spy(TaxonomyRouter.prototype, 'mountRouter');
 
-        req = sandbox.stub();
-        res = sandbox.stub();
-        next = sandbox.stub();
+        req = sinon.stub();
+        res = sinon.stub();
+        next = sinon.stub();
 
         res.locals = {};
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('instantiate', function () {

--- a/core/test/unit/services/routing/controllers/channel_spec.js
+++ b/core/test/unit/services/routing/controllers/channel_spec.js
@@ -6,8 +6,7 @@ const should = require('should'),
     filters = require('../../../../../server/filters'),
     themeService = require('../../../../../server/services/themes'),
     controllers = require('../../../../../server/services/routing/controllers'),
-    helpers = require('../../../../../server/services/routing/helpers'),
-    sandbox = sinon.sandbox.create();
+    helpers = require('../../../../../server/services/routing/helpers');
 
 function failTest(done) {
     return function (err) {
@@ -26,33 +25,33 @@ describe('Unit - services/routing/controllers/channel', function () {
             testUtils.DataGenerator.forKnex.createPost()
         ];
 
-        secureStub = sandbox.stub();
-        fetchDataStub = sandbox.stub();
-        renderStub = sandbox.stub();
+        secureStub = sinon.stub();
+        fetchDataStub = sinon.stub();
+        renderStub = sinon.stub();
 
-        sandbox.stub(helpers, 'fetchData').get(function () {
+        sinon.stub(helpers, 'fetchData').get(function () {
             return fetchDataStub;
         });
 
-        sandbox.stub(security.string, 'safe').returns('safe');
+        sinon.stub(security.string, 'safe').returns('safe');
 
-        sandbox.stub(helpers, 'secure').get(function () {
+        sinon.stub(helpers, 'secure').get(function () {
             return secureStub;
         });
 
-        sandbox.stub(themeService, 'getActive').returns({
-            updateTemplateOptions: sandbox.stub(),
+        sinon.stub(themeService, 'getActive').returns({
+            updateTemplateOptions: sinon.stub(),
             config: function (key) {
                key.should.eql('posts_per_page');
                return postsPerPage;
            }
         });
 
-        sandbox.stub(helpers, 'renderEntries').get(function () {
+        sinon.stub(helpers, 'renderEntries').get(function () {
             return renderStub;
         });
 
-        sandbox.stub(filters, 'doFilter');
+        sinon.stub(filters, 'doFilter');
 
         req = {
             path: '/',
@@ -68,7 +67,7 @@ describe('Unit - services/routing/controllers/channel', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('no params', function (done) {

--- a/core/test/unit/services/routing/controllers/collection_spec.js
+++ b/core/test/unit/services/routing/controllers/collection_spec.js
@@ -7,8 +7,7 @@ const should = require('should'),
     themeService = require('../../../../../server/services/themes'),
     urlService = require('../../../../../server/services/url'),
     controllers = require('../../../../../server/services/routing/controllers'),
-    helpers = require('../../../../../server/services/routing/helpers'),
-    sandbox = sinon.sandbox.create();
+    helpers = require('../../../../../server/services/routing/helpers');
 
 function failTest(done) {
     return function (err) {
@@ -27,35 +26,35 @@ describe('Unit - services/routing/controllers/collection', function () {
             testUtils.DataGenerator.forKnex.createPost()
         ];
 
-        secureStub = sandbox.stub();
-        fetchDataStub = sandbox.stub();
-        renderStub = sandbox.stub();
+        secureStub = sinon.stub();
+        fetchDataStub = sinon.stub();
+        renderStub = sinon.stub();
 
-        sandbox.stub(helpers, 'fetchData').get(function () {
+        sinon.stub(helpers, 'fetchData').get(function () {
             return fetchDataStub;
         });
 
-        sandbox.stub(security.string, 'safe').returns('safe');
+        sinon.stub(security.string, 'safe').returns('safe');
 
-        sandbox.stub(helpers, 'secure').get(function () {
+        sinon.stub(helpers, 'secure').get(function () {
             return secureStub;
         });
 
-        sandbox.stub(themeService, 'getActive').returns({
-            updateTemplateOptions: sandbox.stub(),
+        sinon.stub(themeService, 'getActive').returns({
+            updateTemplateOptions: sinon.stub(),
             config: function (key) {
                key.should.eql('posts_per_page');
                return postsPerPage;
            }
         });
 
-        sandbox.stub(helpers, 'renderEntries').get(function () {
+        sinon.stub(helpers, 'renderEntries').get(function () {
             return renderStub;
         });
 
-        sandbox.stub(filters, 'doFilter');
+        sinon.stub(filters, 'doFilter');
 
-        sandbox.stub(urlService, 'owns');
+        sinon.stub(urlService, 'owns');
         urlService.owns.withArgs('identifier', posts[0].id).returns(true);
 
         req = {
@@ -74,7 +73,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('no params', function (done) {

--- a/core/test/unit/services/routing/controllers/entry_spec.js
+++ b/core/test/unit/services/routing/controllers/entry_spec.js
@@ -5,7 +5,6 @@ const should = require('should'),
     urlService = require('../../../../../server/services/url'),
     controllers = require('../../../../../server/services/routing/controllers'),
     helpers = require('../../../../../server/services/routing/helpers'),
-    sandbox = sinon.sandbox.create(),
     EDITOR_URL = '/editor/';
 
 describe('Unit - services/routing/controllers/entry', function () {
@@ -17,27 +16,27 @@ describe('Unit - services/routing/controllers/entry', function () {
 
         page = testUtils.DataGenerator.forKnex.createPost({page: 1});
 
-        secureStub = sandbox.stub();
-        entryLookUpStub = sandbox.stub();
-        renderStub = sandbox.stub();
+        secureStub = sinon.stub();
+        entryLookUpStub = sinon.stub();
+        renderStub = sinon.stub();
 
-        sandbox.stub(helpers, 'entryLookup').get(function () {
+        sinon.stub(helpers, 'entryLookup').get(function () {
             return entryLookUpStub;
         });
 
-        sandbox.stub(helpers, 'secure').get(function () {
+        sinon.stub(helpers, 'secure').get(function () {
             return secureStub;
         });
 
-        sandbox.stub(helpers, 'renderEntry').get(function () {
+        sinon.stub(helpers, 'renderEntry').get(function () {
             return renderStub;
         });
 
-        sandbox.stub(filters, 'doFilter');
+        sinon.stub(filters, 'doFilter');
 
-        sandbox.stub(urlService.utils, 'redirectToAdmin');
-        sandbox.stub(urlService.utils, 'redirect301');
-        sandbox.stub(urlService, 'getResourceById');
+        sinon.stub(urlService.utils, 'redirectToAdmin');
+        sinon.stub(urlService.utils, 'redirect301');
+        sinon.stub(urlService, 'getResourceById');
 
         req = {
             path: '/',
@@ -53,7 +52,7 @@ describe('Unit - services/routing/controllers/entry', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('resource not found', function (done) {

--- a/core/test/unit/services/routing/controllers/preview_spec.js
+++ b/core/test/unit/services/routing/controllers/preview_spec.js
@@ -7,9 +7,7 @@ const should = require('should'),
     filters = require('../../../../../server/filters'),
     controllers = require('../../../../../server/services/routing/controllers'),
     helpers = require('../../../../../server/services/routing/helpers'),
-    themes = require('../../../../../server/services/themes'),
     urlService = require('../../../../../server/services/url'),
-    sandbox = sinon.sandbox.create(),
     EDITOR_URL = '/editor/';
 
 describe('Unit - services/routing/controllers/preview', function () {
@@ -24,7 +22,7 @@ describe('Unit - services/routing/controllers/preview', function () {
     }
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 
@@ -56,24 +54,24 @@ describe('Unit - services/routing/controllers/preview', function () {
                 set: sinon.spy()
             };
 
-            secureStub = sandbox.stub();
-            renderStub = sandbox.stub();
+            secureStub = sinon.stub();
+            renderStub = sinon.stub();
 
-            sandbox.stub(urlService.utils, 'redirectToAdmin');
-            sandbox.stub(urlService.utils, 'redirect301');
-            sandbox.stub(urlService, 'getUrlByResourceId');
+            sinon.stub(urlService.utils, 'redirectToAdmin');
+            sinon.stub(urlService.utils, 'redirect301');
+            sinon.stub(urlService, 'getUrlByResourceId');
 
-            sandbox.stub(helpers, 'secure').get(function () {
+            sinon.stub(helpers, 'secure').get(function () {
                 return secureStub;
             });
 
-            sandbox.stub(helpers, 'renderEntry').get(function () {
+            sinon.stub(helpers, 'renderEntry').get(function () {
                 return renderStub;
             });
 
-            sandbox.stub(filters, 'doFilter');
+            sinon.stub(filters, 'doFilter');
 
-            sandbox.stub(api.posts, 'read').withArgs({
+            sinon.stub(api.posts, 'read').withArgs({
                 uuid: req.params.uuid,
                 status: 'all',
                 include: 'author,authors,tags'
@@ -175,31 +173,31 @@ describe('Unit - services/routing/controllers/preview', function () {
                 set: sinon.spy()
             };
 
-            secureStub = sandbox.stub();
-            renderStub = sandbox.stub();
+            secureStub = sinon.stub();
+            renderStub = sinon.stub();
 
-            sandbox.stub(urlService.utils, 'redirectToAdmin');
-            sandbox.stub(urlService.utils, 'redirect301');
-            sandbox.stub(urlService, 'getUrlByResourceId');
+            sinon.stub(urlService.utils, 'redirectToAdmin');
+            sinon.stub(urlService.utils, 'redirect301');
+            sinon.stub(urlService, 'getUrlByResourceId');
 
-            sandbox.stub(helpers, 'secure').get(function () {
+            sinon.stub(helpers, 'secure').get(function () {
                 return secureStub;
             });
 
-            sandbox.stub(helpers, 'renderEntry').get(function () {
+            sinon.stub(helpers, 'renderEntry').get(function () {
                 return renderStub;
             });
 
-            sandbox.stub(filters, 'doFilter');
+            sinon.stub(filters, 'doFilter');
 
-            previewStub = sandbox.stub();
+            previewStub = sinon.stub();
             previewStub.withArgs({
                 uuid: req.params.uuid,
                 status: 'all',
                 include: 'author,authors,tags'
             }).resolves(apiResponse);
 
-            sandbox.stub(api.v2, 'preview').get(() => {
+            sinon.stub(api.v2, 'preview').get(() => {
                 return {
                     read: previewStub
                 };

--- a/core/test/unit/services/routing/controllers/rss_spec.js
+++ b/core/test/unit/services/routing/controllers/rss_spec.js
@@ -7,8 +7,7 @@ const should = require('should'),
     settingsCache = require('../../../../../server/services/settings/cache'),
     controllers = require('../../../../../server/services/routing/controllers'),
     helpers = require('../../../../../server/services/routing/helpers'),
-    rssService = require('../../../../../server/services/rss'),
-    sandbox = sinon.sandbox.create();
+    rssService = require('../../../../../server/services/rss');
 
 // Helper function to prevent unit tests
 // from failing via timeout when they
@@ -40,24 +39,24 @@ describe('Unit - services/routing/controllers/rss', function () {
             }
         };
 
-        next = sandbox.stub();
-        fetchDataStub = sandbox.stub();
+        next = sinon.stub();
+        fetchDataStub = sinon.stub();
 
-        sandbox.stub(helpers, 'fetchData').get(function () {
+        sinon.stub(helpers, 'fetchData').get(function () {
             return fetchDataStub;
         });
 
-        sandbox.stub(security.string, 'safe').returns('safe');
+        sinon.stub(security.string, 'safe').returns('safe');
 
-        sandbox.stub(rssService, 'render');
+        sinon.stub(rssService, 'render');
 
-        sandbox.stub(settingsCache, 'get');
+        sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('title').returns('Ghost');
         settingsCache.get.withArgs('description').returns('Ghost is cool!');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should fetch data and attempt to send XML', function (done) {

--- a/core/test/unit/services/routing/controllers/static_spec.js
+++ b/core/test/unit/services/routing/controllers/static_spec.js
@@ -4,8 +4,7 @@ const should = require('should'),
     api = require('../../../../../server/api'),
     themeService = require('../../../../../server/services/themes'),
     helpers = require('../../../../../server/services/routing/helpers'),
-    controllers = require('../../../../../server/services/routing/controllers'),
-    sandbox = sinon.sandbox.create();
+    controllers = require('../../../../../server/services/routing/controllers');
 
 function failTest(done) {
     return function (err) {
@@ -24,23 +23,23 @@ describe('Unit - services/routing/controllers/static', function () {
             testUtils.DataGenerator.forKnex.createPost()
         ];
 
-        secureStub = sandbox.stub();
-        renderStub = sandbox.stub();
-        handleErrorStub = sandbox.stub();
-        formatResponseStub = sandbox.stub();
-        formatResponseStub.entries = sandbox.stub();
+        secureStub = sinon.stub();
+        renderStub = sinon.stub();
+        handleErrorStub = sinon.stub();
+        formatResponseStub = sinon.stub();
+        formatResponseStub.entries = sinon.stub();
 
-        sandbox.stub(api.tags, 'read');
+        sinon.stub(api.tags, 'read');
 
-        sandbox.stub(helpers, 'secure').get(function () {
+        sinon.stub(helpers, 'secure').get(function () {
             return secureStub;
         });
 
-        sandbox.stub(helpers, 'handleError').get(function () {
+        sinon.stub(helpers, 'handleError').get(function () {
             return handleErrorStub;
         });
 
-        sandbox.stub(themeService, 'getActive').returns({
+        sinon.stub(themeService, 'getActive').returns({
             config: function (key) {
                 if (key === 'posts_per_page') {
                     return postsPerPage;
@@ -48,11 +47,11 @@ describe('Unit - services/routing/controllers/static', function () {
             }
         });
 
-        sandbox.stub(helpers, 'renderer').get(function () {
+        sinon.stub(helpers, 'renderer').get(function () {
             return renderStub;
         });
 
-        sandbox.stub(helpers, 'formatResponse').get(function () {
+        sinon.stub(helpers, 'formatResponse').get(function () {
             return formatResponseStub;
         });
 
@@ -73,7 +72,7 @@ describe('Unit - services/routing/controllers/static', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('no extra data to fetch', function (done) {

--- a/core/test/unit/services/routing/helpers/context_spec.js
+++ b/core/test/unit/services/routing/helpers/context_spec.js
@@ -3,8 +3,7 @@ const should = require('should'),
     _ = require('lodash'),
     testUtils = require('../../../../utils'),
     helpers = require('../../../../../server/services/routing/helpers'),
-    labs = require('../../../../../server/services/labs'),
-    sandbox = sinon.sandbox.create();
+    labs = require('../../../../../server/services/labs');
 
 describe('Contexts', function () {
     let req, res, data, setupContext;
@@ -22,7 +21,7 @@ describe('Contexts', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Unknown', function () {
@@ -247,7 +246,7 @@ describe('Contexts', function () {
     describe('Subscribe', function () {
         it('should identify /subscribe/ as the subscribe route if labs flag set', function () {
             res.locals.relativeUrl = '/subscribe/';
-            sandbox.stub(labs, 'isSet').withArgs('subscribers').returns(true);
+            sinon.stub(labs, 'isSet').withArgs('subscribers').returns(true);
 
             delete res.routerOptions;
             helpers.context(req, res, data);
@@ -259,7 +258,7 @@ describe('Contexts', function () {
 
         it('should not identify /subscribe/ as subscribe route if labs flag NOT set', function () {
             res.locals.relativeUrl = '/subscribe/';
-            sandbox.stub(labs, 'isSet').withArgs('subscribers').returns(false);
+            sinon.stub(labs, 'isSet').withArgs('subscribers').returns(false);
             data.post = testUtils.DataGenerator.forKnex.createPost();
 
             delete res.routerOptions;

--- a/core/test/unit/services/routing/helpers/entry-lookup_spec.js
+++ b/core/test/unit/services/routing/helpers/entry-lookup_spec.js
@@ -3,19 +3,18 @@ const should = require('should'),
     Promise = require('bluebird'),
     testUtils = require('../../../../utils'),
     api = require('../../../../../server/api'),
-    helpers = require('../../../../../server/services/routing/helpers'),
-    sandbox = sinon.sandbox.create();
+    helpers = require('../../../../../server/services/routing/helpers');
 
 describe('Unit - services/routing/helpers/entry-lookup', function () {
     let posts, locals;
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('v0.1', function () {
         beforeEach(function () {
-            sandbox.stub(api.posts, 'read');
+            sinon.stub(api.posts, 'read');
 
             locals = {apiVersion: 'v0.1'};
         });
@@ -286,21 +285,21 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
                     testUtils.DataGenerator.forKnex.createPost({url: '/test/', slug: 'test', page: true})
                 ];
 
-                postsReadStub = sandbox.stub();
-                pagesReadStub = sandbox.stub();
+                postsReadStub = sinon.stub();
+                pagesReadStub = sinon.stub();
 
                 pagesReadStub.withArgs({slug: pages[0].slug, include: 'author,authors,tags'})
                     .resolves({
                         pages: pages
                     });
 
-                sandbox.stub(api.v2, 'posts').get(() => {
+                sinon.stub(api.v2, 'posts').get(() => {
                     return {
                         read: postsReadStub
                     };
                 });
 
-                sandbox.stub(api.v2, 'pages').get(() => {
+                sinon.stub(api.v2, 'pages').get(() => {
                     return {
                         read: pagesReadStub
                     };
@@ -337,21 +336,21 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
                     testUtils.DataGenerator.forKnex.createPost({url: '/test/', slug: 'test'})
                 ];
 
-                postsReadStub = sandbox.stub();
-                pagesReadStub = sandbox.stub();
+                postsReadStub = sinon.stub();
+                pagesReadStub = sinon.stub();
 
                 postsReadStub.withArgs({slug: posts[0].slug, include: 'author,authors,tags'})
                     .resolves({
                         posts: posts
                     });
 
-                sandbox.stub(api.v2, 'posts').get(() => {
+                sinon.stub(api.v2, 'posts').get(() => {
                     return {
                         read: postsReadStub
                     };
                 });
 
-                sandbox.stub(api.v2, 'pages').get(() => {
+                sinon.stub(api.v2, 'pages').get(() => {
                     return {
                         read: pagesReadStub
                     };

--- a/core/test/unit/services/routing/helpers/error_spec.js
+++ b/core/test/unit/services/routing/helpers/error_spec.js
@@ -1,18 +1,17 @@
 const should = require('should'),
     sinon = require('sinon'),
     common = require('../../../../../server/lib/common'),
-    helpers = require('../../../../../server/services/routing/helpers'),
-    sandbox = sinon.sandbox.create();
+    helpers = require('../../../../../server/services/routing/helpers');
 
 describe('handleError', function () {
     let next;
 
     beforeEach(function () {
-        next = sandbox.spy();
+        next = sinon.spy();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should call next with no args for 404 errors', function () {

--- a/core/test/unit/services/routing/helpers/fetch-data_spec.js
+++ b/core/test/unit/services/routing/helpers/fetch-data_spec.js
@@ -2,8 +2,7 @@ const should = require('should'),
     sinon = require('sinon'),
     api = require('../../../../../server/api')['v0.1'],
     helpers = require('../../../../../server/services/routing/helpers'),
-    testUtils = require('../../../../utils'),
-    sandbox = sinon.sandbox.create();
+    testUtils = require('../../../../utils');
 
 describe('Unit - services/routing/helpers/fetch-data', function () {
     let posts, tags, locals;
@@ -23,7 +22,7 @@ describe('Unit - services/routing/helpers/fetch-data', function () {
             testUtils.DataGenerator.forKnex.createTag()
         ];
 
-        sandbox.stub(api.posts, 'browse')
+        sinon.stub(api.posts, 'browse')
             .resolves({
                 posts: posts,
                 meta: {
@@ -33,13 +32,13 @@ describe('Unit - services/routing/helpers/fetch-data', function () {
                 }
             });
 
-        sandbox.stub(api.tags, 'read').resolves({tags: tags});
+        sinon.stub(api.tags, 'read').resolves({tags: tags});
 
         locals = {apiVersion: 'v0.1'};
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should handle no options', function (done) {

--- a/core/test/unit/services/routing/helpers/templates_spec.js
+++ b/core/test/unit/services/routing/helpers/templates_spec.js
@@ -2,15 +2,14 @@ const should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
     templates = rewire('../../../../../server/services/routing/helpers/templates'),
-    themes = require('../../../../../server/services/themes'),
-    sandbox = sinon.sandbox.create();
+    themes = require('../../../../../server/services/themes');
 
 describe('templates', function () {
     let getActiveThemeStub, hasTemplateStub,
         _private = templates.__get__('_private');
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('[private fn] getEntriesTemplateHierarchy', function () {
@@ -74,9 +73,9 @@ describe('templates', function () {
 
     describe('[private fn] pickTemplate', function () {
         beforeEach(function () {
-            hasTemplateStub = sandbox.stub().returns(false);
+            hasTemplateStub = sinon.stub().returns(false);
 
-            getActiveThemeStub = sandbox.stub(themes, 'getActive').returns({
+            getActiveThemeStub = sinon.stub(themes, 'getActive').returns({
                 hasTemplate: hasTemplateStub
             });
         });
@@ -120,9 +119,9 @@ describe('templates', function () {
 
     describe('[private fn] getTemplateForEntry', function () {
         beforeEach(function () {
-            hasTemplateStub = sandbox.stub().returns(false);
+            hasTemplateStub = sinon.stub().returns(false);
 
-            getActiveThemeStub = sandbox.stub(themes, 'getActive').returns({
+            getActiveThemeStub = sinon.stub(themes, 'getActive').returns({
                 hasTemplate: hasTemplateStub
             });
         });
@@ -256,9 +255,9 @@ describe('templates', function () {
 
     describe('[private fn] getTemplateForEntries', function () {
         beforeEach(function () {
-            hasTemplateStub = sandbox.stub().returns(false);
+            hasTemplateStub = sinon.stub().returns(false);
 
-            getActiveThemeStub = sandbox.stub(themes, 'getActive').returns({
+            getActiveThemeStub = sinon.stub(themes, 'getActive').returns({
                 hasTemplate: hasTemplateStub
             });
         });
@@ -306,9 +305,9 @@ describe('templates', function () {
 
     describe('[private fn] getTemplateForError', function () {
         beforeEach(function () {
-            hasTemplateStub = sandbox.stub().returns(false);
+            hasTemplateStub = sinon.stub().returns(false);
 
-            getActiveThemeStub = sandbox.stub(themes, 'getActive').returns({
+            getActiveThemeStub = sinon.stub(themes, 'getActive').returns({
                 hasTemplate: hasTemplateStub
             });
         });
@@ -393,10 +392,10 @@ describe('templates', function () {
             };
             data = {};
 
-            stubs.pickTemplate = sandbox.stub(_private, 'pickTemplate').returns('testFromPickTemplate');
-            stubs.getTemplateForEntry = sandbox.stub(_private, 'getTemplateForEntry').returns('testFromEntry');
-            stubs.getTemplateForEntries = sandbox.stub(_private, 'getTemplateForEntries').returns('testFromEntries');
-            stubs.getTemplateForError = sandbox.stub(_private, 'getTemplateForError').returns('testFromError');
+            stubs.pickTemplate = sinon.stub(_private, 'pickTemplate').returns('testFromPickTemplate');
+            stubs.getTemplateForEntry = sinon.stub(_private, 'getTemplateForEntry').returns('testFromEntry');
+            stubs.getTemplateForEntries = sinon.stub(_private, 'getTemplateForEntries').returns('testFromEntries');
+            stubs.getTemplateForError = sinon.stub(_private, 'getTemplateForError').returns('testFromError');
         });
 
         it('does nothing if template is already set', function () {

--- a/core/test/unit/services/routing/middlewares/page-param_spec.js
+++ b/core/test/unit/services/routing/middlewares/page-param_spec.js
@@ -2,24 +2,23 @@ const should = require('should'),
     sinon = require('sinon'),
     common = require('../../../../../server/lib/common'),
     urlService = require('../../../../../server/services/url'),
-    middlewares = require('../../../../../server/services/routing/middlewares'),
-    sandbox = sinon.sandbox.create();
+    middlewares = require('../../../../../server/services/routing/middlewares');
 
 describe('UNIT: services/routing/middlewares/page-param', function () {
     let req, res, next;
 
     beforeEach(function () {
-        req = sandbox.stub();
+        req = sinon.stub();
         req.params = {};
 
-        res = sandbox.stub();
-        next = sandbox.stub();
+        res = sinon.stub();
+        next = sinon.stub();
 
-        sandbox.stub(urlService.utils, 'redirect301');
+        sinon.stub(urlService.utils, 'redirect301');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('success', function () {

--- a/core/test/unit/services/routing/registry_spec.js
+++ b/core/test/unit/services/routing/registry_spec.js
@@ -1,18 +1,17 @@
 const should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
-    registry = rewire('../../../../server/services/routing/registry'),
-    sandbox = sinon.sandbox.create();
+    registry = rewire('../../../../server/services/routing/registry');
 
 describe('UNIT: services/routing/registry', function () {
     let getRssUrlStub;
 
     beforeEach(function () {
-        getRssUrlStub = sandbox.stub();
+        getRssUrlStub = sinon.stub();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('fn: getRssUrl', function () {
@@ -24,7 +23,7 @@ describe('UNIT: services/routing/registry', function () {
             registry.setRouter('CollectionRouter', {
                 name: 'CollectionRouter',
                 routerName: 'podcast',
-                getRssUrl: sandbox.stub().returns('/podcast/rss/')
+                getRssUrl: sinon.stub().returns('/podcast/rss/')
             });
 
             registry.getRssUrl().should.eql('/podcast/rss/');
@@ -34,7 +33,7 @@ describe('UNIT: services/routing/registry', function () {
             registry.setRouter('CollectionRouter', {
                 name: 'CollectionRouter',
                 routerName: 'podcast',
-                getRssUrl: sandbox.stub().returns(null)
+                getRssUrl: sinon.stub().returns(null)
             });
 
             should.not.exist(registry.getRssUrl());
@@ -44,13 +43,13 @@ describe('UNIT: services/routing/registry', function () {
             registry.setRouter('CollectionRouter', {
                 name: 'CollectionRouter',
                 routerName: 'podcast',
-                getRssUrl: sandbox.stub().returns('/podcast/rss/')
+                getRssUrl: sinon.stub().returns('/podcast/rss/')
             });
 
             registry.setRouter('CollectionRouter', {
                 name: 'CollectionRouter',
                 routerName: 'index',
-                getRssUrl: sandbox.stub().returns('/rss/')
+                getRssUrl: sinon.stub().returns('/rss/')
             });
 
             registry.getRssUrl().should.eql('/rss/');

--- a/core/test/unit/services/rss/cache_spec.js
+++ b/core/test/unit/services/rss/cache_spec.js
@@ -2,23 +2,21 @@ var should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
     configUtils = require('../../../utils/configUtils'),
-    rssCache = rewire('../../../../server/services/rss/cache'),
-
-    sandbox = sinon.sandbox.create();
+    rssCache = rewire('../../../../server/services/rss/cache');
 
 describe('RSS: Cache', function () {
     var generateSpy, generateFeedReset;
 
     afterEach(function () {
         configUtils.restore();
-        sandbox.restore();
+        sinon.restore();
         generateFeedReset();
     });
 
     beforeEach(function () {
         configUtils.set({url: 'http://my-ghost-blog.com'});
 
-        generateSpy = sandbox.spy(rssCache.__get__('generateFeed'));
+        generateSpy = sinon.spy(rssCache.__get__('generateFeed'));
         generateFeedReset = rssCache.__set__('generateFeed', generateSpy);
     });
 

--- a/core/test/unit/services/rss/generate-feed_spec.js
+++ b/core/test/unit/services/rss/generate-feed_spec.js
@@ -4,8 +4,7 @@ var should = require('should'),
     testUtils = require('../../../utils'),
     configUtils = require('../../../utils/configUtils'),
     urlService = require('../../../../server/services/url'),
-    generateFeed = require('../../../../server/services/rss/generate-feed'),
-    sandbox = sinon.sandbox.create();
+    generateFeed = require('../../../../server/services/rss/generate-feed');
 
 describe('RSS: Generate Feed', function () {
     var data = {},
@@ -28,13 +27,13 @@ describe('RSS: Generate Feed', function () {
 
     afterEach(function () {
         configUtils.restore();
-        sandbox.restore();
+        sinon.restore();
     });
 
     beforeEach(function () {
         configUtils.set({url: 'http://my-ghost-blog.com'});
 
-        sandbox.stub(urlService, 'getUrlByResourceId');
+        sinon.stub(urlService, 'getUrlByResourceId');
 
         baseUrl = '/rss/';
 

--- a/core/test/unit/services/rss/renderer_spec.js
+++ b/core/test/unit/services/rss/renderer_spec.js
@@ -3,15 +3,13 @@ var should = require('should'),
     Promise = require('bluebird'),
 
     rssCache = require('../../../../server/services/rss/cache'),
-    renderer = require('../../../../server/services/rss/renderer'),
-
-    sandbox = sinon.sandbox.create();
+    renderer = require('../../../../server/services/rss/renderer');
 
 describe('RSS: Renderer', function () {
     var rssCacheStub, res, baseUrl;
 
     beforeEach(function () {
-        rssCacheStub = sandbox.stub(rssCache, 'getXML');
+        rssCacheStub = sinon.stub(rssCache, 'getXML');
 
         res = {
             locals: {},
@@ -23,7 +21,7 @@ describe('RSS: Renderer', function () {
     });
 
     afterEach(function () {
-       sandbox.restore();
+       sinon.restore();
     });
 
     it('calls the cache and attempts to render, even without data', function (done) {

--- a/core/test/unit/services/settings/ensure-settings_spec.js
+++ b/core/test/unit/services/settings/ensure-settings_spec.js
@@ -6,19 +6,17 @@ const sinon = require('sinon'),
     configUtils = require('../../../utils/configUtils'),
     common = require('../../../../server/lib/common'),
 
-    ensureSettings = require('../../../../server/services/settings/ensure-settings'),
-
-    sandbox = sinon.sandbox.create();
+    ensureSettings = require('../../../../server/services/settings/ensure-settings');
 
 describe('UNIT > Settings Service:', function () {
     beforeEach(function () {
         configUtils.set('paths:contentPath', path.join(__dirname, '../../../utils/fixtures/'));
-        sandbox.stub(fs, 'readFile');
-        sandbox.stub(fs, 'copy');
+        sinon.stub(fs, 'readFile');
+        sinon.stub(fs, 'copy');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 

--- a/core/test/unit/services/settings/loader_spec.js
+++ b/core/test/unit/services/settings/loader_spec.js
@@ -5,8 +5,7 @@ const sinon = require('sinon'),
     path = require('path'),
     configUtils = require('../../../utils/configUtils'),
     common = require('../../../../server/lib/common'),
-    loadSettings = rewire('../../../../server/services/settings/loader'),
-    sandbox = sinon.sandbox.create();
+    loadSettings = rewire('../../../../server/services/settings/loader');
 
 describe('UNIT > Settings Service:', function () {
     beforeEach(function () {
@@ -14,7 +13,7 @@ describe('UNIT > Settings Service:', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 
@@ -39,7 +38,7 @@ describe('UNIT > Settings Service:', function () {
         });
 
         it('can find yaml settings file and returns a settings object', function () {
-            const fsReadFileSpy = sandbox.spy(fs, 'readFileSync');
+            const fsReadFileSpy = sinon.spy(fs, 'readFileSync');
             const expectedSettingsFile = path.join(__dirname, '../../../utils/fixtures/settings/goodroutes.yaml');
 
             yamlParserStub.returns(yamlStubFile);
@@ -83,7 +82,7 @@ describe('UNIT > Settings Service:', function () {
             fsError.code = 'EPERM';
 
             const originalFn = fs.readFileSync;
-            const fsReadFileStub = sandbox.stub(fs, 'readFileSync').callsFake(function (filePath, options) {
+            const fsReadFileStub = sinon.stub(fs, 'readFileSync').callsFake(function (filePath, options) {
                 if (filePath.match(/routes\.yaml/)) {
                     throw fsError;
                 }

--- a/core/test/unit/services/settings/settings_spec.js
+++ b/core/test/unit/services/settings/settings_spec.js
@@ -2,12 +2,11 @@ const sinon = require('sinon'),
     should = require('should'),
     rewire = require('rewire'),
     common = require('../../../../server/lib/common'),
-    settings = rewire('../../../../server/services/settings'),
-    sandbox = sinon.sandbox.create();
+    settings = rewire('../../../../server/services/settings');
 
 describe('UNIT > Settings Service:', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('knownSettings', function () {
@@ -34,7 +33,7 @@ describe('UNIT > Settings Service:', function () {
         };
 
         beforeEach(function () {
-            settingsLoaderStub = sandbox.stub();
+            settingsLoaderStub = sinon.stub();
         });
 
         it('returns settings object for `routes`', function () {
@@ -99,9 +98,9 @@ describe('UNIT > Settings Service:', function () {
             };
 
         beforeEach(function () {
-            knownSettingsStub = sandbox.stub().returns(['routes', 'globals']);
+            knownSettingsStub = sinon.stub().returns(['routes', 'globals']);
             settings.__set__('this.knownSettings', knownSettingsStub);
-            settingsLoaderStub = sandbox.stub();
+            settingsLoaderStub = sinon.stub();
         });
 
         it('returns settings object for all known settings', function () {

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -4,7 +4,6 @@ const common = require('../../../../server/lib/common');
 const themesService = require('../../../../server/services/themes');
 const validate = require('../../../../server/services/settings/validate');
 
-
 should.equal(true, true);
 
 describe('UNIT: services/settings/validate', function () {

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const common = require('../../../../server/lib/common');
 const themesService = require('../../../../server/services/themes');
 const validate = require('../../../../server/services/settings/validate');
-const sandbox = sinon.sandbox.create();
+
 
 should.equal(true, true);
 
@@ -11,7 +11,7 @@ describe('UNIT: services/settings/validate', function () {
     let apiVersion;
 
     before(function () {
-        sandbox.stub(themesService, 'getActive').returns({
+        sinon.stub(themesService, 'getActive').returns({
             engine: () => {
                 return apiVersion;
             }
@@ -19,7 +19,7 @@ describe('UNIT: services/settings/validate', function () {
     });
 
     after(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('v0.1', function () {

--- a/core/test/unit/services/settings/yaml-parser_spec.js
+++ b/core/test/unit/services/settings/yaml-parser_spec.js
@@ -4,19 +4,17 @@ const sinon = require('sinon'),
     yaml = require('js-yaml'),
     path = require('path'),
 
-    yamlParser = require('../../../../server/services/settings/yaml-parser'),
-
-    sandbox = sinon.sandbox.create();
+    yamlParser = require('../../../../server/services/settings/yaml-parser');
 
 describe('UNIT > Settings Service:', function () {
     let yamlSpy;
 
     beforeEach(function () {
-        yamlSpy = sandbox.spy(yaml, 'safeLoad');
+        yamlSpy = sinon.spy(yaml, 'safeLoad');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Yaml Parser', function () {

--- a/core/test/unit/services/slack_spec.js
+++ b/core/test/unit/services/slack_spec.js
@@ -1,9 +1,7 @@
 var should = require('should'),
     sinon = require('sinon'),
     _ = require('lodash'),
-    nock = require('nock'),
     rewire = require('rewire'),
-    url = require('url'),
     testUtils = require('../../utils'),
     configUtils = require('../../utils/configUtils'),
 
@@ -14,8 +12,6 @@ var should = require('should'),
     schema = require('../../../server/data/schema').checks,
     settingsCache = require('../../../server/services/settings/cache'),
 
-    sandbox = sinon.sandbox.create(),
-
     // Test data
     slackObjNoUrl = [{url: ''}],
     slackObjWithUrl = [{url: 'https://hooks.slack.com/services/a-b-c-d'}];
@@ -24,11 +20,11 @@ describe('Slack', function () {
     var eventStub;
 
     beforeEach(function () {
-        eventStub = sandbox.stub(common.events, 'on');
+        eventStub = sinon.stub(common.events, 'on');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 
@@ -46,7 +42,7 @@ describe('Slack', function () {
                     return testPost;
                 }
             },
-            pingStub = sandbox.stub(),
+            pingStub = sinon.stub(),
             resetSlack = slack.__set__('ping', pingStub),
             listener = slack.__get__('listener');
 
@@ -66,7 +62,7 @@ describe('Slack', function () {
                     return testPost;
                 }
             },
-            pingStub = sandbox.stub(),
+            pingStub = sinon.stub(),
             resetSlack = slack.__set__('ping', pingStub),
             listener = slack.__get__('listener');
 
@@ -79,7 +75,7 @@ describe('Slack', function () {
     });
 
     it('testPing() calls ping() with default message', function () {
-        var pingStub = sandbox.stub(),
+        var pingStub = sinon.stub(),
             resetSlack = slack.__set__('ping', pingStub),
             testPing = slack.__get__('testPing');
 
@@ -101,13 +97,13 @@ describe('Slack', function () {
             ping = slack.__get__('ping');
 
         beforeEach(function () {
-            isPostStub = sandbox.stub(schema, 'isPost');
-            sandbox.stub(urlService, 'getUrlByResourceId');
+            isPostStub = sinon.stub(schema, 'isPost');
+            sinon.stub(urlService, 'getUrlByResourceId');
 
-            settingsCacheStub = sandbox.stub(settingsCache, 'get');
-            sandbox.spy(common.logging, 'error');
+            settingsCacheStub = sinon.stub(settingsCache, 'get');
+            sinon.spy(common.logging, 'error');
 
-            makeRequestStub = sandbox.stub();
+            makeRequestStub = sinon.stub();
             slackReset = slack.__set__('request', makeRequestStub);
             makeRequestStub.resolves();
 

--- a/core/test/unit/services/themes/active_spec.js
+++ b/core/test/unit/services/themes/active_spec.js
@@ -4,13 +4,11 @@ var should = require('should'),
     config = require('../../../../server/config'),
     // is only exposed via themes.getActive()
     activeTheme = require('../../../../server/services/themes/active'),
-    engine = require('../../../../server/services/themes/engine'),
-
-    sandbox = sinon.sandbox.create();
+    engine = require('../../../../server/services/themes/engine');
 
 describe('Themes', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Active', function () {
@@ -19,13 +17,13 @@ describe('Themes', function () {
                 fakeBlogApp, fakeLoadedTheme, fakeCheckedTheme;
 
             beforeEach(function () {
-                engineStub = sandbox.stub(engine, 'configure');
-                configStub = sandbox.stub(config, 'set');
+                engineStub = sinon.stub(engine, 'configure');
+                configStub = sinon.stub(config, 'set');
 
                 fakeBlogApp = {
                     cache: ['stuff'],
-                    set: sandbox.stub(),
-                    engine: sandbox.stub()
+                    set: sinon.stub(),
+                    engine: sinon.stub()
                 };
 
                 fakeLoadedTheme = {

--- a/core/test/unit/services/themes/config_spec.js
+++ b/core/test/unit/services/themes/config_spec.js
@@ -1,13 +1,11 @@
 var should = require('should'),
     sinon = require('sinon'),
 
-    themeConfig = require('../../../../server/services/themes/config'),
-
-    sandbox = sinon.sandbox.create();
+    themeConfig = require('../../../../server/services/themes/config');
 
 describe('Themes', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Config', function () {

--- a/core/test/unit/services/themes/engines/create_spec.js
+++ b/core/test/unit/services/themes/engines/create_spec.js
@@ -2,7 +2,6 @@ const should = require('should');
 const sinon = require('sinon');
 const themeEngines = require('../../../../../server/services/themes/engines');
 
-
 describe('Themes: engines', function () {
     afterEach(function () {
         sinon.restore();

--- a/core/test/unit/services/themes/engines/create_spec.js
+++ b/core/test/unit/services/themes/engines/create_spec.js
@@ -1,11 +1,11 @@
 const should = require('should');
 const sinon = require('sinon');
 const themeEngines = require('../../../../../server/services/themes/engines');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Themes: engines', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('no engines', function () {

--- a/core/test/unit/services/themes/list_spec.js
+++ b/core/test/unit/services/themes/list_spec.js
@@ -1,15 +1,12 @@
 var should = require('should'),
     sinon = require('sinon'),
     _ = require('lodash'),
-
     themes = require('../../../../server/services/themes'),
-    themeList = themes.list,
-
-    sandbox = sinon.sandbox.create();
+    themeList = themes.list;
 
 describe('Themes', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('List', function () {
@@ -63,7 +60,7 @@ describe('Themes', function () {
         });
 
         it('init() calls set for each theme', function () {
-            var setSpy = sandbox.spy(themeList, 'set');
+            var setSpy = sinon.spy(themeList, 'set');
 
             themeList.init({test: {a: 'b'}, casper: {c: 'd'}});
             setSpy.calledTwice.should.be.true();

--- a/core/test/unit/services/themes/loader_spec.js
+++ b/core/test/unit/services/themes/loader_spec.js
@@ -3,16 +3,13 @@ var should = require('should'),
     fs = require('fs-extra'),
     tmp = require('tmp'),
     join = require('path').join,
-
     config = require('../../../../server/config'),
     themes = require('../../../../server/services/themes'),
-    themeList = themes.list,
-
-    sandbox = sinon.sandbox.create();
+    themeList = themes.list;
 
 describe('Themes', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Loader', function () {
@@ -20,7 +17,7 @@ describe('Themes', function () {
 
         beforeEach(function () {
             themePath = tmp.dirSync({unsafeCleanup: true});
-            sandbox.stub(config, 'getContentPath').withArgs('themes').returns(themePath.name);
+            sinon.stub(config, 'getContentPath').withArgs('themes').returns(themePath.name);
         });
 
         afterEach(function () {

--- a/core/test/unit/services/themes/middleware_spec.js
+++ b/core/test/unit/services/themes/middleware_spec.js
@@ -1,34 +1,31 @@
 var should = require('should'),
     sinon = require('sinon'),
     hbs = require('../../../../server/services/themes/engine'),
-
     themes = require('../../../../server/services/themes'),
     // is only exposed via themes.getActive()
     activeTheme = require('../../../../server/services/themes/active'),
     settingsCache = require('../../../../server/services/settings/cache'),
-    middleware = themes.middleware,
-
-    sandbox = sinon.sandbox.create();
+    middleware = themes.middleware;
 
 describe('Themes', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Middleware', function () {
         var req, res, blogApp, getActiveThemeStub, settingsCacheStub, settingPublicStub;
 
         beforeEach(function () {
-            req = sandbox.spy();
-            res = sandbox.spy();
+            req = sinon.spy();
+            res = sinon.spy();
 
             blogApp = {test: 'obj'};
             req.app = blogApp;
             res.locals = {};
 
-            getActiveThemeStub = sandbox.stub(activeTheme, 'get');
-            settingsCacheStub = sandbox.stub(settingsCache, 'get');
-            settingPublicStub = sandbox.stub(settingsCache, 'getPublic').returns({});
+            getActiveThemeStub = sinon.stub(activeTheme, 'get');
+            settingsCacheStub = sinon.stub(settingsCache, 'get');
+            settingPublicStub = sinon.stub(settingsCache, 'getPublic').returns({});
         });
 
         describe('ensureActiveTheme', function () {
@@ -36,7 +33,7 @@ describe('Themes', function () {
                 mountThemeSpy;
 
             beforeEach(function () {
-                mountThemeSpy = sandbox.spy();
+                mountThemeSpy = sinon.spy();
                 settingsCacheStub.withArgs('active_theme').returns('casper');
             });
 
@@ -100,12 +97,12 @@ describe('Themes', function () {
                 updateOptionsStub;
 
             beforeEach(function () {
-                updateOptionsStub = sandbox.stub(hbs, 'updateTemplateOptions');
+                updateOptionsStub = sinon.stub(hbs, 'updateTemplateOptions');
 
                 settingsCacheStub.withArgs('labs').returns({});
 
                 getActiveThemeStub.returns({
-                    config: sandbox.stub().returns(2)
+                    config: sinon.stub().returns(2)
                 });
             });
 

--- a/core/test/unit/services/themes/validate_spec.js
+++ b/core/test/unit/services/themes/validate_spec.js
@@ -7,7 +7,7 @@ const validate = themes.validate;
 
 const gscan = require('gscan');
 const common = require('../../../../server/lib/common');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Themes', function () {
     let checkZipStub;
@@ -15,13 +15,13 @@ describe('Themes', function () {
     let formatStub;
 
     beforeEach(function () {
-        checkZipStub = sandbox.stub(gscan, 'checkZip');
-        checkStub = sandbox.stub(gscan, 'check');
-        formatStub = sandbox.stub(gscan, 'format');
+        checkZipStub = sinon.stub(gscan, 'checkZip');
+        checkStub = sinon.stub(gscan, 'check');
+        formatStub = sinon.stub(gscan, 'format');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Validate', function () {

--- a/core/test/unit/services/themes/validate_spec.js
+++ b/core/test/unit/services/themes/validate_spec.js
@@ -8,7 +8,6 @@ const validate = themes.validate;
 const gscan = require('gscan');
 const common = require('../../../../server/lib/common');
 
-
 describe('Themes', function () {
     let checkZipStub;
     let checkStub;

--- a/core/test/unit/services/url/Queue_spec.js
+++ b/core/test/unit/services/url/Queue_spec.js
@@ -5,7 +5,7 @@ const should = require('should');
 const sinon = require('sinon');
 const common = require('../../../../server/lib/common');
 const Queue = require('../../../../server/services/url/Queue');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: services/url/Queue', function () {
     let queue;
@@ -13,12 +13,12 @@ describe('Unit: services/url/Queue', function () {
     beforeEach(function () {
         queue = new Queue();
 
-        sandbox.spy(queue, 'run');
-        sandbox.stub(common.logging, 'error');
+        sinon.spy(queue, 'run');
+        sinon.stub(common.logging, 'error');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('fn: register', function () {

--- a/core/test/unit/services/url/Queue_spec.js
+++ b/core/test/unit/services/url/Queue_spec.js
@@ -1,11 +1,9 @@
-
 const _ = require('lodash');
 const Promise = require('bluebird');
 const should = require('should');
 const sinon = require('sinon');
 const common = require('../../../../server/lib/common');
 const Queue = require('../../../../server/services/url/Queue');
-
 
 describe('Unit: services/url/Queue', function () {
     let queue;

--- a/core/test/unit/services/url/Resources_spec.js
+++ b/core/test/unit/services/url/Resources_spec.js
@@ -5,7 +5,7 @@ const testUtils = require('../../../utils');
 const models = require('../../../../server/models');
 const common = require('../../../../server/lib/common');
 const Resources = require('../../../../server/services/url/Resources');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: services/url/Resources', function () {
     let onEvents, emitEvents, resources, queue;
@@ -21,21 +21,21 @@ describe('Unit: services/url/Resources', function () {
         onEvents = {};
         emitEvents = {};
 
-        sandbox.stub(common.events, 'on').callsFake(function (eventName, callback) {
+        sinon.stub(common.events, 'on').callsFake(function (eventName, callback) {
             onEvents[eventName] = callback;
         });
 
-        sandbox.stub(common.events, 'emit').callsFake(function (eventName, data) {
+        sinon.stub(common.events, 'emit').callsFake(function (eventName, data) {
             emitEvents[eventName] = data;
         });
 
         queue = {
-            start: sandbox.stub()
+            start: sinon.stub()
         };
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         resources.reset();
     });
 
@@ -178,7 +178,7 @@ describe('Unit: services/url/Resources', function () {
                 return false;
             });
 
-            sandbox.spy(resourceToUpdate, 'update');
+            sinon.spy(resourceToUpdate, 'update');
 
             queue.start.callsFake(function (options) {
                 options.event.should.eql('added');

--- a/core/test/unit/services/url/Resources_spec.js
+++ b/core/test/unit/services/url/Resources_spec.js
@@ -6,7 +6,6 @@ const models = require('../../../../server/models');
 const common = require('../../../../server/lib/common');
 const Resources = require('../../../../server/services/url/Resources');
 
-
 describe('Unit: services/url/Resources', function () {
     let onEvents, emitEvents, resources, queue;
 

--- a/core/test/unit/services/url/UrlGenerator_spec.js
+++ b/core/test/unit/services/url/UrlGenerator_spec.js
@@ -6,7 +6,6 @@ const sinon = require('sinon');
 const urlUtils = require('../../../../server/services/url/utils');
 const UrlGenerator = require('../../../../server/services/url/UrlGenerator');
 
-
 describe('Unit: services/url/UrlGenerator', function () {
     let queue, router, urls, resources, resource, resource2;
 

--- a/core/test/unit/services/url/UrlGenerator_spec.js
+++ b/core/test/unit/services/url/UrlGenerator_spec.js
@@ -5,55 +5,55 @@ const nql = require('@nexes/nql');
 const sinon = require('sinon');
 const urlUtils = require('../../../../server/services/url/utils');
 const UrlGenerator = require('../../../../server/services/url/UrlGenerator');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: services/url/UrlGenerator', function () {
     let queue, router, urls, resources, resource, resource2;
 
     beforeEach(function () {
         queue = {
-            register: sandbox.stub(),
-            start: sandbox.stub()
+            register: sinon.stub(),
+            start: sinon.stub()
         };
 
         router = {
-            getFilter: sandbox.stub(),
-            addListener: sandbox.stub(),
-            getResourceType: sandbox.stub(),
-            getPermalinks: sandbox.stub()
+            getFilter: sinon.stub(),
+            addListener: sinon.stub(),
+            getResourceType: sinon.stub(),
+            getPermalinks: sinon.stub()
         };
 
         urls = {
-            add: sandbox.stub(),
-            getByUrl: sandbox.stub(),
-            removeResourceId: sandbox.stub(),
-            getByGeneratorId: sandbox.stub()
+            add: sinon.stub(),
+            getByUrl: sinon.stub(),
+            removeResourceId: sinon.stub(),
+            getByGeneratorId: sinon.stub()
         };
 
         resources = {
-            getAllByType: sandbox.stub(),
-            getByIdAndType: sandbox.stub()
+            getAllByType: sinon.stub(),
+            getByIdAndType: sinon.stub()
         };
 
         resource = {
-            reserve: sandbox.stub(),
-            release: sandbox.stub(),
-            isReserved: sandbox.stub(),
-            removeAllListeners: sandbox.stub(),
-            addListener: sandbox.stub()
+            reserve: sinon.stub(),
+            release: sinon.stub(),
+            isReserved: sinon.stub(),
+            removeAllListeners: sinon.stub(),
+            addListener: sinon.stub()
         };
 
         resource2 = {
-            reserve: sandbox.stub(),
-            release: sandbox.stub(),
-            isReserved: sandbox.stub(),
-            removeAllListeners: sandbox.stub(),
-            addListener: sandbox.stub()
+            reserve: sinon.stub(),
+            release: sinon.stub(),
+            isReserved: sinon.stub(),
+            removeAllListeners: sinon.stub(),
+            addListener: sinon.stub()
         };
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('ensure listeners', function () {
@@ -73,7 +73,7 @@ describe('Unit: services/url/UrlGenerator', function () {
     it('routing type has changed', function () {
         const urlGenerator = new UrlGenerator(router, queue, resources, urls);
 
-        sandbox.stub(urlGenerator, '_try');
+        sinon.stub(urlGenerator, '_try');
 
         urls.getByGeneratorId.returns([
             {
@@ -106,7 +106,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             resources.getAllByType.withArgs('posts').returns([resource]);
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-            sandbox.stub(urlGenerator, '_try');
+            sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onInit();
             urlGenerator._try.calledOnce.should.be.true();
@@ -117,7 +117,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             resources.getAllByType.withArgs('posts').returns([]);
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-            sandbox.stub(urlGenerator, '_try');
+            sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onInit();
             urlGenerator._try.called.should.be.false();
@@ -130,7 +130,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             resources.getByIdAndType.withArgs('posts', 1).returns(resource);
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-            sandbox.stub(urlGenerator, '_try');
+            sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onAdded({id: 1, type: 'posts'});
             urlGenerator._try.calledOnce.should.be.true();
@@ -140,7 +140,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             router.getResourceType.returns('pages');
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-            sandbox.stub(urlGenerator, '_try');
+            sinon.stub(urlGenerator, '_try');
 
             urlGenerator._onAdded({id: 1, type: 'posts'});
             urlGenerator._try.called.should.be.false();
@@ -157,8 +157,8 @@ describe('Unit: services/url/UrlGenerator', function () {
                 const urlGenerator = new UrlGenerator(router, queue, resources, urls);
                 should.not.exist(urlGenerator.nql);
 
-                sandbox.stub(urlGenerator, '_generateUrl').returns('something');
-                sandbox.stub(urlGenerator, '_resourceListeners');
+                sinon.stub(urlGenerator, '_generateUrl').returns('something');
+                sinon.stub(urlGenerator, '_resourceListeners');
 
                 urlGenerator._try(resource);
 
@@ -176,8 +176,8 @@ describe('Unit: services/url/UrlGenerator', function () {
                 const urlGenerator = new UrlGenerator(router, queue, resources, urls);
                 should.not.exist(urlGenerator.nql);
 
-                sandbox.stub(urlGenerator, '_generateUrl').returns('something');
-                sandbox.stub(urlGenerator, '_resourceListeners');
+                sinon.stub(urlGenerator, '_generateUrl').returns('something');
+                sinon.stub(urlGenerator, '_resourceListeners');
 
                 urlGenerator._try(resource);
 
@@ -195,10 +195,10 @@ describe('Unit: services/url/UrlGenerator', function () {
                 resource.isReserved.returns(false);
 
                 const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-                sandbox.stub(urlGenerator.nql, 'queryJSON').returns(true);
+                sinon.stub(urlGenerator.nql, 'queryJSON').returns(true);
 
-                sandbox.stub(urlGenerator, '_generateUrl').returns('something');
-                sandbox.stub(urlGenerator, '_resourceListeners');
+                sinon.stub(urlGenerator, '_generateUrl').returns('something');
+                sinon.stub(urlGenerator, '_resourceListeners');
 
                 urlGenerator._try(resource);
 
@@ -215,10 +215,10 @@ describe('Unit: services/url/UrlGenerator', function () {
                 resource.isReserved.returns(false);
 
                 const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-                sandbox.stub(urlGenerator.nql, 'queryJSON').returns(false);
+                sinon.stub(urlGenerator.nql, 'queryJSON').returns(false);
 
-                sandbox.stub(urlGenerator, '_generateUrl').returns('something');
-                sandbox.stub(urlGenerator, '_resourceListeners');
+                sinon.stub(urlGenerator, '_generateUrl').returns('something');
+                sinon.stub(urlGenerator, '_resourceListeners');
 
                 urlGenerator._try(resource);
 
@@ -235,10 +235,10 @@ describe('Unit: services/url/UrlGenerator', function () {
                 resource.isReserved.returns(true);
 
                 const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-                sandbox.stub(urlGenerator.nql, 'queryJSON').returns(true);
+                sinon.stub(urlGenerator.nql, 'queryJSON').returns(true);
 
-                sandbox.stub(urlGenerator, '_generateUrl').returns('something');
-                sandbox.stub(urlGenerator, '_resourceListeners');
+                sinon.stub(urlGenerator, '_generateUrl').returns('something');
+                sinon.stub(urlGenerator, '_resourceListeners');
 
                 urlGenerator._try(resource);
 
@@ -260,7 +260,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             });
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-            sandbox.stub(urlUtils, 'replacePermalink').returns('/url/');
+            sinon.stub(urlUtils, 'replacePermalink').returns('/url/');
 
             urlGenerator._generateUrl(resource).should.eql('/url/');
             urlUtils.replacePermalink.calledWith('/:slug/', resource.data).should.be.true();
@@ -278,8 +278,8 @@ describe('Unit: services/url/UrlGenerator', function () {
 
         it('resource was updated', function () {
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-            sandbox.stub(urlGenerator, '_generateUrl').returns('/welcome/');
-            sandbox.stub(urlGenerator, '_try').returns(true);
+            sinon.stub(urlGenerator, '_generateUrl').returns('/welcome/');
+            sinon.stub(urlGenerator, '_try').returns(true);
 
             resource.data = {
                 id: 'object-id'

--- a/core/test/unit/services/url/UrlService_spec.js
+++ b/core/test/unit/services/url/UrlService_spec.js
@@ -10,7 +10,6 @@ const UrlGenerator = require('../../../../server/services/url/UrlGenerator');
 const Urls = require('../../../../server/services/url/Urls');
 const UrlService = rewire('../../../../server/services/url/UrlService');
 
-
 describe('Unit: services/url/UrlService', function () {
     let QueueStub, ResourcesStub, UrlsStub, UrlGeneratorStub, urlService;
 

--- a/core/test/unit/services/url/UrlService_spec.js
+++ b/core/test/unit/services/url/UrlService_spec.js
@@ -9,36 +9,36 @@ const Resources = require('../../../../server/services/url/Resources');
 const UrlGenerator = require('../../../../server/services/url/UrlGenerator');
 const Urls = require('../../../../server/services/url/Urls');
 const UrlService = rewire('../../../../server/services/url/UrlService');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: services/url/UrlService', function () {
     let QueueStub, ResourcesStub, UrlsStub, UrlGeneratorStub, urlService;
 
     beforeEach(function () {
-        QueueStub = sandbox.stub();
-        QueueStub.returns(sandbox.createStubInstance(Queue));
+        QueueStub = sinon.stub();
+        QueueStub.returns(sinon.createStubInstance(Queue));
 
-        ResourcesStub = sandbox.stub();
-        ResourcesStub.returns(sandbox.createStubInstance(Resources));
+        ResourcesStub = sinon.stub();
+        ResourcesStub.returns(sinon.createStubInstance(Resources));
 
-        UrlsStub = sandbox.stub();
-        UrlsStub.returns(sandbox.createStubInstance(Urls));
+        UrlsStub = sinon.stub();
+        UrlsStub.returns(sinon.createStubInstance(Urls));
 
-        UrlGeneratorStub = sandbox.stub();
-        UrlGeneratorStub.returns(sandbox.createStubInstance(UrlGenerator));
+        UrlGeneratorStub = sinon.stub();
+        UrlGeneratorStub.returns(sinon.createStubInstance(UrlGenerator));
 
         UrlService.__set__('Queue', QueueStub);
         UrlService.__set__('Resources', ResourcesStub);
         UrlService.__set__('Urls', UrlsStub);
         UrlService.__set__('UrlGenerator', UrlGeneratorStub);
 
-        sandbox.stub(common.events, 'on');
+        sinon.stub(common.events, 'on');
 
         urlService = new UrlService();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('instantiate', function () {
@@ -70,7 +70,7 @@ describe('Unit: services/url/UrlService', function () {
     });
 
     it('fn: _onRouterAddedType', function () {
-        urlService._onRouterAddedType({getPermalinks: sandbox.stub().returns({})});
+        urlService._onRouterAddedType({getPermalinks: sinon.stub().returns({})});
         urlService.urlGenerators.length.should.eql(1);
     });
 
@@ -156,12 +156,12 @@ describe('Unit: services/url/UrlService', function () {
 
     describe('fn: getPermalinkByUrl', function () {
         it('found', function () {
-            const permalinkStub1 = sandbox.stub().returns({
-                getValue: sandbox.stub().returns('/:slug/')
+            const permalinkStub1 = sinon.stub().returns({
+                getValue: sinon.stub().returns('/:slug/')
             });
 
-            const permalinkStub2 = sandbox.stub().returns({
-                getValue: sandbox.stub().returns('/:primary_tag/')
+            const permalinkStub2 = sinon.stub().returns({
+                getValue: sinon.stub().returns('/:primary_tag/')
             });
 
             urlService.urlGenerators = [
@@ -179,19 +179,19 @@ describe('Unit: services/url/UrlService', function () {
                 }
             ];
 
-            sandbox.stub(urlService, 'getResource').withArgs('/blog-post/', {returnEverything: true})
+            sinon.stub(urlService, 'getResource').withArgs('/blog-post/', {returnEverything: true})
                 .returns({generatorId: 1, resource: true});
 
             urlService.getPermalinkByUrl('/blog-post/').should.eql('/:primary_tag/');
         });
 
         it('found', function () {
-            const permalinkStub1 = sandbox.stub().returns({
-                getValue: sandbox.stub().returns('/:slug/')
+            const permalinkStub1 = sinon.stub().returns({
+                getValue: sinon.stub().returns('/:slug/')
             });
 
-            const permalinkStub2 = sandbox.stub().returns({
-                getValue: sandbox.stub().returns('/:primary_tag/')
+            const permalinkStub2 = sinon.stub().returns({
+                getValue: sinon.stub().returns('/:primary_tag/')
             });
 
             urlService.urlGenerators = [
@@ -209,7 +209,7 @@ describe('Unit: services/url/UrlService', function () {
                 }
             ];
 
-            sandbox.stub(urlService, 'getResource').withArgs('/blog-post/', {returnEverything: true})
+            sinon.stub(urlService, 'getResource').withArgs('/blog-post/', {returnEverything: true})
                 .returns({generatorId: 0, resource: true});
 
             urlService.getPermalinkByUrl('/blog-post/').should.eql('/:slug/');
@@ -223,8 +223,8 @@ describe('Unit: services/url/UrlService', function () {
         });
 
         it('not found: absolute', function () {
-            urlService.utils = sandbox.stub();
-            urlService.utils.createUrl = sandbox.stub();
+            urlService.utils = sinon.stub();
+            urlService.utils.createUrl = sinon.stub();
 
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {absolute: true});
@@ -238,8 +238,8 @@ describe('Unit: services/url/UrlService', function () {
         });
 
         it('found: absolute', function () {
-            urlService.utils = sandbox.stub();
-            urlService.utils.createUrl = sandbox.stub();
+            urlService.utils = sinon.stub();
+            urlService.utils.createUrl = sinon.stub();
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {absolute: true});
@@ -247,8 +247,8 @@ describe('Unit: services/url/UrlService', function () {
         });
 
         it('found: absolute + secure', function () {
-            urlService.utils = sandbox.stub();
-            urlService.utils.createUrl = sandbox.stub();
+            urlService.utils = sinon.stub();
+            urlService.utils.createUrl = sinon.stub();
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {absolute: true, secure: true});
@@ -256,8 +256,8 @@ describe('Unit: services/url/UrlService', function () {
         });
 
         it('not found: withSubdirectory', function () {
-            urlService.utils = sandbox.stub();
-            urlService.utils.createUrl = sandbox.stub();
+            urlService.utils = sinon.stub();
+            urlService.utils.createUrl = sinon.stub();
 
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {withSubdirectory: true});
@@ -265,8 +265,8 @@ describe('Unit: services/url/UrlService', function () {
         });
 
         it('not found: withSubdirectory + secure', function () {
-            urlService.utils = sandbox.stub();
-            urlService.utils.createUrl = sandbox.stub();
+            urlService.utils = sinon.stub();
+            urlService.utils.createUrl = sinon.stub();
 
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {withSubdirectory: true, secure: true});
@@ -274,8 +274,8 @@ describe('Unit: services/url/UrlService', function () {
         });
 
         it('not found: withSubdirectory + secure + absolute', function () {
-            urlService.utils = sandbox.stub();
-            urlService.utils.createUrl = sandbox.stub();
+            urlService.utils = sinon.stub();
+            urlService.utils.createUrl = sinon.stub();
 
             urlService.urls.getByResourceId.withArgs(1).returns(null);
             urlService.getUrlByResourceId(1, {withSubdirectory: true, secure: true, absolute: true});
@@ -283,8 +283,8 @@ describe('Unit: services/url/UrlService', function () {
         });
 
         it('found: withSubdirectory', function () {
-            urlService.utils = sandbox.stub();
-            urlService.utils.createUrl = sandbox.stub();
+            urlService.utils = sinon.stub();
+            urlService.utils.createUrl = sinon.stub();
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {withSubdirectory: true});
@@ -292,8 +292,8 @@ describe('Unit: services/url/UrlService', function () {
         });
 
         it('found: withSubdirectory + secure', function () {
-            urlService.utils = sandbox.stub();
-            urlService.utils.createUrl = sandbox.stub();
+            urlService.utils = sinon.stub();
+            urlService.utils.createUrl = sinon.stub();
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {withSubdirectory: true, secure: true});
@@ -301,8 +301,8 @@ describe('Unit: services/url/UrlService', function () {
         });
 
         it('found: withSubdirectory + secure + absolute', function () {
-            urlService.utils = sandbox.stub();
-            urlService.utils.createUrl = sandbox.stub();
+            urlService.utils = sinon.stub();
+            urlService.utils.createUrl = sinon.stub();
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {withSubdirectory: true, secure: true, absolute: true});

--- a/core/test/unit/services/url/Urls_spec.js
+++ b/core/test/unit/services/url/Urls_spec.js
@@ -6,7 +6,7 @@ const jsonpath = require('jsonpath');
 const sinon = require('sinon');
 const common = require('../../../../server/lib/common');
 const Urls = require('../../../../server/services/url/Urls');
-const sandbox = sinon.sandbox.create();
+
 
 describe('Unit: services/url/Urls', function () {
     let urls, eventsToRemember;
@@ -45,13 +45,13 @@ describe('Unit: services/url/Urls', function () {
         });
 
         eventsToRemember = {};
-        sandbox.stub(common.events, 'emit').callsFake(function (eventName, data) {
+        sinon.stub(common.events, 'emit').callsFake(function (eventName, data) {
             eventsToRemember[eventName] = data;
         });
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('fn: add', function () {

--- a/core/test/unit/services/url/Urls_spec.js
+++ b/core/test/unit/services/url/Urls_spec.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const Promise = require('bluebird');
 const should = require('should');
@@ -6,7 +5,6 @@ const jsonpath = require('jsonpath');
 const sinon = require('sinon');
 const common = require('../../../../server/lib/common');
 const Urls = require('../../../../server/services/url/Urls');
-
 
 describe('Unit: services/url/Urls', function () {
     let urls, eventsToRemember;

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -7,8 +7,7 @@ const should = require('should'),
     settingsCache = require('../../../../server/services/settings/cache'),
     configUtils = require('../../../utils/configUtils'),
     testUtils = require('../../../utils'),
-    config = configUtils.config,
-    sandbox = sinon.sandbox.create();
+    config = configUtils.config;
 
 describe('Url', function () {
     before(function () {
@@ -17,7 +16,7 @@ describe('Url', function () {
 
     afterEach(function () {
         configUtils.restore();
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('absoluteToRelative', function () {
@@ -615,7 +614,7 @@ describe('Url', function () {
         const localSettingsCache = {};
 
         beforeEach(function () {
-            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return localSettingsCache[key];
             });
         });

--- a/core/test/unit/services/webhooks_spec.js
+++ b/core/test/unit/services/webhooks_spec.js
@@ -10,8 +10,6 @@ const webhooks = {
     trigger: rewire('../../../server/services/webhooks/trigger')
 };
 
-
-
 describe('Webhooks', function () {
     var eventStub;
 

--- a/core/test/unit/services/webhooks_spec.js
+++ b/core/test/unit/services/webhooks_spec.js
@@ -10,17 +10,17 @@ const webhooks = {
     trigger: rewire('../../../server/services/webhooks/trigger')
 };
 
-const sandbox = sinon.sandbox.create();
+
 
 describe('Webhooks', function () {
     var eventStub;
 
     beforeEach(function () {
-        eventStub = sandbox.stub(common.events, 'on');
+        eventStub = sinon.stub(common.events, 'on');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('listen() should initialise events correctly', function () {
@@ -36,7 +36,7 @@ describe('Webhooks', function () {
                 }
             },
             webhooksStub = {
-                trigger: sandbox.stub()
+                trigger: sinon.stub()
             },
             resetWebhooks = webhooks.listen.__set__('webhooks', webhooksStub),
             listener = webhooks.listen.__get__('listener'),
@@ -62,7 +62,7 @@ describe('Webhooks', function () {
                 _previousAttributes: testSubscriber
             },
             webhooksStub = {
-                trigger: sandbox.stub()
+                trigger: sinon.stub()
             },
             resetWebhooks = webhooks.listen.__set__('webhooks', webhooksStub),
             listener = webhooks.listen.__get__('listener'),
@@ -84,7 +84,7 @@ describe('Webhooks', function () {
 
     it('listener() with "site.changed" event calls webhooks.trigger ', function () {
         const webhooksStub = {
-            trigger: sandbox.stub()
+            trigger: sinon.stub()
         };
         const resetWebhooks = webhooks.listen.__set__('webhooks', webhooksStub);
         const listener = webhooks.listen.__get__('listener');

--- a/core/test/unit/services/xmlrpc_spec.js
+++ b/core/test/unit/services/xmlrpc_spec.js
@@ -7,20 +7,18 @@ var should = require('should'),
     testUtils = require('../../utils'),
     configUtils = require('../../utils/configUtils'),
     xmlrpc = rewire('../../../server/services/xmlrpc'),
-    common = require('../../../server/lib/common'),
-
-    sandbox = sinon.sandbox.create();
+    common = require('../../../server/lib/common');
 
 describe('XMLRPC', function () {
     var eventStub;
 
     beforeEach(function () {
-        eventStub = sandbox.stub(common.events, 'on');
+        eventStub = sinon.stub(common.events, 'on');
         configUtils.set('privacy:useRpcPing', true);
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
         nock.cleanAll();
     });
@@ -38,7 +36,7 @@ describe('XMLRPC', function () {
                     return testPost;
                 }
             },
-            pingStub = sandbox.stub(),
+            pingStub = sinon.stub(),
             resetXmlRpc = xmlrpc.__set__('ping', pingStub),
             listener = xmlrpc.__get__('listener');
 
@@ -58,7 +56,7 @@ describe('XMLRPC', function () {
                     return testPost;
                 }
             },
-            pingStub = sandbox.stub(),
+            pingStub = sinon.stub(),
             resetXmlRpc = xmlrpc.__set__('ping', pingStub),
             listener = xmlrpc.__get__('listener');
 
@@ -122,7 +120,7 @@ describe('XMLRPC', function () {
         it('captures && logs errors from requests', function (done) {
             var testPost = _.clone(testUtils.DataGenerator.Content.posts[2]),
                 ping1 = nock('http://rpc.pingomatic.com').post('/').reply(400),
-                loggingStub = sandbox.stub(common.logging, 'error');
+                loggingStub = sinon.stub(common.logging, 'error');
 
             ping(testPost);
 
@@ -163,7 +161,7 @@ describe('XMLRPC', function () {
                      </param>
                    </params>
                  </methodResponse>`),
-                loggingStub = sandbox.stub(common.logging, 'error');
+                loggingStub = sinon.stub(common.logging, 'error');
 
             ping(testPost);
 
@@ -204,7 +202,7 @@ describe('XMLRPC', function () {
                      </param>
                    </params>
                  </methodResponse>`).replace('\n', '')),
-                loggingStub = sandbox.stub(common.logging, 'error');
+                loggingStub = sinon.stub(common.logging, 'error');
 
             ping(testPost);
 
@@ -235,7 +233,7 @@ describe('XMLRPC', function () {
                         </param>
                       </params>
                     </methodResponse>`),
-                loggingStub = sandbox.stub(common.logging, 'error');
+                loggingStub = sinon.stub(common.logging, 'error');
 
             ping(testPost);
 

--- a/core/test/unit/web/admin/middleware_spec.js
+++ b/core/test/unit/web/admin/middleware_spec.js
@@ -2,13 +2,11 @@ var should = require('should'),
     sinon = require('sinon'),
 
     // Thing we are testing
-    redirectAdminUrls = require('../../../../server/web/admin/middleware')[0],
-
-    sandbox = sinon.sandbox.create();
+    redirectAdminUrls = require('../../../../server/web/admin/middleware')[0];
 
 describe('Admin App', function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('middleware', function () {
@@ -19,8 +17,8 @@ describe('Admin App', function () {
             beforeEach(function () {
                 req = {};
                 res = {};
-                next = sandbox.stub();
-                res.redirect = sandbox.stub();
+                next = sinon.stub();
+                res.redirect = sinon.stub();
             });
 
             it('should redirect a url which starts with ghost', function () {

--- a/core/test/unit/web/middleware/api/cors_spec.js
+++ b/core/test/unit/web/middleware/api/cors_spec.js
@@ -2,8 +2,7 @@ var should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
     configUtils = require('../../../../utils/configUtils'),
-    cors = rewire('../../../../../server/web/shared/middlewares/api/cors'),
-    sandbox = sinon.sandbox.create();
+    cors = rewire('../../../../../server/web/shared/middlewares/api/cors');
 
 describe('cors', function () {
     var res, req, next;
@@ -27,11 +26,11 @@ describe('cors', function () {
             }
         };
 
-        next = sandbox.spy();
+        next = sinon.spy();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
         cors = rewire('../../../../../server/web/shared/middlewares/api/cors');
     });

--- a/core/test/unit/web/middleware/api/version-match_spec.js
+++ b/core/test/unit/web/middleware/api/version-match_spec.js
@@ -1,19 +1,16 @@
 var should  = require('should'),
     sinon   = require('sinon'),
-
-    versionMatch = require('../../../../../server/web/shared/middlewares/api/version-match'),
-
-    sandbox = sinon.sandbox.create();
+    versionMatch = require('../../../../../server/web/shared/middlewares/api/version-match');
 
 describe('Version Mismatch', function () {
     var req, res, getStub, nextStub;
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     beforeEach(function () {
-        getStub = sandbox.stub();
-        nextStub = sandbox.stub();
+        getStub = sinon.stub();
+        nextStub = sinon.stub();
 
         req = {
             get: getStub

--- a/core/test/unit/web/middleware/cache-control_spec.js
+++ b/core/test/unit/web/middleware/cache-control_spec.js
@@ -1,20 +1,18 @@
 var should = require('should'),
     sinon = require('sinon'),
-    cacheControl = require('../../../../server/web/shared/middlewares/cache-control'),
-
-    sandbox = sinon.sandbox.create();
+    cacheControl = require('../../../../server/web/shared/middlewares/cache-control');
 
 describe('Middleware: cacheControl', function () {
     var res;
 
     beforeEach(function () {
         res = {
-            set: sandbox.spy()
+            set: sinon.spy()
         };
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('correctly sets the public profile headers', function (done) {

--- a/core/test/unit/web/middleware/ghost-locals_spec.js
+++ b/core/test/unit/web/middleware/ghost-locals_spec.js
@@ -2,17 +2,16 @@ const should = require('should');
 const sinon = require('sinon');
 const ghostLocals = require('../../../../server/web/shared/middlewares/ghost-locals');
 const themeService = require('../../../../server/services/themes');
-const sandbox = sinon.sandbox.create();
 
 describe('Theme Handler', function () {
     let req, res, next;
 
     beforeEach(function () {
-        req = sandbox.spy();
-        res = sandbox.spy();
-        next = sandbox.spy();
+        req = sinon.spy();
+        res = sinon.spy();
+        next = sinon.spy();
 
-        sandbox.stub(themeService, 'getActive').callsFake(() => {
+        sinon.stub(themeService, 'getActive').callsFake(() => {
            return {
                engine() {
                    return 'v0.1';
@@ -22,7 +21,7 @@ describe('Theme Handler', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('ghostLocals', function () {

--- a/core/test/unit/web/middleware/image/normalize_spec.js
+++ b/core/test/unit/web/middleware/image/normalize_spec.js
@@ -5,8 +5,6 @@ const image = require('../../../../../server/lib/image');
 const common = require('../../../../../server/lib/common');
 const normalize = require('../../../../../server/web/shared/middlewares/image/normalize');
 
-const sandbox = sinon.sandbox.create();
-
 describe('normalize', function () {
     let res, req;
 
@@ -19,12 +17,12 @@ describe('normalize', function () {
             }
         };
 
-        sandbox.stub(image.manipulator, 'process');
-        sandbox.stub(common.logging, 'error');
+        sinon.stub(image.manipulator, 'process');
+        sinon.stub(common.logging, 'error');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
     });
 

--- a/core/test/unit/web/middleware/serve-favicon_spec.js
+++ b/core/test/unit/web/middleware/serve-favicon_spec.js
@@ -5,9 +5,7 @@ var should = require('should'),
     settingsCache = require('../../../../server/services/settings/cache'),
     storage = require('../../../../server/adapters/storage'),
     configUtils = require('../../../utils/configUtils'),
-    path = require('path'),
-
-    sandbox = sinon.sandbox.create();
+    path = require('path');
 
 describe('Serve Favicon', function () {
     var req, res, next, blogApp, localSettingsCache = {}, originalStoragePath;
@@ -19,7 +17,7 @@ describe('Serve Favicon', function () {
         blogApp = express();
         req.app = blogApp;
 
-        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
+        sinon.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
 
@@ -27,7 +25,7 @@ describe('Serve Favicon', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
         localSettingsCache = {};
         storage.getStorage().storagePath = originalStoragePath;

--- a/core/test/unit/web/middleware/serve-public-file_spec.js
+++ b/core/test/unit/web/middleware/serve-public-file_spec.js
@@ -1,9 +1,7 @@
 var should = require('should'),
     sinon = require('sinon'),
     fs = require('fs-extra'),
-    servePublicFile = require('../../../../server/web/shared/middlewares/serve-public-file'),
-
-    sandbox = sinon.sandbox.create();
+    servePublicFile = require('../../../../server/web/shared/middlewares/serve-public-file');
 
 describe('servePublicFile', function () {
     var res, req, next;
@@ -15,7 +13,7 @@ describe('servePublicFile', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should return a middleware', function () {
@@ -36,7 +34,7 @@ describe('servePublicFile', function () {
             body = 'User-agent: * Disallow: /';
         req.path = '/robots.txt';
 
-        sandbox.stub(fs, 'readFile').callsFake(function (file, cb) {
+        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
             cb(null, body);
         });
 
@@ -62,7 +60,7 @@ describe('servePublicFile', function () {
             body = 'User-agent: * Disallow: /';
         req.path = '/robots.txt';
 
-        sandbox.stub(fs, 'readFile').callsFake(function (file, cb) {
+        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
             cb(null, body);
         });
 
@@ -86,7 +84,7 @@ describe('servePublicFile', function () {
             body = 'User-agent: {{blog-url}}';
         req.path = '/robots.txt';
 
-        sandbox.stub(fs, 'readFile').callsFake(function (file, cb) {
+        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
             cb(null, body);
         });
 

--- a/core/test/unit/web/middleware/static-theme_spec.js
+++ b/core/test/unit/web/middleware/static-theme_spec.js
@@ -3,9 +3,7 @@ var should = require('should'),
 
     express = require('express'),
     themeUtils = require('../../../../server/services/themes'),
-    staticTheme = require('../../../../server/web/shared/middlewares/static-theme'),
-
-    sandbox = sinon.sandbox.create();
+    staticTheme = require('../../../../server/web/shared/middlewares/static-theme');
 
 describe('staticTheme', function () {
     var expressStaticStub, activeThemeStub, req, res;
@@ -14,15 +12,15 @@ describe('staticTheme', function () {
         req = {};
         res = {};
 
-        activeThemeStub = sandbox.stub(themeUtils, 'getActive').returns({
+        activeThemeStub = sinon.stub(themeUtils, 'getActive').returns({
             path: 'my/fake/path'
         });
 
-        expressStaticStub = sandbox.spy(express, 'static');
+        expressStaticStub = sinon.spy(express, 'static');
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should skip for .hbs file', function (done) {

--- a/core/test/unit/web/middleware/uncapitalise_spec.js
+++ b/core/test/unit/web/middleware/uncapitalise_spec.js
@@ -1,8 +1,6 @@
 var should = require('should'),
     sinon = require('sinon'),
-    uncapitalise = require('../../../../server/web/shared/middlewares/uncapitalise'),
-
-    sandbox = sinon.sandbox.create();
+    uncapitalise = require('../../../../server/web/shared/middlewares/uncapitalise');
 
 // NOTE: all urls will have had trailing slashes added before uncapitalise is called
 
@@ -11,15 +9,15 @@ describe('Middleware: uncapitalise', function () {
 
     beforeEach(function () {
         res = {
-            redirect: sandbox.spy(),
-            set: sandbox.spy()
+            redirect: sinon.spy(),
+            set: sinon.spy()
         };
         req = {};
-        next = sandbox.spy();
+        next = sinon.spy();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe('Signup or reset request', function () {

--- a/core/test/unit/web/middleware/update-user-last-seen_spec.js
+++ b/core/test/unit/web/middleware/update-user-last-seen_spec.js
@@ -4,14 +4,8 @@ const constants = require('../../../../server/lib/constants');
 const updateUserLastSeenMiddleware = require('../../../../server/web/shared/middlewares').updateUserLastSeen;
 
 describe('updateUserLastSeenMiddleware', function () {
-    let sandbox;
-
-    before(function () {
-        sandbox = sinon.sandbox.create();
-    });
-
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('calls next with no error if there is no user on the request', function (done) {
@@ -24,7 +18,7 @@ describe('updateUserLastSeenMiddleware', function () {
     it('calls next with no error if the current last_seen is less than an hour before now', function (done) {
         const fakeLastSeen = new Date();
         const fakeUser = {
-            get: sandbox.stub().withArgs('last_seen').returns(fakeLastSeen)
+            get: sinon.stub().withArgs('last_seen').returns(fakeLastSeen)
         };
         updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
             should.equal(err, undefined);
@@ -36,8 +30,8 @@ describe('updateUserLastSeenMiddleware', function () {
         it('calls updateLastSeen on the req.user, calling next with nothing if success', function (done) {
             const fakeLastSeen = new Date(Date.now() - constants.ONE_HOURS_MS);
             const fakeUser = {
-                get: sandbox.stub().withArgs('last_seen').returns(fakeLastSeen),
-                updateLastSeen: sandbox.stub().resolves()
+                get: sinon.stub().withArgs('last_seen').returns(fakeLastSeen),
+                updateLastSeen: sinon.stub().resolves()
             };
             updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
                 should.equal(err, undefined);
@@ -50,8 +44,8 @@ describe('updateUserLastSeenMiddleware', function () {
             const fakeLastSeen = new Date(Date.now() - constants.ONE_HOURS_MS);
             const fakeError = new Error('gonna need a bigger boat');
             const fakeUser = {
-                get: sandbox.stub().withArgs('last_seen').returns(fakeLastSeen),
-                updateLastSeen: sandbox.stub().rejects(fakeError)
+                get: sinon.stub().withArgs('last_seen').returns(fakeLastSeen),
+                updateLastSeen: sinon.stub().rejects(fakeError)
             };
             updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
                 should.equal(err, fakeError);

--- a/core/test/unit/web/middleware/url-redirects_spec.js
+++ b/core/test/unit/web/middleware/url-redirects_spec.js
@@ -6,8 +6,7 @@ var should = require('should'),
     {adminRedirect} = urlRedirects,
     getAdminRedirectUrl = urlRedirects.__get__('_private.getAdminRedirectUrl'),
     getBlogRedirectUrl = urlRedirects.__get__('_private.getBlogRedirectUrl'),
-    redirect = urlRedirects.__get__('_private.redirect'),
-    sandbox = sinon.sandbox.create();
+    redirect = urlRedirects.__get__('_private.redirect');
 
 describe('UNIT: url redirects', function () {
     var res, req, next, host;
@@ -19,15 +18,15 @@ describe('UNIT: url redirects', function () {
             }
         };
         res = {
-            redirect: sandbox.spy(),
-            set: sandbox.spy()
+            redirect: sinon.spy(),
+            set: sinon.spy()
         };
 
-        next = sandbox.spy();
+        next = sinon.spy();
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
         configUtils.restore();
         host = null;
     });
@@ -36,7 +35,7 @@ describe('UNIT: url redirects', function () {
         let redirectSpy;
 
         beforeEach(function () {
-            redirectSpy = sandbox.spy();
+            redirectSpy = sinon.spy();
             urlRedirects.__set__('_private.redirect', redirectSpy);
         });
 
@@ -227,7 +226,7 @@ describe('UNIT: url redirects', function () {
                 res.redirect.calledWith(301, 'https://default.com:2368/ghost/').should.be.true();
                 res.set.called.should.be.true();
 
-                res.redirect.reset();
+                res.redirect.resetHistory();
 
                 req.secure = true;
                 redirect(req, res, next, getAdminRedirectUrl);

--- a/core/test/unit/web/parent-app_spec.js
+++ b/core/test/unit/web/parent-app_spec.js
@@ -1,7 +1,6 @@
 var should = require('should'),
     sinon = require('sinon'),
-    proxyquire = require('proxyquire'),
-    sandbox = sinon.sandbox.create();
+    proxyquire = require('proxyquire');
 
 describe('parent app', function () {
     let expressStub;
@@ -12,7 +11,7 @@ describe('parent app', function () {
     let siteSpy;
 
     beforeEach(function () {
-        use = sandbox.spy();
+        use = sinon.spy();
         expressStub = () => ({
             use,
             enable: () => {}
@@ -31,7 +30,7 @@ describe('parent app', function () {
     });
 
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     it('should mount 3 apps and assign correct routes to them', function () {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "rewire": "3.0.2",
     "should": "13.2.3",
     "should-http": "0.1.1",
-    "sinon": "4.4.6",
+    "sinon": "7.2.3",
     "supertest": "3.4.1",
     "tmp": "0.0.33"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,17 +48,11 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-"@sinonjs/commons@^1.0.2":
+"@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.3.0.tgz#50a2754016b6f30a994ceda6d9a0a8c36adda849"
   dependencies:
     type-detect "4.0.8"
-
-"@sinonjs/formatio@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
-  dependencies:
-    samsam "1.3.0"
 
 "@sinonjs/formatio@^3.1.0":
   version "3.1.0"
@@ -66,7 +60,7 @@
   dependencies:
     "@sinonjs/samsam" "^2 || ^3"
 
-"@sinonjs/samsam@^2 || ^3":
+"@sinonjs/samsam@^2 || ^3", "@sinonjs/samsam@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.0.2.tgz#304fb33bd5585a0b2df8a4c801fcb47fa84d8e43"
   dependencies:
@@ -1563,7 +1557,7 @@ diff@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
-diff@^3.1.0:
+diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
@@ -4023,9 +4017,13 @@ lodash@~2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
 
-lolex@^2.2.0, lolex@^2.3.2:
+lolex@^2.3.2:
   version "2.7.5"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+
+lolex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
 
 long-timeout@~0.1.1:
   version "0.1.1"
@@ -4521,7 +4519,7 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
-nise@^1.2.0:
+nise@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.8.tgz#ce91c31e86cf9b2c4cac49d7fcd7f56779bfd6b0"
   dependencies:
@@ -5822,10 +5820,6 @@ safefs@~2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-samsam@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
-
 sanitize-html@1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.20.0.tgz#9a602beb1c9faf960fb31f9890f61911cc4d9156"
@@ -6037,17 +6031,17 @@ simple-swizzle@^0.2.2:
     rai "~0.1.11"
     xoauth2 "~0.1.8"
 
-sinon@4.4.6:
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.4.6.tgz#0b21ce56f1b11015749a82a3bbde2f46b78ec0e1"
+sinon@7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.3.tgz#f8bfd956df32ddf592f8c102fd46982366412d8e"
   dependencies:
-    "@sinonjs/formatio" "^2.0.0"
-    diff "^3.1.0"
-    lodash.get "^4.4.2"
-    lolex "^2.2.0"
-    nise "^1.2.0"
-    supports-color "^5.1.0"
-    type-detect "^4.0.5"
+    "@sinonjs/commons" "^1.3.0"
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/samsam" "^3.0.2"
+    diff "^3.5.0"
+    lolex "^3.0.0"
+    nise "^1.4.8"
+    supports-color "^5.5.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -6385,7 +6379,7 @@ supports-color@^3.1.0, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.1.0, supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:


### PR DESCRIPTION
refs #9389

- https://github.com/sinonjs/sinon/blob/master/CHANGELOG.md

**Breaking changes for Ghost:**

- no need to create a sandbox anymore, each file get's it's own sandbox
  - just require sinon and use this sandbox
  - you can still create separate sandboxes with `.createSandbox`
- reset single stubs: use `.resetHistory` instead of `.reset`

This is a global replace for any sandbox creation.

---

From https://sinonjs.org/releases/v7.2.3/sandbox/

> Default sandbox
Since sinon@5.0.0, the sinon object is a default sandbox. Unless you have a very advanced setup or need a special configuration, you probably want to just use that one.

