### PR TITLE
Cleaned up validators & serializers

### DIFF
--- a/core/server/api/shared/validators/input/all.js
+++ b/core/server/api/shared/validators/input/all.js
@@ -118,10 +118,14 @@ module.exports = {
     add(apiConfig, frame) {
         debug('validate add');
 
-        if (_.isEmpty(frame.data) || _.isEmpty(frame.data[apiConfig.docName]) || _.isEmpty(frame.data[apiConfig.docName][0])) {
-            return Promise.reject(new common.errors.BadRequestError({
-                message: common.i18n.t('errors.api.utils.noRootKeyProvided', {docName: apiConfig.docName})
-            }));
+        // NOTE: this block should be removed completely once JSON Schema validations
+        //       are introduced for all of the endpoints
+        if (!['posts', 'tags'].includes(apiConfig.docName)) {
+            if (_.isEmpty(frame.data) || _.isEmpty(frame.data[apiConfig.docName]) || _.isEmpty(frame.data[apiConfig.docName][0])) {
+                return Promise.reject(new common.errors.BadRequestError({
+                    message: common.i18n.t('errors.api.utils.noRootKeyProvided', {docName: apiConfig.docName})
+                }));
+            }
         }
 
         const jsonpath = require('jsonpath');
@@ -166,11 +170,17 @@ module.exports = {
             return result;
         }
 
-        if (frame.options.id && frame.data[apiConfig.docName][0].id
-            && frame.options.id !== frame.data[apiConfig.docName][0].id) {
-            return Promise.reject(new common.errors.BadRequestError({
-                message: common.i18n.t('errors.api.utils.invalidIdProvided')
-            }));
+        // NOTE: this block should be removed completely once JSON Schema validations
+        //       are introduced for all of the endpoints. `id` property is currently
+        //       stripped from the request body and only the one provided in `options`
+        //       is used in later logic
+        if (!['posts', 'tags'].includes(apiConfig.docName)) {
+            if (frame.options.id && frame.data[apiConfig.docName][0].id
+                && frame.options.id !== frame.data[apiConfig.docName][0].id) {
+                return Promise.reject(new common.errors.BadRequestError({
+                    message: common.i18n.t('errors.api.utils.invalidIdProvided')
+                }));
+            }
         }
     },
 

--- a/core/server/api/v2/tags.js
+++ b/core/server/api/v2/tags.js
@@ -77,11 +77,6 @@ module.exports = {
                 include: {
                     values: ALLOWED_INCLUDES
                 }
-            },
-            data: {
-                name: {
-                    required: true
-                }
             }
         },
         permissions: true,

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -109,30 +109,6 @@ module.exports = {
         }
 
         /**
-         * CASE: we don't support updating nested-nested relations e.g. `post.authors[*].roles` yet.
-         *
-         * Bookshelf-relations supports this feature, BUT bookshelf's `hasChanged` fn will currently
-         * clash with this, because `hasChanged` won't be able to tell if relations have changed or not.
-         * It would always return `changed.roles = [....]`. It would always throw a model event that relations
-         * were updated, which is not true.
-         *
-         * Bookshelf-relations can tell us if a relation has changed, it knows that.
-         * But the connection between our model layer, Bookshelf's `hasChanged` fn and Bookshelf-relations
-         * is not present. As long as we don't support this case, we have to ignore this.
-         */
-        if (frame.data.posts[0].authors && frame.data.posts[0].authors.length) {
-            _.each(frame.data.posts[0].authors, (author, index) => {
-                if (author.hasOwnProperty('roles')) {
-                    delete frame.data.posts[0].authors[index].roles;
-                }
-
-                if (author.hasOwnProperty('permissions')) {
-                    delete frame.data.posts[0].authors[index].permissions;
-                }
-            });
-        }
-
-        /**
          * Model notation is: `tag.parent_id`.
          * The API notation is `tag.parent`.
          */

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -108,25 +108,6 @@ module.exports = {
             delete frame.data.posts[0].author;
         }
 
-        /**
-         * Model notation is: `tag.parent_id`.
-         * The API notation is `tag.parent`.
-         */
-        if (frame.data.posts[0].hasOwnProperty('tags')) {
-            if (_.isArray(frame.data.posts[0].tags) && frame.data.posts[0].tags.length) {
-                _.each(frame.data.posts[0].tags, (tag, index) => {
-                    if (tag.hasOwnProperty('parent')) {
-                        frame.data.posts[0].tags[index].parent_id = tag.parent;
-                        delete frame.data.posts[0].tags[index].parent;
-                    }
-
-                    if (tag.hasOwnProperty('posts')) {
-                        delete frame.data.posts[0].tags[index].posts;
-                    }
-                });
-            }
-        }
-
         frame.data.posts[0] = url.forPost(Object.assign({}, frame.data.posts[0]), frame.options);
     },
 

--- a/core/server/api/v2/utils/validators/input/schemas/posts.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts.json
@@ -142,6 +142,12 @@
                     "email": {
                         "type": "string",
                         "maxLength": 191
+                    },
+                    "roles": {
+                        "strip": true
+                    },
+                    "permissions": {
+                        "strip": true
                     }
                 },
                 "anyOf": [

--- a/core/server/api/v2/utils/validators/input/schemas/posts.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts.json
@@ -174,6 +174,15 @@
                     "slug": {
                         "type": ["string", "null"],
                         "maxLength": 191
+                    },
+                    "parent": {
+                        "strip": true
+                    },
+                    "parent_id": {
+                        "strip": true
+                    },
+                    "posts": {
+                        "strip": true
                     }
                 },
                 "anyOf": [

--- a/core/server/api/v2/utils/validators/utils/json-schema.js
+++ b/core/server/api/v2/utils/validators/utils/json-schema.js
@@ -20,6 +20,8 @@ const validate = (schema, definitions, data) => {
 
         if (dataPath) {
             key = dataPath.split('.').pop();
+        } else {
+            key = schema.$id.split('.')[0];
         }
 
         return Promise.reject(new common.errors.ValidationError({

--- a/core/test/unit/api/shared/validators/input/all_spec.js
+++ b/core/test/unit/api/shared/validators/input/all_spec.js
@@ -379,7 +379,7 @@ describe('Unit: api/shared/validators/input/all', function () {
     describe('edit', function () {
         it('id mismatch', function () {
             const apiConfig = {
-                docName: 'posts'
+                docName: 'users'
             };
 
             const frame = {


### PR DESCRIPTION
refs #10438

This PR focuses on cleaning up code that is made redundant by JSON Schema validation layer. 
@kirrg001 would be great to double check on the approach of stripping relations for `post.tags` and `post.users`. Was thinking of having a full schema description for `post-authors` and enable `additionalProperties: false` there, but went with a less restrictive approach for now.
