### PR TITLE
Moved members static pages to members api URL

### DIFF
--- a/core/server/public/members.js
+++ b/core/server/public/members.js
@@ -1,1 +1,1 @@
-MembersThemeBindings.init({ssrUrl: "{{blog-url}}/members/ssr", membersUrl: "{{admin-url}}/members"});
+MembersThemeBindings.init({ssrUrl: "{{blog-url}}/members/ssr", membersUrl: "{{admin-url}}/api/v2/members/static"});

--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -116,6 +116,11 @@ const siteOrigin = doBlock(() => {
     return `${protocol}//${host}`;
 });
 
+const adminOrigin = doBlock(() => {
+    const {protocol, host} = url.parse(urlUtils.urlFor('admin', true));
+    return `${protocol}//${host}`;
+});
+
 const getApiUrl = ({version, type}) => {
     const {href} = new url.URL(
         urlUtils.getApiPath({version, type}),
@@ -180,7 +185,7 @@ const getSiteConfig = () => {
 const membersApiInstance = MembersApi({
     authConfig: {
         issuer: membersApiUrl,
-        ssoOrigin: siteOrigin,
+        ssoOrigin: adminOrigin,
         publicKey: settingsCache.get('members_public_key'),
         privateKey: settingsCache.get('members_private_key'),
         sessionSecret: settingsCache.get('members_session_secret'),

--- a/core/server/services/members/index.js
+++ b/core/server/services/members/index.js
@@ -1,37 +1,9 @@
-const config = require('../../config/index.js');
-const common = require('../../lib/common');
-
 module.exports = {
     get api() {
-        if (!config.get('enableDeveloperExperiments')) {
-            return {
-                apiRouter: function (req, res, next) {
-                    return next(new common.errors.NotFoundError());
-                },
-                staticRouter: function (req, res, next) {
-                    return next(new common.errors.NotFoundError());
-                },
-                ssr: {
-                    exchangeTokenForSession: function () {
-                        return Promise.reject(new common.errors.InternalServerError());
-                    },
-                    deleteSession: function () {
-                        return Promise.reject(new common.errors.InternalServerError());
-                    },
-                    getMemberDataFromSession: function () {
-                        return Promise.reject(new common.errors.InternalServerError());
-                    }
-                }
-            };
-        }
         return require('./api');
     },
 
     get authPages() {
         return require('./authPages');
-    },
-
-    get gateway() {
-        return require('./api').staticRouter;
     }
 };

--- a/core/server/web/api/index.js
+++ b/core/server/web/api/index.js
@@ -14,7 +14,7 @@ module.exports = function setupApiApp() {
     apiApp.use(urlUtils.getVersionPath({version: 'v0.1'}), require('./v0.1/app')());
     apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'content'}), require('./v2/content/app')());
     apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'admin'}), require('./v2/admin/app')());
-    apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'members'}), labs.members, membersService.api.apiRouter);
+    apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'members'}), require('./v2/members/app')());
 
     // Error handling for requests to non-existent API versions
     apiApp.use(errorHandler.resourceNotFound);

--- a/core/server/web/api/index.js
+++ b/core/server/web/api/index.js
@@ -2,9 +2,6 @@ const debug = require('ghost-ignition').debug('web:api:default:app');
 const express = require('express');
 const urlUtils = require('../../lib/url-utils');
 const errorHandler = require('../shared/middlewares/error-handler');
-const membersService = require('../../services/members');
-
-const labs = require('../shared/middlewares/labs');
 
 module.exports = function setupApiApp() {
     debug('Parent API setup start');

--- a/core/server/web/api/v2/members/app.js
+++ b/core/server/web/api/v2/members/app.js
@@ -1,0 +1,27 @@
+const debug = require('ghost-ignition').debug('web:v2:members:app');
+const express = require('express');
+const membersService = require('../../../../services/members');
+const labs = require('../../../shared/middlewares/labs');
+const shared = require('../../../shared');
+
+module.exports = function setupMembersApiApp() {
+    debug('Members API v2 setup start');
+    const apiApp = express();
+
+    // Entire app is behind labs flag
+    apiApp.use(labs.members);
+
+    // Set up the auth pages
+    apiApp.use('/static/auth', membersService.authPages);
+
+    // Set up the api endpoints and the gateway
+    apiApp.use(membersService.api);
+
+    // API error handling
+    apiApp.use(shared.middlewares.errorHandler.resourceNotFound);
+    apiApp.use(shared.middlewares.errorHandler.handleJSONResponseV2);
+
+    debug('Members API v2 setup end');
+
+    return apiApp;
+};

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -4,8 +4,6 @@ const config = require('../config');
 const compress = require('compression');
 const netjet = require('netjet');
 const shared = require('./shared');
-const labs = require('./shared/middlewares/labs');
-const membersService = require('../services/members');
 
 module.exports = function setupParentApp(options = {}) {
     debug('ParentApp setup start');
@@ -44,10 +42,6 @@ module.exports = function setupParentApp(options = {}) {
     // API
     // @TODO: finish refactoring the API app
     parentApp.use('/ghost/api', require('./api')());
-
-    // MEMBERS
-    parentApp.use('/ghost/members', labs.members, membersService.gateway);
-    parentApp.use('/ghost/members/auth', labs.members, membersService.authPages);
 
     // ADMIN
     parentApp.use('/ghost', require('./admin')());

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nexes/nql": "0.2.2",
     "@tryghost/helpers": "1.1.6",
     "@tryghost/members-api": "0.2.0",
-    "@tryghost/members-auth-pages": "0.2.2",
+    "@tryghost/members-auth-pages": "1.0.0",
     "@tryghost/members-ssr": "0.1.5",
     "@tryghost/members-theme-bindings": "0.2.1",
     "@tryghost/social-urls": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@nexes/nql": "0.2.2",
     "@tryghost/helpers": "1.1.6",
-    "@tryghost/members-api": "0.1.2",
+    "@tryghost/members-api": "0.2.0",
     "@tryghost/members-auth-pages": "0.2.2",
     "@tryghost/members-ssr": "0.1.5",
     "@tryghost/members-theme-bindings": "0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,10 +141,10 @@
   dependencies:
     "@tryghost/kg-clean-basic-html" "^0.1.1"
 
-"@tryghost/members-api@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.1.2.tgz#e7ef303e709d44d4f2dc0dda4f38af4f80c21c24"
-  integrity sha512-s8uKedgycszfRu3LH7ZTnLKk3CO099s+n+Kj0nljyb7thCqABiDGCSJ/Fxs72WxGGPVTtDB2WJAPGLkIe89TLQ==
+"@tryghost/members-api@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.2.0.tgz#1f13dabc39015f8a5447a714dc05162426775027"
+  integrity sha512-fLTQylyUz16ZL0KJ4kBvWnUsQbq1NkLFXVkQjOEo/xFV1SG0iJBKlkVtPWfyncSHyGBSXAv9TcQymiT+9vr7pQ==
   dependencies:
     bluebird "^3.5.4"
     body-parser "^1.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,10 +155,10 @@
     lodash "^4.17.11"
     node-jose "^1.1.3"
 
-"@tryghost/members-auth-pages@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-auth-pages/-/members-auth-pages-0.2.2.tgz#c26db5afc8fbe676b1b3e3425ad819c42ee12134"
-  integrity sha512-Dbdz7KDG1cQAen5elNQr5+YwCmRbtAj6g6oGgIF6GjiBzMjtJp8E+Yx7fBAJ3stgkP3i5xLd3iQ+Bo/3h81IuA==
+"@tryghost/members-auth-pages@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-auth-pages/-/members-auth-pages-1.0.0.tgz#9ba9bd6c608a68d782e8b7fd8c2939d8281386f9"
+  integrity sha512-N/NcSEParuV2dJ3WhGvvcwWLGJRha663l7Hs1XDlSKjAE06EsFlVb5uSSQdCLM27SWUXT0Irx8WKDSNa3J0v2A==
   dependencies:
     "@tryghost/members-gateway-protocol" "^0.1.2"
     preact "^8.2.1"


### PR DESCRIPTION
closes #10886 

This includes a minor refactor of the mounting of members, to bring it more in-line with how the rest of the API's are mounted.

We also remove some uneccessary "mock" code.

I have tested this locally and it all works fine.

Outstandings:

- [x] fix tests
- [ ] for some reason the `/ghost/api/v2/members/static/auth` URL redirects to force a trailing `/` - but the gateway doesn't - we should deffo normalise that.