### PR TITLE
Updated check for members-ssr use at theme layer

### DIFF
--- a/core/server/services/members/index.js
+++ b/core/server/services/members/index.js
@@ -10,6 +10,17 @@ module.exports = {
                 },
                 staticRouter: function (req, res, next) {
                     return next(new common.errors.NotFoundError());
+                },
+                ssr: {
+                    exchangeTokenForSession: function (req, res) {
+                        return Promise.reject(new common.errors.InternalServerError());
+                    },
+                    deleteSession: function (req, res) {
+                        return Promise.reject(new common.errors.InternalServerError());
+                    },
+                    getMemberDataFromSession: function (req, res) {
+                        return Promise.reject(new common.errors.InternalServerError());
+                    }
                 }
             };
         }

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -72,7 +72,7 @@ module.exports = function setupSiteApp(options = {}) {
 
     // @TODO only loads this stuff if members is enabled
     // Set req.member & res.locals.member if a cookie is set
-    siteApp.post('/members/ssr', function (req, res) {
+    siteApp.post('/members/ssr', shared.middlewares.labs.members, function (req, res) {
         membersService.api.ssr.exchangeTokenForSession(req, res).then(() => {
             res.writeHead(200);
             res.end();
@@ -81,7 +81,7 @@ module.exports = function setupSiteApp(options = {}) {
             res.end(err.message);
         });
     });
-    siteApp.del('/members/ssr', function (req, res) {
+    siteApp.del('/members/ssr', shared.middlewares.labs.members, function (req, res) {
         membersService.api.ssr.deleteSession(req, res).then(() => {
             res.writeHead(204);
             res.end();


### PR DESCRIPTION
no issue

### Context

As part of updating the theme layer to use members-ssr [here](https://github.com/TryGhost/Ghost/commit/f9899cb8c4815a64f8b2b1b816efd7617a977173), we introduced a case where if `enableDeveloperExperiments` is not switched on, the whole theme loading will crash due to unavailability of `ssr` property on members service [here](https://github.com/TryGhost/Ghost/blob/master/core/server/services/members/index.js#L12). Since we switch on `enableDeveloperExperiments` by default on master now, the issue won't be reproducible locally until explicitly switched off. 

This PR includes a patch fix which adds dummy `ssr` object to members service `api` object and members middleware check on APIs to ensure no crash in case developer flags is not switched on. 

Longer term it will be definitely useful to upgrade the dummy `api` object to trigger on member labs than the developer flag. 
