### PR TITLE
Changed default formats & includes for Admin API v2

### DIFF
--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -12,6 +12,18 @@ function removeMobiledocFormat(frame) {
     }
 }
 
+function defaultRelations(frame) {
+    if (frame.options.withRelated) {
+        return;
+    }
+
+    if (frame.options.columns && !frame.options.withRelated) {
+        return false;
+    }
+
+    frame.options.withRelated = ['tags', 'authors', 'authors.roles'];
+}
+
 function setDefaultOrder(frame) {
     let includesOrderedRelations = false;
 
@@ -71,6 +83,7 @@ module.exports = {
         if (!localUtils.isContentAPI(frame)) {
             forceStatusFilter(frame);
             defaultFormat(frame);
+            defaultRelations(frame);
         }
 
         debug(frame.options);
@@ -89,6 +102,7 @@ module.exports = {
         if (!localUtils.isContentAPI(frame)) {
             forceStatusFilter(frame);
             defaultFormat(frame);
+            defaultRelations(frame);
         }
 
         debug(frame.options);
@@ -134,6 +148,7 @@ module.exports = {
         }
 
         defaultFormat(frame);
+        defaultRelations(frame);
     },
 
     edit(apiConfig, frame) {
@@ -152,5 +167,6 @@ module.exports = {
         };
 
         defaultFormat(frame);
+        defaultRelations(frame);
     }
 };

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -25,6 +25,14 @@ function setDefaultOrder(frame) {
     }
 }
 
+function defaultFormat(frame) {
+    if (frame.options.formats) {
+        return;
+    }
+
+    frame.options.formats = 'mobiledoc';
+}
+
 /**
  * CASE:
  *
@@ -62,6 +70,7 @@ module.exports = {
 
         if (!localUtils.isContentAPI(frame)) {
             forceStatusFilter(frame);
+            defaultFormat(frame);
         }
 
         debug(frame.options);
@@ -79,6 +88,7 @@ module.exports = {
 
         if (!localUtils.isContentAPI(frame)) {
             forceStatusFilter(frame);
+            defaultFormat(frame);
         }
 
         debug(frame.options);
@@ -122,6 +132,8 @@ module.exports = {
                 }
             });
         }
+
+        defaultFormat(frame);
     },
 
     edit(apiConfig, frame) {
@@ -138,5 +150,7 @@ module.exports = {
             id: frame.options.id,
             page: true
         };
+
+        defaultFormat(frame);
     }
 };

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -21,6 +21,18 @@ function includeTags(frame) {
     }
 }
 
+function defaultRelations(frame) {
+    if (frame.options.withRelated) {
+        return;
+    }
+
+    if (frame.options.columns && !frame.options.withRelated) {
+        return false;
+    }
+
+    frame.options.withRelated = ['tags', 'authors', 'authors.roles'];
+}
+
 function setDefaultOrder(frame) {
     let includesOrderedRelations = false;
 
@@ -93,6 +105,7 @@ module.exports = {
         if (!localUtils.isContentAPI(frame)) {
             forceStatusFilter(frame);
             defaultFormat(frame);
+            defaultRelations(frame);
         }
 
         debug(frame.options);
@@ -124,6 +137,7 @@ module.exports = {
         if (!localUtils.isContentAPI(frame)) {
             forceStatusFilter(frame);
             defaultFormat(frame);
+            defaultRelations(frame);
         }
 
         debug(frame.options);
@@ -169,6 +183,7 @@ module.exports = {
         }
 
         defaultFormat(frame);
+        defaultRelations(frame);
     },
 
     edit(apiConfig, frame) {
@@ -185,5 +200,6 @@ module.exports = {
         };
 
         defaultFormat(frame);
+        defaultRelations(frame);
     }
 };

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -34,6 +34,14 @@ function setDefaultOrder(frame) {
     }
 }
 
+function defaultFormat(frame) {
+    if (frame.options.formats) {
+        return;
+    }
+
+    frame.options.formats = 'mobiledoc';
+}
+
 /**
  * CASE:
  *
@@ -84,6 +92,7 @@ module.exports = {
 
         if (!localUtils.isContentAPI(frame)) {
             forceStatusFilter(frame);
+            defaultFormat(frame);
         }
 
         debug(frame.options);
@@ -114,6 +123,7 @@ module.exports = {
 
         if (!localUtils.isContentAPI(frame)) {
             forceStatusFilter(frame);
+            defaultFormat(frame);
         }
 
         debug(frame.options);
@@ -157,6 +167,8 @@ module.exports = {
                 }
             });
         }
+
+        defaultFormat(frame);
     },
 
     edit(apiConfig, frame) {
@@ -171,5 +183,7 @@ module.exports = {
             id: frame.options.id,
             page: false
         };
+
+        defaultFormat(frame);
     }
 };

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -32,9 +32,9 @@ const mapPost = (model, frame) => {
     if (utils.isContentAPI(frame)) {
         date.forPost(jsonModel);
         members.forPost(jsonModel, frame);
-        extraAttrs.forPost(frame, model, jsonModel);
     }
 
+    extraAttrs.forPost(frame, model, jsonModel);
     clean.post(jsonModel, frame);
 
     if (frame.options && frame.options.withRelated) {

--- a/core/test/acceptance/old/admin/pages_spec.js
+++ b/core/test/acceptance/old/admin/pages_spec.js
@@ -72,7 +72,10 @@ describe('Pages API', function () {
             .expect(201)
             .then((res) => {
                 res.body.pages.length.should.eql(1);
-                localUtils.API.checkResponse(res.body.pages[0], 'page', null, ['primary_tag', 'primary_author']);
+
+                // @NOTE: we do not return "excerpt" if custom_excerpt or plaintext is empty
+                // @NOTE: we do not return primary_* if null
+                localUtils.API.checkResponse(res.body.pages[0], 'page', null, ['primary_tag', 'primary_author', 'excerpt']);
                 should.exist(res.headers['x-cache-invalidate']);
 
                 return models.Post.findOne({

--- a/core/test/acceptance/old/admin/pages_spec.js
+++ b/core/test/acceptance/old/admin/pages_spec.js
@@ -45,7 +45,7 @@ describe('Pages API', function () {
                 localUtils.API.checkResponse(jsonResponse, 'pages');
                 jsonResponse.pages.should.have.length(2);
 
-                localUtils.API.checkResponse(jsonResponse.pages[0], 'page', null, ['primary_tag', 'primary_author']);
+                localUtils.API.checkResponse(jsonResponse.pages[0], 'page');
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                 _.isBoolean(jsonResponse.pages[0].featured).should.eql(true);
 
@@ -75,7 +75,7 @@ describe('Pages API', function () {
 
                 // @NOTE: we do not return "excerpt" if custom_excerpt or plaintext is empty
                 // @NOTE: we do not return primary_* if null
-                localUtils.API.checkResponse(res.body.pages[0], 'page', null, ['primary_tag', 'primary_author', 'excerpt']);
+                localUtils.API.checkResponse(res.body.pages[0], 'page', null, ['excerpt']);
                 should.exist(res.headers['x-cache-invalidate']);
 
                 return models.Post.findOne({
@@ -111,7 +111,7 @@ describe('Pages API', function () {
             })
             .then((res) => {
                 should.exist(res.headers['x-cache-invalidate']);
-                localUtils.API.checkResponse(res.body.pages[0], 'page', null, ['primary_tag', 'primary_author']);
+                localUtils.API.checkResponse(res.body.pages[0], 'page');
 
                 return models.Post.findOne({
                     id: res.body.pages[0].id

--- a/core/test/acceptance/old/admin/posts_spec.js
+++ b/core/test/acceptance/old/admin/posts_spec.js
@@ -44,7 +44,7 @@ describe('Posts API', function () {
                 should.exist(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
                 jsonResponse.posts.should.have.length(13);
-                localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, ['primary_tag', 'primary_author']);
+                localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                 _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 
@@ -56,6 +56,12 @@ describe('Posts API', function () {
                 jsonResponse.posts[0].url.should.eql(`${config.get('url')}/404/`);
                 jsonResponse.posts[2].url.should.eql(`${config.get('url')}/welcome/`);
                 jsonResponse.posts[11].feature_image.should.eql(`${config.get('url')}/content/images/2018/hey.jpg`);
+
+                jsonResponse.posts[0].tags.length.should.eql(0);
+                jsonResponse.posts[2].tags.length.should.eql(1);
+                jsonResponse.posts[2].authors.length.should.eql(1);
+                jsonResponse.posts[2].tags[0].url.should.eql(`${config.get('url')}/tag/getting-started/`);
+                jsonResponse.posts[2].authors[0].url.should.eql(`${config.get('url')}/author/ghost/`);
 
                 done();
             });
@@ -77,7 +83,7 @@ describe('Posts API', function () {
                 should.exist(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
                 jsonResponse.posts.should.have.length(3);
-                localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['mobiledoc', 'plaintext'], ['primary_tag', 'primary_author']);
+                localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['plaintext']);
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                 _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 
@@ -88,8 +94,8 @@ describe('Posts API', function () {
             });
     });
 
-    it('Can includes relations', function (done) {
-        request.get(localUtils.API.getApiQuery('posts/?include=tags,authors'))
+    it('Can includes single relation', function (done) {
+        request.get(localUtils.API.getApiQuery('posts/?include=tags'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
@@ -107,17 +113,11 @@ describe('Posts API', function () {
                 localUtils.API.checkResponse(
                     jsonResponse.posts[0],
                     'post',
-                    ['tags', 'authors']
+                    null,
+                    ['authors', 'primary_author']
                 );
 
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
-
-                jsonResponse.posts[0].tags.length.should.eql(0);
-                jsonResponse.posts[2].tags.length.should.eql(1);
-                jsonResponse.posts[2].authors.length.should.eql(1);
-                jsonResponse.posts[2].tags[0].url.should.eql(`${config.get('url')}/tag/getting-started/`);
-                jsonResponse.posts[2].authors[0].url.should.eql(`${config.get('url')}/author/ghost/`);
-
                 done();
             });
     });
@@ -138,7 +138,7 @@ describe('Posts API', function () {
                 should.exist(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
                 jsonResponse.posts.should.have.length(2);
-                localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, ['primary_tag', 'primary_author']);
+                localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                 done();
             });
@@ -196,14 +196,12 @@ describe('Posts API', function () {
                 var jsonResponse = res.body;
                 should.exist(jsonResponse);
                 should.exist(jsonResponse.posts);
-                localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, ['primary_tag', 'primary_author']);
+                localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                 jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[0].id);
 
                 _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 
                 testUtils.API.isISO8601(jsonResponse.posts[0].created_at).should.be.true();
-                // Tags aren't included by default
-                should.not.exist(jsonResponse.posts[0].tags);
                 done();
             });
     });
@@ -223,13 +221,10 @@ describe('Posts API', function () {
                 var jsonResponse = res.body;
                 should.exist(jsonResponse);
                 should.exist(jsonResponse.posts);
-                localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, ['primary_tag', 'primary_author']);
+                localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                 jsonResponse.posts[0].slug.should.equal('welcome');
 
                 _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
-
-                // Tags aren't included by default
-                should.not.exist(jsonResponse.posts[0].tags);
                 done();
             });
     });
@@ -251,7 +246,7 @@ describe('Posts API', function () {
                 should.exist(jsonResponse);
                 should.exist(jsonResponse.posts);
 
-                localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['tags', 'authors']);
+                localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
 
                 jsonResponse.posts[0].authors[0].should.be.an.Object();
                 localUtils.API.checkResponse(jsonResponse.posts[0].authors[0], 'user', ['url']);
@@ -282,7 +277,7 @@ describe('Posts API', function () {
             .expect(201)
             .then((res) => {
                 res.body.posts.length.should.eql(1);
-                localUtils.API.checkResponse(res.body.posts[0], 'post', null, ['primary_tag', 'primary_author']);
+                localUtils.API.checkResponse(res.body.posts[0], 'post');
                 should.not.exist(res.headers['x-cache-invalidate']);
 
                 return models.Post.findOne({

--- a/core/test/acceptance/old/admin/posts_spec.js
+++ b/core/test/acceptance/old/admin/posts_spec.js
@@ -77,7 +77,7 @@ describe('Posts API', function () {
                 should.exist(jsonResponse.posts);
                 localUtils.API.checkResponse(jsonResponse, 'posts');
                 jsonResponse.posts.should.have.length(3);
-                localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['mobiledoc', 'plaintext'], ['html', 'primary_tag', 'primary_author']);
+                localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['mobiledoc', 'plaintext'], ['primary_tag', 'primary_author']);
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                 _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 

--- a/core/test/acceptance/old/admin/utils.js
+++ b/core/test/acceptance/old/admin/utils.js
@@ -24,8 +24,8 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
-        // by default we only return html
-        .without('mobiledoc', 'plaintext')
+        // by default we only return mobildoc
+        .without('html', 'plaintext')
         .without('visibility')
         .without('locale')
         .without('page')
@@ -35,8 +35,8 @@ const expectedProperties = {
 
     page: _(schema.posts)
         .keys()
-        // by default we only return html
-        .without('mobiledoc', 'plaintext')
+        // by default we only return mobildoc
+        .without('html', 'plaintext')
         .without('visibility')
         .without('locale')
         .without('page')

--- a/core/test/acceptance/old/admin/utils.js
+++ b/core/test/acceptance/old/admin/utils.js
@@ -33,6 +33,8 @@ const expectedProperties = {
         .without('author_id')
         // always returns computed properties
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
+        // returned by default
+        .concat('tags', 'authors')
     ,
 
     page: _(schema.posts)
@@ -46,6 +48,8 @@ const expectedProperties = {
         .without('author_id')
         // always returns computed properties
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
+        // returned by default
+        .concat('tags', 'authors')
     ,
 
     user: _(schema.users)

--- a/core/test/acceptance/old/admin/utils.js
+++ b/core/test/acceptance/old/admin/utils.js
@@ -29,8 +29,10 @@ const expectedProperties = {
         .without('visibility')
         .without('locale')
         .without('page')
-        // always returns computed properties: url, comment_id, primary_tag, primary_author
-        .without('author_id').concat('url', 'primary_tag', 'primary_author')
+        // deprecated
+        .without('author_id')
+        // always returns computed properties
+        .concat('url', 'primary_tag', 'primary_author', 'excerpt')
     ,
 
     page: _(schema.posts)
@@ -40,8 +42,10 @@ const expectedProperties = {
         .without('visibility')
         .without('locale')
         .without('page')
-        // always returns computed properties: url, comment_id, primary_tag, primary_author
-        .without('author_id').concat('url', 'primary_tag', 'primary_author')
+        // deprecated
+        .without('author_id')
+        // always returns computed properties
+        .concat('url', 'primary_tag', 'primary_author', 'excerpt')
     ,
 
     user: _(schema.users)

--- a/core/test/regression/api/v2/admin/utils.js
+++ b/core/test/regression/api/v2/admin/utils.js
@@ -25,8 +25,10 @@ const expectedProperties = {
         .without('visibility')
         .without('locale')
         .without('page')
-        // always returns computed properties: url, comment_id, primary_tag, primary_author
-        .without('author_id').concat('url', 'primary_tag', 'primary_author')
+        .without('author_id')
+        // always returns computed properties
+        .concat('url', 'primary_tag', 'primary_author', 'excerpt')
+        .concat('authors', 'tags')
     ,
     user: _(schema.users)
         .keys()

--- a/core/test/regression/api/v2/admin/utils.js
+++ b/core/test/regression/api/v2/admin/utils.js
@@ -20,8 +20,8 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
-        // by default we only return html
-        .without('mobiledoc', 'plaintext')
+        // by default we only return mobiledoc
+        .without('html', 'plaintext')
         .without('visibility')
         .without('locale')
         .without('page')


### PR DESCRIPTION
- html -> mobiledoc (default format)
- return tags & authors by default
- respect custom input for formats and include
- return computed excerpt field