### PR TITLE
Updated audience validation for admin api tokens

### DIFF
--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -90,10 +90,13 @@ const authenticate = (req, res, next) => {
         // https://github.com/auth0/node-jsonwebtoken/issues/208#issuecomment-231861138
         const secret = Buffer.from(apiKey.get('secret'), 'hex');
 
+        // @TODO: Rework this so that we use HTTP verb + resource
         // ensure the token was meant for this endpoint
-        const options = Object.assign({
-            audience: req.originalUrl
-        }, JWT_OPTIONS);
+        //const options = Object.assign({
+        //    audience: req.originalUrl
+        //}, JWT_OPTIONS);
+        
+        const options = JWT_OPTIONS;
 
         try {
             jwt.verify(token, secret, options);

--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -90,13 +90,11 @@ const authenticate = (req, res, next) => {
         // https://github.com/auth0/node-jsonwebtoken/issues/208#issuecomment-231861138
         const secret = Buffer.from(apiKey.get('secret'), 'hex');
 
-        // @TODO: Rework this so that we use HTTP verb + resource
-        // ensure the token was meant for this endpoint
-        //const options = Object.assign({
-        //    audience: req.originalUrl
-        //}, JWT_OPTIONS);
-        
-        const options = JWT_OPTIONS;
+        // @TODO When v3 api hits we should check against the api actually being used
+        // ensure the token was meant for this api
+        const options = Object.assign({
+            audience: '/v2/admin/'
+        }, JWT_OPTIONS);
 
         try {
             jwt.verify(token, secret, options);

--- a/core/test/acceptance/old/admin/actions_spec.js
+++ b/core/test/acceptance/old/admin/actions_spec.js
@@ -110,7 +110,7 @@ describe('Actions API', function () {
                 return integrationRequest
                     .put(localUtils.API.getApiQuery(`posts/${postId}/`))
                     .set('Origin', config.get('url'))
-                    .set('Authorization', `Ghost ${localUtils.getValidAdminToken(localUtils.API.getApiQuery(`posts/${postId}/`))}`)
+                    .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/v2/admin/')}`)
                     .send({
                         posts: [{
                             featured: true,

--- a/core/test/acceptance/old/admin/key_authentication_spec.js
+++ b/core/test/acceptance/old/admin/key_authentication_spec.js
@@ -38,7 +38,7 @@ describe('Admin API key authentication', function () {
 
     it('Can access browse endpoint with correct token', function () {
         return request.get(localUtils.API.getApiQuery('posts/'))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken(localUtils.API.getApiQuery('posts/'))}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/v2/admin/')}`)
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
@@ -55,7 +55,7 @@ describe('Admin API key authentication', function () {
         return request
             .post(localUtils.API.getApiQuery('posts/'))
             .set('Origin', config.get('url'))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken(localUtils.API.getApiQuery('posts/'))}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/v2/admin/')}`)
             .send({
                 posts: [post]
             })

--- a/core/test/acceptance/old/admin/utils.js
+++ b/core/test/acceptance/old/admin/utils.js
@@ -120,7 +120,7 @@ module.exports = {
         const JWT_OPTIONS = {
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: endpoint
+            audience: '/v2/admin/'
         };
 
         return jwt.sign(

--- a/core/test/acceptance/old/admin/utils.js
+++ b/core/test/acceptance/old/admin/utils.js
@@ -115,12 +115,12 @@ module.exports = {
         return testUtils.API.doAuth(`${API_URL}session/`, ...args);
     },
 
-    getValidAdminToken(endpoint) {
+    getValidAdminToken(audience) {
         const jwt = require('jsonwebtoken');
         const JWT_OPTIONS = {
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: '/v2/admin/'
+            audience: audience
         };
 
         return jwt.sign(

--- a/core/test/unit/services/auth/api-key/admin_spec.js
+++ b/core/test/unit/services/auth/api-key/admin_spec.js
@@ -37,7 +37,7 @@ describe('Admin API Key Auth', function () {
         }, this.secret, {
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: '/test/',
+            audience: '/v2/admin/',
             issuer: this.fakeApiKey.id
         });
 
@@ -98,7 +98,7 @@ describe('Admin API Key Auth', function () {
         }, this.secret, {
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: '/test/',
+            audience: 'wrong audience',
             issuer: 'unknown'
         });
 
@@ -127,7 +127,7 @@ describe('Admin API Key Auth', function () {
         const token = jwt.sign(payload, this.secret, {
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: '/test/',
+            audience: '/v2/admin/',
             issuer: this.fakeApiKey.id
         });
 
@@ -157,7 +157,7 @@ describe('Admin API Key Auth', function () {
         const token = jwt.sign(payload, this.secret, {
             algorithm: 'HS256',
             expiresIn: '10m',
-            audience: '/test/',
+            audience: '/v2/admin/',
             issuer: this.fakeApiKey.id
         });
 
@@ -185,7 +185,7 @@ describe('Admin API Key Auth', function () {
         }, this.secret, {
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: '/test/',
+            audience: '/v2/admin/',
             issuer: this.fakeApiKey.id
         });
 


### PR DESCRIPTION
no-issue

This is a temporary solution until we implement token permissions based on actions upon objects, for example using canThis