### PR TITLE
Improved error message when attempting to use disabled v0.1 Public API

### DIFF
--- a/core/server/services/auth/authenticate.js
+++ b/core/server/services/auth/authenticate.js
@@ -5,6 +5,7 @@ const common = require('../../lib/common');
 const session = require('./session');
 const apiKeyAuth = require('./api-key');
 const members = require('./members');
+const labs = require('../labs');
 
 const authenticate = {
     // ### Authenticate Client Middleware
@@ -36,6 +37,14 @@ const authenticate = {
 
         if (req.query && req.query.client_secret) {
             req.body.client_secret = req.query.client_secret;
+        }
+
+        if (labs.isSet('publicAPI') !== true) {
+            return next(new common.errors.NoPermissionError({
+                message: common.i18n.t('errors.middleware.auth.publicAPIDisabled.error'),
+                context: common.i18n.t('errors.middleware.auth.publicAPIDisabled.context'),
+                help: common.i18n.t('errors.middleware.auth.forInformationRead', {url: 'https://docs.ghost.org/api/content/'})
+            }));
         }
 
         if (!req.body.client_id || !req.body.client_secret) {

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -74,6 +74,10 @@
                 "versionMismatch": "Client request for {clientVersion} does not match server version {serverVersion}."
             },
             "auth": {
+                "publicAPIDisabled": {
+                    "error": "Permission error! Public API is disabled.",
+                    "context": "Please enable the deprecated v0.1 Public API or switch to using the v2 Content API."
+                },
                 "clientAuthenticationFailed": "Client Authentication Failed",
                 "clientCredentialsNotProvided": "Client credentials were not provided",
                 "clientCredentialsNotValid": "Client credentials were not valid",

--- a/core/test/unit/services/auth/authenticate_spec.js
+++ b/core/test/unit/services/auth/authenticate_spec.js
@@ -6,6 +6,7 @@ const ClientPasswordStrategy = require('passport-oauth2-client-password').Strate
 const auth = require('../../../../server/services/auth');
 const common = require('../../../../server/lib/common');
 const models = require('../../../../server/models');
+const labs = require('../../../../server/services/labs');
 const user = {id: 1};
 const info = {scope: '*'};
 const token = 'test_token';
@@ -203,6 +204,10 @@ describe('Auth', function () {
     });
 
     describe('Client Authentication', function () {
+        beforeEach(function () {
+            sinon.stub(labs, 'isSet').withArgs('publicAPI').returns(true);
+        });
+
         it('shouldn\'t require authorized client with bearer token', function (done) {
             req.headers = {};
             req.headers.authorization = 'Bearer ' + token;
@@ -342,6 +347,25 @@ describe('Auth', function () {
             next.called.should.be.true();
             next.calledWith(null, client).should.be.true();
             done();
+        });
+
+        it('shouldn\'t authenticate when publicAPI is disabled', function (done) {
+            labs.isSet.restore();
+            sinon.stub(labs, 'isSet').withArgs('publicAPI').returns(false);
+
+            req.body = {};
+            req.body.client_id = testClient;
+            req.body.client_secret = testSecret;
+            req.headers = {};
+
+            var next = function next(err) {
+                err.statusCode.should.eql(403);
+                (err instanceof common.errors.NoPermissionError).should.eql(true);
+                done();
+            };
+
+            registerSuccessfulClientPasswordStrategy();
+            auth.authenticate.authenticateClient(req, res, next);
         });
 
         it('shouldn\'t authenticate when error', function (done) {


### PR DESCRIPTION
no issue
- trying to use the v0.1 Public API when it was disabled led to a confusing error message, see https://forum.ghost.org/t/403-forbidden-error-on-postman-api-call/6017
- adds an explicit check for the Public API being enabled in the client authentication step and throws a useful error message if client auth is attempted when it's disabled