### PR TITLE
Add support for stripe coupons in members

### DIFF
--- a/core/server/lib/members/index.js
+++ b/core/server/lib/members/index.js
@@ -118,7 +118,7 @@ module.exports = function MembersApi({
     }
 
     /* subscriptions */
-    apiRouter.post('/subscription', getData('adapter', 'plan', 'stripeToken'), ssoOriginCheck, (req, res) => {
+    apiRouter.post('/subscription', getData('adapter', 'plan', 'stripeToken', 'coupon'), ssoOriginCheck, (req, res) => {
         const {signedin} = getCookie(req);
         if (!signedin) {
             res.writeHead(401, {
@@ -127,7 +127,7 @@ module.exports = function MembersApi({
             return res.end();
         }
 
-        const {plan, adapter, stripeToken} = req.data;
+        const {plan, adapter, stripeToken, coupon} = req.data;
 
         subscriptions.getAdapters()
             .then((adapters) => {
@@ -140,7 +140,8 @@ module.exports = function MembersApi({
                 return subscriptions.createSubscription(member, {
                     adapter,
                     plan,
-                    stripeToken
+                    stripeToken,
+                    coupon
                 });
             })
             .then(() => {

--- a/core/server/lib/members/static/auth/components/CouponInput.js
+++ b/core/server/lib/members/static/auth/components/CouponInput.js
@@ -1,0 +1,19 @@
+import FormInput from './FormInput';
+import { IconName } from './icons';
+
+export default ({value, disabled, error, children, onInput, className}) => (
+    <FormInput
+        type="text"
+        name="coupon"
+        label="coupon"
+        value={value}
+        error={error}
+        icon={IconName}
+        placeholder="Coupon..."
+        required={false}
+        disabled={disabled}
+        className={className}
+        onInput={onInput}>
+        {children}
+    </FormInput>
+);

--- a/core/server/lib/members/static/auth/components/FormInput.js
+++ b/core/server/lib/members/static/auth/components/FormInput.js
@@ -1,4 +1,4 @@
-export default ({type, name, placeholder, value = '', error, onInput, required, className, children, icon}) => (
+export default ({type, name, placeholder, value = '', error, onInput, required, disabled, className, children, icon}) => (
     <div className="gm-form-element">
         <div className={[
                 (className ? className : ""),
@@ -12,6 +12,7 @@ export default ({type, name, placeholder, value = '', error, onInput, required, 
                 value={ value }
                 onInput={ (e) => onInput(e, name) }
                 required={ required }
+                disabled={ disabled }
                 className={[
                     (value ? "gm-input-filled" : ""),
                     (error ? "gm-error" : "")

--- a/core/server/lib/members/static/auth/components/FormInput.js
+++ b/core/server/lib/members/static/auth/components/FormInput.js
@@ -1,4 +1,4 @@
-export default ({type, name, placeholder, value = '', error, onInput, required, disabled, className, children, icon}) => (
+export default ({type, name, placeholder, value = '', error, onInput, required, disabled = false, className, children, icon}) => (
     <div className="gm-form-element">
         <div className={[
                 (className ? className : ""),

--- a/core/server/lib/members/static/auth/components/Modal.js
+++ b/core/server/lib/members/static/auth/components/Modal.js
@@ -51,8 +51,8 @@ export default class Modal extends Component {
         if (stripeConfig) {
             const createAccountWithSubscription = (data) => {
                 this.setState({showSpinner: true});
-                members.signup(data).then((success) => {
-                    members.createSubscription(data).then((success) => {
+                return members.signup(data).then((success) => {
+                    return members.createSubscription(data).then((success) => {
                         this.setState({showSpinner: false});
                         window.location.hash = 'signup-complete';
                     }, (error) => {
@@ -78,7 +78,7 @@ export default class Modal extends Component {
             members.createSubscription(data)
         );
         const stripeConfig = paymentConfig && paymentConfig.find(({adapter}) => adapter === 'stripe');
-        return <StripeUpgradePage frameLocation={props.frameLocation} stripeConfig={stripeConfig} error={error} hash="upgrade" handleSubmit={createSubscription} handleClose={closeModal}/>
+        return <StripeUpgradePage stripeConfig={stripeConfig} error={error} hash="upgrade" handleSubmit={createSubscription} handleClose={closeModal}/>
 
     }
 
@@ -91,7 +91,7 @@ export default class Modal extends Component {
 
         const signup = (data) => {
             this.setState({showSpinner: true});
-            members.signup(data).then((success) => {
+            return members.signup(data).then((success) => {
                 this.setState({showSpinner: false});
                 window.location.hash = 'signup-complete';
             }, (error) => {

--- a/core/server/lib/members/static/auth/pages/StripeSubscribePage.js
+++ b/core/server/lib/members/static/auth/pages/StripeSubscribePage.js
@@ -5,10 +5,16 @@ import FormSubmit from '../components/FormSubmit';
 import FormHeaderCTA from '../components/FormHeaderCTA';
 import NameInput from '../components/NameInput';
 import EmailInput from '../components/EmailInput';
+import CouponInput from '../components/CouponInput';
 import PasswordInput from '../components/PasswordInput';
 import CheckoutForm from '../components/CheckoutForm';
 import Form from '../components/Form';
 
+const getCouponData = frameLocation => {
+    const params = new URLSearchParams(frameLocation.query);
+    const coupon = params.get('coupon') || '';
+    return { coupon };
+};
 
 class PaymentForm extends Component {
 
@@ -16,7 +22,7 @@ class PaymentForm extends Component {
         super(props);
     }
 
-    handleSubmit = ({ name, email, password, plan }) => {
+    handleSubmit = ({ name, email, password, plan, coupon }) => {
         // Within the context of `Elements`, this call to createToken knows which Element to
         // tokenize, since there's only one in this group.
         plan = this.props.selectedPlan ? this.props.selectedPlan.name : "";
@@ -25,7 +31,7 @@ class PaymentForm extends Component {
                 adapter: 'stripe',
                 plan: plan,
                 stripeToken: token.id,
-                name, email, password
+                name, email, password, coupon
             });
         });
     };
@@ -34,17 +40,19 @@ class PaymentForm extends Component {
         this.props.stripe.createToken({ name: name });
     }
 
-    render() {
+    render({frameLocation}) {
         let label = this.props.showSpinner ? (
             (
                 <span><span class="gm-spinner"></span> Signing up... </span>
-            ) 
+            )
         ) : "Confirm payment";
+        const { coupon } = getCouponData(frameLocation);
         return (
-            <Form bindTo="request-password-reset" onSubmit={(data) => this.handleSubmit(data)}>
+            <Form includeData={getCouponData(frameLocation)} bindTo="request-password-reset" onSubmit={(data) => this.handleSubmit(data)}>
                 <NameInput bindTo="name" className="first" />
                 <EmailInput bindTo="email" />
                 <PasswordInput bindTo="password" />
+                { coupon ? <CouponInput disabled={true} bindTo="coupon" /> : '' }
                 <CheckoutForm />
                 <FormSubmit label={label} onClick={() => this.onClick()}/>
             </Form>
@@ -109,7 +117,7 @@ export default class StripePaymentPage extends Component {
         )
     }
 
-    render({ error, handleSubmit, stripeConfig, siteConfig, showSpinner }) {
+    render({ error, handleSubmit, stripeConfig, siteConfig, showSpinner, frameLocation }) {
         const publicKey = stripeConfig.config.publicKey || '';
         let iconUrl = siteConfig && siteConfig.icon;
         let title = (siteConfig && siteConfig.title) || "Ghost Publication";
@@ -124,7 +132,7 @@ export default class StripePaymentPage extends Component {
                     <div className="gm-modal-form gm-subscribe-form">
                         <StripeProvider apiKey={publicKey}>
                             <Elements>
-                                <PaymentFormWrapped handleSubmit={handleSubmit} publicKey={publicKey} selectedPlan={this.state.selectedPlan} showSpinner={showSpinner} />
+                                <PaymentFormWrapped handleSubmit={handleSubmit} frameLocation={frameLocation} publicKey={publicKey} selectedPlan={this.state.selectedPlan} showSpinner={showSpinner} />
                             </Elements>
                         </StripeProvider>
                         <div className="flex justify-center mt4">

--- a/core/server/lib/members/static/auth/pages/StripeSubscribePage.js
+++ b/core/server/lib/members/static/auth/pages/StripeSubscribePage.js
@@ -36,10 +36,6 @@ class PaymentForm extends Component {
         });
     };
 
-    onClick = () => {
-        this.props.stripe.createToken({ name: name });
-    }
-
     render({frameLocation}) {
         let label = this.props.showSpinner ? (
             (
@@ -54,7 +50,7 @@ class PaymentForm extends Component {
                 <PasswordInput bindTo="password" />
                 { coupon ? <CouponInput disabled={true} bindTo="coupon" /> : '' }
                 <CheckoutForm />
-                <FormSubmit label={label} onClick={() => this.onClick()}/>
+                <FormSubmit label={label} />
             </Form>
         );
     }

--- a/core/server/lib/members/static/auth/pages/StripeUpgradePage.js
+++ b/core/server/lib/members/static/auth/pages/StripeUpgradePage.js
@@ -30,7 +30,7 @@ class PaymentForm extends Component {
         });
     };
 
-    render({frameLocation}) {
+    render() {
         return (
             <Form onSubmit={(data) => this.handleSubmit(data)}>
                 <CheckoutForm />

--- a/core/server/lib/members/static/gateway/bundle.js
+++ b/core/server/lib/members/static/gateway/bundle.js
@@ -141,7 +141,7 @@
 
     addMethod('getToken', getToken);
 
-    addMethod('createSubscription', function createSubscription({adapter, plan, stripeToken}) {
+    addMethod('createSubscription', function createSubscription({adapter, plan, stripeToken, coupon}) {
         return fetch(`${membersApiUrl}subscription`, {
             method: 'POST',
             headers: {
@@ -151,7 +151,8 @@
                 origin,
                 adapter,
                 plan,
-                stripeToken
+                stripeToken,
+                coupon
             })
         }).then((res) => {
             if (res.ok) {

--- a/core/server/lib/members/subscriptions/payment-processors/stripe/api.js
+++ b/core/server/lib/members/subscriptions/payment-processors/stripe/api.js
@@ -77,7 +77,8 @@ function createSubscription(stripe, member, metadata) {
         }).then(() => {
             return stripe.subscriptions.create({
                 customer: customer.id,
-                items: [{plan: metadata.plan.id}]
+                items: [{plan: metadata.plan.id}],
+                coupon: metadata.coupon
             });
         });
     });

--- a/core/server/lib/members/subscriptions/payment-processors/stripe/index.js
+++ b/core/server/lib/members/subscriptions/payment-processors/stripe/index.js
@@ -77,7 +77,8 @@ module.exports = class StripePaymentProcessor {
 
             return api.subscriptions.create(this._stripe, member, {
                 plan,
-                stripeToken: metadata.stripeToken
+                stripeToken: metadata.stripeToken,
+                coupon: metadata.coupon
             });
         });
     }


### PR DESCRIPTION
This adds support for passing coupons stripe on creation of a subscription. You pass the coupon into the auth pages via a query param (same as how the reset password token works) and if there's a coupon, a disabled input will be shown for it.

Some other nice to haves (I think we should do them as a separate PR): 
 - optional coupon on the upgrade page
 - ability to signup with just coupon, not including payment details (currently need those, though won't be charged if it's a 100% coupon)

This will have an accompanying change to the members SDK to allow the coupon to be passed in a function call, ala `members.signup({coupon: 'xxx'});`