### PR TITLE
Added caption support to code card renderer

### DIFF
--- a/core/server/lib/mobiledoc/cards/code.js
+++ b/core/server/lib/mobiledoc/cards/code.js
@@ -21,6 +21,17 @@ module.exports = createCard({
         code.appendChild(dom.createTextNode(payload.code));
         pre.appendChild(code);
 
-        return pre;
+        if (payload.caption) {
+            let figure = dom.createElement('figure');
+            figure.appendChild(pre);
+
+            let figcaption = dom.createElement('figcaption');
+            figcaption.appendChild(dom.createRawHTMLSection(payload.caption));
+            figure.appendChild(figcaption);
+
+            return figure;
+        } else {
+            return pre;
+        }
     }
 });

--- a/core/server/lib/mobiledoc/cards/code.js
+++ b/core/server/lib/mobiledoc/cards/code.js
@@ -23,6 +23,7 @@ module.exports = createCard({
 
         if (payload.caption) {
             let figure = dom.createElement('figure');
+            figure.setAttribute('class', 'kg-card kg-code-card');
             figure.appendChild(pre);
 
             let figcaption = dom.createElement('figcaption');

--- a/core/test/unit/lib/mobiledoc/cards/code_spec.js
+++ b/core/test/unit/lib/mobiledoc/cards/code_spec.js
@@ -43,4 +43,19 @@ describe('Code card', function () {
 
         serializer.serialize(card.render(opts)).should.match('');
     });
+
+    it('Renders a figure if a caption is provided', function () {
+        let opts = {
+            env: {
+                dom: new SimpleDom.Document()
+            },
+            payload: {
+                code: '<p>Test</p>',
+                language: 'html',
+                caption: 'Some <strong>HTML</strong>'
+            }
+        };
+
+        serializer.serialize(card.render(opts)).should.match('<!--kg-card-begin: code--><figure><pre><code class="language-html">&lt;p&gt;Test&lt;/p&gt;</code></pre><figcaption>Some <strong>HTML</strong></figcaption></figure><!--kg-card-end: code-->');
+    });
 });

--- a/core/test/unit/lib/mobiledoc/cards/code_spec.js
+++ b/core/test/unit/lib/mobiledoc/cards/code_spec.js
@@ -56,6 +56,6 @@ describe('Code card', function () {
             }
         };
 
-        serializer.serialize(card.render(opts)).should.match('<!--kg-card-begin: code--><figure class="kg-card kg-card-code"><pre><code class="language-html">&lt;p&gt;Test&lt;/p&gt;</code></pre><figcaption>Some <strong>HTML</strong></figcaption></figure><!--kg-card-end: code-->');
+        serializer.serialize(card.render(opts)).should.match('<!--kg-card-begin: code--><figure class="kg-card kg-code-card"><pre><code class="language-html">&lt;p&gt;Test&lt;/p&gt;</code></pre><figcaption>Some <strong>HTML</strong></figcaption></figure><!--kg-card-end: code-->');
     });
 });

--- a/core/test/unit/lib/mobiledoc/cards/code_spec.js
+++ b/core/test/unit/lib/mobiledoc/cards/code_spec.js
@@ -56,6 +56,6 @@ describe('Code card', function () {
             }
         };
 
-        serializer.serialize(card.render(opts)).should.match('<!--kg-card-begin: code--><figure><pre><code class="language-html">&lt;p&gt;Test&lt;/p&gt;</code></pre><figcaption>Some <strong>HTML</strong></figcaption></figure><!--kg-card-end: code-->');
+        serializer.serialize(card.render(opts)).should.match('<!--kg-card-begin: code--><figure class="kg-card kg-card-code"><pre><code class="language-html">&lt;p&gt;Test&lt;/p&gt;</code></pre><figcaption>Some <strong>HTML</strong></figcaption></figure><!--kg-card-end: code-->');
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost-Admin/pull/1181

- when a caption for a code card is provided, render the contents inside a `<figure>` element with a `<figcaption>` to match other caption-enabled cards

Non-captioned code cards will continue to render as before:
```html
<pre><code>....</code></pre>
```

Captioned code cards will be rendered inside a `<figure>` element:
```html
<figure class="kg-card kg-code-card">
    <pre><code>...</code></pre>
    <figcaption>...<figcaption>
</figure>
```