### PR TITLE
Simplify contributions through automated dev env

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,18 @@
+ports:
+- port: 2368
+  onOpen: open-preview
+- port: 4200
+  onOpen: ignore
+- port: 4201
+  onOpen: ignore
+tasks:
+- before: >
+    echo '{
+      "enableDeveloperExperiments": true,
+      "server": {
+        "host": "0.0.0.0"
+      }
+    }' > config.development.json &&
+    yarn global add knex-migrator grunt-cli ember-cli bower
+  init: yarn setup
+  command: npx grunt dev


### PR DESCRIPTION
Hi! 👋 
this adds a small config file for Gitpod, a free dev environment that we've built to ease the onboarding for contributors and working on GitHub projects generally. It allows anyone to get a ready-to-code dev environment for any branch, issue and pull request by prefixing the URL with `gitpod.io/#`.

You can give it a try with my fork of Ghost: https://gitpod.io/#https://github.com/svenefftinge/ghost.

<img width="1547" alt="Screenshot 2019-06-18 at 14 17 35" src="https://user-images.githubusercontent.com/372735/59681363-10a73a80-91d4-11e9-8958-11113109bc0e.png">

The setup follows the description from here (https://docs.ghost.org/install/local/) in that it automatically installs the prerequisites and runs the install, build and dev task. Also the relevant ports are exposed appropriately (At least I hope so :-)).

If you think this is useful I suggest you put some link (or button) into the setup documentation. I wasn't sure where you think users would best find it. Probably here https://docs.ghost.org/install/local/ ?

Also there is a [GitHub app](https://github.com/marketplace/gitpod-io) that will automatically pre-build pull requests and add a check, so users don't have to wait for builds when opening a workspace. Finally, if you open a PR with gitpod it opens in code-review mode (incl. inline comments), which is a very convenient way to do a deeper code review without going locally.

If you like it I'll be happy to reiterate and make it even better (with your help). I'm also happy to support you in future in case anything doesn't work well.