### PR TITLE
Themes controllers code extraction

### DIFF
--- a/core/frontend/services/themes/activate.js
+++ b/core/frontend/services/themes/activate.js
@@ -1,0 +1,32 @@
+const common = require('../../../server/lib/common');
+const active = require('./active');
+
+function activate(loadedTheme, checkedTheme, error) {
+    // no need to check the score, activation should be used in combination with validate.check
+    // Use the two theme objects to set the current active theme
+    try {
+        let previousGhostAPI;
+
+        if (this.getActive()) {
+            previousGhostAPI = this.getApiVersion();
+        }
+
+        active.set(loadedTheme, checkedTheme, error);
+        const currentGhostAPI = this.getApiVersion();
+
+        common.events.emit('services.themes.activated');
+
+        if (previousGhostAPI !== undefined && (previousGhostAPI !== currentGhostAPI)) {
+            common.events.emit('services.themes.api.changed');
+            const siteApp = require('../../../server/web/site/app');
+            siteApp.reload();
+        }
+    } catch (err) {
+        common.logging.error(new common.errors.InternalServerError({
+            message: common.i18n.t('errors.middleware.themehandler.activateFailed', {theme: loadedTheme.name}),
+            err: err
+        }));
+    }
+}
+
+module.exports = activate;

--- a/core/frontend/services/themes/activate.js
+++ b/core/frontend/services/themes/activate.js
@@ -7,12 +7,12 @@ function activate(loadedTheme, checkedTheme, error) {
     try {
         let previousGhostAPI;
 
-        if (this.getActive()) {
-            previousGhostAPI = this.getApiVersion();
+        if (active.get()) {
+            previousGhostAPI = active.get().engine('ghost-api');
         }
 
         active.set(loadedTheme, checkedTheme, error);
-        const currentGhostAPI = this.getApiVersion();
+        const currentGhostAPI = active.get().engine('ghost-api');
 
         common.events.emit('services.themes.activated');
 

--- a/core/frontend/services/themes/index.js
+++ b/core/frontend/services/themes/index.js
@@ -3,6 +3,7 @@ const debug = require('ghost-ignition').debug('themes');
 const common = require('../../../server/lib/common');
 const themeLoader = require('./loader');
 const active = require('./active');
+const activate = require('./activate');
 const validate = require('./validate');
 const Storage = require('./Storage');
 const settingsCache = require('../../../server/services/settings/cache');
@@ -16,8 +17,7 @@ module.exports = {
     // Init themes module
     // TODO: move this once we're clear what needs to happen here
     init: function initThemes() {
-        var activeThemeName = settingsCache.get('active_theme'),
-            self = this;
+        var activeThemeName = settingsCache.get('active_theme');
 
         debug('init themes', activeThemeName);
 
@@ -46,7 +46,7 @@ module.exports = {
 
                             common.logging.error(checkError);
 
-                            self.activate(theme, checkedTheme, checkError);
+                            activate(theme, checkedTheme, checkError);
                         } else {
                             // CASE: inform that the theme has errors, but not fatal (theme still works)
                             if (checkedTheme.results.error.length) {
@@ -63,7 +63,7 @@ module.exports = {
 
                             debug('Activating theme (method A on boot)', activeThemeName);
 
-                            self.activate(theme, checkedTheme);
+                            activate(theme, checkedTheme);
                         }
                     });
             })
@@ -97,7 +97,24 @@ module.exports = {
             return engineDefaults['ghost-api'];
         }
     },
-    activate: require('./activate'),
+    activate: function (themeName) {
+        const loadedTheme = this.list.get(themeName);
+
+        if (!loadedTheme) {
+            return Promise.reject(new common.errors.ValidationError({
+                message: common.i18n.t('notices.data.validation.index.themeCannotBeActivated', {themeName: themeName}),
+                errorDetails: themeName
+            }));
+        }
+
+        return validate.checkSafe(loadedTheme)
+            .then((checkedTheme) => {
+                debug('Activating theme (method B on API "activate")', themeName);
+                activate(loadedTheme, checkedTheme);
+
+                return checkedTheme;
+            });
+    },
     settings: require('./settings'),
     middleware: require('./middleware')
 };

--- a/core/frontend/services/themes/index.js
+++ b/core/frontend/services/themes/index.js
@@ -124,5 +124,6 @@ module.exports = {
             }));
         }
     },
+    settings: require('./settings'),
     middleware: require('./middleware')
 };

--- a/core/frontend/services/themes/index.js
+++ b/core/frontend/services/themes/index.js
@@ -97,33 +97,7 @@ module.exports = {
             return engineDefaults['ghost-api'];
         }
     },
-    activate: function activate(loadedTheme, checkedTheme, error) {
-        // no need to check the score, activation should be used in combination with validate.check
-        // Use the two theme objects to set the current active theme
-        try {
-            let previousGhostAPI;
-
-            if (this.getActive()) {
-                previousGhostAPI = this.getApiVersion();
-            }
-
-            active.set(loadedTheme, checkedTheme, error);
-            const currentGhostAPI = this.getApiVersion();
-
-            common.events.emit('services.themes.activated');
-
-            if (previousGhostAPI !== undefined && (previousGhostAPI !== currentGhostAPI)) {
-                common.events.emit('services.themes.api.changed');
-                const siteApp = require('../../../server/web/site/app');
-                siteApp.reload();
-            }
-        } catch (err) {
-            common.logging.error(new common.errors.InternalServerError({
-                message: common.i18n.t('errors.middleware.themehandler.activateFailed', {theme: loadedTheme.name}),
-                err: err
-            }));
-        }
-    },
+    activate: require('./activate'),
     settings: require('./settings'),
     middleware: require('./middleware')
 };

--- a/core/frontend/services/themes/settings.js
+++ b/core/frontend/services/themes/settings.js
@@ -1,11 +1,12 @@
 const fs = require('fs-extra');
 
-// const activate = require('./activate');
+const activate = require('./activate');
 const validate = require('./validate');
 const Storage = require('./Storage');
 const themeLoader = require('./loader');
 const toJSON = require('./to-json');
 
+const settingsCache = require('../../../server/services/settings/cache');
 const common = require('../../../server/lib/common');
 const debug = require('ghost-ignition').debug('api:themes');
 

--- a/core/frontend/services/themes/settings.js
+++ b/core/frontend/services/themes/settings.js
@@ -1,0 +1,82 @@
+const fs = require('fs-extra');
+
+// const activate = require('./activate');
+const validate = require('./validate');
+const Storage = require('./Storage');
+const themeLoader = require('./loader');
+const toJSON = require('./to-json');
+
+const common = require('../../../server/lib/common');
+const debug = require('ghost-ignition').debug('api:themes');
+
+let themeStorage;
+
+const getStorage = () => {
+    themeStorage = themeStorage || new Storage();
+
+    return themeStorage;
+};
+
+module.exports = {
+    get: require('./to-json'),
+    setFromZip: (zip) => {
+        // check if zip name is casper.zip
+        if (zip.name === 'casper.zip') {
+            throw new common.errors.ValidationError({
+                message: common.i18n.t('errors.api.themes.overrideCasper')
+            });
+        }
+
+        let checkedTheme;
+
+        return validate.checkSafe(zip, true)
+            .then((_checkedTheme) => {
+                checkedTheme = _checkedTheme;
+
+                return getStorage().exists(zip.shortName);
+            })
+            .then((themeExists) => {
+                // CASE: delete existing theme
+                if (themeExists) {
+                    return getStorage().delete(zip.shortName);
+                }
+            })
+            .then(() => {
+                // CASE: store extracted theme
+                return getStorage().save({
+                    name: zip.shortName,
+                    path: checkedTheme.path
+                });
+            })
+            .then(() => {
+                // CASE: loads the theme from the fs & sets the theme on the themeList
+                return themeLoader.loadOneTheme(zip.shortName);
+            })
+            .then((loadedTheme) => {
+                // CASE: if this is the active theme, we are overriding
+                if (zip.shortName === settingsCache.get('active_theme')) {
+                    debug('Activating theme (method C, on API "override")', zip.shortName);
+                    activate(loadedTheme, checkedTheme);
+
+                    // CASE: clear cache
+                    this.headers.cacheInvalidate = true;
+                }
+
+                common.events.emit('theme.uploaded');
+
+                // @TODO: unify the name across gscan and Ghost!
+                return toJSON(zip.shortName, checkedTheme);
+            })
+            .finally(() => {
+                // @TODO: we should probably do this as part of saving the theme
+                // CASE: remove extracted dir from gscan
+                // happens in background
+                if (checkedTheme) {
+                    fs.remove(checkedTheme.path)
+                        .catch((err) => {
+                            common.logging.error(new common.errors.GhostError({err: err}));
+                        });
+                }
+            });
+    }
+};

--- a/core/frontend/services/themes/settings.js
+++ b/core/frontend/services/themes/settings.js
@@ -35,6 +35,8 @@ module.exports = {
         });
     },
     setFromZip: (zip) => {
+        const shortName = getStorage().getSanitizedFileName(zip.name.split('.zip')[0]);
+
         // check if zip name is casper.zip
         if (zip.name === 'casper.zip') {
             throw new common.errors.ValidationError({
@@ -48,29 +50,29 @@ module.exports = {
             .then((_checkedTheme) => {
                 checkedTheme = _checkedTheme;
 
-                return getStorage().exists(zip.shortName);
+                return getStorage().exists(shortName);
             })
             .then((themeExists) => {
                 // CASE: delete existing theme
                 if (themeExists) {
-                    return getStorage().delete(zip.shortName);
+                    return getStorage().delete(shortName);
                 }
             })
             .then(() => {
                 // CASE: store extracted theme
                 return getStorage().save({
-                    name: zip.shortName,
+                    name: shortName,
                     path: checkedTheme.path
                 });
             })
             .then(() => {
                 // CASE: loads the theme from the fs & sets the theme on the themeList
-                return themeLoader.loadOneTheme(zip.shortName);
+                return themeLoader.loadOneTheme(shortName);
             })
             .then((loadedTheme) => {
                 // CASE: if this is the active theme, we are overriding
-                if (zip.shortName === settingsCache.get('active_theme')) {
-                    debug('Activating theme (method C, on API "override")', zip.shortName);
+                if (shortName === settingsCache.get('active_theme')) {
+                    debug('Activating theme (method C, on API "override")', shortName);
                     activate(loadedTheme, checkedTheme);
 
                     // CASE: clear cache
@@ -78,7 +80,7 @@ module.exports = {
                 }
 
                 // @TODO: unify the name across gscan and Ghost!
-                return toJSON(zip.shortName, checkedTheme);
+                return toJSON(shortName, checkedTheme);
             })
             .finally(() => {
                 // @TODO: we should probably do this as part of saving the theme

--- a/core/frontend/services/themes/settings.js
+++ b/core/frontend/services/themes/settings.js
@@ -21,6 +21,19 @@ const getStorage = () => {
 
 module.exports = {
     get: require('./to-json'),
+    getZip: (themeName) => {
+        const theme = list.get(themeName);
+
+        if (!theme) {
+            return Promise.reject(new common.errors.BadRequestError({
+                message: common.i18n.t('errors.api.themes.invalidThemeName')
+            }));
+        }
+
+        return getStorage().serve({
+            name: themeName
+        });
+    },
     setFromZip: (zip) => {
         // check if zip name is casper.zip
         if (zip.name === 'casper.zip') {

--- a/core/frontend/services/themes/settings.js
+++ b/core/frontend/services/themes/settings.js
@@ -63,8 +63,6 @@ module.exports = {
                     this.headers.cacheInvalidate = true;
                 }
 
-                common.events.emit('theme.uploaded');
-
                 // @TODO: unify the name across gscan and Ghost!
                 return toJSON(zip.shortName, checkedTheme);
             })

--- a/core/frontend/services/themes/settings.js
+++ b/core/frontend/services/themes/settings.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra');
 
 const activate = require('./activate');
 const validate = require('./validate');
+const list = require('./list');
 const Storage = require('./Storage');
 const themeLoader = require('./loader');
 const toJSON = require('./to-json');
@@ -76,6 +77,32 @@ module.exports = {
                             common.logging.error(new common.errors.GhostError({err: err}));
                         });
                 }
+            });
+    },
+    destroy: function (themeName) {
+        if (themeName === 'casper') {
+            throw new common.errors.ValidationError({
+                message: common.i18n.t('errors.api.themes.destroyCasper')
+            });
+        }
+
+        if (themeName === settingsCache.get('active_theme')) {
+            throw new common.errors.ValidationError({
+                message: common.i18n.t('errors.api.themes.destroyActive')
+            });
+        }
+
+        const theme = list.get(themeName);
+
+        if (!theme) {
+            throw new common.errors.NotFoundError({
+                message: common.i18n.t('errors.api.themes.themeDoesNotExist')
+            });
+        }
+
+        return getStorage().delete(themeName)
+            .then(() => {
+                list.del(themeName);
             });
     }
 };

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -64,8 +64,7 @@ themes = {
 
         let zip = {
             path: options.path,
-            name: options.originalname,
-            shortName: themeService.storage.getSanitizedFileName(options.originalname.split('.zip')[0])
+            name: options.originalname
         };
 
         return localUtils

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -26,7 +26,7 @@ themes = {
             // Main action
             .then(() => {
                 // Return JSON result
-                return themeService.toJSON();
+                return themeService.settings.get();
             });
     },
 
@@ -52,7 +52,7 @@ themes = {
             })
             .then((checkedTheme) => {
                 // Return JSON result
-                return themeService.toJSON(themeName, checkedTheme);
+                return themeService.settings.get(themeName, checkedTheme);
             });
     },
 

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -124,35 +124,14 @@ themes = {
      * remove theme folder
      */
     destroy(options) {
-        let themeName = options.name,
-            theme;
+        let themeName = options.name;
 
         return localUtils
         // Permissions
             .handlePermissions('themes', 'destroy')(options)
             // Validation
             .then(() => {
-                if (themeName === 'casper') {
-                    throw new common.errors.ValidationError({message: common.i18n.t('errors.api.themes.destroyCasper')});
-                }
-
-                if (themeName === settingsCache.get('active_theme')) {
-                    throw new common.errors.ValidationError({message: common.i18n.t('errors.api.themes.destroyActive')});
-                }
-
-                theme = themeList.get(themeName);
-
-                if (!theme) {
-                    throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.themes.themeDoesNotExist')});
-                }
-
-                // Actually do the deletion here
-                return themeService.storage.delete(themeName);
-            })
-            // And some extra stuff to maintain state here
-            .then(() => {
-                themeList.del(themeName);
-                // Delete returns an empty 204 response
+                return themeService.settings.destroy(themeName);
             });
     }
 };

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -1,12 +1,9 @@
 // # Themes API
 // RESTful API for Themes
-const debug = require('ghost-ignition').debug('api:themes'),
-    Promise = require('bluebird'),
-    localUtils = require('./utils'),
+const localUtils = require('./utils'),
     common = require('../../lib/common'),
     models = require('../../models'),
-    themeService = require('../../../frontend/services/themes'),
-    themeList = themeService.list;
+    themeService = require('../../../frontend/services/themes');
 
 let themes;
 

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -38,37 +38,22 @@ themes = {
             newSettings = [{
                 key: 'active_theme',
                 value: themeName
-            }],
-            loadedTheme,
-            checkedTheme;
+            }];
 
         return localUtils
         // Permissions
             .handlePermissions('themes', 'activate')(options)
-            // Validation
+            // Validation & activation
             .then(() => {
-                loadedTheme = themeList.get(themeName);
-
-                if (!loadedTheme) {
-                    return Promise.reject(new common.errors.ValidationError({
-                        message: common.i18n.t('notices.data.validation.index.themeCannotBeActivated', {themeName: themeName}),
-                        errorDetails: newSettings
-                    }));
-                }
-
-                return themeService.validate.checkSafe(loadedTheme);
+                return themeService.activate(themeName);
             })
             // Update setting
-            .then((_checkedTheme) => {
-                checkedTheme = _checkedTheme;
-
-                debug('Activating theme (method B on API "activate")', themeName);
-                themeService.activate(loadedTheme, checkedTheme);
-
-                // We use the model, not the API here, as we don't want to trigger permissions
-                return models.Settings.edit(newSettings, options);
+            .then((checkedTheme) => {
+                // @NOTE: We use the model, not the API here, as we don't want to trigger permissions
+                return models.Settings.edit(newSettings, options)
+                    .then(() => checkedTheme);
             })
-            .then(() => {
+            .then((checkedTheme) => {
                 // Return JSON result
                 return themeService.toJSON(themeName, checkedTheme);
             });

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -61,15 +61,14 @@ themes = {
             // Update setting
             .then((_checkedTheme) => {
                 checkedTheme = _checkedTheme;
-                // We use the model, not the API here, as we don't want to trigger permissions
-                return models.Settings.edit(newSettings, options);
-            })
-            // Call activate
-            .then(() => {
-                // Activate! (sort of)
+
                 debug('Activating theme (method B on API "activate")', themeName);
                 themeService.activate(loadedTheme, checkedTheme);
 
+                // We use the model, not the API here, as we don't want to trigger permissions
+                return models.Settings.edit(newSettings, options);
+            })
+            .then(() => {
                 // Return JSON result
                 return themeService.toJSON(themeName, checkedTheme);
             });

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -102,20 +102,13 @@ themes = {
     },
 
     download(options) {
-        let themeName = options.name,
-            theme = themeList.get(themeName);
-
-        if (!theme) {
-            return Promise.reject(new common.errors.BadRequestError({message: common.i18n.t('errors.api.themes.invalidThemeName')}));
-        }
+        let themeName = options.name;
 
         return localUtils
         // Permissions
             .handlePermissions('themes', 'read')(options)
             .then(() => {
-                return themeService.storage.serve({
-                    name: themeName
-                });
+                return themeService.settings.getZip(themeName);
             });
     },
 

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -5,7 +5,6 @@ const debug = require('ghost-ignition').debug('api:themes'),
     localUtils = require('./utils'),
     common = require('../../lib/common'),
     models = require('../../models'),
-    settingsCache = require('../../services/settings/cache'),
     themeService = require('../../../frontend/services/themes'),
     themeList = themeService.list;
 

--- a/core/server/api/v2/themes.js
+++ b/core/server/api/v2/themes.js
@@ -2,7 +2,6 @@ const Promise = require('bluebird');
 const debug = require('ghost-ignition').debug('api:themes');
 const common = require('../../lib/common');
 const themeService = require('../../../frontend/services/themes');
-const settingsCache = require('../../services/settings/cache');
 const models = require('../../models');
 
 module.exports = {

--- a/core/server/api/v2/themes.js
+++ b/core/server/api/v2/themes.js
@@ -8,7 +8,7 @@ module.exports = {
     browse: {
         permissions: true,
         query() {
-            return themeService.toJSON();
+            return themeService.settings.get();
         }
     },
 
@@ -41,7 +41,7 @@ module.exports = {
                         .then(() => checkedTheme);
                 })
                 .then((checkedTheme) => {
-                    return themeService.toJSON(themeName, checkedTheme);
+                    return themeService.settings.get(themeName, checkedTheme);
                 });
         }
     },
@@ -57,8 +57,7 @@ module.exports = {
 
             let zip = {
                 path: frame.file.path,
-                name: frame.file.originalname,
-                shortName: themeService.storage.getSanitizedFileName(frame.file.originalname.split('.zip')[0])
+                name: frame.file.originalname
             };
 
             return themeService.settings.setFromZip(zip)

--- a/core/server/api/v2/themes.js
+++ b/core/server/api/v2/themes.js
@@ -78,7 +78,11 @@ module.exports = {
                 shortName: themeService.storage.getSanitizedFileName(frame.file.originalname.split('.zip')[0])
             };
 
-            return themeService.settings.setFromZip(zip);
+            return themeService.settings.setFromZip(zip)
+                .then((theme) => {
+                    common.events.emit('theme.uploaded');
+                    return theme;
+                });
         }
     },
 

--- a/core/server/api/v2/themes.js
+++ b/core/server/api/v2/themes.js
@@ -135,30 +135,7 @@ module.exports = {
         query(frame) {
             let themeName = frame.options.name;
 
-            if (themeName === 'casper') {
-                throw new common.errors.ValidationError({
-                    message: common.i18n.t('errors.api.themes.destroyCasper')
-                });
-            }
-
-            if (themeName === settingsCache.get('active_theme')) {
-                throw new common.errors.ValidationError({
-                    message: common.i18n.t('errors.api.themes.destroyActive')
-                });
-            }
-
-            const theme = themeService.list.get(themeName);
-
-            if (!theme) {
-                throw new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.themes.themeDoesNotExist')
-                });
-            }
-
-            return themeService.storage.delete(themeName)
-                .then(() => {
-                    themeService.list.del(themeName);
-                });
+            return themeService.settings.destroy(themeName);
         }
     }
 };

--- a/core/server/api/v2/themes.js
+++ b/core/server/api/v2/themes.js
@@ -102,17 +102,8 @@ module.exports = {
         },
         query(frame) {
             let themeName = frame.options.name;
-            const theme = themeService.list.get(themeName);
 
-            if (!theme) {
-                return Promise.reject(new common.errors.BadRequestError({
-                    message: common.i18n.t('errors.api.themes.invalidThemeName')
-                }));
-            }
-
-            return themeService.storage.serve({
-                name: themeName
-            });
+            return themeService.settings.getZip(themeName);
         }
     },
 

--- a/core/server/api/v2/themes.js
+++ b/core/server/api/v2/themes.js
@@ -1,5 +1,4 @@
 const Promise = require('bluebird');
-const fs = require('fs-extra');
 const debug = require('ghost-ignition').debug('api:themes');
 const common = require('../../lib/common');
 const themeService = require('../../../frontend/services/themes');
@@ -52,14 +51,13 @@ module.exports = {
             return themeService.validate.checkSafe(loadedTheme)
                 .then((_checkedTheme) => {
                     checkedTheme = _checkedTheme;
+                    debug('Activating theme (method B on API "activate")', themeName);
+                    themeService.activate(loadedTheme, checkedTheme);
 
                     // @NOTE: we use the model, not the API here, as we don't want to trigger permissions
                     return models.Settings.edit(newSettings, frame.options);
                 })
                 .then(() => {
-                    debug('Activating theme (method B on API "activate")', themeName);
-                    themeService.activate(loadedTheme, checkedTheme);
-
                     return themeService.toJSON(themeName, checkedTheme);
                 });
         }
@@ -80,64 +78,7 @@ module.exports = {
                 shortName: themeService.storage.getSanitizedFileName(frame.file.originalname.split('.zip')[0])
             };
 
-            let checkedTheme;
-
-            // check if zip name is casper.zip
-            if (zip.name === 'casper.zip') {
-                throw new common.errors.ValidationError({
-                    message: common.i18n.t('errors.api.themes.overrideCasper')
-                });
-            }
-
-            return themeService.validate.checkSafe(zip, true)
-                .then((_checkedTheme) => {
-                    checkedTheme = _checkedTheme;
-
-                    return themeService.storage.exists(zip.shortName);
-                })
-                .then((themeExists) => {
-                    // CASE: delete existing theme
-                    if (themeExists) {
-                        return themeService.storage.delete(zip.shortName);
-                    }
-                })
-                .then(() => {
-                    // CASE: store extracted theme
-                    return themeService.storage.save({
-                        name: zip.shortName,
-                        path: checkedTheme.path
-                    });
-                })
-                .then(() => {
-                    // CASE: loads the theme from the fs & sets the theme on the themeList
-                    return themeService.loadOne(zip.shortName);
-                })
-                .then((loadedTheme) => {
-                    // CASE: if this is the active theme, we are overriding
-                    if (zip.shortName === settingsCache.get('active_theme')) {
-                        debug('Activating theme (method C, on API "override")', zip.shortName);
-                        themeService.activate(loadedTheme, checkedTheme);
-
-                        // CASE: clear cache
-                        this.headers.cacheInvalidate = true;
-                    }
-
-                    common.events.emit('theme.uploaded');
-
-                    // @TODO: unify the name across gscan and Ghost!
-                    return themeService.toJSON(zip.shortName, checkedTheme);
-                })
-                .finally(() => {
-                    // @TODO: we should probably do this as part of saving the theme
-                    // CASE: remove extracted dir from gscan
-                    // happens in background
-                    if (checkedTheme) {
-                        fs.remove(checkedTheme.path)
-                            .catch((err) => {
-                                common.logging.error(new common.errors.GhostError({err: err}));
-                            });
-                    }
-                });
+            return themeService.settings.setFromZip(zip);
         }
     },
 


### PR DESCRIPTION
refs #10790

The main goal this extraction achieves is limiting the themes service accessed by API. It achieves 2 goals at once less coupling surface and being able to finally [clean up](https://github.com/TryGhost/Ghost/blob/2.25.3/core/frontend/services/themes/index.js#L13-L14) theme service index file (will come in follow-up PR).


Changes that would love to get an opinion on:
1. Order change for when `models.Settings.edit(newSettings, frame.options)` is being called. Previously it was called between `themeService.validate.checkSafe` and `themeService.activate` calls. Now it had to be moved to after `themeService.validate.activate` call so that the rest of methods could be grouped together. It should not introduce any difference in the behavior, because `activate` method didn't have any returns, and the whole method was already wrapped in one big try/catch so there are no side-effects.
2. The `settings` module in themes service was extracted to follow convention similar to routes/redirects services. The naming for methods there was same as in other services apart from new: 
   - `getZip` - returns a zip file
   - `setFromZip` - the same as `setFromFilePath` convention
   - `destroy` - this naming is prevalent in "server" so decided to stick with it instead of dubious: `del` and `delete`

There will be a follow-up RP that removes and cleans up methods in `core/frontend/services/themes/index.js` - the properties left will be: `init`, `getApiVersion`, `activate`, `settings` and `middleware`. A lot more approachable then it is now :smiley: 

The commits were done after each method was extracted following up some cleanup with clarifying messages in commits, hopefully, easy to follow.