### PR TITLE
Fixed sitemap regressions

### DIFF
--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -65,7 +65,13 @@ class BaseSiteMapGenerator {
     }
 
     getLastModifiedForDatum(datum) {
-        return datum.updated_at || datum.published_at || datum.created_at;
+        if (datum.updated_at || datum.published_at || datum.created_at) {
+            const modifiedDate = datum.updated_at || datum.published_at || datum.created_at;
+
+            return moment(modifiedDate);
+        } else {
+            return moment();
+        }
     }
 
     updateLastModified(datum) {

--- a/core/server/services/url/configs/v0.1.js
+++ b/core/server/services/url/configs/v0.1.js
@@ -27,7 +27,6 @@ module.exports = [
                 'twitter_title',
                 'twitter_description',
                 'custom_template',
-                'feature_image',
                 'locale'
             ],
             withRelated: ['tags', 'authors'],
@@ -68,7 +67,6 @@ module.exports = [
                 'twitter_title',
                 'twitter_description',
                 'custom_template',
-                'feature_image',
                 'locale',
                 'tags',
                 'authors',

--- a/core/server/services/url/configs/v2.js
+++ b/core/server/services/url/configs/v2.js
@@ -30,7 +30,6 @@ module.exports = [
                 'twitter_title',
                 'twitter_description',
                 'custom_template',
-                'feature_image',
                 'locale'
             ],
             withRelated: ['tags', 'authors'],
@@ -74,7 +73,6 @@ module.exports = [
                 'twitter_title',
                 'twitter_description',
                 'custom_template',
-                'feature_image',
                 'locale',
                 'tags',
                 'authors',
@@ -98,9 +96,7 @@ module.exports = [
                 'description',
                 'meta_title',
                 'meta_description',
-                'parent_id',
-                'created_at',
-                'updated_at'
+                'parent_id'
             ],
             filter: 'visibility:public',
             shouldHavePosts: {


### PR DESCRIPTION
refs #10640 and [Forum](https://forum.ghost.org/t/images-not-included-in-the-sitemap/6692/1)

- Updated resources config to include certain fields needed for correct sitemap generation
--------------
### Context

We have seen 2 main regressions that have popped up for sitemaps - 
- Incorrect last modified Date - #10640 
- Incorrect image count - [Forum](https://forum.ghost.org/t/images-not-included-in-the-sitemap/6692/1)

The value calculation of both last modified date and image count are part of sitemap generation in [base generator](https://github.com/TryGhost/Ghost/blob/master/core/server/data/xml/sitemap/base-generator.js), which applies to all sitemap resources. These values are calculated based on values of certain fields for the resource, which in case of date and image are calculated here - 
- For Date: https://github.com/TryGhost/Ghost/blob/master/core/server/data/xml/sitemap/base-generator.js#L68
- For Images: https://github.com/TryGhost/Ghost/blob/master/core/server/data/xml/sitemap/base-generator.js#L100


### Problem

Digging into data available for individual resource, the root cause for both issues is unavailability of some or all of date/image fields on the resources(tags, posts, pages, authors) during sitemap generation. As a result, since fields like `created_at`, `updated_at`, `feature_image` etc are not available on resource, the resulting values calculated are incorrect or incomplete on sitemap.

Sitemap base generator gets resources data generated from [Resources](https://github.com/TryGhost/Ghost/blob/master/core/server/services/url/Resources.js) file. The Resources file uses the config as [here](https://github.com/TryGhost/Ghost/blob/master/core/server/services/url/Resources.js#L49) to determine allowed fields on the resource data. The [config](https://github.com/TryGhost/Ghost/blob/master/core/server/services/url/configs/v2.js) itself excludes a lot of fields from different resources, which eventually leads to incorrect sitemap calculation.

### Possible solutions

🤔 This one seems to be a bit tricky on quick look to solve, without affecting either the global url config file or Resources config. While changing the config file is a quick fix for sitemap issue(tested locally), it needs to be seen if it has any other unwanted side-affects.(cc @gargol) 