### PR TITLE
Use v4 instead of v1 uuids

### DIFF
--- a/core/server/web/shared/middlewares/log-request.js
+++ b/core/server/web/shared/middlewares/log-request.js
@@ -7,7 +7,7 @@ const common = require('../../../lib/common');
  */
 module.exports = function logRequest(req, res, next) {
     const startTime = Date.now(),
-        requestId = req.get('X-Request-ID') || uuid.v1();
+        requestId = req.get('X-Request-ID') || uuid.v4();
 
     function logResponse() {
         res.responseTime = (Date.now() - startTime) + 'ms';

--- a/core/test/regression/api/v0.1/themes_spec.js
+++ b/core/test/regression/api/v0.1/themes_spec.js
@@ -25,7 +25,7 @@ describe('Themes API', function () {
                 .attach(fieldName, themePath);
         },
         editor: null
-    }, ghostServer, contentFolder = path.join(os.tmpdir(), uuid.v1(), 'ghost-test');
+    }, ghostServer, contentFolder = path.join(os.tmpdir(), uuid.v4(), 'ghost-test');
 
     before(function () {
         return ghost()

--- a/core/test/regression/api/v2/admin/db_spec.js
+++ b/core/test/regression/api/v2/admin/db_spec.js
@@ -68,7 +68,7 @@ describe('DB API', () => {
     });
 
     it('can export & import', () => {
-        const exportFolder = path.join(os.tmpdir(), uuid.v1());
+        const exportFolder = path.join(os.tmpdir(), uuid.v4());
         const exportPath = path.join(exportFolder, 'export.json');
 
         return request.put(localUtils.API.getApiQuery('settings/'))

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -851,7 +851,7 @@ startGhost = function startGhost(options) {
         forceStart: false,
         copyThemes: true,
         copySettings: true,
-        contentFolder: path.join(os.tmpdir(), uuid.v1(), 'ghost-test'),
+        contentFolder: path.join(os.tmpdir(), uuid.v4(), 'ghost-test'),
         subdir: false
     }, options);
 


### PR DESCRIPTION
I'm a co-author of the [uuid npm module](https://github.com/kelektiv/node-uuid) which is being used in some places within the code base of Ghost.

I'm currently trying to understand real-world use cases of [time-based UUIDs ("v1 UUIDs")](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

I found three occurrences where v1 UUIDs were being used instead of v4 UUIDs and I was wondering if any of these cases really require the semantically much more complex v1 UUIDs or whether we could live equally well with purely random v4 UUIDs?

At least the test suite still passes after my changes, so apparently this doesn't seem to introduce any known regressions.

I'd be really curious to understand the motivation for choosing v1 over v4 UUIDs in the first place, so any feedback on this would be highly appreciated!