### PR TITLE
Fix some helper output when using `data: page.{slug}` in routes

### DIFF
--- a/core/server/data/meta/description.js
+++ b/core/server/data/meta/description.js
@@ -24,12 +24,27 @@ function getDescription(data, root, options) {
         description = data.author.meta_description || '';
     } else if (_.includes(context, 'tag') && data.tag) {
         description = data.tag.meta_description || '';
-    } else if ((_.includes(context, 'post') || _.includes(context, 'page')) && data.post) {
+    } else if (_.includes(context, 'post') && data.post) {
         if (options && options.property) {
             postSdDescription = options.property + '_description';
             description = data.post[postSdDescription] || '';
         } else {
             description = data.post.meta_description || '';
+        }
+    } else if (_.includes(context, 'page') && data.post) {
+        // @NOTE: v0.1
+        if (options && options.property) {
+            postSdDescription = options.property + '_description';
+            description = data.post[postSdDescription] || '';
+        } else {
+            description = data.post.meta_description || '';
+        }
+    } else if (_.includes(context, 'page') && data.page) {
+        if (options && options.property) {
+            postSdDescription = options.property + '_description';
+            description = data.page[postSdDescription] || '';
+        } else {
+            description = data.page.meta_description || '';
         }
     }
 

--- a/core/server/data/meta/title.js
+++ b/core/server/data/meta/title.js
@@ -34,12 +34,28 @@ function getTitle(data, root, options) {
     } else if (_.includes(context, 'tag') && data.tag) {
         title = data.tag.meta_title || data.tag.name + ' - ' + blogTitle;
     // Post title
-    } else if ((_.includes(context, 'post') || _.includes(context, 'page')) && data.post) {
+    } else if (_.includes(context, 'post') && data.post) {
         if (options && options.property) {
             postSdTitle = options.property + '_title';
             title = data.post[postSdTitle] || '';
         } else {
             title = data.post.meta_title || data.post.title;
+        }
+    // Page title v0.1
+    } else if (_.includes(context, 'page') && data.post) {
+        if (options && options.property) {
+            postSdTitle = options.property + '_title';
+            title = data.post[postSdTitle] || '';
+        } else {
+            title = data.post.meta_title || data.post.title;
+        }
+    // Page title v2
+    } else if (_.includes(context, 'page') && data.page) {
+        if (options && options.property) {
+            postSdTitle = options.property + '_title';
+            title = data.page[postSdTitle] || '';
+        } else {
+            title = data.page.meta_title || data.page.title;
         }
     // Fallback
     } else {

--- a/core/server/helpers/body_class.js
+++ b/core/server/helpers/body_class.js
@@ -8,19 +8,19 @@ var proxy = require('./proxy'),
 
 // We use the name body_class to match the helper for consistency:
 module.exports = function body_class(options) { // eslint-disable-line camelcase
-    var classes = [],
-        context = options.data.root.context,
-        post = this.post,
-        tags = this.post && this.post.tags ? this.post.tags : this.tags || [],
-        page = this.post && this.post.page ? this.post.page : this.page || false;
+    let classes = [];
+    const context = options.data.root.context;
+    const obj = this.post || this.page;
+    const tags = obj && obj.tags ? obj.tags : [];
+    const isPage = !!(obj && obj.page);
 
     if (_.includes(context, 'home')) {
         classes.push('home-template');
-    } else if (_.includes(context, 'post') && post) {
+    } else if (_.includes(context, 'post') && obj) {
         classes.push('post-template');
-    } else if (_.includes(context, 'page') && page) {
+    } else if (_.includes(context, 'page') && obj && isPage) {
         classes.push('page-template');
-        classes.push('page-' + this.post.slug);
+        classes.push('page-' + obj.slug);
     } else if (_.includes(context, 'tag') && this.tag) {
         classes.push('tag-template');
         classes.push('tag-' + this.tag.slug);
@@ -33,7 +33,7 @@ module.exports = function body_class(options) { // eslint-disable-line camelcase
 
     if (tags) {
         classes = classes.concat(tags.map(function (tag) {
-            return 'tag-' + tag.slug; 
+            return 'tag-' + tag.slug;
         }));
     }
 
@@ -42,8 +42,9 @@ module.exports = function body_class(options) { // eslint-disable-line camelcase
     }
 
     classes = _.reduce(classes, function (memo, item) {
-        return memo + ' ' + item; 
+        return memo + ' ' + item;
     }, '');
+
     return new SafeString(classes.trim());
 };
 

--- a/core/server/services/routing/helpers/context.js
+++ b/core/server/services/routing/helpers/context.js
@@ -71,6 +71,10 @@ function setResponseContext(req, res, data) {
         if (!res.locals.context.includes('post')) {
             res.locals.context.push('post');
         }
+    } else if (data && data.page) {
+        if (!res.locals.context.includes('page')) {
+            res.locals.context.push('page');
+        }
     }
 }
 

--- a/core/test/unit/data/meta/description_spec.js
+++ b/core/test/unit/data/meta/description_spec.js
@@ -126,9 +126,20 @@ describe('getMetaDescription', function () {
         description.should.equal('Best AMP post ever!');
     });
 
-    it('should return data post meta description if on root context contains page', function () {
+    it('v0.1: should return data post meta description if on root context contains page', function () {
         var description = getMetaDescription({
             post: {
+                meta_description: 'Best page ever!'
+            }
+        }, {
+            context: ['page']
+        });
+        description.should.equal('Best page ever!');
+    });
+
+    it('v2: should return data page meta description if on root context contains page', function () {
+        var description = getMetaDescription({
+            page: {
                 meta_description: 'Best page ever!'
             }
         }, {

--- a/core/test/unit/data/meta/title_spec.js
+++ b/core/test/unit/data/meta/title_spec.js
@@ -190,9 +190,19 @@ describe('getTitle', function () {
         title.should.equal('My awesome post!');
     });
 
-    it('should return post title if in page context', function () {
+    it('v0.1: should return post title if in page context', function () {
         var title = getTitle({
             post: {
+                title: 'My awesome page!'
+            }
+        }, {context: ['page']});
+
+        title.should.equal('My awesome page!');
+    });
+
+    it('v2: should return page title if in page context', function () {
+        var title = getTitle({
+            page: {
                 title: 'My awesome page!'
             }
         }, {context: ['page']});

--- a/core/test/unit/helpers/body_class_spec.js
+++ b/core/test/unit/helpers/body_class_spec.js
@@ -133,10 +133,19 @@ describe('{{body_class}} helper', function () {
             rendered.string.should.equal('post-template tag-foo tag-bar');
         });
 
-        it('a static page', function () {
+        it('v0.1: a static page', function () {
             var rendered = callBodyClassWithContext(
                 ['page'],
                 {relativeUrl: '/about', post: {page: true, slug: 'about'}}
+            );
+
+            rendered.string.should.equal('page-template page-about');
+        });
+
+        it('v2: a static page', function () {
+            var rendered = callBodyClassWithContext(
+                ['page'],
+                {relativeUrl: '/about', page: {page: true, slug: 'about'}}
             );
 
             rendered.string.should.equal('page-template page-about');


### PR DESCRIPTION
refs #10082

3 commits. Please rebase & merge.

1. data: page.{slug} throwed a 500 if using {{body_class}}
2. meta_title output wrong meta title
3. meta_description output wrong meta description
