### PR TITLE
🎨 Allowed overwrite of protocol for canonical URLs

### DIFF
--- a/core/server/api/v2/utils/serializers/input/utils/url.js
+++ b/core/server/api/v2/utils/serializers/input/utils/url.js
@@ -1,15 +1,21 @@
 const _ = require('lodash');
+const url = require('url');
 const {absoluteToRelative, getBlogUrl, STATIC_IMAGE_URL_PREFIX} = require('../../../../../../services/url/utils');
 
-const handleCanonicalUrl = (url) => {
-    const blogDomain = getBlogUrl().replace(/^http(s?):\/\//, '').replace(/\/$/, '');
-    const absolute = url.replace(/^http(s?):\/\//, '');
+const handleCanonicalUrl = (canonicalUrl) => {
+    const blogURl = getBlogUrl();
+    const isSameProtocol = url.parse(canonicalUrl).protocol === url.parse(blogURl).protocol;
+    const blogDomain = blogURl.replace(/^http(s?):\/\//, '').replace(/\/$/, '');
+    const absolute = canonicalUrl.replace(/^http(s?):\/\//, '');
 
-    if (absolute.startsWith(blogDomain)) {
-        return absoluteToRelative(url, {withoutSubdirectory: true});
+    // We only want to tranform to a relative URL when the canoncial URL matches the current
+    // Blog URL incl. the same protocol. This allows users to keep e. g. Facebook comments after
+    // a http -> https switch. See https://github.com/TryGhost/Ghost/issues/10709
+    if (absolute.startsWith(blogDomain) && isSameProtocol) {
+        return absoluteToRelative(canonicalUrl, {withoutSubdirectory: true});
     }
 
-    return url;
+    return canonicalUrl;
 };
 
 const handleImageUrl = (imageUrl) => {

--- a/core/server/api/v2/utils/serializers/input/utils/url.js
+++ b/core/server/api/v2/utils/serializers/input/utils/url.js
@@ -1,9 +1,9 @@
 const _ = require('lodash');
 const url = require('url');
-const {absoluteToRelative, getBlogUrl, STATIC_IMAGE_URL_PREFIX} = require('../../../../../../services/url/utils');
+const utils = require('../../../../../../services/url/utils');
 
 const handleCanonicalUrl = (canonicalUrl) => {
-    const blogURl = getBlogUrl();
+    const blogURl = utils.getBlogUrl();
     const isSameProtocol = url.parse(canonicalUrl).protocol === url.parse(blogURl).protocol;
     const blogDomain = blogURl.replace(/^http(s?):\/\//, '').replace(/\/$/, '');
     const absolute = canonicalUrl.replace(/^http(s?):\/\//, '');
@@ -12,33 +12,33 @@ const handleCanonicalUrl = (canonicalUrl) => {
     // Blog URL incl. the same protocol. This allows users to keep e. g. Facebook comments after
     // a http -> https switch. See https://github.com/TryGhost/Ghost/issues/10709
     if (absolute.startsWith(blogDomain) && isSameProtocol) {
-        return absoluteToRelative(canonicalUrl, {withoutSubdirectory: true});
+        return utils.absoluteToRelative(canonicalUrl, {withoutSubdirectory: true});
     }
 
     return canonicalUrl;
 };
 
 const handleImageUrl = (imageUrl) => {
-    const blogDomain = getBlogUrl().replace(/^http(s?):\/\//, '').replace(/\/$/, '');
+    const blogDomain = utils.getBlogUrl().replace(/^http(s?):\/\//, '').replace(/\/$/, '');
     const imageUrlAbsolute = imageUrl.replace(/^http(s?):\/\//, '');
-    const imagePathRe = new RegExp(`^${blogDomain}/${STATIC_IMAGE_URL_PREFIX}`);
+    const imagePathRe = new RegExp(`^${blogDomain}/${utils.STATIC_IMAGE_URL_PREFIX}`);
 
     if (imagePathRe.test(imageUrlAbsolute)) {
-        return absoluteToRelative(imageUrl);
+        return utils.absoluteToRelative(imageUrl);
     }
 
     return imageUrl;
 };
 
 const handleContentUrls = (content) => {
-    const blogDomain = getBlogUrl().replace(/^http(s?):\/\//, '').replace(/\/$/, '');
-    const imagePathRe = new RegExp(`(http(s?)://)?${blogDomain}/${STATIC_IMAGE_URL_PREFIX}`, 'g');
+    const blogDomain = utils.getBlogUrl().replace(/^http(s?):\/\//, '').replace(/\/$/, '');
+    const imagePathRe = new RegExp(`(http(s?)://)?${blogDomain}/${utils.STATIC_IMAGE_URL_PREFIX}`, 'g');
 
     const matches = _.uniq(content.match(imagePathRe));
 
     if (matches) {
         matches.forEach((match) => {
-            const relative = absoluteToRelative(match);
+            const relative = utils.absoluteToRelative(match);
             content = content.replace(new RegExp(match, 'g'), relative);
         });
     }

--- a/core/server/api/v2/utils/serializers/input/utils/url.js
+++ b/core/server/api/v2/utils/serializers/input/utils/url.js
@@ -8,9 +8,9 @@ const handleCanonicalUrl = (canonicalUrl) => {
     const blogDomain = blogURl.replace(/^http(s?):\/\//, '').replace(/\/$/, '');
     const absolute = canonicalUrl.replace(/^http(s?):\/\//, '');
 
-    // We only want to tranform to a relative URL when the canoncial URL matches the current
-    // Blog URL incl. the same protocol. This allows users to keep e. g. Facebook comments after
-    // a http -> https switch. See https://github.com/TryGhost/Ghost/issues/10709
+    // We only want to transform to a relative URL when the canonical URL matches the current
+    // Blog URL incl. the same protocol. This allows users to keep e.g. Facebook comments after
+    // a http -> https switch
     if (absolute.startsWith(blogDomain) && isSameProtocol) {
         return utils.absoluteToRelative(canonicalUrl, {withoutSubdirectory: true});
     }

--- a/core/test/unit/api/shared/serializers/input/utils/url_spec.js
+++ b/core/test/unit/api/shared/serializers/input/utils/url_spec.js
@@ -1,0 +1,59 @@
+const should = require('should');
+const sinon = require('sinon');
+const utils = require('../../../../../../../server/services/url/utils');
+const url = require('../../../../../../../server/api/v2/utils/serializers/input/utils/url');
+
+describe('Unit: v2/utils/serializers/input/utils/url', function () {
+    describe('forPost', function () {
+        beforeEach(function () {
+            sinon.stub(utils, 'getBlogUrl')
+                .returns('https://blogurl.com');
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('should transform canonical_url when protocol and domain match', function () {
+
+            const attrs = {
+                canonical_url: 'https://blogurl.com/hello-world'
+            };
+
+            url.forPost(attrs, {});
+
+            should.equal(attrs.canonical_url, '/hello-world');
+        });
+
+        it('should transform canonical_url when protocol and domain match with backslash in the end', function () {
+
+            const attrs = {
+                canonical_url: 'https://blogurl.com/hello-world/'
+            };
+
+            url.forPost(attrs, {});
+
+            should.equal(attrs.canonical_url, '/hello-world/');
+        });
+
+        it('should not transform canonical_url when different domains', function () {
+            const attrs = {
+                canonical_url: 'http://ghost.org/no-transform'
+            };
+
+            url.forPost(attrs, {});
+
+            should.equal(attrs.canonical_url, 'http://ghost.org/no-transform');
+        });
+
+        it('should not transform canonical_url when different protocols', function () {
+            const attrs = {
+                canonical_url: 'http://blogurl.com/no-transform'
+            };
+
+            url.forPost(attrs, {});
+
+            should.equal(attrs.canonical_url, 'http://blogurl.com/no-transform');
+        });
+    });
+});

--- a/core/test/unit/api/shared/serializers/input/utils/url_spec.js
+++ b/core/test/unit/api/shared/serializers/input/utils/url_spec.js
@@ -15,7 +15,6 @@ describe('Unit: v2/utils/serializers/input/utils/url', function () {
         });
 
         it('should transform canonical_url when protocol and domain match', function () {
-
             const attrs = {
                 canonical_url: 'https://blogurl.com/hello-world'
             };
@@ -26,7 +25,6 @@ describe('Unit: v2/utils/serializers/input/utils/url', function () {
         });
 
         it('should transform canonical_url when protocol and domain match with backslash in the end', function () {
-
             const attrs = {
                 canonical_url: 'https://blogurl.com/hello-world/'
             };


### PR DESCRIPTION
closes #10709

- Only transform a canonical URL that is identical with the Blog URL to a relative URL when the protocol matches as well
- Leave the canonical URL absolute for all other cases
- Use case for this is e. g. when users want to port over their Facebook comments/shares/likes after a move from `http` to `https`