### PR TITLE
Absolute url support false string

### DIFF
--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -19,7 +19,7 @@ module.exports = function imgUrl(attr, options) {
         return;
     }
 
-    const absolute = options && options.hash && options.hash.absolute;
+    const absolute = options && options.hash && options.hash.absolute && options.hash.absolute !== 'false';
 
     const size = options && options.hash && options.hash.size;
     const imageSizes = options && options.data && options.data.config && options.data.config.image_sizes;

--- a/core/server/helpers/url.js
+++ b/core/server/helpers/url.js
@@ -9,7 +9,7 @@ var proxy = require('./proxy'),
     getMetaDataUrl = proxy.metaData.getMetaDataUrl;
 
 module.exports = function url(options) {
-    var absolute = options && options.hash.absolute,
+    var absolute = options && options.hash.absolute && options.hash.absolute !== 'false',
         outputUrl = getMetaDataUrl(this, absolute);
 
     outputUrl = encodeURI(decodeURI(outputUrl));

--- a/core/test/unit/helpers/img_url_spec.js
+++ b/core/test/unit/helpers/img_url_spec.js
@@ -39,6 +39,12 @@ describe('{{image}} helper', function () {
         logWarnStub.called.should.be.false();
     });
 
+    it('should NOT output absolute url of image if the option is "false" ', function () {
+        var rendered = helpers.img_url('/content/images/image-relative-url.png', {hash: {absolute: 'false'}});
+        should.exist(rendered);
+        rendered.should.equal('/content/images/image-relative-url.png');
+    });
+
     it('should output author url', function () {
         var rendered = helpers.img_url('/content/images/author-image-relative-url.png', {});
         should.exist(rendered);

--- a/core/test/unit/helpers/url_spec.js
+++ b/core/test/unit/helpers/url_spec.js
@@ -60,7 +60,7 @@ describe('{{url}} helper', function () {
             created_at: new Date(0)
         });
 
-        urlService.getUrlByResourceId.withArgs(post.id, {absolute: 'true', secure: undefined, withSubdirectory: true}).returns('http://localhost:82832/slug/');
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: true, secure: undefined, withSubdirectory: true}).returns('http://localhost:82832/slug/');
 
         rendered = helpers.url.call(post, {hash: {absolute: 'true'}});
         should.exist(rendered);
@@ -78,7 +78,7 @@ describe('{{url}} helper', function () {
             secure: true
         });
 
-        urlService.getUrlByResourceId.withArgs(post.id, {absolute: 'true', secure: true, withSubdirectory: true}).returns('https://localhost:82832/slug/');
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: true, secure: true, withSubdirectory: true}).returns('https://localhost:82832/slug/');
 
         rendered = helpers.url.call(post, {hash: {absolute: 'true'}});
         should.exist(rendered);


### PR DESCRIPTION
relates to https://github.com/TryGhost/docs-api/pull/29

This allows the helpers to be used like:

```hbs
{{url absolute="false"}}

{{img_url profile_image absolute="false"}}
```

And have a NON absolute url output