### PR TITLE
Node v6 v10 upgrades for Ghost 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: node_js
 # When changing node version also update it on lines 31 and 49.
 node_js:
@@ -17,6 +18,9 @@ addons:
         key_url: 'https://dl.yarnpkg.com/debian/pubkey.gpg'
     packages:
       - yarn
+
+services:
+  - mysql
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 language: node_js
 # When changing node version also update it on lines 31 and 49.
 node_js:
+  - "10"
   - "8"
   - "6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 node_js:
   - "10"
   - "8"
-  - "6"
 
 sudo: false
 

--- a/core/test/unit/apps/amp/amp_content_spec.js
+++ b/core/test/unit/apps/amp/amp_content_spec.js
@@ -1,9 +1,10 @@
-var should = require('should'),
-    rewire = require('rewire'),
-    configUtils = require('../../../../test/utils/configUtils'),
+const should = require('should');
+const rewire = require('rewire');
+const configUtils = require('../../../../test/utils/configUtils');
+const nock = require('nock');
 
 // Stuff we are testing
-    ampContentHelper = rewire('../../../../server/apps/amp/lib/helpers/amp_content');
+const ampContentHelper = rewire('../../../../server/apps/amp/lib/helpers/amp_content');
 
 // TODO: Amperize really needs to get stubbed, so we can test returning errors
 // properly and make this test faster!
@@ -111,7 +112,7 @@ describe('{{amp_content}} helper', function () {
 
     describe('Transforms and sanitizes HTML', function () {
         beforeEach(function () {
-            configUtils.set({url: 'https://blog.ghost.org/'});
+            configUtils.set({url: 'https://blog.ghost.org/content'});
         });
 
         afterEach(function () {
@@ -120,12 +121,18 @@ describe('{{amp_content}} helper', function () {
         });
 
         it('can transform img tags to amp-img', function (done) {
+            const GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');
+
+            nock('https://blog.ghost.org')
+                .get('/content/images/2019/06/test.jpg')
+                .reply(200, GIF1x1);
+
             var testData = {
-                    html: '<img src="/content/images/2016/08/scheduled2-1.jpg" alt="The Ghost Logo" />',
+                    html: '<img src="/content/images/2019/06/test.jpg" alt="The Ghost Logo" />',
                     updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',
                     id: 1
                 },
-                expectedResult = '<amp-img src="https://blog.ghost.org/content/images/2016/08/scheduled2-1.jpg" alt="The Ghost Logo" width="1000" height="281" layout="responsive"></amp-img>',
+                expectedResult = '<amp-img src="https://blog.ghost.org/content/images/2019/06/test.jpg" alt="The Ghost Logo" width="1" height="1" layout="fixed"></amp-img>',
                 ampResult = ampContentHelper.call(testData);
 
             ampResult.then(function (rendered) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "grunt lint"
   },
   "engines": {
-    "node": "^6.9.0 || ^8.9.0 || ^10.13.0",
+    "node": "^8.9.0 || ^10.13.0",
     "cli": "^1.7.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@nexes/nql": "0.0.1",
-    "amperize": "0.3.7",
+    "amperize": "0.3.8",
     "analytics-node": "2.4.1",
     "archiver": "1.3.0",
     "bcryptjs": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "grunt lint"
   },
   "engines": {
-    "node": "^6.9.0 || ^8.9.0",
+    "node": "^6.9.0 || ^8.9.0 || ^10.13.0",
     "cli": "^1.7.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,7 +55,15 @@ abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
-accepts@~1.3.4, accepts@~1.3.5:
+accepts@~1.3.4:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
+  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
+  dependencies:
+    mime-types "~2.1.24"
+    negotiator "0.6.2"
+
+accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
@@ -107,9 +115,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-amperize@0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/amperize/-/amperize-0.3.7.tgz#88efb8dc814782dd31b724178a8bf8ed028db395"
+amperize@0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/amperize/-/amperize-0.3.8.tgz#d928295ff5ca9bfa4afec24ed70e77382c3181a2"
+  integrity sha512-FK3VmBcpo+NlOPxO9XR+S0O8FegBXIitVjREkFoSIEUUhvbrOQwZgVMzrgP6kEtLLtmp+5GjVf4tkCdv9W5apA==
   dependencies:
     async "^2.1.4"
     emits "^3.0.0"
@@ -522,6 +531,7 @@ block-stream@*:
 bluebird@3.5.1, bluebird@^3.4.1, bluebird@^3.4.3, bluebird@^3.4.6, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
 bluebird@^3.0.5:
   version "3.5.3"
@@ -643,6 +653,7 @@ brute-knex@3.0.0:
 bson-objectid@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/bson-objectid/-/bson-objectid-1.2.3.tgz#af6bc55b0b3f63a9512352f424a2d84c3f17bd5c"
+  integrity sha512-Q19/ibJQlO1z4UOJTyaEpWmJ+IdPQfvoKRPBy5GADIbByxyxk6lSN5m82KHMmKCygBnvPl7Wd9kLlG5VVCBWQQ==
 
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
@@ -1010,14 +1021,16 @@ compress-commons@^1.2.0:
     readable-stream "^2.0.0"
 
 compressible@~2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.13.tgz#0d1020ab924b2fdb4d6279875c7d6daba6baa7a9"
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.17.tgz#6e8c108a16ad58384a977f3a482ca20bff2f38c1"
+  integrity sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==
   dependencies:
-    mime-db ">= 1.33.0 < 2"
+    mime-db ">= 1.40.0 < 2"
 
 compression@1.7.2:
   version "1.7.2"
-  resolved "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz#aaffbcd6aaf854b44ebb280353d5ad1651f59a69"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.2.tgz#aaffbcd6aaf854b44ebb280353d5ad1651f59a69"
+  integrity sha1-qv+81qr4VLROuygDU9WtFlH1mmk=
   dependencies:
     accepts "~1.3.4"
     bytes "3.0.0"
@@ -1752,6 +1765,7 @@ express-hbs@1.0.5, express-hbs@^1.0.3:
 express@4.16.3, express@^4.16.2:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
+  integrity sha1-avilAjUNsyRuzEvs9rWjTSL37VM=
   dependencies:
     accepts "~1.3.5"
     array-flatten "1.1.1"
@@ -3753,9 +3767,10 @@ micromatch@^3.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-"mime-db@>= 1.33.0 < 2":
-  version "1.34.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.34.0.tgz#452d0ecff5c30346a6dc1e64b1eaee0d3719ff9a"
+mime-db@1.40.0, "mime-db@>= 1.40.0 < 2":
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
+  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
 mime-db@~1.25.0:
   version "1.25.0"
@@ -3776,6 +3791,13 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@~2.1.24:
+  version "2.1.24"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
+  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+  dependencies:
+    mime-db "1.40.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -4046,6 +4068,11 @@ needle@^2.2.0:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+negotiator@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
+  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
 netjet@1.3.0:
   version "1.3.0"


### PR DESCRIPTION
no issue

- [x] drops support for Node v6
- [x] package bumps needed to update to Node v10
- [x] adds support for Node v10
- [x] fixes Travis CI on 1.x branch
- [x] unit test rewrite that was doing a real HTTP request to now unexistent resource

Kept the changes to the minimum to only allow version bump to v10.