### PR TITLE
Exposed global site SEO related data in Conent API & @site theme helper

### DIFF
--- a/core/server/services/settings/public.js
+++ b/core/server/services/settings/public.js
@@ -18,5 +18,13 @@ module.exports = {
     active_timezone: 'timezone',
     ghost_head: 'ghost_head',
     ghost_foot: 'ghost_foot',
-    navigation: 'navigation'
+    navigation: 'navigation',
+    meta_title: 'meta_title',
+    meta_description: 'meta_description',
+    og_image: 'og_image',
+    og_title: 'og_title',
+    og_description: 'og_description',
+    twitter_image: 'twitter_image',
+    twitter_title: 'twitter_title',
+    twitter_description: 'twitter_description'
 };

--- a/core/test/acceptance/old/content/settings_spec.js
+++ b/core/test/acceptance/old/content/settings_spec.js
@@ -43,6 +43,7 @@ describe('Settings Content API', function () {
 
                 // Verify we have the right keys for settings
                 settings.should.have.properties(_.values(publicSettings));
+                Object.keys(settings).length.should.equal(22);
 
                 // Verify that we are returning the defaults for each value
                 _.forEach(settings, (value, key) => {


### PR DESCRIPTION
refs #10921

These changes add new SEO related fields to {{@site.*}} helper and makes them available through Content API at `GET /settings`.

@peterzimon @JohnONolan would like a second pair of :eyes: as these names will become publicly facing. 

Naming is the same as key names stored in `settings` table and are exact ones (including order) taken from [post schema](https://github.com/TryGhost/Ghost/blob/master/core/server/data/schema/schema.js#L53-L58).

For reference an example output of `GET /settings` request:
```
{
    "settings": {
        "title": "Naz Dev Instance",
        "description": "I have come here to chew bubblegum",
        "logo": "https://static.ghost.org/v1.0.0/images/ghost-logo.svg",
        "icon": null,
        "cover_image": "https://static.ghost.org/v1.0.0/images/blog-cover.jpg",
        "facebook": "ghost",
        "twitter": "@tryghost",
        "lang": "en",
        "timezone": "Etc/UTC",
        "ghost_head": null,
        "ghost_foot": null,
        "navigation": [
            {
                "label": "Home",
                "url": "/"
            },
            {
                "label": "Tag",
                "url": "/tag/getting-started/"
            },
            {
                "label": "Author",
                "url": "/author/ghost/"
            },
            {
                "label": "Help",
                "url": "https://docs.ghost.org"
            }
        ],
        "meta_title": "custom SEO title",
        "meta_description": null,
        "og_image": null,
        "og_title": "facebook SEO title",
        "og_description": null,
        "twitter_image": null,
        "twitter_title": null,
        "twitter_description": null,
        "codeinjection_head": null,
        "codeinjection_foot": null
    },
    "meta": {}
}
```

