### PR TITLE
🐛 Remove extraneous log message for missing en.json locale file

### DIFF
--- a/core/server/lib/common/i18n.js
+++ b/core/server/lib/common/i18n.js
@@ -210,7 +210,9 @@ I18n = {
             } catch (err) {
                 themeStrings = undefined;
                 if (err.code === 'ENOENT') {
-                    logging.warn(`Theme's file locales/${currentLocale}.json not found.`);
+                    if (currentLocale !== 'en') {
+                        logging.warn(`Theme's file locales/${currentLocale}.json not found.`);
+                    }
                 } else {
                     throw err;
                 }


### PR DESCRIPTION
no issue
Content is in english (en) by default.

===========

Currently if there is no 'locales/en.json' file for a theme a warning message is emitted to the log. Since Ghost is 'en' by default this just creates noise in the log.

Example log message:
{"name":"Log","hostname":"redacted","pid":43854,"level":40,"msg":"Theme's file locales/en.json not found. ","time":"2019-04-04T19:21:59.360Z","v":0}
