### PR TITLE
add yarn caching to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
 sudo: false
 
 cache:
+  yarn: true
   directories:
     - node_modules
 


### PR DESCRIPTION
adding yarn cache to travis.ci should speed up builds.
see [yarn doc](https://yarnpkg.com/lang/en/docs/install-ci/#travis)

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [?] The build will pass (run `yarn test` and `yarn lint`)

