### PR TITLE
🐛 Fixed crash on startup when no active theme

### DIFF
--- a/core/server/services/routing/bootstrap.js
+++ b/core/server/services/routing/bootstrap.js
@@ -38,7 +38,7 @@ module.exports.init = (options = {start: false}) => {
  *   - is the PreviewRouter an app?
  */
 module.exports.start = () => {
-    const apiVersion = themeService.getActive().engine('ghost-api');
+    const apiVersion = themeService.getApiVersion();
     const RESOURCE_CONFIG = require(`../../services/routing/config/${apiVersion}`);
 
     const previewRouter = new PreviewRouter(RESOURCE_CONFIG);

--- a/core/server/services/settings/validate.js
+++ b/core/server/services/settings/validate.js
@@ -392,7 +392,7 @@ module.exports = function validate(object) {
         object.taxonomies = {};
     }
 
-    const apiVersion = themeService.getActive().engine('ghost-api');
+    const apiVersion = themeService.getApiVersion();
 
     debug('api version', apiVersion);
 

--- a/core/server/services/themes/index.js
+++ b/core/server/services/themes/index.js
@@ -1,11 +1,13 @@
-var debug = require('ghost-ignition').debug('themes'),
-    common = require('../../lib/common'),
-    themeLoader = require('./loader'),
-    active = require('./active'),
-    validate = require('./validate'),
-    Storage = require('./Storage'),
-    settingsCache = require('../settings/cache'),
-    themeStorage;
+const debug = require('ghost-ignition').debug('themes');
+const common = require('../../lib/common');
+const themeLoader = require('./loader');
+const active = require('./active');
+const validate = require('./validate');
+const Storage = require('./Storage');
+const settingsCache = require('../settings/cache');
+const engineDefaults = require('./engines/defaults');
+
+let themeStorage;
 
 // @TODO: reduce the amount of things we expose to the outside world
 // Make this a nice clean sensible API we can all understand!
@@ -79,6 +81,13 @@ module.exports = {
     validate: validate,
     toJSON: require('./to-json'),
     getActive: active.get,
+    getApiVersion: function getApiVersion() {
+        if (this.getActive()) {
+            return this.getActive().engine('ghost-api');
+        } else {
+            return engineDefaults['ghost-api'];
+        }
+    },
     activate: function activate(loadedTheme, checkedTheme, error) {
         // no need to check the score, activation should be used in combination with validate.check
         // Use the two theme objects to set the current active theme
@@ -86,11 +95,11 @@ module.exports = {
             let previousGhostAPI;
 
             if (this.getActive()) {
-                previousGhostAPI = this.getActive().engine('ghost-api');
+                previousGhostAPI = this.getApiVersion();
             }
 
             active.set(loadedTheme, checkedTheme, error);
-            const currentGhostAPI = this.getActive().engine('ghost-api');
+            const currentGhostAPI = this.getApiVersion();
 
             common.events.emit('services.themes.activated');
 

--- a/core/server/services/url/Resources.js
+++ b/core/server/services/url/Resources.js
@@ -45,7 +45,7 @@ class Resources {
             return this.resourceConfig;
         }
 
-        this.resourcesAPIVersion = require('../themes').getActive().engine('ghost-api') || 'v0.1';
+        this.resourcesAPIVersion = require('../themes').getApiVersion();
         this.resourcesConfig = require(`./configs/${this.resourcesAPIVersion}`);
     }
 

--- a/core/server/web/shared/middlewares/ghost-locals.js
+++ b/core/server/web/shared/middlewares/ghost-locals.js
@@ -13,7 +13,7 @@ module.exports = function ghostLocals(req, res, next) {
     // relative path from the URL
     res.locals.relativeUrl = req.path;
     // make ghost api version available for the theme + routing
-    res.locals.apiVersion = themeService.getActive().engine('ghost-api');
+    res.locals.apiVersion = themeService.getApiVersion();
 
     next();
 };


### PR DESCRIPTION
closes #10416

- Updated to use default theme engine values when no active theme is found

--------------------------------------------------

The only instances of no active theme causing startup to fail are where its trying to access active theme engine (`getActive().engine`) to get the `ghost-api` property, like [here](https://github.com/TryGhost/Ghost/blob/6b758bda7917420dc567210f0f7e039c7f48a7d2/core/server/services/routing/bootstrap.js#L41).

Protecting these instances against active theme being null, a good fallback for `ghost-api` property if no active theme is found seems to be fetching default value from [here](https://github.com/TryGhost/Ghost/blob/master/core/server/services/themes/engines/defaults.json#L2) instead of hardcoding a particular API version.
