### PR TITLE
Updated renovate ignore list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,8 @@
   },
   "ignoreDeps": [
       "nodemailer",
-      "validator"
+      "validator",
+      "simple-dom"
     ],
   "ignorePaths": ["core/test"]
 }


### PR DESCRIPTION
no issue

- Added `simple-dom` to renovate ignore dependency list. Mobiledoc-kit's dom renderer will need updates for it to be compatible so we stick to one version across the dom renderer and our own usage of simple-dom
