### PR TITLE
Removed unneeded role="navigation" attribute from <nav> in pagination.hbs

### DIFF
--- a/core/frontend/helpers/tpl/pagination.hbs
+++ b/core/frontend/helpers/tpl/pagination.hbs
@@ -1,4 +1,4 @@
-<nav class="pagination" role="navigation">
+<nav class="pagination">
     {{#if prev}}
         <a class="newer-posts" href="{{page_url prev}}"><span aria-hidden="true">&larr;</span> Newer Posts</a>
     {{/if}}


### PR DESCRIPTION
Hi! 👋

I removed unneeded `role="navigation"` attribute from `nav` in pagination.hbs. Markup like `nav role="navigation"` or `button role="button"` is superfluous since the HTML elements themselves already explain their role. Having these attributes makes W3C validation fail.