### PR TITLE
Remove obsolete comment

### DIFF
--- a/core/server/services/auth/authorize.js
+++ b/core/server/services/auth/authorize.js
@@ -66,12 +66,6 @@ const authorize = {
         }));
     },
 
-    /**
-     * @NOTE:
-     *
-     * We don't support admin api keys yet, but we can already use this authorization helper, because
-     * we have not connected authenticating with admin api keys yet. `req.api_key` will be always null.
-     */
     authorizeAdminApi(req, res, next) {
         const hasUser = req.user && req.user.id;
         const hasApiKey = req.api_key && req.api_key.id;


### PR DESCRIPTION
I noticed an outdated comment in the codebase ([confirmed by Kevin](https://forum.ghost.org/t/code-comment-says-we-dont-support-admin-api-keys-yet-is-this-true/6344/4?u=grant)). This PR removes it.