### PR TITLE
🐛 Fixed async helpers nested in template helpers

### DIFF
--- a/core/frontend/helpers/navigation.js
+++ b/core/frontend/helpers/navigation.js
@@ -75,8 +75,11 @@ module.exports = function navigation(options) {
         return out;
     });
 
-    const context = _.merge({}, this, options.hash, {navigation: output});
+    // CASE: The navigation helper should have access to the navigation items at the top level.
+    this.navigation = output;
+    // CASE: The navigation helper will forward attributes passed to it.
+    _.merge(this, options.hash);
     const data = createFrame(options.data);
 
-    return templates.execute('navigation', context, {data});
+    return templates.execute('navigation', this, {data});
 };

--- a/core/frontend/helpers/pagination.js
+++ b/core/frontend/helpers/pagination.js
@@ -41,10 +41,14 @@ pagination = function (options) {
         !_.isNumber(this.pagination.total) || !_.isNumber(this.pagination.limit)) {
         throw new errors.IncorrectUsageError({message: i18n.t('warnings.helpers.pagination.valuesMustBeNumeric')});
     }
-    const context = _.merge({}, this, options.hash, this.pagination);
+
+    // CASE: The pagination helper should have access to the pagination properties at the top level.
+    _.merge(this, this.pagination);
+    // CASE: The pagination helper will forward attributes passed to it.
+    _.merge(this, options.hash);
     const data = createFrame(options.data);
 
-    return templates.execute('pagination', context, {data});
+    return templates.execute('pagination', this, {data});
 };
 
 module.exports = pagination;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "downsize": "0.0.8",
     "express": "4.16.4",
     "express-brute": "1.0.1",
-    "express-hbs": "1.1.1",
+    "express-hbs": "2.1.2",
     "express-jwt": "5.3.1",
     "express-query-boolean": "2.0.0",
     "express-session": "1.15.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,6 +1888,16 @@ editorconfig@^0.13.2:
     semver "^5.1.0"
     sigmund "^1.0.1"
 
+editorconfig@^0.15.0:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
+  integrity sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==
+  dependencies:
+    commander "^2.19.0"
+    lru-cache "^4.1.5"
+    semver "^5.6.0"
+    sigmund "^1.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -2226,6 +2236,17 @@ express-hbs@1.1.1:
     js-beautify "1.6.8"
     lodash "4.17.11"
     readdirp "2.1.0"
+
+express-hbs@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/express-hbs/-/express-hbs-2.1.2.tgz#212ebebb14e2d0ed3e6834c06a9f462cc323a1ba"
+  integrity sha512-5Wh4v7v2kXBQY6IYa6/tG1SM3OlFMKE631Twm2MoyVSTmMvF+pkuj3EvYyVrH6mHdVLM7ao/cRnTY2BI18gTog==
+  dependencies:
+    bluebird "^3.5.3"
+    handlebars "4.1.2"
+    js-beautify "1.8.8"
+    lodash "^4.17.11"
+    readdirp "2.2.1"
 
 express-jwt@5.3.1:
   version "5.3.1"
@@ -2870,7 +2891,7 @@ got@8.3.2:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.0, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
 
@@ -3705,6 +3726,16 @@ js-beautify@1.6.8:
     mkdirp "~0.5.0"
     nopt "~3.0.1"
 
+js-beautify@1.8.8:
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.8.8.tgz#1eb175b73a3571a5f1ed8d98e7cf2b05bfa98471"
+  integrity sha512-qVNq7ZZ7ZbLdzorvSlRDadS0Rh5oyItaE95v6I4wbbuSiijxn7SnnsV6dvKlcXuO2jX7lK8tn9fBulx34K/Ejg==
+  dependencies:
+    config-chain "~1.1.5"
+    editorconfig "^0.15.0"
+    mkdirp "~0.5.0"
+    nopt "~4.0.1"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4278,9 +4309,10 @@ lru-cache@^3.2.0:
   dependencies:
     pseudomap "^1.0.1"
 
-lru-cache@^4.0.0, lru-cache@^4.0.1:
+lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -5991,6 +6023,15 @@ readdirp@2.1.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
+
+readdirp@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
+  integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    readable-stream "^2.0.2"
 
 rechoir@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
closes #10643

The async resolver in express-hbs relies on storing the state of the
promises on the `this` value inside of a helper, which is always set to
the `context`. This patch updates our helpers which render templates, to
use `this` as the context when rendering their templates.