### PR TITLE
Moved visibility utility from static model fn to Ghost-SDK

### DIFF
--- a/core/server/data/meta/keywords.js
+++ b/core/server/data/meta/keywords.js
@@ -1,8 +1,8 @@
-const models = require('../../models');
+const ghostHelperUtils = require('@tryghost/helpers').utils;
 
 function getKeywords(data) {
     if (data.post && data.post.tags && data.post.tags.length > 0) {
-        return models.Base.Model.filterByVisibility(data.post.tags, ['public'], false, function processItem(item) {
+        return ghostHelperUtils.visibility.filter(data.post.tags, ['public'], function processItem(item) {
             return item.name;
         });
     }

--- a/core/server/helpers/authors.js
+++ b/core/server/helpers/authors.js
@@ -9,7 +9,8 @@
 const proxy = require('./proxy');
 const _ = require('lodash');
 const urlService = require('../services/url');
-const {SafeString, templates, models} = proxy;
+const {SafeString, templates} = proxy;
+const ghostHelperUtils = require('@tryghost/helpers').utils;
 
 module.exports = function authors(options = {}) {
     options.hash = options.hash || {};
@@ -25,7 +26,6 @@ module.exports = function authors(options = {}) {
         to
     } = options.hash;
     let output = '';
-    const visibilityArr = models.Base.Model.parseVisibilityString(visibility);
 
     autolink = !(_.isString(autolink) && autolink === 'false');
     limit = limit ? parseInt(limit, 10) : limit;
@@ -40,7 +40,7 @@ module.exports = function authors(options = {}) {
             }) : _.escape(author.name);
         }
 
-        return models.Base.Model.filterByVisibility(authors, visibilityArr, !!visibility, processAuthor);
+        return ghostHelperUtils.visibility.filter(authors, visibility, processAuthor);
     }
 
     if (this.authors && this.authors.length) {

--- a/core/server/helpers/foreach.js
+++ b/core/server/helpers/foreach.js
@@ -3,14 +3,9 @@
 //
 // Block helper designed for looping through posts
 const _ = require('lodash');
-const {logging, i18n, models, hbs} = require('./proxy');
+const {logging, i18n, hbs} = require('./proxy');
 const {Utils: hbsUtils, handlebars: {createFrame}} = hbs;
-
-function filterItemsByVisibility(items, options) {
-    const visibilityArr = models.Base.Model.parseVisibilityString(options.hash.visibility);
-
-    return models.Base.Model.filterByVisibility(items, visibilityArr, !!options.hash.visibility);
-}
+const ghostHelperUtils = require('@tryghost/helpers').utils;
 
 module.exports = function foreach(items, options) {
     if (!options) {
@@ -22,7 +17,7 @@ module.exports = function foreach(items, options) {
     }
 
     // Exclude items which should not be visible in the theme
-    items = filterItemsByVisibility(items, options);
+    items = ghostHelperUtils.visibility.filter(items, options.hash.visibility);
 
     // Initial values set based on parameters sent through. If nothing sent, set to defaults
     const {fn, inverse, hash, data, ids} = options;

--- a/core/server/helpers/proxy.js
+++ b/core/server/helpers/proxy.js
@@ -19,7 +19,6 @@ module.exports = {
 
     // TODO: Expose less of the API to make this safe
     api: require('../api'),
-    models: require('../models'),
 
     // TODO: Only expose "get"
     settingsCache: settingsCache,

--- a/core/server/helpers/tags.js
+++ b/core/server/helpers/tags.js
@@ -5,12 +5,13 @@
 // By default, tags are separated by commas.
 //
 // Note that the standard {{#each tags}} implementation is unaffected by this helper
-const proxy = require('./proxy'),
-    _ = require('lodash'),
-    urlService = proxy.urlService,
-    SafeString = proxy.SafeString,
-    templates = proxy.templates,
-    models = proxy.models;
+const proxy = require('./proxy');
+const _ = require('lodash');
+const ghostHelperUtils = require('@tryghost/helpers').utils;
+
+const urlService = proxy.urlService;
+const SafeString = proxy.SafeString;
+const templates = proxy.templates;
 
 module.exports = function tags(options) {
     options = options || {};
@@ -20,8 +21,7 @@ module.exports = function tags(options) {
         separator = _.isString(options.hash.separator) ? options.hash.separator : ', ',
         prefix = _.isString(options.hash.prefix) ? options.hash.prefix : '',
         suffix = _.isString(options.hash.suffix) ? options.hash.suffix : '',
-        limit = options.hash.limit ? parseInt(options.hash.limit, 10) : undefined,
-        visibilityArr = models.Base.Model.parseVisibilityString(options.hash.visibility);
+        limit = options.hash.limit ? parseInt(options.hash.limit, 10) : undefined;
 
     let output = '',
         from = options.hash.from ? parseInt(options.hash.from, 10) : 1,
@@ -35,7 +35,7 @@ module.exports = function tags(options) {
             }) : _.escape(tag.name);
         }
 
-        return models.Base.Model.filterByVisibility(tags, visibilityArr, !!options.hash.visibility, processTag);
+        return ghostHelperUtils.visibility.filter(tags, options.hash.visibility, processTag);
     }
 
     if (this.tags && this.tags.length) {

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -1156,51 +1156,6 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     /**
-     * All models which have a visibility property, can use this static helper function.
-     * Filter models by visibility.
-     *
-     * @param {Array|Object} items
-     * @param {Array} visibility
-     * @param {Boolean} [explicit]
-     * @param {Function} [fn]
-     * @returns {Array|Object} filtered items
-     */
-    filterByVisibility: function filterByVisibility(items, visibility, explicit, fn) {
-        var memo = _.isArray(items) ? [] : {};
-
-        if (_.includes(visibility, 'all')) {
-            return fn ? _.map(items, fn) : items;
-        }
-
-        // We don't want to change the structure of what is returned
-        return _.reduce(items, function (items, item, key) {
-            if (!item.visibility && !explicit || _.includes(visibility, item.visibility)) {
-                var newItem = fn ? fn(item) : item;
-                if (_.isArray(items)) {
-                    memo.push(newItem);
-                } else {
-                    memo[key] = newItem;
-                }
-            }
-            return memo;
-        }, memo);
-    },
-
-    /**
-     * Returns an Array of visibility values.
-     * e.g. public,all => ['public, 'all']
-     * @param visibility
-     * @returns {*}
-     */
-    parseVisibilityString: function parseVisibilityString(visibility) {
-        if (!visibility) {
-            return ['public'];
-        }
-
-        return _.map(visibility.split(','), _.trim);
-    },
-
-    /**
      * If you want to fetch all data fast, i recommend using this function.
      * Bookshelf is just too slow, too much ORM overhead.
      *

--- a/core/test/unit/helpers/foreach_spec.js
+++ b/core/test/unit/helpers/foreach_spec.js
@@ -506,7 +506,7 @@ describe('{{#foreach}} helper', function () {
                         {name: 'second', visibility: 'public'},
                         {name: 'third', visibility: 'internal'},
                         {name: 'fourth', visibility: 'public'},
-                        {name: 'fifth'}
+                        {name: 'fifth', visibility: 'public'}
                     ]
                 },
                 tagObjectHash = {
@@ -515,7 +515,7 @@ describe('{{#foreach}} helper', function () {
                         second: {name: 'second', visibility: 'public'},
                         third: {name: 'third', visibility: 'internal'},
                         fourth: {name: 'fourth', visibility: 'public'},
-                        fifth: {name: 'fifth'}
+                        fifth: {name: 'fifth', visibility: 'public'}
                     }
                 };
 
@@ -545,7 +545,7 @@ describe('{{#foreach}} helper', function () {
 
             it('should output all tags with visibility property set with visibility="public,internal"', function () {
                 var templateString = '<ul>{{#foreach tags visibility="public,internal"}}<li>{{@index}} {{name}}</li>{{/foreach}}</ul>',
-                    expected = '<ul><li>0 first</li><li>1 second</li><li>2 third</li><li>3 fourth</li></ul>';
+                    expected = '<ul><li>0 first</li><li>1 second</li><li>2 third</li><li>3 fourth</li><li>4 fifth</li></ul>';
 
                 shouldCompileToExpected(templateString, tagObjectHash, expected);
                 shouldCompileToExpected(templateString, tagArrayHash, expected);


### PR DESCRIPTION
refs #10618

- Visibility methods don't belong on model, but are generic utils
- Visibility methods used from [SDK](https://github.com/TryGhost/Ghost-SDK/blob/master/packages/helpers/lib/utils/visibility.js)
- Used directly from ghost helper's visibility methods, cleans up core
- Removes direct model dependency of theme helper
- Removes usage of `parseVisibilityString` visibility string directly from code as its now implicitly taken care of in `filterVisibility` Uttil.
