### PR TITLE
Added tests to ghost release process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -639,6 +639,7 @@ const configureGrunt = function (grunt) {
     grunt.registerTask('release',
         'Release task - creates a final built zip\n' +
         ' - Do our standard build steps \n' +
+        ' - Run all tests(acceptance + regression + unit) \n' +
         ' - Copy files to release-folder/#/#{version} directory\n' +
         ' - Clean out unnecessary files (travis, .git*, etc)\n' +
         ' - Zip files in release-folder to dist-folder/#{version} directory',
@@ -662,8 +663,14 @@ const configureGrunt = function (grunt) {
                     dest: 'core/server/web/admin/views/default.html'
                 }]
             });
-
-            grunt.task.run(['update_submodules:pinned', 'subgrunt:init', 'clean:built', 'clean:tmp', 'prod', 'clean:release', 'copy:admin_html', 'copy:release', 'compress:release']);
+            if (!grunt.option('skip-tests')) {
+                grunt.task.run(['update_submodules:pinned', 'subgrunt:init', 'test-all', 'clean:built', 'clean:tmp', 'prod', 'clean:release', 'copy:admin_html', 'copy:release', 'compress:release']);
+            } else {
+                grunt.log.writeln(chalk.red(
+                    chalk.bold('Skipping tests...')
+                ));
+                grunt.task.run(['update_submodules:pinned', 'subgrunt:init', 'clean:built', 'clean:tmp', 'prod', 'clean:release', 'copy:admin_html', 'copy:release', 'compress:release']);
+            }
         }
     );
 };


### PR DESCRIPTION
no issue

- Runs all tests after initial setup in release process, aborts immediately in case of any failures.

Pro: Always ensures all tests are green before cutting out a release.
Con: Increases overall duration of generating a release by (~20 mins) as all tests need to pass before by default. Though this can be bypassed as its possible to skip tests by calling release with flag like `grunt release --skip-tests`

~~Alternative approach was to run tests in the `release` task in `Ghost-Release`, but downside in that case is its only possible to run tests after the main [release task](https://github.com/TryGhost/Ghost/blob/master/Gruntfile.js#L666) as tests can only be run after initial setup. Since ideally we shouldn't wait for rest of the release tasks to complete before aborting the release in case of a failure, adding it here seems to make more sense.~~

~~Possible downside of adding the task here instead of `Ghost-Release` is in this case its not straight-forward to add a flag to `grunt release` to skip tests for a release(e.g `grunt release --skip-tests`) as we don't pass grunt flags down to subgrunt 😬~~
