### PR TITLE
Updated member plans

### DIFF
--- a/core/server/lib/members/index.js
+++ b/core/server/lib/members/index.js
@@ -84,7 +84,7 @@ module.exports = function MembersApi({
                 return users.get({id: signedin})
                     .then(member => encodeToken({
                         sub: member.id,
-                        plans: member.subscriptions.map(sub => sub.plan),
+                        plans: member.plans,
                         exp: tokenLength,
                         aud: audience
                     }));

--- a/core/server/lib/members/users.js
+++ b/core/server/lib/members/users.js
@@ -39,8 +39,10 @@ module.exports = function ({
                     });
                 }));
             }).then((subscriptions) => {
+                const activeSubscriptions = subscriptions.filter(sub => sub.status === 'active');
                 return Object.assign({}, member, {
-                    subscriptions: subscriptions.filter(sub => sub.status === 'active')
+                    subscriptions: activeSubscriptions,
+                    plans: activeSubscriptions.map(sub => sub.plan)
                 });
             });
         });


### PR DESCRIPTION
This adds `plans` to the member object when retrieved via the api, meaning that SSR and SPA style auth have the same information available to them