### PR TITLE
Update member static mount points

### DIFF
--- a/core/server/public/members-theme-bindings.js
+++ b/core/server/public/members-theme-bindings.js
@@ -778,8 +778,10 @@ var each = require('lodash/each');
 var browserAuth = require('@tryghost/members-browser-auth');
 module.exports.init = init;
 function init($__0) {
-  var siteUrl = $__0.siteUrl;
-  var auth = browserAuth({membersUrl: siteUrl + '/members'});
+  var $__1 = $__0,
+      membersUrl = $__1.membersUrl,
+      ssrUrl = $__1.ssrUrl;
+  var auth = browserAuth({membersUrl: membersUrl});
   var $__2 = window.location.hash.match(/^#([^?]+)\??(.*)$/) || [],
       hashMatch = $__2[0],
       hash = $__2[1],
@@ -797,7 +799,7 @@ function init($__0) {
   }
   auth.on('signedin', function() {
     auth.getSSRToken({fresh: true}).then(function(token) {
-      createSession(token);
+      createSession(token, ssrUrl);
     });
   });
   auth.on('signedout', function() {
@@ -805,13 +807,13 @@ function init($__0) {
   });
   function signout() {
     auth.signout().then((function() {
-      return destroySession();
+      return destroySession(ssrUrl);
     })).then(reload);
   }
   function signin() {
     auth.signin().then((function() {
       return auth.getSSRToken({fresh: true}).then(function(token) {
-        return createSession(token);
+        return createSession(token, ssrUrl);
       });
     })).then(reload);
   }
@@ -821,14 +823,14 @@ function init($__0) {
         coupon = ($__6 = $__5.coupon) === void 0 ? '' : $__6;
     auth.signup({coupon: coupon}).then((function() {
       return auth.getSSRToken({fresh: true}).then(function(token) {
-        return createSession(token);
+        return createSession(token, ssrUrl);
       });
     })).then(reload);
   }
   function upgrade() {
     auth.upgrade().then((function() {
       return auth.getSSRToken({fresh: true}).then(function(token) {
-        return createSession(token);
+        return createSession(token, ssrUrl);
       });
     })).then(reload);
   }
@@ -867,8 +869,8 @@ function reload(success) {
     window.location.reload();
   }
 }
-function createSession(token) {
-  return fetch('/members/ssr', {
+function createSession(token, ssrUrl) {
+  return fetch(ssrUrl, {
     method: 'post',
     credentials: 'include',
     body: token
@@ -876,8 +878,8 @@ function createSession(token) {
     return !!res.ok;
   });
 }
-function destroySession() {
-  return fetch('/members/ssr', {method: 'delete'}).then(function(res) {
+function destroySession(ssrUrl) {
+  return fetch(ssrUrl, {method: 'delete'}).then(function(res) {
     return !!res.ok;
   });
 }

--- a/core/server/public/members.js
+++ b/core/server/public/members.js
@@ -1,1 +1,1 @@
-MembersThemeBindings.init({siteUrl: "{{blog-url}}"});
+MembersThemeBindings.init({ssrUrl: "{{blog-url}}/members/ssr", membersUrl: "{{blog-url}}/members"});

--- a/core/server/public/members.js
+++ b/core/server/public/members.js
@@ -1,1 +1,1 @@
-MembersThemeBindings.init({ssrUrl: "{{blog-url}}/members/ssr", membersUrl: "{{blog-url}}/members"});
+MembersThemeBindings.init({ssrUrl: "{{blog-url}}/members/ssr", membersUrl: "{{admin-url}}/members"});

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -45,12 +45,12 @@ module.exports = function setupParentApp(options = {}) {
     // @TODO: finish refactoring the API app
     parentApp.use('/ghost/api', require('./api')());
 
+    // MEMBERS
+    parentApp.use('/ghost/members', labs.members, membersService.gateway);
+    parentApp.use('/ghost/members/auth', labs.members, membersService.authPages);
+
     // ADMIN
     parentApp.use('/ghost', require('./admin')());
-
-    // MEMBERS
-    parentApp.use('/members', labs.members, membersService.gateway);
-    parentApp.use('/members/auth', labs.members, membersService.authPages);
 
     // BLOG
     parentApp.use(require('./site')(options));

--- a/core/server/web/shared/middlewares/serve-public-file.js
+++ b/core/server/web/shared/middlewares/serve-public-file.js
@@ -9,6 +9,7 @@ function createPublicFileMiddleware(file, type, maxAge) {
     const publicFilePath = config.get('paths').publicFilePath;
     const filePath = file.match(/^public/) ? path.join(publicFilePath, file.replace(/^public/, '')) : path.join(publicFilePath, file);
     const blogRegex = /(\{\{blog-url\}\})/g;
+    const adminRegex = /(\{\{admin-url\}\})/g;
     const apiRegex = /(\{\{api-url\}\})/g;
 
     return function servePublicFile(req, res, next) {
@@ -26,6 +27,7 @@ function createPublicFileMiddleware(file, type, maxAge) {
             if (type === 'text/xsl' || type === 'text/plain' || type === 'application/javascript') {
                 str = str.replace(blogRegex, urlUtils.urlFor('home', true).replace(/\/$/, ''));
                 str = str.replace(apiRegex, urlUtils.urlFor('api', {cors: true, version: 'v0.1', versionType: 'content'}, true));
+                str = str.replace(adminRegex, urlUtils.urlFor('admin', true).replace(/\/$/, ''));
             }
 
             content = {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@tryghost/members-api": "0.1.1",
     "@tryghost/members-auth-pages": "0.2.1",
     "@tryghost/members-ssr": "0.1.5",
-    "@tryghost/members-theme-bindings": "^0.1.0",
+    "@tryghost/members-theme-bindings": "0.2.1",
     "@tryghost/social-urls": "0.1.0",
     "@tryghost/string": "^0.1.3",
     "@tryghost/url-utils": "0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,31 +156,40 @@
     preact-compat "^3.17.0"
     react-stripe-elements "^2.0.3"
 
-"@tryghost/members-browser-auth@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-browser-auth/-/members-browser-auth-0.1.1.tgz#f68fcca2b551c3af1dcdc78ed00c75df7456d943"
-  integrity sha512-RwhZxEUgVcZFrTZPnPdTSypkdSxgsnfx3/NZ+ZyLxgS2HuyI3ApQb8m/thwdUDu//LZrmlIvVryXu3eV3JzKNg==
+"@tryghost/members-browser-auth@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-browser-auth/-/members-browser-auth-0.1.2.tgz#49a9346ce2c44e27cc7b58fe354941c865051a63"
+  integrity sha512-9Fa0C1iCBdp7BAPSR1GZrNS5ke2ynSLkJED82uZ2tPZqD5saRMwHSPMnoLJJwOvwLLSEWtnAvijXzsKiDael1w==
   dependencies:
-    "@tryghost/members-gateway-api" "^0.1.2"
+    "@tryghost/members-gateway-api" "^0.1.3"
     bluebird "^3.5.4"
     ghost-ignition "^3.1.0"
     lodash "^4.17.11"
 
-"@tryghost/members-gateway-api@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-gateway-api/-/members-gateway-api-0.1.2.tgz#7955ccfe096834283fe219d37ec13cb616a38c9e"
-  integrity sha512-ZLlinu5+e5mIrBFRTzB7+0LaNYomc+rogEuqxS4gFzQAn9Qh23U+82c8JSVlnL33o4rQb077gl3rx8dqWIU+LQ==
+"@tryghost/members-gateway-api@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-gateway-api/-/members-gateway-api-0.1.3.tgz#c0f30534a821c566c69a39849449d5bc61409d7b"
+  integrity sha512-aWXPguGvGSA+Ly0j4C76bDPqsMe/Nzq8O8ytXrWdVmEhh7eXU631swGwrb3rCc8VHOSQvNUn6xPtx6+AMWPXVQ==
   dependencies:
-    "@tryghost/members-gateway-protocol" "^0.1.1"
+    "@tryghost/members-gateway-protocol" "^0.1.2"
     bluebird "^3.5.4"
     ghost-ignition "^3.1.0"
     lodash "^4.17.11"
     minivents "^2.2.0"
 
-"@tryghost/members-gateway-protocol@^0.1.0", "@tryghost/members-gateway-protocol@^0.1.1":
+"@tryghost/members-gateway-protocol@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@tryghost/members-gateway-protocol/-/members-gateway-protocol-0.1.1.tgz#90fa1f5774ea5967c800fbbbce55cba310149a23"
   integrity sha512-dv5fjZs/L2vMIGdxOUSatVyMvAHoUwUlnFUNdd0SnZ2fBZt5+JpBCsxnDyP43AkxD5R+Lc1cuo4QipAN5Tn9ZA==
+  dependencies:
+    bluebird "^3.5.4"
+    ghost-ignition "^3.1.0"
+    lodash "^4.17.11"
+
+"@tryghost/members-gateway-protocol@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-gateway-protocol/-/members-gateway-protocol-0.1.2.tgz#afd004bd91b5e403ebb9e130d3208046ce621bc2"
+  integrity sha512-lZVJ5tKqAiGZhZ+JD+dSjHKN9q04W7JkWPVl/+zOl2FuVbMiIOvlcmrHWug++hZhAyYHcWjnRPM/paRkiR/KBQ==
   dependencies:
     bluebird "^3.5.4"
     ghost-ignition "^3.1.0"
@@ -198,12 +207,12 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.11"
 
-"@tryghost/members-theme-bindings@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-theme-bindings/-/members-theme-bindings-0.1.0.tgz#4b4c46573d09446819f8bf4cccc1fc59b7398001"
-  integrity sha512-nC3Rq8cAtVfr58l7ukASXU1yb051goow0TpI2zoDCnPwrzZ3b9oiuaTglot1pQKqSGxyhbcdFSCBuU3p0082Xg==
+"@tryghost/members-theme-bindings@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-theme-bindings/-/members-theme-bindings-0.2.1.tgz#cf49a2b1d35f676c5f11e1d2f107182231a9204e"
+  integrity sha512-pwrHDp+Vvo/0JeHpcmmRvUNOPTREwSgIq3wRRj+bUR75yFr6YXEOrX4QTppoM0MuzwG7ejO/hKHyRaSl1gRNjg==
   dependencies:
-    "@tryghost/members-browser-auth" "^0.1.1"
+    "@tryghost/members-browser-auth" "^0.1.2"
     bluebird "^3.5.4"
     ghost-ignition "^3.1.0"
     lodash "^4.17.11"


### PR DESCRIPTION
no-issue

This alleviates the CORS requests failing for members when the admin is
hosted on a different domain than the site.

By moving the static pages from `/members` to `/ghost/members` we make sure that the two parts of the members api (static & auth endpoints) are hosted on same domain.