### PR TITLE
Updated posts JSON Schema with 'strip' properties

### DIFF
--- a/core/server/api/v2/utils/validators/input/schemas/posts-add.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts-add.json
@@ -9,6 +9,8 @@
     "properties": {
         "posts": {
             "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
             "items": {
                 "type": "object",
                 "allOf": [{"$ref": "posts#/definitions/post"}],

--- a/core/server/api/v2/utils/validators/input/schemas/posts-edit.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts-edit.json
@@ -9,6 +9,8 @@
     "properties": {
         "posts": {
             "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
             "items": {"$ref": "posts#/definitions/post"}
         }
     },

--- a/core/server/api/v2/utils/validators/input/schemas/posts.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts.json
@@ -9,10 +9,6 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "id": {
-                    "type": "string",
-                    "maxLength": 24
-                },
                 "title": {
                     "type": "string",
                     "maxLength": 2000
@@ -27,7 +23,7 @@
                 },
                 "feature_image": {
                     "type": ["string", "null"],
-                    "format": "uri",
+                    "format": "uri-reference",
                     "maxLength": 2000
                 },
                 "featured": {
@@ -56,29 +52,13 @@
                     "type": ["string", "null"],
                     "maxLength": 500
                 },
-                "created_at": {
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "created_by": {
-                    "type": "string",
-                    "maxLength": 24
-                },
                 "updated_at": {
                     "type": ["string", "null"],
                     "format": "date-time"
                 },
-                "updated_by": {
-                    "type": ["string", "null"],
-                    "maxLength": 24
-                },
                 "published_at": {
                     "type": ["string", "null"],
                     "format": "date-time"
-                },
-                "published_by": {
-                    "type": ["string", "null"],
-                    "maxLength": 24
                 },
                 "custom_excerpt": {
                     "type": ["string", "null"],
@@ -94,7 +74,7 @@
                 },
                 "og_image": {
                     "type": ["string", "null"],
-                    "format": "uri",
+                    "format": "uri-reference",
                     "maxLength": 2000
                 },
                 "og_title": {
@@ -107,7 +87,7 @@
                 },
                 "twitter_image": {
                     "type": ["string", "null"],
-                    "format": "uri",
+                    "format": "uri-reference",
                     "maxLength": 2000
                 },
                 "twitter_title": {
@@ -127,6 +107,21 @@
                 },
                 "tags": {
                     "$ref": "#/definitions/post-tags"
+                },
+                "id": {
+                    "strip": true
+                },
+                "created_at": {
+                    "strip": true
+                },
+                "created_by": {
+                    "strip": true
+                },
+                "updated_by": {
+                    "strip": true
+                },
+                "published_by": {
+                    "strip": true
                 }
             }
         },
@@ -153,6 +148,14 @@
                     "id": {
                         "type": "string",
                         "maxLength": 24
+                    },
+                    "name": {
+                        "type": "string",
+                        "maxLength": 191
+                    },
+                    "slug": {
+                        "type": "string",
+                        "maxLength": 191
                     }
                 },
                 "anyOf": [
@@ -163,4 +166,4 @@
             }
         }
     }
-  }
+}

--- a/core/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -44,6 +44,21 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     });
             });
 
+            it('should fail with no posts in array', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: []
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
             it('should fail with more than post', function () {
                 const frame = {
                     options: {},
@@ -90,6 +105,35 @@ describe('Unit: v2/utils/validators/input/posts', function () {
 
                 return validators.input.posts.add(apiConfig, frame);
             });
+
+            it('should remove `strip`able fields and leave regular fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}],
+                            id: 'strip me',
+                            created_at: 'strip me',
+                            created_by: 'strip me',
+                            updated_by: 'strip me',
+                            published_by: 'strip me'
+                        }],
+                    }
+                };
+
+                let result = validators.input.posts.add(apiConfig, frame);
+
+                should.exist(frame.data.posts[0].title);
+                should.exist(frame.data.posts[0].authors);
+                should.not.exist(frame.data.posts[0].id);
+                should.not.exist(frame.data.posts[0].created_at);
+                should.not.exist(frame.data.posts[0].created_by);
+                should.not.exist(frame.data.posts[0].updated_by);
+                should.not.exist(frame.data.posts[0].published_by);
+
+                return result;
+            });
         });
 
         describe('field formats', function () {
@@ -97,7 +141,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 title: [123, new Date(), _.repeat('a', 2001)],
                 slug: [123, new Date(), _.repeat('a', 192)],
                 mobiledoc: [123, new Date()],
-                feature_image: [123, new Date(), 'abc'],
+                feature_image: [123, new Date(), 'random words'],
                 featured: [123, new Date(), 'abc'],
                 page: [123, new Date(), 'abc'],
                 status: [123, new Date(), 'abc'],


### PR DESCRIPTION
refs #10438
refs #9100

- Added 'strip' attributes to properties that need to be ignored
- Relaxed 'uri' format to 'uri-reference'
- Made input array for posts more restrictive

@kirrg001 similarly to the previous PR for /tags endpoint, posts schema needs a quick look into fields that can be stripped. Thanks!