### PR TITLE
🐛 Added migration to update empty strings to null

### DIFF
--- a/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
+++ b/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
@@ -1,0 +1,52 @@
+const Promise = require('bluebird');
+const common = require('../../../../lib/common');
+const schema = require('../../../schema');
+
+/*
+ * [{
+ *   tableName: 'posts',
+ *   columns: ['custom_excerpt', 'description', 'etc...']
+ * }]
+ * */
+const tablesToUpdate = Object.keys(schema.tables).reduce((tablesToUpdate, tableName) => {
+    const table = schema.tables[tableName];
+    const columns = Object.keys(table).filter(columnName => table[columnName].nullable);
+    return tablesToUpdate.concat({
+        tableName,
+        columns
+    });
+}, []);
+
+const createReplace = (connection, from, to) => (tableName, columnName) => {
+    common.logging.info(
+        `Updating ${tableName}, setting all '${from}' in ${columnName} to ${to}`
+    );
+
+    return connection(tableName)
+        .where(columnName, from)
+        .update(columnName, to);
+};
+
+module.exports.up = ({connection}) => {
+    const replaceEmptyStringWithNull = createReplace(connection, '', null);
+
+    return Promise.all(
+        tablesToUpdate.map(({tableName, columns}) => Promise.all(
+            columns.map(
+                columnName => replaceEmptyStringWithNull(tableName, columnName)
+            )
+        ))
+    );
+};
+
+module.exports.down = ({connection}) => {
+    const replaceNullWithEmptyString = createReplace(connection, null, '');
+
+    return Promise.all(
+        tablesToUpdate.map(({tableName, columns}) => Promise.all(
+            columns.map(
+                columnName => replaceNullWithEmptyString(tableName, columnName)
+            )
+        ))
+    );
+};

--- a/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
+++ b/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
@@ -52,8 +52,8 @@ const createReplace = (connection, from, to) => (tableName, columnName) => {
         });
 };
 
-module.exports.up = ({connection}) => {
-    const replaceEmptyStringWithNull = createReplace(connection, '', null);
+module.exports.up = ({transacting}) => {
+    const replaceEmptyStringWithNull = createReplace(transacting, '', null);
 
     return Promise.all(
         tablesToUpdate.map(({tableName, columns}) => Promise.all(

--- a/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
+++ b/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
@@ -72,3 +72,7 @@ module.exports.down = ({connection}) => {
         ))
     );
 };
+
+module.exports.config = {
+      transaction: true
+};

--- a/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
+++ b/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
@@ -10,7 +10,10 @@ const schema = require('../../../schema');
  * */
 const tablesToUpdate = Object.keys(schema.tables).reduce((tablesToUpdate, tableName) => {
     const table = schema.tables[tableName];
-    const columns = Object.keys(table).filter(columnName => table[columnName].nullable);
+    const columns = Object.keys(table).filter((columnName) => {
+        const column = table[columnName];
+        return column.nullable && ['string', 'text'].includes(column.type);
+    });
     if (!columns.length) {
         return tablesToUpdate;
     }
@@ -74,5 +77,5 @@ module.exports.down = ({connection}) => {
 };
 
 module.exports.config = {
-      transaction: true
+    transaction: true
 };

--- a/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
+++ b/core/server/data/migrations/versions/2.13/1-remove-empty-strings.js
@@ -11,6 +11,9 @@ const schema = require('../../../schema');
 const tablesToUpdate = Object.keys(schema.tables).reduce((tablesToUpdate, tableName) => {
     const table = schema.tables[tableName];
     const columns = Object.keys(table).filter(columnName => table[columnName].nullable);
+    if (!columns.length) {
+        return tablesToUpdate;
+    }
     return tablesToUpdate.concat({
         tableName,
         columns


### PR DESCRIPTION
closes #10388

This migration finds all tables with nullable columns, it then loops through the tables and their nullable columns, updating each column to a null when its current value is an empty string.

