### PR TITLE
Fixed previews not reflecting changes to scheduled posts on Ghost(Pro)

### DIFF
--- a/core/server/api/v2/pages.js
+++ b/core/server/api/v2/pages.js
@@ -132,10 +132,15 @@ module.exports = {
         query(frame) {
             return models.Post.edit(frame.data.pages[0], frame.options)
                 .then((model) => {
-                    if (model.get('status') === 'published' && model.wasChanged() ||
-                        model.get('status') === 'draft' && model.previous('status') === 'published') {
+                    if (
+                        model.get('status') === 'published' && model.wasChanged() ||
+                        model.get('status') === 'draft' && model.previous('status') === 'published'
+                    ) {
                         this.headers.cacheInvalidate = true;
-                    } else if (model.get('status') === 'draft' && model.previous('status') !== 'published') {
+                    } else if (
+                        model.get('status') === 'draft' && model.previous('status') !== 'published' ||
+                        model.get('status') === 'scheduled' && model.wasChanged()
+                    ) {
                         this.headers.cacheInvalidate = {
                             value: urlService.utils.urlFor({
                                 relativeUrl: urlService.utils.urlJoin('/p', model.get('uuid'), '/')

--- a/core/server/api/v2/posts.js
+++ b/core/server/api/v2/posts.js
@@ -136,10 +136,15 @@ module.exports = {
         query(frame) {
             return models.Post.edit(frame.data.posts[0], frame.options)
                 .then((model) => {
-                    if (model.get('status') === 'published' && model.wasChanged() ||
-                        model.get('status') === 'draft' && model.previous('status') === 'published') {
+                    if (
+                        model.get('status') === 'published' && model.wasChanged() ||
+                        model.get('status') === 'draft' && model.previous('status') === 'published'
+                    ) {
                         this.headers.cacheInvalidate = true;
-                    } else if (model.get('status') === 'draft' && model.previous('status') !== 'published') {
+                    } else if (
+                        model.get('status') === 'draft' && model.previous('status') !== 'published' ||
+                        model.get('status') === 'scheduled' && model.wasChanged()
+                    ) {
                         this.headers.cacheInvalidate = {
                             value: urlService.utils.urlFor({
                                 relativeUrl: urlService.utils.urlJoin('/p', model.get('uuid'), '/')


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/10600
- modifies conditions for when to send a cache invalidation header for preview URLs to include changes to scheduled posts