### PR TITLE
Removed `id` restriction for posts relations in Admin API v2

### DIFF
--- a/core/server/api/v2/utils/validators/input/schemas/posts.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts.json
@@ -134,9 +134,21 @@
                     "id": {
                         "type": "string",
                         "maxLength": 24
+                    },
+                    "slug": {
+                        "type": "string",
+                        "maxLength": 191
+                    },
+                    "email": {
+                        "type": "string",
+                        "maxLength": 191
                     }
                 },
-                "required": ["id"]
+                "anyOf": [
+                    {"required": ["id"]},
+                    {"required": ["slug"]},
+                    {"required": ["email"]}
+                ]
             }
         },
         "post-tags": {

--- a/core/test/acceptance/old/content/authors_spec.js
+++ b/core/test/acceptance/old/content/authors_spec.js
@@ -20,7 +20,7 @@ describe('Authors Content API', function () {
                 request = supertest.agent(config.get('url'));
             })
             .then(function () {
-                return testUtils.initFixtures('users:no-owner', 'user:inactive', 'posts', 'api_keys');
+                return testUtils.initFixtures('owner:post', 'users:no-owner', 'user:inactive', 'posts', 'api_keys');
             });
     });
 

--- a/core/test/acceptance/old/content/posts_spec.js
+++ b/core/test/acceptance/old/content/posts_spec.js
@@ -19,7 +19,7 @@ describe('Posts Content API', function () {
                 request = supertest.agent(config.get('url'));
             })
             .then(function () {
-                return testUtils.initFixtures('users:no-owner', 'user:inactive', 'posts', 'tags:extra', 'api_keys');
+                return testUtils.initFixtures('owner:post', 'users:no-owner', 'user:inactive', 'posts', 'tags:extra', 'api_keys');
             });
     });
 


### PR DESCRIPTION
refs #10438

- we try to match with slug or id or email
- fallback to owner
- you cannot create a user via post endpoint

Just running travis.