### PR TITLE
🐛 Fixed private blogging getting enabled when saving any setting

### DIFF
--- a/core/server/api/v2/utils/serializers/input/settings.js
+++ b/core/server/api/v2/utils/serializers/input/settings.js
@@ -17,11 +17,16 @@ module.exports = {
             frame.data = {settings: [{key: frame.data, value: frame.options}]};
         }
 
-        // CASE: transform objects/arrays into string (we store stringified objects in the db)
         frame.data.settings.forEach((setting) => {
-            // @TODO: This belongs into the model layer?
+            // CASE: transform objects/arrays into string (we store stringified objects in the db)
+            // @TODO: This belongs into the model layer. We should stringify before saving and parse when fetching from db.
+            // @TODO: Fix when dropping v0.1
             if (_.isObject(setting.value)) {
                 setting.value = JSON.stringify(setting.value);
+            }
+
+            if (setting.value === '0' || setting.value === '1') {
+                setting.value = !!+setting.value;
             }
 
             if (setting.key === 'codeinjection_head') {

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -98,6 +98,27 @@ Settings = ghostBookshelf.Model.extend({
             .then(function then() {
                 return validation.validateSettings(getDefaultSettings(), self);
             });
+    },
+
+    parse() {
+        const attrs = ghostBookshelf.Model.prototype.parse.apply(this, arguments);
+
+        // transform "0" to false
+        // transform "false" to false
+        // transform "null" to null
+        if (attrs.value === '0' || attrs.value === '1') {
+            attrs.value = !!+attrs.value;
+        }
+
+        if (attrs.value === 'false' || attrs.value === 'true') {
+            attrs.value = JSON.parse(attrs.value);
+        }
+
+        if (attrs.value === 'null') {
+            attrs.value = null;
+        }
+
+        return attrs;
     }
 }, {
     findOne: function (data, options) {

--- a/core/test/acceptance/old/admin/settings_spec.js
+++ b/core/test/acceptance/old/admin/settings_spec.js
@@ -114,6 +114,10 @@ describe('Settings API', function () {
                             {
                                 key: 'slack',
                                 value: JSON.stringify({username: 'username'})
+                            },
+                            {
+                                key: 'is_private',
+                                value: false
                             }
                         ]
                     };
@@ -147,6 +151,9 @@ describe('Settings API', function () {
 
                         putBody.settings[3].key.should.eql('slack');
                         should.equal(putBody.settings[3].value, JSON.stringify({username: 'username'}));
+
+                        putBody.settings[4].key.should.eql('is_private');
+                        should.equal(putBody.settings[4].value, false);
 
                         localUtils.API.checkResponse(putBody, 'settings');
                         done();

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -1,0 +1,35 @@
+const should = require('should');
+const models = require('../../../server/models');
+
+describe('Unit: models/settings', function () {
+    before(function () {
+        models.init();
+    });
+
+    describe('parse', function () {
+        it('ensure correct parsing when fetching from db', function () {
+            const setting = models.Settings.forge();
+
+            let returns = setting.parse({key: 'is_private', value: 'false'});
+            should.equal(returns.value, false);
+
+            returns = setting.parse({key: 'is_private', value: false});
+            should.equal(returns.value, false);
+
+            returns = setting.parse({key: 'is_private', value: true});
+            should.equal(returns.value, true);
+
+            returns = setting.parse({key: 'is_private', value: 'true'});
+            should.equal(returns.value, true);
+
+            returns = setting.parse({key: 'is_private', value: '0'});
+            should.equal(returns.value, false);
+
+            returns = setting.parse({key: 'is_private', value: '1'});
+            should.equal(returns.value, true);
+
+            returns = setting.parse({key: 'something', value: 'null'});
+            should.equal(returns.value, null);
+        });
+    });
+});


### PR DESCRIPTION
no issue

- https://forum.ghost.org/t/in-version-2-16-3-found-bug/6065/3

Admin Client sends false or true for `is_private`.
The settings table has two columns "key" and "value". And "value" is always type TEXT.

If you pass `value=false`, the db will transform this value into "0".
`settingsCache.get('is_private')` is then always true, even though the value is meant to be false.

We should add a migration in v3 and normalize all setting values to ensure consistentcy. Furthermore we could clarify the data type for each value.

For now we protect parsing values from db, which we anyway need to transform the values into the correct data type. 
