### PR TITLE
Fix import overriding private setting

### DIFF
--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -6,6 +6,33 @@ const debug = require('ghost-ignition').debug('importer:settings'),
     defaultSettings = require('../../../schema').defaultSettings,
     labsDefaults = JSON.parse(defaultSettings.blog.labs.defaultValue);
 
+const isFalse = (value) => {
+    // Catches false, null, undefined, empty string
+    if (!value) {
+        return true;
+    }
+    if (value === 'false') {
+        return true;
+    }
+    if (value === '0') {
+        return true;
+    }
+    return false;
+};
+
+const isTrue = (value) => {
+    if (value === true) {
+        return true;
+    }
+    if (value === 'true') {
+        return true;
+    }
+    if (value === '1') {
+        return true;
+    }
+    return false;
+};
+
 class SettingsImporter extends BaseImporter {
     constructor(allDataFromFile) {
         super(allDataFromFile, {
@@ -88,7 +115,7 @@ class SettingsImporter extends BaseImporter {
         });
 
         // Only show warning if we are importing a private site into a non-private site.
-        if (oldIsPrivate === false && newIsPrivate === true) {
+        if (isFalse(oldIsPrivate) && isTrue(newIsPrivate)) {
             this.problems.push({
                 message: 'IMPORTANT: Content in this import was previously published on a private Ghost install, but the current site is public. Are your privacy settings up to date?',
                 help: this.modelName,

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -114,6 +114,10 @@ class SettingsImporter extends BaseImporter {
             return data.key !== 'is_private';
         });
 
+        this.dataToImport = _.filter(this.dataToImport, (data) => {
+            return data.key !== 'password';
+        });
+
         // Only show warning if we are importing a private site into a non-private site.
         if (isFalse(oldIsPrivate) && isTrue(newIsPrivate)) {
             this.problems.push({

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -119,7 +119,7 @@ class SettingsImporter extends BaseImporter {
         });
 
         // Only show warning if we are importing a private site into a non-private site.
-        if (isFalse(oldIsPrivate) && isTrue(newIsPrivate)) {
+        if (oldIsPrivate && newIsPrivate && isFalse(oldIsPrivate.value) && isTrue(newIsPrivate.value)) {
             this.problems.push({
                 message: 'IMPORTANT: Content in this import was previously published on a private Ghost install, but the current site is public. Are your privacy settings up to date?',
                 help: this.modelName,

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -112,6 +112,13 @@ class SettingsImporter extends BaseImporter {
         return super.beforeImport();
     }
 
+    fetchExisting(modelOptions) {
+        return models.Settings.findAll(modelOptions)
+            .then((existingData) => {
+                this.existingData = existingData.toJSON();
+            });
+    }
+
     generateIdentifier() {
         this.stripProperties(['id']);
         return Promise.resolve();

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -80,6 +80,10 @@ class SettingsImporter extends BaseImporter {
             return ['core', 'theme'].indexOf(data.type) === -1;
         });
 
+        this.dataToImport = _.filter(this.dataToImport, (data) => {
+            return data.key !== 'is_private';
+        });
+
         _.each(this.dataToImport, (obj) => {
             if (obj.key === 'labs' && obj.value) {
                 // Overwrite the labs setting with our current defaults

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -80,9 +80,21 @@ class SettingsImporter extends BaseImporter {
             return ['core', 'theme'].indexOf(data.type) === -1;
         });
 
+        const newIsPrivate = _.find(this.dataToImport, {key: 'is_private'});
+        const oldIsPrivate = _.find(this.existingData, {key: 'is_private'});
+
         this.dataToImport = _.filter(this.dataToImport, (data) => {
             return data.key !== 'is_private';
         });
+
+        // Only show warning if we are importing a private site into a non-private site.
+        if (oldIsPrivate === false && newIsPrivate === true) {
+            this.problems.push({
+                message: 'IMPORTANT: Content in this import was previously published on a private Ghost install, but the current site is public. Are your privacy settings up to date?',
+                help: this.modelName,
+                context: JSON.stringify(newIsPrivate)
+            });
+        }
 
         _.each(this.dataToImport, (obj) => {
             if (obj.key === 'labs' && obj.value) {

--- a/core/test/unit/data/importer/importers/data/settings_spec.js
+++ b/core/test/unit/data/importer/importers/data/settings_spec.js
@@ -1,0 +1,69 @@
+const find = require('lodash/find');
+const should = require('should');
+const SettingsImporter = require('../../../../../../server/data/importer/importers/data/settings');
+
+describe('SettingsImporter', function () {
+    describe('#beforeImport', function () {
+        it('Removes the password setting', function () {
+            const fakeSettings = [{
+                key: 'password',
+                value: 'hunter2'
+            }, {
+                key: 'is_private',
+                value: true
+            }];
+
+            const importer = new SettingsImporter({settings: fakeSettings}, {dataKeyToImport: 'settings'});
+
+            importer.beforeImport();
+
+            const passwordSetting = find(importer.dataToImport, {key: 'password'});
+
+            should.equal(passwordSetting, undefined);
+        });
+
+        it('Removes the is_private setting', function () {
+            const fakeSettings = [{
+                key: 'password',
+                value: 'hunter2'
+            }, {
+                key: 'is_private',
+                value: true
+            }];
+
+            const importer = new SettingsImporter({settings: fakeSettings}, {dataKeyToImport: 'settings'});
+
+            importer.beforeImport();
+
+            const passwordSetting = find(importer.dataToImport, {key: 'is_private'});
+
+            should.equal(passwordSetting, undefined);
+        });
+
+        it('Adds a problem if the existing data is_private is false, and new data is_private is true', function () {
+            const fakeSettings = [{
+                key: 'password',
+                value: 'hunter2'
+            }, {
+                key: 'is_private',
+                value: true
+            }];
+
+            const fakeExistingSettings = [{
+                key: 'is_private',
+                value: false
+            }];
+
+            const importer = new SettingsImporter({settings: fakeSettings}, {dataKeyToImport: 'settings'});
+
+            importer.existingData = fakeExistingSettings;
+            importer.beforeImport();
+
+            const problem = find(importer.problems, {
+                message: 'IMPORTANT: Content in this import was previously published on a private Ghost install, but the current site is public. Are your privacy settings up to date?'
+            });
+
+            should.exist(problem);
+        });
+    });
+});


### PR DESCRIPTION
closes #10788 

- This removes the `is_private` setting from imports under *all* conditions.
- This outputs a "problem" when the import data's `is_private` settings differs from the current databases `is_private` setting.