### PR TITLE
Fixed img_url helper when using image sizes with relative paths which have no leading slash

### DIFF
--- a/core/frontend/helpers/img_url.js
+++ b/core/frontend/helpers/img_url.js
@@ -11,7 +11,7 @@ const url = require('url');
 const _ = require('lodash');
 const proxy = require('./proxy');
 const urlUtils = proxy.urlUtils;
-const STATIC_IMAGE_URL_PREFIX = `/${urlUtils.STATIC_IMAGE_URL_PREFIX}`;
+const STATIC_IMAGE_URL_PREFIX = `${urlUtils.STATIC_IMAGE_URL_PREFIX}`;
 
 module.exports = function imgUrl(requestedImageUrl, options) {
     // CASE: if no url is passed, e.g. `{{img_url}}` we show a warning

--- a/core/frontend/helpers/img_url.js
+++ b/core/frontend/helpers/img_url.js
@@ -94,6 +94,12 @@ function detectInternalImage(requestedImageUrl) {
 }
 
 function getImageWithSize(imagePath, requestedSize, imageSizes) {
+    const hasLeadingSlash = imagePath[0] === '/';
+
+    if (hasLeadingSlash) {
+        return '/' + getImageWithSize(imagePath.slice(1), requestedSize, imageSizes);
+    }
+
     if (!requestedSize) {
         return imagePath;
     }

--- a/core/test/unit/helpers/img_url_spec.js
+++ b/core/test/unit/helpers/img_url_spec.js
@@ -179,5 +179,24 @@ describe('{{image}} helper', function () {
             should.exist(rendered);
             rendered.should.equal('/content/images/size/w400/my-coole-img.jpg');
         });
+
+        it('should output the correct url for relative paths without leading slash', function () {
+            var rendered = helpers.img_url('content/images/my-coole-img.jpg', {
+                hash: {
+                    size: 'medium'
+                },
+                data: {
+                    config: {
+                        image_sizes: {
+                            medium: {
+                                width: 400
+                            }
+                        }
+                    }
+                }
+            });
+            should.exist(rendered);
+            rendered.should.equal('content/images/size/w400/my-coole-img.jpg');
+        });
     });
 });


### PR DESCRIPTION
This updates the `getImageWithSize` function in the `img_url` helper to consider relative paths WITHOUT a leading slash the "base case". If a path does have a leading slash, we remove it, pass it through the function again, and then prepend the slash.

