### PR TITLE
Fixed `null` sometimes displayed on empty post content

### DIFF
--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -18,6 +18,10 @@ module.exports = function content(options) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
 
+    if (this.html === null) {
+        this.html = '';
+    }
+
     if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
         return new SafeString(
             downsize(this.html, truncateOptions)


### PR DESCRIPTION
refs #10612
excerpt helper was displaying the correct content while the content helper wasn't

The code checks if the html is equal to `null` in `core/server/helpers/content.js`, assuming this null state is an expected behavior until this point.
If not, this is maybe a bug with Mobiledoc or with the auto-saving system.

- [:white_check_mark:] There's a clear use-case for this code change
- [:white_check_mark:] Commit message has a short title & references relevant issues
- [:white_check_mark:] The build will pass (run `yarn test` and `yarn lint`)