### PR TITLE
Migrated encode, facebook_url and foreach helpers to es6

### DIFF
--- a/core/server/helpers/encode.js
+++ b/core/server/helpers/encode.js
@@ -4,10 +4,9 @@
 //
 // Returns URI encoded string
 
-var proxy = require('./proxy'),
-    SafeString = proxy.SafeString;
+const {SafeString} = require('./proxy');
 
 module.exports = function encode(string, options) {
-    var uri = string || options;
+    const uri = string || options;
     return new SafeString(encodeURIComponent(uri));
 };

--- a/core/server/helpers/facebook_url.js
+++ b/core/server/helpers/facebook_url.js
@@ -2,9 +2,7 @@
 // Usage: `{{facebook_url}}` or `{{facebook_url author.facebook}}`
 //
 // Output a url for a facebook username
-var proxy = require('./proxy'),
-    socialUrls = proxy.socialUrls,
-    localUtils = proxy.localUtils;
+const {socialUrls, localUtils} = require('./proxy');
 
 // We use the name facebook_url to match the helper for consistency:
 module.exports = function facebook_url(username, options) { // eslint-disable-line camelcase


### PR DESCRIPTION
Refs #9589 

 - Update code style and migrate encode, facebook_url and foreach helpers
 - Skipping migrating `excerpt` helper since it's probably going to get nuked in Ghost 3.0