### PR TITLE
Improved grunt express watcher

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,8 @@ const configureGrunt = function (grunt) {
                     'content/themes/casper/assets/js/*.js'
                 ],
                 options: {
-                    livereload: true
+                    livereload: true,
+                    interval: 500
                 }
             },
             express: {
@@ -84,7 +85,8 @@ const configureGrunt = function (grunt) {
                 tasks: ['express:dev'],
                 options: {
                     spawn: false,
-                    livereload: true
+                    livereload: true,
+                    interval: 500
                 }
             }
         },


### PR DESCRIPTION
closes #9718

@kevinansfield after starting to consider to move to suggested https://github.com/BuddyBuild/bb-grunt-watch that substitutes Gaze watcher with Watchman. Found the interval option that looks like a good enough solution without having to worry about other bugs that could happen in the new package (it wasn't too active, so had some doubts about it). Would love to hear what you think and check how's the performance on non-Linux environment. For me, it dropped from 7% of CPU load to almost nothing after this change.