### PR TITLE
[HOLD] Split pages & posts in Admin API v2

### DIFF
--- a/core/server/api/v2/index.js
+++ b/core/server/api/v2/index.js
@@ -23,6 +23,10 @@ module.exports = {
         return shared.pipeline(require('./pages-public'), localUtils);
     },
 
+    get pages() {
+        return shared.pipeline(require('./pages'), localUtils);
+    },
+
     get redirects() {
         return shared.pipeline(require('./redirects'), localUtils);
     },

--- a/core/server/api/v2/index.js
+++ b/core/server/api/v2/index.js
@@ -47,6 +47,10 @@ module.exports = {
         return shared.pipeline(require('./posts'), localUtils);
     },
 
+    get postsPublic() {
+        return shared.pipeline(require('./posts-public'), localUtils);
+    },
+
     get invites() {
         return shared.pipeline(require('./invites'), localUtils);
     },

--- a/core/server/api/v2/index.js
+++ b/core/server/api/v2/index.js
@@ -19,8 +19,8 @@ module.exports = {
         return require('./session');
     },
 
-    get pages() {
-        return shared.pipeline(require('./pages'), localUtils);
+    get pagesPublic() {
+        return shared.pipeline(require('./pages-public'), localUtils);
     },
 
     get redirects() {

--- a/core/server/api/v2/pages-public.js
+++ b/core/server/api/v2/pages-public.js
@@ -1,6 +1,6 @@
 const common = require('../../lib/common');
 const models = require('../../models');
-const ALLOWED_INCLUDES = ['author', 'tags', 'authors'];
+const ALLOWED_INCLUDES = ['tags', 'authors'];
 
 module.exports = {
     docName: 'pages',

--- a/core/server/api/v2/pages-public.js
+++ b/core/server/api/v2/pages-public.js
@@ -1,14 +1,14 @@
 const common = require('../../lib/common');
 const models = require('../../models');
-const ALLOWED_INCLUDES = ['author', 'tags', 'authors', 'authors.roles'];
+const ALLOWED_INCLUDES = ['author', 'tags', 'authors'];
 
 module.exports = {
     docName: 'pages',
+
     browse: {
         options: [
             'include',
             'filter',
-            'status',
             'fields',
             'formats',
             'absolute_urls',
@@ -37,7 +37,6 @@ module.exports = {
         options: [
             'include',
             'fields',
-            'status',
             'formats',
             'debug',
             'absolute_urls'

--- a/core/server/api/v2/pages-public.js
+++ b/core/server/api/v2/pages-public.js
@@ -44,7 +44,6 @@ module.exports = {
         data: [
             'id',
             'slug',
-            'status',
             'uuid'
         ],
         validation: {

--- a/core/server/api/v2/pages.js
+++ b/core/server/api/v2/pages.js
@@ -12,7 +12,6 @@ module.exports = {
             'filter',
             'fields',
             'formats',
-            'status',
             'limit',
             'order',
             'page',
@@ -42,7 +41,6 @@ module.exports = {
         options: [
             'include',
             'fields',
-            'status',
             'formats',
             'debug',
             'absolute_urls'
@@ -50,7 +48,6 @@ module.exports = {
         data: [
             'id',
             'slug',
-            'status',
             'uuid'
         ],
         validation: {

--- a/core/server/api/v2/pages.js
+++ b/core/server/api/v2/pages.js
@@ -1,0 +1,191 @@
+const models = require('../../models');
+const common = require('../../lib/common');
+const urlService = require('../../services/url');
+const ALLOWED_INCLUDES = ['author', 'tags', 'authors', 'authors.roles'];
+const UNSAFE_ATTRS = ['author_id', 'status', 'authors'];
+
+module.exports = {
+    docName: 'pages',
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'formats',
+            'status',
+            'limit',
+            'order',
+            'page',
+            'debug',
+            'absolute_urls'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return models.Post.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'fields',
+            'status',
+            'formats',
+            'debug',
+            'absolute_urls'
+        ],
+        data: [
+            'id',
+            'slug',
+            'status',
+            'uuid'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return models.Post.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        throw new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.pages.pageNotFound')
+                        });
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    add: {
+        statusCode: 201,
+        headers: {},
+        options: [
+            'include'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return models.Post.add(frame.data.pages[0], frame.options)
+                .then((model) => {
+                    if (model.get('status') !== 'published') {
+                        this.headers.cacheInvalidate = false;
+                    } else {
+                        this.headers.cacheInvalidate = true;
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    edit: {
+        headers: {},
+        options: [
+            'include',
+            'id'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return models.Post.edit(frame.data.pages[0], frame.options)
+                .then((model) => {
+                    if (model.get('status') === 'published' && model.wasChanged() ||
+                        model.get('status') === 'draft' && model.previous('status') === 'published') {
+                        this.headers.cacheInvalidate = true;
+                    } else if (model.get('status') === 'draft' && model.previous('status') !== 'published') {
+                        this.headers.cacheInvalidate = {
+                            value: urlService.utils.urlFor({
+                                relativeUrl: urlService.utils.urlJoin('/p', model.get('uuid'), '/')
+                            })
+                        };
+                    } else {
+                        this.headers.cacheInvalidate = false;
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'include',
+            'id'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            frame.options.require = true;
+
+            return models.Post.destroy(frame.options)
+                .return(null)
+                .catch(models.Post.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.pages.pageNotFound')
+                    });
+                });
+        }
+    }
+};

--- a/core/server/api/v2/pages.js
+++ b/core/server/api/v2/pages.js
@@ -1,8 +1,8 @@
 const models = require('../../models');
 const common = require('../../lib/common');
 const urlService = require('../../services/url');
-const ALLOWED_INCLUDES = ['author', 'tags', 'authors', 'authors.roles'];
-const UNSAFE_ATTRS = ['author_id', 'status', 'authors'];
+const ALLOWED_INCLUDES = ['tags', 'authors', 'authors.roles'];
+const UNSAFE_ATTRS = ['status', 'authors'];
 
 module.exports = {
     docName: 'pages',

--- a/core/server/api/v2/posts-public.js
+++ b/core/server/api/v2/posts-public.js
@@ -1,0 +1,76 @@
+const models = require('../../models');
+const common = require('../../lib/common');
+const allowedIncludes = ['tags', 'authors'];
+
+module.exports = {
+    docName: 'posts',
+
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'formats',
+            'status',
+            'limit',
+            'order',
+            'page',
+            'debug',
+            'absolute_urls'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Post.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'fields',
+            'status',
+            'formats',
+            'debug',
+            'absolute_urls'
+        ],
+        data: [
+            'id',
+            'slug',
+            'status',
+            'uuid'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Post.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        throw new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        });
+                    }
+
+                    return model;
+                });
+        }
+    }
+};

--- a/core/server/api/v2/posts-public.js
+++ b/core/server/api/v2/posts-public.js
@@ -11,7 +11,6 @@ module.exports = {
             'filter',
             'fields',
             'formats',
-            'status',
             'limit',
             'order',
             'page',
@@ -38,7 +37,6 @@ module.exports = {
         options: [
             'include',
             'fields',
-            'status',
             'formats',
             'debug',
             'absolute_urls'
@@ -46,7 +44,6 @@ module.exports = {
         data: [
             'id',
             'slug',
-            'status',
             'uuid'
         ],
         validation: {

--- a/core/server/api/v2/posts.js
+++ b/core/server/api/v2/posts.js
@@ -1,8 +1,8 @@
 const models = require('../../models');
 const common = require('../../lib/common');
 const urlService = require('../../services/url');
-const allowedIncludes = ['author', 'tags', 'authors', 'authors.roles'];
-const unsafeAttrs = ['author_id', 'status', 'authors'];
+const allowedIncludes = ['tags', 'authors', 'authors.roles'];
+const unsafeAttrs = ['status', 'authors'];
 
 module.exports = {
     docName: 'posts',

--- a/core/server/api/v2/posts.js
+++ b/core/server/api/v2/posts.js
@@ -12,7 +12,6 @@ module.exports = {
             'filter',
             'fields',
             'formats',
-            'status',
             'limit',
             'order',
             'page',
@@ -41,7 +40,6 @@ module.exports = {
         options: [
             'include',
             'fields',
-            'status',
             'formats',
             'debug',
             'absolute_urls'
@@ -49,7 +47,6 @@ module.exports = {
         data: [
             'id',
             'slug',
-            'status',
             'uuid'
         ],
         validation: {

--- a/core/server/api/v2/preview.js
+++ b/core/server/api/v2/preview.js
@@ -1,6 +1,6 @@
 const common = require('../../lib/common');
 const models = require('../../models');
-const ALLOWED_INCLUDES = ['author', 'authors', 'tags'];
+const ALLOWED_INCLUDES = ['authors', 'tags'];
 
 module.exports = {
     docName: 'preview',

--- a/core/server/api/v2/users.js
+++ b/core/server/api/v2/users.js
@@ -14,7 +14,6 @@ module.exports = {
             'filter',
             'fields',
             'limit',
-            'status',
             'order',
             'page',
             'debug'
@@ -42,7 +41,6 @@ module.exports = {
         data: [
             'id',
             'slug',
-            'status',
             'email',
             'role'
         ],

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -48,6 +48,13 @@ module.exports = {
             setDefaultOrder(frame);
         }
 
+        if (!localUtils.isContentAPI(frame)) {
+            // @TODO: remove when we drop v0.1
+            if (!frame.options.filter || !frame.options.filter.match(/status:/)) {
+                frame.options.status = 'all';
+            }
+        }
+
         debug(frame.options);
     },
 
@@ -59,6 +66,13 @@ module.exports = {
         if (localUtils.isContentAPI(frame)) {
             removeMobiledocFormat(frame);
             setDefaultOrder(frame);
+        }
+
+        if (!localUtils.isContentAPI(frame)) {
+            // @TODO: remove when we drop v0.1
+            if (!frame.options.filter || !frame.options.filter.match(/status:/)) {
+                frame.data.status = 'all';
+            }
         }
 
         debug(frame.options);

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -1,5 +1,8 @@
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:pages');
+const converters = require('../../../../../lib/mobiledoc/converters');
+const url = require('./utils/url');
+const localUtils = require('../../index');
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -40,9 +43,10 @@ module.exports = {
             frame.options.filter = 'page:true';
         }
 
-        removeMobiledocFormat(frame);
-
-        setDefaultOrder(frame);
+        if (localUtils.isContentAPI(frame)) {
+            removeMobiledocFormat(frame);
+            setDefaultOrder(frame);
+        }
 
         debug(frame.options);
     },
@@ -51,10 +55,45 @@ module.exports = {
         debug('read');
 
         frame.data.page = true;
-        removeMobiledocFormat(frame);
 
-        setDefaultOrder(frame);
+        if (localUtils.isContentAPI(frame)) {
+            removeMobiledocFormat(frame);
+            setDefaultOrder(frame);
+        }
 
         debug(frame.options);
+    },
+
+    add(apiConfig, frame) {
+        debug('add');
+
+        if (_.get(frame,'options.source')) {
+            const html = frame.data.pages[0].html;
+
+            if (frame.options.source === 'html' && !_.isEmpty(html)) {
+                frame.data.pages[0].mobiledoc = JSON.stringify(converters.htmlToMobiledocConverter(html));
+            }
+        }
+
+        frame.data.pages[0] = url.forPost(Object.assign({}, frame.data.pages[0]), frame.options);
+
+        // @NOTE: force storing page
+        frame.data.pages[0].page = true;
+    },
+
+    edit(apiConfig, frame) {
+        this.add(...arguments);
+
+        debug('edit');
+
+        // @NOTE: force not being able to update a page via pages endpoint
+        frame.options.page = true;
+    },
+
+    destroy(apiConfig, frame) {
+        frame.options.destroyBy = {
+            id: frame.options.id,
+            page: true
+        };
     }
 };

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:posts');
 const url = require('./utils/url');
-const utils = require('../../index');
+const localUtils = require('../../index');
 const labs = require('../../../../../services/labs');
 const converters = require('../../../../../lib/mobiledoc/converters');
 
@@ -58,7 +58,7 @@ module.exports = {
          * - api_key.type == 'content' ? content api access
          * - user exists? admin api access
          */
-        if (utils.isContentAPI(frame)) {
+        if (localUtils.isContentAPI(frame)) {
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
 
@@ -68,6 +68,13 @@ module.exports = {
             }
 
             setDefaultOrder(frame);
+        }
+
+        if (!localUtils.isContentAPI(frame)) {
+            // @TODO: remove when we drop v0.1
+            if (!frame.options.filter || !frame.options.filter.match(/status:/)) {
+                frame.options.status = 'all';
+            }
         }
 
         debug(frame.options);
@@ -84,7 +91,7 @@ module.exports = {
          * - api_key.type == 'content' ? content api access
          * - user exists? admin api access
          */
-        if (utils.isContentAPI(frame)) {
+        if (localUtils.isContentAPI(frame)) {
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
 
@@ -94,6 +101,13 @@ module.exports = {
             }
 
             setDefaultOrder(frame);
+        }
+
+        if (!localUtils.isContentAPI(frame)) {
+            // @TODO: remove when we drop v0.1
+            if (!frame.options.filter || !frame.options.filter.match(/status:/)) {
+                frame.data.status = 'all';
+            }
         }
 
         debug(frame.options);

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -101,15 +101,6 @@ module.exports = {
 
     add(apiConfig, frame) {
         debug('add');
-        /**
-         * Convert author property to author_id to match the name in the database.
-         *
-         * @deprecated: `author`, might be removed in Ghost 3.0
-         */
-        if (frame.data.posts[0].hasOwnProperty('author')) {
-            frame.data.posts[0].author_id = frame.data.posts[0].author;
-            delete frame.data.posts[0].author;
-        }
 
         if (_.get(frame,'options.source')) {
             const html = frame.data.posts[0].html;

--- a/core/server/api/v2/utils/serializers/output/pages.js
+++ b/core/server/api/v2/utils/serializers/output/pages.js
@@ -5,6 +5,11 @@ module.exports = {
     all(models, apiConfig, frame) {
         debug('all');
 
+        // CASE: e.g. destroy returns null
+        if (!models) {
+            return;
+        }
+
         if (models.meta) {
             frame.response = {
                 pages: models.data.map(model => mapper.mapPost(model, frame)),

--- a/core/server/api/v2/utils/serializers/output/utils/clean.js
+++ b/core/server/api/v2/utils/serializers/output/utils/clean.js
@@ -98,6 +98,8 @@ const post = (attrs, frame) => {
         if (attrs.og_description === '') {
             attrs.og_description = null;
         }
+    } else {
+        delete attrs.page;
     }
 
     delete attrs.locale;

--- a/core/server/api/v2/utils/validators/input/index.js
+++ b/core/server/api/v2/utils/validators/input/index.js
@@ -3,6 +3,10 @@ module.exports = {
         return require('./posts');
     },
 
+    get pages() {
+        return require('./pages');
+    },
+
     get invites() {
         return require('./invites');
     },

--- a/core/server/api/v2/utils/validators/input/pages.js
+++ b/core/server/api/v2/utils/validators/input/pages.js
@@ -24,24 +24,6 @@ module.exports = {
             }
         }
 
-        /**
-         * Ensure correct incoming `page.authors` structure.
-         *
-         * NOTE:
-         * The `page.authors[*].id` attribute is required till we release Ghost 3.0.
-         * Ghost 1.x keeps the deprecated support for `page.author_id`, which is the primary author id and needs to be
-         * updated if the order of the `page.authors` array changes.
-         * If we allow adding authors via the page endpoint e.g. `authors=[{name: 'newuser']` (no id property), it's hard
-             * to update the primary author id (`page.author_id`), because the new author `id` is generated when attaching
-             * the author to the page. And the attach operation happens in bookshelf-relations, which happens after
-             * the event handling in the page model.
-             *
-             * It's solvable, but not worth right now solving, because the admin UI does not support this feature.
-             *
-             * TLDR; You can only attach existing authors to a page.
-             *
-         * @TODO: remove `id` restriction in Ghost 3.0
-         */
         const schema = require(`./schemas/pages-add`);
         const definitions = require('./schemas/pages');
         return jsonSchema.validate(schema, definitions, frame.data);

--- a/core/server/api/v2/utils/validators/input/pages.js
+++ b/core/server/api/v2/utils/validators/input/pages.js
@@ -1,0 +1,55 @@
+const Promise = require('bluebird');
+const common = require('../../../../../lib/common');
+const utils = require('../../index');
+const jsonSchema = require('../utils/json-schema');
+
+module.exports = {
+    add(apiConfig, frame) {
+        /**
+         * @NOTE:
+         *
+         * Session authentication does not require authors, because the logged in user
+         * becomes the primary author.
+         *
+         * Admin API key requires sending authors, because there is no user id.
+         */
+        if (utils.isAdminAPIKey(frame)) {
+            if (!frame.data.pages[0].hasOwnProperty('authors')) {
+                return Promise.reject(new common.errors.ValidationError({
+                    message: common.i18n.t('notices.data.validation.index.validationFailed', {
+                        validationName: 'FieldIsRequired',
+                        key: '"authors"'
+                    })
+                }));
+            }
+        }
+
+        /**
+         * Ensure correct incoming `page.authors` structure.
+         *
+         * NOTE:
+         * The `page.authors[*].id` attribute is required till we release Ghost 3.0.
+         * Ghost 1.x keeps the deprecated support for `page.author_id`, which is the primary author id and needs to be
+         * updated if the order of the `page.authors` array changes.
+         * If we allow adding authors via the page endpoint e.g. `authors=[{name: 'newuser']` (no id property), it's hard
+             * to update the primary author id (`page.author_id`), because the new author `id` is generated when attaching
+             * the author to the page. And the attach operation happens in bookshelf-relations, which happens after
+             * the event handling in the page model.
+             *
+             * It's solvable, but not worth right now solving, because the admin UI does not support this feature.
+             *
+             * TLDR; You can only attach existing authors to a page.
+             *
+         * @TODO: remove `id` restriction in Ghost 3.0
+         */
+        const schema = require(`./schemas/pages-add`);
+        const definitions = require('./schemas/pages');
+        return jsonSchema.validate(schema, definitions, frame.data);
+    },
+
+    edit(apiConfig, frame) {
+        const schema = require(`./schemas/pages-edit`);
+        const definitions = require('./schemas/pages');
+        return jsonSchema.validate(schema, definitions, frame.data);
+    }
+};

--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -24,24 +24,6 @@ module.exports = {
             }
         }
 
-        /**
-         * Ensure correct incoming `post.authors` structure.
-         *
-         * NOTE:
-         * The `post.authors[*].id` attribute is required till we release Ghost 3.0.
-         * Ghost 1.x keeps the deprecated support for `post.author_id`, which is the primary author id and needs to be
-         * updated if the order of the `post.authors` array changes.
-         * If we allow adding authors via the post endpoint e.g. `authors=[{name: 'newuser']` (no id property), it's hard
-             * to update the primary author id (`post.author_id`), because the new author `id` is generated when attaching
-             * the author to the post. And the attach operation happens in bookshelf-relations, which happens after
-             * the event handling in the post model.
-             *
-             * It's solvable, but not worth right now solving, because the admin UI does not support this feature.
-             *
-             * TLDR; You can only attach existing authors to a post.
-             *
-         * @TODO: remove `id` restriction in Ghost 3.0
-         */
         const schema = require(`./schemas/posts-add`);
         const definitions = require('./schemas/posts');
         return jsonSchema.validate(schema, definitions, frame.data);

--- a/core/server/api/v2/utils/validators/input/schemas/pages-add.json
+++ b/core/server/api/v2/utils/validators/input/schemas/pages-add.json
@@ -1,0 +1,22 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "pages.add",
+    "title": "pages.add",
+    "description": "Schema for pages.add",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "pages": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+                "type": "object",
+                "allOf": [{"$ref": "pages#/definitions/page"}],
+                "required": ["title"]
+            }
+        }
+    },
+    "required": ["pages"]
+  }

--- a/core/server/api/v2/utils/validators/input/schemas/pages-edit.json
+++ b/core/server/api/v2/utils/validators/input/schemas/pages-edit.json
@@ -1,0 +1,22 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "pages.edit",
+    "title": "pages.edit",
+    "description": "Schema for pages.edit",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "pages": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+                "type": "object",
+                "allOf": [{"$ref": "pages#/definitions/page"}],
+                "required": ["updated_at"]
+            }
+        }
+    },
+    "required": ["pages"]
+  }

--- a/core/server/api/v2/utils/validators/input/schemas/pages.json
+++ b/core/server/api/v2/utils/validators/input/schemas/pages.json
@@ -115,6 +115,12 @@
                 "page": {
                     "strip": true
                 },
+                "author": {
+                    "strip": true
+                },
+                "author_id": {
+                    "strip": true
+                },
                 "created_at": {
                     "strip": true
                 },

--- a/core/server/api/v2/utils/validators/input/schemas/pages.json
+++ b/core/server/api/v2/utils/validators/input/schemas/pages.json
@@ -1,11 +1,11 @@
 
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "posts",
-    "title": "posts",
-    "description": "Base posts definitions",
+    "$id": "pages",
+    "title": "pages",
+    "description": "Base pages definitions",
     "definitions": {
-        "post": {
+        "page": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -104,10 +104,10 @@
                     "maxLength": 100
                 },
                 "authors": {
-                    "$ref": "#/definitions/post-authors"
+                    "$ref": "#/definitions/page-authors"
                 },
                 "tags": {
-                    "$ref": "#/definitions/post-tags"
+                    "$ref": "#/definitions/page-tags"
                 },
                 "id": {
                     "strip": true
@@ -129,8 +129,8 @@
                 }
             }
         },
-        "post-authors": {
-            "description": "Authors of the post",
+        "page-authors": {
+            "description": "Authors of the page",
             "type": "array",
             "items": {
                 "type": "object",
@@ -161,8 +161,8 @@
                 ]
             }
         },
-        "post-tags": {
-            "description": "Tags of the post",
+        "page-tags": {
+            "description": "Tags of the page",
             "type": "array",
             "items": {
                 "type": "object",
@@ -185,7 +185,7 @@
                     "parent_id": {
                         "strip": true
                     },
-                    "posts": {
+                    "pages": {
                         "strip": true
                     }
                 },

--- a/core/server/api/v2/utils/validators/input/schemas/posts.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts.json
@@ -112,6 +112,12 @@
                 "id": {
                     "strip": true
                 },
+                "author": {
+                    "strip": true
+                },
+                "author_id": {
+                    "strip": true
+                },
                 "page": {
                     "strip": true
                 },

--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -17,7 +17,7 @@ var proxy = require('./proxy'),
 
 /**
  * v0.1: users, posts, tags
- * v2: authors, pages, posts, tagsPublic
+ * v2: authors, pagesPublic, posts, tagsPublic
  *
  * @NOTE: if you use "users" in v2, we should fallback to authors
  */
@@ -35,7 +35,7 @@ const RESOURCES = {
         resource: 'users'
     },
     pages: {
-        alias: 'pages',
+        alias: 'pagesPublic',
         resource: 'posts'
     },
     authors: {

--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -23,7 +23,7 @@ var proxy = require('./proxy'),
  */
 const RESOURCES = {
     posts: {
-        alias: 'posts',
+        alias: 'postsPublic',
         resource: 'posts'
     },
     tags: {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -704,7 +704,8 @@ Post = ghostBookshelf.Model.extend({
                 findOne: ['columns', 'importing', 'withRelated', 'require'],
                 findPage: ['status', 'staticPages'],
                 findAll: ['columns', 'filter'],
-                destroy: ['destroyAll']
+                destroy: ['destroyAll', 'destroyBy'],
+                edit: ['page']
             };
 
         // The post model additionally supports having a formats option

--- a/core/server/services/routing/config/v2.js
+++ b/core/server/services/routing/config/v2.js
@@ -18,7 +18,7 @@ module.exports.QUERY = {
         }
     },
     post: {
-        controller: 'posts',
+        controller: 'postsPublic',
         type: 'read',
         resource: 'posts',
         options: {

--- a/core/server/services/routing/config/v2.js
+++ b/core/server/services/routing/config/v2.js
@@ -26,7 +26,7 @@ module.exports.QUERY = {
         }
     },
     page: {
-        controller: 'pages',
+        controller: 'pagesPublic',
         type: 'read',
         resource: 'pages',
         options: {

--- a/core/server/web/api/v2/admin/middleware.js
+++ b/core/server/web/api/v2/admin/middleware.js
@@ -12,6 +12,7 @@ const notImplemented = function (req, res, next) {
     const whitelisted = {
         // @NOTE: stable
         posts: ['GET', 'PUT', 'DELETE', 'POST'],
+        pages: ['GET', 'PUT', 'DELETE', 'POST'],
         tags: ['GET', 'PUT', 'DELETE', 'POST'],
         images: ['POST'],
         // @NOTE: experimental

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -32,6 +32,14 @@ module.exports = function apiRoutes() {
     router.put('/posts/:id', mw.authAdminApi, http(apiv2.posts.edit));
     router.del('/posts/:id', mw.authAdminApi, http(apiv2.posts.destroy));
 
+    // ## Pages
+    router.get('/pages', mw.authAdminApi, http(apiv2.pages.browse));
+    router.post('/pages', mw.authAdminApi, http(apiv2.pages.add));
+    router.get('/pages/:id', mw.authAdminApi, http(apiv2.pages.read));
+    router.get('/pages/slug/:slug', mw.authAdminApi, http(apiv2.pages.read));
+    router.put('/pages/:id', mw.authAdminApi, http(apiv2.pages.edit));
+    router.del('/pages/:id', mw.authAdminApi, http(apiv2.pages.destroy));
+
     // # Integrations
 
     router.get('/integrations', mw.authAdminApi, http(apiv2.integrations.browse));

--- a/core/server/web/api/v2/content/routes.js
+++ b/core/server/web/api/v2/content/routes.js
@@ -11,9 +11,9 @@ module.exports = function apiRoutes() {
     const http = apiImpl => apiv2.http(apiImpl, 'content');
 
     // ## Posts
-    router.get('/posts', mw.authenticatePublic, http(apiv2.posts.browse));
-    router.get('/posts/:id', mw.authenticatePublic, http(apiv2.posts.read));
-    router.get('/posts/slug/:slug', mw.authenticatePublic, http(apiv2.posts.read));
+    router.get('/posts', mw.authenticatePublic, http(apiv2.postsPublic.browse));
+    router.get('/posts/:id', mw.authenticatePublic, http(apiv2.postsPublic.read));
+    router.get('/posts/slug/:slug', mw.authenticatePublic, http(apiv2.postsPublic.read));
 
     // ## Pages
     router.get('/pages', mw.authenticatePublic, http(apiv2.pagesPublic.browse));

--- a/core/server/web/api/v2/content/routes.js
+++ b/core/server/web/api/v2/content/routes.js
@@ -16,9 +16,9 @@ module.exports = function apiRoutes() {
     router.get('/posts/slug/:slug', mw.authenticatePublic, http(apiv2.posts.read));
 
     // ## Pages
-    router.get('/pages', mw.authenticatePublic, http(apiv2.pages.browse));
-    router.get('/pages/:id', mw.authenticatePublic, http(apiv2.pages.read));
-    router.get('/pages/slug/:slug', mw.authenticatePublic, http(apiv2.pages.read));
+    router.get('/pages', mw.authenticatePublic, http(apiv2.pagesPublic.browse));
+    router.get('/pages/:id', mw.authenticatePublic, http(apiv2.pagesPublic.read));
+    router.get('/pages/slug/:slug', mw.authenticatePublic, http(apiv2.pagesPublic.read));
 
     // ## Users
     router.get('/authors', mw.authenticatePublic, http(apiv2.authors.browse));

--- a/core/test/acceptance/old/admin/db_spec.js
+++ b/core/test/acceptance/old/admin/db_spec.js
@@ -102,7 +102,6 @@ describe('DB API', () => {
                         let jsonResponse = res.body;
                         let results = jsonResponse.posts;
                         jsonResponse.posts.should.have.length(7);
-                        _.filter(results, {page: false, status: 'published'}).length.should.equal(7);
                     });
             });
     });
@@ -118,7 +117,6 @@ describe('DB API', () => {
                 let jsonResponse = res.body;
                 let results = jsonResponse.posts;
                 jsonResponse.posts.should.have.length(7);
-                _.filter(results, {page: false, status: 'published'}).length.should.equal(7);
             })
             .then(() => {
                 return request.delete(localUtils.API.getApiQuery('db/'))

--- a/core/test/acceptance/old/admin/pages_spec.js
+++ b/core/test/acceptance/old/admin/pages_spec.js
@@ -1,0 +1,153 @@
+const should = require('should');
+const supertest = require('supertest');
+const _ = require('lodash');
+const ObjectId = require('bson-objectid');
+const moment = require('moment-timezone');
+const testUtils = require('../../../utils');
+const localUtils = require('./utils');
+const config = require('../../../../server/config');
+const models = require('../../../../server/models');
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Pages API', function () {
+    let ghostServer;
+    let ownerCookie;
+
+    before(function () {
+        return ghost()
+            .then(function (_ghostServer) {
+                ghostServer = _ghostServer;
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return localUtils.doAuth(request, 'users:extra', 'posts');
+            })
+            .then(function (cookie) {
+                ownerCookie = cookie;
+            });
+    });
+
+    it('Can retrieve all pages', function (done) {
+        request.get(localUtils.API.getApiQuery('pages/'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse.pages);
+                localUtils.API.checkResponse(jsonResponse, 'pages');
+                jsonResponse.pages.should.have.length(1);
+
+                localUtils.API.checkResponse(jsonResponse.pages[0], 'page');
+                localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+                _.isBoolean(jsonResponse.pages[0].featured).should.eql(true);
+
+                // Absolute urls by default
+                jsonResponse.pages[0].url.should.eql(`${config.get('url')}/static-page-test/`);
+
+                done();
+            });
+    });
+
+    it('Can add a page', function () {
+        const page = {
+            title: 'My Page',
+            page: false,
+            status: 'published'
+        };
+
+        return request.post(localUtils.API.getApiQuery('pages/'))
+            .set('Origin', config.get('url'))
+            .send({pages: [page]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201)
+            .then((res) => {
+                res.body.pages.length.should.eql(1);
+                localUtils.API.checkResponse(res.body.pages[0], 'page');
+                should.exist(res.headers['x-cache-invalidate']);
+
+                return models.Post.findOne({
+                    id: res.body.pages[0].id
+                }, testUtils.context.internal);
+            })
+            .then((model) => {
+                model.get('title').should.eql(page.title);
+                model.get('status').should.eql(page.status);
+                model.get('page').should.eql(true);
+            });
+    });
+
+    it('Can update a page', function () {
+        const page = {
+            title: 'updated page',
+            page: false
+        };
+
+        return request
+            .get(localUtils.API.getApiQuery(`pages/${testUtils.DataGenerator.Content.posts[5].id}/`))
+            .set('Origin', config.get('url'))
+            .expect(200)
+            .then((res) => {
+                page.updated_at = res.body.pages[0].updated_at;
+
+                return request.put(localUtils.API.getApiQuery('pages/' + testUtils.DataGenerator.Content.posts[5].id))
+                    .set('Origin', config.get('url'))
+                    .send({pages: [page]})
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200);
+            })
+            .then((res) => {
+                should.exist(res.headers['x-cache-invalidate']);
+                localUtils.API.checkResponse(res.body.pages[0], 'page');
+
+                return models.Post.findOne({
+                    id: res.body.pages[0].id
+                }, testUtils.context.internal);
+            })
+            .then((model) => {
+                model.get('page').should.eql(true);
+            });
+    });
+
+    it('Cannot get page via posts endpoint', function () {
+        return request.get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[5].id}/`))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(404);
+    });
+
+    it('Cannot update page via posts endpoint', function () {
+        const page = {
+            title: 'fails',
+            updated_at: new Date().toISOString()
+        };
+
+        return request.put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[5].id))
+            .set('Origin', config.get('url'))
+            .send({posts: [page]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(404);
+    });
+
+    it('Can delete a page', function () {
+        return request.del(localUtils.API.getApiQuery('pages/' + testUtils.DataGenerator.Content.posts[5].id))
+            .set('Origin', config.get('url'))
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(204)
+            .then((res) => {
+                res.body.should.be.empty();
+                res.headers['x-cache-invalidate'].should.eql('/*');
+            });
+    });
+});

--- a/core/test/acceptance/old/admin/pages_spec.js
+++ b/core/test/acceptance/old/admin/pages_spec.js
@@ -43,14 +43,15 @@ describe('Pages API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.pages);
                 localUtils.API.checkResponse(jsonResponse, 'pages');
-                jsonResponse.pages.should.have.length(1);
+                jsonResponse.pages.should.have.length(2);
 
                 localUtils.API.checkResponse(jsonResponse.pages[0], 'page');
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                 _.isBoolean(jsonResponse.pages[0].featured).should.eql(true);
 
                 // Absolute urls by default
-                jsonResponse.pages[0].url.should.eql(`${config.get('url')}/static-page-test/`);
+                jsonResponse.pages[0].url.should.eql(`${config.get('url')}/404/`);
+                jsonResponse.pages[1].url.should.eql(`${config.get('url')}/static-page-test/`);
 
                 done();
             });

--- a/core/test/acceptance/old/admin/posts_spec.js
+++ b/core/test/acceptance/old/admin/posts_spec.js
@@ -43,18 +43,19 @@ describe('Posts API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
-                jsonResponse.posts.should.have.length(11);
+                jsonResponse.posts.should.have.length(13);
                 localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                 _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 
                 // Ensure default order
-                jsonResponse.posts[0].slug.should.eql('welcome');
-                jsonResponse.posts[10].slug.should.eql('html-ipsum');
+                jsonResponse.posts[0].slug.should.eql('scheduled-post');
+                jsonResponse.posts[12].slug.should.eql('html-ipsum');
 
                 // Absolute urls by default
-                jsonResponse.posts[0].url.should.eql(`${config.get('url')}/welcome/`);
-                jsonResponse.posts[9].feature_image.should.eql(`${config.get('url')}/content/images/2018/hey.jpg`);
+                jsonResponse.posts[0].url.should.eql(`${config.get('url')}/404/`);
+                jsonResponse.posts[2].url.should.eql(`${config.get('url')}/welcome/`);
+                jsonResponse.posts[11].feature_image.should.eql(`${config.get('url')}/content/images/2018/hey.jpg`);
 
                 done();
             });
@@ -102,7 +103,7 @@ describe('Posts API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
-                jsonResponse.posts.should.have.length(11);
+                jsonResponse.posts.should.have.length(13);
                 localUtils.API.checkResponse(
                     jsonResponse.posts[0],
                     'post',
@@ -111,10 +112,11 @@ describe('Posts API', function () {
 
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
 
-                jsonResponse.posts[0].tags.length.should.eql(1);
-                jsonResponse.posts[0].authors.length.should.eql(1);
-                jsonResponse.posts[0].tags[0].url.should.eql(`${config.get('url')}/tag/getting-started/`);
-                jsonResponse.posts[0].authors[0].url.should.eql(`${config.get('url')}/author/ghost/`);
+                jsonResponse.posts[0].tags.length.should.eql(0);
+                jsonResponse.posts[2].tags.length.should.eql(1);
+                jsonResponse.posts[2].authors.length.should.eql(1);
+                jsonResponse.posts[2].tags[0].url.should.eql(`${config.get('url')}/tag/getting-started/`);
+                jsonResponse.posts[2].authors[0].url.should.eql(`${config.get('url')}/author/ghost/`);
 
                 done();
             });
@@ -305,7 +307,7 @@ describe('Posts API', function () {
         };
 
         return request
-            .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[3].id}/?status=all`))
+            .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[3].id}/`))
             .set('Origin', config.get('url'))
             .expect(200)
             .then((res) => {
@@ -329,7 +331,7 @@ describe('Posts API', function () {
         };
 
         return request
-            .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[1].id}/?status=all`))
+            .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[1].id}/?`))
             .set('Origin', config.get('url'))
             .expect(200)
             .then((res) => {

--- a/core/test/acceptance/old/admin/utils.js
+++ b/core/test/acceptance/old/admin/utils.js
@@ -7,6 +7,7 @@ const API_URL = '/ghost/api/v2/admin/';
 const expectedProperties = {
     // API top level
     posts: ['posts', 'meta'],
+    pages: ['pages', 'meta'],
     tags: ['tags', 'meta'],
     users: ['users', 'meta'],
     settings: ['settings', 'meta'],
@@ -27,9 +28,22 @@ const expectedProperties = {
         .without('mobiledoc', 'plaintext')
         .without('visibility')
         .without('locale')
+        .without('page')
         // always returns computed properties: url, comment_id, primary_tag, primary_author
         .without('author_id').concat('url', 'primary_tag', 'primary_author')
     ,
+
+    page: _(schema.posts)
+        .keys()
+        // by default we only return html
+        .without('mobiledoc', 'plaintext')
+        .without('visibility')
+        .without('locale')
+        .without('page')
+        // always returns computed properties: url, comment_id, primary_tag, primary_author
+        .without('author_id').concat('url', 'primary_tag', 'primary_author')
+    ,
+
     user: _(schema.users)
         .keys()
         .without('visibility')

--- a/core/test/regression/api/v2/admin/posts_spec.js
+++ b/core/test/regression/api/v2/admin/posts_spec.js
@@ -43,7 +43,7 @@ describe('Posts API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(11);
+                    jsonResponse.posts.should.have.length(13);
 
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],
@@ -74,7 +74,8 @@ describe('Posts API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(11);
+                    jsonResponse.posts.should.have.length(13);
+
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],
                         'post',

--- a/core/test/regression/api/v2/admin/utils.js
+++ b/core/test/regression/api/v2/admin/utils.js
@@ -24,6 +24,7 @@ const expectedProperties = {
         .without('mobiledoc', 'plaintext')
         .without('visibility')
         .without('locale')
+        .without('page')
         // always returns computed properties: url, comment_id, primary_tag, primary_author
         .without('author_id').concat('url', 'primary_tag', 'primary_author')
     ,

--- a/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
@@ -35,7 +35,7 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.browse(apiConfig, frame);
-            should.equal(frame.options.filter, undefined);
+            should.equal(frame.options.filter, 'page:false');
         });
 
         it('combine filters', function () {
@@ -178,28 +178,7 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
             };
 
             serializers.input.posts.read(apiConfig, frame);
-            should.not.exist(frame.data.page);
-        });
-
-        it('with non public request it does not override data.page', function () {
-            const apiConfig = {};
-            const frame = {
-                apiType: 'admin',
-                options: {
-                    context: {
-                        api_key: {
-                            id: 1,
-                            type: 'admin'
-                        }
-                    }
-                },
-                data: {
-                    page: true
-                }
-            };
-
-            serializers.input.posts.read(apiConfig, frame);
-            frame.data.page.should.eql(true);
+            should.equal(frame.data.page, false);
         });
 
         it('remove mobiledoc option from formats', function () {
@@ -382,6 +361,7 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
                 const apiConfig = {};
                 const mobiledoc = '{"version":"0.3.1","atoms":[],"cards":[],"sections":[]}';
                 const frame = {
+                    options: {},
                     data: {
                         posts: [
                             {

--- a/core/test/unit/api/v2/utils/validators/input/pages_spec.js
+++ b/core/test/unit/api/v2/utils/validators/input/pages_spec.js
@@ -5,14 +5,14 @@ const Promise = require('bluebird');
 const common = require('../../../../../../../server/lib/common');
 const validators = require('../../../../../../../server/api/v2/utils/validators');
 
-describe('Unit: v2/utils/validators/input/posts', function () {
+describe('Unit: v2/utils/validators/input/pages', function () {
     afterEach(function () {
         sinon.restore();
     });
 
     describe('add', function () {
         const apiConfig = {
-            docName: 'posts'
+            docName: 'pages'
         };
 
         describe('required fields', function () {
@@ -22,14 +22,14 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     data: {}
                 };
 
-                return validators.input.posts.add(apiConfig, frame)
+                return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
-            it('should fail with no posts', function () {
+            it('should fail with no pages', function () {
                 const frame = {
                     options: {},
                     data: {
@@ -37,38 +37,38 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                return validators.input.posts.add(apiConfig, frame)
+                return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
-            it('should fail with no posts in array', function () {
+            it('should fail with no pages in array', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: []
+                        pages: []
                     }
                 };
 
-                return validators.input.posts.add(apiConfig, frame)
+                return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
-            it('should fail with more than post', function () {
+            it('should fail with more than page', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [],
+                        pages: [],
                         tags: []
                     }
                 };
 
-                return validators.input.posts.add(apiConfig, frame)
+                return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
@@ -79,13 +79,13 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [{
+                        pages: [{
                             what: 'a fail'
                         }],
                     }
                 };
 
-                return validators.input.posts.add(apiConfig, frame)
+                return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
@@ -96,21 +96,21 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [{
+                        pages: [{
                             title: 'pass',
                             authors: [{id: 'correct'}]
                         }],
                     }
                 };
 
-                return validators.input.posts.add(apiConfig, frame);
+                return validators.input.pages.add(apiConfig, frame);
             });
 
             it('should remove `strip`able fields and leave regular fields', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [{
+                        pages: [{
                             title: 'pass',
                             authors: [{id: 'correct'}],
                             id: 'strip me',
@@ -122,15 +122,15 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                let result = validators.input.posts.add(apiConfig, frame);
+                let result = validators.input.pages.add(apiConfig, frame);
 
-                should.exist(frame.data.posts[0].title);
-                should.exist(frame.data.posts[0].authors);
-                should.not.exist(frame.data.posts[0].id);
-                should.not.exist(frame.data.posts[0].created_at);
-                should.not.exist(frame.data.posts[0].created_by);
-                should.not.exist(frame.data.posts[0].updated_by);
-                should.not.exist(frame.data.posts[0].published_by);
+                should.exist(frame.data.pages[0].title);
+                should.exist(frame.data.pages[0].authors);
+                should.not.exist(frame.data.pages[0].id);
+                should.not.exist(frame.data.pages[0].created_at);
+                should.not.exist(frame.data.pages[0].created_by);
+                should.not.exist(frame.data.pages[0].updated_by);
+                should.not.exist(frame.data.pages[0].published_by);
 
                 return result;
             });
@@ -155,21 +155,21 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     const badValues = fieldMap[key];
 
                     const checks = badValues.map((value) => {
-                        const post = {};
-                        post[key] = value;
+                        const page = {};
+                        page[key] = value;
 
                         if (key !== 'title') {
-                            post.title = 'abc';
+                            page.title = 'abc';
                         }
 
                         const frame = {
                             options: {},
                             data: {
-                                posts: [post]
+                                pages: [page]
                             }
                         };
 
-                        return validators.input.posts.add(apiConfig, frame)
+                        return validators.input.pages.add(apiConfig, frame)
                             .then(Promise.reject)
                             .catch((err) => {
                                 (err instanceof common.errors.ValidationError).should.be.true();
@@ -186,7 +186,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [
+                        pages: [
                             {
                                 title: 'cool',
                                 authors: {}
@@ -195,7 +195,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                return validators.input.posts.add(apiConfig, frame)
+                return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
@@ -206,7 +206,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [
+                        pages: [
                             {
                                 title: 'cool',
                                 authors: [{
@@ -217,7 +217,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                return validators.input.posts.add(apiConfig, frame)
+                return validators.input.pages.add(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
@@ -228,7 +228,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [
+                        pages: [
                             {
                                 title: 'cool',
                                 authors: [{
@@ -240,14 +240,14 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                return validators.input.posts.add(apiConfig, frame);
+                return validators.input.pages.add(apiConfig, frame);
             });
         });
     });
 
     describe('edit', function () {
         const apiConfig = {
-            docName: 'posts'
+            docName: 'pages'
         };
 
         describe('required fields', function () {
@@ -257,14 +257,14 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     data: {}
                 };
 
-                return validators.input.posts.edit(apiConfig, frame)
+                return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
-            it('should fail with no posts', function () {
+            it('should fail with no pages', function () {
                 const frame = {
                     options: {},
                     data: {
@@ -272,23 +272,23 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                return validators.input.posts.edit(apiConfig, frame)
+                return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
                     });
             });
 
-            it('should fail with more than post', function () {
+            it('should fail with more than page', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [],
+                        pages: [],
                         tags: []
                     }
                 };
 
-                return validators.input.posts.edit(apiConfig, frame)
+                return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
@@ -299,14 +299,14 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [{
+                        pages: [{
                             title: 'pass',
                             updated_at: new Date().toISOString()
                         }],
                     }
                 };
 
-                return validators.input.posts.edit(apiConfig, frame);
+                return validators.input.pages.edit(apiConfig, frame);
             });
         });
 
@@ -315,7 +315,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [
+                        pages: [
                             {
                                 title: 'cool',
                                 authors: {}
@@ -324,7 +324,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                return validators.input.posts.edit(apiConfig, frame)
+                return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
@@ -335,7 +335,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [
+                        pages: [
                             {
                                 title: 'cool',
                                 authors: [{
@@ -346,7 +346,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                return validators.input.posts.edit(apiConfig, frame)
+                return validators.input.pages.edit(apiConfig, frame)
                     .then(Promise.reject)
                     .catch((err) => {
                         (err instanceof common.errors.ValidationError).should.be.true();
@@ -357,7 +357,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [
+                        pages: [
                             {
                                 title: 'cool',
                                 updated_at: new Date().toISOString(),
@@ -370,14 +370,14 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                return validators.input.posts.edit(apiConfig, frame);
+                return validators.input.pages.edit(apiConfig, frame);
             });
 
             it('should pass without authors', function () {
                 const frame = {
                     options: {},
                     data: {
-                        posts: [
+                        pages: [
                             {
                                 title: 'cool',
                                 updated_at: new Date().toISOString()
@@ -386,7 +386,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
                     }
                 };
 
-                return validators.input.posts.edit(apiConfig, frame);
+                return validators.input.pages.edit(apiConfig, frame);
             });
         });
     });

--- a/core/test/unit/models/base/index_spec.js
+++ b/core/test/unit/models/base/index_spec.js
@@ -4,6 +4,7 @@ var should = require('should'),
     Promise = require('bluebird'),
     security = require('../../../../server/lib/security'),
     models = require('../../../../server/models'),
+    common = require('../../../../server/lib/common'),
     urlService = require('../../../../server/services/url'),
     filters = require('../../../../server/filters'),
     testUtils = require('../../../utils');
@@ -338,7 +339,7 @@ describe('Models: base', function () {
             });
         });
 
-        it('resolves with nothing and does not call save if no model is fetched', function () {
+        it('throws an error if model cannot be found on edit', function () {
             const data = {
                 db: 'cooper'
             };
@@ -354,9 +355,10 @@ describe('Models: base', function () {
                 .resolves();
             const saveSpy = sinon.stub(model, 'save');
 
-            return models.Base.Model.edit(data, unfilteredOptions).then((result) => {
-                should.equal(result, undefined);
-                should.equal(saveSpy.callCount, 0);
+            return models.Base.Model.edit(data, unfilteredOptions).then(() => {
+                throw new Error('That should not happen');
+            }).catch((err) => {
+                (err instanceof common.errors.NotFoundError).should.be.true();
             });
         });
     });

--- a/core/test/unit/services/routing/helpers/entry-lookup_spec.js
+++ b/core/test/unit/services/routing/helpers/entry-lookup_spec.js
@@ -273,7 +273,7 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
         describe('static pages', function () {
             const routerOptions = {
                 permalinks: '/:slug/',
-                query: {controller: 'pages', resource: 'pages'}
+                query: {controller: 'pagesPublic', resource: 'pages'}
             };
 
             let pages;
@@ -299,7 +299,7 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
                     };
                 });
 
-                sinon.stub(api.v2, 'pages').get(() => {
+                sinon.stub(api.v2, 'pagesPublic').get(() => {
                     return {
                         read: pagesReadStub
                     };
@@ -350,7 +350,7 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
                     };
                 });
 
-                sinon.stub(api.v2, 'pages').get(() => {
+                sinon.stub(api.v2, 'pagesPublic').get(() => {
                     return {
                         read: pagesReadStub
                     };

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -1399,7 +1399,7 @@ describe('UNIT: services/settings/validate', function () {
                             data: {
                                 query: {
                                     food: {
-                                        controller: 'posts',
+                                        controller: 'postsPublic',
                                         resource: 'posts',
                                         type: 'browse',
                                         options: {}
@@ -1415,7 +1415,7 @@ describe('UNIT: services/settings/validate', function () {
                             data: {
                                 query: {
                                     posts: {
-                                        controller: 'posts',
+                                        controller: 'postsPublic',
                                         resource: 'posts',
                                         type: 'read',
                                         options: {
@@ -1454,7 +1454,7 @@ describe('UNIT: services/settings/validate', function () {
                             data: {
                                 query: {
                                     gym: {
-                                        controller: 'posts',
+                                        controller: 'postsPublic',
                                         resource: 'posts',
                                         type: 'read',
                                         options: {

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -1288,7 +1288,7 @@ describe('UNIT: services/settings/validate', function () {
                             data: {
                                 query: {
                                     home: {
-                                        controller: 'pages',
+                                        controller: 'pagesPublic',
                                         resource: 'pages',
                                         type: 'read',
                                         options: {


### PR DESCRIPTION
refs #10438 

We have recently splitted pages & posts for Content API v2.
We want to do the same for the Admin API v2. Consistency change.

- [ ] discuss https://github.com/TryGhost/Ghost/pull/10494#issuecomment-465074656
- [ ] discuss that subscribers table keeps a reference to post_id. do we have to expose "page_id"?
- [x] pages json schema
- [x] compare post serializer & validation with pages
- [x] public controller for posts
- [x] get rid of required status=all for admin api posts/pages
- [x] get rid of required status=all for admin api users 