### PR TITLE
Updated routing service to explicitly request html format

### DIFF
--- a/core/server/services/routing/controllers/preview.js
+++ b/core/server/services/routing/controllers/preview.js
@@ -11,7 +11,8 @@ module.exports = function previewController(req, res, next) {
     const params = {
         uuid: req.params.uuid,
         status: 'all',
-        include: 'author,authors,tags'
+        include: 'author,authors,tags',
+        formats: 'html'
     };
 
     api[res.routerOptions.query.controller]

--- a/core/server/services/routing/controllers/static.js
+++ b/core/server/services/routing/controllers/static.js
@@ -14,7 +14,8 @@ function processQuery(query, locals) {
     //       We override the `include` property for now, because the full data set is required anyway.
     if (_.get(query, 'resource') === 'posts') {
         _.extend(query.options, {
-            include: 'author,authors,tags'
+            include: 'author,authors,tags',
+            formats: 'html'
         });
     }
 

--- a/core/server/services/routing/helpers/entry-lookup.js
+++ b/core/server/services/routing/helpers/entry-lookup.js
@@ -37,7 +37,8 @@ function entryLookup(postUrl, routerOptions, locals) {
      * @deprecated: `author`, will be removed in Ghost 3.0
      */
     let options = {
-        include: 'author,authors,tags'
+        include: 'author,authors,tags',
+        formats: 'html'
     };
     if (config.get('enableDeveloperExperiments')) {
         options.context = {member: locals.member};

--- a/core/server/services/routing/helpers/fetch-data.js
+++ b/core/server/services/routing/helpers/fetch-data.js
@@ -20,7 +20,8 @@ const queryDefaults = {
  */
 const defaultQueryOptions = {
     options: {
-        include: 'author,authors,tags'
+        include: 'author,authors,tags',
+        formats: 'html'
     }
 };
 

--- a/core/test/unit/services/routing/controllers/preview_spec.js
+++ b/core/test/unit/services/routing/controllers/preview_spec.js
@@ -74,7 +74,8 @@ describe('Unit - services/routing/controllers/preview', function () {
             sinon.stub(api.posts, 'read').withArgs({
                 uuid: req.params.uuid,
                 status: 'all',
-                include: 'author,authors,tags'
+                include: 'author,authors,tags',
+                formats: 'html'
             }).callsFake(function () {
                 return Promise.resolve(apiResponse);
             });
@@ -194,7 +195,8 @@ describe('Unit - services/routing/controllers/preview', function () {
             previewStub.withArgs({
                 uuid: req.params.uuid,
                 status: 'all',
-                include: 'author,authors,tags'
+                include: 'author,authors,tags',
+                formats: 'html'
             }).resolves(apiResponse);
 
             sinon.stub(api.v2, 'preview').get(() => {


### PR DESCRIPTION
no-issue

This is because the routing service uses the admin api rather than the
content, and since e65a82833ce3c049d7498d4b5e44215a528bb549 the default
format is mobiledoc. So we explicitly require html, for the rendering.