### PR TITLE
🐛 Fixed image resizing when sharp is not installed

### DIFF
--- a/core/server/lib/image/manipulator.js
+++ b/core/server/lib/image/manipulator.js
@@ -46,6 +46,7 @@ const makeSafe = fn => (...args) => {
     try {
         require('sharp');
     } catch (err) {
+        delete err.code;
         return Promise.reject(new common.errors.InternalServerError({
             message: 'Sharp wasn\'t installed',
             code: 'SHARP_INSTALLATION',


### PR DESCRIPTION
refs #10181

The ghost-ignition library overrides any passed props such as `code`
when passing an error, this fix removes the original `err.code` so that
we can be explicit in which errors we are throwing and catching.