### PR TITLE
Update active installed apps import check

### DIFF
--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -41,7 +41,15 @@ class SettingsImporter extends BaseImporter {
         const activeApps = _.find(this.dataToImport, {key: 'active_apps'});
         const installedApps = _.find(this.dataToImport, {key: 'installed_apps'});
 
-        if (activeApps || installedApps) {
+        const hasValueEntries = (setting = {}) => {
+            try {
+                return JSON.parse(setting.value || '[]').length !== 0;
+            } catch (e) {
+                return false;
+            }
+        };
+
+        if (hasValueEntries(activeApps) || hasValueEntries(installedApps)) {
             this.problems.push({
                 message: 'Old settings for apps were not imported',
                 help: this.modelName,

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -55,11 +55,11 @@ class SettingsImporter extends BaseImporter {
                 help: this.modelName,
                 context: JSON.stringify({activeApps, installedApps})
             });
-
-            this.dataToImport = _.filter(this.dataToImport, (data) => {
-                return data.key !== 'active_apps' && data.key !== 'installed_apps';
-            });
         }
+
+        this.dataToImport = _.filter(this.dataToImport, (data) => {
+            return data.key !== 'active_apps' && data.key !== 'installed_apps';
+        });
 
         const permalinks = _.find(this.dataToImport, {key: 'permalinks'});
 

--- a/core/test/acceptance/old/admin/db_spec.js
+++ b/core/test/acceptance/old/admin/db_spec.js
@@ -89,7 +89,7 @@ describe('DB API', () => {
                         const jsonResponse = res.body;
                         should.exist(jsonResponse.db);
                         should.exist(jsonResponse.problems);
-                        jsonResponse.problems.should.have.length(4);
+                        jsonResponse.problems.should.have.length(3);
                     });
             })
             .then(() => {


### PR DESCRIPTION
Updates the import check for `installed_apps` and `active_apps` settings, so that anyone with default values will not see the warning.

Also ensure that any import will never import the `installed_apps` and `active_apps` settings.