### PR TITLE
Authentication controller migration to v2

### DIFF
--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -4,7 +4,6 @@ const Promise = require('bluebird'),
     config = require('../../config'),
     common = require('../../lib/common'),
     security = require('../../lib/security'),
-    constants = require('../../lib/constants'),
     pipeline = require('../../lib/promise/pipeline'),
     urlUtils = require('../../lib/url-utils'),
     mail = require('../../services/mail'),
@@ -79,32 +78,7 @@ authentication = {
         }
 
         function generateToken(email) {
-            const options = {context: {internal: true}};
-            let dbHash, token;
-
-            return settingsAPI.read(merge({key: 'db_hash'}, options))
-                .then((response) => {
-                    dbHash = response.settings[0].value;
-
-                    return models.User.getByEmail(email, options);
-                })
-                .then((user) => {
-                    if (!user) {
-                        throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.users.userNotFound')});
-                    }
-
-                    token = security.tokens.resetToken.generateHash({
-                        expires: Date.now() + constants.ONE_DAY_MS,
-                        email: email,
-                        dbHash: dbHash,
-                        password: user.get('password')
-                    });
-
-                    return {
-                        email: email,
-                        resetToken: token
-                    };
-                });
+            return auth.passwordreset.generateToken(email, settingsAPI);
         }
 
         function sendResetNotification(data) {

--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -22,10 +22,8 @@ let authentication;
  *
  * @return {Promise<Boolean>}
  */
-function checkSetup() {
-    return authentication.isSetup().then((result) => {
-        return result.setup[0].status;
-    });
+function checkIsSetup() {
+    models.User.isSetup();
 }
 
 /**
@@ -36,7 +34,7 @@ function checkSetup() {
  */
 function assertSetupCompleted(status) {
     return function checkPermission(__) {
-        return checkSetup().then((isSetup) => {
+        return checkIsSetup().then((isSetup) => {
             if (isSetup === status) {
                 return __;
             }
@@ -486,10 +484,6 @@ authentication = {
     isSetup() {
         let tasks;
 
-        function checkSetupStatus() {
-            return models.User.isSetup();
-        }
-
         function formatResponse(isSetup) {
             return {
                 setup: [
@@ -505,7 +499,7 @@ authentication = {
         }
 
         tasks = [
-            checkSetupStatus,
+            checkIsSetup,
             formatResponse
         ];
 

--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -8,6 +8,7 @@ const Promise = require('bluebird'),
     pipeline = require('../../lib/promise/pipeline'),
     urlUtils = require('../../lib/url-utils'),
     mail = require('../../services/mail'),
+    auth = require('../../services/auth'),
     localUtils = require('./utils'),
     models = require('../../models'),
     web = require('../../web'),
@@ -18,15 +19,6 @@ const Promise = require('bluebird'),
 let authentication;
 
 /**
- * Returns setup status
- *
- * @return {Promise<Boolean>}
- */
-function checkIsSetup() {
-    models.User.isSetup();
-}
-
-/**
  * Allows an assertion to be made about setup status.
  *
  * @param  {Boolean} status True: setup must be complete. False: setup must not be complete.
@@ -34,7 +26,7 @@ function checkIsSetup() {
  */
 function assertSetupCompleted(status) {
     return function checkPermission(__) {
-        return checkIsSetup().then((isSetup) => {
+        return auth.setup.checkIsSetup().then((isSetup) => {
             if (isSetup === status) {
                 return __;
             }
@@ -499,7 +491,7 @@ authentication = {
         }
 
         tasks = [
-            checkIsSetup,
+            auth.setup.checkIsSetup,
             formatResponse
         ];
 

--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird'),
-    {merge, omit, cloneDeep, assign} = require('lodash'),
+    {cloneDeep, assign} = require('lodash'),
     validator = require('validator'),
     config = require('../../config'),
     common = require('../../lib/common'),

--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -35,25 +35,6 @@ function setupTasks(setupData) {
         });
     }
 
-    function doSettings(data) {
-        const user = data.user,
-            blogTitle = data.userData.blogTitle,
-            context = {context: {user: data.user.id}};
-
-        let userSettings;
-
-        if (!blogTitle || typeof blogTitle !== 'string') {
-            return user;
-        }
-
-        userSettings = [
-            {key: 'title', value: blogTitle.trim()},
-            {key: 'description', value: common.i18n.t('common.api.authentication.sampleBlogDescription')}
-        ];
-
-        return settingsAPI.edit({settings: userSettings}, context).return(user);
-    }
-
     function formatResponse(user) {
         return user.toJSON({context: {internal: true}});
     }
@@ -61,7 +42,7 @@ function setupTasks(setupData) {
     tasks = [
         validateData,
         auth.setup.setupUser,
-        doSettings,
+        auth.setup.doSettings,
         formatResponse
     ];
 

--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird'),
-    {extend, merge, omit, cloneDeep, assign} = require('lodash'),
+    {merge, omit, cloneDeep, assign} = require('lodash'),
     validator = require('validator'),
     config = require('../../config'),
     common = require('../../lib/common'),
@@ -35,26 +35,6 @@ function setupTasks(setupData) {
         });
     }
 
-    function setupUser(userData) {
-        const context = {context: {internal: true}},
-            User = models.User;
-
-        return User.findOne({role: 'Owner', status: 'all'}).then((owner) => {
-            if (!owner) {
-                throw new common.errors.GhostError({
-                    message: common.i18n.t('errors.api.authentication.setupUnableToRun')
-                });
-            }
-
-            return User.setup(userData, extend({id: owner.id}, context));
-        }).then((user) => {
-            return {
-                user: user,
-                userData: userData
-            };
-        });
-    }
-
     function doSettings(data) {
         const user = data.user,
             blogTitle = data.userData.blogTitle,
@@ -80,7 +60,7 @@ function setupTasks(setupData) {
 
     tasks = [
         validateData,
-        setupUser,
+        auth.setup.setupUser,
         doSettings,
         formatResponse
     ];

--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -443,38 +443,7 @@ authentication = {
         }
 
         function sendNotification(setupUser) {
-            const data = {
-                ownerEmail: setupUser.email
-            };
-
-            common.events.emit('setup.completed', setupUser);
-
-            if (config.get('sendWelcomeEmail')) {
-                return mail.utils.generateContent({data: data, template: 'welcome'})
-                    .then((content) => {
-                        const message = {
-                                to: setupUser.email,
-                                subject: common.i18n.t('common.api.authentication.mail.yourNewGhostBlog'),
-                                html: content.html,
-                                text: content.text
-                            },
-                            payload = {
-                                mail: [{
-                                    message: message,
-                                    options: {}
-                                }]
-                            };
-
-                        mailAPI.send(payload, {context: {internal: true}})
-                            .catch((err) => {
-                                err.context = common.i18n.t('errors.api.authentication.unableToSendWelcomeEmail');
-                                common.logging.error(err);
-                            });
-                    })
-                    .return(setupUser);
-            }
-
-            return setupUser;
+            return auth.setup.sendNotification(setupUser, mailAPI);
         }
 
         function formatResponse(setupUser) {

--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -3,10 +3,7 @@ const Promise = require('bluebird'),
     validator = require('validator'),
     config = require('../../config'),
     common = require('../../lib/common'),
-    security = require('../../lib/security'),
     pipeline = require('../../lib/promise/pipeline'),
-    urlUtils = require('../../lib/url-utils'),
-    mail = require('../../services/mail'),
     auth = require('../../services/auth'),
     invitations = require('../../services/invitations'),
     localUtils = require('./utils'),
@@ -85,29 +82,7 @@ authentication = {
         }
 
         function sendResetNotification(data) {
-            const adminUrl = urlUtils.urlFor('admin', true),
-                resetUrl = urlUtils.urlJoin(adminUrl, 'reset', security.url.encodeBase64(data.resetToken), '/');
-
-            return mail.utils.generateContent({
-                data: {
-                    resetUrl: resetUrl
-                },
-                template: 'reset-password'
-            }).then((content) => {
-                const payload = {
-                    mail: [{
-                        message: {
-                            to: data.email,
-                            subject: common.i18n.t('common.api.authentication.mail.resetPassword'),
-                            html: content.html,
-                            text: content.text
-                        },
-                        options: {}
-                    }]
-                };
-
-                return mailAPI.send(payload, {context: {internal: true}});
-            });
+            return auth.passwordreset.sendResetNotification(data, mailAPI);
         }
 
         function formatResponse() {

--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -18,35 +18,6 @@ const Promise = require('bluebird'),
 
 let authentication;
 
-/**
- * Allows an assertion to be made about setup status.
- *
- * @param  {Boolean} status True: setup must be complete. False: setup must not be complete.
- * @return {Function} returns a "task ready" function
- */
-function assertSetupCompleted(status) {
-    return function checkPermission(__) {
-        return auth.setup.checkIsSetup().then((isSetup) => {
-            if (isSetup === status) {
-                return __;
-            }
-
-            const completed = common.i18n.t('errors.api.authentication.setupAlreadyCompleted'),
-                notCompleted = common.i18n.t('errors.api.authentication.setupMustBeCompleted');
-
-            function throwReason(reason) {
-                throw new common.errors.NoPermissionError({message: reason});
-            }
-
-            if (isSetup) {
-                throwReason(completed);
-            } else {
-                throwReason(notCompleted);
-            }
-        });
-    };
-}
-
 function setupTasks(setupData) {
     let tasks;
 
@@ -209,7 +180,7 @@ authentication = {
         }
 
         tasks = [
-            assertSetupCompleted(true),
+            auth.setup.assertSetupCompleted(true),
             validateRequest,
             generateToken,
             sendResetNotification,
@@ -338,7 +309,7 @@ authentication = {
 
         tasks = [
             validateRequest,
-            assertSetupCompleted(true),
+            auth.setup.assertSetupCompleted(true),
             extractTokenParts,
             protectBruteForce,
             doReset,
@@ -418,7 +389,7 @@ authentication = {
         }
 
         tasks = [
-            assertSetupCompleted(true),
+            auth.setup.assertSetupCompleted(true),
             validateInvitation,
             processInvitation,
             formatResponse
@@ -462,7 +433,7 @@ authentication = {
 
         tasks = [
             processArgs,
-            assertSetupCompleted(true),
+            auth.setup.assertSetupCompleted(true),
             checkInvitation
         ];
 
@@ -550,7 +521,7 @@ authentication = {
         }
 
         tasks = [
-            assertSetupCompleted(false),
+            auth.setup.assertSetupCompleted(false),
             doSetup,
             sendNotification,
             formatResponse
@@ -594,7 +565,7 @@ authentication = {
 
         tasks = [
             processArgs,
-            assertSetupCompleted(true),
+            auth.setup.assertSetupCompleted(true),
             checkPermission,
             setupTasks,
             formatResponse

--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -34,6 +34,10 @@ function setupTasks(setupData) {
         });
     }
 
+    function doSettings(data) {
+        return auth.setup.doSettings(data, settingsAPI);
+    }
+
     function formatResponse(user) {
         return user.toJSON({context: {internal: true}});
     }
@@ -41,7 +45,7 @@ function setupTasks(setupData) {
     tasks = [
         validateData,
         auth.setup.setupUser,
-        auth.setup.doSettings,
+        doSettings,
         formatResponse
     ];
 

--- a/core/server/services/auth/index.js
+++ b/core/server/services/auth/index.js
@@ -10,6 +10,11 @@ module.exports = {
     get session() {
         return require('./session');
     },
+
+    get setup() {
+        return require('./setup');
+    },
+
     /*
      * TODO: Get rid of these when v0.1 is gone
      */

--- a/core/server/services/auth/index.js
+++ b/core/server/services/auth/index.js
@@ -15,6 +15,10 @@ module.exports = {
         return require('./setup');
     },
 
+    get passwordreset() {
+        return require('./passwordreset');
+    },
+
     /*
      * TODO: Get rid of these when v0.1 is gone
      */

--- a/core/server/services/auth/passwordreset.js
+++ b/core/server/services/auth/passwordreset.js
@@ -1,0 +1,38 @@
+const _ = require('lodash');
+const security = require('../../lib/security');
+const constants = require('../../lib/constants');
+const common = require('../../lib/common');
+const models = require('../../models');
+
+function generateToken(email, settingsAPI) {
+    const options = {context: {internal: true}};
+    let dbHash, token;
+
+    return settingsAPI.read(_.merge({key: 'db_hash'}, options))
+        .then((response) => {
+            dbHash = response.settings[0].value;
+
+            return models.User.getByEmail(email, options);
+        })
+        .then((user) => {
+            if (!user) {
+                throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.users.userNotFound')});
+            }
+
+            token = security.tokens.resetToken.generateHash({
+                expires: Date.now() + constants.ONE_DAY_MS,
+                email: email,
+                dbHash: dbHash,
+                password: user.get('password')
+            });
+
+            return {
+                email: email,
+                resetToken: token
+            };
+        });
+}
+
+module.exports = {
+    generateToken: generateToken
+};

--- a/core/server/services/auth/passwordreset.js
+++ b/core/server/services/auth/passwordreset.js
@@ -66,7 +66,6 @@ function protectBruteForce({options, tokenParts}) {
 }
 
 function doReset(options, tokenParts, settingsAPI) {
-    let tokenIsCorrect;
     let dbHash;
 
     const data = options.data.passwordreset[0];
@@ -85,7 +84,7 @@ function doReset(options, tokenParts, settingsAPI) {
                 throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.users.userNotFound')});
             }
 
-            tokenIsCorrect = security.tokens.resetToken.compare({
+            let tokenIsCorrect = security.tokens.resetToken.compare({
                 token: resetToken,
                 dbHash: dbHash,
                 password: user.get('password')

--- a/core/server/services/auth/passwordreset.js
+++ b/core/server/services/auth/passwordreset.js
@@ -118,30 +118,30 @@ function doReset(options, tokenParts, settingsAPI) {
         });
 }
 
-function sendResetNotification(data, mailAPI) {
-    const adminUrl = urlUtils.urlFor('admin', true),
-        resetUrl = urlUtils.urlJoin(adminUrl, 'reset', security.url.encodeBase64(data.resetToken), '/');
+async function sendResetNotification(data, mailAPI) {
+    const adminUrl = urlUtils.urlFor('admin', true);
+    const resetUrl = urlUtils.urlJoin(adminUrl, 'reset', security.url.encodeBase64(data.resetToken), '/');
 
-    return mail.utils.generateContent({
+    const content = await mail.utils.generateContent({
         data: {
             resetUrl: resetUrl
         },
         template: 'reset-password'
-    }).then((content) => {
-        const payload = {
-            mail: [{
-                message: {
-                    to: data.email,
-                    subject: common.i18n.t('common.api.authentication.mail.resetPassword'),
-                    html: content.html,
-                    text: content.text
-                },
-                options: {}
-            }]
-        };
-
-        return mailAPI.send(payload, {context: {internal: true}});
     });
+
+    const payload = {
+        mail: [{
+            message: {
+                to: data.email,
+                subject: common.i18n.t('common.api.authentication.mail.resetPassword'),
+                html: content.html,
+                text: content.text
+            },
+            options: {}
+        }]
+    };
+
+    return mailAPI.send(payload, {context: {internal: true}});
 }
 
 module.exports = {

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -43,20 +43,20 @@ function assertSetupCompleted(status) {
 async function setupUser(userData) {
     const context = {context: {internal: true}};
 
-    return models.User.findOne({role: 'Owner', status: 'all'}).then((owner) => {
-        if (!owner) {
-            throw new common.errors.GhostError({
-                message: common.i18n.t('errors.api.authentication.setupUnableToRun')
-            });
-        }
+    const owner = await models.User.findOne({role: 'Owner', status: 'all'});
 
-        return models.User.setup(userData, _.extend({id: owner.id}, context));
-    }).then((user) => {
-        return {
-            user: user,
-            userData: userData
-        };
-    });
+    if (!owner) {
+        throw new common.errors.GhostError({
+            message: common.i18n.t('errors.api.authentication.setupUnableToRun')
+        });
+    }
+
+    const user = await models.User.setup(userData, _.extend({id: owner.id}, context));
+
+    return {
+        user: user,
+        userData: userData
+    };
 }
 
 module.exports = {

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -1,0 +1,14 @@
+const models = require('../../models');
+
+/**
+ * Returns setup status
+ *
+ * @return {Promise<Boolean>}
+ */
+function checkIsSetup() {
+    return models.User.isSetup();
+}
+
+module.exports = {
+    checkIsSetup: checkIsSetup
+};

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -1,3 +1,4 @@
+const common = require('../../lib/common');
 const models = require('../../models');
 
 /**
@@ -9,6 +10,36 @@ function checkIsSetup() {
     return models.User.isSetup();
 }
 
+/**
+ * Allows an assertion to be made about setup status.
+ *
+ * @param  {Boolean} status True: setup must be complete. False: setup must not be complete.
+ * @return {Function} returns a "task ready" function
+ */
+function assertSetupCompleted(status) {
+    return function checkPermission(__) {
+        return checkIsSetup().then((isSetup) => {
+            if (isSetup === status) {
+                return __;
+            }
+
+            const completed = common.i18n.t('errors.api.authentication.setupAlreadyCompleted'),
+                notCompleted = common.i18n.t('errors.api.authentication.setupMustBeCompleted');
+
+            function throwReason(reason) {
+                throw new common.errors.NoPermissionError({message: reason});
+            }
+
+            if (isSetup) {
+                throwReason(completed);
+            } else {
+                throwReason(notCompleted);
+            }
+        });
+    };
+}
+
 module.exports = {
-    checkIsSetup: checkIsSetup
+    checkIsSetup: checkIsSetup,
+    assertSetupCompleted: assertSetupCompleted
 };

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -59,9 +59,9 @@ async function setupUser(userData) {
     };
 }
 
-function doSettings(data) {
-    const user = data.user,
-        blogTitle = data.userData.blogTitle;
+async function doSettings(data) {
+    const user = data.user;
+    const blogTitle = data.userData.blogTitle;
 
     let userSettings;
 
@@ -74,10 +74,9 @@ function doSettings(data) {
         {key: 'description', value: common.i18n.t('common.api.authentication.sampleBlogDescription')}
     ];
 
-    return models.Settings.edit(userSettings)
-        .then(() => {
-            return user;
-        });
+    await models.Settings.edit(userSettings);
+
+    return user;
 }
 
 module.exports = {

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -59,8 +59,30 @@ async function setupUser(userData) {
     };
 }
 
+function doSettings(data) {
+    const user = data.user,
+        blogTitle = data.userData.blogTitle;
+
+    let userSettings;
+
+    if (!blogTitle || typeof blogTitle !== 'string') {
+        return user;
+    }
+
+    userSettings = [
+        {key: 'title', value: blogTitle.trim()},
+        {key: 'description', value: common.i18n.t('common.api.authentication.sampleBlogDescription')}
+    ];
+
+    return models.Settings.edit(userSettings)
+        .then(() => {
+            return user;
+        });
+}
+
 module.exports = {
     checkIsSetup: checkIsSetup,
     assertSetupCompleted: assertSetupCompleted,
-    setupUser: setupUser
+    setupUser: setupUser,
+    doSettings: doSettings
 };

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -6,7 +6,7 @@ const models = require('../../models');
  *
  * @return {Promise<Boolean>}
  */
-function checkIsSetup() {
+async function checkIsSetup() {
     return models.User.isSetup();
 }
 
@@ -17,25 +17,25 @@ function checkIsSetup() {
  * @return {Function} returns a "task ready" function
  */
 function assertSetupCompleted(status) {
-    return function checkPermission(__) {
-        return checkIsSetup().then((isSetup) => {
-            if (isSetup === status) {
-                return __;
-            }
+    return async function checkPermission(__) {
+        const isSetup = await checkIsSetup();
 
-            const completed = common.i18n.t('errors.api.authentication.setupAlreadyCompleted'),
-                notCompleted = common.i18n.t('errors.api.authentication.setupMustBeCompleted');
+        if (isSetup === status) {
+            return __;
+        }
 
-            function throwReason(reason) {
-                throw new common.errors.NoPermissionError({message: reason});
-            }
+        const completed = common.i18n.t('errors.api.authentication.setupAlreadyCompleted');
+        const notCompleted = common.i18n.t('errors.api.authentication.setupMustBeCompleted');
 
-            if (isSetup) {
-                throwReason(completed);
-            } else {
-                throwReason(notCompleted);
-            }
-        });
+        function throwReason(reason) {
+            throw new common.errors.NoPermissionError({message: reason});
+        }
+
+        if (isSetup) {
+            throwReason(completed);
+        } else {
+            throwReason(notCompleted);
+        }
     };
 }
 

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const config = require('../../config');
 const common = require('../../lib/common');
 const models = require('../../models');
-const mail = require('../../services/mail');
+const mail = require('../mail');
 
 /**
  * Returns setup status
@@ -61,7 +61,8 @@ async function setupUser(userData) {
     };
 }
 
-async function doSettings(data) {
+async function doSettings(data, settingsAPI) {
+    const context = {context: {user: data.user.id}};
     const user = data.user;
     const blogTitle = data.userData.blogTitle;
 
@@ -76,7 +77,7 @@ async function doSettings(data) {
         {key: 'description', value: common.i18n.t('common.api.authentication.sampleBlogDescription')}
     ];
 
-    await models.Settings.edit(userSettings);
+    await settingsAPI.edit({settings: userSettings}, context);
 
     return user;
 }

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -40,18 +40,17 @@ function assertSetupCompleted(status) {
     };
 }
 
-function setupUser(userData) {
-    const context = {context: {internal: true}},
-        User = models.User;
+async function setupUser(userData) {
+    const context = {context: {internal: true}};
 
-    return User.findOne({role: 'Owner', status: 'all'}).then((owner) => {
+    return models.User.findOne({role: 'Owner', status: 'all'}).then((owner) => {
         if (!owner) {
             throw new common.errors.GhostError({
                 message: common.i18n.t('errors.api.authentication.setupUnableToRun')
             });
         }
 
-        return User.setup(userData, _.extend({id: owner.id}, context));
+        return models.User.setup(userData, _.extend({id: owner.id}, context));
     }).then((user) => {
         return {
             user: user,

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const common = require('../../lib/common');
 const models = require('../../models');
 
@@ -39,7 +40,28 @@ function assertSetupCompleted(status) {
     };
 }
 
+function setupUser(userData) {
+    const context = {context: {internal: true}},
+        User = models.User;
+
+    return User.findOne({role: 'Owner', status: 'all'}).then((owner) => {
+        if (!owner) {
+            throw new common.errors.GhostError({
+                message: common.i18n.t('errors.api.authentication.setupUnableToRun')
+            });
+        }
+
+        return User.setup(userData, _.extend({id: owner.id}, context));
+    }).then((user) => {
+        return {
+            user: user,
+            userData: userData
+        };
+    });
+}
+
 module.exports = {
     checkIsSetup: checkIsSetup,
-    assertSetupCompleted: assertSetupCompleted
+    assertSetupCompleted: assertSetupCompleted,
+    setupUser: setupUser
 };

--- a/core/server/services/invitations/accept.js
+++ b/core/server/services/invitations/accept.js
@@ -1,0 +1,36 @@
+const common = require('../../lib/common');
+const models = require('../../models');
+const security = require('../../lib/security');
+
+function accept(invitation) {
+    const data = invitation.invitation[0];
+    const inviteToken = security.url.decodeBase64(data.token);
+    const options = {context: {internal: true}};
+
+    let invite;
+
+    return models.Invite.findOne({token: inviteToken, status: 'sent'}, options)
+        .then((_invite) => {
+            invite = _invite;
+
+            if (!invite) {
+                throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.invites.inviteNotFound')});
+            }
+
+            if (invite.get('expires') < Date.now()) {
+                throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.invites.inviteExpired')});
+            }
+
+            return models.User.add({
+                email: data.email,
+                name: data.name,
+                password: data.password,
+                roles: [invite.toJSON().role_id]
+            }, options);
+        })
+        .then(() => {
+            return invite.destroy(options);
+        });
+}
+
+module.exports = accept;

--- a/core/server/services/invitations/accept.js
+++ b/core/server/services/invitations/accept.js
@@ -2,35 +2,29 @@ const common = require('../../lib/common');
 const models = require('../../models');
 const security = require('../../lib/security');
 
-function accept(invitation) {
+async function accept(invitation) {
     const data = invitation.invitation[0];
     const inviteToken = security.url.decodeBase64(data.token);
     const options = {context: {internal: true}};
 
-    let invite;
+    let invite = await models.Invite.findOne({token: inviteToken, status: 'sent'}, options);
 
-    return models.Invite.findOne({token: inviteToken, status: 'sent'}, options)
-        .then((_invite) => {
-            invite = _invite;
+    if (!invite) {
+        throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.invites.inviteNotFound')});
+    }
 
-            if (!invite) {
-                throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.invites.inviteNotFound')});
-            }
+    if (invite.get('expires') < Date.now()) {
+        throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.invites.inviteExpired')});
+    }
 
-            if (invite.get('expires') < Date.now()) {
-                throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.invites.inviteExpired')});
-            }
+    await models.User.add({
+        email: data.email,
+        name: data.name,
+        password: data.password,
+        roles: [invite.toJSON().role_id]
+    }, options);
 
-            return models.User.add({
-                email: data.email,
-                name: data.name,
-                password: data.password,
-                roles: [invite.toJSON().role_id]
-            }, options);
-        })
-        .then(() => {
-            return invite.destroy(options);
-        });
+    return invite.destroy(options);
 }
 
 module.exports = accept;

--- a/core/server/services/invitations/index.js
+++ b/core/server/services/invitations/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+    get accept() {
+        return require('./accept');
+    }
+};


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/10060

This is a prep work to extract logic into v2 authentication controller. 
@allouis just heads up that this is in progress. The plan is to first extract logic into manageable components/services then copy code across to v2. This extraction is meant to save time and code duplication when we'll be copying the code from v2 to v3.

TODO:
- [x] extract logic out of authentication's setup methods
- [x] extract logic out of authentication's notifications methods
- [x] extract logic out of authentication's passwordreset methods
  - [x] extract logic out of `authentication.resetPassword` method 
  - [x] extract logic out of `authentication.generateResetToken` method 

Will come in follow up PR:
- [ ] define authentication v2 controller using new extracted modules