### PR TITLE
🐛 Fixed post scheduling on restart

### DIFF
--- a/core/server/adapters/scheduling/SchedulingDefault.js
+++ b/core/server/adapters/scheduling/SchedulingDefault.js
@@ -74,9 +74,24 @@ SchedulingDefault.prototype.schedule = function (object) {
  *                              oldTime:    [Number] The previous published time.
  *                          }
  *                       }
+ * @param {Object} options
+ *                      {
+ *                          bootstrap: [Boolean]
+ *                      }
  */
-SchedulingDefault.prototype.reschedule = function (object) {
-    this._deleteJob({time: object.extra.oldTime, url: object.url});
+SchedulingDefault.prototype.reschedule = function (object, options = {bootstrap: false}) {
+    /**
+     * CASE:
+     * The post scheduling unit calls "reschedule" on bootstrap, because other custom scheduling implementations
+     * could use a database and we need to give the chance to update the job (delete + re-add).
+     *
+     * We receive a "bootstrap" variable to ensure that jobs are scheduled correctly for this scheduler implementation,
+     * because "object.extra.oldTime" === "object.time". If we mark the job as deleted, it won't get scheduled.
+     */
+    if (!options.bootstrap) {
+        this._deleteJob({time: object.extra.oldTime, url: object.url});
+    }
+
     this._addJob(object);
 };
 

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -86,7 +86,9 @@ exports.init = function init(options = {}) {
             }
 
             scheduledPosts.forEach((model) => {
-                adapter.reschedule(_private.normalize({model, apiUrl, client}));
+                // NOTE: We are using reschedule, because custom scheduling adapter could use a database, which needs to be updated
+                //       and not an in-process implementation!
+                adapter.reschedule(_private.normalize({model, apiUrl, client}), {bootstrap: true});
             });
         })
         .then(() => {

--- a/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
+++ b/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
@@ -63,7 +63,7 @@ describe('Scheduling Default Adapter', function () {
         it('reschedule: default', function (done) {
             sinon.stub(scope.adapter, '_pingUrl');
 
-            const time = moment().add(200, 'milliseconds').valueOf();
+            const time = moment().add(20, 'milliseconds').valueOf();
 
             scope.adapter.schedule({
                 time: time,
@@ -86,13 +86,13 @@ describe('Scheduling Default Adapter', function () {
             setTimeout(() => {
                 scope.adapter._pingUrl.calledOnce.should.eql(true);
                 done();
-            }, 250);
+            }, 50);
         });
 
         it('reschedule: simulate restart', function (done) {
             sinon.stub(scope.adapter, '_pingUrl');
 
-            const time = moment().add(100, 'milliseconds').valueOf();
+            const time = moment().add(20, 'milliseconds').valueOf();
 
             scope.adapter.reschedule({
                time: time,
@@ -106,7 +106,7 @@ describe('Scheduling Default Adapter', function () {
             setTimeout(() => {
                 scope.adapter._pingUrl.calledOnce.should.eql(true);
                 done();
-            }, 150);
+            }, 50);
         });
 
         it('run', function (done) {

--- a/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
+++ b/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
@@ -60,6 +60,55 @@ describe('Scheduling Default Adapter', function () {
             ]);
         });
 
+        it('reschedule: default', function (done) {
+            sinon.stub(scope.adapter, '_pingUrl');
+
+            const time = moment().add(200, 'milliseconds').valueOf();
+
+            scope.adapter.schedule({
+                time: time,
+                url: 'something',
+                extra: {
+                    oldTime: null,
+                    method: 'PUT'
+                }
+            });
+
+            scope.adapter.reschedule({
+                time: time,
+                url: 'something',
+                extra: {
+                    oldTime: time,
+                    method: 'PUT'
+                }
+            });
+
+            setTimeout(() => {
+                scope.adapter._pingUrl.calledOnce.should.eql(true);
+                done();
+            }, 250);
+        });
+
+        it('reschedule: simulate restart', function (done) {
+            sinon.stub(scope.adapter, '_pingUrl');
+
+            const time = moment().add(100, 'milliseconds').valueOf();
+
+            scope.adapter.reschedule({
+               time: time,
+                url: 'something',
+                extra: {
+                   oldTime: time,
+                    method: 'PUT'
+                }
+            }, {bootstrap: true});
+
+            setTimeout(() => {
+                scope.adapter._pingUrl.calledOnce.should.eql(true);
+                done();
+            }, 150);
+        });
+
         it('run', function (done) {
             // 1000 jobs, but only the number x are under 1 minute
             var timestamps = _.map(_.range(1000), function (i) {


### PR DESCRIPTION
no issue

- might fix https://forum.ghost.org/t/scheduled-posts-never-publish/6873/10
- CASES:
  - You restart Ghost and you have a post to schedule
  - I am not aware of any other use cases right now
- caused by https://github.com/TryGhost/Ghost/commit/4acc375fb600bf9b46041e26e3d06b71a5b141b1#diff-4726ce3c4d18d41afad4b46cb0aa7dd3
  - the bug exists since 2.12
  - Bookshelf added support (or better said fixed a bug) for accessing previous attributes
  - `object.updated('published_at')` always returned "undefined", because the self-implementation < 2.12 only remembered previous attributes after update ([see](https://github.com/TryGhost/Ghost/blob/2.11.0/core/server/models/base/index.js#L234))
  - but `object.previous('published_at')` returns the current value (`object.get('published_at') === object.previous('published_at')` -> and that's why rescheduling on bootstrap never worked since 2.12

