### PR TITLE
Added new members block helper

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -36,6 +36,7 @@ coreHelpers.tags = require('./tags');
 coreHelpers.title = require('./title');
 coreHelpers.twitter_url = require('./twitter_url');
 coreHelpers.url = require('./url');
+coreHelpers.member = require('./member');
 
 registerAllCoreHelpers = function registerAllCoreHelpers() {
     // Register theme helpers
@@ -67,6 +68,7 @@ registerAllCoreHelpers = function registerAllCoreHelpers() {
     registerThemeHelper('twitter_url', coreHelpers.twitter_url);
     registerThemeHelper('facebook_url', coreHelpers.facebook_url);
     registerThemeHelper('url', coreHelpers.url);
+    registerThemeHelper('member', coreHelpers.member);
 
     // Async theme helpers
     registerAsyncThemeHelper('ghost_head', coreHelpers.ghost_head);

--- a/core/server/helpers/member.js
+++ b/core/server/helpers/member.js
@@ -1,54 +1,36 @@
-// # Members block helper
+// # Members helper
 // Usage: `{{#member}} {{/member}}`
+// OR `{{member 'property'}}`
 //
 const  proxy = require('./proxy');
 const labs = proxy.labs;
 const SafeString = proxy.SafeString;
 
 // Block helper designed for members context
-// module.exports = function member(options) {
-//     let ret = '';
-//     if (labs.isSet('members')) {
-//         let context = {
-//             loggedIn: !!options.data.member,
-//             memberName: (options.data.member && options.data.member.name) || '',
-//             memberEmail: (options.data.email && options.data.member.email) || '',
-//         };
-//         if (options.data.root.context.includes('post')) {
-//             context.restrictedPost = !options.data.root.post.html;
-//         }
-//         ret = options.fn(Object.assign({}, this, context));
-//     }
-//     return ret;
-// };
-
-// Block helper designed for members context
 module.exports = function member(...args) {
-    let options = {};
-    let prop = '';
-    if (args.length === 1) {
-        options = args[0];
-    } else if (args.length === 2) {
-        prop = args[0];
-        options = args[1];
+    if (args.length < 1) {
+        return null;
     }
+    let options = args[args.length - 1];
+    let prop = '';
     let context = {};
-    let ret = '';
+    if (args.length === 2) {
+        prop = args[0];
+    }
     if (labs.isSet('members')) {
         context = {
-            loggedIn: !!options.data.member,
+            isLoggedIn: !!options.data.member,
             name: (options.data.member && options.data.member.name) || '',
             email: (options.data.email && options.data.member.email) || '',
         };
         if (options.data.root.context.includes('post')) {
-            context.restrictedPost = !options.data.root.post.html;
+            context.isRestrictedPost = !options.data.root.post.html;
         }
     }
     if (options.fn) {
-        ret = options.fn(Object.assign({}, this, {
+        return options.fn(Object.assign({}, this, {
             member: context
         }));
-        return ret;
     }
     return context[prop] || '';
 };

--- a/core/server/helpers/member.js
+++ b/core/server/helpers/member.js
@@ -1,0 +1,54 @@
+// # Members block helper
+// Usage: `{{#member}} {{/member}}`
+//
+const  proxy = require('./proxy');
+const labs = proxy.labs;
+const SafeString = proxy.SafeString;
+
+// Block helper designed for members context
+// module.exports = function member(options) {
+//     let ret = '';
+//     if (labs.isSet('members')) {
+//         let context = {
+//             loggedIn: !!options.data.member,
+//             memberName: (options.data.member && options.data.member.name) || '',
+//             memberEmail: (options.data.email && options.data.member.email) || '',
+//         };
+//         if (options.data.root.context.includes('post')) {
+//             context.restrictedPost = !options.data.root.post.html;
+//         }
+//         ret = options.fn(Object.assign({}, this, context));
+//     }
+//     return ret;
+// };
+
+// Block helper designed for members context
+module.exports = function member(...args) {
+    let options = {};
+    let prop = '';
+    if (args.length === 1) {
+        options = args[0];
+    } else if (args.length === 2) {
+        prop = args[0];
+        options = args[1];
+    }
+    let context = {};
+    let ret = '';
+    if (labs.isSet('members')) {
+        context = {
+            loggedIn: !!options.data.member,
+            name: (options.data.member && options.data.member.name) || '',
+            email: (options.data.email && options.data.member.email) || '',
+        };
+        if (options.data.root.context.includes('post')) {
+            context.restrictedPost = !options.data.root.post.html;
+        }
+    }
+    if (options.fn) {
+        ret = options.fn(Object.assign({}, this, {
+            member: context
+        }));
+        return ret;
+    }
+    return context[prop] || '';
+};

--- a/core/server/services/routing/helpers/renderer.js
+++ b/core/server/services/routing/helpers/renderer.js
@@ -11,7 +11,7 @@ const debug = require('ghost-ignition').debug('services:routing:helpers:renderer
 module.exports = function renderer(req, res, data) {
     // Set response context
     setContext(req, res, data);
-
+    console.log("SETTING RENDERER");
     // Set template
     templates.setTemplate(req, res, data);
 

--- a/core/server/services/routing/helpers/templates.js
+++ b/core/server/services/routing/helpers/templates.js
@@ -166,7 +166,7 @@ module.exports.setTemplate = function setTemplate(req, res, data) {
     if (res._template && !req.err) {
         return;
     }
-
+    console.log("SETTING TEMPLATE");
     if (req.err) {
         res._template = _private.getTemplateForError(res.statusCode);
         return;

--- a/core/server/services/themes/middleware.js
+++ b/core/server/services/themes/middleware.js
@@ -77,7 +77,9 @@ function updateLocalTemplateOptions(req, res, next) {
     const siteData = {
         url: urlService.utils.urlFor('home', {secure: req.secure, trailingSlash: false}, true)
     };
-
+    console.log("Context", res.locals.context);
+    console.log("Context Here!", res.locals);
+    console.log("SETTING LOCAL OPTIONS");
     hbs.updateLocalTemplateOptions(res.locals, _.merge({}, localTemplateOptions, {
         data: {
             member: req.member,


### PR DESCRIPTION
- Adds new members block helper to wrap members context in existing context
- Allows theme developer to use member context like `loggedIn`, `restrictedPost`, `memberName` etc to use in theme
- Allows scope for addition of new member context, as well as member context for only certain parent contexts like `post` or `page`
- Allows flexibility for theme developer to use custom tags on top of member features
- Allows scope of updating logic of existing member context in future without affecting theme changes, like `loggedIn` or `restrictedPost`