### PR TITLE
Shortened admin key length

### DIFF
--- a/core/server/models/api-key.js
+++ b/core/server/models/api-key.js
@@ -18,10 +18,10 @@ const {Role} = require('./role');
  * ref: https://en.wikipedia.org/wiki/Birthday_problem#Approximations
  *
  * 26 char hex string = 13 bytes
- * 512 bit JWT secret     = 64 bytes
+ * 64 char hex string JWT secret = 32 bytes
  */
 const createSecret = (type) => {
-    const bytes = type === 'content' ? 13 : 64;
+    const bytes = type === 'content' ? 13 : 32;
     return crypto.randomBytes(bytes).toString('hex');
 };
 
@@ -68,7 +68,7 @@ const ApiKey = ghostBookshelf.Model.extend({
     }
 }, {
     refreshSecret(data, options) {
-        const secret = createSecret();
+        const secret = createSecret(data.type);
         return this.edit(Object.assign({}, data, {secret}), options);
     }
 });

--- a/core/test/acceptance/old/admin/integrations_spec.js
+++ b/core/test/acceptance/old/admin/integrations_spec.js
@@ -57,7 +57,7 @@ describe('Integrations API', function () {
                     should.exist(id);
                     should.equal(id, adminApiKey.id);
                     should.exist(secret);
-                    secret.length.should.equal(128);
+                    secret.length.should.equal(64);
 
                     done();
                 });

--- a/core/test/unit/models/api-key_spec.js
+++ b/core/test/unit/models/api-key_spec.js
@@ -7,11 +7,12 @@ describe('Unit: models/api_key', function () {
     before(models.init);
 
     describe('fn: refreshSecret', function () {
-        it('returns a call to edit passing a new secret', function () {
+        it('returns a call to edit passing a new admin secret', function () {
             const editStub = sinon.stub(models.ApiKey, 'edit').resolves();
 
             const fakeData = {
-                id: 'TREVOR'
+                id: 'TREVOR',
+                type: 'admin'
             };
             const fakeOptions = {};
 
@@ -19,7 +20,26 @@ describe('Unit: models/api_key', function () {
 
             should.equal(result, editStub.returnValues[0]);
             should.equal(editStub.args[0][0].id, 'TREVOR');
-            should.equal(editStub.args[0][0].secret.length, 128);
+            should.equal(editStub.args[0][0].secret.length, 64);
+            should.equal(editStub.args[0][1], fakeOptions);
+
+            sinon.restore();
+        });
+
+        it('returns a call to edit passing a new content secret', function () {
+            const editStub = sinon.stub(models.ApiKey, 'edit').resolves();
+
+            const fakeData = {
+                id: 'TREVOR',
+                type: 'content'
+            };
+            const fakeOptions = {};
+
+            const result = models.ApiKey.refreshSecret(fakeData, fakeOptions);
+
+            should.equal(result, editStub.returnValues[0]);
+            should.equal(editStub.args[0][0].id, 'TREVOR');
+            should.equal(editStub.args[0][0].secret.length, 26);
             should.equal(editStub.args[0][1], fakeOptions);
 
             sinon.restore();

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -386,7 +386,7 @@ DataGenerator.Content = {
         {
             id: ObjectId.generate(),
             type: 'admin',
-            secret: _.repeat('a', 128)
+            secret: _.repeat('a', 64)
             // integration_id: DataGenerator.Content.integrations[0].id
         },
         {


### PR DESCRIPTION
refs #10156

- Updated ApiKey model to use shorter secrets for admin keys
