### PR TITLE
[WIP]Updated theme helpers to use settings controller

### DIFF
--- a/core/frontend/helpers/ghost_foot.js
+++ b/core/frontend/helpers/ghost_foot.js
@@ -2,24 +2,31 @@
 // Usage: `{{ghost_foot}}`
 //
 // Outputs scripts and other assets at the bottom of a Ghost theme
-var proxy = require('./proxy'),
-    _ = require('lodash'),
-    SafeString = proxy.SafeString,
-    settingsCache = proxy.settingsCache;
+const proxy = require('./proxy');
+const _ = require('lodash');
+const SafeString = proxy.SafeString;
+const api = proxy.api;
 
 // We use the name ghost_foot to match the helper for consistency:
 module.exports = function ghost_foot(options) { // eslint-disable-line camelcase
-    var foot = [],
-        globalCodeinjection = settingsCache.get('ghost_foot'),
-        postCodeinjection = options.data.root && options.data.root.post ? options.data.root.post.codeinjection_foot : null;
-
-    if (!_.isEmpty(globalCodeinjection)) {
-        foot.push(globalCodeinjection);
-    }
-
-    if (!_.isEmpty(postCodeinjection)) {
-        foot.push(postCodeinjection);
-    }
-
-    return new SafeString(foot.join(' ').trim());
+    const apiVersion = data.root._locals.apiVersion;
+    let settingsController = api[apiVersion].publicSettings || api[apiVersion].settings;
+    return settingsController.browse({}).then((settings) => {
+        let globalCodeinjection = '';
+        if (_.isArray(settings)) {
+            globalCodeinjection = settings.find(setting => setting.key === 'ghost_foot').value;
+        } else {
+            globalCodeinjection = settings.settings['ghost_foot'];
+        }
+        const postCodeinjection = options.data.root && options.data.root.post ? options.data.root.post.codeinjection_foot : null;
+        let foot = [];
+        if (!_.isEmpty(globalCodeinjection)) {
+            foot.push(globalCodeinjection);
+        }
+    
+        if (!_.isEmpty(postCodeinjection)) {
+            foot.push(postCodeinjection);
+        }
+        return new SafeString(foot.join(' ').trim());
+    });
 };

--- a/core/frontend/helpers/index.js
+++ b/core/frontend/helpers/index.js
@@ -48,7 +48,6 @@ registerAllCoreHelpers = function registerAllCoreHelpers() {
     registerThemeHelper('encode', coreHelpers.encode);
     registerThemeHelper('excerpt', coreHelpers.excerpt);
     registerThemeHelper('foreach', coreHelpers.foreach);
-    registerThemeHelper('ghost_foot', coreHelpers.ghost_foot);
     registerThemeHelper('has', coreHelpers.has);
     registerThemeHelper('is', coreHelpers.is);
     registerThemeHelper('img_url', coreHelpers.img_url);
@@ -70,6 +69,7 @@ registerAllCoreHelpers = function registerAllCoreHelpers() {
 
     // Async theme helpers
     registerAsyncThemeHelper('ghost_head', coreHelpers.ghost_head);
+    registerAsyncThemeHelper('ghost_foot', coreHelpers.ghost_foot);
     registerAsyncThemeHelper('next_post', coreHelpers.next_post);
     registerAsyncThemeHelper('prev_post', coreHelpers.prev_post);
     registerAsyncThemeHelper('get', coreHelpers.get);

--- a/core/frontend/helpers/proxy.js
+++ b/core/frontend/helpers/proxy.js
@@ -2,7 +2,6 @@
 // With the exception of modules like lodash, Bluebird
 // We can later refactor to enforce this something like we do in apps
 var hbs = require('../services/themes/engine'),
-    settingsCache = require('../../server/services/settings/cache'),
     config = require('../../server/config');
 
 // Direct requires:
@@ -19,9 +18,6 @@ module.exports = {
 
     // TODO: Expose less of the API to make this safe
     api: require('../../server/api'),
-
-    // TODO: Only expose "get"
-    settingsCache: settingsCache,
 
     // These 3 are kind of core and required all the time
     errors: require('../../server/lib/common/errors'),


### PR DESCRIPTION
refs #10381

- Remove theme helpers directly accessing settings cache
- Forces theme helpers to use settings from api/controllers
- Special hatch for v0.1/v2 APIs currently
- Converts `ghost_foot` to async helper

-------
This PR forces theme helpers to use settings from API controllers instead of direct access to `settingsCache`. Since `v0.1` and `v2` have slightly different ways of fetching settings currently, and only `v2` exposes the public settings endpoint, this PR handles the 2 API responses separately. As a future update, this needs some sort of serializer/hatch to be able to use API controller directly irrespective of version condition.

We had to register `ghost_foot` as an `async` helper with handlebars since it needs to fetch value from settings controller instead of settingsCache.