### PR TITLE
Added global site SEO fields to theme helpers

### DIFF
--- a/core/frontend/meta/description.js
+++ b/core/frontend/meta/description.js
@@ -5,7 +5,7 @@ function getDescription(data, root, options) {
     var description = '',
         postSdDescription,
         context = root ? root.context : null,
-        blogDescription = settingsCache.get('description');
+        blogDescription = settingsCache.get('meta_description') || settingsCache.get('description');
 
     options = options ? options : {};
 

--- a/core/frontend/meta/description.js
+++ b/core/frontend/meta/description.js
@@ -16,7 +16,12 @@ function getDescription(data, root, options) {
     } else if (_.includes(context, 'paged')) {
         description = '';
     } else if (_.includes(context, 'home')) {
-        description = blogDescription;
+        if (options && options.property) {
+            const blogSdDescription = options.property + '_description';
+            description = settingsCache.get(blogSdDescription) || '';
+        } else {
+            description = blogDescription;
+        }
     } else if (_.includes(context, 'author') && data.author) {
         // The usage of meta data fields for author is currently not implemented.
         // We do have meta_description and meta_title fields

--- a/core/frontend/meta/description.js
+++ b/core/frontend/meta/description.js
@@ -1,16 +1,16 @@
-var _ = require('lodash'),
-    settingsCache = require('../../server/services/settings/cache');
+const _ = require('lodash');
+const settingsCache = require('../../server/services/settings/cache');
 
 function getDescription(data, root, options) {
-    var description = '',
-        postSdDescription,
-        context = root ? root.context : null,
-        blogDescription = settingsCache.get('meta_description') || settingsCache.get('description');
+    const context = root ? root.context : null;
+    const siteDescription = settingsCache.get('meta_description') || settingsCache.get('description');
+
+    let description = '';
+    let postSdDescription;
 
     options = options ? options : {};
 
-    // We only return meta_description if provided. Only exception is the Blog
-    // description, which doesn't rely on meta_description.
+    // We only return meta_description if provided
     if (data.meta_description) {
         description = data.meta_description;
     } else if (_.includes(context, 'paged')) {
@@ -20,7 +20,7 @@ function getDescription(data, root, options) {
             const blogSdDescription = options.property + '_description';
             description = settingsCache.get(blogSdDescription) || '';
         } else {
-            description = blogDescription;
+            description = siteDescription;
         }
     } else if (_.includes(context, 'author') && data.author) {
         // The usage of meta data fields for author is currently not implemented.

--- a/core/frontend/meta/description.js
+++ b/core/frontend/meta/description.js
@@ -17,8 +17,8 @@ function getDescription(data, root, options) {
         description = '';
     } else if (_.includes(context, 'home')) {
         if (options && options.property) {
-            const blogSdDescription = options.property + '_description';
-            description = settingsCache.get(blogSdDescription) || '';
+            const siteSdDescription = options.property + '_description';
+            description = settingsCache.get(siteSdDescription) || '';
         } else {
             description = siteDescription;
         }

--- a/core/frontend/meta/og_image.js
+++ b/core/frontend/meta/og_image.js
@@ -6,7 +6,7 @@ const settingsCache = require('../../server/services/settings/cache');
 function getOgImage(data) {
     const context = data.context ? data.context : null;
     const contextObject = getContextObject(data, context);
-    const blogOgImage = settingsCache.get('og_image');
+    const siteOgImage = settingsCache.get('og_image');
 
     if (_.includes(context, 'post') || _.includes(context, 'page') || _.includes(context, 'amp')) {
         if (contextObject.og_image) {
@@ -16,8 +16,8 @@ function getOgImage(data) {
         }
     }
 
-    if (_.includes(context, 'home') && blogOgImage) {
-        return urlUtils.urlFor('image', {image: blogOgImage}, true);
+    if (_.includes(context, 'home') && siteOgImage) {
+        return urlUtils.urlFor('image', {image: siteOgImage}, true);
     }
 
     return null;

--- a/core/frontend/meta/og_image.js
+++ b/core/frontend/meta/og_image.js
@@ -1,10 +1,12 @@
-var urlUtils = require('../../server/lib/url-utils'),
-    getContextObject = require('./context_object.js'),
-    _ = require('lodash');
+const _ = require('lodash');
+const getContextObject = require('./context_object.js');
+const urlUtils = require('../../server/lib/url-utils');
+const settingsCache = require('../../server/services/settings/cache');
 
 function getOgImage(data) {
-    var context = data.context ? data.context : null,
-        contextObject = getContextObject(data, context);
+    const context = data.context ? data.context : null;
+    const contextObject = getContextObject(data, context);
+    const blogOgImage = settingsCache.get('og_image');
 
     if (_.includes(context, 'post') || _.includes(context, 'page') || _.includes(context, 'amp')) {
         if (contextObject.og_image) {
@@ -12,6 +14,10 @@ function getOgImage(data) {
         } else if (contextObject.feature_image) {
             return urlUtils.urlFor('image', {image: contextObject.feature_image}, true);
         }
+    }
+
+    if (_.includes(context, 'home') && blogOgImage) {
+        return urlUtils.urlFor('image', {image: blogOgImage}, true);
     }
 
     return null;

--- a/core/frontend/meta/title.js
+++ b/core/frontend/meta/title.js
@@ -5,7 +5,7 @@ function getTitle(data, root, options) {
     var title = '',
         context = root ? root.context : null,
         postSdTitle,
-        blogTitle = settingsCache.get('meta_title') || settingsCache.get('title'),
+        siteTitle = settingsCache.get('meta_title') || settingsCache.get('title'),
         pagination = root ? root.pagination : null,
         pageString = '';
 
@@ -28,16 +28,16 @@ function getTitle(data, root, options) {
         }
     // Author title, paged
     } else if (_.includes(context, 'author') && data.author && _.includes(context, 'paged')) {
-        title = data.author.name + ' - ' + blogTitle + pageString;
+        title = data.author.name + ' - ' + siteTitle + pageString;
     // Author title, index
     } else if (_.includes(context, 'author') && data.author) {
-        title = data.author.name + ' - ' + blogTitle;
+        title = data.author.name + ' - ' + siteTitle;
     // Tag title, paged
     } else if (_.includes(context, 'tag') && data.tag && _.includes(context, 'paged')) {
-        title = data.tag.meta_title || data.tag.name + ' - ' + blogTitle + pageString;
+        title = data.tag.meta_title || data.tag.name + ' - ' + siteTitle + pageString;
     // Tag title, index
     } else if (_.includes(context, 'tag') && data.tag) {
-        title = data.tag.meta_title || data.tag.name + ' - ' + blogTitle;
+        title = data.tag.meta_title || data.tag.name + ' - ' + siteTitle;
     // Post title
     } else if (_.includes(context, 'post') && data.post) {
         if (options && options.property) {
@@ -64,7 +64,7 @@ function getTitle(data, root, options) {
         }
     // Fallback
     } else {
-        title = blogTitle + pageString;
+        title = siteTitle + pageString;
     }
 
     return (title || '').trim();

--- a/core/frontend/meta/title.js
+++ b/core/frontend/meta/title.js
@@ -20,7 +20,12 @@ function getTitle(data, root, options) {
         title = data.meta_title;
     // Home title
     } else if (_.includes(context, 'home')) {
-        title = blogTitle;
+        if (options && options.property) {
+            const siteSdTitle = options.property + '_title';
+            title = settingsCache.get(siteSdTitle) || '';
+        } else {
+            title = siteTitle;
+        }
     // Author title, paged
     } else if (_.includes(context, 'author') && data.author && _.includes(context, 'paged')) {
         title = data.author.name + ' - ' + blogTitle + pageString;

--- a/core/frontend/meta/title.js
+++ b/core/frontend/meta/title.js
@@ -1,13 +1,14 @@
-var _ = require('lodash'),
-    settingsCache = require('../../server/services/settings/cache');
+const _ = require('lodash');
+const settingsCache = require('../../server/services/settings/cache');
 
 function getTitle(data, root, options) {
-    var title = '',
-        context = root ? root.context : null,
-        postSdTitle,
-        siteTitle = settingsCache.get('meta_title') || settingsCache.get('title'),
-        pagination = root ? root.pagination : null,
-        pageString = '';
+    const context = root ? root.context : null;
+    const siteTitle = settingsCache.get('meta_title') || settingsCache.get('title');
+    const pagination = root ? root.pagination : null;
+
+    let title = '';
+    let postSdTitle;
+    let pageString = '';
 
     options = options ? options : {};
 

--- a/core/frontend/meta/title.js
+++ b/core/frontend/meta/title.js
@@ -5,7 +5,7 @@ function getTitle(data, root, options) {
     var title = '',
         context = root ? root.context : null,
         postSdTitle,
-        blogTitle = settingsCache.get('title'),
+        blogTitle = settingsCache.get('meta_title') || settingsCache.get('title'),
         pagination = root ? root.pagination : null,
         pageString = '';
 

--- a/core/frontend/meta/twitter_image.js
+++ b/core/frontend/meta/twitter_image.js
@@ -6,7 +6,7 @@ const settingsCache = require('../../server/services/settings/cache');
 function getTwitterImage(data) {
     const context = data.context ? data.context : null;
     const contextObject = getContextObject(data, context);
-    const blogOgImage = settingsCache.get('twitter_image');
+    const siteTwitterImage = settingsCache.get('twitter_image');
 
     if (_.includes(context, 'post') || _.includes(context, 'page') || _.includes(context, 'amp')) {
         if (contextObject.twitter_image) {
@@ -16,8 +16,8 @@ function getTwitterImage(data) {
         }
     }
 
-    if (_.includes(context, 'home') && blogOgImage) {
-        return urlUtils.urlFor('image', {image: blogOgImage}, true);
+    if (_.includes(context, 'home') && siteTwitterImage) {
+        return urlUtils.urlFor('image', {image: siteTwitterImage}, true);
     }
 
     return null;

--- a/core/frontend/meta/twitter_image.js
+++ b/core/frontend/meta/twitter_image.js
@@ -1,10 +1,12 @@
-var urlUtils = require('../../server/lib/url-utils'),
-    getContextObject = require('./context_object.js'),
-    _ = require('lodash');
+const _ = require('lodash');
+const urlUtils = require('../../server/lib/url-utils');
+const getContextObject = require('./context_object.js');
+const settingsCache = require('../../server/services/settings/cache');
 
 function getTwitterImage(data) {
-    var context = data.context ? data.context : null,
-        contextObject = getContextObject(data, context);
+    const context = data.context ? data.context : null;
+    const contextObject = getContextObject(data, context);
+    const blogOgImage = settingsCache.get('twitter_image');
 
     if (_.includes(context, 'post') || _.includes(context, 'page') || _.includes(context, 'amp')) {
         if (contextObject.twitter_image) {
@@ -12,6 +14,10 @@ function getTwitterImage(data) {
         } else if (contextObject.feature_image) {
             return urlUtils.urlFor('image', {image: contextObject.feature_image}, true);
         }
+    }
+
+    if (_.includes(context, 'home') && blogOgImage) {
+        return urlUtils.urlFor('image', {image: blogOgImage}, true);
     }
 
     return null;

--- a/core/test/unit/data/meta/description_spec.js
+++ b/core/test/unit/data/meta/description_spec.js
@@ -1,7 +1,46 @@
-var should = require('should'),
-    getMetaDescription = require('../../../../frontend/meta/description');
+const should = require('should');
+const sinon = require('sinon');
+const getMetaDescription = require('../../../../frontend/meta/description');
+const settingsCache = require('../../../../server/services/settings/cache');
 
 describe('getMetaDescription', function () {
+    let localSettingsCache = {};
+
+    before(function () {
+        sinon.stub(settingsCache, 'get').callsFake(function (key) {
+            return localSettingsCache[key];
+        });
+    });
+
+    after(function () {
+        sinon.restore();
+    });
+
+    afterEach(function () {
+        localSettingsCache = {};
+    });
+
+    it('should return site description when in home context', function () {
+        localSettingsCache.description = 'Site description';
+
+        var description = getMetaDescription({
+        }, {
+            context: ['home']
+        });
+        description.should.equal('Site description');
+    });
+
+    it('should return site meta_description when it is defined and in home context', function () {
+        localSettingsCache.description = 'Site description';
+        localSettingsCache.meta_description = 'Site meta description';
+
+        var description = getMetaDescription({
+        }, {
+            context: ['home']
+        });
+        description.should.equal('Site meta description');
+    });
+
     it('should return meta_description if on data root', function () {
         var description = getMetaDescription({
             meta_description: 'My test description.'

--- a/core/test/unit/data/meta/description_spec.js
+++ b/core/test/unit/data/meta/description_spec.js
@@ -30,6 +30,30 @@ describe('getMetaDescription', function () {
         description.should.equal('Site description');
     });
 
+    it('should return site OG description when in home context', function () {
+        localSettingsCache.og_description = 'My site Facebook description';
+
+        var description = getMetaDescription({
+        }, {
+            context: ['home']
+        }, {
+            property: 'og'
+        });
+        description.should.equal('My site Facebook description');
+    });
+
+    it('should return site twitter description when in home context', function () {
+        localSettingsCache.twitter_description = 'My site Twitter description';
+
+        var description = getMetaDescription({
+        }, {
+            context: ['home']
+        }, {
+            property: 'twitter'
+        });
+        description.should.equal('My site Twitter description');
+    });
+
     it('should return site meta_description when it is defined and in home context', function () {
         localSettingsCache.description = 'Site description';
         localSettingsCache.meta_description = 'Site meta description';

--- a/core/test/unit/data/meta/og_image_spec.js
+++ b/core/test/unit/data/meta/og_image_spec.js
@@ -1,8 +1,45 @@
-var should = require('should'),
-    getOgImage = require('../../../../frontend/meta/og_image');
+const should = require('should');
+const sinon = require('sinon');
+const getOgImage = require('../../../../frontend/meta/og_image');
+const settingsCache = require('../../../../server/services/settings/cache');
 
 describe('getOgImage', function () {
-    it('[home] should return null if not post context [home]', function () {
+    describe('[home]', function () {
+        it('should return null if not post context [home] and no og_image set', function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    og_image: null
+                }[key];
+            });
+
+            var ogImageUrl = getOgImage({
+                context: ['home'],
+                home: {}
+            });
+            should(ogImageUrl).equal(null);
+
+            sinon.restore();
+        });
+
+        it('should return null if not post context [home] and no og_image set', function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    og_image: '/content/images/home-og.jpg'
+                }[key];
+            });
+
+            var ogImageUrl = getOgImage({
+                context: ['home'],
+                home: {}
+            });
+            ogImageUrl.should.not.equal('/content/images/home-og.jpg');
+            ogImageUrl.should.match(/\/content\/images\/home-og\.jpg$/);
+
+            sinon.restore();
+        });
+    });
+
+    it('[home] should return null if not post context [home] and no og_image set', function () {
         var ogImageUrl = getOgImage({
             context: ['home'],
             home: {}

--- a/core/test/unit/data/meta/og_image_spec.js
+++ b/core/test/unit/data/meta/og_image_spec.js
@@ -5,7 +5,7 @@ const settingsCache = require('../../../../server/services/settings/cache');
 
 describe('getOgImage', function () {
     describe('[home]', function () {
-        it('should return null if not post context [home] and no og_image set', function () {
+        it('should return null if [home] context and no og_image set', function () {
             sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return {
                     og_image: null
@@ -21,7 +21,7 @@ describe('getOgImage', function () {
             sinon.restore();
         });
 
-        it('should return null if not post context [home] and no og_image set', function () {
+        it('should return image URL if [home] context and og_image set', function () {
             sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return {
                     og_image: '/content/images/home-og.jpg'

--- a/core/test/unit/data/meta/title_spec.js
+++ b/core/test/unit/data/meta/title_spec.js
@@ -40,6 +40,34 @@ describe('getTitle', function () {
         title.should.equal('My blog meta title');
     });
 
+    it('should return facebook blog title if in home context', function () {
+        localSettingsCache.title = 'My blog title';
+        localSettingsCache.og_title = 'My blog facebook meta title';
+
+        var title = getTitle({
+        }, {
+            context: ['home']
+        }, {
+            property: 'og'
+        });
+
+        title.should.equal('My blog facebook meta title');
+    });
+
+    it('should return twitter blog title if in home context', function () {
+        localSettingsCache.title = 'My blog title';
+        localSettingsCache.twitter_title = 'My blog twitter meta title';
+
+        var title = getTitle({
+        }, {
+            context: ['home']
+        }, {
+            property: 'twitter'
+        });
+
+        title.should.equal('My blog twitter meta title');
+    });
+
     it('should return author name - blog title if on data author page', function () {
         localSettingsCache.title = 'My blog title 2';
 

--- a/core/test/unit/data/meta/title_spec.js
+++ b/core/test/unit/data/meta/title_spec.js
@@ -25,24 +25,24 @@ describe('getTitle', function () {
         title.should.equal('My test title');
     });
 
-    it('should return blog title if on home', function () {
-        localSettingsCache.title = 'My blog title';
+    it('should return site title if on home', function () {
+        localSettingsCache.title = 'My site title';
 
         var title = getTitle({}, {context: 'home'});
-        title.should.equal('My blog title');
+        title.should.equal('My site title');
     });
 
-    it('should return blog meta_title if on home and mata_title present', function () {
-        localSettingsCache.title = 'My blog title';
-        localSettingsCache.meta_title = 'My blog meta title';
+    it('should return site meta_title if on home and mata_title present', function () {
+        localSettingsCache.title = 'My site title';
+        localSettingsCache.meta_title = 'My site meta title';
 
         var title = getTitle({}, {context: 'home'});
-        title.should.equal('My blog meta title');
+        title.should.equal('My site meta title');
     });
 
-    it('should return facebook blog title if in home context', function () {
-        localSettingsCache.title = 'My blog title';
-        localSettingsCache.og_title = 'My blog facebook meta title';
+    it('should return facebook site title if in home context', function () {
+        localSettingsCache.title = 'My site title';
+        localSettingsCache.og_title = 'My site facebook meta title';
 
         var title = getTitle({
         }, {
@@ -51,12 +51,12 @@ describe('getTitle', function () {
             property: 'og'
         });
 
-        title.should.equal('My blog facebook meta title');
+        title.should.equal('My site facebook meta title');
     });
 
-    it('should return twitter blog title if in home context', function () {
-        localSettingsCache.title = 'My blog title';
-        localSettingsCache.twitter_title = 'My blog twitter meta title';
+    it('should return twitter site title if in home context', function () {
+        localSettingsCache.title = 'My site title';
+        localSettingsCache.twitter_title = 'My site twitter meta title';
 
         var title = getTitle({
         }, {
@@ -65,11 +65,11 @@ describe('getTitle', function () {
             property: 'twitter'
         });
 
-        title.should.equal('My blog twitter meta title');
+        title.should.equal('My site twitter meta title');
     });
 
-    it('should return author name - blog title if on data author page', function () {
-        localSettingsCache.title = 'My blog title 2';
+    it('should return author name - site title if on data author page', function () {
+        localSettingsCache.title = 'My site title 2';
 
         var title = getTitle({
             author: {
@@ -77,11 +77,11 @@ describe('getTitle', function () {
             }
         }, {context: ['author']});
 
-        title.should.equal('Author Name - My blog title 2');
+        title.should.equal('Author Name - My site title 2');
     });
 
     it('should return author page title if on data author page with more then one page', function () {
-        localSettingsCache.title = 'My blog title 2';
+        localSettingsCache.title = 'My site title 2';
 
         var title = getTitle({
             author: {
@@ -95,11 +95,11 @@ describe('getTitle', function () {
             }
         });
 
-        title.should.equal('Author Name - My blog title 2 (Page 3)');
+        title.should.equal('Author Name - My site title 2 (Page 3)');
     });
 
-    it('should return tag name - blog title if on data tag page no meta_title', function () {
-        localSettingsCache.title = 'My blog title 3';
+    it('should return tag name - site title if on data tag page no meta_title', function () {
+        localSettingsCache.title = 'My site title 3';
 
         var title = getTitle({
             tag: {
@@ -107,11 +107,11 @@ describe('getTitle', function () {
             }
         }, {context: ['tag']});
 
-        title.should.equal('Tag Name - My blog title 3');
+        title.should.equal('Tag Name - My site title 3');
     });
 
-    it('should return tag name - blog title if on data tag page no meta_title (Page #)', function () {
-        localSettingsCache.title = 'My blog title 3';
+    it('should return tag name - site title if on data tag page no meta_title (Page #)', function () {
+        localSettingsCache.title = 'My site title 3';
 
         var title = getTitle({
             tag: {
@@ -125,11 +125,11 @@ describe('getTitle', function () {
             }
         });
 
-        title.should.equal('Tag Name - My blog title 3 (Page 39)');
+        title.should.equal('Tag Name - My site title 3 (Page 39)');
     });
 
     it('should return translated pagination-string if passed in options object', function () {
-        localSettingsCache.title = 'This is my blog title';
+        localSettingsCache.title = 'This is my site title';
 
         var title = getTitle({
             tag: {
@@ -147,7 +147,7 @@ describe('getTitle', function () {
             }
         });
 
-        title.should.equal('Tag Name - This is my blog title p.23');
+        title.should.equal('Tag Name - This is my site title p.23');
     });
 
     it('should return tag meta_title if in tag data', function () {
@@ -278,8 +278,8 @@ describe('getTitle', function () {
         title.should.equal('My Tag Meta Title Post!');
     });
 
-    it('should return blog title with page if unknown type', function () {
-        localSettingsCache.title = 'My blog title 4';
+    it('should return site title with page if unknown type', function () {
+        localSettingsCache.title = 'My site title 4';
 
         var title = getTitle({}, {
             context: ['paged'],
@@ -289,6 +289,6 @@ describe('getTitle', function () {
             }
         });
 
-        title.should.equal('My blog title 4 (Page 35)');
+        title.should.equal('My site title 4 (Page 35)');
     });
 });

--- a/core/test/unit/data/meta/title_spec.js
+++ b/core/test/unit/data/meta/title_spec.js
@@ -32,6 +32,14 @@ describe('getTitle', function () {
         title.should.equal('My blog title');
     });
 
+    it('should return blog meta_title if on home and mata_title present', function () {
+        localSettingsCache.title = 'My blog title';
+        localSettingsCache.meta_title = 'My blog meta title';
+
+        var title = getTitle({}, {context: 'home'});
+        title.should.equal('My blog meta title');
+    });
+
     it('should return author name - blog title if on data author page', function () {
         localSettingsCache.title = 'My blog title 2';
 

--- a/core/test/unit/data/meta/twitter_image_spec.js
+++ b/core/test/unit/data/meta/twitter_image_spec.js
@@ -1,13 +1,42 @@
-var should = require('should'),
-    getTwitterImage = require('../../../../frontend/meta/twitter_image');
+const should = require('should');
+const sinon = require('sinon');
+const getTwitterImage = require('../../../../frontend/meta/twitter_image');
+const settingsCache = require('../../../../server/services/settings/cache');
 
 describe('getTwitterImage', function () {
-    it('[home] should return null if not post context [home]', function () {
-        var twitterImageUrl = getTwitterImage({
-            context: ['home'],
-            home: {}
+    describe('[home]', function () {
+        it('should return null if [home] context and no twitter_image set', function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    twitter_image: null
+                }[key];
+            });
+
+            var twitterImageUrl = getTwitterImage({
+                context: ['home'],
+                home: {}
+            });
+            should(twitterImageUrl).equal(null);
+
+            sinon.restore();
         });
-        should(twitterImageUrl).equal(null);
+
+        it('should return image URL if [home] context and twitter_image set', function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    twitter_image: '/content/images/home-twitter.jpg'
+                }[key];
+            });
+
+            var twitterImageUrl = getTwitterImage({
+                context: ['home'],
+                home: {}
+            });
+            twitterImageUrl.should.not.equal('/content/images/home-twitter.jpg');
+            twitterImageUrl.should.match(/\/content\/images\/home-twitter\.jpg$/);
+
+            sinon.restore();
+        });
     });
 
     it('should return null if not post context [author]', function () {

--- a/core/test/unit/helpers/ghost_head_spec.js
+++ b/core/test/unit/helpers/ghost_head_spec.js
@@ -369,6 +369,54 @@ describe('{{ghost_head}} helper', function () {
             }).catch(done);
         });
 
+        it('returns meta structured data on homepage with site metadata defined', function (done) {
+            settingsCache.get.withArgs('meta_description').returns('blog SEO description');
+
+            settingsCache.get.withArgs('og_title').returns('facebook site title');
+            settingsCache.get.withArgs('og_description').returns('facebook site description');
+            settingsCache.get.withArgs('og_image').returns('/content/images/facebook-image.png');
+
+            settingsCache.get.withArgs('twitter_title').returns('twitter site title');
+            settingsCache.get.withArgs('twitter_description').returns('twitter site description');
+            settingsCache.get.withArgs('twitter_image').returns('/content/images/twitter-image.png');
+
+            helpers.ghost_head(testUtils.createHbsResponse({
+                locals: {
+                    relativeUrl: '/',
+                    context: ['home', 'index'],
+                    safeVersion: '0.3'
+                }
+            })).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="image\/x-icon" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/" \/>/);
+                rendered.string.should.match(/<meta name="referrer" content="no-referrer-when-downgrade" \/>/);
+                rendered.string.should.match(/<meta name="description" content="blog SEO description" \/>/);
+                rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
+                rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
+                rendered.string.should.match(/<meta property="og:title" content="facebook site title" \/>/);
+                rendered.string.should.match(/<meta property="og:description" content="facebook site description" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/facebook-image.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
+                rendered.string.should.match(/<meta name="twitter:title" content="twitter site title" \/>/);
+                rendered.string.should.match(/<meta name="twitter:description" content="twitter site description" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/twitter-image.png" \/>/);
+                rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
+                rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
+                rendered.string.should.match(/"@type": "WebSite"/);
+                rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/blog-cover.png"/);
+                rendered.string.should.match(/"description": "blog SEO description"/);
+
+                done();
+            }).catch(done);
+        });
+
         it('returns structured data on static page', function (done) {
             var renderObject = {
                 post: posts[0]

--- a/core/test/unit/helpers/ghost_head_spec.js
+++ b/core/test/unit/helpers/ghost_head_spec.js
@@ -370,7 +370,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('returns meta structured data on homepage with site metadata defined', function (done) {
-            settingsCache.get.withArgs('meta_description').returns('blog SEO description');
+            settingsCache.get.withArgs('meta_description').returns('site SEO description');
 
             settingsCache.get.withArgs('og_title').returns('facebook site title');
             settingsCache.get.withArgs('og_description').returns('facebook site description');
@@ -391,7 +391,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="image\/x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/" \/>/);
                 rendered.string.should.match(/<meta name="referrer" content="no-referrer-when-downgrade" \/>/);
-                rendered.string.should.match(/<meta name="description" content="blog SEO description" \/>/);
+                rendered.string.should.match(/<meta name="description" content="site SEO description" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="facebook site title" \/>/);
@@ -411,7 +411,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/"/);
                 rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/blog-cover.png"/);
-                rendered.string.should.match(/"description": "blog SEO description"/);
+                rendered.string.should.match(/"description": "site SEO description"/);
 
                 done();
             }).catch(done);

--- a/core/test/unit/helpers/meta_description_spec.js
+++ b/core/test/unit/helpers/meta_description_spec.js
@@ -5,122 +5,164 @@ var should = require('should'),
     settingsCache = require('../../../server/services/settings/cache');
 
 describe('{{meta_description}} helper', function () {
-    before(function () {
-        sinon.stub(settingsCache, 'get').returns('The professional publishing platform');
+    describe('no meta_description', function () {
+        before(function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    description: 'The professional publishing platform'
+                }[key];
+            });
+        });
+
+        after(function () {
+            configUtils.restore();
+            sinon.restore();
+        });
+
+        it('returns correct blog description', function () {
+            var rendered = helpers.meta_description.call(
+                {},
+                {data: {root: {context: ['home', 'index']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('The professional publishing platform');
+        });
+
+        it('returns empty description on paginated page', function () {
+            var rendered = helpers.meta_description.call(
+                {},
+                {data: {root: {context: ['index', 'paged']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('');
+        });
+
+        it('returns empty description for a tag page', function () {
+            var rendered = helpers.meta_description.call(
+                {tag: {name: 'Rasper Red'}},
+                {data: {root: {context: ['tag']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('');
+        });
+
+        it('returns empty description for a paginated tag page', function () {
+            var rendered = helpers.meta_description.call(
+                {tag: {name: 'Rasper Red'}},
+                {data: {root: {context: ['tag', 'paged']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('');
+        });
+
+        it('returns tag meta_description if present for a tag page', function () {
+            var rendered = helpers.meta_description.call(
+                {tag: {name: 'Rasper Red', meta_description: 'Rasper is the Cool Red Casper'}},
+                {data: {root: {context: ['tag']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Rasper is the Cool Red Casper');
+        });
+
+        it('returns empty description on paginated tag page that has meta data', function () {
+            var rendered = helpers.meta_description.call(
+                {tag: {name: 'Rasper Red', meta_description: 'Rasper is the Cool Red Casper'}},
+                {data: {root: {context: ['tag', 'paged']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('');
+        });
+
+        it('returns empty description for an author page', function () {
+            var rendered = helpers.meta_description.call(
+                {author: {bio: 'I am a Duck.'}},
+                {data: {root: {context: ['author']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('');
+        });
+
+        it('returns empty description for a paginated author page', function () {
+            var rendered = helpers.meta_description.call(
+                {author: {name: 'Donald Duck'}},
+                {data: {root: {context: ['author', 'paged']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('');
+        });
+
+        it('returns empty description when meta_description is not set', function () {
+            var rendered = helpers.meta_description.call(
+                {post: {title: 'Post Title', html: 'Very nice post indeed.'}},
+                {data: {root: {context: ['post']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('');
+        });
+
+        it('returns meta_description on post with meta_description set', function () {
+            var rendered = helpers.meta_description.call(
+                {post: {title: 'Post Title', meta_description: 'Nice post about stuff.'}},
+                {data: {root: {context: ['post']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Nice post about stuff.');
+        });
+
+        it('returns meta_description on post when used within {{#foreach posts}}', function () {
+            var rendered = helpers.meta_description.call(
+                {meta_description: 'Nice post about stuff.'},
+                {data: {root: {context: ['home']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Nice post about stuff.');
+        });
     });
 
-    after(function () {
-        configUtils.restore();
-        sinon.restore();
-    });
+    describe('with meta_description', function () {
+        before(function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    description: 'The professional publishing platform',
+                    meta_description: 'Meta description of the professional publishing platform'
+                }[key];
+            });
+        });
 
-    it('returns correct blog description', function () {
-        var rendered = helpers.meta_description.call(
-            {},
-            {data: {root: {context: ['home', 'index']}}}
-        );
+        after(function () {
+            configUtils.restore();
+            sinon.restore();
+        });
 
-        should.exist(rendered);
-        String(rendered).should.equal('The professional publishing platform');
-    });
+        it('returns correct blog description', function () {
+            var rendered = helpers.meta_description.call(
+                {},
+                {data: {root: {context: ['home', 'index']}}}
+            );
 
-    it('returns empty description on paginated page', function () {
-        var rendered = helpers.meta_description.call(
-            {},
-            {data: {root: {context: ['index', 'paged']}}}
-        );
+            should.exist(rendered);
+            String(rendered).should.equal('Meta description of the professional publishing platform');
+        });
 
-        should.exist(rendered);
-        String(rendered).should.equal('');
-    });
+        it('returns tag meta_description if present for a tag page', function () {
+            var rendered = helpers.meta_description.call(
+                {tag: {name: 'Rasper Red', meta_description: 'Rasper is the Cool Red Casper'}},
+                {data: {root: {context: ['tag']}}}
+            );
 
-    it('returns empty description for a tag page', function () {
-        var rendered = helpers.meta_description.call(
-            {tag: {name: 'Rasper Red'}},
-            {data: {root: {context: ['tag']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('');
-    });
-
-    it('returns empty description for a paginated tag page', function () {
-        var rendered = helpers.meta_description.call(
-            {tag: {name: 'Rasper Red'}},
-            {data: {root: {context: ['tag', 'paged']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('');
-    });
-
-    it('returns tag meta_description if present for a tag page', function () {
-        var rendered = helpers.meta_description.call(
-            {tag: {name: 'Rasper Red', meta_description: 'Rasper is the Cool Red Casper'}},
-            {data: {root: {context: ['tag']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('Rasper is the Cool Red Casper');
-    });
-
-    it('returns empty description on paginated tag page that has meta data', function () {
-        var rendered = helpers.meta_description.call(
-            {tag: {name: 'Rasper Red', meta_description: 'Rasper is the Cool Red Casper'}},
-            {data: {root: {context: ['tag', 'paged']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('');
-    });
-
-    it('returns empty description for an author page', function () {
-        var rendered = helpers.meta_description.call(
-            {author: {bio: 'I am a Duck.'}},
-            {data: {root: {context: ['author']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('');
-    });
-
-    it('returns empty description for a paginated author page', function () {
-        var rendered = helpers.meta_description.call(
-            {author: {name: 'Donald Duck'}},
-            {data: {root: {context: ['author', 'paged']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('');
-    });
-
-    it('returns empty description when meta_description is not set', function () {
-        var rendered = helpers.meta_description.call(
-            {post: {title: 'Post Title', html: 'Very nice post indeed.'}},
-            {data: {root: {context: ['post']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('');
-    });
-
-    it('returns meta_description on post with meta_description set', function () {
-        var rendered = helpers.meta_description.call(
-            {post: {title: 'Post Title', meta_description: 'Nice post about stuff.'}},
-            {data: {root: {context: ['post']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('Nice post about stuff.');
-    });
-
-    it('returns meta_description on post when used within {{#foreach posts}}', function () {
-        var rendered = helpers.meta_description.call(
-            {meta_description: 'Nice post about stuff.'},
-            {data: {root: {context: ['home']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('Nice post about stuff.');
+            should.exist(rendered);
+            String(rendered).should.equal('Rasper is the Cool Red Casper');
+        });
     });
 });

--- a/core/test/unit/helpers/meta_description_spec.js
+++ b/core/test/unit/helpers/meta_description_spec.js
@@ -1,22 +1,24 @@
-var should = require('should'),
-    sinon = require('sinon'),
-    configUtils = require('../../utils/configUtils'),
-    helpers = require('../../../frontend/helpers'),
-    settingsCache = require('../../../server/services/settings/cache');
+const should = require('should');
+const sinon = require('sinon');
+const helpers = require('../../../frontend/helpers');
+const settingsCache = require('../../../server/services/settings/cache');
 
 describe('{{meta_description}} helper', function () {
+    const localSettingsCache = {};
+
+    before(function () {
+        sinon.stub(settingsCache, 'get').callsFake(function (key) {
+            return localSettingsCache[key];
+        });
+    });
+
+    after(function () {
+        sinon.restore();
+    });
+
     describe('no meta_description', function () {
         before(function () {
-            sinon.stub(settingsCache, 'get').callsFake(function (key) {
-                return {
-                    description: 'The professional publishing platform'
-                }[key];
-            });
-        });
-
-        after(function () {
-            configUtils.restore();
-            sinon.restore();
+            localSettingsCache.description = 'The professional publishing platform';
         });
 
         it('returns correct blog description', function () {
@@ -132,17 +134,7 @@ describe('{{meta_description}} helper', function () {
 
     describe('with meta_description', function () {
         before(function () {
-            sinon.stub(settingsCache, 'get').callsFake(function (key) {
-                return {
-                    description: 'The professional publishing platform',
-                    meta_description: 'Meta description of the professional publishing platform'
-                }[key];
-            });
-        });
-
-        after(function () {
-            configUtils.restore();
-            sinon.restore();
+            localSettingsCache.meta_description = 'Meta description of the professional publishing platform';
         });
 
         it('returns correct blog description', function () {

--- a/core/test/unit/helpers/meta_description_spec.js
+++ b/core/test/unit/helpers/meta_description_spec.js
@@ -21,7 +21,7 @@ describe('{{meta_description}} helper', function () {
             localSettingsCache.description = 'The professional publishing platform';
         });
 
-        it('returns correct blog description', function () {
+        it('returns correct site description', function () {
             var rendered = helpers.meta_description.call(
                 {},
                 {data: {root: {context: ['home', 'index']}}}
@@ -137,7 +137,7 @@ describe('{{meta_description}} helper', function () {
             localSettingsCache.meta_description = 'Meta description of the professional publishing platform';
         });
 
-        it('returns correct blog description', function () {
+        it('returns correct site description', function () {
             var rendered = helpers.meta_description.call(
                 {},
                 {data: {root: {context: ['home', 'index']}}}

--- a/core/test/unit/helpers/meta_title_spec.js
+++ b/core/test/unit/helpers/meta_title_spec.js
@@ -5,147 +5,209 @@ var should = require('should'),
     settingsCache = require('../../../server/services/settings/cache');
 
 describe('{{meta_title}} helper', function () {
-    before(function () {
-        sinon.stub(settingsCache, 'get').callsFake(function (key) {
-            return {
-                title: 'Ghost'
-            }[key];
+    describe('no meta_title', function () {
+        before(function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    title: 'Ghost'
+                }[key];
+            });
         });
-    });
 
-    after(function () {
-        configUtils.restore();
-        sinon.restore();
-    });
+        after(function () {
+            configUtils.restore();
+            sinon.restore();
+        });
 
-    it('returns correct title for homepage', function () {
-        var rendered = helpers.meta_title.call(
-            {},
-            {data: {root: {context: ['home']}}}
-        );
+        it('returns correct title for homepage', function () {
+            var rendered = helpers.meta_title.call(
+                {},
+                {data: {root: {context: ['home']}}}
+            );
 
-        should.exist(rendered);
-        String(rendered).should.equal('Ghost');
-    });
+            should.exist(rendered);
+            String(rendered).should.equal('Ghost');
+        });
 
-    it('returns correct title for paginated page', function () {
-        var rendered = helpers.meta_title.call(
-            {},
-            {data: {root: {context: [], pagination: {total: 2, page: 2}}}}
-        );
+        it('returns correct title for paginated page', function () {
+            var rendered = helpers.meta_title.call(
+                {},
+                {data: {root: {context: [], pagination: {total: 2, page: 2}}}}
+            );
 
-        should.exist(rendered);
-        String(rendered).should.equal('Ghost (Page 2)');
-    });
+            should.exist(rendered);
+            String(rendered).should.equal('Ghost (Page 2)');
+        });
 
-    it('returns correct title for a post', function () {
-        var rendered = helpers.meta_title.call(
-            {post: {title: 'Post Title'}},
-            {data: {root: {context: ['post']}}}
-        );
+        it('returns correct title for a post', function () {
+            var rendered = helpers.meta_title.call(
+                {post: {title: 'Post Title'}},
+                {data: {root: {context: ['post']}}}
+            );
 
-        should.exist(rendered);
-        String(rendered).should.equal('Post Title');
-    });
+            should.exist(rendered);
+            String(rendered).should.equal('Post Title');
+        });
 
-    it('returns correct title for a post with meta_title set', function () {
-        var rendered = helpers.meta_title.call(
-            {post: {title: 'Post Title', meta_title: 'Awesome Post'}},
-            {data: {root: {context: ['post']}}}
-        );
+        it('returns correct title for a post with meta_title set', function () {
+            var rendered = helpers.meta_title.call(
+                {post: {title: 'Post Title', meta_title: 'Awesome Post'}},
+                {data: {root: {context: ['post']}}}
+            );
 
-        should.exist(rendered);
-        String(rendered).should.equal('Awesome Post');
-    });
+            should.exist(rendered);
+            String(rendered).should.equal('Awesome Post');
+        });
 
-    it('returns correct title for a page with meta_title set', function () {
-        var rendered = helpers.meta_title.call(
-            {post: {title: 'About Page', meta_title: 'All about my awesomeness', page: true}},
-            {data: {root: {context: ['page']}}}
-        );
+        it('returns correct title for a page with meta_title set', function () {
+            var rendered = helpers.meta_title.call(
+                {post: {title: 'About Page', meta_title: 'All about my awesomeness', page: true}},
+                {data: {root: {context: ['page']}}}
+            );
 
-        should.exist(rendered);
-        String(rendered).should.equal('All about my awesomeness');
-    });
+            should.exist(rendered);
+            String(rendered).should.equal('All about my awesomeness');
+        });
 
-    it('returns correct title for a tag page', function () {
-        var tag = {relativeUrl: '/tag/rasper-red', tag: {name: 'Rasper Red'}},
-            rendered = helpers.meta_title.call(
-                tag,
+        it('returns correct title for a tag page', function () {
+            var tag = {relativeUrl: '/tag/rasper-red', tag: {name: 'Rasper Red'}},
+                rendered = helpers.meta_title.call(
+                    tag,
+                    {data: {root: {context: ['tag']}}}
+                );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Rasper Red - Ghost');
+        });
+
+        it('returns correct title for a paginated tag page', function () {
+            var rendered = helpers.meta_title.call(
+                {tag: {name: 'Rasper Red'}},
+                {data: {root: {context: ['tag', 'paged'], pagination: {total: 2, page: 2}}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Rasper Red - Ghost (Page 2)');
+        });
+
+        it('uses tag meta_title to override default response on tag page', function () {
+            var rendered = helpers.meta_title.call(
+                {tag: {name: 'Rasper Red', meta_title: 'Sasper Red'}},
                 {data: {root: {context: ['tag']}}}
             );
 
-        should.exist(rendered);
-        String(rendered).should.equal('Rasper Red - Ghost');
+            should.exist(rendered);
+            String(rendered).should.equal('Sasper Red');
+        });
+
+        it('uses tag meta_title to override default response on paginated tag page', function () {
+            var rendered = helpers.meta_title.call(
+                {tag: {name: 'Rasper Red', meta_title: 'Sasper Red'}},
+                {data: {root: {context: ['tag']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Sasper Red');
+        });
+
+        it('returns correct title for an author page', function () {
+            var rendered = helpers.meta_title.call(
+                {author: {name: 'Donald Duck'}},
+                {data: {root: {context: ['author']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Donald Duck - Ghost');
+        });
+
+        it('returns correct title for a paginated author page', function () {
+            var rendered = helpers.meta_title.call(
+                {author: {name: 'Donald Duck'}},
+                {data: {root: {context: ['author', 'paged'], pagination: {total: 2, page: 2}}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Donald Duck - Ghost (Page 2)');
+        });
+
+        it('returns correctly escaped title of a post', function () {
+            var rendered = helpers.meta_title.call(
+                {post: {title: 'Post Title "</>'}},
+                {data: {root: {context: ['post']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Post Title "</>');
+        });
+
+        it('returns meta_title on post when used within {{#foreach posts}}', function () {
+            var rendered = helpers.meta_title.call(
+                {meta_title: 'Awesome Post'},
+                {data: {root: {context: ['home']}}}
+            );
+
+            should.exist(rendered);
+            String(rendered).should.equal('Awesome Post');
+        });
     });
 
-    it('returns correct title for a paginated tag page', function () {
-        var rendered = helpers.meta_title.call(
-            {tag: {name: 'Rasper Red'}},
-            {data: {root: {context: ['tag', 'paged'], pagination: {total: 2, page: 2}}}}
-        );
+    describe('with meta_title', function () {
+        it('returns correct title for homepage when meta_title is defined', function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    title: 'Ghost',
+                    meta_title: 'Meta Title Ghost'
+                }[key];
+            });
 
-        should.exist(rendered);
-        String(rendered).should.equal('Rasper Red - Ghost (Page 2)');
-    });
+            var rendered = helpers.meta_title.call(
+                {},
+                {data: {root: {context: ['home']}}}
+            );
 
-    it('uses tag meta_title to override default response on tag page', function () {
-        var rendered = helpers.meta_title.call(
-            {tag: {name: 'Rasper Red', meta_title: 'Sasper Red'}},
-            {data: {root: {context: ['tag']}}}
-        );
+            should.exist(rendered);
+            String(rendered).should.equal('Meta Title Ghost');
+        });
 
-        should.exist(rendered);
-        String(rendered).should.equal('Sasper Red');
-    });
+        it('returns correct title for paginated page', function () {
+            var rendered = helpers.meta_title.call(
+                {},
+                {data: {root: {context: [], pagination: {total: 2, page: 2}}}}
+            );
 
-    it('uses tag meta_title to override default response on paginated tag page', function () {
-        var rendered = helpers.meta_title.call(
-            {tag: {name: 'Rasper Red', meta_title: 'Sasper Red'}},
-            {data: {root: {context: ['tag']}}}
-        );
+            should.exist(rendered);
+            String(rendered).should.equal('Meta Title Ghost (Page 2)');
+        });
 
-        should.exist(rendered);
-        String(rendered).should.equal('Sasper Red');
-    });
+        it('returns correct title for a tag page', function () {
+            var tag = {relativeUrl: '/tag/rasper-red', tag: {name: 'Rasper Red'}},
+                rendered = helpers.meta_title.call(
+                    tag,
+                    {data: {root: {context: ['tag']}}}
+                );
 
-    it('returns correct title for an author page', function () {
-        var rendered = helpers.meta_title.call(
-            {author: {name: 'Donald Duck'}},
-            {data: {root: {context: ['author']}}}
-        );
+            should.exist(rendered);
+            String(rendered).should.equal('Rasper Red - Meta Title Ghost');
+        });
 
-        should.exist(rendered);
-        String(rendered).should.equal('Donald Duck - Ghost');
-    });
+        it('returns correct title for an author page', function () {
+            var rendered = helpers.meta_title.call(
+                {author: {name: 'Donald Duck'}},
+                {data: {root: {context: ['author']}}}
+            );
 
-    it('returns correct title for a paginated author page', function () {
-        var rendered = helpers.meta_title.call(
-            {author: {name: 'Donald Duck'}},
-            {data: {root: {context: ['author', 'paged'], pagination: {total: 2, page: 2}}}}
-        );
+            should.exist(rendered);
+            String(rendered).should.equal('Donald Duck - Meta Title Ghost');
+        });
 
-        should.exist(rendered);
-        String(rendered).should.equal('Donald Duck - Ghost (Page 2)');
-    });
+        it('returns correct title for a paginated author page', function () {
+            var rendered = helpers.meta_title.call(
+                {author: {name: 'Donald Duck'}},
+                {data: {root: {context: ['author', 'paged'], pagination: {total: 2, page: 2}}}}
+            );
 
-    it('returns correctly escaped title of a post', function () {
-        var rendered = helpers.meta_title.call(
-            {post: {title: 'Post Title "</>'}},
-            {data: {root: {context: ['post']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('Post Title "</>');
-    });
-
-    it('returns meta_title on post when used within {{#foreach posts}}', function () {
-        var rendered = helpers.meta_title.call(
-            {meta_title: 'Awesome Post'},
-            {data: {root: {context: ['home']}}}
-        );
-
-        should.exist(rendered);
-        String(rendered).should.equal('Awesome Post');
+            should.exist(rendered);
+            String(rendered).should.equal('Donald Duck - Meta Title Ghost (Page 2)');
+        });
     });
 });


### PR DESCRIPTION
refs #10921

PR to use newly introduced SEO fields in theme helpers. Would need a review of priorities for the field fallbacks.

TODO:
- [x] proper {{ghost_head}} helper test covering site meta fields usage
- [x] double check blog title/meta_title usages (same as for tag)