### PR TITLE
Decoupled asset hash calculation from package.json

### DIFF
--- a/core/server/data/meta/asset_url.js
+++ b/core/server/data/meta/asset_url.js
@@ -1,8 +1,7 @@
 const crypto = require('crypto'),
     config = require('../../config'),
     imageLib = require('../../lib/image'),
-    urlService = require('../../services/url'),
-    packageInfo = require('../../../../package.json');
+    urlService = require('../../services/url');
 
 /**
  * Serve either uploaded favicon or default
@@ -39,7 +38,7 @@ function getAssetUrl(path, hasMinFile) {
     // Ensure we have an assetHash
     // @TODO rework this!
     if (!config.get('assetHash')) {
-        config.set('assetHash', (crypto.createHash('md5').update(packageInfo.version + Date.now()).digest('hex')).substring(0, 10));
+        config.set('assetHash', (crypto.createHash('md5').update(Date.now().toString()).digest('hex')).substring(0, 10));
     }
 
     // Finally add the asset hash to the output URL


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/9414
refs https://github.com/TryGhost/Ghost/pull/9459/commits/c9b95b4bbd9605e4d7bebf79cab27d641e049ae3

- Removed package version from asset hash calculation
- Package version doesn't introduce any value when calculating a hash because Date.now() provides enough randomization

@rishabhgrg just want a couple of :eyes: to make sure this makes sense :smile: 