### PR TITLE
🐛 ignore base path on external redirects

### DIFF
--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -53,7 +53,9 @@ _private.registerRoutes = () => {
                 const fromURL = url.parse(req.originalUrl);
                 const toURL = url.parse(redirect.to);
 
-                toURL.pathname = fromURL.pathname.replace(new RegExp(redirect.from, options), toURL.pathname),
+                toURL.pathname = (toURL.hostname)
+                    ? toURL.pathname
+                    : fromURL.pathname.replace(new RegExp(redirect.from, options), toURL.pathname);
                 toURL.search = fromURL.search;
 
                 res.set({


### PR DESCRIPTION
closes #10776

Prevents the issue in #10776 by not using the base url path when the to property of the redirect includes a host (implying an external or fully qualified url).

Alternatively we could achieve a similar result by adding an 'external' flag to the redirect.json format.
