### PR TITLE
🐛 Updated base model to store null instead of empty string

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -200,9 +200,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      * @returns {*}
      */
     onValidate: function onValidate(model, columns, options) {
-        return this.setEmptyValuesToNull(options).then(() => {
-            return validation.validateSchema(this.tableName, this, options);
-        });
+        this.setEmptyValuesToNull();
+        return validation.validateSchema(this.tableName, this, options);
     },
 
     /**
@@ -374,25 +373,18 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         return attrs;
     },
 
-    getNullableStringProperties: _.memoize(function getNullableStringProperties(options) {
-        return options.query.columnInfo().then((columns) => {
-            return Object.keys(columns).filter((column) => {
-                return columns[column].nullable;
-            });
-        });
-    }, function getCacheKey() {
-        return this.tableName;
-    }),
+    getNullableStringProperties() {
+        const table = schema.tables[this.tableName];
+        return Object.keys(table).filter(column => table[column].nullable);
+    },
 
-    setEmptyValuesToNull: function setEmptyValuesToNull(options) {
-        return this.getNullableStringProperties(options)
-            .then((attributes = []) => {
-                return attributes.forEach((attr) => {
-                    if (this.get(attr) === '') {
-                        this.set(attr, null);
-                    }
-                });
-            });
+    setEmptyValuesToNull: function setEmptyValuesToNull() {
+        const nullableStringProps = this.getNullableStringProperties();
+        return nullableStringProps.forEach((prop) => {
+            if (this.get(prop) === '') {
+                this.set(prop, null);
+            }
+        });
     },
 
     // Get the user from the options object

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -374,7 +374,6 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         return attrs;
     },
 
-    // Gets nullable strings
     getNullableStringProperties: _.memoize(function getNullableStringProperties(options) {
         return options.query.columnInfo().then((columns) => {
             return Object.keys(columns).filter((column) => {
@@ -385,7 +384,6 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         return this.tableName;
     }),
 
-    // Sets given values to `null`
     setEmptyValuesToNull: function setEmptyValuesToNull(options) {
         return this.getNullableStringProperties(options)
             .then((attributes = []) => {

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -375,13 +375,18 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     // Gets nullable strings
-    getNullableStringProperties(options) {
-        return options.query.columnInfo().then((columns) => {
-            return Object.keys(columns).filter((column) => {
-                return columns[column].nullable;
-            });
-        });
-    },
+    getNullableStringProperties: (function (cache = {}) {
+        return function getNullableStringProperties(options) {
+            if (!cache[this.tableName]) {
+                cache[this.tableName] = options.query.columnInfo().then((columns) => {
+                    return Object.keys(columns).filter((column) => {
+                        return columns[column].nullable;
+                    });
+                });
+            }
+            return cache[this.tableName];
+        }
+    })(),
 
     // Sets given values to `null`
     setEmptyValuesToNull: function setEmptyValuesToNull(options) {

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -375,18 +375,15 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     // Gets nullable strings
-    getNullableStringProperties: (function (cache = {}) {
-        return function getNullableStringProperties(options) {
-            if (!cache[this.tableName]) {
-                cache[this.tableName] = options.query.columnInfo().then((columns) => {
-                    return Object.keys(columns).filter((column) => {
-                        return columns[column].nullable;
-                    });
-                });
-            }
-            return cache[this.tableName];
-        }
-    })(),
+    getNullableStringProperties: _.memoize(function getNullableStringProperties(options) {
+        return options.query.columnInfo().then((columns) => {
+            return Object.keys(columns).filter((column) => {
+                return columns[column].nullable;
+            });
+        });
+    }, function getCacheKey() {
+        return this.tableName;
+    }),
 
     // Sets given values to `null`
     setEmptyValuesToNull: function setEmptyValuesToNull(options) {

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -375,7 +375,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     // Gets nullable strings
-    emptyStringProperties(options) {
+    getNullableStringProperties(options) {
         return options.query.columnInfo().then((columns) => {
             return Object.keys(columns).filter((column) => {
                 return columns[column].nullable;
@@ -385,7 +385,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
     // Sets given values to `null`
     setEmptyValuesToNull: function setEmptyValuesToNull(options) {
-        return this.emptyStringProperties(options)
+        return this.getNullableStringProperties(options)
             .then((attributes = []) => {
                 return attributes.forEach((attr) => {
                     if (this.get(attr) === '') {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -454,13 +454,6 @@ Post = ghostBookshelf.Model.extend({
         return sequence(ops);
     },
 
-    emptyStringProperties: function emptyStringProperties() {
-        // CASE: the client might send empty image properties with "" instead of setting them to null.
-        // This can cause GQL to fail. We therefore enforce 'null' for empty image properties.
-        // See https://github.com/TryGhost/GQL/issues/24
-        return ['feature_image', 'og_image', 'twitter_image'];
-    },
-
     created_by: function createdBy() {
         return this.belongsTo('User', 'created_by');
     },

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -49,13 +49,6 @@ Tag = ghostBookshelf.Model.extend({
         }
     },
 
-    emptyStringProperties: function emptyStringProperties() {
-        // CASE: the client might send empty image properties with "" instead of setting them to null.
-        // This can cause GQL to fail. We therefore enforce 'null' for empty image properties.
-        // See https://github.com/TryGhost/GQL/issues/24
-        return ['feature_image'];
-    },
-
     posts: function posts() {
         return this.belongsToMany('Post');
     },

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -230,13 +230,6 @@ User = ghostBookshelf.Model.extend({
         return attrs;
     },
 
-    emptyStringProperties: function emptyStringProperties() {
-        // CASE: the client might send empty image properties with "" instead of setting them to null.
-        // This can cause GQL to fail. We therefore enforce 'null' for empty image properties.
-        // See https://github.com/TryGhost/GQL/issues/24
-        return ['profile_image', 'cover_image'];
-    },
-
     format: function format(options) {
         if (!_.isEmpty(options.website) &&
             !validator.isURL(options.website, {

--- a/core/test/unit/models/base/index_spec.js
+++ b/core/test/unit/models/base/index_spec.js
@@ -174,21 +174,14 @@ describe('Models: base', function () {
         it('resets given empty value to null', function () {
             const base = models.Base.Model.forge({a: '', b: ''});
 
-            base.emptyStringProperties = sinon.stub();
-            base.emptyStringProperties.returns(['a']);
+            base.getNullableStringProperties = sinon.stub();
+            base.getNullableStringProperties.returns(['a']);
 
             base.get('a').should.eql('');
             base.get('b').should.eql('');
             base.setEmptyValuesToNull();
             should.not.exist(base.get('a'));
             base.get('b').should.eql('');
-        });
-
-        it('does not reset to null if model does\'t provide properties', function () {
-            const base = models.Base.Model.forge({a: ''});
-            base.get('a').should.eql('');
-            base.setEmptyValuesToNull();
-            base.get('a').should.eql('');
         });
     });
 


### PR DESCRIPTION
refs #10388 

This updates the base model to retrieve column information, and explicitly set every property whose column is `nullable` and content is the empty string (`""`) to `null`

This is the first half of solving https://github.com/TryGhost/Ghost/issues/10388 - This will stop all future updates from storing empty strings, but we will still need to clean up the DB.