### PR TITLE
Fixed grunt master to work with submodules correctly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -218,7 +218,7 @@ const configureGrunt = function (grunt) {
                         git submodule sync
                         git submodule update
 
-                        if ! git diff --exit-code --quiet; then
+                        if ! git diff --exit-code --quiet --ignore-submodules=untracked; then
                             echo "Working directory is not clean, do you have uncommited changes? Please commit, stash or discard changes to continue."
                             exit 1
                         fi

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -215,6 +215,9 @@ const configureGrunt = function (grunt) {
                     var upstream = grunt.option('upstream') || process.env.GHOST_UPSTREAM || 'upstream';
                     grunt.log.writeln('Pulling down the latest master from ' + upstream);
                     return `
+                        git submodule sync
+                        git submodule update
+
                         if ! git diff --exit-code --quiet; then
                             echo "Working directory is not clean, do you have uncommited changes? Please commit, stash or discard changes to continue."
                             exit 1


### PR DESCRIPTION
refs #9441

This should bring `grunt master` command in line with how it should work.

It should only error if there are changes to tracked files which have not been committed - this ensures no work is lost.