### PR TITLE
Add a glob pattern to ignore the node_modules while zipping the…

### DIFF
--- a/core/server/lib/fs/zip-folder.js
+++ b/core/server/lib/fs/zip-folder.js
@@ -18,8 +18,10 @@ module.exports = function zipFolder(folderToZip, destination, callback) {
     archive.on('error', function (err) {
         callback(err, null);
     });
-
-    archive.directory(folderToZip, '/');
+    archive.glob(`**/*`, {
+        cwd: folderToZip,
+        ignore: ['node_modules/**']
+    });
     archive.pipe(output);
     archive.finalize();
 };


### PR DESCRIPTION
- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

Fixes #10929