### PR TITLE
Reviewed error context usage

### DIFF
--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -63,10 +63,9 @@ module.exports = function (Bookshelf) {
                                     message: 'Saving failed! Someone else is editing this post.',
                                     code: 'UPDATE_COLLISION',
                                     level: 'critical',
-                                    context: {
+                                    errorDetails: {
                                         clientUpdatedAt: self.clientData.updated_at,
-                                        serverUpdatedAt: self.serverData.updated_at,
-                                        changed: changed
+                                        serverUpdatedAt: self.serverData.updated_at
                                     }
                                 }));
                             }

--- a/core/server/services/themes/validate.js
+++ b/core/server/services/themes/validate.js
@@ -1,7 +1,9 @@
-var Promise = require('bluebird'),
-    config = require('../../config'),
-    common = require('../../lib/common'),
-    checkTheme;
+const _ = require('lodash');
+const Promise = require('bluebird');
+const config = require('../../config');
+const common = require('../../lib/common');
+
+let checkTheme;
 
 checkTheme = function checkTheme(theme, isZip) {
     var checkPromise,
@@ -31,8 +33,11 @@ checkTheme = function checkTheme(theme, isZip) {
 
             return Promise.reject(new common.errors.ThemeValidationError({
                 message: common.i18n.t('errors.api.themes.invalidTheme'),
-                errorDetails: checkedTheme.results.error,
-                context: checkedTheme
+                errorDetails: Object.assign(
+                    _.pick(checkedTheme, ['checkedVersion', 'name', 'path', 'version']), {
+                        errors: checkedTheme.results.error
+                    }
+                )
             }));
         }).catch(function (error) {
             return Promise.reject(error);

--- a/core/server/services/themes/validate.js
+++ b/core/server/services/themes/validate.js
@@ -37,7 +37,10 @@ checkTheme = function checkTheme(theme, isZip) {
                     _.pick(checkedTheme, ['checkedVersion', 'name', 'path', 'version']), {
                         errors: checkedTheme.results.error
                     }
-                )
+                ),
+                // NOTE: needs to be removed but first has to be decoupled
+                //       from logic here: https://github.com/TryGhost/Ghost/blob/9810834/core/server/services/themes/index.js#L56-L57
+                context: checkedTheme
             }));
         }).catch(function (error) {
             return Promise.reject(error);


### PR DESCRIPTION
refs #10571

Reduced and improved error handling in places where `context` was polluting the output. @ErisDS there are couple questions around these changes will leave them in the code comments :+1: 