### PR TITLE
Added x-frame-options header to /ghost/ route

### DIFF
--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -94,5 +94,6 @@
     },
     "compress": true,
     "preloadHeaders": false,
+    "adminFrameProtection": true,
     "sendWelcomeEmail": true
 }

--- a/core/server/web/admin/controller.js
+++ b/core/server/web/admin/controller.js
@@ -23,6 +23,11 @@ module.exports = function adminController(req, res) {
 
     const defaultTemplate = config.get('env') === 'production' ? 'default-prod.html' : 'default.html';
     const templatePath = path.resolve(config.get('paths').adminViews, defaultTemplate);
+    const headers = {};
 
-    res.sendFile(templatePath);
+    if (config.get('adminFrameProtection')) {
+        headers['X-Frame-Options'] = 'sameorigin';
+    }
+
+    res.sendFile(templatePath, {headers});
 };

--- a/core/test/unit/web/admin/controller_spec.js
+++ b/core/test/unit/web/admin/controller_spec.js
@@ -1,0 +1,45 @@
+require('should');
+const sinon = require('sinon');
+const configUtils = require('../../../utils/configUtils');
+const controller = require('../../../../server/web/admin/controller');
+
+describe('Admin App', function () {
+   describe('controller', function () {
+        const req = {};
+        let res;
+
+        beforeEach(function () {
+            res = {
+                sendFile: sinon.spy()
+            };
+
+            configUtils.restore();
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('adds x-frame-options header when adminFrameProtection is enabled (default)', function () {
+            // default config: configUtils.set('adminFrameProtection', true);
+            controller(req, res);
+
+            res.sendFile.called.should.be.true();
+            res.sendFile.calledWith(
+                sinon.match.string,
+                sinon.match.hasNested('headers.X-Frame-Options', sinon.match('sameorigin'))
+            ).should.be.true();
+        });
+
+        it('doesn\'t add x-frame-options header when adminFrameProtection is disabled', function () {
+            configUtils.set('adminFrameProtection', false);
+            controller(req, res);
+
+            res.sendFile.called.should.be.true();
+            res.sendFile.calledWith(
+                sinon.match.string,
+                sinon.match.hasNested('headers.X-Frame-Options')
+            ).should.be.false();
+        });
+   });
+});


### PR DESCRIPTION
no issue
- by default the `/ghost/` route response will have an `x-frame-options: sameorigin` header to help protect the admin area against clickjacking in setups which do not already add the header
- the header can be disabled by adding `"adminFrameProtection": false` to the `config.{env}.json` configuration file

Credits: Muhammad Fawwad Obaida