### PR TITLE
Bumped ghost-ignition version to 3.1.0

### DIFF
--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -372,7 +372,7 @@ validateRedirects = function validateRedirects(redirects) {
         if (!redirect.from || !redirect.to) {
             throw new common.errors.ValidationError({
                 message: common.i18n.t('errors.utils.redirectsWrongFormat'),
-                context: JSON.stringify(redirect),
+                context: redirect,
                 help: 'https://docs.ghost.org/v1/docs/redirects'
             });
         }

--- a/core/server/lib/common/logging.js
+++ b/core/server/lib/common/logging.js
@@ -2,12 +2,14 @@ var config = require('../../config'),
     logging = require('ghost-ignition').logging;
 
 module.exports = logging({
+    name: config.get('logging:name'),
     env: config.get('env'),
     path: config.get('logging:path') || config.getContentPath('logs'),
     domain: config.get('url'),
     mode: config.get('logging:mode'),
     level: config.get('logging:level'),
     transports: config.get('logging:transports'),
+    gelf: config.get('logging:gelf'),
     loggly: config.get('logging:loggly'),
     rotation: config.get('logging:rotation')
 });

--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -60,11 +60,11 @@ module.exports = function (Bookshelf) {
                             message: 'Saving failed! Someone else is editing this post.',
                             code: 'UPDATE_COLLISION',
                             level: 'critical',
-                            context: JSON.stringify({
+                            context: {
                                 clientUpdatedAt: self.clientData.updated_at,
                                 serverUpdatedAt: self.serverData.updated_at,
                                 changed: changed
-                            })
+                            }
                         }));
                     }
                 }

--- a/core/server/services/themes/index.js
+++ b/core/server/services/themes/index.js
@@ -36,7 +36,7 @@ module.exports = {
                             common.logging.warn(new common.errors.ThemeValidationError({
                                 errorType: 'ThemeWorksButHasErrors',
                                 message: common.i18n.t('errors.middleware.themehandler.themeHasErrors', {theme: activeThemeName}),
-                                errorDetails: JSON.stringify(checkedTheme.results.error, null, '\t')
+                                errorDetails: checkedTheme.results.error
                             }));
                         }
 
@@ -47,7 +47,7 @@ module.exports = {
                         if (err.errorDetails) {
                             common.logging.error(new common.errors.ThemeValidationError({
                                 message: common.i18n.t('errors.middleware.themehandler.invalidTheme', {theme: activeThemeName}),
-                                errorDetails: JSON.stringify(err.errorDetails, null, '\t')
+                                errorDetails: err.errorDetails
                             }));
                         }
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "extract-zip": "1.6.7",
     "fs-extra": "3.0.1",
     "ghost-gql": "0.0.10",
-    "ghost-ignition": "2.9.4",
+    "ghost-ignition": "3.1.0",
     "ghost-storage-base": "0.0.3",
     "glob": "5.0.15",
     "got": "7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,6 +1269,13 @@ debug@3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2081,6 +2088,18 @@ gaze@^1.1.0:
   dependencies:
     globule "^1.0.0"
 
+gelf-stream@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/gelf-stream/-/gelf-stream-1.1.1.tgz#9cea9b6386ac301c741838ca3cb91e66dbfbf669"
+  integrity sha1-nOqbY4asMBx0GDjKPLkeZtv79mk=
+  dependencies:
+    gelfling "^0.3.0"
+
+gelfling@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/gelfling/-/gelfling-0.3.1.tgz#336a98f81510f9ae0af2a494e17468a116a9dc04"
+  integrity sha1-M2qY+BUQ+a4K8qSU4XRooRap3AQ=
+
 generate-function@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-1.1.0.tgz#54c21b080192b16d9877779c5bb81666e772365f"
@@ -2146,16 +2165,18 @@ ghost-ignition@2.9.2:
     prettyjson "^1.1.3"
     uuid "^3.0.0"
 
-ghost-ignition@2.9.4:
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/ghost-ignition/-/ghost-ignition-2.9.4.tgz#068359a3d5b98f43666e42220afc8a61ccb1e85e"
+ghost-ignition@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ghost-ignition/-/ghost-ignition-3.1.0.tgz#4a0d7f0a15e54fbc0e16d398da62ff68737e4e23"
+  integrity sha512-ae0r/yBJDo9SkeLfy0ecrHVqO0gt9l07wiCOWmdzdvbmoU24AB881PjymnM/DLP9SY6E33mLYtT8K3ximgieLg==
   dependencies:
     bunyan "1.8.12"
     bunyan-loggly "^1.3.1"
     caller "1.0.1"
-    debug "^2.6.9"
+    debug "^4.0.0"
     find-root "1.1.0"
     fs-extra "^3.0.1"
+    gelf-stream "^1.1.1"
     json-stringify-safe "^5.0.1"
     lodash "^4.16.4"
     moment "^2.15.2"
@@ -3910,6 +3931,11 @@ moment@2.22.2, "moment@>= 2.9.0", moment@^2.10.6, moment@^2.15.2, moment@^2.18.1
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 multer@1.3.1:
   version "1.3.1"


### PR DESCRIPTION
no issue

- Bumped ghost ignition to 3.1.0 for unified logging across all Ghost Pro blogs
- Added new logger options
- Includes stringification update for Ignition based on https://github.com/TryGhost/Ghost/commit/9810834f7b4b5728590839254d6e365d291e8265