### PR TITLE
🐛 Changed hardcoded value on subscribed page title

### DIFF
--- a/core/server/apps/subscribers/lib/views/subscribe.hbs
+++ b/core/server/apps/subscribers/lib/views/subscribe.hbs
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
-    <title>Ghost - Subscribe</title>
+    <title>{{@site.title}} - Subscribe</title>
 
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">


### PR DESCRIPTION
no issue
- The subscribed title was being hardcoded as "Ghost" instead of using the title of the site.