### PR TITLE
🐛 Allow administrators to change other users' passwords

### DIFF
--- a/core/server/api/v2/users.js
+++ b/core/server/api/v2/users.js
@@ -146,7 +146,7 @@ module.exports = {
             data: {
                 newPassword: {required: true},
                 ne2Password: {required: true},
-                oldPassword: {required: true},
+                oldPassword: {required: false},
                 user_id: {required: true}
             }
         },


### PR DESCRIPTION
closes #10427

- Administrators don't know other users' passwords, but they should be able to change other users' password
- Don't require oldPassword to be provided

I've manually tested that Authors cannot change other users' passwords, but I'm not sure where the tests are for that; I'm not sure if I need to add any additional tests as well