### PR TITLE
Speed up `image-size` utility functions

### DIFF
--- a/core/server/lib/image/image-size.js
+++ b/core/server/lib/image/image-size.js
@@ -1,5 +1,6 @@
 const debug = require('ghost-ignition').debug('utils:image-size');
 const sizeOf = require('image-size');
+const probeSizeOf = require('probe-image-size');
 const url = require('url');
 const Promise = require('bluebird');
 const _ = require('lodash');
@@ -9,50 +10,96 @@ const common = require('../common');
 const config = require('../../config');
 const storage = require('../../adapters/storage');
 const storageUtils = require('../../adapters/storage/utils');
-let getImageSizeFromUrl;
-let getImageSizeFromStoragePath;
-let getImageSizeFromPath;
+const validator = require('../../data/validation').validator;
 
-/**
- * @description processes the Buffer result of an image file
- * @param {Object} options
- * @returns {Object} dimensions
- */
-function fetchDimensionsFromBuffer(options) {
-    const buffer = options.buffer;
-    const imagePath = options.imagePath;
-    const imageObject = {};
-    let dimensions;
+// these are formats supported by image-size but not probe-image-size
+const FETCH_ONLY_FORMATS = [
+    'cur', 'icns', 'ico', 'dds'
+];
 
-    imageObject.url = imagePath;
+const REQUEST_OPTIONS = {
+    // we need the user-agent, otherwise some https request may fail (e.g. cloudfare)
+    headers: {
+        'User-Agent': 'Mozilla/5.0 Safari/537.36'
+    },
+    timeout: config.get('times:getImageSizeTimeoutInMS') || 10000,
+    retry: 0, // for `got`, used with image-size
+    encoding: null
+};
 
-    try {
-        // Using the Buffer rather than an URL requires to use sizeOf synchronously.
-        // See https://github.com/image-size/image-size#asynchronous
-        dimensions = sizeOf(buffer);
+// processes the Buffer result of an image file using image-size
+// returns promise which resolves dimensions
+function _imageSizeFromBuffer(buffer) {
+    return new Promise((resolve, reject) => {
+        try {
+            const dimensions = sizeOf(buffer);
 
-        // CASE: `.ico` files might have multiple images and therefore multiple sizes.
-        // We return the largest size found (image-size default is the first size found)
-        if (dimensions.images) {
-            dimensions.width = _.maxBy(dimensions.images, (w) => {
-                return w.width;
-            }).width;
-            dimensions.height = _.maxBy(dimensions.images, (h) => {
-                return h.height;
-            }).height;
+            // CASE: `.ico` files might have multiple images and therefore multiple sizes.
+            // We return the largest size found (image-size default is the first size found)
+            if (dimensions.images) {
+                dimensions.width = _.maxBy(dimensions.images, img => img.width).width;
+                dimensions.height = _.maxBy(dimensions.images, img => img.height).height;
+            }
+
+            return resolve(dimensions);
+        } catch (err) {
+            return reject(err);
         }
+    });
+}
 
-        imageObject.width = dimensions.width;
-        imageObject.height = dimensions.height;
-
-        return Promise.resolve(imageObject);
-    } catch (err) {
+// use probe-image-size to download enough of an image to get it's dimensions
+// returns promise which resolves dimensions
+function _probeImageSizeFromUrl(url) {
+    // probe-image-size uses `request` npm module which doesn't have our `got`
+    // override with custom URL validation so it needs duplicating here
+    if (_.isEmpty(url) || !validator.isURL(url)) {
         return Promise.reject(new common.errors.InternalServerError({
-            code: 'IMAGE_SIZE',
-            err: err,
-            context: imagePath
+            message: 'URL empty or invalid.',
+            code: 'URL_MISSING_INVALID',
+            context: url
         }));
     }
+
+    return probeSizeOf(url, REQUEST_OPTIONS);
+}
+
+// download full image then use image-size to get it's dimensions
+// returns promise which resolves dimensions
+function _fetchImageSizeFromUrl(url) {
+    return request(url, REQUEST_OPTIONS).then((response) => {
+        return _imageSizeFromBuffer(response.body);
+    });
+}
+
+// wrapper for appropriate probe/fetch method for getting image dimensions from a URL
+// returns promise which resolves dimensions
+function _imageSizeFromUrl(imageUrl) {
+    return new Promise((resolve, reject) => {
+        let parsedUrl;
+
+        try {
+            parsedUrl = url.parse(imageUrl);
+        } catch (err) {
+            reject(err);
+        }
+
+        // check if we got an url without any protocol
+        if (!parsedUrl.protocol) {
+            // CASE: our gravatar URLs start with '//' and we need to add 'http:'
+            // to make the request work
+            imageUrl = 'http:' + imageUrl;
+        }
+
+        const extensionMatch = imageUrl.match(/(?:\.)([a-zA-Z]{3,4})(\?|$)/) || [];
+        const extension = (extensionMatch[1] || '').toLowerCase();
+
+        if (FETCH_ONLY_FORMATS.includes(extension)) {
+            return resolve(_fetchImageSizeFromUrl(imageUrl));
+        } else {
+            return resolve(_probeImageSizeFromUrl(imageUrl));
+        }
+    });
 }
 
 // Supported formats of https://github.com/image-size/image-size:
@@ -78,11 +125,7 @@ function fetchDimensionsFromBuffer(options) {
  * @param {String} imagePath as URL
  * @returns {Promise<Object>} imageObject or error
  */
-getImageSizeFromUrl = (imagePath) => {
-    let requestOptions;
-    let parsedUrl;
-    let timeout = config.get('times:getImageSizeTimeoutInMS') || 10000;
-
+const getImageSizeFromUrl = (imagePath) => {
     if (storageUtils.isLocalImage(imagePath)) {
         // don't make a request for a locally stored image
         return getImageSizeFromStoragePath(imagePath);
@@ -93,36 +136,16 @@ getImageSizeFromUrl = (imagePath) => {
         imagePath = urlService.utils.urlJoin(urlService.utils.urlFor('home', true), urlService.utils.getSubdir(), '/', imagePath);
     }
 
-    parsedUrl = url.parse(imagePath);
-
-    // check if we got an url without any protocol
-    if (!parsedUrl.protocol) {
-        // CASE: our gravatar URLs start with '//' and we need to add 'http:'
-        // to make the request work
-        imagePath = 'http:' + imagePath;
-    }
-
     debug('requested imagePath:', imagePath);
-    requestOptions = {
-        headers: {
-            'User-Agent': 'Mozilla/5.0 Safari/537.36'
-        },
-        timeout: timeout,
-        encoding: null
-    };
 
-    return request(
-        imagePath,
-        requestOptions
-    ).then((response) => {
+    return _imageSizeFromUrl(imagePath).then((dimensions) => {
         debug('Image fetched (URL):', imagePath);
 
-        return fetchDimensionsFromBuffer({
-            buffer: response.body,
-            // we need to return the URL that's accessible for network requests as this imagePath
-            // value will be used as the URL for structured data
-            imagePath: parsedUrl.href
-        });
+        return {
+            url: imagePath,
+            width: dimensions.width,
+            height: dimensions.height
+        };
     }).catch({code: 'URL_MISSING_INVALID'}, (err) => {
         return Promise.reject(new common.errors.InternalServerError({
             message: err.message,
@@ -176,7 +199,7 @@ getImageSizeFromUrl = (imagePath) => {
  * @param {String} imagePath
  * @returns {object} imageObject or error
  */
-getImageSizeFromStoragePath = (imagePath) => {
+const getImageSizeFromStoragePath = (imagePath) => {
     let filePath;
 
     imagePath = urlService.utils.urlFor('image', {image: imagePath}, true);
@@ -188,14 +211,16 @@ getImageSizeFromStoragePath = (imagePath) => {
         .read({path: filePath})
         .then((buf) => {
             debug('Image fetched (storage):', filePath);
-
-            return fetchDimensionsFromBuffer({
-                buffer: buf,
-                // we need to return the URL that's accessible for network requests as this imagePath
-                // value will be used as the URL for structured data
-                imagePath: imagePath
-            });
-        }).catch({code: 'ENOENT'}, (err) => {
+            return _imageSizeFromBuffer(buf);
+        })
+        .then((dimensions) => {
+            return {
+                url: imagePath,
+                width: dimensions.width,
+                height: dimensions.height
+            };
+        })
+        .catch({code: 'ENOENT'}, (err) => {
             return Promise.reject(new common.errors.NotFoundError({
                 message: err.message,
                 code: 'IMAGE_SIZE_STORAGE',
@@ -233,7 +258,7 @@ getImageSizeFromStoragePath = (imagePath) => {
  * @returns {Promise<Object>} getImageDimensions
  * @description Takes a file path and returns width and height.
  */
-getImageSizeFromPath = (path) => {
+const getImageSizeFromPath = (path) => {
     return new Promise(function getSize(resolve, reject) {
         let dimensions;
 

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",
     "path-match": "1.2.4",
-    "probe-image-size": "^4.0.0",
+    "probe-image-size": "4.0.0",
     "rss": "1.2.2",
     "sanitize-html": "1.20.0",
     "semver": "5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5701,7 +5701,7 @@ prettyjson@^1.1.3:
     colors "^1.1.2"
     minimist "^1.2.0"
 
-probe-image-size@^4.0.0:
+probe-image-size@4.0.0, probe-image-size@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-4.0.0.tgz#d35b71759e834bcf580ea9f18ec8b9265c0977eb"
   integrity sha512-nm7RvWUxps+2+jZKNLkd04mNapXNariS6G5WIEVzvAqjx7EUuKcY1Dp3e6oUK7GLwzJ+3gbSbPLFAASHFQrPcQ==


### PR DESCRIPTION
no issue

- add `probe-image-size` dependency
- use `probe-image-size` to fetch partial image data over the network where possible