### PR TITLE
JSON Schema validation for posts

### DIFF
--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -44,7 +44,8 @@ module.exports = {
          * @TODO: remove `id` restriction in Ghost 3.0
          */
         const schema = require(`./schemas/posts-add`);
-        const errors = jsonSchema.validate(schema, frame.data);
+        const definitions = require('./schemas/posts');
+        const errors = jsonSchema.validate(schema, definitions, frame.data);
 
         if (errors) {
             // TODO: consider better parsing of `errors` messages
@@ -64,11 +65,22 @@ module.exports = {
     },
 
     edit(apiConfig, frame) {
-        if (frame.data.posts[0].hasOwnProperty('authors')) {
-            if (!_.isArray(frame.data.posts[0].authors) ||
-                (frame.data.posts[0].authors.length && _.filter(frame.data.posts[0].authors, 'id').length !== frame.data.posts[0].authors.length)) {
+        const schema = require(`./schemas/posts-edit`);
+        const definitions = require('./schemas/posts');
+        const errors = jsonSchema.validate(schema, definitions, frame.data);
+
+        if (errors) {
+            // TODO: consider better parsing of `errors` messages
+            if (['type', 'required'].includes(errors[0].keyword)) {
                 return Promise.reject(new common.errors.BadRequestError({
-                    message: common.i18n.t('errors.api.utils.invalidStructure', {key: 'posts[*].authors'})
+                    message: common.i18n.t('errors.api.utils.invalidStructure', {key: errors[0].dataPath})
+                }));
+            } else {
+                return Promise.reject(new common.errors.ValidationError({
+                    message: common.i18n.t('notices.data.validation.index.validationFailed', {
+                        validationName: `${errors[0].dataPath} ${errors[0].keyword}`,
+                        context: errors[0]
+                    })
                 }));
             }
         }

--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -3,24 +3,6 @@ const common = require('../../../../../lib/common');
 const utils = require('../../index');
 const jsonSchema = require('../utils/json-schema');
 
-const handleErrors = (errors) => {
-    // TODO: consider better parsing of `errors` messages
-    // also might be a good idea to move this handling into more central
-    // place once validations are introduced for more endpoints
-    if (['type', 'required'].includes(errors[0].keyword)) {
-        return Promise.reject(new common.errors.BadRequestError({
-            message: common.i18n.t('errors.api.utils.invalidStructure', {key: errors[0].dataPath})
-        }));
-    } else {
-        return Promise.reject(new common.errors.ValidationError({
-            message: common.i18n.t('notices.data.validation.index.validationFailed', {
-                validationName: `${errors[0].dataPath} ${errors[0].keyword}`,
-                context: errors[0]
-            })
-        }));
-    }
-};
-
 module.exports = {
     add(apiConfig, frame) {
         /**
@@ -62,20 +44,12 @@ module.exports = {
          */
         const schema = require(`./schemas/posts-add`);
         const definitions = require('./schemas/posts');
-        const errors = jsonSchema.validate(schema, definitions, frame.data);
-
-        if (errors) {
-            return handleErrors(errors);
-        }
+        return jsonSchema.validate(schema, definitions, frame.data);
     },
 
     edit(apiConfig, frame) {
         const schema = require(`./schemas/posts-edit`);
         const definitions = require('./schemas/posts');
-        const errors = jsonSchema.validate(schema, definitions, frame.data);
-
-        if (errors) {
-            return handleErrors(errors);
-        }
+        return jsonSchema.validate(schema, definitions, frame.data);
     }
 };

--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const Promise = require('bluebird');
 const common = require('../../../../../lib/common');
 const utils = require('../../index');
+const jsonSchema = require('../utils/json-schema');
 
 module.exports = {
     add(apiConfig, frame) {
@@ -49,6 +50,18 @@ module.exports = {
                     message: common.i18n.t('errors.api.utils.invalidStructure', {key: 'posts[*].authors'})
                 }));
             }
+        }
+
+        const errors = jsonSchema.validate('posts-add', frame.data);
+
+        if (errors) {
+            // TODO: consider better parsing of `errors` messages
+            return Promise.reject(new common.errors.ValidationError({
+                message: common.i18n.t('notices.data.validation.index.validationFailed', {
+                    validationName: `${errors[0].dataPath} ${errors[0].keyword}`,
+                    context: errors[0]
+                })
+            }));
         }
     },
 

--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -43,25 +43,23 @@ module.exports = {
              *
          * @TODO: remove `id` restriction in Ghost 3.0
          */
-        if (frame.data.posts[0].hasOwnProperty('authors')) {
-            if (!_.isArray(frame.data.posts[0].authors) ||
-                (frame.data.posts[0].authors.length && _.filter(frame.data.posts[0].authors, 'id').length !== frame.data.posts[0].authors.length)) {
-                return Promise.reject(new common.errors.BadRequestError({
-                    message: common.i18n.t('errors.api.utils.invalidStructure', {key: 'posts[*].authors'})
-                }));
-            }
-        }
-
-        const errors = jsonSchema.validate('posts-add', frame.data);
+        const schema = require(`./schemas/posts-add`);
+        const errors = jsonSchema.validate(schema, frame.data);
 
         if (errors) {
             // TODO: consider better parsing of `errors` messages
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('notices.data.validation.index.validationFailed', {
-                    validationName: `${errors[0].dataPath} ${errors[0].keyword}`,
-                    context: errors[0]
-                })
-            }));
+            if (['type', 'required'].includes(errors[0].keyword)) {
+                return Promise.reject(new common.errors.BadRequestError({
+                    message: common.i18n.t('errors.api.utils.invalidStructure', {key: errors[0].dataPath})
+                }));
+            } else {
+                return Promise.reject(new common.errors.ValidationError({
+                    message: common.i18n.t('notices.data.validation.index.validationFailed', {
+                        validationName: `${errors[0].dataPath} ${errors[0].keyword}`,
+                        context: errors[0]
+                    })
+                }));
+            }
         }
     },
 

--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -1,8 +1,25 @@
-const _ = require('lodash');
 const Promise = require('bluebird');
 const common = require('../../../../../lib/common');
 const utils = require('../../index');
 const jsonSchema = require('../utils/json-schema');
+
+const handleErrors = (errors) => {
+    // TODO: consider better parsing of `errors` messages
+    // also might be a good idea to move this handling into more central
+    // place once validations are introduced for more endpoints
+    if (['type', 'required'].includes(errors[0].keyword)) {
+        return Promise.reject(new common.errors.BadRequestError({
+            message: common.i18n.t('errors.api.utils.invalidStructure', {key: errors[0].dataPath})
+        }));
+    } else {
+        return Promise.reject(new common.errors.ValidationError({
+            message: common.i18n.t('notices.data.validation.index.validationFailed', {
+                validationName: `${errors[0].dataPath} ${errors[0].keyword}`,
+                context: errors[0]
+            })
+        }));
+    }
+};
 
 module.exports = {
     add(apiConfig, frame) {
@@ -48,19 +65,7 @@ module.exports = {
         const errors = jsonSchema.validate(schema, definitions, frame.data);
 
         if (errors) {
-            // TODO: consider better parsing of `errors` messages
-            if (['type', 'required'].includes(errors[0].keyword)) {
-                return Promise.reject(new common.errors.BadRequestError({
-                    message: common.i18n.t('errors.api.utils.invalidStructure', {key: errors[0].dataPath})
-                }));
-            } else {
-                return Promise.reject(new common.errors.ValidationError({
-                    message: common.i18n.t('notices.data.validation.index.validationFailed', {
-                        validationName: `${errors[0].dataPath} ${errors[0].keyword}`,
-                        context: errors[0]
-                    })
-                }));
-            }
+            return handleErrors(errors);
         }
     },
 
@@ -70,19 +75,7 @@ module.exports = {
         const errors = jsonSchema.validate(schema, definitions, frame.data);
 
         if (errors) {
-            // TODO: consider better parsing of `errors` messages
-            if (['type', 'required'].includes(errors[0].keyword)) {
-                return Promise.reject(new common.errors.BadRequestError({
-                    message: common.i18n.t('errors.api.utils.invalidStructure', {key: errors[0].dataPath})
-                }));
-            } else {
-                return Promise.reject(new common.errors.ValidationError({
-                    message: common.i18n.t('notices.data.validation.index.validationFailed', {
-                        validationName: `${errors[0].dataPath} ${errors[0].keyword}`,
-                        context: errors[0]
-                    })
-                }));
-            }
+            return handleErrors(errors);
         }
     }
 };

--- a/core/server/api/v2/utils/validators/input/schemas/posts-add.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts-add.json
@@ -12,7 +12,7 @@
             "items": {
                 "type": "object",
                 "allOf": [{"$ref": "posts#/definitions/post"}],
-                "required": ["title", "authors"]
+                "required": ["title"]
             }
         }
     },

--- a/core/server/api/v2/utils/validators/input/schemas/posts-add.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts-add.json
@@ -1,7 +1,8 @@
 
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Post",
+    "$id": "posts.add",
+    "title": "posts.add",
     "description": "Schema for posts.add",
     "type": "object",
     "additionalProperties": false,
@@ -10,120 +11,7 @@
             "type": "array",
             "items": {
                 "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "title": {
-                        "type": "string",
-                        "maxLength": 2000
-                    },
-                    "slug": {
-                        "type": "string",
-                        "maxLength": 191
-                    },
-                    "mobiledoc": {
-                        "type": "string",
-                        "maxLength": 1000000000
-                    },
-                    "feature_image": {
-                        "type": "string",
-                        "format": "uri",
-                        "maxLength": 2000
-                    },
-                    "featured": {
-                        "type": "boolean"
-                    },
-                    "page": {
-                        "type": "boolean"
-                    },
-                    "status": {
-                        "type": "string",
-                        "enum": ["published", "draft", "scheduled"]
-                    },
-                    "locale": {
-                        "type": "string",
-                        "maxLength": 6
-                    },
-                    "visibility": {
-                        "type": "string",
-                        "enum": ["public"]
-                    },
-                    "meta_title": {
-                        "type": "string",
-                        "maxLength": 300
-                    },
-                    "meta_description": {
-                        "type": "string",
-                        "maxLength": 500
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "published_at": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "custom_excerpt": {
-                        "type": "string",
-                        "maxLength": 300
-                    },
-                    "codeinjection_head": {
-                        "type": "string",
-                        "maxLength": 65535
-                    },
-                    "codeinjection_foot": {
-                        "type": "string",
-                        "maxLength": 65535
-                    },
-                    "og_image": {
-                        "type": "string",
-                        "format": "uri",
-                        "maxLength": 2000
-                    },
-                    "og_title": {
-                        "type": "string",
-                        "maxLength": 300
-                    },
-                    "og_description": {
-                        "type": "string",
-                        "maxLength": 500
-                    },
-                    "twitter_image": {
-                        "type": "string",
-                        "format": "uri",
-                        "maxLength": 2000
-                    },
-                    "twitter_title": {
-                        "type": "string",
-                        "maxLength": 300
-                    },
-                    "twitter_description": {
-                        "type": "string",
-                        "maxLength": 500
-                    },
-                    "custom_template": {
-                        "type": "string",
-                        "maxLength": 100
-                    },
-                    "authors": {
-                        "description": "Authors of the post",
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "maxLength": 24
-                                }
-                            },
-                            "required": ["id"]
-                        }
-                    }
-                },
+                "allOf": [{"$ref": "posts#/definitions/post"}],
                 "required": ["title", "authors"]
             }
         }

--- a/core/server/api/v2/utils/validators/input/schemas/posts-add.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts-add.json
@@ -113,20 +113,14 @@
                         "description": "Authors of the post",
                         "type": "array",
                         "items": {
-                            "oneOf": [{
-                                "type": "string"
-                            }, {
-                                "type": "string",
-                                "maxLength": 24
-                            }, {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "string",
-                                        "maxLength": 24
-                                    }
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "maxLength": 24
                                 }
-                            }]
+                            },
+                            "required": ["id"]
                         }
                     }
                 },

--- a/core/server/api/v2/utils/validators/input/schemas/posts-edit.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts-edit.json
@@ -1,0 +1,16 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "posts.edit",
+    "title": "posts.edit",
+    "description": "Schema for posts.edit",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "posts": {
+            "type": "array",
+            "items": {"$ref": "posts#/definitions/post"}
+        }
+    },
+    "required": [ "posts" ]
+  }

--- a/core/server/api/v2/utils/validators/input/schemas/posts.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts.json
@@ -1,0 +1,129 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "posts",
+    "title": "posts",
+    "description": "Base posts definitions",
+    "definitions": {
+        "post": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "slug": {
+                    "type": "string",
+                    "maxLength": 191
+                },
+                "mobiledoc": {
+                    "type": "string",
+                    "maxLength": 1000000000
+                },
+                "feature_image": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2000
+                },
+                "featured": {
+                    "type": "boolean"
+                },
+                "page": {
+                    "type": "boolean"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["published", "draft", "scheduled"]
+                },
+                "locale": {
+                    "type": "string",
+                    "maxLength": 6
+                },
+                "visibility": {
+                    "type": "string",
+                    "enum": ["public"]
+                },
+                "meta_title": {
+                    "type": "string",
+                    "maxLength": 300
+                },
+                "meta_description": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "created_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "published_at": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "custom_excerpt": {
+                    "type": "string",
+                    "maxLength": 300
+                },
+                "codeinjection_head": {
+                    "type": "string",
+                    "maxLength": 65535
+                },
+                "codeinjection_foot": {
+                    "type": "string",
+                    "maxLength": 65535
+                },
+                "og_image": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2000
+                },
+                "og_title": {
+                    "type": "string",
+                    "maxLength": 300
+                },
+                "og_description": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "twitter_image": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2000
+                },
+                "twitter_title": {
+                    "type": "string",
+                    "maxLength": 300
+                },
+                "twitter_description": {
+                    "type": "string",
+                    "maxLength": 500
+                },
+                "custom_template": {
+                    "type": "string",
+                    "maxLength": 100
+                },
+                "authors": {
+                    "$ref": "#/definitions/post-authors"
+                }
+            }
+        },
+        "post-authors": {
+            "description": "Authors of the post",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "maxLength": 24
+                    }
+                },
+                "required": ["id"]
+            }
+        }
+    }
+  }

--- a/core/server/api/v2/utils/validators/input/schemas/posts.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts.json
@@ -9,6 +9,10 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "id": {
+                    "type": "string",
+                    "maxLength": 24
+                },
                 "title": {
                     "type": "string",
                     "maxLength": 2000
@@ -18,11 +22,11 @@
                     "maxLength": 191
                 },
                 "mobiledoc": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 1000000000
                 },
                 "feature_image": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "format": "uri",
                     "maxLength": 2000
                 },
@@ -37,82 +41,111 @@
                     "enum": ["published", "draft", "scheduled"]
                 },
                 "locale": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 6
                 },
                 "visibility": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "enum": ["public"]
                 },
                 "meta_title": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 300
                 },
                 "meta_description": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 500
                 },
                 "created_at": {
                     "type": "string",
                     "format": "date-time"
                 },
-                "updated_at": {
+                "created_by": {
                     "type": "string",
+                    "maxLength": 24
+                },
+                "updated_at": {
+                    "type": ["string", "null"],
                     "format": "date-time"
+                },
+                "updated_by": {
+                    "type": ["string", "null"],
+                    "maxLength": 24
                 },
                 "published_at": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "format": "date-time"
                 },
+                "published_by": {
+                    "type": ["string", "null"],
+                    "maxLength": 24
+                },
                 "custom_excerpt": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 300
                 },
                 "codeinjection_head": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 65535
                 },
                 "codeinjection_foot": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 65535
                 },
                 "og_image": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "format": "uri",
                     "maxLength": 2000
                 },
                 "og_title": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 300
                 },
                 "og_description": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 500
                 },
                 "twitter_image": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "format": "uri",
                     "maxLength": 2000
                 },
                 "twitter_title": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 300
                 },
                 "twitter_description": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 500
                 },
                 "custom_template": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "maxLength": 100
                 },
                 "authors": {
                     "$ref": "#/definitions/post-authors"
+                },
+                "tags": {
+                    "$ref": "#/definitions/post-tags"
                 }
             }
         },
         "post-authors": {
             "description": "Authors of the post",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "maxLength": 24
+                    }
+                },
+                "required": ["id"]
+            }
+        },
+        "post-tags": {
+            "description": "Tags of the post",
             "type": "array",
             "items": {
                 "type": "object",

--- a/core/server/api/v2/utils/validators/utils/json-schema.js
+++ b/core/server/api/v2/utils/validators/utils/json-schema.js
@@ -1,15 +1,22 @@
 const Ajv = require('ajv');
+const common = require('../../../../../lib/common');
 
 const validate = (schema, definitions, json) => {
     const ajv = new Ajv({
         allErrors: true
     });
 
-    const validator = ajv.addSchema(definitions).compile(schema);
+    const validation = ajv.addSchema(definitions).compile(schema);
 
-    validator(json);
+    validation(json);
 
-    return validator.errors;
+    if (validation.errors) {
+        return Promise.reject(new common.errors.ValidationError({
+            message: common.i18n.t('notices.data.validation.index.validationFailed', {
+                errorDetails: validation.errors
+            })
+        }));
+    }
 };
 
 module.exports.validate = validate;

--- a/core/server/api/v2/utils/validators/utils/json-schema.js
+++ b/core/server/api/v2/utils/validators/utils/json-schema.js
@@ -1,0 +1,15 @@
+const Ajv = require('ajv');
+
+const validate = (schemaName, json) => {
+    const ajv = new Ajv({
+        allErrors: true
+    });
+
+    const schema = require(`./schemas/${schemaName}`);
+    const validator = ajv.compile(schema);
+    validator(json);
+
+    return validator.errors;
+};
+
+module.exports.validate = validate;

--- a/core/server/api/v2/utils/validators/utils/json-schema.js
+++ b/core/server/api/v2/utils/validators/utils/json-schema.js
@@ -17,6 +17,8 @@ const validate = (schema, definitions, json) => {
             })
         }));
     }
+
+    return Promise.resolve();
 };
 
 module.exports.validate = validate;

--- a/core/server/api/v2/utils/validators/utils/json-schema.js
+++ b/core/server/api/v2/utils/validators/utils/json-schema.js
@@ -1,11 +1,12 @@
 const Ajv = require('ajv');
 
-const validate = (schema, json) => {
+const validate = (schema, definitions, json) => {
     const ajv = new Ajv({
         allErrors: true
     });
 
-    const validator = ajv.compile(schema);
+    const validator = ajv.addSchema(definitions).compile(schema);
+
     validator(json);
 
     return validator.errors;

--- a/core/server/api/v2/utils/validators/utils/json-schema.js
+++ b/core/server/api/v2/utils/validators/utils/json-schema.js
@@ -1,11 +1,10 @@
 const Ajv = require('ajv');
 
-const validate = (schemaName, json) => {
+const validate = (schema, json) => {
     const ajv = new Ajv({
         allErrors: true
     });
 
-    const schema = require(`./schemas/${schemaName}`);
     const validator = ajv.compile(schema);
     validator(json);
 

--- a/core/server/api/v2/utils/validators/utils/schemas/posts-add.json
+++ b/core/server/api/v2/utils/validators/utils/schemas/posts-add.json
@@ -1,0 +1,138 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Post",
+    "description": "Schema for posts.add",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "posts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "maxLength": 2000
+                    },
+                    "slug": {
+                        "type": "string",
+                        "maxLength": 191
+                    },
+                    "mobiledoc": {
+                        "type": "string",
+                        "maxLength": 1000000000
+                    },
+                    "feature_image": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2000
+                    },
+                    "featured": {
+                        "type": "boolean"
+                    },
+                    "page": {
+                        "type": "boolean"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["published", "draft", "scheduled"]
+                    },
+                    "locale": {
+                        "type": "string",
+                        "maxLength": 6
+                    },
+                    "visibility": {
+                        "type": "string",
+                        "enum": ["public"]
+                    },
+                    "meta_title": {
+                        "type": "string",
+                        "maxLength": 300
+                    },
+                    "meta_description": {
+                        "type": "string",
+                        "maxLength": 500
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "published_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "custom_excerpt": {
+                        "type": "string",
+                        "maxLength": 300
+                    },
+                    "codeinjection_head": {
+                        "type": "string",
+                        "maxLength": 65535
+                    },
+                    "codeinjection_foot": {
+                        "type": "string",
+                        "maxLength": 65535
+                    },
+                    "og_image": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2000
+                    },
+                    "og_title": {
+                        "type": "string",
+                        "maxLength": 300
+                    },
+                    "og_description": {
+                        "type": "string",
+                        "maxLength": 500
+                    },
+                    "twitter_image": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2000
+                    },
+                    "twitter_title": {
+                        "type": "string",
+                        "maxLength": 300
+                    },
+                    "twitter_description": {
+                        "type": "string",
+                        "maxLength": 500
+                    },
+                    "custom_template": {
+                        "type": "string",
+                        "maxLength": 100
+                    },
+                    "authors": {
+                        "description": "Authors of the post",
+                        "type": "array",
+                        "items": {
+                            "oneOf": [{
+                                "type": "string"
+                            }, {
+                                "type": "string",
+                                "maxLength": 24
+                            }, {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "maxLength": 24
+                                    }
+                                }
+                            }]
+                        }
+                    }
+                },
+                "required": ["title", "authors"]
+            }
+        }
+    },
+    "required": [ "posts" ]
+  }

--- a/core/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -91,6 +91,10 @@ describe('Unit: v2/utils/validators/input/posts', function () {
             });
         });
 
+        describe('field formats', function () {
+            // TODO: add checks for correct format validations
+        });
+
         describe('authors structure', function () {
             it('should require properties', function () {
                 const frame = {

--- a/core/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -24,7 +24,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        (err instanceof common.errors.BadRequestError).should.be.true();
+                        (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
@@ -72,7 +72,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        (err instanceof common.errors.BadRequestError).should.be.true();
+                        (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
@@ -112,7 +112,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        (err instanceof common.errors.BadRequestError).should.be.true();
+                        (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
@@ -134,7 +134,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        (err instanceof common.errors.BadRequestError).should.be.true();
+                        (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
@@ -174,7 +174,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 return validators.input.posts.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        (err instanceof common.errors.BadRequestError).should.be.true();
+                        (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
@@ -240,7 +240,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 return validators.input.posts.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        (err instanceof common.errors.BadRequestError).should.be.true();
+                        (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
@@ -262,7 +262,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 return validators.input.posts.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        (err instanceof common.errors.BadRequestError).should.be.true();
+                        (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 

--- a/core/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -10,77 +10,79 @@ describe('Unit: v2/utils/validators/input/posts', function () {
     });
 
     describe('add', function () {
-        it('authors structure', function () {
-            const apiConfig = {
-                docName: 'posts'
-            };
+        describe('authors structure', function () {
+            it('should require properties', function () {
+                const apiConfig = {
+                    docName: 'posts'
+                };
 
-            const frame = {
-                options: {},
-                data: {
-                    posts: [
-                        {
-                            title: 'cool',
-                            authors: {}
-                        }
-                    ]
-                }
-            };
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: {}
+                            }
+                        ]
+                    }
+                };
 
-            return validators.input.posts.add(apiConfig, frame)
-                .then(Promise.reject)
-                .catch((err) => {
-                    (err instanceof common.errors.BadRequestError).should.be.true();
-                });
-        });
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.BadRequestError).should.be.true();
+                    });
+            });
 
-        it('authors structure', function () {
-            const apiConfig = {
-                docName: 'posts'
-            };
+            it('should require id', function () {
+                const apiConfig = {
+                    docName: 'posts'
+                };
 
-            const frame = {
-                options: {},
-                data: {
-                    posts: [
-                        {
-                            title: 'cool',
-                            authors: [{
-                                name: 'hey'
-                            }]
-                        }
-                    ]
-                }
-            };
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    name: 'hey'
+                                }]
+                            }
+                        ]
+                    }
+                };
 
-            return validators.input.posts.add(apiConfig, frame)
-                .then(Promise.reject)
-                .catch((err) => {
-                    (err instanceof common.errors.BadRequestError).should.be.true();
-                });
-        });
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.BadRequestError).should.be.true();
+                    });
+            });
 
-        it('authors structure', function () {
-            const apiConfig = {
-                docName: 'posts'
-            };
+            it('should pass', function () {
+                const apiConfig = {
+                    docName: 'posts'
+                };
 
-            const frame = {
-                options: {},
-                data: {
-                    posts: [
-                        {
-                            title: 'cool',
-                            authors: [{
-                                id: 'correct',
-                                name: 'ja'
-                            }]
-                        }
-                    ]
-                }
-            };
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    id: 'correct',
+                                    name: 'ja'
+                                }]
+                            }
+                        ]
+                    }
+                };
 
-            return validators.input.posts.add(apiConfig, frame);
+                return validators.input.posts.add(apiConfig, frame);
+            });
         });
     });
 });

--- a/core/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -72,7 +72,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 return validators.input.posts.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
-                        (err instanceof common.errors.ValidationError).should.be.true();
+                        (err instanceof common.errors.BadRequestError).should.be.true();
                     });
             });
 
@@ -151,6 +151,149 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 };
 
                 return validators.input.posts.add(apiConfig, frame);
+            });
+        });
+    });
+
+    describe('edit', function () {
+        const apiConfig = {
+            docName: 'posts'
+        };
+
+        describe('required fields', function () {
+            it('should fail with no data', function () {
+                const frame = {
+                    options: {},
+                    data: {}
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.BadRequestError).should.be.true();
+                    });
+            });
+
+            it('should fail with no posts', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: []
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with more than post', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [],
+                        tags: []
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with some fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            title: 'pass'
+                        }],
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame);
+            });
+        });
+
+        describe('authors structure', function () {
+            it('should require properties', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: {}
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.BadRequestError).should.be.true();
+                    });
+            });
+
+            it('should require id', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    name: 'hey'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.BadRequestError).should.be.true();
+                    });
+            });
+
+            it('should pass with valid authors', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    id: 'correct',
+                                    name: 'ja'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame);
+            });
+
+            it('should pass without authors', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool'
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame);
             });
         });
     });

--- a/core/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
@@ -92,7 +93,49 @@ describe('Unit: v2/utils/validators/input/posts', function () {
         });
 
         describe('field formats', function () {
-            // TODO: add checks for correct format validations
+            const fieldMap = {
+                title: [123, new Date(), _.repeat('a', 2001)],
+                slug: [123, new Date(), _.repeat('a', 192)],
+                mobiledoc: [123, new Date()],
+                feature_image: [123, new Date(), 'abc'],
+                featured: [123, new Date(), 'abc'],
+                page: [123, new Date(), 'abc'],
+                status: [123, new Date(), 'abc'],
+                locale: [123, new Date(), _.repeat('a', 7)],
+                visibility: [123, new Date(), 'abc'],
+                meta_title: [123, new Date(), _.repeat('a', 301)],
+                meta_description: [123, new Date(), _.repeat('a', 501)],
+            };
+
+            Object.keys(fieldMap).forEach(key => {
+                it(`should fail for bad ${key}`, function () {
+                    const badValues = fieldMap[key];
+
+                    const checks = badValues.map((value) => {
+                        const post = {};
+                        post[key] = value;
+
+                        if (key !== 'title') {
+                            post.title = 'abc';
+                        }
+
+                        const frame = {
+                            options: {},
+                            data: {
+                                posts: [post]
+                            }
+                        };
+
+                        return validators.input.posts.add(apiConfig, frame)
+                            .then(Promise.reject)
+                            .catch((err) => {
+                                (err instanceof common.errors.ValidationError).should.be.true();
+                            });
+                    });
+
+                    return Promise.all(checks);
+                });
+            });
         });
 
         describe('authors structure', function () {

--- a/core/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -10,12 +10,89 @@ describe('Unit: v2/utils/validators/input/posts', function () {
     });
 
     describe('add', function () {
-        describe('authors structure', function () {
-            it('should require properties', function () {
-                const apiConfig = {
-                    docName: 'posts'
+        const apiConfig = {
+            docName: 'posts'
+        };
+
+        describe('required fields', function () {
+            it('should fail with no data', function () {
+                const frame = {
+                    options: {},
+                    data: {}
                 };
 
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.BadRequestError).should.be.true();
+                    });
+            });
+
+            it('should fail with no posts', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: []
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with more than post', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [],
+                        tags: []
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail without required fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            what: 'a fail'
+                        }],
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with required fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}]
+                        }],
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame);
+            });
+        });
+
+        describe('authors structure', function () {
+            it('should require properties', function () {
                 const frame = {
                     options: {},
                     data: {
@@ -36,10 +113,6 @@ describe('Unit: v2/utils/validators/input/posts', function () {
             });
 
             it('should require id', function () {
-                const apiConfig = {
-                    docName: 'posts'
-                };
-
                 const frame = {
                     options: {},
                     data: {
@@ -62,10 +135,6 @@ describe('Unit: v2/utils/validators/input/posts', function () {
             });
 
             it('should pass', function () {
-                const apiConfig = {
-                    docName: 'posts'
-                };
-
                 const frame = {
                     options: {},
                     data: {

--- a/core/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -20,6 +20,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 data: {
                     posts: [
                         {
+                            title: 'cool',
                             authors: {}
                         }
                     ]
@@ -43,6 +44,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 data: {
                     posts: [
                         {
+                            title: 'cool',
                             authors: [{
                                 name: 'hey'
                             }]
@@ -68,6 +70,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 data: {
                     posts: [
                         {
+                            title: 'cool',
                             authors: [{
                                 id: 'correct',
                                 name: 'ja'

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@nexes/nql": "0.2.1",
-    "ajv": "^6.8.1",
+    "ajv": "6.8.1",
     "amperize": "0.3.8",
     "analytics-node": "3.3.0",
     "archiver": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@nexes/nql": "0.2.1",
+    "ajv": "^6.8.1",
     "amperize": "0.3.8",
     "analytics-node": "3.3.0",
     "archiver": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -144,6 +144,16 @@ ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
+ajv@6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.8.1.tgz#0890b93742985ebf8973cd365c5b23920ce3cb20"
+  integrity sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"


### PR DESCRIPTION
refs #10438

This is a POC for JSON Schema validation of `/posts` endpoints. Would love to get feedback on the general placement of this validation and approach used. Also would need to consider better placement of validation error handlers as I think they could be extracted into a separate layer of the application for better reuse. Some more points to discuss directly in code comments :wink: 

In progress:
- [x] unit test coverage for format validations 