### PR TITLE
Added logging of slow {{#get}} helper uses

### DIFF
--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -30,7 +30,11 @@
             "period": "1d",
             "count": 10
         },
-        "transports": ["stdout"]
+        "transports": ["stdout"],
+        "slowHelper": {
+            "level": "warn",
+            "threshold": 200
+        }
     },
     "spam": {
         "user_login": {

--- a/core/server/lib/common/errors.js
+++ b/core/server/lib/common/errors.js
@@ -54,6 +54,12 @@ const ghostErrors = {
             statusCode: 409,
             errorType: 'UpdateCollisionError'
         }, options));
+    },
+    HelperWarning: function HelperWarning(options) {
+        GhostError.call(this, merge({
+            errorType: 'HelperWarning',
+            hideStack: true
+        }, options));
     }
 };
 


### PR DESCRIPTION
no issue

- `{{#get}}` can slow down requests a lot if not used carefully, typically by using `limit="all"` or similar which can force a lot of data to be fetched and processed
- adds a warning log if we detect any `{{#get}}` helper call which takes longer than a certain threshold (default 200ms)
- allow log level and threshold to be configured via config to allow for different environments behaviours and requirements

New config options:
```
{
    "logging": {
        "slowHelper": {
            "level": "warn",
            "threshold": 200
        }
    }
}
```

Example output for `{{#get "tags" limit="all" order="name asc"}}` with a lot of tags:

```
[2019-06-07 10:35:52] WARN {{#get}} helper took 453ms to complete

{{#get}} helper took 453ms to complete

Error ID:
    062daed0-8910-11e9-8185-3b615ad8677d

Error Code:
    SLOW_GET_HELPER

Details:
    api:          v2.tagsPublic.browse
    apiOptions:
      order: name asc
      limit: all
    returnedRows: 1698
```