### PR TITLE
🐛 Allowed data to be read from root of specified key rather than root.resource

### DIFF
--- a/core/server/services/routing/controllers/static.js
+++ b/core/server/services/routing/controllers/static.js
@@ -43,7 +43,7 @@ module.exports = function staticController(req, res, next) {
                     if (config.type === 'browse') {
                         response.data[name].meta = result[name].meta;
                         // @TODO: remove in v3
-                        response.data[name][config.resource] = result[name][config.resource]
+                        response.data[name][config.resource] = result[name][config.resource];
                     }
                 });
             }

--- a/core/server/services/routing/controllers/static.js
+++ b/core/server/services/routing/controllers/static.js
@@ -38,10 +38,12 @@ module.exports = function staticController(req, res, next) {
                 response.data = {};
 
                 _.each(res.routerOptions.data, function (config, name) {
+                    response.data[name] = result[name][config.resource];
+
                     if (config.type === 'browse') {
-                        response.data[name] = result[name];
-                    } else {
-                        response.data[name] = result[name][config.resource];
+                        response.data[name].meta = result[name].meta;
+                        // @TODO: remove in v3
+                        response.data[name][config.resource] = result[name][config.resource]
                     }
                 });
             }


### PR DESCRIPTION
refs #10434

When defining a static route like:

```yaml
routes:
  /whatever/:
    template: whatever
    data:
      things:
        resource: tags
        type: browse
```

The context passed to the template will look like this:

```js
{
  things: {
    tags: [tag1, tag2],
    pagination: { pagination }
  }
}
```

This changes the context so it looks like
```
{
  things: [tag1, tag2],
  [things.tags]: [tag1, tag2], // The "things" array above has a `tags` property
  [things.pagination]: { pagination }
}
```

This allows us to use the nicer handlebars syntax

```hbs
{{#each things}}
  {{this.stuff}}
{{/each}}
```

rather than

```hbs
{{#each things.tags}}
  {{this.stuff}}
{{/each}}
```