### PR TITLE
🐛 Fixed CORS errors when making incorrect requests to content and admin api

### DIFF
--- a/config.development.json
+++ b/config.development.json
@@ -1,3 +1,7 @@
 {
-   "enableDeveloperExperiments": true
+   "enableDeveloperExperiments": true,
+   "url": "http://site.egg",
+   "admin": {
+       "url": "http://site.ghost.egg"
+   }
 }

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -15,8 +15,7 @@ module.exports = function apiRoutes() {
     // alias delete with del
     router.del = router.delete;
 
-    // ## CORS pre-flight check
-    router.options('*', shared.middlewares.api.cors);
+    router.use(shared.middlewares.api.cors);
 
     const http = apiv2.http;
 

--- a/core/server/web/api/v2/content/routes.js
+++ b/core/server/web/api/v2/content/routes.js
@@ -6,7 +6,7 @@ const mw = require('./middleware');
 module.exports = function apiRoutes() {
     const router = express.Router();
 
-    router.options('*', cors());
+    router.use(cors());
 
     const http = apiv2.http;
 


### PR DESCRIPTION
Previously we were only applying the cors middleware to the options
preflight request, which meant that if the request errored, the cors
headers would not be applied, resulting in the client being unable to
read response data. This applies the cors middleware to _all_ requests
to both the Content & Admin API.