### PR TITLE
🐛 disallowed inactive users from being made owner

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -284,7 +284,8 @@
                 "userNotFound": "User not found",
                 "ownerNotFound": "Owner not found",
                 "onlyOwnerCanTransferOwnerRole": "Only owners are able to transfer the owner role.",
-                "onlyAdmCanBeAssignedOwnerRole": "Only administrators can be assigned the owner role."
+                "onlyAdmCanBeAssignedOwnerRole": "Only administrators can be assigned the owner role.",
+                "onlyActiveAdmCanBeAssignedOwnerRole": "Only active administrators can be assigned the owner role."
             },
             "api_key": {
                 "apiKeyNotFound": "API Key not found"


### PR DESCRIPTION
- closes #10555 
- Added a check to the user modal that the new owner is active 
- Had to refactor Owner->Author unit test (also renamed it)
  - Based on the first 2 lines, owner->editor change is attempted (hence the rename)
  - Since both stubs return a 'modal' with owner role which means owner->owner change is actually attempted
  - Now that there's a user status check, added the `status` property to the user receiving owernship