### PR TITLE
🐛 Fixed theme upload error when overriding existing

### DIFF
--- a/core/frontend/services/themes/storage.js
+++ b/core/frontend/services/themes/storage.js
@@ -69,17 +69,18 @@ module.exports = {
                 return themeLoader.loadOneTheme(shortName);
             })
             .then((loadedTheme) => {
+                const overrideTheme = (shortName === settingsCache.get('active_theme'));
                 // CASE: if this is the active theme, we are overriding
-                if (shortName === settingsCache.get('active_theme')) {
+                if (overrideTheme) {
                     debug('Activating theme (method C, on API "override")', shortName);
                     activate(loadedTheme, checkedTheme);
-
-                    // CASE: clear cache
-                    this.headers.cacheInvalidate = true;
                 }
 
                 // @TODO: unify the name across gscan and Ghost!
-                return toJSON(shortName, checkedTheme);
+                return {
+                    themeOverridden: overrideTheme,
+                    theme: toJSON(shortName, checkedTheme)
+                };
             })
             .finally(() => {
                 // @TODO: we should probably do this as part of saving the theme

--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -74,7 +74,7 @@ themes = {
             .then(() => {
                 return themeService.storage.setFromZip(zip);
             })
-            .then((theme) => {
+            .then(({theme}) => {
                 common.events.emit('theme.uploaded');
                 return theme;
             });

--- a/core/server/api/v2/themes.js
+++ b/core/server/api/v2/themes.js
@@ -61,7 +61,11 @@ module.exports = {
             };
 
             return themeService.storage.setFromZip(zip)
-                .then((theme) => {
+                .then(({theme, themeOverriden}) => {
+                    if (themeOverriden) {
+                        // CASE: clear cache
+                        this.headers.cacheInvalidate = true;
+                    }
                     common.events.emit('theme.uploaded');
                     return theme;
                 });


### PR DESCRIPTION
Cache invalidation header was set wrongly in frontend theme service, instead of themes controller. Since headers don't exist in the frontend theme service, it failed when uploading and overriding the same theme zip.

This PR moves cache invalidation out of theme service to themes controller, but causes a minor change in behavior. Previously, cache invalidation header was only set when uploaded theme is same as current theme and overrides it. This change will always set cache invalidation header on theme upload.

To fallback to previous behavior, theme service needs to return header or some flag back to controller to set correctly the header, which is ideal but slightly more verbose change for frontend to return.
