### PR TITLE
Added user friendly error messages to Admin API

### DIFF
--- a/core/server/api/shared/http.js
+++ b/core/server/api/shared/http.js
@@ -79,7 +79,8 @@ const http = (apiImpl, apiType) => {
                 debug('json response');
                 res.json(result || {});
             })
-            .catch((err) => {
+            .catch(({err, docName, method}) => {
+                req.frameOptions = {docName, method};
                 next(err);
             });
     };

--- a/core/server/api/shared/pipeline.js
+++ b/core/server/api/shared/pipeline.js
@@ -156,6 +156,9 @@ const pipeline = (apiController, apiUtils) => {
                 })
                 .then(() => {
                     return frame.response;
+                })
+                .catch((err) => {
+                    throw {err, docName, method};
                 });
         };
 

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -28,6 +28,11 @@
             },
             "clients": {
                 "clientNotFound": "Client not found"
+            },
+            "actions": {
+                "upload": {
+                    "image": "upload image"
+                }
             }
         }
     },
@@ -472,6 +477,29 @@
             "oembed": {
                 "noUrlProvided": "No url provided.",
                 "unknownProvider": "No provider found for supplied URL."
+            },
+            "userMessages": {
+                "InternalServerError": "Internal server error, cannot {action}.",
+                "IncorrectUsageError": "Incorrect usage error, cannot {action}.",
+                "NotFoundError": "Resource not found error, cannot {action}.",
+                "BadRequestError": "Request not understood error, cannot {action}.",
+                "UnauthorizedError": "Authorisation error, cannot {action}.",
+                "NoPermissionError": "Permission error, cannot {action}.",
+                "ValidationError": "Validation error, cannot {action}.",
+                "UnsupportedMediaTypeError": "Unsupported media error, cannot {action}.",
+                "TooManyRequestsError": "Too many requests error, cannot {action}.",
+                "MaintenanceError": "Server down for maintenance, cannot {action}.",
+                "MethodNotAllowedError": "Method not allowed, cannot {action}.",
+                "RequestEntityTooLargeError": "Request too large, cannot {action}.",
+                "TokenRevocationError": "Token is not available, cannot {action}.",
+                "VersionMismatchError": "Version mismatch error, cannot {action}.",
+                "DataExportError": "Error exporting content.",
+                "DataImportError": "Duplicated entry, cannot save {action}.",
+                "DatabaseVersionError": "Database version compatibility error, cannot {action}.",
+                "EmailError": "Error sending email!",
+                "ThemeValidationError": "Theme validation error, cannot {action}.",
+                "DisabledFeatureError": "Theme validation error, the {{{helperName}}} helper is not available. Cannot {action}.",
+                "UpdateCollisionError": "Saving failed! Someone else is editing this post."
             }
         },
         "data": {

--- a/core/server/web/api/v2/admin/app.js
+++ b/core/server/web/api/v2/admin/app.js
@@ -33,7 +33,7 @@ module.exports = function setupApiApp() {
 
     // API error handling
     apiApp.use(shared.middlewares.errorHandler.resourceNotFound);
-    apiApp.use(shared.middlewares.errorHandler.handleJSONResponse);
+    apiApp.use(shared.middlewares.errorHandler.handleJSONResponseV2);
 
     debug('Admin API v2 setup end');
 


### PR DESCRIPTION
refs #10438

- Adds new fields to errors returned from API:  help, code, and id
- Makes `message` more descriptive towards non-technical users

@kirrg001 this is WIP and needs more detailed work around the error messages and `actions`. But would love to receive feedback around the overall placement of these new user friendly messages :+1: 