### PR TITLE
Move development configuration settings from custom file

### DIFF
--- a/config.development.json
+++ b/config.development.json
@@ -1,3 +1,0 @@
-{
-   "enableDeveloperExperiments": true
-}

--- a/core/server/config/env/config.development.json
+++ b/core/server/config/env/config.development.json
@@ -14,6 +14,7 @@
         "useRpcPing": false,
         "useUpdateCheck": true
     },
+    "enableDeveloperExperiments": true,
     "useMinFiles": false,
     "caching": {
         "theme": {


### PR DESCRIPTION
In commit 6f677a5b2fcc8e1bc94a2d7cf217dcfbc140dbe6 configuration option was added in a custom file config.development.json in root of repository that is meant to be used for local settings, as is mentioned in .gitignore file:

> \# ignore all custom json files for config
> /config.*.json

This PR reverts 6f677a5b2fcc8e1bc94a2d7cf217dcfbc140dbe6 and adds enableDeveloperExperiments to core/server/config/env/config.development.json to preserve functional change introduced in 6f677a5b2fcc8e1bc94a2d7cf217dcfbc140dbe6.