### PR TITLE
Removed grunt-docker from dev dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -254,21 +254,6 @@ var config = require('./core/server/config'),
                 }
             },
 
-            // ### grunt-docker
-            // Generate documentation from code
-            docker: {
-                docs: {
-                    dest: 'docs',
-                    src: ['.'],
-                    options: {
-                        onlyUpdated: true,
-                        exclude: 'node_modules,bower_components,content,core/client,*test,*doc*,' +
-                        '*vendor,config.*.json,*buil*,.dist*,.idea,.git*,.travis.yml,.bower*,.editorconfig,.js*,*.md,' +
-                        'MigratorConfig.js'
-                    }
-                }
-            },
-
             // ### grunt-contrib-clean
             // Clean up files as part of other tasks
             clean: {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "grunt-contrib-uglify": "4.0.0",
     "grunt-contrib-watch": "1.1.0",
     "grunt-cssnano": "2.1.0",
-    "grunt-docker": "0.0.11",
     "grunt-eslint": "21.0.0",
     "grunt-express-server": "0.5.4",
     "grunt-mocha-cli": "4.0.0",


### PR DESCRIPTION
no issue

- this npm package is very out-of-date
- it shows 5-6 security warnings
- i don't really know why this grunt command exists
- it was added 5 years ago: https://github.com/TryGhost/Ghost/commit/f84d3d32e52e87158da031ecef6f7d60da753bef

