### PR TITLE
Updated Admin API key auth to require `kid` in header

### DIFF
--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -64,8 +64,8 @@ const authenticate = (req, res, next) => {
 
     if (!apiKeyId) {
         return next(new common.errors.BadRequestError({
-            message: common.i18n.t('errors.middleware.auth.adminApiKeyMissing'),
-            code: 'MISSING_ADMIN_API_KEY'
+            message: common.i18n.t('errors.middleware.auth.adminApiKidMissing'),
+            code: 'MISSING_ADMIN_API_KID'
         }));
     }
 

--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -60,7 +60,7 @@ const authenticate = (req, res, next) => {
         }));
     }
 
-    const apiKeyId = decoded.payload.kid;
+    const apiKeyId = decoded.header.kid;
 
     if (!apiKeyId) {
         return next(new common.errors.BadRequestError({

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -81,7 +81,7 @@
                 "authorizationFailed": "Authorization failed",
                 "missingContentMemberOrIntegration": "Unable to determine the authenticated member or integration. Check the supplied Content API Key and ensure cookies are being passed through if member auth is failing.",
                 "missingAdminUserOrIntegration": "Unable to determine the authenticated user or integration. Check that cookies are being passed through if using session authentication.",
-                "adminApiKeyMissing": "Admin API Key missing.",
+                "adminApiKeyMissing": "Admin API Token missing kid header claim.",
                 "unknownAdminApiKey": "Unknown Admin API Key",
                 "unknownContentApiKey": "Unknown Content API Key",
                 "invalidApiKeyType": "Invalid API Key type",

--- a/core/test/acceptance/old/admin/utils.js
+++ b/core/test/acceptance/old/admin/utils.js
@@ -118,15 +118,14 @@ module.exports = {
     getValidAdminToken(audience) {
         const jwt = require('jsonwebtoken');
         const JWT_OPTIONS = {
+            keyid: testUtils.DataGenerator.Content.api_keys[0].id,
             algorithm: 'HS256',
             expiresIn: '5m',
             audience: audience
         };
 
         return jwt.sign(
-            {
-                kid: testUtils.DataGenerator.Content.api_keys[0].id
-            },
+            {},
             Buffer.from(testUtils.DataGenerator.Content.api_keys[0].secret, 'hex'),
             JWT_OPTIONS
         );

--- a/core/test/regression/api/v2/admin/utils.js
+++ b/core/test/regression/api/v2/admin/utils.js
@@ -102,15 +102,14 @@ module.exports = {
     getValidAdminToken(endpoint) {
         const jwt = require('jsonwebtoken');
         const JWT_OPTIONS = {
+            keyid: testUtils.DataGenerator.Content.api_keys[0].id,
             algorithm: 'HS256',
             expiresIn: '5m',
             audience: endpoint
         };
 
         return jwt.sign(
-            {
-                kid: testUtils.DataGenerator.Content.api_keys[0].id
-            },
+            {},
             Buffer.from(testUtils.DataGenerator.Content.api_keys[0].secret, 'hex'),
             JWT_OPTIONS
         );

--- a/core/test/unit/services/auth/api-key/admin_spec.js
+++ b/core/test/unit/services/auth/api-key/admin_spec.js
@@ -33,8 +33,8 @@ describe('Admin API Key Auth', function () {
 
     it('should authenticate known+valid API key', function (done) {
         const token = jwt.sign({
-            kid: this.fakeApiKey.id
         }, this.secret, {
+            keyid: this.fakeApiKey.id,
             algorithm: 'HS256',
             expiresIn: '5m',
             audience: '/v2/admin/',
@@ -94,8 +94,8 @@ describe('Admin API Key Auth', function () {
 
     it('shouldn\'t authenticate with invalid/unknown key', function (done) {
         const token = jwt.sign({
-            kid: 'unknown'
         }, this.secret, {
+            keyid: 'unknown',
             algorithm: 'HS256',
             expiresIn: '5m',
             audience: 'wrong audience',
@@ -121,10 +121,10 @@ describe('Admin API Key Auth', function () {
 
     it('shouldn\'t authenticate with JWT signed > 5min ago', function (done) {
         const payload = {
-            kid: this.fakeApiKey.id,
             iat: Math.floor(Date.now() / 1000) - 6 * 60
         };
         const token = jwt.sign(payload, this.secret, {
+            keyid: this.fakeApiKey.id,
             algorithm: 'HS256',
             expiresIn: '5m',
             audience: '/v2/admin/',
@@ -151,10 +151,10 @@ describe('Admin API Key Auth', function () {
 
     it('shouldn\'t authenticate with JWT with maxAge > 5min', function (done) {
         const payload = {
-            kid: this.fakeApiKey.id,
             iat: Math.floor(Date.now() / 1000) - 6 * 60
         };
         const token = jwt.sign(payload, this.secret, {
+            keyid: this.fakeApiKey.id,
             algorithm: 'HS256',
             expiresIn: '10m',
             audience: '/v2/admin/',
@@ -181,8 +181,8 @@ describe('Admin API Key Auth', function () {
 
     it('shouldn\'t authenticate with a Content API Key', function (done) {
         const token = jwt.sign({
-            kid: this.fakeApiKey.id
         }, this.secret, {
+            keyid: this.fakeApiKey.id,
             algorithm: 'HS256',
             expiresIn: '5m',
             audience: '/v2/admin/',


### PR DESCRIPTION
no-issue

- Updates admin api key auth to read `kid` from header
- Updates error message for missing `kid` claim
- Updates tests and test helpers to correctly set `kid` header claim

Update to the SDK is here: https://github.com/TryGhost/Ghost-SDK/pull/64

From the spec: https://tools.ietf.org/html/rfc7515#section-4.1.4

`kid` should be a header claim, this updates our usage to be in line with the spec
