### PR TITLE
[WIP] Reverted: Fixed image URL to be stored as relative in mobiledoc

### DIFF
--- a/core/server/api/v2/utils/serializers/input/utils/url.js
+++ b/core/server/api/v2/utils/serializers/input/utils/url.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const {absoluteToRelative, getBlogUrl, STATIC_IMAGE_URL_PREFIX} = require('../../../../../../services/url/utils');
 
 const handleCanonicalUrl = (url) => {
@@ -24,6 +23,7 @@ const handleImageUrl = (imageUrl) => {
     return imageUrl;
 };
 
+/*
 const handleContentUrls = (content) => {
     const blogDomain = getBlogUrl().replace(/^http(s?):\/\//, '').replace(/\/$/, '');
     const imagePathRe = new RegExp(`(http(s?)://)?${blogDomain}/${STATIC_IMAGE_URL_PREFIX}`, 'g');
@@ -39,12 +39,20 @@ const handleContentUrls = (content) => {
 
     return content;
 };
+*/
 
 const forPost = (attrs, options) => {
-    // make all content image URLs relative, ref: https://github.com/TryGhost/Ghost/issues/10477
-    if (attrs.mobiledoc) {
-        attrs.mobiledoc = handleContentUrls(attrs.mobiledoc);
-    }
+    /**
+     * NOTE: make all content image URLs relative, ref: https://github.com/TryGhost/Ghost/issues/10477
+     *
+     *  if (attrs.mobiledoc) {
+     *    attrs.mobiledoc = handleContentUrls(attrs.mobiledoc);
+     *  }
+     *
+     *  @TODO: It's really hard to transform the links back from relative to absolute in mobiledoc.
+     *  We will store absolute urls for now. It's less error-prone than reg exing mobiledoc incorrectly.
+     *  Refs https://github.com/TryGhost/Ghost/issues/10477
+     */
 
     if (attrs.feature_image) {
         attrs.feature_image = handleImageUrl(attrs.feature_image);

--- a/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
@@ -251,7 +251,7 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
                 serializers.input.posts.edit(apiConfig, frame);
 
                 let postData = frame.data.posts[0];
-                postData.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"/content/images/2019/02/image.jpg"}]]}');
+                postData.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"https://mysite.com/content/images/2019/02/image.jpg"}]]}');
             });
 
             it('when mobiledoc contains multiple absolute URLs to images with different protocols', function () {
@@ -280,7 +280,7 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
                 serializers.input.posts.edit(apiConfig, frame);
 
                 let postData = frame.data.posts[0];
-                postData.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"/content/images/2019/02/image.jpg"}],["image",{"src":"/content/images/2019/02/image.png"}]]');
+                postData.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"https://mysite.com/content/images/2019/02/image.jpg"}],["image",{"src":"http://mysite.com/content/images/2019/02/image.png"}]]');
             });
 
             it('when blog url is without subdir', function () {


### PR DESCRIPTION
refs #10477, refs #10620

- Refs: https://github.com/TryGhost/Ghost/commit/e47d1e275ffaf88d83abce199ac8d1efa729a001

Case:
- editor uploads an image
- receives absolute path
- inserts into mobiledoc
- updates post
- server stores relative asset paths
- we need to serve absolute asset paths, otherwise, editor could mark content as "dirty"