### PR TITLE
Blacklisted private member settings for HTTP calls

### DIFF
--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -9,6 +9,12 @@ const urlService = require('../../services/url');
 const common = require('../../lib/common');
 const settingsCache = require('../../services/settings/cache');
 
+const SETTINGS_BLACKLIST = [
+    'members_public_key',
+    'members_private_key',
+    'members_session_secret'
+];
+
 module.exports = {
     docName: 'settings',
 
@@ -28,7 +34,9 @@ module.exports = {
             // CASE: omit core settings unless internal request
             if (!frame.options.context.internal) {
                 settings = _.filter(settings, (setting) => {
-                    return setting.type !== 'core';
+                    const isCore = setting.type === 'core';
+                    const isBlacklisted = SETTINGS_BLACKLIST.includes(setting.key);
+                    return !isBlacklisted && !isCore;
                 });
             }
 


### PR DESCRIPTION
no-issue

Previously it was possible to fetch the private key and session secret
for the members service, this is a security issue as we do not have
specific permissions for individual settings yet, and could have
possibly exposed secrets to admin integrations.