### PR TITLE
🐛 Fixed 404 in collection index page if using data.slug

### DIFF
--- a/core/server/data/meta/schema.js
+++ b/core/server/data/meta/schema.js
@@ -38,15 +38,15 @@ function trimSchema(schema) {
 function trimSameAs(data, context) {
     var sameAs = [];
 
-    if (context === 'post') {
-        if (data.post.primary_author.website) {
-            sameAs.push(escapeExpression(data.post.primary_author.website));
+    if (context === 'post' || context === 'page') {
+        if (data[context].primary_author.website) {
+            sameAs.push(escapeExpression(data[context].primary_author.website));
         }
-        if (data.post.primary_author.facebook) {
-            sameAs.push(social.urls.facebook(data.post.primary_author.facebook));
+        if (data[context].primary_author.facebook) {
+            sameAs.push(social.urls.facebook(data[context].primary_author.facebook));
         }
-        if (data.post.primary_author.twitter) {
-            sameAs.push(social.urls.twitter(data.post.primary_author.twitter));
+        if (data[context].primary_author.twitter) {
+            sameAs.push(social.urls.twitter(data[context].primary_author.twitter));
         }
     } else if (context === 'author') {
         if (data.author.website) {
@@ -69,6 +69,8 @@ function getPostSchema(metaData, data) {
     var description = metaData.excerpt ? escapeExpression(metaData.excerpt) : null,
         schema;
 
+    const context = data.page ? 'page' : 'post';
+
     schema = {
         '@context': 'https://schema.org',
         '@type': 'Article',
@@ -79,12 +81,12 @@ function getPostSchema(metaData, data) {
         },
         author: {
             '@type': 'Person',
-            name: escapeExpression(data.post.primary_author.name),
+            name: escapeExpression(data[context].primary_author.name),
             image: schemaImageObject(metaData.authorImage),
             url: metaData.authorUrl,
-            sameAs: trimSameAs(data, 'post'),
-            description: data.post.primary_author.metaDescription ?
-                escapeExpression(data.post.primary_author.metaDescription) :
+            sameAs: trimSameAs(data, context),
+            description: data[context].primary_author.metaDescription ?
+                escapeExpression(data[context].primary_author.metaDescription) :
                 null
         },
         headline: escapeExpression(metaData.metaTitle),

--- a/core/server/services/routing/helpers/fetch-data.js
+++ b/core/server/services/routing/helpers/fetch-data.js
@@ -28,6 +28,13 @@ const defaultQueryOptions = {
     }
 };
 
+const defaultDataQueryOptions = {
+    post: _.cloneDeep(defaultQueryOptions),
+    page: _.cloneDeep(defaultQueryOptions),
+    tag: null,
+    author: null
+};
+
 const defaultPostQuery = _.cloneDeep(queryDefaults);
 defaultPostQuery.options = defaultQueryOptions.options;
 
@@ -97,7 +104,8 @@ function fetchData(pathOptions, routerOptions, locals) {
 
     // CASE: fetch more data defined by the router e.g. tags, authors - see TaxonomyRouter
     _.each(routerOptions.data, function (query, name) {
-        props[name] = processQuery(query, pathOptions.slug, locals);
+        const dataQueryOptions = _.merge(query, defaultDataQueryOptions[name]);
+        props[name] = processQuery(dataQueryOptions, pathOptions.slug, locals);
     });
 
     return Promise.props(props)

--- a/core/test/unit/data/meta/schema_spec.js
+++ b/core/test/unit/data/meta/schema_spec.js
@@ -102,6 +102,106 @@ describe('getSchema', function () {
         done();
     });
 
+    it('should return page schema if context starts with page', function (done) {
+        var metadata = {
+            blog: {
+                title: 'Blog Title',
+                url: 'http://mysite.com',
+                logo: {
+                    url: 'http://mysite.com/author/image/url/logo.jpg',
+                    dimensions: {
+                        width: 500,
+                        height: 500
+                    }
+                }
+            },
+            authorImage: {
+                url: 'http://mysite.com/author/image/url/me.jpg',
+                dimensions: {
+                    width: 500,
+                    height: 500
+                }
+            },
+            authorFacebook: 'testuser',
+            creatorTwitter: '@testuser',
+            authorUrl: 'http://mysite.com/author/me/',
+            metaTitle: 'Page Title',
+            url: 'http://mysite.com/post/my-page-slug/',
+            publishedDate: '2015-12-25T05:35:01.234Z',
+            modifiedDate: '2016-01-21T22:13:05.412Z',
+            coverImage: {
+                url: 'http://mysite.com/content/image/mypagecoverimage.jpg',
+                dimensions: {
+                    width: 500,
+                    height: 500
+                }
+            },
+            keywords: ['one', 'two'],
+            metaDescription: 'Post meta description',
+            excerpt: 'Custom excerpt for description'
+        },  data = {
+            context: ['page'],
+            page: {
+                primary_author: {
+                    name: 'Page Author',
+                    website: 'http://myblogsite.com/',
+                    bio: 'My author bio.',
+                    facebook: 'testuser',
+                    twitter: '@testuser'
+                }
+            }
+        },
+        schema = getSchema(metadata, data);
+
+        should.deepEqual(schema, {
+            '@context': 'https://schema.org',
+            '@type': 'Article',
+            author: {
+                '@type': 'Person',
+                image: {
+                    '@type': 'ImageObject',
+                    url: 'http://mysite.com/author/image/url/me.jpg',
+                    width: 500,
+                    height: 500
+                },
+                name: 'Page Author',
+                sameAs: [
+                    'http://myblogsite.com/',
+                    'https://www.facebook.com/testuser',
+                    'https://twitter.com/testuser'
+                ],
+                url: 'http://mysite.com/author/me/'
+            },
+            dateModified: '2016-01-21T22:13:05.412Z',
+            datePublished: '2015-12-25T05:35:01.234Z',
+            description: 'Custom excerpt for description',
+            headline: 'Page Title',
+            image: {
+                '@type': 'ImageObject',
+                url: 'http://mysite.com/content/image/mypagecoverimage.jpg',
+                width: 500,
+                height: 500
+            },
+            keywords: 'one, two',
+            mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': 'http://mysite.com'
+            },
+            publisher: {
+                '@type': 'Organization',
+                name: 'Blog Title',
+                logo: {
+                    '@type': 'ImageObject',
+                    url: 'http://mysite.com/author/image/url/logo.jpg',
+                    width: 500,
+                    height: 500
+                }
+            },
+            url: 'http://mysite.com/post/my-page-slug/'
+        });
+        done();
+    });
+
     it('should return post schema if context starts with amp', function (done) {
         var metadata = {
             blog: {


### PR DESCRIPTION
closes #10542

@kirrg001 seems like a pretty straight forward fix but maybe you could think of some of the edge cases that could've been broken. One thing that I was puzzled about for a while when testing is that alliased resource in `data: {resource.slug}` e.g.: `data: post.know` wasn't accessible anymore and redirected me to the collection page, but later found the answer in the docs: `The source route of the data will be redirected to the new custom route. ` :grimacing: 
