### PR TITLE
Added notification access persmission for users of Editor role

### DIFF
--- a/core/server/data/migrations/versions/2.21/1-update-editor-permissions.js
+++ b/core/server/data/migrations/versions/2.21/1-update-editor-permissions.js
@@ -1,0 +1,51 @@
+const _ = require('lodash');
+const utils = require('../../../schema/fixtures/utils');
+const permissions = require('../../../../services/permissions');
+const logging = require('../../../../lib/common/logging');
+
+const resources = ['notification'];
+
+const _private = {};
+
+_private.getRelations = function getRelations(resource, role) {
+    return utils.findPermissionRelationsForObject(resource, role);
+};
+
+_private.printResult = function printResult(result, message) {
+    if (result.done === result.expected) {
+        logging.info(message);
+    } else {
+        logging.warn(`(${result.done}/${result.expected}) ${message}`);
+    }
+};
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    const localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+
+    return Promise.map(resources, (resource) => {
+        const relations = _private.getRelations(resource, 'Editor');
+
+        return Promise.resolve()
+            .then(() => utils.addFixturesForRelation(relations, localOptions))
+            .then(result => _private.printResult(result, `Adding permissions_roles fixtures for ${resource}s`))
+            .then(() => permissions.init(localOptions));
+    });
+};
+
+module.exports.down = (options) => {
+    const localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+
+    return Promise.map(resources, (resource) => {
+        const relations = _private.getRelations(resource, 'Editor');
+
+        return utils.removeFixturesForRelation(relations, localOptions);
+    });
+};

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -624,6 +624,7 @@
                     "members": "all"
                 },
                 "Editor": {
+                    "notification": "all",
                     "post": "all",
                     "setting": ["browse", "read"],
                     "slug": "all",

--- a/core/test/regression/api/v2/admin/notifications_spec.js
+++ b/core/test/regression/api/v2/admin/notifications_spec.js
@@ -7,12 +7,9 @@ const ghost = testUtils.startGhost;
 let request;
 
 describe('Notifications API', function () {
-    let ghostServer;
-
     before(function () {
         return ghost()
             .then(function (_ghostServer) {
-                ghostServer = _ghostServer;
                 request = supertest.agent(config.get('url'));
             })
             .then(function () {
@@ -24,13 +21,71 @@ describe('Notifications API', function () {
         before(function () {
             return ghost()
                 .then(function (_ghostServer) {
-                    ghostServer = _ghostServer;
                     request = supertest.agent(config.get('url'));
                 })
                 .then(function () {
                     return testUtils.createUser({
                         user: testUtils.DataGenerator.forKnex.createUser({
-                            email: 'test+1@ghost.org'
+                            email: 'test+editor@ghost.org'
+                        }),
+                        role: testUtils.DataGenerator.Content.roles[1].name
+                    });
+                })
+                .then((user) => {
+                    request.user = user;
+                    return localUtils.doAuth(request);
+                });
+        });
+
+        it('Add notification', function () {
+            const newNotification = {
+                type: 'info',
+                message: 'test notification',
+                custom: true,
+                id: 'customId'
+            };
+
+            return request.post(localUtils.API.getApiQuery('notifications/'))
+                .set('Origin', config.get('url'))
+                .send({notifications: [newNotification]})
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201)
+                .then((res) => {
+                    const jsonResponse = res.body;
+
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.notifications);
+                    should.equal(jsonResponse.notifications.length, 1);
+                });
+        });
+
+        it('Read notifications', function () {
+            return request.get(localUtils.API.getApiQuery('notifications/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .then((res) => {
+                    const jsonResponse = res.body;
+
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.notifications);
+                    should.equal(jsonResponse.notifications.length, 1);
+                });
+        });
+    });
+
+    describe('As Author', function () {
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({
+                            email: 'test+author@ghost.org'
                         }),
                         role: testUtils.DataGenerator.Content.roles[2].name
                     });
@@ -52,6 +107,14 @@ describe('Notifications API', function () {
             return request.post(localUtils.API.getApiQuery('notifications/'))
                 .set('Origin', config.get('url'))
                 .send({notifications: [newNotification]})
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(403);
+        });
+
+        it('Read notifications', function () {
+            return request.get(localUtils.API.getApiQuery('notifications/'))
+                .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(403);

--- a/core/test/regression/migrations/migration_spec.js
+++ b/core/test/regression/migrations/migration_spec.js
@@ -47,11 +47,11 @@ describe('Database Migration (special functions)', function () {
 
             // Notifications
             permissions[4].name.should.eql('Browse notifications');
-            permissions[4].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
+            permissions[4].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
             permissions[5].name.should.eql('Add notifications');
-            permissions[5].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
+            permissions[5].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
             permissions[6].name.should.eql('Delete notifications');
-            permissions[6].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
+            permissions[6].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
 
             // Posts
             permissions[7].name.should.eql('Browse posts');

--- a/core/test/unit/data/schema/fixtures/utils_spec.js
+++ b/core/test/unit/data/schema/fixtures/utils_spec.js
@@ -150,19 +150,19 @@ describe('Migration Fixture Utils', function () {
             fixtureUtils.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
-                result.should.have.property('expected', 63);
-                result.should.have.property('done', 63);
+                result.should.have.property('expected', 64);
+                result.should.have.property('done', 64);
 
                 // Permissions & Roles
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(63);
+                dataMethodStub.filter.callCount.should.eql(64);
                 dataMethodStub.find.callCount.should.eql(5);
-                baseUtilAttachStub.callCount.should.eql(63);
+                baseUtilAttachStub.callCount.should.eql(64);
 
-                fromItem.related.callCount.should.eql(63);
-                fromItem.findWhere.callCount.should.eql(63);
-                toItem[0].get.callCount.should.eql(126);
+                fromItem.related.callCount.should.eql(64);
+                fromItem.findWhere.callCount.should.eql(64);
+                toItem[0].get.callCount.should.eql(128);
 
                 done();
             }).catch(done);

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -20,7 +20,7 @@ var should = require('should'),
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'fda0398e93a74b2dc435cb4c026679ba';
-    const currentFixturesHash = '42e15796b3c9bdcf0d0ec7eb66a1abf5';
+    const currentFixturesHash = '6be3e640cb0f757d472c140e59418f54';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
closes #9546

These changes include migrations, would love an extra pair of eyes on them :) 

A specific area that probably needs attention is `down` migration as it's something that has been newly written and not used previously in migration scripts. 

Tip. To debug which queries are executed exactly use:
```
DEBUG=knex:(query|bindings)* knex-migrator rollback --v 2.18 --force
```