### PR TITLE
Set Ghost user-agent header for got requests

### DIFF
--- a/core/server/lib/request.js
+++ b/core/server/lib/request.js
@@ -1,7 +1,14 @@
 var got = require('got'),
     _ = require('lodash'),
     validator = require('../data/validation').validator,
-    common = require('./common');
+    common = require('./common'),
+    ghostVersion = require('./ghost-version');
+
+var defaultOptions = {
+    headers: {
+        'user-agent': 'Ghost/' + ghostVersion.original + ' (https://github.com/TryGhost/Ghost)'
+    }
+};
 
 module.exports = function request(url, options) {
     if (_.isEmpty(url) || !validator.isURL(url)) {
@@ -12,5 +19,7 @@ module.exports = function request(url, options) {
         }));
     }
 
-    return got(url, options);
+    var mergedOptions = _.merge({}, defaultOptions, options);
+
+    return got(url, mergedOptions);
 };


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Currently the `user-agent` header is the for outgoing webhook calls is the `got` default: `User-Agent: got/8.3.2 (https://github.com/sindresorhus/got)`.

This is pretty unfriendly to the receiver of the webhook who may wish to perform analytics on calling systems, implement security features based on calling system or take action based on different versions of a client.

This PR sets the header to: `User-Agent: Ghost/2.12.0 (https://github.com/TryGhost/Ghost)` which is much more descriptive. 

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
