### PR TITLE
Added back theme upload event

### DIFF
--- a/core/server/analytics-events.js
+++ b/core/server/analytics-events.js
@@ -18,6 +18,10 @@ module.exports.init = function () {
         {
             event: 'page.published',
             name: 'Blog Page Published'
+        },
+        {
+            event: 'theme.uploaded',
+            name: 'Uploaded Theme'
         }
     ];
 

--- a/core/server/analytics-events.js
+++ b/core/server/analytics-events.js
@@ -13,15 +13,15 @@ module.exports.init = function () {
     toTrack = [
         {
             event: 'post.published',
-            name: 'Blog Post Published'
+            name: 'Post Published'
         },
         {
             event: 'page.published',
-            name: 'Blog Page Published'
+            name: 'Page Published'
         },
         {
             event: 'theme.uploaded',
-            name: 'Uploaded Theme'
+            name: 'Theme Uploaded'
         }
     ];
 

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -136,6 +136,8 @@ themes = {
                     themeUtils.activate(loadedTheme, checkedTheme);
                 }
 
+                common.events.emit('theme.uploaded');
+
                 // @TODO: unify the name across gscan and Ghost!
                 return themeUtils.toJSON(zip.shortName, checkedTheme);
             })

--- a/core/server/api/v2/themes.js
+++ b/core/server/api/v2/themes.js
@@ -122,6 +122,8 @@ module.exports = {
                         this.headers.cacheInvalidate = true;
                     }
 
+                    common.events.emit('theme.uploaded');
+
                     // @TODO: unify the name across gscan and Ghost!
                     return themeService.toJSON(zip.shortName, checkedTheme);
                 })


### PR DESCRIPTION
no issue

- With the changes in https://github.com/TryGhost/Ghost/commit/79ca6c575c2a10e77ddf618dfb20a571bd4c5655 we removed old unused events
- The theme upload event is still used and needed to be put back
- Added the event emit right after the successful upload of the theme