### PR TITLE
Removed redundant errorDetail stringification

### DIFF
--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -372,7 +372,7 @@ validateRedirects = function validateRedirects(redirects) {
         if (!redirect.from || !redirect.to) {
             throw new common.errors.ValidationError({
                 message: common.i18n.t('errors.utils.redirectsWrongFormat'),
-                context: JSON.stringify(redirect),
+                context: redirect,
                 help: 'https://docs.ghost.org/concepts/redirects/'
             });
         }

--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -63,11 +63,11 @@ module.exports = function (Bookshelf) {
                                     message: 'Saving failed! Someone else is editing this post.',
                                     code: 'UPDATE_COLLISION',
                                     level: 'critical',
-                                    context: JSON.stringify({
+                                    context: {
                                         clientUpdatedAt: self.clientData.updated_at,
                                         serverUpdatedAt: self.serverData.updated_at,
                                         changed: changed
-                                    })
+                                    }
                                 }));
                             }
                         }

--- a/core/server/services/themes/index.js
+++ b/core/server/services/themes/index.js
@@ -38,7 +38,7 @@ module.exports = {
                             common.logging.warn(new common.errors.ThemeValidationError({
                                 errorType: 'ThemeWorksButHasErrors',
                                 message: common.i18n.t('errors.middleware.themehandler.themeHasErrors', {theme: activeThemeName}),
-                                errorDetails: JSON.stringify(checkedTheme.results.error, null, '\t')
+                                errorDetails: checkedTheme.results.error
                             }));
                         }
 
@@ -49,7 +49,7 @@ module.exports = {
                         if (err.errorDetails) {
                             common.logging.error(new common.errors.ThemeValidationError({
                                 message: common.i18n.t('errors.middleware.themehandler.invalidTheme', {theme: activeThemeName}),
-                                errorDetails: JSON.stringify(err.errorDetails, null, '\t')
+                                errorDetails: err.errorDetails
                             }));
                         }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ignition/issues/69

@kirrg001 found similar usages of `JSON.stringify()` for `context` property like [here](https://github.com/TryGhost/Ghost/blob/master/core/server/data/validation/index.js#L375). The also seem redundant since stringification is handled on the Ignition side similarly to `errorDetails` - https://github.com/TryGhost/Ignition/blob/master/lib/logging/GhostLogger.js#L237. Maybe there's some other reason for this stringification that I'm missing? :thinking:  Let me know what you think :smiley: 