### PR TITLE
Destroyed user sessions when changing password

### DIFF
--- a/core/test/regression/models/model_users_spec.js
+++ b/core/test/regression/models/model_users_spec.js
@@ -462,7 +462,7 @@ describe('User Model', function run() {
                 });
             });
 
-            it('password matches users email adress', function (done) {
+            it('password matches users email address', function (done) {
                 UserModel.changePassword({
                     newPassword: 'jbloggs@example.com',
                     ne2Password: 'jbloggs@example.com',


### PR DESCRIPTION
- includes refactoring to use modern js features

closes #10323 

I've done what I'm relatively confident in for now, but there are a things:

- Ghost Admin doesn't work because all requests 403 - this might be bug that needs to be addressed, or an edge case that needs to be handled. Currently, getting a 403 is pretty much the same UX as getting a 404.
  - This could be prevented by not signing the user out, but I'm not entirely sure how I would go about doing this... my first thought is adding the current session_id to the changePassword model call in the API microframework layer, but I'm not entirely sure how to do that, or if it's realistic.

- No tests... I'm not exactly sure where to add them 🌵 

edit: ran `grunt validate` but totally forgot to run `grunt lint`... locally I'm getting an eslint parsing error which is weird 😕 	