### PR TITLE
🎨 Added `url` value to the Content API /settings/ endpoint

### DIFF
--- a/core/server/api/v2/settings-public.js
+++ b/core/server/api/v2/settings-public.js
@@ -1,4 +1,5 @@
 const settingsCache = require('../../services/settings/cache');
+const urlUtils = require('../../lib/url-utils');
 
 module.exports = {
     docName: 'settings',
@@ -8,7 +9,9 @@ module.exports = {
         query() {
             // @TODO: decouple settings cache from API knowledge
             // The controller fetches models (or cached models) and the API frame for the target API version formats the response.
-            return settingsCache.getPublic();
+            return Object.assign({}, settingsCache.getPublic(), {
+                url: urlUtils.urlFor('home', true)
+            });
         }
     }
 };

--- a/core/test/acceptance/old/content/settings_spec.js
+++ b/core/test/acceptance/old/content/settings_spec.js
@@ -43,7 +43,7 @@ describe('Settings Content API', function () {
 
                 // Verify we have the right keys for settings
                 settings.should.have.properties(_.values(publicSettings));
-                Object.keys(settings).length.should.equal(22);
+                Object.keys(settings).length.should.equal(23);
 
                 // Verify that we are returning the defaults for each value
                 _.forEach(settings, (value, key) => {
@@ -57,6 +57,12 @@ describe('Settings Content API', function () {
                      * This is just a hack to be able to alias ghost_head & ghost_foot quickly.
                      */
                     if (['codeinjection_head', 'codeinjection_foot'].includes(key)) {
+                        return;
+                    }
+
+                    // `url` does not come from the settings cache
+                    if (key === 'url') {
+                        should(value).eql(`${config.get('url')}/`);
                         return;
                     }
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/10945

- adds the `url` property to the returned output manually because it's a config value rather than a settings value