### PR TITLE
[WIP] 🐛 Fixed mobiledoc returning relative asset urls 

### DIFF
--- a/core/server/api/v2/utils/serializers/output/utils/url.js
+++ b/core/server/api/v2/utils/serializers/output/utils/url.js
@@ -73,8 +73,8 @@ const forPost = (id, attrs, frame) => {
         if (matches) {
             matches.forEach((match) => {
                 // @NOTE: the utility will skip the match if it's already absolute
-                const relative = urlService.utils.relativeToAbsolute(match);
-                attrs.mobiledoc = attrs.mobiledoc.replace(new RegExp(match, 'g'), relative);
+                const absolute = urlService.utils.relativeToAbsolute(match);
+                attrs.mobiledoc = attrs.mobiledoc.replace(new RegExp(match, 'g'), absolute);
             });
         }
     }

--- a/core/server/api/v2/utils/serializers/output/utils/url.js
+++ b/core/server/api/v2/utils/serializers/output/utils/url.js
@@ -64,7 +64,7 @@ const forPost = (id, attrs, frame) => {
         ).html();
     }
 
-    // CASE: we always need to return absolute urls for content urls
+    // CASE: we always need to return absolute urls for content urls, even in mobiledoc
     if (attrs.mobiledoc && !localUtils.isContentAPI(frame)) {
         const imagePathRe = new RegExp(`/${urlService.utils.STATIC_IMAGE_URL_PREFIX}`, 'g');
 
@@ -72,6 +72,7 @@ const forPost = (id, attrs, frame) => {
 
         if (matches) {
             matches.forEach((match) => {
+                // @NOTE: the utility will skip the match if it's already absolute
                 const relative = urlService.utils.relativeToAbsolute(match);
                 attrs.mobiledoc = attrs.mobiledoc.replace(new RegExp(match, 'g'), relative);
             });

--- a/core/server/api/v2/utils/serializers/output/utils/url.js
+++ b/core/server/api/v2/utils/serializers/output/utils/url.js
@@ -64,6 +64,20 @@ const forPost = (id, attrs, frame) => {
         ).html();
     }
 
+    // CASE: we always need to return absolute urls for content urls
+    if (attrs.mobiledoc && !localUtils.isContentAPI(frame)) {
+        const imagePathRe = new RegExp(`/${urlService.utils.STATIC_IMAGE_URL_PREFIX}`, 'g');
+
+        const matches = _.uniq(attrs.mobiledoc.match(imagePathRe));
+
+        if (matches) {
+            matches.forEach((match) => {
+                const relative = urlService.utils.relativeToAbsolute(match);
+                attrs.mobiledoc = attrs.mobiledoc.replace(new RegExp(match, 'g'), relative);
+            });
+        }
+    }
+
     if (frame.options.columns && !frame.options.columns.includes('url')) {
         delete attrs.url;
     }


### PR DESCRIPTION
refs #10620, refs #10477

- editor uploads an image
- receives absolute path
- inserts into mobiledoc
- updates post
- server stores relative asset paths
- we need to serve absolute asset paths, otherwise, editor could mark content as "dirty"
- should work for pages & posts (they use the same url serializer)

**not done, needs proof testing & a regression test**