### PR TITLE
🐛 output proper error message when get helper doesn't have API access

### DIFF
--- a/core/server/services/labs.js
+++ b/core/server/services/labs.js
@@ -40,14 +40,10 @@ labs.enabledHelper = function enabledHelper(options, callback) {
 
     common.logging.error(new common.errors.DisabledFeatureError(errDetails));
 
-    errString = new SafeString(
-        '<script>console.error("' + _.values(errDetails).join(' ') + '");</script>'
-    );
+    errString = new SafeString(`<script>console.error("${_.values(errDetails).join(' ')}");</script>`);
 
     if (options.async) {
-        return Promise.resolve(function asyncError() {
-            return errString;
-        });
+        return Promise.resolve(errString);
     }
 
     return errString;

--- a/core/test/unit/helpers/get_spec.js
+++ b/core/test/unit/helpers/get_spec.js
@@ -42,8 +42,7 @@ describe('{{#get}} helper', function () {
             inverse.called.should.be.false();
 
             should.exist(result);
-            result.should.be.a.Function();
-            result().should.be.an.Object().with.property(
+            result.should.be.an.Object().with.property(
                 'string',
                 '<script>console.error("The {{#get}} helper requires your theme to have API access. ' +
                 'Please enable the v2 API via your theme\'s package.json file. ' +


### PR DESCRIPTION
closes #10875
