### PR TITLE
New helpers: {{concat}}, {{link}} and {{link_class}}

### DIFF
--- a/core/frontend/helpers/concat.js
+++ b/core/frontend/helpers/concat.js
@@ -1,0 +1,8 @@
+const {SafeString} = require('./proxy');
+
+module.exports = function concat(...args) {
+    const options = args.pop();
+    const separator = options.hash.separator || '';
+
+    return new SafeString(args.join(separator));
+};

--- a/core/frontend/helpers/index.js
+++ b/core/frontend/helpers/index.js
@@ -8,6 +8,7 @@ coreHelpers.asset = require('./asset');
 coreHelpers.author = require('./author');
 coreHelpers.authors = require('./authors');
 coreHelpers.body_class = require('./body_class');
+coreHelpers.concat = require('./concat');
 coreHelpers.content = require('./content');
 coreHelpers.date = require('./date');
 coreHelpers.encode = require('./encode');
@@ -43,6 +44,7 @@ registerAllCoreHelpers = function registerAllCoreHelpers() {
     registerThemeHelper('author', coreHelpers.author);
     registerThemeHelper('authors', coreHelpers.authors);
     registerThemeHelper('body_class', coreHelpers.body_class);
+    registerThemeHelper('concat', coreHelpers.concat);
     registerThemeHelper('content', coreHelpers.content);
     registerThemeHelper('date', coreHelpers.date);
     registerThemeHelper('encode', coreHelpers.encode);

--- a/core/frontend/helpers/index.js
+++ b/core/frontend/helpers/index.js
@@ -22,6 +22,7 @@ coreHelpers.img_url = require('./img_url');
 coreHelpers.is = require('./is');
 coreHelpers.has = require('./has');
 coreHelpers.lang = require('./lang');
+coreHelpers.link = require('./link');
 coreHelpers.meta_description = require('./meta_description');
 coreHelpers.meta_title = require('./meta_title');
 coreHelpers.navigation = require('./navigation');
@@ -55,6 +56,7 @@ registerAllCoreHelpers = function registerAllCoreHelpers() {
     registerThemeHelper('is', coreHelpers.is);
     registerThemeHelper('img_url', coreHelpers.img_url);
     registerThemeHelper('lang', coreHelpers.lang);
+    registerThemeHelper('link', coreHelpers.link);
     registerThemeHelper('meta_description', coreHelpers.meta_description);
     registerThemeHelper('meta_title', coreHelpers.meta_title);
     registerThemeHelper('navigation', coreHelpers.navigation);

--- a/core/frontend/helpers/index.js
+++ b/core/frontend/helpers/index.js
@@ -23,6 +23,7 @@ coreHelpers.is = require('./is');
 coreHelpers.has = require('./has');
 coreHelpers.lang = require('./lang');
 coreHelpers.link = require('./link');
+coreHelpers.link_class = require('./link_class');
 coreHelpers.meta_description = require('./meta_description');
 coreHelpers.meta_title = require('./meta_title');
 coreHelpers.navigation = require('./navigation');
@@ -57,6 +58,7 @@ registerAllCoreHelpers = function registerAllCoreHelpers() {
     registerThemeHelper('img_url', coreHelpers.img_url);
     registerThemeHelper('lang', coreHelpers.lang);
     registerThemeHelper('link', coreHelpers.link);
+    registerThemeHelper('link_class', coreHelpers.link_class);
     registerThemeHelper('meta_description', coreHelpers.meta_description);
     registerThemeHelper('meta_title', coreHelpers.meta_title);
     registerThemeHelper('navigation', coreHelpers.navigation);

--- a/core/frontend/helpers/link.js
+++ b/core/frontend/helpers/link.js
@@ -1,0 +1,101 @@
+// # link helper
+const _ = require('lodash');
+const {config, SafeString} = require('./proxy');
+
+const managedAttributes = ['href', 'class', 'activeClass', 'parentActiveClass', 'tagName', 'nohref'];
+
+function _getHref(hash) {
+    let href = hash.href || '/';
+    return href.string ? href.string : href;
+}
+
+function _clean(url) {
+    // Strips anchors and leading and trailing slashes
+    return url.replace(/#.*?$/, '').replace(/^\/|\/$/g, '');
+}
+
+// strips trailing slashes and compares urls
+function _urlMatch(href, location) {
+    if (!location) {
+        return false;
+    }
+
+    const strippedHref = _clean(href);
+    const strippedLocation = _clean(location);
+
+    return strippedHref === strippedLocation;
+}
+
+// We want to check if the first part of the current url is a match for href
+function _parentMatch(href, location) {
+    if (!location) {
+        return false;
+    }
+
+    let parent = false;
+    let locParts = _clean(location).split('/');
+    let hrefParts = _clean(href).split('/');
+
+    if (locParts.length <= hrefParts.length) {
+        return false;
+    }
+
+    for (let i = 0; i < hrefParts.length; i += 1) {
+        parent = hrefParts[i] === locParts[i];
+    }
+
+    return parent;
+}
+
+function _formatAttrs(attributes) {
+    let attributeString = '';
+    Object.keys(attributes).forEach((key) => {
+        let value = attributes[key];
+
+        // @TODO handle non-string attributes?
+        attributeString += `${key}="${value}"`;
+    });
+
+    return attributeString;
+}
+
+module.exports = function link(options) {
+    options = options || {};
+    options.hash = options.hash || {};
+    options.data = options.data || {};
+
+    let href = _getHref(options.hash);
+    let location = options.data.root.relativeUrl;
+    let tagName = options.hash.tagName || 'a';
+    let activeClass = _.has(options.hash, 'activeClass') ? options.hash.activeClass : 'nav-current';
+    let parentActiveClass = _.has(options.hash, 'parentActiveClass') ? options.hash.parentActiveClass : `${activeClass || 'nav-current'}-parent`;
+    let classes = options.hash.class ? options.hash.class.toString().split(' ') : [];
+    let noHref = _.has(options.hash, 'nohref') ? options.hash.nohref : false;
+
+    // Remove all the attributes we don't want to do a one-to-one mapping of
+    managedAttributes.forEach((attr) => {
+        delete options.hash[attr];
+    });
+
+    // Setup our one-to-one mapping of attributes;
+    let attributes = options.hash;
+
+    // Calculate dynamic properties
+    let relativeHref = href.replace(config.get('url'), '');
+    if (_urlMatch(relativeHref, location) && activeClass) {
+        classes.push(activeClass);
+    } else if (_parentMatch(relativeHref, location) && parentActiveClass) {
+        classes.push(parentActiveClass);
+    }
+
+    // Prepare output
+    let classString = classes.length > 0 ? `class="${classes.join(' ')}"` : '';
+    let hrefString = !noHref ? `href="${href}"` : '';
+    let attributeString = _.size(attributes) > 0 ? _formatAttrs(attributes) : '';
+    let openingTag = `<${tagName} ${classString} ${hrefString} ${attributeString}>`;
+    let closingTag = `</${tagName}>`;
+    // Clean up any extra spaces
+    openingTag = openingTag.replace(/\s{2,}/g, ' ').replace(/\s>/, '>');
+
+    return new SafeString(`${openingTag}${options.fn(this)}${closingTag}`);
+};

--- a/core/frontend/helpers/link_class.js
+++ b/core/frontend/helpers/link_class.js
@@ -1,0 +1,29 @@
+// # link_class helper
+const _ = require('lodash');
+const {config, SafeString, errors, i18n} = require('./proxy');
+const {buildLinkClasses} = require('./utils');
+
+module.exports = function link_class(options) { // eslint-disable-line camelcase
+    options = options || {};
+    options.hash = options.hash || {};
+    options.data = options.data || {};
+
+    // If there is no for provided, this is theme dev error, so we throw an error to make this clear.
+    if (!_.has(options.hash, 'for')) {
+        throw new errors.IncorrectUsageError({
+            message: i18n.t('warnings.helpers.link_class.forIsRequired')
+        });
+    }
+
+    // If the for attribute is present but empty, this is probably a dynamic data problem, hard for theme devs to track down
+    // E.g. {{link_class for=slug}} in a context where slug returns an empty string
+    // Error's here aren't useful (same as with empty get helper filters) so we fallback gracefully
+    if (!options.hash.for) {
+        options.hash.for = '';
+    }
+
+    let href = options.hash.for.string || options.hash.for;
+    let classes = buildLinkClasses(config.get('url'), href, options);
+
+    return new SafeString(classes.join(' '));
+};

--- a/core/frontend/helpers/tpl/navigation.hbs
+++ b/core/frontend/helpers/tpl/navigation.hbs
@@ -1,5 +1,5 @@
 <ul class="nav" role="menu">
     {{#foreach navigation}}
-    <li class="nav-{{slug}}{{#if current}} nav-current{{/if}}" role="menuitem"><a href="{{url absolute="true"}}">{{label}}</a></li>
+    <li class="{{link_class for=(url) class=(concat "nav-" slug)}}" role="menuitem"><a href="{{url absolute="true"}}">{{label}}</a></li>
     {{/foreach}}
 </ul>

--- a/core/frontend/helpers/utils.js
+++ b/core/frontend/helpers/utils.js
@@ -11,3 +11,58 @@ module.exports.findKey = function findKey(key /* ...objects... */) {
         return result;
     }, null);
 };
+
+function _urlClean(url) {
+    // Strips anchors and leading and trailing slashes
+    return url.replace(/#.*?$/, '').replace(/^\/|\/$/g, '');
+}
+
+// strips trailing slashes and compares urls
+function _urlMatch(href, location) {
+    if (!location) {
+        return false;
+    }
+
+    const strippedHref = _urlClean(href);
+    const strippedLocation = _urlClean(location);
+
+    return strippedHref === strippedLocation;
+}
+
+// We want to check if the first part of the current url is a match for href
+function _urlParentMatch(href, location) {
+    if (!location) {
+        return false;
+    }
+
+    let parent = false;
+    let locParts = _urlClean(location).split('/');
+    let hrefParts = _urlClean(href).split('/');
+
+    if (locParts.length <= hrefParts.length) {
+        return false;
+    }
+
+    for (let i = 0; i < hrefParts.length; i += 1) {
+        parent = hrefParts[i] === locParts[i];
+    }
+
+    return parent;
+}
+
+module.exports.buildLinkClasses = function buildLinkClasses(siteUrl, href, options) {
+    let relativeHref = href.replace(siteUrl, '');
+    let location = options.data.root.relativeUrl;
+    let classes = options.hash.class ? options.hash.class.toString().split(' ') : [];
+    let activeClass = _.has(options.hash, 'activeClass') ? options.hash.activeClass : 'nav-current';
+    let parentActiveClass = _.has(options.hash, 'parentActiveClass') ? options.hash.parentActiveClass : `${activeClass || 'nav-current'}-parent`;
+
+    // Calculate dynamic properties
+    if (_urlMatch(relativeHref, location) && activeClass) {
+        classes.push(activeClass);
+    } else if (_urlParentMatch(relativeHref, location) && parentActiveClass) {
+        classes.push(parentActiveClass);
+    }
+
+    return classes;
+};

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -596,6 +596,12 @@
             "is": {
                 "invalidAttribute": "Invalid or no attribute given to is helper"
             },
+            "link": {
+                "hrefIsRequired": "The \\{\\{#link\\}\\}\\{\\{/link\\}\\} helper requires an href=\"\" attribute."
+            },
+            "link_class": {
+                "forIsRequired": "The \\{\\{link_class\\}\\} helper requires a for=\"\" attribute."
+            },
             "navigation": {
                 "invalidData": "navigation data is not an object or is a function",
                 "valuesMustBeDefined": "All values must be defined for label, url and current",

--- a/core/test/unit/helpers/concat_spec.js
+++ b/core/test/unit/helpers/concat_spec.js
@@ -1,0 +1,98 @@
+const should = require('should');
+const helpers = require.main.require('core/frontend/helpers');
+const handlebars = require.main.require('core/frontend/services/themes/engine').handlebars;
+
+const configUtils = require('../../utils/configUtils');
+
+let defaultGlobals;
+
+function compile(templateString) {
+    const template = handlebars.compile(templateString);
+    template.with = (locals = {}, globals) => {
+        globals = globals || defaultGlobals;
+
+        return template(locals, globals);
+    };
+
+    return template;
+}
+
+describe('{{concat}} helper', function () {
+    before(function () {
+        handlebars.registerHelper('concat', helpers.concat);
+        handlebars.registerHelper('url', helpers.url);
+        configUtils.config.set('url', 'https://siteurl.com');
+
+        defaultGlobals = {
+            data: {
+                site: {
+                    url: configUtils.config.get('url')
+                }
+            }
+        };
+    });
+
+    it('can correctly concat nothing', function () {
+        compile('{{concat}}')
+            .with({})
+            .should.eql('');
+    });
+
+    it('can correctly concat things that resolve to empty', function () {
+        compile('{{concat tag.slug slug}}')
+        .with({tag: {}})
+        .should.eql('');
+    });
+
+    it('can concat simple strings', function () {
+        compile('{{concat "hello" "world"}}')
+            .with({})
+            .should.eql('helloworld');
+    });
+
+    it('can concat simple strings with a custom separator', function () {
+        compile('{{concat "hello" "world" separator=" "}}')
+            .with({})
+            .should.eql('hello world');
+    });
+
+    it('can concat strings and numbers', function () {
+        compile('{{concat "abcd" 1234}}')
+            .with({})
+            .should.eql('abcd1234');
+    });
+
+    it('can concat strings and global variables', function () {
+        compile('{{concat @site.url "?my=param"}}')
+            .with({})
+            .should.eql('https://siteurl.com?my=param');
+    });
+
+    it('can concat strings and local variables', function () {
+        compile('{{concat tag.slug "?my=param"}}')
+            .with({tag: {slug: 'my-tag'}})
+            .should.eql('my-tag?my=param');
+    });
+
+    it('can concat strings from custom helpers (SafeStrings)', function () {
+        compile('{{concat (url) "?my=param"}}')
+            // Simulate a post - using a draft to prove url helper gets called
+            // because published posts get their urls from a cache that we don't have access to, so we just get 404
+            .with({title: 'My Draft Post', slug: 'my-post', html: '<p>My Post</p>', uuid: '1234'})
+            .should.eql('/p/1234/?my=param');
+    });
+
+    it('can concat mixed args', function () {
+        compile('{{concat @site.url (url) "?slug=" slug}}')
+            // Simulate a post - using a draft to prove url helper gets called
+            // because published posts get their urls from a cache that we don't have access to, so we just get 404
+            .with({title: 'My Draft Post', slug: 'my-post', html: '<p>My Post</p>', uuid: '1234'})
+            .should.eql('https://siteurl.com/p/1234/?slug=my-post');
+    });
+
+    it('will output object Object for sill args', function () {
+        compile('{{concat @site "?my=param"}}')
+            .with({})
+            .should.eql('[object Object]?my=param');
+    });
+});

--- a/core/test/unit/helpers/index_spec.js
+++ b/core/test/unit/helpers/index_spec.js
@@ -9,7 +9,7 @@ describe('Helpers', function () {
     var hbsHelpers = ['each', 'if', 'unless', 'with', 'helperMissing', 'blockHelperMissing', 'log', 'lookup', 'block', 'contentFor'],
         ghostHelpers = [
             'asset', 'author', 'authors', 'body_class', 'concat', 'content', 'date', 'encode', 'excerpt', 'facebook_url', 'foreach', 'get',
-            'ghost_foot', 'ghost_head', 'has', 'img_url', 'is', 'lang', 'meta_description', 'meta_title', 'navigation',
+            'ghost_foot', 'ghost_head', 'has', 'img_url', 'is', 'lang', 'link', 'meta_description', 'meta_title', 'navigation',
             'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'reading_time', 't', 'tags', 'title', 'twitter_url',
             'url'
         ],

--- a/core/test/unit/helpers/index_spec.js
+++ b/core/test/unit/helpers/index_spec.js
@@ -9,7 +9,7 @@ describe('Helpers', function () {
     var hbsHelpers = ['each', 'if', 'unless', 'with', 'helperMissing', 'blockHelperMissing', 'log', 'lookup', 'block', 'contentFor'],
         ghostHelpers = [
             'asset', 'author', 'authors', 'body_class', 'concat', 'content', 'date', 'encode', 'excerpt', 'facebook_url', 'foreach', 'get',
-            'ghost_foot', 'ghost_head', 'has', 'img_url', 'is', 'lang', 'link', 'meta_description', 'meta_title', 'navigation',
+            'ghost_foot', 'ghost_head', 'has', 'img_url', 'is', 'lang', 'link', 'link_class', 'meta_description', 'meta_title', 'navigation',
             'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'reading_time', 't', 'tags', 'title', 'twitter_url',
             'url'
         ],

--- a/core/test/unit/helpers/index_spec.js
+++ b/core/test/unit/helpers/index_spec.js
@@ -8,7 +8,7 @@ var should = require('should'),
 describe('Helpers', function () {
     var hbsHelpers = ['each', 'if', 'unless', 'with', 'helperMissing', 'blockHelperMissing', 'log', 'lookup', 'block', 'contentFor'],
         ghostHelpers = [
-            'asset', 'author', 'authors', 'body_class', 'content', 'date', 'encode', 'excerpt', 'facebook_url', 'foreach', 'get',
+            'asset', 'author', 'authors', 'body_class', 'concat', 'content', 'date', 'encode', 'excerpt', 'facebook_url', 'foreach', 'get',
             'ghost_foot', 'ghost_head', 'has', 'img_url', 'is', 'lang', 'meta_description', 'meta_title', 'navigation',
             'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'reading_time', 't', 'tags', 'title', 'twitter_url',
             'url'

--- a/core/test/unit/helpers/link_class_spec.js
+++ b/core/test/unit/helpers/link_class_spec.js
@@ -1,0 +1,276 @@
+const should = require('should');
+const helpers = require.main.require('core/frontend/helpers');
+const handlebars = require.main.require('core/frontend/services/themes/engine').handlebars;
+
+const configUtils = require('../../utils/configUtils');
+
+let defaultGlobals;
+
+function compile(templateString) {
+    const template = handlebars.compile(templateString);
+    template.with = (locals = {}, globals) => {
+        globals = globals || defaultGlobals;
+
+        return template(locals, globals);
+    };
+
+    return template;
+}
+
+describe('{{link_class}} helper', function () {
+    before(function () {
+        handlebars.registerHelper('link_class', helpers.link_class);
+        handlebars.registerHelper('concat', helpers.concat);
+        configUtils.config.set('url', 'https://siteurl.com');
+        defaultGlobals = {
+            data: {
+                site: {
+                    url: configUtils.config.get('url')
+                }
+            }
+        };
+    });
+
+    after(function () {
+        configUtils.restore();
+    });
+
+    it('throws an error for missing for=""', function () {
+        (function compileWith() {
+            compile('{{link_class}}')
+                .with({});
+        }).should.throw();
+    });
+
+    it('silently accepts an empty for...', function () {
+        compile('{{link_class for=tag.slug}}')
+            .with({tag: null})
+            .should.eql('');
+    });
+
+    describe('activeClass', function () {
+        it('gets applied correctly', function () {
+            // Test matching relative URL
+            compile('{{link_class for="/about/"}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('nav-current');
+
+            // Test non-matching relative URL
+            compile('{{link_class for="/about/"}}')
+                .with({relativeUrl: '/'})
+                .should.eql('');
+        });
+
+        it('ignores anchors', function () {
+            // Anchor in href
+            compile('{{link_class for="/about/#me"}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('nav-current');
+
+            // Anchor in relative URL
+            compile('{{link_class for="/about/"}}')
+                .with({relativeUrl: '/about/#me'})
+                .should.eql('nav-current');
+        });
+
+        it('handles missing trailing slashes', function () {
+            compile('{{link_class for="/about"}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('nav-current');
+        });
+
+        it('handles absolute URLs', function () {
+            // Correct URL gets class
+            compile('{{link_class for="https://siteurl.com/about/"}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('nav-current');
+
+            // Incorrect URL doesn't get class
+            compile('{{link_class for="https://othersite.com/about/"}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('');
+        });
+
+        it('handles absolute URL with missing trailing slash', function () {
+            compile('{{link_class for="https://siteurl.com/about"}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('nav-current');
+        });
+
+        it('activeClass can be customised', function () {
+            compile('{{link_class for="/about/" activeClass="nav-active"}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('nav-active');
+
+            compile('{{link_class for="/about/" activeClass=slug}}')
+                .with({relativeUrl: '/about/', slug: 'fred'})
+                .should.eql('fred');
+
+            compile('{{link_class for="/about/" activeClass=(concat slug "active" separator="-")}}')
+                .with({relativeUrl: '/about/', slug: 'fred'})
+                .should.eql('fred-active');
+        });
+
+        it('activeClass and other classes work together', function () {
+            // Single extra class
+            compile('{{link_class for="/about/" class="about"}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('about nav-current');
+
+            // Multiple extra classes
+            compile('{{link_class for="/about/" class="about my-link"}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('about my-link nav-current');
+        });
+
+        it('can disable activeClass with falsey values', function () {
+            // Empty string
+            compile('{{link_class for="/about/" activeClass=""}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('');
+
+            // false
+            compile('{{link_class for="/about/" activeClass=false}}')
+                .with({relativeUrl: '/about/'})
+                .should.eql('');
+        });
+    });
+
+    describe('parentActiveClass', function () {
+        it('gets applied correctly', function () {
+            // Parent and child links with PARENT as relative URL
+            compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/'})
+                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+
+            // Parent and child links with CHILD as relative URL
+            compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+        });
+
+        it('ignores anchors', function () {
+            // Anchor in href
+
+            // Parent and child links with PARENT as relative URL
+            compile('<li class="{{link_class for="/about/#me"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/'})
+                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+
+            // Parent and child links with CHILD as relative URL
+            compile('<li class="{{link_class for="/about/#me"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+
+            // Anchor in relative URL
+
+            // Parent and child links with PARENT as relative URL
+            compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/#me'})
+                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+
+            // Parent and child links with CHILD as relative URL
+            compile('<li class="{{link_class for="/about/"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/#me'})
+                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+        });
+
+        it('handles missing trailing slashes', function () {
+            // Parent and child links with PARENT as relative URL
+            compile('<li class="{{link_class for="/about"}}">parent</li><li class="{{link_class for="/about/team"}}">child</li>')
+                .with({relativeUrl: '/about/'})
+                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+
+            // Parent and child links with CHILD as relative URL
+            compile('<li class="{{link_class for="/about"}}">parent</li><li class="{{link_class for="/about/team"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+        });
+
+        it('handles absolute URLs', function () {
+            // Correct URL gets class
+
+            // Parent and child links with PARENT as relative URL
+            compile('<li class="{{link_class for="https://siteurl.com/about/"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/'})
+                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+
+            // Parent and child links with CHILD as relative URL
+            compile('<li class="{{link_class for="https://siteurl.com/about/"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+
+            // Incorrect URL doesn't get class
+
+            // Parent and child links with PARENT as relative URL
+            compile('<li class="{{link_class for="https://othersite.com/about/"}}">parent</li><li class="{{link_class for="https://othersite.com/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/'})
+                .should.eql('<li class="">parent</li><li class="">child</li>');
+
+            // Parent and child links with CHILD as relative URL
+            compile('<li class="{{link_class for="https://othersite.com/about/"}}">parent</li><li class="{{link_class for="https://othersite.com/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="">parent</li><li class="">child</li>');
+        });
+
+        it('handles absolute URLs with missing trailing slashes', function () {
+            // Parent and child links with PARENT as relative URL
+            compile('<li class="{{link_class for="https://siteurl.com/about"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team"}}">child</li>')
+                .with({relativeUrl: '/about/'})
+                .should.eql('<li class="nav-current">parent</li><li class="">child</li>');
+
+            // Parent and child links with CHILD as relative URL
+            compile('<li class="{{link_class for="https://siteurl.com/about"}}">parent</li><li class="{{link_class for="https://siteurl.com/about/team"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="nav-current-parent">parent</li><li class="nav-current">child</li>');
+        });
+
+        it('parentActiveClass can be customised', function () {
+            compile('<li class="{{link_class for="/about/" parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="parent">parent</li><li class="nav-current">child</li>');
+
+            compile('<li class="{{link_class for="/about/" parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/" parentActiveClass="parent"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="parent">parent</li><li class="nav-current">child</li>');
+
+            compile('<li class="{{link_class for="/about/" parentActiveClass=slug}}">parent</li><li class="{{link_class for="/about/team/" parentActiveClass="parent"}}">child</li>')
+                .with({relativeUrl: '/about/team/', slug: 'fred'})
+                .should.eql('<li class="fred">parent</li><li class="nav-current">child</li>');
+
+            compile('<li class="{{link_class for="/about/" parentActiveClass=(concat slug "-parent")}}">parent</li><li class="{{link_class for="/about/team/" parentActiveClass="parent"}}">child</li>')
+                .with({relativeUrl: '/about/team/', slug: 'fred'})
+                .should.eql('<li class="fred-parent">parent</li><li class="nav-current">child</li>');
+        });
+
+        it('customising activeClass also customises parentActiveClass', function () {
+            compile('<li class="{{link_class for="/about/" activeClass="active"}}">parent</li><li class="{{link_class for="/about/team/" activeClass="active"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="active-parent">parent</li><li class="active">child</li>');
+
+            compile('<li class="{{link_class for="/about/" activeClass="active" parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/" activeClass="active"}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="parent">parent</li><li class="active">child</li>');
+        });
+
+        it('can disable parentActiveClass with falsey values', function () {
+            compile('{{link_class for="/about/" parentActiveClass=""}}')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('');
+
+            compile('{{link_class for="/about/" parentActiveClass=false}}')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('');
+        });
+
+        it('disabling activeClass does not affect parentActiveClass', function () {
+            compile('<li class="{{link_class for="/about/" activeClass=""}}">parent</li><li class="{{link_class for="/about/team/" activeClass=""}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="nav-current-parent">parent</li><li class="">child</li>');
+
+            compile('<li class="{{link_class for="/about/" activeClass=false parentActiveClass="parent"}}">parent</li><li class="{{link_class for="/about/team/" activeClass=false}}">child</li>')
+                .with({relativeUrl: '/about/team/'})
+                .should.eql('<li class="parent">parent</li><li class="">child</li>');
+        });
+    });
+});

--- a/core/test/unit/helpers/link_spec.js
+++ b/core/test/unit/helpers/link_spec.js
@@ -1,0 +1,356 @@
+const should = require('should');
+const helpers = require.main.require('core/frontend/helpers');
+const handlebars = require.main.require('core/frontend/services/themes/engine').handlebars;
+
+const configUtils = require('../../utils/configUtils');
+
+let defaultGlobals;
+
+function compile(templateString) {
+    const template = handlebars.compile(templateString);
+    template.with = (locals = {}, globals) => {
+        globals = globals || defaultGlobals;
+
+        return template(locals, globals);
+    };
+
+    return template;
+}
+
+describe('{{link}} helper', function () {
+    before(function () {
+        handlebars.registerHelper('link', helpers.link);
+        handlebars.registerHelper('url', helpers.url);
+        handlebars.registerHelper('concat', helpers.concat);
+        configUtils.config.set('url', 'https://siteurl.com');
+        defaultGlobals = {
+            data: {
+                site: {
+                    url: configUtils.config.get('url')
+                }
+            }
+        };
+    });
+
+    after(function () {
+        configUtils.restore();
+    });
+
+    describe('basic behaviour: simple links without context', function () {
+        it('basic <a> tag with default url', function () {
+            compile('{{#link}}text{{/link}}')
+                .with({})
+                .should.eql('<a href="/">text</a>');
+        });
+
+        it('<a> tag with a specific URL', function () {
+            compile('{{#link href="/about/"}}text{{/link}}')
+                .with({})
+                .should.eql('<a href="/about/">text</a>');
+        });
+
+        it('<a> tag with an anchor', function () {
+            compile('{{#link href="#myheading"}}text{{/link}}')
+                .with({})
+                .should.eql('<a href="#myheading">text</a>');
+        });
+
+        it('<a> tag with global variable', function () {
+            compile('{{#link href=@site.url}}text{{/link}}')
+                .with({})
+                .should.eql('<a href="https://siteurl.com">text</a>');
+        });
+
+        it('<a> tag with local variable', function () {
+            compile('{{#link href=tag.slug}}text{{/link}}')
+                .with({tag: {slug: 'my-tag'}})
+                .should.eql('<a href="my-tag">text</a>');
+        });
+
+        it('<a> tag with nested helpers', function () {
+            compile('{{#link href=(url)}}{{title}}{{/link}}')
+            // Simulate a post - using a draft to prove url helper gets called
+            // because published posts get their urls from a cache that we don't have access to, so we just get 404
+                .with({title: 'My Draft Post', slug: 'my-post', html: '<p>My Post</p>', uuid: '1234'})
+                .should.eql('<a href="/p/1234/">My Draft Post</a>');
+        });
+
+        it('can wrap html content', function () {
+            compile('{{#link href="/"}}<img src="myfile.jpg" />{{/link}}')
+                .with({})
+                .should.eql('<a href="/"><img src="myfile.jpg" /></a>');
+        });
+
+        it('honours class attribute', function () {
+            compile('{{#link href="#myheading" class="my-class"}}text{{/link}}')
+                .with({})
+                .should.eql('<a class="my-class" href="#myheading">text</a>');
+        });
+
+        it('supports multiple classes', function () {
+            compile('{{#link href="#myheading" class="my-class and-stuff"}}text{{/link}}')
+                .with({})
+                .should.eql('<a class="my-class and-stuff" href="#myheading">text</a>');
+        });
+
+        it('can handle classes that come from variables', function () {
+            compile('{{#link href="#myheading" class=slug}}text{{/link}}')
+            .with({slug: 'fred'})
+            .should.eql('<a class="fred" href="#myheading">text</a>');
+        });
+
+        it('can handle classes that come from helpers', function () {
+            compile('{{#link href="#myheading" class=(concat "my-" slug)}}text{{/link}}')
+            .with({slug: 'fred'})
+            .should.eql('<a class="my-fred" href="#myheading">text</a>');
+        });
+
+        it('supports multiple attributes', function () {
+            compile('{{#link href="#myheading" class="my-class" target="_blank"}}text{{/link}}')
+                .with({})
+                .should.eql('<a class="my-class" href="#myheading" target="_blank">text</a>');
+        });
+    });
+
+    describe('dynamic behaviour: advanced links using context', function () {
+        describe('activeClass', function () {
+            it('gets applied correctly', function () {
+                // Test matching relative URL
+                compile('{{#link href="/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="/about/">text</a>');
+
+                // Test non-matching relative URL
+                compile('{{#link href="/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/'})
+                    .should.eql('<a href="/about/">text</a>');
+            });
+
+            it('ignores anchors', function () {
+                // Anchor in href
+                compile('{{#link href="/about/#me"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="/about/#me">text</a>');
+
+                // Anchor in relative URL
+                compile('{{#link href="/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/about/#me'})
+                    .should.eql('<a class="nav-current" href="/about/">text</a>');
+            });
+
+            it('handles missing trailing slashes', function () {
+                compile('{{#link href="/about"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="/about">text</a>');
+            });
+
+            it('handles absolute URLs', function () {
+                // Correct URL gets class
+                compile('{{#link href="https://siteurl.com/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="https://siteurl.com/about/">text</a>');
+
+                // Incorrect URL doesn't get class
+                compile('{{#link href="https://othersite.com/about/"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a href="https://othersite.com/about/">text</a>');
+            });
+
+            it('handles absolute URL with missing trailing slash', function () {
+                compile('{{#link href="https://siteurl.com/about"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="https://siteurl.com/about">text</a>');
+            });
+
+            it('activeClass can be customised', function () {
+                compile('{{#link href="/about/" activeClass="nav-active"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-active" href="/about/">text</a>');
+
+                compile('{{#link href="/about/" activeClass=slug}}text{{/link}}')
+                    .with({relativeUrl: '/about/', slug: 'fred'})
+                    .should.eql('<a class="fred" href="/about/">text</a>');
+
+                compile('{{#link href="/about/" activeClass=(concat slug "active" separator="-")}}text{{/link}}')
+                    .with({relativeUrl: '/about/', slug: 'fred'})
+                    .should.eql('<a class="fred-active" href="/about/">text</a>');
+            });
+
+            it('activeClass and other classes work together', function () {
+                // Single extra class
+                compile('{{#link href="/about/" class="about"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="about nav-current" href="/about/">text</a>');
+
+                // Multiple extra classes
+                compile('{{#link href="/about/" class="about my-link"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="about my-link nav-current" href="/about/">text</a>');
+            });
+
+            it('can disable activeClass with falsey values', function () {
+                // Empty string
+                compile('{{#link href="/about/" activeClass=""}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a href="/about/">text</a>');
+
+                // false
+                compile('{{#link href="/about/" activeClass=false}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a href="/about/">text</a>');
+            });
+        });
+
+        describe('parentActiveClass', function () {
+            it('gets applied correctly', function () {
+                // Parent and child links with PARENT as relative URL
+                compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="/about/">parent</a><a href="/about/team/">child</a>');
+
+                // Parent and child links with CHILD as relative URL
+                compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="nav-current-parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+            });
+
+            it('ignores anchors', function () {
+                // Anchor in href
+
+                // Parent and child links with PARENT as relative URL
+                compile('{{#link href="/about/#me"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="/about/#me">parent</a><a href="/about/team/">child</a>');
+
+                // Parent and child links with CHILD as relative URL
+                compile('{{#link href="/about/#me"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="nav-current-parent" href="/about/#me">parent</a><a class="nav-current" href="/about/team/">child</a>');
+
+                // Anchor in relative URL
+
+                // Parent and child links with PARENT as relative URL
+                compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/#me'})
+                    .should.eql('<a class="nav-current" href="/about/">parent</a><a href="/about/team/">child</a>');
+
+                // Parent and child links with CHILD as relative URL
+                compile('{{#link href="/about/"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/#me'})
+                    .should.eql('<a class="nav-current-parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+            });
+
+            it('handles missing trailing slashes', function () {
+                // Parent and child links with PARENT as relative URL
+                compile('{{#link href="/about"}}parent{{/link}}{{#link href="/about/team"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="/about">parent</a><a href="/about/team">child</a>');
+
+                // Parent and child links with CHILD as relative URL
+                compile('{{#link href="/about"}}parent{{/link}}{{#link href="/about/team"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="nav-current-parent" href="/about">parent</a><a class="nav-current" href="/about/team">child</a>');
+            });
+
+            it('handles absolute URLs', function () {
+                // Correct URL gets class
+
+                // Parent and child links with PARENT as relative URL
+                compile('{{#link href="https://siteurl.com/about/"}}parent{{/link}}{{#link href="https://siteurl.com/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="https://siteurl.com/about/">parent</a><a href="https://siteurl.com/about/team/">child</a>');
+
+                // Parent and child links with CHILD as relative URL
+                compile('{{#link href="https://siteurl.com/about/"}}parent{{/link}}{{#link href="https://siteurl.com/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="nav-current-parent" href="https://siteurl.com/about/">parent</a><a class="nav-current" href="https://siteurl.com/about/team/">child</a>');
+
+                // Incorrect URL doesn't get class
+
+                // Parent and child links with PARENT as relative URL
+                compile('{{#link href="https://othersite.com/about/"}}parent{{/link}}{{#link href="https://othersite.com/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a href="https://othersite.com/about/">parent</a><a href="https://othersite.com/about/team/">child</a>');
+
+                // Parent and child links with CHILD as relative URL
+                compile('{{#link href="https://othersite.com/about/"}}parent{{/link}}{{#link href="https://othersite.com/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a href="https://othersite.com/about/">parent</a><a href="https://othersite.com/about/team/">child</a>');
+            });
+
+            it('handles absolute URLs with missing trailing slashes', function () {
+                // Parent and child links with PARENT as relative URL
+                compile('{{#link href="https://siteurl.com/about"}}parent{{/link}}{{#link href="https://siteurl.com/about/team"}}child{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<a class="nav-current" href="https://siteurl.com/about">parent</a><a href="https://siteurl.com/about/team">child</a>');
+
+                // Parent and child links with CHILD as relative URL
+                compile('{{#link href="https://siteurl.com/about"}}parent{{/link}}{{#link href="https://siteurl.com/about/team"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="nav-current-parent" href="https://siteurl.com/about">parent</a><a class="nav-current" href="https://siteurl.com/about/team">child</a>');
+            });
+
+            it('parentActiveClass can be customised', function () {
+                compile('{{#link href="/about/" parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+
+                compile('{{#link href="/about/" parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" parentActiveClass="parent"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+
+                compile('{{#link href="/about/" parentActiveClass=slug}}parent{{/link}}{{#link href="/about/team/" parentActiveClass="parent"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/', slug: 'fred'})
+                    .should.eql('<a class="fred" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+
+                compile('{{#link href="/about/" parentActiveClass=(concat slug "-parent")}}parent{{/link}}{{#link href="/about/team/" parentActiveClass="parent"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/', slug: 'fred'})
+                    .should.eql('<a class="fred-parent" href="/about/">parent</a><a class="nav-current" href="/about/team/">child</a>');
+            });
+
+            it('customising activeClass also customises parentActiveClass', function () {
+                compile('{{#link href="/about/" activeClass="active"}}parent{{/link}}{{#link href="/about/team/" activeClass="active"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="active-parent" href="/about/">parent</a><a class="active" href="/about/team/">child</a>');
+
+                compile('{{#link href="/about/" activeClass="active" parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" activeClass="active"}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="parent" href="/about/">parent</a><a class="active" href="/about/team/">child</a>');
+            });
+
+            it('can disable parentActiveClass with falsey values', function () {
+                compile('{{#link href="/about/" parentActiveClass=""}}text{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a href="/about/">text</a>');
+
+                compile('{{#link href="/about/" parentActiveClass=false}}text{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a href="/about/">text</a>');
+            });
+
+            it('disabling activeClass does not affect parentActiveClass', function () {
+                compile('{{#link href="/about/" activeClass=""}}parent{{/link}}{{#link href="/about/team/" activeClass=""}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="nav-current-parent" href="/about/">parent</a><a href="/about/team/">child</a>');
+
+                compile('{{#link href="/about/" activeClass=false parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" activeClass=false}}child{{/link}}')
+                    .with({relativeUrl: '/about/team/'})
+                    .should.eql('<a class="parent" href="/about/">parent</a><a href="/about/team/">child</a>');
+            });
+        });
+
+        describe('custom tag', function () {
+            it('can change tag', function () {
+                compile('{{#link href="/about/" class="my-class" tagName="li"}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<li class="my-class nav-current" href="/about/">text</li>');
+            });
+
+            it('can change tag and disable href', function () {
+                compile('{{#link href="/about/" class="my-class" tagName="li" nohref=true}}text{{/link}}')
+                    .with({relativeUrl: '/about/'})
+                    .should.eql('<li class="my-class nav-current">text</li>');
+            });
+        });
+    });
+});

--- a/core/test/unit/helpers/link_spec.js
+++ b/core/test/unit/helpers/link_spec.js
@@ -37,10 +37,17 @@ describe('{{link}} helper', function () {
     });
 
     describe('basic behaviour: simple links without context', function () {
-        it('basic <a> tag with default url', function () {
-            compile('{{#link}}text{{/link}}')
-                .with({})
-                .should.eql('<a href="/">text</a>');
+        it('throws an error for missing href=""', function () {
+            (function compileWith() {
+                compile('{{#link}}text{{/link}}')
+                    .with({});
+            }).should.throw();
+        });
+
+        it('silently accepts an empty href...', function () {
+            compile('{{#link href=tag.slug}}text{{/link}}')
+                .with({tag: null})
+                .should.eql('<a href="">text</a>');
         });
 
         it('<a> tag with a specific URL', function () {
@@ -336,20 +343,6 @@ describe('{{link}} helper', function () {
                 compile('{{#link href="/about/" activeClass=false parentActiveClass="parent"}}parent{{/link}}{{#link href="/about/team/" activeClass=false}}child{{/link}}')
                     .with({relativeUrl: '/about/team/'})
                     .should.eql('<a class="parent" href="/about/">parent</a><a href="/about/team/">child</a>');
-            });
-        });
-
-        describe('custom tag', function () {
-            it('can change tag', function () {
-                compile('{{#link href="/about/" class="my-class" tagName="li"}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<li class="my-class nav-current" href="/about/">text</li>');
-            });
-
-            it('can change tag and disable href', function () {
-                compile('{{#link href="/about/" class="my-class" tagName="li" nohref=true}}text{{/link}}')
-                    .with({relativeUrl: '/about/'})
-                    .should.eql('<li class="my-class nav-current">text</li>');
             });
         });
     });

--- a/core/test/unit/helpers/navigation_spec.js
+++ b/core/test/unit/helpers/navigation_spec.js
@@ -21,6 +21,8 @@ describe('{{navigation}} helper', function () {
 
         // The navigation partial expects this helper
         // @TODO: change to register with Ghost's own registration tools
+        hbs.registerHelper('link_class', helpers.link_class);
+        hbs.registerHelper('concat', helpers.concat);
         hbs.registerHelper('url', helpers.url);
         hbs.registerHelper('foreach', helpers.foreach);
     });


### PR DESCRIPTION
@kevinansfield I think it makes sense to merge this as 4 commits, but wanted to check.

----

closes: #5162

This PR introduces 3 new helpers intended to give theme developers more control over creating navigation and also updates our internal navigation.hbs template to use these new helpers.

Summary behaviour:

**{{link_class}} helper**

Purpose: output dynamic classes for a given URL

E.g.

`{{link_class for="/about/"}}`

outputs:

- `` when the current URL is not /about/
- `nav-current` when the current URL is /about/

**{{#link}}{{/link}} helper**

Purpose: output an <a> tag with dynamic classes

E.g.

`{{#link href="/about/"}}About{{/link}}`

outputs:

- `<a href="/about/">About</a>` when the current URL is not /about/
- `<a class="nav-current" href="/about/">About</a>` when the current URL is /about/

**{{concat}} helper**

Purpose: concatenate multiple strings together

E.g.

`{{concat "a" "b" "c"}}` -> "abc"

----

These 3 helpers together give full flexibility to build dynamic linking into a theme. The utility of concat becomes apparent inside the attributes of other helpers, where it's no longer possible to write the natural concatenation that's possible with HTML.

Slightly contrived example:

```
In HTML:
<a class="post-card {{post_class}}" href="{{url}}?ref={{slug}}">{{title}}</a>` becomes

When using a helper:
{{#link class=(concat "post-card" (post_class) separator=" ") href=(concat (url) "?ref=" slug)}}{{title}}{{/link}}
```

