### PR TITLE
Prevented makePathsAbsolute changing mysql values

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -48,8 +48,9 @@ _private.loadNconf = function loadNconf(options) {
 
     nconf.sanitizeDatabaseProperties();
     nconf.makePathsAbsolute(nconf.get('paths'), 'paths');
-    nconf.makePathsAbsolute(nconf.get('database:connection'), 'database:connection');
-
+    if (nconf.get('database:client') === 'sqlite3') {
+        nconf.makePathsAbsolute(nconf.get('database:connection'), 'database:connection');
+    }
     /**
      * Check if the URL in config has a protocol
      */


### PR DESCRIPTION
closes #10570
Added a conditional to only run makePathsAbsolute when database:client
is sqlite3, which keeps expected behaviour (make the
database:connection:filename path absolute when running SQLite) while
not breaking MySQL behaviour (makePathsAbsolute detects SSL certificates
as being filenames and tries to prepend the full directory path to the
string).

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [*] There's a clear use-case for this code change
- [*] Commit message has a short title & references relevant issues
- [*] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
