### PR TITLE
Added global site SEO fields

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -99,6 +99,22 @@
         },
         "unsplash": {
             "defaultValue": "{\"isActive\": true}"
+        },
+        "meta_title": {
+            "defaultValue": null,
+            "validations": {
+                "isLength": {
+                    "max": 150
+                }
+            }
+        },
+        "meta_description": {
+            "defaultValue": null,
+            "validations": {
+                "isLength": {
+                    "max": 200
+                }
+            }
         }
     },
     "theme": {

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -104,7 +104,7 @@
             "defaultValue": null,
             "validations": {
                 "isLength": {
-                    "max": 150
+                    "max": 300
                 }
             }
         },
@@ -112,7 +112,55 @@
             "defaultValue": null,
             "validations": {
                 "isLength": {
-                    "max": 200
+                    "max": 500
+                }
+            }
+        },
+        "og_image": {
+            "defaultValue": null,
+            "validations": {
+                "isLength": {
+                    "max": 2000
+                }
+            }
+        },
+        "og_title": {
+            "defaultValue": null,
+            "validations": {
+                "isLength": {
+                    "max": 300
+                }
+            }
+        },
+        "og_description": {
+            "defaultValue": null,
+            "validations": {
+                "isLength": {
+                    "max": 300
+                }
+            }
+        },
+        "twitter_image": {
+            "defaultValue": null,
+            "validations": {
+                "isLength": {
+                    "max": 2000
+                }
+            }
+        },
+        "twitter_title": {
+            "defaultValue": null,
+            "validations": {
+                "isLength": {
+                    "max": 300
+                }
+            }
+        },
+        "twitter_description": {
+            "defaultValue": null,
+            "validations": {
+                "isLength": {
+                    "max": 300
                 }
             }
         }

--- a/core/server/services/settings/public.js
+++ b/core/server/services/settings/public.js
@@ -9,6 +9,8 @@
 module.exports = {
     title: 'title',
     description: 'description',
+    meta_title: 'meta_title',
+    meta_description: 'meta_description',
     logo: 'logo',
     icon: 'icon',
     cover_image: 'cover_image',

--- a/core/server/services/settings/public.js
+++ b/core/server/services/settings/public.js
@@ -9,8 +9,6 @@
 module.exports = {
     title: 'title',
     description: 'description',
-    meta_title: 'meta_title',
-    meta_description: 'meta_description',
     logo: 'logo',
     icon: 'icon',
     cover_image: 'cover_image',

--- a/core/test/acceptance/old/admin/settings_spec.js
+++ b/core/test/acceptance/old/admin/settings_spec.js
@@ -85,7 +85,7 @@ describe('Settings API', function () {
             });
     });
 
-    it.only('Can edit a setting', function (done) {
+    it('Can edit a setting', function (done) {
         request.get(localUtils.API.getApiQuery('settings/'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
@@ -104,10 +104,6 @@ describe('Settings API', function () {
                                 value: changedValue
                             },
                             {
-                                key: 'meta_title',
-                                value: 'SEO title'
-                            },
-                            {
                                 key: 'codeinjection_head',
                                 value: null
                             },
@@ -122,6 +118,38 @@ describe('Settings API', function () {
                             {
                                 key: 'is_private',
                                 value: false
+                            },
+                            {
+                                key: 'meta_title',
+                                value: 'SEO title'
+                            },
+                            {
+                                key: 'meta_description',
+                                value: 'SEO description'
+                            },
+                            {
+                                key: 'og_image',
+                                value: '/content/images/2019/07/facebook.png'
+                            },
+                            {
+                                key: 'og_title',
+                                value: 'facebook title'
+                            },
+                            {
+                                key: 'og_description',
+                                value: 'facebook description'
+                            },
+                            {
+                                key: 'twitter_image',
+                                value: '/content/images/2019/07/twitter.png'
+                            },
+                            {
+                                key: 'twitter_title',
+                                value: 'twitter title'
+                            },
+                            {
+                                key: 'twitter_description',
+                                value: 'twitter description'
                             }
                         ]
                     };
@@ -147,20 +175,44 @@ describe('Settings API', function () {
                         putBody.settings[0].key.should.eql('title');
                         putBody.settings[0].value.should.eql(JSON.stringify(changedValue));
 
-                        putBody.settings[1].key.should.eql('meta_title');
-                        should.equal(putBody.settings[1].value, 'SEO title');
+                        putBody.settings[1].key.should.eql('codeinjection_head');
+                        should.equal(putBody.settings[1].value, null);
 
-                        putBody.settings[2].key.should.eql('codeinjection_head');
-                        should.equal(putBody.settings[2].value, null);
+                        putBody.settings[2].key.should.eql('navigation');
+                        should.equal(putBody.settings[2].value, JSON.stringify({label: 'label1'}));
 
-                        putBody.settings[3].key.should.eql('navigation');
-                        should.equal(putBody.settings[3].value, JSON.stringify({label: 'label1'}));
+                        putBody.settings[3].key.should.eql('slack');
+                        should.equal(putBody.settings[3].value, JSON.stringify({username: 'username'}));
 
-                        putBody.settings[4].key.should.eql('slack');
-                        should.equal(putBody.settings[4].value, JSON.stringify({username: 'username'}));
+                        putBody.settings[4].key.should.eql('is_private');
+                        should.equal(putBody.settings[4].value, false);
 
-                        putBody.settings[5].key.should.eql('is_private');
-                        should.equal(putBody.settings[5].value, false);
+                        putBody.settings[5].key.should.eql('meta_title');
+                        should.equal(putBody.settings[5].value, 'SEO title');
+
+                        putBody.settings[6].key.should.eql('meta_description');
+                        should.equal(putBody.settings[6].value, 'SEO description');
+
+                        putBody.settings[6].key.should.eql('meta_description');
+                        should.equal(putBody.settings[6].value, 'SEO description');
+
+                        putBody.settings[7].key.should.eql('og_image');
+                        should.equal(putBody.settings[7].value, '/content/images/2019/07/facebook.png');
+
+                        putBody.settings[8].key.should.eql('og_title');
+                        should.equal(putBody.settings[8].value, 'facebook title');
+
+                        putBody.settings[9].key.should.eql('og_description');
+                        should.equal(putBody.settings[9].value, 'facebook description');
+
+                        putBody.settings[10].key.should.eql('twitter_image');
+                        should.equal(putBody.settings[10].value, '/content/images/2019/07/twitter.png');
+
+                        putBody.settings[11].key.should.eql('twitter_title');
+                        should.equal(putBody.settings[11].value, 'twitter title');
+
+                        putBody.settings[12].key.should.eql('twitter_description');
+                        should.equal(putBody.settings[12].value, 'twitter description');
 
                         localUtils.API.checkResponse(putBody, 'settings');
                         done();

--- a/core/test/acceptance/old/admin/settings_spec.js
+++ b/core/test/acceptance/old/admin/settings_spec.js
@@ -85,7 +85,7 @@ describe('Settings API', function () {
             });
     });
 
-    it('Can edit a setting', function (done) {
+    it.only('Can edit a setting', function (done) {
         request.get(localUtils.API.getApiQuery('settings/'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
@@ -102,6 +102,10 @@ describe('Settings API', function () {
                             {
                                 key: 'title',
                                 value: changedValue
+                            },
+                            {
+                                key: 'meta_title',
+                                value: 'SEO title'
                             },
                             {
                                 key: 'codeinjection_head',
@@ -143,17 +147,20 @@ describe('Settings API', function () {
                         putBody.settings[0].key.should.eql('title');
                         putBody.settings[0].value.should.eql(JSON.stringify(changedValue));
 
-                        putBody.settings[1].key.should.eql('codeinjection_head');
-                        should.equal(putBody.settings[1].value, null);
+                        putBody.settings[1].key.should.eql('meta_title');
+                        should.equal(putBody.settings[1].value, 'SEO title');
 
-                        putBody.settings[2].key.should.eql('navigation');
-                        should.equal(putBody.settings[2].value, JSON.stringify({label: 'label1'}));
+                        putBody.settings[2].key.should.eql('codeinjection_head');
+                        should.equal(putBody.settings[2].value, null);
 
-                        putBody.settings[3].key.should.eql('slack');
-                        should.equal(putBody.settings[3].value, JSON.stringify({username: 'username'}));
+                        putBody.settings[3].key.should.eql('navigation');
+                        should.equal(putBody.settings[3].value, JSON.stringify({label: 'label1'}));
 
-                        putBody.settings[4].key.should.eql('is_private');
-                        should.equal(putBody.settings[4].value, false);
+                        putBody.settings[4].key.should.eql('slack');
+                        should.equal(putBody.settings[4].value, JSON.stringify({username: 'username'}));
+
+                        putBody.settings[5].key.should.eql('is_private');
+                        should.equal(putBody.settings[5].value, false);
 
                         localUtils.API.checkResponse(putBody, 'settings');
                         done();

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -113,7 +113,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(62);
+                    eventSpy.callCount.should.equal(78);
 
                     eventSpy.args[1][0].should.equal('settings.db_hash.added');
                     eventSpy.args[1][1].attributes.type.should.equal('core');

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -122,7 +122,7 @@ describe('Unit: models/settings', function () {
                     eventSpy.args[13][1].attributes.type.should.equal('blog');
                     eventSpy.args[13][1].attributes.value.should.equal('The professional publishing platform');
 
-                    eventSpy.args[61][0].should.equal('settings.members_subscription_settings.added');
+                    eventSpy.args[77][0].should.equal('settings.members_subscription_settings.added');
                 });
         });
 
@@ -136,7 +136,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(60);
+                    eventSpy.callCount.should.equal(76);
 
                     eventSpy.args[13][0].should.equal('settings.logo.added');
                 });


### PR DESCRIPTION
refs #10921

@kevinansfield 	just a conceptual Q about this change. Not sure if we want to be strict about accepting edits for these new fields on the v0.1 level? It's an additive change so nothing breaks and don't think it's a big deal in this situation.

But maybe for future, we'd want to have a concept of 'whitelist' of fields that setting controller for each API can modify (for example, something we could utilize for image_sizes). 