### PR TITLE
Fixed generation of api urls for members service

### DIFF
--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -116,8 +116,16 @@ const siteOrigin = doBlock(() => {
     return `${protocol}//${host}`;
 });
 
-const contentApiUrl = urlUtils.urlFor('api', {version: 'v2', type: 'content'}, true);
-const membersApiUrl = urlUtils.urlFor('api', {version: 'v2', type: 'members'}, true);
+const getApiUrl = ({version, type}) => {
+    const {href} = new url.URL(
+        urlUtils.getApiPath({version, type}),
+        urlUtils.urlFor('admin', true)
+    );
+    return href;
+};
+
+const contentApiUrl = getApiUrl({version: 'v2', type: 'content'});
+const membersApiUrl = getApiUrl({version: 'v2', type: 'members'});
 
 const accessControl = {
     [siteOrigin]: {


### PR DESCRIPTION
no-issue

Previously we used urlFor which wasn't setup to correctly support
members. This changes members service to use the admin URL directly