### PR TITLE
Updated backup file names to include timestamp

### DIFF
--- a/core/server/data/exporter/index.js
+++ b/core/server/data/exporter/index.js
@@ -25,7 +25,7 @@ var _ = require('lodash'),
     exportFileName;
 
 exportFileName = function exportFileName(options) {
-    var datetime = (new Date()).toJSON(),
+    var datetime = require('moment')().format('YYYY-MM-DD-HH-mm-ss'),
         title = '';
 
     options = options || {};

--- a/core/server/data/exporter/index.js
+++ b/core/server/data/exporter/index.js
@@ -25,7 +25,7 @@ var _ = require('lodash'),
     exportFileName;
 
 exportFileName = function exportFileName(options) {
-    var datetime = (new Date()).toJSON().substring(0, 10),
+    var datetime = (new Date()).toJSON(),
         title = '';
 
     options = options || {};

--- a/core/test/unit/data/exporter/index_spec.js
+++ b/core/test/unit/data/exporter/index_spec.js
@@ -160,7 +160,7 @@ describe('Exporter', function () {
             exporter.fileName().then(function (result) {
                 should.exist(result);
                 settingsStub.calledOnce.should.be.true();
-                result.should.match(/^testblog\.ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.json$/);
+                result.should.match(/^testblog\.ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
             }).catch(done);
@@ -174,7 +174,7 @@ describe('Exporter', function () {
             exporter.fileName().then(function (result) {
                 should.exist(result);
                 settingsStub.calledOnce.should.be.true();
-                result.should.match(/^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.json$/);
+                result.should.match(/^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
             }).catch(done);
@@ -188,7 +188,7 @@ describe('Exporter', function () {
             exporter.fileName().then(function (result) {
                 should.exist(result);
                 settingsStub.calledOnce.should.be.true();
-                result.should.match(/^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.json$/);
+                result.should.match(/^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
             }).catch(done);


### PR DESCRIPTION
no-issue

Currently if you run two migrations on the same day, the backup is overwritten. This change adds the `HH-mm-ss` to the file name, meaning that you get a unique backup for each migration.