### PR TITLE
Updated npmignore to ignore custom config file in releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -42,3 +42,5 @@ bower_components/**
 gulpfile.js
 !content/themes/casper/gulpfile.js
 package-lock.json
+config.*.json
+!core/server/config/env/**


### PR DESCRIPTION
no issue

- Ignores custom config.*.json files on npm operations(e.g pack) in `core/server/config/` but allows in `core/server/config/env/*`
- Boosts release process to also catch and ignore any such file from leaking into the final publish
