### PR TITLE
🐛 Fixed Twittercard having wrong property when no feature image provided

### DIFF
--- a/core/server/data/meta/structured_data.js
+++ b/core/server/data/meta/structured_data.js
@@ -4,7 +4,7 @@ function getStructuredData(metaData) {
     var structuredData,
         card = 'summary';
 
-    if (metaData.coverImage.url) {
+    if (metaData.twitterImage || metaData.coverImage.url) {
         card = 'summary_large_image';
     }
 

--- a/core/test/unit/data/meta/structured_data_spec.js
+++ b/core/test/unit/data/meta/structured_data_spec.js
@@ -65,7 +65,7 @@ describe('getStructuredData', function () {
         done();
     });
 
-    it('should return structured data from metadata with provided og and twitter images per post', function (done) {
+    it('should return structured data from metadata with provided og and twitter images only per post', function (done) {
         var metadata = {
             blog: {
                 title: 'Blog Title',
@@ -78,13 +78,6 @@ describe('getStructuredData', function () {
             canonicalUrl: 'http://mysite.com/post/my-post-slug/',
             publishedDate: '2015-12-25T05:35:01.234Z',
             modifiedDate: '2016-01-21T22:13:05.412Z',
-            coverImage: {
-                url: 'http://mysite.com/content/image/mypostcoverimage.jpg',
-                dimensions: {
-                    width: 500,
-                    height: 500
-                }
-            },
             ogImage: {
                 url: 'http://mysite.com/content/image/mypostogimage.jpg',
                 dimensions: {


### PR DESCRIPTION
closes #10706

- Fixed a bug where we weren't assigning `summary_large_image` as Twitter card property when no feature image is provided, but a dedicated Twitter image
- Updated test to reflect this case to be tested better