### PR TITLE
🐛 Allowed Ghost to run without rsa-keypair module

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "js-yaml": "3.13.1",
     "jsonpath": "1.0.0",
     "jsonwebtoken": "8.4.0",
+    "keypair": "1.0.1",
     "knex": "0.14.6",
     "knex-migrator": "3.2.5",
     "lodash": "4.17.11",
@@ -112,7 +113,6 @@
     "passport-oauth2-client-password": "0.1.2",
     "path-match": "1.2.4",
     "probe-image-size": "4.0.0",
-    "rsa-keypair": "^2.0.2",
     "rss": "1.2.2",
     "sanitize-html": "1.20.0",
     "semver": "5.6.0",
@@ -125,6 +125,7 @@
   },
   "optionalDependencies": {
     "@tryghost/html-to-mobiledoc": "0.4.1",
+    "rsa-keypair": "^2.0.2",
     "sharp": "0.21.3",
     "sqlite3": "4.0.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,6 +3949,11 @@ keygrip@~1.0.2, keygrip@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.3.tgz#399d709f0aed2bab0a059e0cdd3a5023a053e1dc"
 
+keypair@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/keypair/-/keypair-1.0.1.tgz#7603719270afb6564ed38a22087a06fc9aa4ea1b"
+  integrity sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs=
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"


### PR DESCRIPTION
closes #10813

This allows us to fallback to a pure js implementation for those
platforms which don't support the rsa-keypair module - at the expense of
being slower.