### PR TITLE
Update Renovate Configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "@tryghost:groupBuildTools",
     "@tryghost:automergeSilentTestLintNonMajor"
   ],
+  "schedule": "before 3am on Tuesday",
   "travis": { "enabled": true },
   "node": {
     "supportPolicy": ["lts"]


### PR DESCRIPTION
To go through an initial flood of PRs we want to have schedule changed just for the first week. This change should be reverted next week.
