### PR TITLE
🐛 Fixed v0.1 API user/password authentication when public API is disabled

### DIFF
--- a/core/server/services/auth/authenticate.js
+++ b/core/server/services/auth/authenticate.js
@@ -5,7 +5,6 @@ const common = require('../../lib/common');
 const session = require('./session');
 const apiKeyAuth = require('./api-key');
 const members = require('./members');
-const labs = require('../labs');
 
 const authenticate = {
     // ### Authenticate Client Middleware
@@ -37,14 +36,6 @@ const authenticate = {
 
         if (req.query && req.query.client_secret) {
             req.body.client_secret = req.query.client_secret;
-        }
-
-        if (labs.isSet('publicAPI') !== true) {
-            return next(new common.errors.NoPermissionError({
-                message: common.i18n.t('errors.middleware.auth.publicAPIDisabled.error'),
-                context: common.i18n.t('errors.middleware.auth.publicAPIDisabled.context'),
-                help: common.i18n.t('errors.middleware.auth.forInformationRead', {url: 'https://docs.ghost.org/api/content/'})
-            }));
         }
 
         if (!req.body.client_id || !req.body.client_secret) {

--- a/core/server/services/auth/authorize.js
+++ b/core/server/services/auth/authorize.js
@@ -23,7 +23,9 @@ const authorize = {
                 return next();
             } else {
                 return next(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.middleware.auth.pleaseSignIn')
+                    message: common.i18n.t('errors.middleware.auth.publicAPIDisabled.error'),
+                    context: common.i18n.t('errors.middleware.auth.publicAPIDisabled.context'),
+                    help: common.i18n.t('errors.middleware.auth.forInformationRead', {url: 'https://docs.ghost.org/api/content/'})
                 }));
             }
         }


### PR DESCRIPTION
no issue
- https://github.com/TryGhost/Ghost/commit/39edb7646e32b6597466e37218118de578dda864#r32609795 introduced improved error validation that performed a "public api enabled" check too early in the authentication process which meant that v0.1 password authentication was stopped in it's tracks before being able to sign in when the public api is disabled
- moves the error handling to the authorisation layer instead once we're sure that there's no authenticated user available