### PR TITLE
Add new api endpoint for canary

### DIFF
--- a/core/frontend/services/routing/config/canary.js
+++ b/core/frontend/services/routing/config/canary.js
@@ -1,0 +1,54 @@
+/* eslint-disable */
+module.exports.QUERY = {
+    tag: {
+        controller: 'tagsPublic',
+        type: 'read',
+        resource: 'tags',
+        options: {
+            slug: '%s',
+            visibility: 'public'
+        }
+    },
+    author: {
+        controller: 'authorsPublic',
+        type: 'read',
+        resource: 'authors',
+        options: {
+            slug: '%s'
+        }
+    },
+    post: {
+        controller: 'postsPublic',
+        type: 'read',
+        resource: 'posts',
+        options: {
+            slug: '%s'
+        }
+    },
+    page: {
+        controller: 'pagesPublic',
+        type: 'read',
+        resource: 'pages',
+        options: {
+            slug: '%s'
+        }
+    },
+    preview: {
+        controller: 'preview',
+        resource: 'preview'
+    }
+};
+
+module.exports.TAXONOMIES = {
+    tag: {
+        filter: 'tags:\'%s\'+tags.visibility:public',
+        editRedirect: '#/settings/tags/:slug/',
+        resource: 'tags'
+    },
+    author: {
+        filter: 'authors:\'%s\'',
+        editRedirect: '#/team/:slug/',
+        resource: 'authors'
+    }
+};
+/* eslint-enable */

--- a/core/frontend/services/themes/engines/create.js
+++ b/core/frontend/services/themes/engines/create.js
@@ -14,7 +14,8 @@ const allowedKeys = ['ghost-api'];
  * 2.0.0
  * v2
  * v0.1
- *
+ * canary
+ * 
  * Goal: Extract major version from input.
  *
  * @param packageJson
@@ -27,13 +28,16 @@ module.exports = (packageJson) => {
         // CASE: validate
         if (packageJson.engines['ghost-api']) {
             const availableApiVersions = {};
-
             config.get('api:versions:all').forEach((version) => {
-                availableApiVersions[semver(semver.coerce(version).version).major] = version;
+                if (version === 'canary') {
+                    availableApiVersions.canary = version;
+                } else {
+                    availableApiVersions[semver(semver.coerce(version).version).major] = version;
+                }
             });
 
             const apiVersion = packageJson.engines['ghost-api'];
-            const apiVersionMajor = semver(semver.coerce(apiVersion).version).major;
+            const apiVersionMajor = apiVersion === 'canary' ? 'canary' : semver(semver.coerce(apiVersion).version).major;
 
             if (availableApiVersions[apiVersionMajor]) {
                 packageJson.engines['ghost-api'] = availableApiVersions[apiVersionMajor];

--- a/core/frontend/services/url/configs/canary.js
+++ b/core/frontend/services/url/configs/canary.js
@@ -1,0 +1,141 @@
+/*
+ * These are the default resources and filters.
+ * They contain minimum filters for public accessibility of resources.
+ */
+
+module.exports = [
+    {
+        type: 'posts',
+        modelOptions: {
+            modelName: 'Post',
+            filter: 'visibility:public+status:published+page:false',
+            exclude: [
+                'title',
+                'mobiledoc',
+                'html',
+                'plaintext',
+                // @TODO: https://github.com/TryGhost/Ghost/issues/10335
+                // 'page',
+                'status',
+                'amp',
+                'codeinjection_head',
+                'codeinjection_foot',
+                'meta_title',
+                'meta_description',
+                'custom_excerpt',
+                'og_image',
+                'og_title',
+                'og_description',
+                'twitter_image',
+                'twitter_title',
+                'twitter_description',
+                'custom_template',
+                'locale'
+            ],
+            withRelated: ['tags', 'authors'],
+            withRelatedPrimary: {
+                primary_tag: 'tags',
+                primary_author: 'authors'
+            },
+            withRelatedFields: {
+                tags: ['tags.id', 'tags.slug'],
+                authors: ['users.id', 'users.slug']
+            }
+        },
+        events: {
+            add: 'post.published',
+            update: 'post.published.edited',
+            remove: 'post.unpublished'
+        }
+    },
+    {
+        type: 'pages',
+        modelOptions: {
+            modelName: 'Post',
+            exclude: [
+                'title',
+                'mobiledoc',
+                'html',
+                'plaintext',
+                // @TODO: https://github.com/TryGhost/Ghost/issues/10335
+                // 'page',
+                // 'status',
+                'amp',
+                'codeinjection_head',
+                'codeinjection_foot',
+                'meta_title',
+                'meta_description',
+                'custom_excerpt',
+                'og_image',
+                'og_title',
+                'og_description',
+                'twitter_image',
+                'twitter_title',
+                'twitter_description',
+                'custom_template',
+                'locale',
+                'tags',
+                'authors',
+                'primary_tag',
+                'primary_author'
+            ],
+            filter: 'visibility:public+status:published+page:true'
+        },
+        events: {
+            add: 'page.published',
+            update: 'page.published.edited',
+            remove: 'page.unpublished'
+        }
+    },
+    {
+        type: 'tags',
+        keep: ['id', 'slug'],
+        modelOptions: {
+            modelName: 'Tag',
+            exclude: [
+                'description',
+                'meta_title',
+                'meta_description',
+                'parent_id'
+            ],
+            filter: 'visibility:public',
+            shouldHavePosts: {
+                joinTo: 'tag_id',
+                joinTable: 'posts_tags'
+            }
+        },
+        events: {
+            add: 'tag.added',
+            update: ['tag.edited', 'tag.attached', 'tag.detached'],
+            remove: 'tag.deleted'
+        }
+    },
+    {
+        type: 'authors',
+        modelOptions: {
+            modelName: 'User',
+            exclude: [
+                'bio',
+                'website',
+                'location',
+                'facebook',
+                'twitter',
+                'locale',
+                'accessibility',
+                'meta_title',
+                'meta_description',
+                'tour'
+            ],
+            filter: 'visibility:public',
+            shouldHavePosts: {
+                joinTo: 'author_id',
+                joinTable: 'posts_authors'
+            }
+        },
+        events: {
+            add: 'user.activated',
+            update: ['user.activated.edited', 'user.attached', 'user.detached'],
+            remove: 'user.deleted'
+        }
+    }
+];

--- a/core/server/api/canary/actions.js
+++ b/core/server/api/canary/actions.js
@@ -1,0 +1,38 @@
+const models = require('../../models');
+
+module.exports = {
+    docName: 'actions',
+
+    browse: {
+        options: [
+            'page',
+            'limit',
+            'fields'
+        ],
+        data: [
+            'id',
+            'type'
+        ],
+        validation: {
+            id: {
+                required: true
+            },
+            type: {
+                required: true,
+                values: ['resource', 'actor']
+            }
+        },
+        permissions: true,
+        query(frame) {
+            if (frame.data.type === 'resource') {
+                frame.options.withRelated = ['actor'];
+                frame.options.filter = `resource_id:${frame.data.id}`;
+            } else {
+                frame.options.withRelated = ['resource'];
+                frame.options.filter = `actor_id:${frame.data.id}`;
+            }
+
+            return models.Action.findPage(frame.options);
+        }
+    }
+};

--- a/core/server/api/canary/authentication.js
+++ b/core/server/api/canary/authentication.js
@@ -1,0 +1,186 @@
+const api = require('./index');
+const config = require('../../config');
+const common = require('../../lib/common');
+const web = require('../../web');
+const models = require('../../models');
+const auth = require('../../services/auth');
+const invitations = require('../../services/invitations');
+
+module.exports = {
+    docName: 'authentication',
+
+    setup: {
+        statusCode: 201,
+        permissions: false,
+        validation: {
+            docName: 'setup'
+        },
+        query(frame) {
+            return Promise.resolve()
+                .then(() => {
+                    return auth.setup.assertSetupCompleted(false)();
+                })
+                .then(() => {
+                    const setupDetails = {
+                        name: frame.data.setup[0].name,
+                        email: frame.data.setup[0].email,
+                        password: frame.data.setup[0].password,
+                        blogTitle: frame.data.setup[0].blogTitle,
+                        status: 'active'
+                    };
+
+                    return auth.setup.setupUser(setupDetails);
+                })
+                .then((data) => {
+                    return auth.setup.doSettings(data, api.settings);
+                })
+                .then((user) => {
+                    return auth.setup.sendWelcomeEmail(user.get('email'), api.mail)
+                        .then(() => user);
+                });
+        }
+    },
+
+    updateSetup: {
+        permissions: (frame) => {
+            return models.User.findOne({role: 'Owner', status: 'all'})
+                .then((owner) => {
+                    if (owner.id !== frame.options.context.user) {
+                        throw new common.errors.NoPermissionError({message: common.i18n.t('errors.api.authentication.notTheBlogOwner')});
+                    }
+                });
+        },
+        validation: {
+            docName: 'setup'
+        },
+        query(frame) {
+            return Promise.resolve()
+                .then(() => {
+                    return auth.setup.assertSetupCompleted(true)();
+                })
+                .then(() => {
+                    const setupDetails = {
+                        name: frame.data.setup[0].name,
+                        email: frame.data.setup[0].email,
+                        password: frame.data.setup[0].password,
+                        blogTitle: frame.data.setup[0].blogTitle,
+                        status: 'active'
+                    };
+
+                    return auth.setup.setupUser(setupDetails);
+                })
+                .then((data) => {
+                    return auth.setup.doSettings(data, api.settings);
+                });
+        }
+    },
+
+    isSetup: {
+        permissions: false,
+        query() {
+            return auth.setup.checkIsSetup()
+                .then((isSetup) => {
+                    return {
+                        status: isSetup,
+                        // Pre-populate from config if, and only if the values exist in config.
+                        title: config.title || undefined,
+                        name: config.user_name || undefined,
+                        email: config.user_email || undefined
+                    };
+                });
+        }
+    },
+
+    generateResetToken: {
+        validation: {
+            docName: 'passwordreset'
+        },
+        permissions: true,
+        options: [
+            'email'
+        ],
+        query(frame) {
+            return Promise.resolve()
+                .then(() => {
+                    return auth.setup.assertSetupCompleted(true)();
+                })
+                .then(() => {
+                    return auth.passwordreset.generateToken(frame.data.passwordreset[0].email, api.settings);
+                })
+                .then((token) => {
+                    return auth.passwordreset.sendResetNotification(token, api.mail);
+                });
+        }
+    },
+
+    resetPassword: {
+        validation: {
+            docName: 'passwordreset',
+            data: {
+                newPassword: {required: true},
+                ne2Password: {required: true}
+            }
+        },
+        permissions: false,
+        options: [
+            'ip'
+        ],
+        query(frame) {
+            return Promise.resolve()
+                .then(() => {
+                    return auth.setup.assertSetupCompleted(true)();
+                })
+                .then(() => {
+                    return auth.passwordreset.extractTokenParts(frame);
+                })
+                .then((params) => {
+                    return auth.passwordreset.protectBruteForce(params);
+                })
+                .then(({options, tokenParts}) => {
+                    options = Object.assign(options, {context: {internal: true}});
+                    return auth.passwordreset.doReset(options, tokenParts, api.settings)
+                        .then((params) => {
+                            web.shared.middlewares.api.spamPrevention.userLogin().reset(frame.options.ip, `${tokenParts.email}login`);
+                            return params;
+                        });
+                });
+        }
+    },
+
+    acceptInvitation: {
+        validation: {
+            docName: 'invitations'
+        },
+        permissions: false,
+        query(frame) {
+            return Promise.resolve()
+                .then(() => {
+                    return auth.setup.assertSetupCompleted(true)();
+                })
+                .then(() => {
+                    return invitations.accept(frame.data);
+                });
+        }
+    },
+
+    isInvitation: {
+        data: [
+            'email'
+        ],
+        validation: {
+            docName: 'invitations'
+        },
+        permissions: false,
+        query(frame) {
+            return Promise.resolve()
+                .then(() => {
+                    return auth.setup.assertSetupCompleted(true)();
+                })
+                .then(() => {
+                    const email = frame.data.email;
+
+                    return models.Invite.findOne({email: email, status: 'sent'}, frame.options);
+                });
+        }
+    }
+};

--- a/core/server/api/canary/authors-public.js
+++ b/core/server/api/canary/authors-public.js
@@ -1,0 +1,64 @@
+const Promise = require('bluebird');
+const common = require('../../lib/common');
+const models = require('../../models');
+const ALLOWED_INCLUDES = ['count.posts'];
+
+module.exports = {
+    docName: 'authors',
+
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'limit',
+            'order',
+            'page'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Author.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'filter',
+            'fields'
+        ],
+        data: [
+            'id',
+            'slug',
+            'email',
+            'role'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Author.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        return Promise.reject(new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.authors.notFound')
+                        }));
+                    }
+
+                    return model;
+                });
+        }
+    }
+};

--- a/core/server/api/canary/config.js
+++ b/core/server/api/canary/config.js
@@ -1,0 +1,24 @@
+const {isPlainObject} = require('lodash');
+const config = require('../../config');
+const labs = require('../../services/labs');
+const ghostVersion = require('../../lib/ghost-version');
+
+module.exports = {
+    docName: 'config',
+
+    read: {
+        permissions: false,
+        query() {
+            return {
+                version: ghostVersion.full,
+                environment: config.get('env'),
+                database: config.get('database').client,
+                mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
+                useGravatar: !config.isPrivacyDisabled('useGravatar'),
+                labs: labs.getAll(),
+                clientExtensions: config.get('clientExtensions') || {},
+                enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false
+            };
+        }
+    }
+};

--- a/core/server/api/canary/db.js
+++ b/core/server/api/canary/db.js
@@ -1,0 +1,120 @@
+const Promise = require('bluebird');
+const backupDatabase = require('../../data/db/backup');
+const exporter = require('../../data/exporter');
+const importer = require('../../data/importer');
+const common = require('../../lib/common');
+const models = require('../../models');
+
+module.exports = {
+    docName: 'db',
+
+    backupContent: {
+        permissions: true,
+        options: [
+            'include',
+            'filename'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: exporter.EXCLUDED_TABLES
+                }
+            }
+        },
+        query(frame) {
+            // NOTE: we need to have `include` property available as backupDatabase uses it internally
+            Object.assign(frame.options, {include: frame.options.withRelated});
+
+            return backupDatabase(frame.options);
+        }
+    },
+
+    exportContent: {
+        options: [
+            'include'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: exporter.EXCLUDED_TABLES
+                }
+            }
+        },
+        headers: {
+            disposition: {
+                type: 'file',
+                value: () => (exporter.fileName())
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return Promise.resolve()
+                .then(() => exporter.doExport({include: frame.options.withRelated}))
+                .catch((err) => {
+                    return Promise.reject(new common.errors.GhostError({err: err}));
+                });
+        }
+    },
+
+    importContent: {
+        options: [
+            'include'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: exporter.EXCLUDED_TABLES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return importer.importFromFile(frame.file, {include: frame.options.withRelated});
+        }
+    },
+
+    deleteAllContent: {
+        statusCode: 204,
+        permissions: true,
+        query() {
+            /**
+             * @NOTE:
+             * We fetch all posts with `columns:id` to increase the speed of this endpoint.
+             * And if you trigger `post.destroy(..)`, this will trigger bookshelf and model events.
+             * But we only have to `id` available in the model. This won't work, because:
+             *   - model layer can't trigger event e.g. `post.page` to trigger `post|page.unpublished`.
+             *   - `onDestroyed` or `onDestroying` can contain custom logic
+             */
+            function deleteContent() {
+                return models.Base.transaction((transacting) => {
+                    const queryOpts = {
+                        columns: 'id',
+                        context: {internal: true},
+                        destroyAll: true,
+                        transacting: transacting
+                    };
+
+                    return models.Post.findAll(queryOpts)
+                        .then((response) => {
+                            return Promise.map(response.models, (post) => {
+                                return models.Post.destroy(Object.assign({id: post.id}, queryOpts));
+                            }, {concurrency: 100});
+                        })
+                        .then(() => models.Tag.findAll(queryOpts))
+                        .then((response) => {
+                            return Promise.map(response.models, (tag) => {
+                                return models.Tag.destroy(Object.assign({id: tag.id}, queryOpts));
+                            }, {concurrency: 100});
+                        })
+                        .catch((err) => {
+                            throw new common.errors.GhostError({
+                                err: err
+                            });
+                        });
+                });
+            }
+
+            return backupDatabase().then(deleteContent);
+        }
+    }
+};

--- a/core/server/api/canary/images.js
+++ b/core/server/api/canary/images.js
@@ -1,0 +1,19 @@
+const storage = require('../../adapters/storage');
+
+module.exports = {
+    docName: 'images',
+    upload: {
+        statusCode: 201,
+        permissions: false,
+        query(frame) {
+            const store = storage.getStorage();
+
+            if (frame.files) {
+                return Promise
+                    .map(frame.files, file => store.save(file))
+                    .then(paths => paths[0]);
+            }
+            return store.save(frame.file);
+        }
+    }
+};

--- a/core/server/api/canary/index.js
+++ b/core/server/api/canary/index.js
@@ -1,0 +1,149 @@
+const shared = require('../shared');
+const localUtils = require('./utils');
+
+module.exports = {
+    get http() {
+        return shared.http;
+    },
+
+    get authentication() {
+        return shared.pipeline(require('./authentication'), localUtils);
+    },
+
+    get db() {
+        return shared.pipeline(require('./db'), localUtils);
+    },
+
+    get integrations() {
+        return shared.pipeline(require('./integrations'), localUtils);
+    },
+
+    // @TODO: transform
+    get session() {
+        return require('./session');
+    },
+
+    get schedules() {
+        return shared.pipeline(require('./schedules'), localUtils);
+    },
+
+    get pages() {
+        return shared.pipeline(require('./pages'), localUtils);
+    },
+
+    get redirects() {
+        return shared.pipeline(require('./redirects'), localUtils);
+    },
+
+    get roles() {
+        return shared.pipeline(require('./roles'), localUtils);
+    },
+
+    get slugs() {
+        return shared.pipeline(require('./slugs'), localUtils);
+    },
+
+    get webhooks() {
+        return shared.pipeline(require('./webhooks'), localUtils);
+    },
+
+    get posts() {
+        return shared.pipeline(require('./posts'), localUtils);
+    },
+
+    get invites() {
+        return shared.pipeline(require('./invites'), localUtils);
+    },
+
+    get mail() {
+        return shared.pipeline(require('./mail'), localUtils);
+    },
+
+    get notifications() {
+        return shared.pipeline(require('./notifications'), localUtils);
+    },
+
+    get settings() {
+        return shared.pipeline(require('./settings'), localUtils);
+    },
+
+    get subscribers() {
+        return shared.pipeline(require('./subscribers'), localUtils);
+    },
+
+    get members() {
+        return shared.pipeline(require('./members'), localUtils);
+    },
+
+    get images() {
+        return shared.pipeline(require('./images'), localUtils);
+    },
+
+    get tags() {
+        return shared.pipeline(require('./tags'), localUtils);
+    },
+
+    get users() {
+        return shared.pipeline(require('./users'), localUtils);
+    },
+
+    get preview() {
+        return shared.pipeline(require('./preview'), localUtils);
+    },
+
+    get oembed() {
+        return shared.pipeline(require('./oembed'), localUtils);
+    },
+
+    get slack() {
+        return shared.pipeline(require('./slack'), localUtils);
+    },
+
+    get config() {
+        return shared.pipeline(require('./config'), localUtils);
+    },
+
+    get themes() {
+        return shared.pipeline(require('./themes'), localUtils);
+    },
+
+    get actions() {
+        return shared.pipeline(require('./actions'), localUtils);
+    },
+
+    get site() {
+        return shared.pipeline(require('./site'), localUtils);
+    },
+
+    get serializers() {
+        return require('./utils/serializers');
+    },
+
+    /**
+     * Content API Controllers
+     *
+     * @NOTE:
+     *
+     * Please create separate controllers for Content & Admin API. The goal is to expose `api.canary.content` and
+     * `api.canary.admin` soon. Need to figure out how serializers & validation works then.
+     */
+    get pagesPublic() {
+        return shared.pipeline(require('./pages-public'), localUtils, 'content');
+    },
+
+    get tagsPublic() {
+        return shared.pipeline(require('./tags-public'), localUtils, 'content');
+    },
+
+    get publicSettings() {
+        return shared.pipeline(require('./settings-public'), localUtils, 'content');
+    },
+
+    get postsPublic() {
+        return shared.pipeline(require('./posts-public'), localUtils, 'content');
+    },
+
+    get authorsPublic() {
+        return shared.pipeline(require('./authors-public'), localUtils, 'content');
+    }
+};

--- a/core/server/api/canary/integrations.js
+++ b/core/server/api/canary/integrations.js
@@ -1,0 +1,145 @@
+const common = require('../../lib/common');
+const models = require('../../models');
+
+module.exports = {
+    docName: 'integrations',
+    browse: {
+        permissions: true,
+        options: [
+            'include',
+            'limit'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ['api_keys', 'webhooks']
+                }
+            }
+        },
+        query({options}) {
+            return models.Integration.findPage(options);
+        }
+    },
+    read: {
+        permissions: true,
+        data: [
+            'id'
+        ],
+        options: [
+            'include'
+        ],
+        validation: {
+            data: {
+                id: {
+                    required: true
+                }
+            },
+            options: {
+                include: {
+                    values: ['api_keys', 'webhooks']
+                }
+            }
+        },
+        query({data, options}) {
+            return models.Integration.findOne(data, Object.assign(options, {require: true}))
+                .catch(models.Integration.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Integration'
+                        })
+                    });
+                });
+        }
+    },
+    edit: {
+        permissions: true,
+        data: [
+            'name',
+            'icon_image',
+            'description',
+            'webhooks'
+        ],
+        options: [
+            'id',
+            'include'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                },
+                include: {
+                    values: ['api_keys', 'webhooks']
+                }
+            }
+        },
+        query({data, options}) {
+            return models.Integration.edit(data, Object.assign(options, {require: true}))
+                .catch(models.Integration.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Integration'
+                        })
+                    });
+                });
+        }
+    },
+    add: {
+        statusCode: 201,
+        permissions: true,
+        data: [
+            'name',
+            'icon_image',
+            'description',
+            'webhooks'
+        ],
+        options: [
+            'include'
+        ],
+        validation: {
+            data: {
+                name: {
+                    required: true
+                }
+            },
+            options: {
+                include: {
+                    values: ['api_keys', 'webhooks']
+                }
+            }
+        },
+        query({data, options}) {
+            const dataWithApiKeys = Object.assign({
+                api_keys: [
+                    {type: 'content'},
+                    {type: 'admin'}
+                ]
+            }, data);
+            return models.Integration.add(dataWithApiKeys, options);
+        }
+    },
+    destroy: {
+        statusCode: 204,
+        permissions: true,
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        query({options}) {
+            return models.Integration.destroy(Object.assign(options, {require: true}))
+                .catch(models.Integration.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Integration'
+                        })
+                    });
+                });
+        }
+    }
+};

--- a/core/server/api/canary/invites.js
+++ b/core/server/api/canary/invites.js
@@ -1,0 +1,176 @@
+const Promise = require('bluebird');
+const common = require('../../lib/common');
+const security = require('../../lib/security');
+const mailService = require('../../services/mail');
+const urlUtils = require('../../lib/url-utils');
+const settingsCache = require('../../services/settings/cache');
+const models = require('../../models');
+const api = require('./index');
+const ALLOWED_INCLUDES = [];
+const UNSAFE_ATTRS = ['role_id'];
+
+module.exports = {
+    docName: 'invites',
+
+    browse: {
+        options: [
+            'include',
+            'page',
+            'limit',
+            'fields',
+            'filter',
+            'order',
+            'debug'
+        ],
+        validation: {
+            options: {
+                include: ALLOWED_INCLUDES
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Invite.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include'
+        ],
+        data: [
+            'id',
+            'email'
+        ],
+        validation: {
+            options: {
+                include: ALLOWED_INCLUDES
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Invite.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        return Promise.reject(new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.invites.inviteNotFound')
+                        }));
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        options: [
+            'include',
+            'id'
+        ],
+        validation: {
+            options: {
+                include: ALLOWED_INCLUDES
+            }
+        },
+        permissions: true,
+        query(frame) {
+            frame.options.require = true;
+
+            return models.Invite.destroy(frame.options)
+                .return(null);
+        }
+    },
+
+    add: {
+        statusCode: 201,
+        options: [
+            'include',
+            'email'
+        ],
+        validation: {
+            options: {
+                include: ALLOWED_INCLUDES
+            },
+            data: {
+                role_id: {
+                    required: true
+                },
+                email: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            let invite;
+            let emailData;
+
+            // CASE: ensure we destroy the invite before
+            return models.Invite.findOne({email: frame.data.invites[0].email}, frame.options)
+                .then((invite) => {
+                    if (!invite) {
+                        return;
+                    }
+
+                    return invite.destroy(frame.options);
+                })
+                .then(() => {
+                    return models.Invite.add(frame.data.invites[0], frame.options);
+                })
+                .then((_invite) => {
+                    invite = _invite;
+
+                    const adminUrl = urlUtils.urlFor('admin', true);
+
+                    emailData = {
+                        blogName: settingsCache.get('title'),
+                        invitedByName: frame.user.get('name'),
+                        invitedByEmail: frame.user.get('email'),
+                        resetLink: urlUtils.urlJoin(adminUrl, 'signup', security.url.encodeBase64(invite.get('token')), '/')
+                    };
+
+                    return mailService.utils.generateContent({data: emailData, template: 'invite-user'});
+                })
+                .then((emailContent) => {
+                    const payload = {
+                        mail: [{
+                            message: {
+                                to: invite.get('email'),
+                                subject: common.i18n.t('common.api.users.mail.invitedByName', {
+                                    invitedByName: emailData.invitedByName,
+                                    blogName: emailData.blogName
+                                }),
+                                html: emailContent.html,
+                                text: emailContent.text
+                            },
+                            options: {}
+                        }]
+                    };
+
+                    return api.mail.send(payload, {context: {internal: true}});
+                })
+                .then(() => {
+                    return models.Invite.edit({
+                        status: 'sent'
+                    }, Object.assign({id: invite.id}, frame.options));
+                })
+                .then((invite) => {
+                    return invite;
+                })
+                .catch((err) => {
+                    if (err && err.errorType === 'EmailError') {
+                        const errorMessage = common.i18n.t('errors.api.invites.errorSendingEmail.error', {
+                            message: err.message
+                        });
+                        const helpText = common.i18n.t('errors.api.invites.errorSendingEmail.help');
+                        err.message = `${errorMessage} ${helpText}`;
+                        common.logging.warn(err.message);
+                    }
+
+                    return Promise.reject(err);
+                });
+        }
+    }
+};

--- a/core/server/api/canary/mail.js
+++ b/core/server/api/canary/mail.js
@@ -1,0 +1,60 @@
+const Promise = require('bluebird');
+const common = require('../../lib/common');
+const mailService = require('../../services/mail');
+const api = require('./');
+let mailer;
+let _private = {};
+
+_private.sendMail = (object) => {
+    if (!(mailer instanceof mailService.GhostMailer)) {
+        mailer = new mailService.GhostMailer();
+    }
+
+    return mailer.send(object.mail[0].message).catch((err) => {
+        if (mailer.state.usingDirect) {
+            api.notifications.add(
+                {
+                    notifications: [{
+                        type: 'warn',
+                        message: [
+                            common.i18n.t('warnings.index.unableToSendEmail'),
+                            common.i18n.t('common.seeLinkForInstructions', {link: 'https://ghost.org/docs/concepts/config/#mail'})
+                        ].join(' ')
+                    }]
+                },
+                {context: {internal: true}}
+            );
+        }
+
+        return Promise.reject(err);
+    });
+};
+
+module.exports = {
+    docName: 'mail',
+
+    send: {
+        permissions: true,
+        query(frame) {
+            return _private.sendMail(frame.data);
+        }
+    },
+
+    sendTest(frame) {
+        return mailService.utils.generateContent({template: 'test'})
+            .then((content) => {
+                const payload = {
+                    mail: [{
+                        message: {
+                            to: frame.user.get('email'),
+                            subject: common.i18n.t('common.api.mail.testGhostEmail'),
+                            html: content.html,
+                            text: content.text
+                        }
+                    }]
+                };
+
+                return _private.sendMail(payload);
+            });
+    }
+};

--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -1,0 +1,57 @@
+// NOTE: We must not cache references to membersService.api
+// as it is a getter and may change during runtime.
+const membersService = require('../../services/members');
+
+const members = {
+    docName: 'members',
+    browse: {
+        options: [
+            'limit',
+            'fields',
+            'filter',
+            'order',
+            'debug',
+            'page'
+        ],
+        permissions: true,
+        validation: {},
+        query(frame) {
+            return membersService.api.members.list(frame.options);
+        }
+    },
+
+    read: {
+        headers: {},
+        data: [
+            'id',
+            'email'
+        ],
+        validation: {},
+        permissions: true,
+        query(frame) {
+            return membersService.api.members.get(frame.data, frame.options);
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {},
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            frame.options.require = true;
+            return membersService.api.members.destroy(frame.options).return(null);
+        }
+    }
+};
+
+module.exports = members;

--- a/core/server/api/canary/notifications.js
+++ b/core/server/api/canary/notifications.js
@@ -1,0 +1,231 @@
+const moment = require('moment-timezone');
+const semver = require('semver');
+const Promise = require('bluebird');
+const _ = require('lodash');
+const settingsCache = require('../../services/settings/cache');
+const ghostVersion = require('../../lib/ghost-version');
+const common = require('../../lib/common');
+const ObjectId = require('bson-objectid');
+const api = require('./index');
+const internalContext = {context: {internal: true}};
+const _private = {};
+
+_private.fetchAllNotifications = () => {
+    let allNotifications = settingsCache.get('notifications');
+
+    allNotifications.forEach((notification) => {
+        notification.addedAt = moment(notification.addedAt).toDate();
+    });
+
+    return allNotifications;
+};
+
+_private.wasSeen = (notification, user) => {
+    if (notification.seenBy === undefined) {
+        return notification.seen;
+    } else {
+        return notification.seenBy.includes(user.id);
+    }
+};
+
+module.exports = {
+    docName: 'notifications',
+
+    browse: {
+        permissions: true,
+        query(frame) {
+            let allNotifications = _private.fetchAllNotifications();
+            allNotifications = _.orderBy(allNotifications, 'addedAt', 'desc');
+
+            allNotifications = allNotifications.filter((notification) => {
+                // NOTE: Filtering by version below is just a patch for bigger problem - notifications are not removed
+                //       after Ghost update. Logic below should be removed when Ghost upgrade detection
+                //       is done (https://github.com/TryGhost/Ghost/issues/10236) and notifications are
+                //       be removed permanently on upgrade event.
+                const ghost20RegEx = /Ghost 2.0 is now available/gi;
+
+                // CASE: do not return old release notification
+                if (notification.message && (!notification.custom || notification.message.match(ghost20RegEx))) {
+                    let notificationVersion = notification.message.match(/(\d+\.)(\d+\.)(\d+)/);
+
+                    if (notification.message.match(ghost20RegEx)) {
+                        notificationVersion = '2.0.0';
+                    } else if (notificationVersion){
+                        notificationVersion = notificationVersion[0];
+                    }
+
+                    const blogVersion = ghostVersion.full.match(/^(\d+\.)(\d+\.)(\d+)/);
+
+                    if (notificationVersion && blogVersion && semver.gt(notificationVersion, blogVersion[0])) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
+
+                return !_private.wasSeen(notification, frame.user);
+            });
+
+            return allNotifications;
+        }
+    },
+
+    add: {
+        statusCode(result) {
+            if (result.notifications.length) {
+                return 201;
+            } else {
+                return 200;
+            }
+        },
+        permissions: true,
+        query(frame) {
+            const defaults = {
+                dismissible: true,
+                location: 'bottom',
+                status: 'alert',
+                id: ObjectId.generate()
+            };
+
+            const overrides = {
+                seen: false,
+                addedAt: moment().toDate()
+            };
+
+            let notificationsToCheck = frame.data.notifications;
+            let notificationsToAdd = [];
+
+            const allNotifications = _private.fetchAllNotifications();
+
+            notificationsToCheck.forEach((notification) => {
+                const isDuplicate = allNotifications.find((n) => {
+                    return n.id === notification.id;
+                });
+
+                if (!isDuplicate) {
+                    notificationsToAdd.push(Object.assign({}, defaults, notification, overrides));
+                }
+            });
+
+            const hasReleaseNotification = notificationsToCheck.find((notification) => {
+                return !notification.custom;
+            });
+
+            // CASE: remove any existing release notifications if a new release notification comes in
+            if (hasReleaseNotification) {
+                _.remove(allNotifications, (el) => {
+                    return !el.custom;
+                });
+            }
+
+            // CASE: nothing to add, skip
+            if (!notificationsToAdd.length) {
+                return Promise.resolve();
+            }
+
+            const releaseNotificationsToAdd = notificationsToAdd.filter((notification) => {
+                return !notification.custom;
+            });
+
+            // CASE: reorder notifications before save
+            if (releaseNotificationsToAdd.length > 1) {
+                notificationsToAdd = notificationsToAdd.filter((notification) => {
+                    return notification.custom;
+                });
+                notificationsToAdd.push(_.orderBy(releaseNotificationsToAdd, 'created_at', 'desc')[0]);
+            }
+
+            return api.settings.edit({
+                settings: [{
+                    key: 'notifications',
+                    // @NOTE: We always need to store all notifications!
+                    value: allNotifications.concat(notificationsToAdd)
+                }]
+            }, internalContext).then(() => {
+                return notificationsToAdd;
+            });
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        options: ['notification_id'],
+        validation: {
+            options: {
+                notification_id: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            const allNotifications = _private.fetchAllNotifications();
+
+            const notificationToMarkAsSeen = allNotifications.find((notification) => {
+                    return notification.id === frame.options.notification_id;
+                }),
+                notificationToMarkAsSeenIndex = allNotifications.findIndex((notification) => {
+                    return notification.id === frame.options.notification_id;
+                });
+
+            if (notificationToMarkAsSeenIndex > -1 && !notificationToMarkAsSeen.dismissible) {
+                return Promise.reject(new common.errors.NoPermissionError({
+                    message: common.i18n.t('errors.api.notifications.noPermissionToDismissNotif')
+                }));
+            }
+
+            if (notificationToMarkAsSeenIndex < 0) {
+                return Promise.reject(new common.errors.NotFoundError({
+                    message: common.i18n.t('errors.api.notifications.notificationDoesNotExist')
+                }));
+            }
+
+            if (_private.wasSeen(notificationToMarkAsSeen, frame.user)) {
+                return Promise.resolve();
+            }
+
+            // @NOTE: We don't remove the notifications, because otherwise we will receive them again from the service.
+            allNotifications[notificationToMarkAsSeenIndex].seen = true;
+
+            if (!allNotifications[notificationToMarkAsSeenIndex].seenBy) {
+                allNotifications[notificationToMarkAsSeenIndex].seenBy = [];
+            }
+
+            allNotifications[notificationToMarkAsSeenIndex].seenBy.push(frame.user.id);
+
+            return api.settings.edit({
+                settings: [{
+                    key: 'notifications',
+                    value: allNotifications
+                }]
+            }, internalContext).return();
+        }
+    },
+
+    /**
+     * Clears all notifications. Method used in tests only
+     *
+     * @private Not exposed over HTTP
+     */
+    destroyAll: {
+        statusCode: 204,
+        permissions: {
+            method: 'destroy'
+        },
+        query() {
+            const allNotifications = _private.fetchAllNotifications();
+
+            allNotifications.forEach((notification) => {
+                // @NOTE: We don't remove the notifications, because otherwise we will receive them again from the service.
+                notification.seen = true;
+            });
+
+            return api.settings.edit({
+                settings: [{
+                    key: 'notifications',
+                    value: allNotifications
+                }]
+            }, internalContext).return();
+        }
+    }
+};

--- a/core/server/api/canary/oembed.js
+++ b/core/server/api/canary/oembed.js
@@ -1,0 +1,97 @@
+const common = require('../../lib/common');
+const {extract, hasProvider} = require('oembed-parser');
+const Promise = require('bluebird');
+const request = require('../../lib/request');
+const cheerio = require('cheerio');
+
+const findUrlWithProvider = (url) => {
+    let provider;
+
+    // build up a list of URL variations to test against because the oembed
+    // providers list is not always up to date with scheme or www vs non-www
+    let baseUrl = url.replace(/^\/\/|^https?:\/\/(?:www\.)?/, '');
+    let testUrls = [
+        `http://${baseUrl}`,
+        `https://${baseUrl}`,
+        `http://www.${baseUrl}`,
+        `https://www.${baseUrl}`
+    ];
+
+    for (let testUrl of testUrls) {
+        provider = hasProvider(testUrl);
+        if (provider) {
+            url = testUrl;
+            break;
+        }
+    }
+
+    return {url, provider};
+};
+
+const getOembedUrlFromHTML = (html) => {
+    return cheerio('link[type="application/json+oembed"]', html).attr('href');
+};
+
+module.exports = {
+    docName: 'oembed',
+
+    read: {
+        permissions: false,
+        data: [
+            'url'
+        ],
+        options: [],
+        query({data}) {
+            let {url} = data;
+
+            function unknownProvider() {
+                return Promise.reject(new common.errors.ValidationError({
+                    message: common.i18n.t('errors.api.oembed.unknownProvider'),
+                    context: url
+                }));
+            }
+
+            function knownProvider(url) {
+                return extract(url).catch((err) => {
+                    return Promise.reject(new common.errors.InternalServerError({
+                        message: err.message
+                    }));
+                });
+            }
+
+            let provider;
+            ({url, provider} = findUrlWithProvider(url));
+
+            if (provider) {
+                return knownProvider(url);
+            }
+
+            // see if the URL is a redirect to cater for shortened urls
+            return request(url, {
+                method: 'GET',
+                timeout: 2 * 1000,
+                followRedirect: true
+            }).then((response) => {
+                if (response.url !== url) {
+                    ({url, provider} = findUrlWithProvider(response.url));
+                    return provider ? knownProvider(url) : unknownProvider();
+                }
+
+                const oembedUrl = getOembedUrlFromHTML(response.body);
+
+                if (!oembedUrl) {
+                    return unknownProvider();
+                }
+
+                return request(oembedUrl, {
+                    method: 'GET',
+                    json: true
+                }).then((response) => {
+                    return response.body;
+                });
+            }).catch(() => {
+                return unknownProvider();
+            });
+        }
+    }
+};

--- a/core/server/api/canary/pages-public.js
+++ b/core/server/api/canary/pages-public.js
@@ -1,0 +1,73 @@
+const common = require('../../lib/common');
+const models = require('../../models');
+const ALLOWED_INCLUDES = ['tags', 'authors'];
+
+module.exports = {
+    docName: 'pages',
+
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'formats',
+            'absolute_urls',
+            'page',
+            'limit',
+            'order',
+            'debug'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Post.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'fields',
+            'formats',
+            'debug',
+            'absolute_urls'
+        ],
+        data: [
+            'id',
+            'slug',
+            'uuid'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Post.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        throw new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.pages.pageNotFound')
+                        });
+                    }
+
+                    return model;
+                });
+        }
+    }
+};

--- a/core/server/api/canary/pages.js
+++ b/core/server/api/canary/pages.js
@@ -1,0 +1,199 @@
+const models = require('../../models');
+const common = require('../../lib/common');
+const urlUtils = require('../../lib/url-utils');
+const ALLOWED_INCLUDES = ['tags', 'authors', 'authors.roles'];
+const UNSAFE_ATTRS = ['status', 'authors'];
+
+module.exports = {
+    docName: 'pages',
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'formats',
+            'limit',
+            'order',
+            'page',
+            'debug',
+            'absolute_urls'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return models.Post.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'fields',
+            'formats',
+            'debug',
+            'absolute_urls',
+            // NOTE: only for internal context
+            'forUpdate',
+            'transacting'
+        ],
+        data: [
+            'id',
+            'slug',
+            'uuid'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return models.Post.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        throw new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.pages.pageNotFound')
+                        });
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    add: {
+        statusCode: 201,
+        headers: {},
+        options: [
+            'include'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return models.Post.add(frame.data.pages[0], frame.options)
+                .then((model) => {
+                    if (model.get('status') !== 'published') {
+                        this.headers.cacheInvalidate = false;
+                    } else {
+                        this.headers.cacheInvalidate = true;
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    edit: {
+        headers: {},
+        options: [
+            'include',
+            'id',
+            // NOTE: only for internal context
+            'forUpdate',
+            'transacting'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return models.Post.edit(frame.data.pages[0], frame.options)
+                .then((model) => {
+                    if (
+                        model.get('status') === 'published' && model.wasChanged() ||
+                        model.get('status') === 'draft' && model.previous('status') === 'published'
+                    ) {
+                        this.headers.cacheInvalidate = true;
+                    } else if (
+                        model.get('status') === 'draft' && model.previous('status') !== 'published' ||
+                        model.get('status') === 'scheduled' && model.wasChanged()
+                    ) {
+                        this.headers.cacheInvalidate = {
+                            value: urlUtils.urlFor({
+                                relativeUrl: urlUtils.urlJoin('/p', model.get('uuid'), '/')
+                            })
+                        };
+                    } else {
+                        this.headers.cacheInvalidate = false;
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'include',
+            'id'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts',
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            frame.options.require = true;
+
+            return models.Post.destroy(frame.options)
+                .return(null)
+                .catch(models.Post.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.pages.pageNotFound')
+                    });
+                });
+        }
+    }
+};

--- a/core/server/api/canary/posts-public.js
+++ b/core/server/api/canary/posts-public.js
@@ -1,0 +1,73 @@
+const models = require('../../models');
+const common = require('../../lib/common');
+const allowedIncludes = ['tags', 'authors'];
+
+module.exports = {
+    docName: 'posts',
+
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'formats',
+            'limit',
+            'order',
+            'page',
+            'debug',
+            'absolute_urls'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Post.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'fields',
+            'formats',
+            'debug',
+            'absolute_urls'
+        ],
+        data: [
+            'id',
+            'slug',
+            'uuid'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Post.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        throw new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        });
+                    }
+
+                    return model;
+                });
+        }
+    }
+};

--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -1,0 +1,202 @@
+const models = require('../../models');
+const common = require('../../lib/common');
+const urlUtils = require('../../lib/url-utils');
+const allowedIncludes = ['tags', 'authors', 'authors.roles'];
+const unsafeAttrs = ['status', 'authors'];
+
+module.exports = {
+    docName: 'posts',
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'formats',
+            'limit',
+            'order',
+            'page',
+            'debug',
+            'absolute_urls'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: {
+            unsafeAttrs: unsafeAttrs
+        },
+        query(frame) {
+            return models.Post.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'fields',
+            'formats',
+            'debug',
+            'absolute_urls',
+            // NOTE: only for internal context
+            'forUpdate',
+            'transacting'
+        ],
+        data: [
+            'id',
+            'slug',
+            'uuid'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                },
+                formats: {
+                    values: models.Post.allowedFormats
+                }
+            }
+        },
+        permissions: {
+            unsafeAttrs: unsafeAttrs
+        },
+        query(frame) {
+            return models.Post.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        throw new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        });
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    add: {
+        statusCode: 201,
+        headers: {},
+        options: [
+            'include',
+            'source'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                },
+                source: {
+                    values: ['html']
+                }
+            }
+        },
+        permissions: {
+            unsafeAttrs: unsafeAttrs
+        },
+        query(frame) {
+            return models.Post.add(frame.data.posts[0], frame.options)
+                .then((model) => {
+                    if (model.get('status') !== 'published') {
+                        this.headers.cacheInvalidate = false;
+                    } else {
+                        this.headers.cacheInvalidate = true;
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    edit: {
+        headers: {},
+        options: [
+            'include',
+            'id',
+            'source',
+            // NOTE: only for internal context
+            'forUpdate',
+            'transacting'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                },
+                id: {
+                    required: true
+                },
+                source: {
+                    values: ['html']
+                }
+            }
+        },
+        permissions: {
+            unsafeAttrs: unsafeAttrs
+        },
+        query(frame) {
+            return models.Post.edit(frame.data.posts[0], frame.options)
+                .then((model) => {
+                    if (
+                        model.get('status') === 'published' && model.wasChanged() ||
+                        model.get('status') === 'draft' && model.previous('status') === 'published'
+                    ) {
+                        this.headers.cacheInvalidate = true;
+                    } else if (
+                        model.get('status') === 'draft' && model.previous('status') !== 'published' ||
+                        model.get('status') === 'scheduled' && model.wasChanged()
+                    ) {
+                        this.headers.cacheInvalidate = {
+                            value: urlUtils.urlFor({
+                                relativeUrl: urlUtils.urlJoin('/p', model.get('uuid'), '/')
+                            })
+                        };
+                    } else {
+                        this.headers.cacheInvalidate = false;
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'include',
+            'id'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                },
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            unsafeAttrs: unsafeAttrs
+        },
+        query(frame) {
+            frame.options.require = true;
+
+            return models.Post.destroy(frame.options)
+                .return(null)
+                .catch(models.Post.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.posts.postNotFound')
+                    });
+                });
+        }
+    }
+};

--- a/core/server/api/canary/preview.js
+++ b/core/server/api/canary/preview.js
@@ -1,0 +1,41 @@
+const common = require('../../lib/common');
+const models = require('../../models');
+const ALLOWED_INCLUDES = ['authors', 'tags'];
+
+module.exports = {
+    docName: 'preview',
+
+    read: {
+        permissions: true,
+        options: [
+            'include'
+        ],
+        data: [
+            'uuid'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            },
+            data: {
+                uuid: {
+                    required: true
+                }
+            }
+        },
+        query(frame) {
+            return models.Post.findOne(Object.assign({status: 'all'}, frame.data), frame.options)
+                .then((model) => {
+                    if (!model) {
+                        throw new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        });
+                    }
+
+                    return model;
+                });
+        }
+    }
+};

--- a/core/server/api/canary/redirects.js
+++ b/core/server/api/canary/redirects.js
@@ -1,0 +1,33 @@
+const web = require('../../web');
+const redirects = require('../../../frontend/services/redirects');
+
+module.exports = {
+    docName: 'redirects',
+
+    download: {
+        headers: {
+            disposition: {
+                type: 'file',
+                value: 'redirects.json'
+            }
+        },
+        permissions: true,
+        query() {
+            return redirects.settings.get();
+        }
+    },
+
+    upload: {
+        permissions: true,
+        headers: {
+            cacheInvalidate: true
+        },
+        query(frame) {
+            return redirects.settings.setFromFilePath(frame.file.path)
+                .then(() => {
+                    // CASE: trigger that redirects are getting re-registered
+                    web.shared.middlewares.customRedirects.reload();
+                });
+        }
+    }
+};

--- a/core/server/api/canary/roles.js
+++ b/core/server/api/canary/roles.js
@@ -1,0 +1,19 @@
+const models = require('../../models');
+
+module.exports = {
+    docName: 'roles',
+    browse: {
+        options: [
+            'permissions'
+        ],
+        validation: {
+            options: {
+                permissions: ['assign']
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Role.findAll(frame.options);
+        }
+    }
+};

--- a/core/server/api/canary/schedules.js
+++ b/core/server/api/canary/schedules.js
@@ -1,0 +1,130 @@
+const _ = require('lodash');
+const moment = require('moment');
+const config = require('../../config');
+const models = require('../../models');
+const urlUtils = require('../../lib/url-utils');
+const common = require('../../lib/common');
+const api = require('./index');
+
+module.exports = {
+    docName: 'schedules',
+    publish: {
+        headers: {},
+        options: [
+            'id',
+            'resource'
+        ],
+        data: [
+            'force'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                },
+                resource: {
+                    required: true,
+                    values: ['posts', 'pages']
+                }
+            }
+        },
+        permissions: {
+            docName: 'posts'
+        },
+        query(frame) {
+            let resource;
+            const resourceType = frame.options.resource;
+            const publishAPostBySchedulerToleranceInMinutes = config.get('times').publishAPostBySchedulerToleranceInMinutes;
+
+            return models.Base.transaction((transacting) => {
+                const options = {
+                    transacting: transacting,
+                    status: 'scheduled',
+                    forUpdate: true,
+                    id: frame.options.id,
+                    context: {
+                        internal: true
+                    }
+                };
+
+                return api[resourceType].read({id: frame.options.id}, options)
+                    .then((result) => {
+                        resource = result[resourceType][0];
+                        const publishedAtMoment = moment(resource.published_at);
+
+                        if (publishedAtMoment.diff(moment(), 'minutes') > publishAPostBySchedulerToleranceInMinutes) {
+                            return Promise.reject(new common.errors.NotFoundError({message: common.i18n.t('errors.api.job.notFound')}));
+                        }
+
+                        if (publishedAtMoment.diff(moment(), 'minutes') < publishAPostBySchedulerToleranceInMinutes * -1 && frame.data.force !== true) {
+                            return Promise.reject(new common.errors.NotFoundError({message: common.i18n.t('errors.api.job.publishInThePast')}));
+                        }
+
+                        const editedResource = {};
+                        editedResource[resourceType] = [{
+                            status: 'published',
+                            updated_at: moment(resource.updated_at).toISOString(true)
+                        }];
+
+                        return api[resourceType].edit(
+                            editedResource,
+                            _.pick(options, ['context', 'id', 'transacting', 'forUpdate'])
+                        );
+                    })
+                    .then((result) => {
+                        const scheduledResource = result[resourceType][0];
+
+                        if (
+                            (scheduledResource.status === 'published' && resource.status !== 'published') ||
+                            (scheduledResource.status === 'draft' && resource.status === 'published')
+                        ) {
+                            this.headers.cacheInvalidate = true;
+                        } else if (
+                            (scheduledResource.status === 'draft' && resource.status !== 'published') ||
+                            (scheduledResource.status === 'scheduled' && resource.status !== 'scheduled')
+                        ) {
+                            this.headers.cacheInvalidate = {
+                                value: urlUtils.urlFor({
+                                    relativeUrl: urlUtils.urlJoin('/p', scheduledResource.uuid, '/')
+                                })
+                            };
+                        } else {
+                            this.headers.cacheInvalidate = false;
+                        }
+
+                        return result;
+                    });
+            });
+        }
+    },
+
+    getScheduled: {
+        // NOTE: this method is for internal use only by DefaultScheduler
+        //       it is not exposed anywhere!
+        permissions: false,
+        validation: {
+            options: {
+                resource: {
+                    required: true,
+                    values: ['posts', 'pages']
+                }
+            }
+        },
+        query(frame) {
+            const resourceType = frame.options.resource;
+            const resourceModel = (resourceType === 'posts') ? 'Post' : 'Page';
+
+            const cleanOptions = {};
+            cleanOptions.filter = 'status:scheduled';
+            cleanOptions.columns = ['id', 'published_at', 'created_at'];
+
+            return models[resourceModel].findAll(cleanOptions)
+                .then((result) => {
+                    let response = {};
+                    response[resourceType] = result;
+
+                    return response;
+                });
+        }
+    }
+};

--- a/core/server/api/canary/session.js
+++ b/core/server/api/canary/session.js
@@ -1,0 +1,50 @@
+const Promise = require('bluebird');
+const common = require('../../lib/common');
+const models = require('../../models');
+const auth = require('../../services/auth');
+
+const session = {
+    read(options) {
+        /*
+         * TODO
+         * Don't query db for user, when new api http wrapper is in we can
+         * have direct access to req.user, we can also get access to some session
+         * inofrmation too and send it back
+         */
+        return models.User.findOne({id: options.context.user});
+    },
+    add(object) {
+        if (!object || !object.username || !object.password) {
+            return Promise.reject(new common.errors.UnauthorizedError({
+                message: common.i18n.t('errors.middleware.auth.accessDenied')
+            }));
+        }
+
+        return models.User.check({
+            email: object.username,
+            password: object.password
+        }).then((user) => {
+            return Promise.resolve((req, res, next) => {
+                req.brute.reset(function (err) {
+                    if (err) {
+                        return next(err);
+                    }
+                    req.user = user;
+                    auth.session.createSession(req, res, next);
+                });
+            });
+        }).catch((err) => {
+            throw new common.errors.UnauthorizedError({
+                message: common.i18n.t('errors.middleware.auth.accessDenied'),
+                err
+            });
+        });
+    },
+    delete() {
+        return Promise.resolve((req, res, next) => {
+            auth.session.destroySession(req, res, next);
+        });
+    }
+};
+
+module.exports = session;

--- a/core/server/api/canary/settings-public.js
+++ b/core/server/api/canary/settings-public.js
@@ -1,0 +1,17 @@
+const settingsCache = require('../../services/settings/cache');
+const urlUtils = require('../../lib/url-utils');
+
+module.exports = {
+    docName: 'settings',
+
+    browse: {
+        permissions: true,
+        query() {
+            // @TODO: decouple settings cache from API knowledge
+            // The controller fetches models (or cached models) and the API frame for the target API version formats the response.
+            return Object.assign({}, settingsCache.getPublic(), {
+                url: urlUtils.urlFor('home', true)
+            });
+        }
+    }
+};

--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -1,0 +1,171 @@
+const Promise = require('bluebird');
+const _ = require('lodash');
+const models = require('../../models');
+const routing = require('../../../frontend/services/routing');
+const common = require('../../lib/common');
+const settingsCache = require('../../services/settings/cache');
+
+const SETTINGS_BLACKLIST = [
+    'members_public_key',
+    'members_private_key',
+    'members_session_secret'
+];
+
+module.exports = {
+    docName: 'settings',
+
+    browse: {
+        options: ['type'],
+        permissions: true,
+        query(frame) {
+            let settings = settingsCache.getAll();
+
+            // CASE: no context passed (functional call)
+            if (!frame.options.context) {
+                return Promise.resolve(settings.filter((setting) => {
+                    return setting.type === 'blog';
+                }));
+            }
+
+            // CASE: omit core settings unless internal request
+            if (!frame.options.context.internal) {
+                settings = _.filter(settings, (setting) => {
+                    const isCore = setting.type === 'core';
+                    const isBlacklisted = SETTINGS_BLACKLIST.includes(setting.key);
+                    return !isBlacklisted && !isCore;
+                });
+            }
+
+            return settings;
+        }
+    },
+
+    read: {
+        options: ['key'],
+        validation: {
+            options: {
+                key: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            identifier(frame) {
+                return frame.options.key;
+            }
+        },
+        query(frame) {
+            let setting = settingsCache.get(frame.options.key, {resolve: false});
+
+            if (!setting) {
+                return Promise.reject(new common.errors.NotFoundError({
+                    message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+                        key: frame.options.key
+                    })
+                }));
+            }
+
+            // @TODO: handle in settings model permissible fn
+            if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
+                return Promise.reject(new common.errors.NoPermissionError({
+                    message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                }));
+            }
+
+            return {
+                [frame.options.key]: setting
+            };
+        }
+    },
+
+    edit: {
+        headers: {
+            cacheInvalidate: true
+        },
+        permissions: {
+            before(frame) {
+                const errors = [];
+
+                frame.data.settings.map((setting) => {
+                    if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
+                        errors.push(new common.errors.NoPermissionError({
+                            message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                        }));
+                    }
+                });
+
+                if (errors.length) {
+                    return Promise.reject(errors[0]);
+                }
+            }
+        },
+        query(frame) {
+            let type = frame.data.settings.find((setting) => {
+                return setting.key === 'type';
+            });
+
+            if (_.isObject(type)) {
+                type = type.value;
+            }
+
+            frame.data.settings = _.reject(frame.data.settings, (setting) => {
+                return setting.key === 'type';
+            });
+
+            const errors = [];
+
+            _.each(frame.data.settings, (setting) => {
+                const settingFromCache = settingsCache.get(setting.key, {resolve: false});
+
+                if (!settingFromCache) {
+                    errors.push(new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+                            key: setting.key
+                        })
+                    }));
+                } else if (settingFromCache.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
+                    // @TODO: handle in settings model permissible fn
+                    errors.push(new common.errors.NoPermissionError({
+                        message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                    }));
+                }
+            });
+
+            if (errors.length) {
+                return Promise.reject(errors[0]);
+            }
+
+            return models.Settings.edit(frame.data.settings, frame.options);
+        }
+    },
+
+    upload: {
+        headers: {
+            cacheInvalidate: true
+        },
+        permissions: {
+            method: 'edit'
+        },
+        query(frame) {
+            return routing.settings.setFromFilePath(frame.file.path);
+        }
+    },
+
+    download: {
+        headers: {
+            disposition: {
+                type: 'yaml',
+                value: 'routes.yaml'
+            }
+        },
+        response: {
+            format: 'plain'
+        },
+        permissions: {
+            method: 'browse'
+        },
+        query() {
+            return routing.settings.get();
+        }
+    }
+};

--- a/core/server/api/canary/site.js
+++ b/core/server/api/canary/site.js
@@ -1,0 +1,20 @@
+const ghostVersion = require('../../lib/ghost-version');
+const settingsCache = require('../../services/settings/cache');
+const urlUtils = require('../../lib/url-utils');
+
+const site = {
+    docName: 'site',
+
+    read: {
+        permissions: false,
+        query() {
+            return {
+                title: settingsCache.get('title'),
+                url: urlUtils.urlFor('home', true),
+                version: ghostVersion.safe
+            };
+        }
+    }
+};
+
+module.exports = site;

--- a/core/server/api/canary/slack.js
+++ b/core/server/api/canary/slack.js
@@ -1,0 +1,11 @@
+const common = require('../../lib/common');
+
+module.exports = {
+    docName: 'slack',
+    sendTest: {
+        permissions: false,
+        query() {
+            common.events.emit('slack.test');
+        }
+    }
+};

--- a/core/server/api/canary/slugs.js
+++ b/core/server/api/canary/slugs.js
@@ -1,0 +1,47 @@
+const models = require('../../models');
+const common = require('../../lib/common');
+
+const allowedTypes = {
+    post: models.Post,
+    tag: models.Tag,
+    user: models.User,
+    app: models.App
+};
+
+module.exports = {
+    docName: 'slugs',
+    generate: {
+        options: [
+            'include',
+            'type'
+        ],
+        data: [
+            'name'
+        ],
+        permissions: true,
+        validation: {
+            options: {
+                type: {
+                    required: true,
+                    values: Object.keys(allowedTypes)
+                }
+            },
+            data: {
+                name: {
+                    required: true
+                }
+            }
+        },
+        query(frame) {
+            return models.Base.Model.generateSlug(allowedTypes[frame.options.type], frame.data.name, {status: 'all'})
+                .then((slug) => {
+                    if (!slug) {
+                        return Promise.reject(new common.errors.GhostError({
+                            message: common.i18n.t('errors.api.slugs.couldNotGenerateSlug')
+                        }));
+                    }
+                    return slug;
+                });
+        }
+    }
+};

--- a/core/server/api/canary/subscribers.js
+++ b/core/server/api/canary/subscribers.js
@@ -1,0 +1,215 @@
+const Promise = require('bluebird');
+const models = require('../../models');
+const fsLib = require('../../lib/fs');
+const common = require('../../lib/common');
+
+const subscribers = {
+    docName: 'subscribers',
+    browse: {
+        options: [
+            'limit',
+            'fields',
+            'filter',
+            'order',
+            'debug',
+            'page'
+        ],
+        permissions: true,
+        validation: {},
+        query(frame) {
+            return models.Subscriber.findPage(frame.options);
+        }
+    },
+
+    read: {
+        headers: {},
+        data: [
+            'id',
+            'email'
+        ],
+        validation: {},
+        permissions: true,
+        query(frame) {
+            return models.Subscriber.findOne(frame.data);
+        }
+    },
+
+    add: {
+        statusCode: 201,
+        headers: {},
+        validation: {
+            data: {
+                email: {required: true}
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Subscriber.getByEmail(frame.data.subscribers[0].email)
+                .then((subscriber) => {
+                    if (subscriber && frame.options.context.external) {
+                        // we don't expose this information
+                        return Promise.resolve(subscriber);
+                    } else if (subscriber) {
+                        return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.subscribers.subscriberAlreadyExists')}));
+                    }
+
+                    return models.Subscriber
+                        .add(frame.data.subscribers[0])
+                        .catch((error) => {
+                            if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
+                                return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.subscribers.subscriberAlreadyExists')}));
+                            }
+
+                            return Promise.reject(error);
+                        });
+                });
+        }
+    },
+
+    edit: {
+        headers: {},
+        options: [
+            'id'
+        ],
+        validation: {
+            id: {
+                required: true
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Subscriber.edit(frame.data.subscribers[0], frame.options)
+                .then((model) => {
+                    if (!model) {
+                        return Promise.reject(new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.subscribers.subscriberNotFound')
+                        }));
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'id',
+            'email'
+        ],
+        validation: {},
+        permissions: true,
+        query(frame) {
+            /**
+             * ### Delete Subscriber
+             * If we have an email param, check the subscriber exists
+             * @type {[type]}
+             */
+            function getSubscriberByEmail(options) {
+                if (options.email) {
+                    return models.Subscriber.getByEmail(options.email, options)
+                        .then((subscriber) => {
+                            if (!subscriber) {
+                                return Promise.reject(new common.errors.NotFoundError({
+                                    message: common.i18n.t('errors.api.subscribers.subscriberNotFound')
+                                }));
+                            }
+
+                            options.id = subscriber.get('id');
+
+                            return options;
+                        });
+                }
+
+                return Promise.resolve(options);
+            }
+
+            return getSubscriberByEmail(frame.options)
+                .then((options) => {
+                    return models.Subscriber
+                        .destroy(options)
+                        .return(null);
+                });
+        }
+    },
+
+    exportCSV: {
+        headers: {
+            disposition: {
+                type: 'csv',
+                value() {
+                    const datetime = (new Date()).toJSON().substring(0, 10);
+                    return `subscribers.${datetime}.csv`;
+                }
+            }
+        },
+        response: {
+            format: 'plain'
+        },
+        permissions: {
+            method: 'browse'
+        },
+        validation: {},
+        query(frame) {
+            return models.Subscriber.findAll(frame.options)
+                .catch((err) => {
+                    return Promise.reject(new common.errors.GhostError({err: err}));
+                });
+        }
+    },
+
+    importCSV: {
+        statusCode: 201,
+        permissions: {
+            method: 'add'
+        },
+        validation: {},
+        query(frame) {
+            let filePath = frame.file.path,
+                fulfilled = 0,
+                invalid = 0,
+                duplicates = 0;
+
+            return fsLib.readCSV({
+                path: filePath,
+                columnsToExtract: [{name: 'email', lookup: /email/i}]
+            }).then((result) => {
+                return Promise.all(result.map((entry) => {
+                    const apiCanary = require('./index');
+
+                    return apiCanary.subscribers.add.query({
+                        data: {subscribers: [{email: entry.email}]},
+                        options: {
+                            context: frame.options.context
+                        }
+                    }).reflect();
+                })).each((inspection) => {
+                    if (inspection.isFulfilled()) {
+                        fulfilled = fulfilled + 1;
+                    } else {
+                        if (inspection.reason() instanceof common.errors.ValidationError) {
+                            duplicates = duplicates + 1;
+                        } else {
+                            invalid = invalid + 1;
+                        }
+                    }
+                });
+            }).then(() => {
+                return {
+                    meta: {
+                        stats: {
+                            imported: fulfilled,
+                            duplicates: duplicates,
+                            invalid: invalid
+                        }
+                    }
+                };
+            });
+        }
+    }
+};
+
+module.exports = subscribers;

--- a/core/server/api/canary/tags-public.js
+++ b/core/server/api/canary/tags-public.js
@@ -1,0 +1,66 @@
+const Promise = require('bluebird');
+const common = require('../../lib/common');
+const models = require('../../models');
+
+const ALLOWED_INCLUDES = ['count.posts'];
+
+module.exports = {
+    docName: 'tags',
+
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'limit',
+            'order',
+            'page',
+            'debug'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.TagPublic.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'debug'
+        ],
+        data: [
+            'id',
+            'slug',
+            'visibility'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.TagPublic.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        return Promise.reject(new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.tags.tagNotFound')
+                        }));
+                    }
+
+                    return model;
+                });
+        }
+    }
+};

--- a/core/server/api/canary/tags.js
+++ b/core/server/api/canary/tags.js
@@ -1,0 +1,148 @@
+const Promise = require('bluebird');
+const common = require('../../lib/common');
+const models = require('../../models');
+
+const ALLOWED_INCLUDES = ['count.posts'];
+
+module.exports = {
+    docName: 'tags',
+
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'limit',
+            'order',
+            'page',
+            'debug'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Tag.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'debug'
+        ],
+        data: [
+            'id',
+            'slug',
+            'visibility'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Tag.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        return Promise.reject(new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.tags.tagNotFound')
+                        }));
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    add: {
+        statusCode: 201,
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'include'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Tag.add(frame.data.tags[0], frame.options);
+        }
+    },
+
+    edit: {
+        headers: {},
+        options: [
+            'id',
+            'include'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Tag.edit(frame.data.tags[0], frame.options)
+                .then((model) => {
+                    if (!model) {
+                        return Promise.reject(new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.tags.tagNotFound')
+                        }));
+                    }
+
+                    if (model.wasChanged()) {
+                        this.headers.cacheInvalidate = true;
+                    } else {
+                        this.headers.cacheInvalidate = false;
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Tag.destroy(frame.options).return(null);
+        }
+    }
+};

--- a/core/server/api/canary/themes.js
+++ b/core/server/api/canary/themes.js
@@ -1,0 +1,118 @@
+const common = require('../../lib/common');
+const themeService = require('../../../frontend/services/themes');
+const models = require('../../models');
+
+module.exports = {
+    docName: 'themes',
+
+    browse: {
+        permissions: true,
+        query() {
+            return themeService.getJSON();
+        }
+    },
+
+    activate: {
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'name'
+        ],
+        validation: {
+            options: {
+                name: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            let themeName = frame.options.name;
+            const newSettings = [{
+                key: 'active_theme',
+                value: themeName
+            }];
+
+            return themeService.activate(themeName)
+                .then((checkedTheme) => {
+                    // @NOTE: we use the model, not the API here, as we don't want to trigger permissions
+                    return models.Settings.edit(newSettings, frame.options)
+                        .then(() => checkedTheme);
+                })
+                .then((checkedTheme) => {
+                    return themeService.getJSON(themeName, checkedTheme);
+                });
+        }
+    },
+
+    upload: {
+        headers: {},
+        permissions: {
+            method: 'add'
+        },
+        query(frame) {
+            // @NOTE: consistent filename uploads
+            frame.options.originalname = frame.file.originalname.toLowerCase();
+
+            let zip = {
+                path: frame.file.path,
+                name: frame.file.originalname
+            };
+
+            return themeService.storage.setFromZip(zip)
+                .then(({theme, themeOverridden}) => {
+                    if (themeOverridden) {
+                        // CASE: clear cache
+                        this.headers.cacheInvalidate = true;
+                    }
+                    common.events.emit('theme.uploaded');
+                    return theme;
+                });
+        }
+    },
+
+    download: {
+        options: [
+            'name'
+        ],
+        validation: {
+            options: {
+                name: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            method: 'read'
+        },
+        query(frame) {
+            let themeName = frame.options.name;
+
+            return themeService.storage.getZip(themeName);
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'name'
+        ],
+        validation: {
+            options: {
+                name: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            let themeName = frame.options.name;
+
+            return themeService.storage.destroy(themeName);
+        }
+    }
+};

--- a/core/server/api/canary/users.js
+++ b/core/server/api/canary/users.js
@@ -1,0 +1,175 @@
+const Promise = require('bluebird');
+const common = require('../../lib/common');
+const models = require('../../models');
+const permissionsService = require('../../services/permissions');
+const ALLOWED_INCLUDES = ['count.posts', 'permissions', 'roles', 'roles.permissions'];
+const UNSAFE_ATTRS = ['status', 'roles'];
+
+module.exports = {
+    docName: 'users',
+
+    browse: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'limit',
+            'order',
+            'page',
+            'debug'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.User.findPage(frame.options);
+        }
+    },
+
+    read: {
+        options: [
+            'include',
+            'filter',
+            'fields',
+            'debug'
+        ],
+        data: [
+            'id',
+            'slug',
+            'email',
+            'role'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.User.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        return Promise.reject(new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.users.userNotFound')
+                        }));
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    edit: {
+        headers: {},
+        options: [
+            'id',
+            'include'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ALLOWED_INCLUDES
+                },
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            unsafeAttrs: UNSAFE_ATTRS
+        },
+        query(frame) {
+            return models.User.edit(frame.data.users[0], frame.options)
+                .then((model) => {
+                    if (!model) {
+                        return Promise.reject(new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.users.userNotFound')
+                        }));
+                    }
+
+                    if (model.wasChanged()) {
+                        this.headers.cacheInvalidate = true;
+                    } else {
+                        this.headers.cacheInvalidate = false;
+                    }
+
+                    return model;
+                });
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Base.transaction((t) => {
+                frame.options.transacting = t;
+
+                return Promise.all([
+                    models.Accesstoken.destroyByUser(frame.options),
+                    models.Refreshtoken.destroyByUser(frame.options),
+                    models.Post.destroyByAuthor(frame.options)
+                ]).then(() => {
+                    return models.User.destroy(Object.assign({status: 'all'}, frame.options));
+                }).return(null);
+            }).catch((err) => {
+                return Promise.reject(new common.errors.NoPermissionError({
+                    err: err
+                }));
+            });
+        }
+    },
+
+    changePassword: {
+        validation: {
+            docName: 'password',
+            data: {
+                newPassword: {required: true},
+                ne2Password: {required: true},
+                user_id: {required: true}
+            }
+        },
+        permissions: {
+            docName: 'user',
+            method: 'edit',
+            identifier(frame) {
+                return frame.data.password[0].user_id;
+            }
+        },
+        query(frame) {
+            return models.User.changePassword(frame.data.password[0], frame.options);
+        }
+    },
+
+    transferOwnership: {
+        permissions(frame) {
+            return models.Role.findOne({name: 'Owner'})
+                .then((ownerRole) => {
+                    return permissionsService.canThis(frame.options.context).assign.role(ownerRole);
+                });
+        },
+        query(frame) {
+            return models.User.transferOwnership(frame.data.owner[0], frame.options);
+        }
+    }
+};

--- a/core/server/api/canary/utils/index.js
+++ b/core/server/api/canary/utils/index.js
@@ -1,0 +1,34 @@
+module.exports = {
+    get permissions() {
+        return require('./permissions');
+    },
+
+    get serializers() {
+        return require('./serializers');
+    },
+
+    get validators() {
+        return require('./validators');
+    },
+
+    /**
+     * @description Does the request access the Content API?
+     *
+     * Each controller is either for the Content or for the Admin API.
+     * When Ghost registers each controller, it currently passes a String "content" if the controller
+     * is a Content API implementation -  see index.js file.
+     *
+     * @TODO: Move this helper function into a utils.js file.
+     * @param {Object} frame
+     * @return {boolean}
+     */
+    isContentAPI: (frame) => {
+        return frame.apiType === 'content';
+    },
+
+    // @TODO: Remove, not used.
+    isAdminAPIKey: (frame) => {
+        return frame.options.context && Object.keys(frame.options.context).length !== 0 && frame.options.context.api_key &&
+            frame.options.context.api_key.type === 'admin';
+    }
+};

--- a/core/server/api/canary/utils/permissions.js
+++ b/core/server/api/canary/utils/permissions.js
@@ -1,0 +1,102 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:permissions');
+const Promise = require('bluebird');
+const _ = require('lodash');
+const permissions = require('../../../services/permissions');
+const common = require('../../../lib/common');
+
+/**
+ * @description Handle requests, which need authentication.
+ *
+ * @param {Object} apiConfig - Docname & method of API ctrl
+ * @param {Object} frame
+ * @return {Promise}
+ */
+const nonePublicAuth = (apiConfig, frame) => {
+    debug('check admin permissions');
+
+    const singular = apiConfig.docName.replace(/s$/, '');
+
+    let permissionIdentifier = frame.options.id;
+
+    // CASE: Target ctrl can override the identifier. The identifier is the unique identifier of the target resource
+    //       e.g. edit a setting -> the key of the setting
+    //       e.g. edit a post -> post id from url param
+    //       e.g. change user password -> user id inside of the body structure
+    if (apiConfig.identifier) {
+        permissionIdentifier = apiConfig.identifier(frame);
+    }
+
+    const unsafeAttrObject = apiConfig.unsafeAttrs && _.has(frame, `data.[${apiConfig.docName}][0]`) ? _.pick(frame.data[apiConfig.docName][0], apiConfig.unsafeAttrs) : {};
+    const permsPromise = permissions.canThis(frame.options.context)[apiConfig.method][singular](permissionIdentifier, unsafeAttrObject);
+
+    return permsPromise.then((result) => {
+        /*
+         * Allow the permissions function to return a list of excluded attributes.
+         * If it does, omit those attrs from the data passed through
+         *
+         * NOTE: excludedAttrs differ from unsafeAttrs in that they're determined by the model's permissible function,
+         * and the attributes are simply excluded rather than throwing a NoPermission exception
+         *
+         * TODO: This is currently only needed because of the posts model and the contributor role. Once we extend the
+         * contributor role to be able to edit existing tags, this concept can be removed.
+         */
+        if (result && result.excludedAttrs && _.has(frame, `data.[${apiConfig.docName}][0]`)) {
+            frame.data[apiConfig.docName][0] = _.omit(frame.data[apiConfig.docName][0], result.excludedAttrs);
+        }
+    }).catch((err) => {
+        if (err instanceof common.errors.NoPermissionError) {
+            err.message = common.i18n.t('errors.api.utils.noPermissionToCall', {
+                method: apiConfig.method,
+                docName: apiConfig.docName
+            });
+            return Promise.reject(err);
+        }
+
+        if (common.errors.utils.isIgnitionError(err)) {
+            return Promise.reject(err);
+        }
+
+        return Promise.reject(new common.errors.GhostError({
+            err: err
+        }));
+    });
+};
+
+// @TODO: https://github.com/TryGhost/Ghost/issues/10735
+module.exports = {
+    /**
+     * @description Handle permission stage for canary API.
+     *
+     * @param {Object} apiConfig - Docname & method of target ctrl.
+     * @param {Object} frame
+     * @return {Promise}
+     */
+    handle(apiConfig, frame) {
+        debug('handle');
+
+        // @TODO: https://github.com/TryGhost/Ghost/issues/10099
+        frame.options.context = permissions.parseContext(frame.options.context);
+
+        // CASE: Content API access
+        if (frame.options.context.public) {
+            debug('check content permissions');
+
+            // @TODO: Remove when we drop v0.1
+            // @TODO: https://github.com/TryGhost/Ghost/issues/10733
+            return permissions.applyPublicRules(apiConfig.docName, apiConfig.method, {
+                status: frame.options.status,
+                id: frame.options.id,
+                uuid: frame.options.uuid,
+                slug: frame.options.slug,
+                data: {
+                    status: frame.data.status,
+                    id: frame.data.id,
+                    uuid: frame.data.uuid,
+                    slug: frame.data.slug
+                }
+            });
+        }
+
+        return nonePublicAuth(apiConfig, frame);
+    }
+};

--- a/core/server/api/canary/utils/serializers/index.js
+++ b/core/server/api/canary/utils/serializers/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+    get input() {
+        return require('./input');
+    },
+
+    get output() {
+        return require('./output');
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/authors.js
+++ b/core/server/api/canary/utils/serializers/input/authors.js
@@ -1,0 +1,26 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:input:authors');
+const utils = require('../../index');
+
+function setDefaultOrder(frame) {
+    if (!frame.options.order) {
+        frame.options.order = 'name asc';
+    }
+}
+
+module.exports = {
+    browse(apiConfig, frame) {
+        debug('browse');
+
+        if (utils.isContentAPI(frame)) {
+            setDefaultOrder(frame);
+        }
+    },
+
+    read(apiConfig, frame) {
+        debug('read');
+
+        if (utils.isContentAPI(frame)) {
+            setDefaultOrder(frame);
+        }
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/db.js
+++ b/core/server/api/canary/utils/serializers/input/db.js
@@ -1,0 +1,22 @@
+const _ = require('lodash');
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:input:db');
+const optionsUtil = require('../../../../shared/utils/options');
+
+const INTERNAL_OPTIONS = ['transacting', 'forUpdate'];
+
+module.exports = {
+    all(apiConfig, frame) {
+        debug('serialize all');
+
+        if (frame.options.include) {
+            frame.options.include = optionsUtil.trimAndLowerCase(frame.options.include);
+        }
+
+        if (!frame.options.context.internal) {
+            debug('omit internal options');
+            frame.options = _.omit(frame.options, INTERNAL_OPTIONS);
+        }
+
+        debug(frame.options);
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/index.js
+++ b/core/server/api/canary/utils/serializers/input/index.js
@@ -1,0 +1,29 @@
+module.exports = {
+    get db() {
+        return require('./db');
+    },
+
+    get integrations() {
+        return require('./integrations');
+    },
+
+    get pages() {
+        return require('./pages');
+    },
+
+    get posts() {
+        return require('./posts');
+    },
+
+    get settings() {
+        return require('./settings');
+    },
+
+    get users() {
+        return require('./users');
+    },
+
+    get tags() {
+        return require('./tags');
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/integrations.js
+++ b/core/server/api/canary/utils/serializers/input/integrations.js
@@ -1,0 +1,33 @@
+const _ = require('lodash');
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:input:integrations');
+
+function setDefaultFilter(frame) {
+    if (frame.options.filter) {
+        frame.options.filter = `(${frame.options.filter})+type:[custom,builtin]`;
+    } else {
+        frame.options.filter = 'type:[custom,builtin]';
+    }
+}
+
+module.exports = {
+    browse(apiConfig, frame) {
+        debug('browse');
+
+        setDefaultFilter(frame);
+    },
+    read(apiConfig, frame) {
+        debug('read');
+
+        setDefaultFilter(frame);
+    },
+    add(apiConfig, frame) {
+        debug('add');
+
+        frame.data = _.pick(frame.data.integrations[0], apiConfig.data);
+    },
+    edit(apiConfig, frame) {
+        debug('edit');
+
+        frame.data = _.pick(frame.data.integrations[0], apiConfig.data);
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/pages.js
+++ b/core/server/api/canary/utils/serializers/input/pages.js
@@ -1,0 +1,172 @@
+const _ = require('lodash');
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:input:pages');
+const converters = require('../../../../../lib/mobiledoc/converters');
+const url = require('./utils/url');
+const localUtils = require('../../index');
+
+function removeMobiledocFormat(frame) {
+    if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
+        frame.options.formats = frame.options.formats.filter((format) => {
+            return (format !== 'mobiledoc');
+        });
+    }
+}
+
+function defaultRelations(frame) {
+    if (frame.options.withRelated) {
+        return;
+    }
+
+    if (frame.options.columns && !frame.options.withRelated) {
+        return false;
+    }
+
+    frame.options.withRelated = ['tags', 'authors', 'authors.roles'];
+}
+
+function setDefaultOrder(frame) {
+    let includesOrderedRelations = false;
+
+    if (frame.options.withRelated) {
+        const orderedRelations = ['author', 'authors', 'tag', 'tags'];
+        includesOrderedRelations = _.intersection(orderedRelations, frame.options.withRelated).length > 0;
+    }
+
+    if (!frame.options.order && !includesOrderedRelations) {
+        frame.options.order = 'title asc';
+    }
+}
+
+function defaultFormat(frame) {
+    if (frame.options.formats) {
+        return;
+    }
+
+    frame.options.formats = 'mobiledoc';
+}
+
+/**
+ * CASE:
+ *
+ * - the content api endpoints for pages forces the model layer to return static pages only
+ * - we have to enforce the filter
+ *
+ * @TODO: https://github.com/TryGhost/Ghost/issues/10268
+ */
+const forcePageFilter = (frame) => {
+    if (frame.options.filter) {
+        frame.options.filter = `(${frame.options.filter})+page:true`;
+    } else {
+        frame.options.filter = 'page:true';
+    }
+};
+
+const forceStatusFilter = (frame) => {
+    if (!frame.options.filter) {
+        frame.options.filter = 'status:[draft,published,scheduled]';
+    } else if (!frame.options.filter.match(/status:/)) {
+        frame.options.filter = `(${frame.options.filter})+status:[draft,published,scheduled]`;
+    }
+};
+
+module.exports = {
+    browse(apiConfig, frame) {
+        debug('browse');
+
+        forcePageFilter(frame);
+
+        if (localUtils.isContentAPI(frame)) {
+            removeMobiledocFormat(frame);
+            setDefaultOrder(frame);
+        }
+
+        if (!localUtils.isContentAPI(frame)) {
+            forceStatusFilter(frame);
+            defaultFormat(frame);
+            defaultRelations(frame);
+        }
+
+        debug(frame.options);
+    },
+
+    read(apiConfig, frame) {
+        debug('read');
+
+        forcePageFilter(frame);
+
+        if (localUtils.isContentAPI(frame)) {
+            removeMobiledocFormat(frame);
+            setDefaultOrder(frame);
+        }
+
+        if (!localUtils.isContentAPI(frame)) {
+            forceStatusFilter(frame);
+            defaultFormat(frame);
+            defaultRelations(frame);
+        }
+
+        debug(frame.options);
+    },
+
+    add(apiConfig, frame, options = {add: true}) {
+        debug('add');
+
+        if (_.get(frame,'options.source')) {
+            const html = frame.data.pages[0].html;
+
+            if (frame.options.source === 'html' && !_.isEmpty(html)) {
+                frame.data.pages[0].mobiledoc = JSON.stringify(converters.htmlToMobiledocConverter(html));
+            }
+        }
+
+        frame.data.pages[0] = url.forPost(Object.assign({}, frame.data.pages[0]), frame.options);
+
+        // @NOTE: force storing page
+        if (options.add) {
+            frame.data.pages[0].page = true;
+        }
+
+        // CASE: Transform short to long format
+        if (frame.data.pages[0].authors) {
+            frame.data.pages[0].authors.forEach((author, index) => {
+                if (_.isString(author)) {
+                    frame.data.pages[0].authors[index] = {
+                        email: author
+                    };
+                }
+            });
+        }
+
+        if (frame.data.pages[0].tags) {
+            frame.data.pages[0].tags.forEach((tag, index) => {
+                if (_.isString(tag)) {
+                    frame.data.pages[0].tags[index] = {
+                        name: tag
+                    };
+                }
+            });
+        }
+
+        defaultFormat(frame);
+        defaultRelations(frame);
+    },
+
+    edit(apiConfig, frame) {
+        this.add(...arguments, {add: false});
+
+        debug('edit');
+
+        forceStatusFilter(frame);
+        forcePageFilter(frame);
+    },
+
+    destroy(apiConfig, frame) {
+        frame.options.destroyBy = {
+            id: frame.options.id,
+            page: true
+        };
+
+        defaultFormat(frame);
+        defaultRelations(frame);
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/posts.js
+++ b/core/server/api/canary/utils/serializers/input/posts.js
@@ -1,0 +1,205 @@
+const _ = require('lodash');
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:input:posts');
+const url = require('./utils/url');
+const localUtils = require('../../index');
+const labs = require('../../../../../services/labs');
+const converters = require('../../../../../lib/mobiledoc/converters');
+
+function removeMobiledocFormat(frame) {
+    if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
+        frame.options.formats = frame.options.formats.filter((format) => {
+            return (format !== 'mobiledoc');
+        });
+    }
+}
+
+function includeTags(frame) {
+    if (!frame.options.withRelated) {
+        frame.options.withRelated = ['tags'];
+    } else if (!frame.options.withRelated.includes('tags')) {
+        frame.options.withRelated.push('tags');
+    }
+}
+
+function defaultRelations(frame) {
+    if (frame.options.withRelated) {
+        return;
+    }
+
+    if (frame.options.columns && !frame.options.withRelated) {
+        return false;
+    }
+
+    frame.options.withRelated = ['tags', 'authors', 'authors.roles'];
+}
+
+function setDefaultOrder(frame) {
+    let includesOrderedRelations = false;
+
+    if (frame.options.withRelated) {
+        const orderedRelations = ['author', 'authors', 'tag', 'tags'];
+        includesOrderedRelations = _.intersection(orderedRelations, frame.options.withRelated).length > 0;
+    }
+
+    if (!frame.options.order && !includesOrderedRelations) {
+        frame.options.order = 'published_at desc';
+    }
+}
+
+function defaultFormat(frame) {
+    if (frame.options.formats) {
+        return;
+    }
+
+    frame.options.formats = 'mobiledoc';
+}
+
+/**
+ * CASE:
+ *
+ * - posts endpoint only returns posts, not pages
+ * - we have to enforce the filter
+ *
+ * @TODO: https://github.com/TryGhost/Ghost/issues/10268
+ */
+const forcePageFilter = (frame) => {
+    if (frame.options.filter) {
+        frame.options.filter = `(${frame.options.filter})+page:false`;
+    } else {
+        frame.options.filter = 'page:false';
+    }
+};
+
+const forceStatusFilter = (frame) => {
+    if (!frame.options.filter) {
+        frame.options.filter = 'status:[draft,published,scheduled]';
+    } else if (!frame.options.filter.match(/status:/)) {
+        frame.options.filter = `(${frame.options.filter})+status:[draft,published,scheduled]`;
+    }
+};
+
+module.exports = {
+    browse(apiConfig, frame) {
+        debug('browse');
+
+        forcePageFilter(frame);
+
+        /**
+         * ## current cases:
+         * - context object is empty (functional call, content api access)
+         * - api_key.type == 'content' ? content api access
+         * - user exists? admin api access
+         */
+        if (localUtils.isContentAPI(frame)) {
+            // CASE: the content api endpoint for posts should not return mobiledoc
+            removeMobiledocFormat(frame);
+
+            // CASE: Members needs to have the tags to check if its allowed access
+            if (labs.isSet('members')) {
+                includeTags(frame);
+            }
+
+            setDefaultOrder(frame);
+        }
+
+        if (!localUtils.isContentAPI(frame)) {
+            forceStatusFilter(frame);
+            defaultFormat(frame);
+            defaultRelations(frame);
+        }
+
+        debug(frame.options);
+    },
+
+    read(apiConfig, frame) {
+        debug('read');
+
+        forcePageFilter(frame);
+
+        /**
+         * ## current cases:
+         * - context object is empty (functional call, content api access)
+         * - api_key.type == 'content' ? content api access
+         * - user exists? admin api access
+         */
+        if (localUtils.isContentAPI(frame)) {
+            // CASE: the content api endpoint for posts should not return mobiledoc
+            removeMobiledocFormat(frame);
+
+            if (labs.isSet('members')) {
+                // CASE: Members needs to have the tags to check if its allowed access
+                includeTags(frame);
+            }
+
+            setDefaultOrder(frame);
+        }
+
+        if (!localUtils.isContentAPI(frame)) {
+            forceStatusFilter(frame);
+            defaultFormat(frame);
+            defaultRelations(frame);
+        }
+
+        debug(frame.options);
+    },
+
+    add(apiConfig, frame, options = {add: true}) {
+        debug('add');
+
+        if (_.get(frame,'options.source')) {
+            const html = frame.data.posts[0].html;
+
+            if (frame.options.source === 'html' && !_.isEmpty(html)) {
+                frame.data.posts[0].mobiledoc = JSON.stringify(converters.htmlToMobiledocConverter(html));
+            }
+        }
+
+        frame.data.posts[0] = url.forPost(Object.assign({}, frame.data.posts[0]), frame.options);
+
+        // @NOTE: force adding post
+        if (options.add) {
+            frame.data.posts[0].page = false;
+        }
+
+        // CASE: Transform short to long format
+        if (frame.data.posts[0].authors) {
+            frame.data.posts[0].authors.forEach((author, index) => {
+                if (_.isString(author)) {
+                    frame.data.posts[0].authors[index] = {
+                        email: author
+                    };
+                }
+            });
+        }
+
+        if (frame.data.posts[0].tags) {
+            frame.data.posts[0].tags.forEach((tag, index) => {
+                if (_.isString(tag)) {
+                    frame.data.posts[0].tags[index] = {
+                        name: tag
+                    };
+                }
+            });
+        }
+
+        defaultFormat(frame);
+        defaultRelations(frame);
+    },
+
+    edit(apiConfig, frame) {
+        this.add(apiConfig, frame, {add: false});
+
+        forceStatusFilter(frame);
+        forcePageFilter(frame);
+    },
+
+    destroy(apiConfig, frame) {
+        frame.options.destroyBy = {
+            id: frame.options.id,
+            page: false
+        };
+
+        defaultFormat(frame);
+        defaultRelations(frame);
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/settings.js
+++ b/core/server/api/canary/utils/serializers/input/settings.js
@@ -1,0 +1,61 @@
+const _ = require('lodash');
+const url = require('./utils/url');
+
+module.exports = {
+    read(apiConfig, frame) {
+        if (frame.options.key === 'codeinjection_head') {
+            frame.options.key = 'ghost_head';
+        }
+
+        if (frame.options.key === 'codeinjection_foot') {
+            frame.options.key = 'ghost_foot';
+        }
+    },
+
+    edit(apiConfig, frame) {
+        // CASE: allow shorthand syntax where a single key and value are passed to edit instead of object and options
+        if (_.isString(frame.data)) {
+            frame.data = {settings: [{key: frame.data, value: frame.options}]};
+        }
+
+        frame.data.settings.forEach((setting) => {
+            // CASE: transform objects/arrays into string (we store stringified objects in the db)
+            // @TODO: This belongs into the model layer. We should stringify before saving and parse when fetching from db.
+            // @TODO: Fix when dropping v0.1
+            if (_.isObject(setting.value)) {
+                setting.value = JSON.stringify(setting.value);
+            }
+
+            // @TODO: handle these transformations in a centralised API place (these rules should apply for ALL resources)
+
+            // CASE: Ensure we won't forward strings, otherwise model events or model interactions can fail
+            if (setting.value === '0' || setting.value === '1') {
+                setting.value = !!+setting.value;
+            }
+
+            // CASE: Ensure we won't forward strings, otherwise model events or model interactions can fail
+            if (setting.value === 'false' || setting.value === 'true') {
+                setting.value = setting.value === 'true';
+            }
+
+            if (setting.key === 'codeinjection_head') {
+                setting.key = 'ghost_head';
+            }
+
+            if (setting.key === 'codeinjection_foot') {
+                setting.key = 'ghost_foot';
+            }
+
+            if (['cover_image', 'icon', 'logo'].includes(setting.key)) {
+                setting = url.forSetting(setting);
+            }
+        });
+
+        // CASE: deprecated, won't accept
+        const index = _.findIndex(frame.data.settings, {key: 'force_i18n'});
+
+        if (index !== -1) {
+            frame.data.settings.splice(index, 1);
+        }
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/tags.js
+++ b/core/server/api/canary/utils/serializers/input/tags.js
@@ -1,0 +1,35 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:input:tags');
+const url = require('./utils/url');
+const utils = require('../../index');
+
+function setDefaultOrder(frame) {
+    if (!frame.options.order) {
+        frame.options.order = 'name asc';
+    }
+}
+
+module.exports = {
+    browse(apiConfig, frame) {
+        debug('browse');
+
+        if (utils.isContentAPI(frame)) {
+            setDefaultOrder(frame);
+        }
+    },
+
+    read() {
+        debug('read');
+
+        this.browse(...arguments);
+    },
+
+    add(apiConfig, frame) {
+        debug('add');
+        frame.data.tags[0] = url.forTag(Object.assign({}, frame.data.tags[0]));
+    },
+
+    edit(apiConfig, frame) {
+        debug('edit');
+        this.add(apiConfig, frame);
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/users.js
+++ b/core/server/api/canary/utils/serializers/input/users.js
@@ -1,0 +1,26 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:input:users');
+const url = require('./utils/url');
+
+module.exports = {
+    read(apiConfig, frame) {
+        debug('read');
+
+        if (frame.data.id === 'me' && frame.options.context && frame.options.context.user) {
+            frame.data.id = frame.options.context.user;
+        }
+    },
+
+    edit(apiConfig, frame) {
+        debug('edit');
+
+        if (frame.options.id === 'me' && frame.options.context && frame.options.context.user) {
+            frame.options.id = frame.options.context.user;
+        }
+
+        if (frame.data.users[0].password) {
+            delete frame.data.users[0].password;
+        }
+
+        frame.data.users[0] = url.forUser(Object.assign({}, frame.data.users[0]));
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/utils/url.js
+++ b/core/server/api/canary/utils/serializers/input/utils/url.js
@@ -1,0 +1,121 @@
+const _ = require('lodash');
+const url = require('url');
+const urlUtils = require('../../../../../../lib/url-utils');
+
+const handleCanonicalUrl = (canonicalUrl) => {
+    const blogURl = urlUtils.getBlogUrl();
+    const isSameProtocol = url.parse(canonicalUrl).protocol === url.parse(blogURl).protocol;
+    const blogDomain = blogURl.replace(/^http(s?):\/\//, '').replace(/\/$/, '');
+    const absolute = canonicalUrl.replace(/^http(s?):\/\//, '');
+
+    // We only want to transform to a relative URL when the canonical URL matches the current
+    // Blog URL incl. the same protocol. This allows users to keep e.g. Facebook comments after
+    // a http -> https switch
+    if (absolute.startsWith(blogDomain) && isSameProtocol) {
+        return urlUtils.absoluteToRelative(canonicalUrl);
+    }
+
+    return canonicalUrl;
+};
+
+const handleImageUrl = (imageUrl) => {
+    const blogDomain = urlUtils.getBlogUrl().replace(/^http(s?):\/\//, '').replace(/\/$/, '');
+    const imageUrlAbsolute = imageUrl.replace(/^http(s?):\/\//, '');
+    const imagePathRe = new RegExp(`^${blogDomain}/${urlUtils.STATIC_IMAGE_URL_PREFIX}`);
+
+    if (imagePathRe.test(imageUrlAbsolute)) {
+        return urlUtils.absoluteToRelative(imageUrl);
+    }
+
+    return imageUrl;
+};
+
+const handleContentUrls = (content) => {
+    const blogDomain = urlUtils.getBlogUrl().replace(/^http(s?):\/\//, '').replace(/\/$/, '');
+    const imagePathRe = new RegExp(`(http(s?)://)?${blogDomain}/${urlUtils.STATIC_IMAGE_URL_PREFIX}`, 'g');
+
+    const matches = _.uniq(content.match(imagePathRe));
+
+    if (matches) {
+        matches.forEach((match) => {
+            const relative = urlUtils.absoluteToRelative(match);
+            content = content.replace(new RegExp(match, 'g'), relative);
+        });
+    }
+
+    return content;
+};
+
+const forPost = (attrs, options) => {
+    // make all content image URLs relative, ref: https://github.com/TryGhost/Ghost/issues/10477
+    if (attrs.mobiledoc) {
+        attrs.mobiledoc = handleContentUrls(attrs.mobiledoc);
+    }
+
+    if (attrs.feature_image) {
+        attrs.feature_image = handleImageUrl(attrs.feature_image);
+    }
+
+    if (attrs.og_image) {
+        attrs.og_image = handleImageUrl(attrs.og_image);
+    }
+
+    if (attrs.twitter_image) {
+        attrs.twitter_image = handleImageUrl(attrs.twitter_image);
+    }
+
+    if (attrs.canonical_url) {
+        attrs.canonical_url = handleCanonicalUrl(attrs.canonical_url);
+    }
+
+    if (options && options.withRelated) {
+        options.withRelated.forEach((relation) => {
+            if (relation === 'tags' && attrs.tags) {
+                attrs.tags = attrs.tags.map(tag => forTag(tag));
+            }
+
+            if (relation === 'author' && attrs.author) {
+                attrs.author = forUser(attrs.author, options);
+            }
+
+            if (relation === 'authors' && attrs.authors) {
+                attrs.authors = attrs.authors.map(author => forUser(author, options));
+            }
+        });
+    }
+
+    return attrs;
+};
+
+const forUser = (attrs) => {
+    if (attrs.profile_image) {
+        attrs.profile_image = handleImageUrl(attrs.profile_image);
+    }
+
+    if (attrs.cover_image) {
+        attrs.cover_image = handleImageUrl(attrs.cover_image);
+    }
+
+    return attrs;
+};
+
+const forTag = (attrs) => {
+    if (attrs.feature_image) {
+        attrs.feature_image = handleImageUrl(attrs.feature_image);
+    }
+
+    return attrs;
+};
+
+const forSetting = (attrs) => {
+    if (attrs.value) {
+        attrs.value = handleImageUrl(attrs.value);
+    }
+
+    return attrs;
+};
+
+module.exports.forPost = forPost;
+module.exports.forUser = forUser;
+module.exports.forTag = forTag;
+module.exports.forSetting = forSetting;

--- a/core/server/api/canary/utils/serializers/output/actions.js
+++ b/core/server/api/canary/utils/serializers/output/actions.js
@@ -1,0 +1,15 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:actions');
+const mapper = require('./utils/mapper');
+
+module.exports = {
+    browse(models, apiConfig, frame) {
+        debug('browse');
+
+        frame.response = {
+            actions: models.data.map(model => mapper.mapAction(model, frame)),
+            meta: models.meta
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/all.js
+++ b/core/server/api/canary/utils/serializers/output/all.js
@@ -1,0 +1,25 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:all');
+const _ = require('lodash');
+
+const removeXBY = (object) => {
+    _.each(object, (value, key) => {
+        // CASE: go deeper
+        if (_.isObject(value) || _.isArray(value)) {
+            removeXBY(value);
+        } else if (['updated_by', 'created_by', 'published_by'].includes(key)) {
+            delete object[key];
+        }
+    });
+
+    return object;
+};
+
+module.exports = {
+    after(apiConfig, frame) {
+        debug('all after');
+
+        if (frame.response) {
+            frame.response = removeXBY(frame.response);
+        }
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/authentication.js
+++ b/core/server/api/canary/utils/serializers/output/authentication.js
@@ -1,0 +1,63 @@
+const common = require('../../../../../lib/common');
+const mapper = require('./utils/mapper');
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:authentication');
+
+module.exports = {
+    setup(user, apiConfig, frame) {
+        frame.response = {
+            users: [
+                mapper.mapUser(user, {options: {context: {internal: true}}})
+            ]
+        };
+    },
+
+    updateSetup(user, apiConfig, frame) {
+        frame.response = {
+            users: [
+                mapper.mapUser(user, {options: {context: {internal: true}}})
+            ]
+        };
+    },
+
+    isSetup(data, apiConfig, frame) {
+        frame.response = {
+            setup: [data]
+        };
+    },
+
+    generateResetToken(data, apiConfig, frame) {
+        frame.response = {
+            passwordreset: [{
+                message: common.i18n.t('common.api.authentication.mail.checkEmailForInstructions')
+            }]
+        };
+    },
+
+    resetPassword(data, apiConfig, frame) {
+        frame.response = {
+            passwordreset: [{
+                message: common.i18n.t('common.api.authentication.mail.passwordChanged')
+            }]
+        };
+    },
+
+    acceptInvitation(data, apiConfig, frame) {
+        debug('acceptInvitation');
+
+        frame.response = {
+            invitation: [
+                {message: common.i18n.t('common.api.authentication.mail.invitationAccepted')}
+            ]
+        };
+    },
+
+    isInvitation(data, apiConfig, frame) {
+        debug('acceptInvitation');
+
+        frame.response = {
+            invitation: [{
+                valid: !!data
+            }]
+        };
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/authors.js
+++ b/core/server/api/canary/utils/serializers/output/authors.js
@@ -1,0 +1,25 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:authors');
+const mapper = require('./utils/mapper');
+
+module.exports = {
+    browse(models, apiConfig, frame) {
+        debug('browse');
+
+        frame.response = {
+            authors: models.data.map(model => mapper.mapUser(model, frame)),
+            meta: models.meta
+        };
+
+        debug(frame.response);
+    },
+
+    read(model, apiConfig, frame) {
+        debug('read');
+
+        frame.response = {
+            authors: [mapper.mapUser(model, frame)]
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/config.js
+++ b/core/server/api/canary/utils/serializers/output/config.js
@@ -1,0 +1,11 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:config');
+
+module.exports = {
+    all(data, apiConfig, frame) {
+        frame.response = {
+            config: data
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/db.js
+++ b/core/server/api/canary/utils/serializers/output/db.js
@@ -1,0 +1,40 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:db');
+
+module.exports = {
+    backupContent(filename, apiConfig, frame) {
+        debug('backupContent');
+
+        frame.response = {
+            db: [{filename: filename}]
+        };
+    },
+
+    exportContent(exportedData, apiConfig, frame) {
+        debug('exportContent');
+
+        frame.response = {
+            db: [exportedData]
+        };
+    },
+
+    importContent(response, apiConfig, frame) {
+        debug('importContent');
+
+        // NOTE: response can contain 2 objects if images are imported
+        const problems = (response.length === 2)
+            ? response[1].problems
+            : response[0].problems;
+
+        frame.response = {
+            db: [],
+            problems: problems
+        };
+    },
+
+    deleteAllContent(response, apiConfig, frame) {
+        frame.response = {
+            db: []
+        };
+    }
+};
+

--- a/core/server/api/canary/utils/serializers/output/images.js
+++ b/core/server/api/canary/utils/serializers/output/images.js
@@ -1,0 +1,15 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:images');
+const mapper = require('./utils/mapper');
+
+module.exports = {
+    upload(path, apiConfig, frame) {
+        debug('upload');
+
+        return frame.response = {
+            images: [{
+                url: mapper.mapImage(path),
+                ref: frame.data.ref || null
+            }]
+        };
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/index.js
+++ b/core/server/api/canary/utils/serializers/output/index.js
@@ -1,0 +1,109 @@
+module.exports = {
+    get all() {
+        return require('./all');
+    },
+
+    get authentication() {
+        return require('./authentication');
+    },
+
+    get db() {
+        return require('./db');
+    },
+
+    get integrations() {
+        return require('./integrations');
+    },
+
+    get pages() {
+        return require('./pages');
+    },
+
+    get redirects() {
+        return require('./redirects');
+    },
+
+    get roles() {
+        return require('./roles');
+    },
+
+    get slugs() {
+        return require('./slugs');
+    },
+
+    get schedules() {
+        return require('./schedules');
+    },
+
+    get webhooks() {
+        return require('./webhooks');
+    },
+
+    get posts() {
+        return require('./posts');
+    },
+
+    get invites() {
+        return require('./invites');
+    },
+
+    get settings() {
+        return require('./settings');
+    },
+
+    get notifications() {
+        return require('./notifications');
+    },
+
+    get mail() {
+        return require('./mail');
+    },
+
+    get subscribers() {
+        return require('./subscribers');
+    },
+
+    get members() {
+        return require('./members');
+    },
+
+    get images() {
+        return require('./images');
+    },
+
+    get tags() {
+        return require('./tags');
+    },
+
+    get users() {
+        return require('./users');
+    },
+
+    get preview() {
+        return require('./preview');
+    },
+
+    get oembed() {
+        return require('./oembed');
+    },
+
+    get authors() {
+        return require('./authors');
+    },
+
+    get config() {
+        return require('./config');
+    },
+
+    get themes() {
+        return require('./themes');
+    },
+
+    get actions() {
+        return require('./actions');
+    },
+
+    get site() {
+        return require('./site');
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/integrations.js
+++ b/core/server/api/canary/utils/serializers/output/integrations.js
@@ -1,0 +1,35 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:integrations');
+const mapper = require('./utils/mapper');
+
+module.exports = {
+    browse({data, meta}, apiConfig, frame) {
+        debug('browse');
+
+        frame.response = {
+            integrations: data.map(model => mapper.mapIntegration(model, frame)),
+            meta
+        };
+    },
+    read(model, apiConfig, frame) {
+        debug('read');
+
+        frame.response = {
+            integrations: [mapper.mapIntegration(model, frame)]
+        };
+    },
+    add(model, apiConfig, frame) {
+        debug('add');
+
+        frame.response = {
+            integrations: [mapper.mapIntegration(model, frame)]
+        };
+    },
+    edit(model, apiConfig, frame) {
+        debug('edit');
+
+        frame.response = {
+            integrations: [mapper.mapIntegration(model, frame)]
+        };
+    }
+};
+

--- a/core/server/api/canary/utils/serializers/output/invites.js
+++ b/core/server/api/canary/utils/serializers/output/invites.js
@@ -1,0 +1,26 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:invites');
+
+module.exports = {
+    all(models, apiConfig, frame) {
+        debug('all');
+
+        if (!models) {
+            return;
+        }
+
+        if (models.meta) {
+            frame.response = {
+                invites: models.data.map(model => model.toJSON(frame.options)),
+                meta: models.meta
+            };
+
+            return;
+        }
+
+        frame.response = {
+            invites: [models.toJSON(frame.options)]
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/mail.js
+++ b/core/server/api/canary/utils/serializers/output/mail.js
@@ -1,0 +1,20 @@
+const _ = require('lodash');
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:mail');
+
+module.exports = {
+    all(response, apiConfig, frame) {
+        const toReturn = _.cloneDeep(frame.data);
+
+        delete toReturn.mail[0].options;
+        // Sendmail returns extra details we don't need and that don't convert to JSON
+        delete toReturn.mail[0].message.transport;
+
+        toReturn.mail[0].status = {
+            message: response.message
+        };
+
+        frame.response = toReturn;
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -1,0 +1,24 @@
+const common = require('../../../../../lib/common');
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:members');
+
+module.exports = {
+    browse(data, apiConfig, frame) {
+        debug('browse');
+
+        frame.response = data;
+    },
+
+    read(data, apiConfig, frame) {
+        debug('read');
+
+        if (!data) {
+            return Promise.reject(new common.errors.NotFoundError({
+                message: common.i18n.t('errors.api.members.memberNotFound')
+            }));
+        }
+
+        frame.response = {
+            members: [data]
+        };
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/notifications.js
+++ b/core/server/api/canary/utils/serializers/output/notifications.js
@@ -1,0 +1,29 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:notifications');
+
+module.exports = {
+    all(response, apiConfig, frame) {
+        if (!response) {
+            return;
+        }
+
+        if (!response || !response.length) {
+            frame.response = {
+                notifications: []
+            };
+
+            return;
+        }
+
+        response.forEach((notification) => {
+            delete notification.seen;
+            delete notification.seenBy;
+            delete notification.addedAt;
+        });
+
+        frame.response = {
+            notifications: response
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/oembed.js
+++ b/core/server/api/canary/utils/serializers/output/oembed.js
@@ -1,0 +1,9 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:oembed');
+
+module.exports = {
+    all(res, apiConfig, frame) {
+        debug('all');
+        frame.response = res;
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/pages.js
+++ b/core/server/api/canary/utils/serializers/output/pages.js
@@ -1,0 +1,28 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:pages');
+const mapper = require('./utils/mapper');
+
+module.exports = {
+    all(models, apiConfig, frame) {
+        debug('all');
+
+        // CASE: e.g. destroy returns null
+        if (!models) {
+            return;
+        }
+
+        if (models.meta) {
+            frame.response = {
+                pages: models.data.map(model => mapper.mapPost(model, frame)),
+                meta: models.meta
+            };
+
+            return;
+        }
+
+        frame.response = {
+            pages: [mapper.mapPost(models, frame)]
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/posts.js
+++ b/core/server/api/canary/utils/serializers/output/posts.js
@@ -1,0 +1,29 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:posts');
+const mapper = require('./utils/mapper');
+
+module.exports = {
+    all(models, apiConfig, frame) {
+        debug('all');
+
+        // CASE: e.g. destroy returns null
+        if (!models) {
+            return;
+        }
+
+        if (models.meta) {
+            frame.response = {
+                posts: models.data.map(model => mapper.mapPost(model, frame)),
+                meta: models.meta
+            };
+
+            debug(frame.response);
+            return;
+        }
+
+        frame.response = {
+            posts: [mapper.mapPost(models, frame)]
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/preview.js
+++ b/core/server/api/canary/utils/serializers/output/preview.js
@@ -1,0 +1,7 @@
+module.exports = {
+    all(model, apiConfig, frame) {
+        frame.response = {
+            preview: [model.toJSON(frame.options)]
+        };
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/redirects.js
+++ b/core/server/api/canary/utils/serializers/output/redirects.js
@@ -1,0 +1,5 @@
+module.exports = {
+    download(response, apiConfig, frame) {
+        frame.response = response;
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/roles.js
+++ b/core/server/api/canary/utils/serializers/output/roles.js
@@ -1,0 +1,28 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:roles');
+const canThis = require('../../../../../services/permissions').canThis;
+
+module.exports = {
+    browse(models, apiConfig, frame) {
+        debug('browse');
+
+        const roles = models.toJSON(frame.options);
+
+        if (frame.options.permissions !== 'assign') {
+            return frame.response = {
+                roles: roles
+            };
+        } else {
+            return Promise.filter(roles.map((role) => {
+                return canThis(frame.options.context).assign.role(role)
+                    .return(role)
+                    .catch(() => {});
+            }), (value) => {
+                return value && (value.name !== 'Owner');
+            }).then((roles) => {
+                return frame.response = {
+                    roles: roles
+                };
+            });
+        }
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/schedules.js
+++ b/core/server/api/canary/utils/serializers/output/schedules.js
@@ -1,0 +1,5 @@
+module.exports = {
+    all(model, apiConfig, frame) {
+        frame.response = model;
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/settings.js
+++ b/core/server/api/canary/utils/serializers/output/settings.js
@@ -1,0 +1,61 @@
+const _ = require('lodash');
+const utils = require('../../index');
+const mapper = require('./utils/mapper');
+const _private = {};
+const deprecatedSettings = ['force_i18n', 'permalinks'];
+
+/**
+ * ### Settings Filter
+ * Filters an object based on a given filter object
+ * @private
+ * @param {Object} settings
+ * @param {String} filter
+ * @returns {*}
+ */
+_private.settingsFilter = (settings, filter) => {
+    let filteredTypes = filter ? filter.split(',') : false;
+    return _.filter(settings, (setting) => {
+        if (filteredTypes) {
+            return _.includes(filteredTypes, setting.type) && !_.includes(deprecatedSettings, setting.key);
+        }
+
+        return !_.includes(deprecatedSettings, setting.key);
+    });
+};
+
+module.exports = {
+    browse(models, apiConfig, frame) {
+        let filteredSettings;
+
+        // If this is public, we already have the right data, we just need to add an Array wrapper
+        if (utils.isContentAPI(frame)) {
+            filteredSettings = models;
+        } else {
+            filteredSettings = _.values(_private.settingsFilter(models, frame.options.type));
+        }
+
+        frame.response = {
+            settings: mapper.mapSettings(filteredSettings, frame),
+            meta: {}
+        };
+
+        if (frame.options.type) {
+            frame.response.meta.filters = {
+                type: frame.options.type
+            };
+        }
+    },
+
+    read() {
+        this.browse(...arguments);
+    },
+
+    edit(models, apiConfig, frame) {
+        const settingsKeyedJSON = _.keyBy(_.invokeMap(models, 'toJSON'), 'key');
+        this.browse(settingsKeyedJSON, apiConfig, frame);
+    },
+
+    download(bytes, apiConfig, frame) {
+        frame.response = bytes;
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/site.js
+++ b/core/server/api/canary/utils/serializers/output/site.js
@@ -1,0 +1,11 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:site');
+
+module.exports = {
+    read(data, apiConfig, frame) {
+        debug('read');
+
+        frame.response = {
+            site: data
+        };
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/slugs.js
+++ b/core/server/api/canary/utils/serializers/output/slugs.js
@@ -1,0 +1,13 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:slugs');
+
+module.exports = {
+    all(slug, apiConfig, frame) {
+        debug('all');
+
+        frame.response = {
+            slugs: [{slug}]
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/subscribers.js
+++ b/core/server/api/canary/utils/serializers/output/subscribers.js
@@ -1,0 +1,83 @@
+const common = require('../../../../../lib/common');
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:subscribers');
+
+module.exports = {
+    browse(models, apiConfig, frame) {
+        debug('browse');
+
+        frame.response = {
+            subscribers: models.data.map(model => model.toJSON(frame.options)),
+            meta: models.meta
+        };
+    },
+
+    read(models, apiConfig, frame) {
+        debug('read');
+
+        if (!models) {
+            return Promise.reject(new common.errors.NotFoundError({
+                message: common.i18n.t('errors.api.subscribers.subscriberNotFound')
+            }));
+        }
+
+        frame.response = {
+            subscribers: [models.toJSON(frame.options)]
+        };
+    },
+
+    add(models, apiConfig, frame) {
+        debug('add');
+
+        frame.response = {
+            subscribers: [models.toJSON(frame.options)]
+        };
+    },
+
+    edit(models, apiConfig, frame) {
+        debug('edit');
+
+        frame.response = {
+            subscribers: [models.toJSON(frame.options)]
+        };
+    },
+
+    destroy(models, apiConfig, frame) {
+        frame.response = models;
+    },
+
+    exportCSV(models, apiConfig, frame) {
+        debug('exportCSV');
+
+        function formatCSV(data) {
+            let fields = ['id', 'email', 'created_at', 'deleted_at'],
+                csv = `${fields.join(',')}\r\n`,
+                subscriber,
+                field,
+                j,
+                i;
+
+            for (j = 0; j < data.length; j = j + 1) {
+                subscriber = data[j];
+
+                for (i = 0; i < fields.length; i = i + 1) {
+                    field = fields[i];
+                    csv += subscriber[field] !== null ? subscriber[field] : '';
+                    if (i !== fields.length - 1) {
+                        csv += ',';
+                    }
+                }
+                csv += '\r\n';
+            }
+
+            return csv;
+        }
+
+        frame.response = formatCSV(models.toJSON(frame.options), frame.options);
+    },
+
+    importCSV(models, apiConfig, frame) {
+        debug('importCSV');
+
+        frame.response = models;
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/tags.js
+++ b/core/server/api/canary/utils/serializers/output/tags.js
@@ -1,0 +1,27 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:tags');
+const mapper = require('./utils/mapper');
+
+module.exports = {
+    all(models, apiConfig, frame) {
+        debug('all');
+
+        if (!models) {
+            return;
+        }
+
+        if (models.meta) {
+            frame.response = {
+                tags: models.data.map(model => mapper.mapTag(model, frame)),
+                meta: models.meta
+            };
+
+            return;
+        }
+
+        frame.response = {
+            tags: [mapper.mapTag(models, frame)]
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/themes.js
+++ b/core/server/api/canary/utils/serializers/output/themes.js
@@ -1,0 +1,29 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:themes');
+
+module.exports = {
+    browse(themes, apiConfig, frame) {
+        debug('browse');
+
+        frame.response = themes;
+
+        debug(frame.response);
+    },
+
+    upload() {
+        debug('upload');
+        this.browse(...arguments);
+    },
+
+    activate() {
+        debug('activate');
+        this.browse(...arguments);
+    },
+
+    download(fn, apiConfig, frame) {
+        debug('download');
+
+        frame.response = fn;
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/users.js
+++ b/core/server/api/canary/utils/serializers/output/users.js
@@ -1,0 +1,49 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:users');
+const common = require('../../../../../lib/common');
+const mapper = require('./utils/mapper');
+
+module.exports = {
+    browse(models, apiConfig, frame) {
+        debug('browse');
+
+        frame.response = {
+            users: models.data.map(model => mapper.mapUser(model, frame)),
+            meta: models.meta
+        };
+
+        debug(frame.response);
+    },
+
+    read(model, apiConfig, frame) {
+        debug('read');
+
+        frame.response = {
+            users: [mapper.mapUser(model, frame)]
+        };
+
+        debug(frame.response);
+    },
+
+    edit() {
+        debug('edit');
+        this.read(...arguments);
+    },
+
+    changePassword(models, apiConfig, frame) {
+        debug('changePassword');
+
+        frame.response = {
+            password: [{message: common.i18n.t('notices.api.users.pwdChangedSuccessfully')}]
+        };
+    },
+
+    transferOwnership(models, apiConfig, frame) {
+        debug('transferOwnership');
+
+        frame.response = {
+            users: models.map(model => model.toJSON(frame.options))
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -1,0 +1,148 @@
+const _ = require('lodash');
+const localUtils = require('../../../index');
+
+const tag = (attrs, frame) => {
+    if (localUtils.isContentAPI(frame)) {
+        delete attrs.created_at;
+        delete attrs.updated_at;
+
+        // We are standardising on returning null from the Content API for any empty values
+        if (attrs.meta_title === '') {
+            attrs.meta_title = null;
+        }
+        if (attrs.meta_description === '') {
+            attrs.meta_description = null;
+        }
+        if (attrs.description === '') {
+            attrs.description = null;
+        }
+    }
+
+    // Already deleted in model.toJSON, but leaving here so that we can clean that up when we deprecate v0.1
+    delete attrs.parent_id;
+
+    // @NOTE: unused fields
+    delete attrs.parent;
+
+    return attrs;
+};
+
+const author = (attrs, frame) => {
+    if (localUtils.isContentAPI(frame)) {
+        // Already deleted in model.toJSON, but leaving here so that we can clean that up when we deprecate v0.1
+        delete attrs.created_at;
+        delete attrs.updated_at;
+        delete attrs.last_seen;
+        delete attrs.status;
+
+        // @NOTE: used for night shift
+        delete attrs.accessibility;
+
+        // Extra properties removed from canary
+        delete attrs.tour;
+
+        // We are standardising on returning null from the Content API for any empty values
+        if (attrs.twitter === '') {
+            attrs.twitter = null;
+        }
+        if (attrs.bio === '') {
+            attrs.bio = null;
+        }
+        if (attrs.website === '') {
+            attrs.website = null;
+        }
+        if (attrs.facebook === '') {
+            attrs.facebook = null;
+        }
+        if (attrs.meta_title === '') {
+            attrs.meta_title = null;
+        }
+        if (attrs.meta_description === '') {
+            attrs.meta_description = null;
+        }
+        if (attrs.location === '') {
+            attrs.location = null;
+        }
+    }
+
+    // @NOTE: unused fields
+    delete attrs.visibility;
+    delete attrs.locale;
+    delete attrs.ghost_auth_id;
+
+    return attrs;
+};
+
+const post = (attrs, frame) => {
+    if (localUtils.isContentAPI(frame)) {
+        // @TODO: https://github.com/TryGhost/Ghost/issues/10335
+        // delete attrs.page;
+        delete attrs.status;
+
+        // We are standardising on returning null from the Content API for any empty values
+        if (attrs.twitter_title === '') {
+            attrs.twitter_title = null;
+        }
+        if (attrs.twitter_description === '') {
+            attrs.twitter_description = null;
+        }
+        if (attrs.meta_title === '') {
+            attrs.meta_title = null;
+        }
+        if (attrs.meta_description === '') {
+            attrs.meta_description = null;
+        }
+        if (attrs.og_title === '') {
+            attrs.og_title = null;
+        }
+        if (attrs.og_description === '') {
+            attrs.og_description = null;
+        }
+    } else {
+        delete attrs.page;
+
+        if (!attrs.tags) {
+            delete attrs.primary_tag;
+        }
+
+        if (!attrs.authors) {
+            delete attrs.primary_author;
+        }
+    }
+
+    delete attrs.locale;
+    delete attrs.visibility;
+    delete attrs.author;
+
+    return attrs;
+};
+
+const action = (attrs) => {
+    if (attrs.actor) {
+        delete attrs.actor_id;
+        delete attrs.resource_id;
+
+        if (attrs.actor_type === 'user') {
+            attrs.actor = _.pick(attrs.actor, ['id', 'name', 'slug', 'profile_image']);
+            attrs.actor.image = attrs.actor.profile_image;
+            delete attrs.actor.profile_image;
+        } else {
+            attrs.actor = _.pick(attrs.actor, ['id', 'name', 'slug', 'icon_image']);
+            attrs.actor.image = attrs.actor.icon_image;
+            delete attrs.actor.icon_image;
+        }
+    } else if (attrs.resource) {
+        delete attrs.actor_id;
+        delete attrs.resource_id;
+
+        // @NOTE: we only support posts right now
+        attrs.resource = _.pick(attrs.resource, ['id', 'title', 'slug', 'feature_image']);
+        attrs.resource.image = attrs.resource.feature_image;
+        delete attrs.resource.feature_image;
+    }
+};
+
+module.exports.post = post;
+module.exports.tag = tag;
+module.exports.author = author;
+module.exports.action = action;

--- a/core/server/api/canary/utils/serializers/output/utils/date.js
+++ b/core/server/api/canary/utils/serializers/output/utils/date.js
@@ -1,0 +1,21 @@
+const moment = require('moment-timezone');
+const settingsCache = require('../../../../../../services/settings/cache');
+
+const format = (date) => {
+    return moment(date)
+        .tz(settingsCache.get('active_timezone'))
+        .toISOString(true);
+};
+
+const forPost = (attrs) => {
+    ['created_at', 'updated_at', 'published_at'].forEach((field) => {
+        if (attrs[field]) {
+            attrs[field] = format(attrs[field]);
+        }
+    });
+
+    return attrs;
+};
+
+module.exports.format = format;
+module.exports.forPost = forPost;

--- a/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
@@ -1,0 +1,80 @@
+module.exports.forPost = (frame, model, attrs) => {
+    const _ = require('lodash');
+
+    if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') ||
+        (frame.options.columns.includes('excerpt') && frame.options.formats && frame.options.formats.includes('plaintext'))) {
+        if (_.isEmpty(attrs.custom_excerpt)) {
+            const plaintext = model.get('plaintext');
+
+            if (plaintext) {
+                attrs.excerpt = plaintext.substring(0, 500);
+            } else {
+                attrs.excerpt = null;
+            }
+        } else {
+            attrs.excerpt = attrs.custom_excerpt;
+        }
+    }
+};
+
+// @NOTE: ghost_head & ghost_foot are deprecated, remove in Ghost 3.0
+module.exports.forSettings = (attrs, frame) => {
+    const _ = require('lodash');
+
+    // @TODO: https://github.com/TryGhost/Ghost/issues/10106
+    // @NOTE: Admin & Content API return a different format, need to mappers
+    if (_.isArray(attrs)) {
+        // CASE: read single setting
+        if (frame.original.params && frame.original.params.key) {
+            if (frame.original.params.key === 'ghost_head') {
+                return;
+            }
+
+            if (frame.original.params.key === 'ghost_foot') {
+                return;
+            }
+
+            if (frame.original.params.key === 'codeinjection_head') {
+                attrs[0].key = 'codeinjection_head';
+                return;
+            }
+
+            if (frame.original.params.key === 'codeinjection_foot') {
+                attrs[0].key = 'codeinjection_foot';
+                return;
+            }
+        }
+
+        // CASE: edit
+        if (frame.original.body && frame.original.body.settings) {
+            frame.original.body.settings.forEach((setting) => {
+                if (setting.key === 'codeinjection_head') {
+                    const target = _.find(attrs, {key: 'ghost_head'});
+                    target.key = 'codeinjection_head';
+                } else if (setting.key === 'codeinjection_foot') {
+                    const target = _.find(attrs, {key: 'ghost_foot'});
+                    target.key = 'codeinjection_foot';
+                }
+            });
+
+            return;
+        }
+
+        // CASE: browse all settings, add extra keys and keep deprecated
+        const ghostHead = _.cloneDeep(_.find(attrs, {key: 'ghost_head'}));
+        const ghostFoot = _.cloneDeep(_.find(attrs, {key: 'ghost_foot'}));
+
+        if (ghostHead) {
+            ghostHead.key = 'codeinjection_head';
+            attrs.push(ghostHead);
+        }
+
+        if (ghostFoot) {
+            ghostFoot.key = 'codeinjection_foot';
+            attrs.push(ghostFoot);
+        }
+    } else {
+        attrs.codeinjection_head = attrs.ghost_head;
+        attrs.codeinjection_foot = attrs.ghost_foot;
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -1,0 +1,99 @@
+const _ = require('lodash');
+const utils = require('../../../index');
+const url = require('./url');
+const date = require('./date');
+const members = require('./members');
+const clean = require('./clean');
+const extraAttrs = require('./extra-attrs');
+
+const mapUser = (model, frame) => {
+    const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
+
+    url.forUser(model.id, jsonModel, frame.options);
+
+    clean.author(jsonModel, frame);
+
+    return jsonModel;
+};
+
+const mapTag = (model, frame) => {
+    const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
+
+    url.forTag(model.id, jsonModel, frame.options);
+    clean.tag(jsonModel, frame);
+
+    return jsonModel;
+};
+
+const mapPost = (model, frame) => {
+    const extendedOptions = Object.assign(_.cloneDeep(frame.options), {
+        extraProperties: ['canonical_url']
+    });
+
+    const jsonModel = model.toJSON(extendedOptions);
+
+    url.forPost(model.id, jsonModel, frame);
+
+    if (utils.isContentAPI(frame)) {
+        date.forPost(jsonModel);
+        members.forPost(jsonModel, frame);
+    }
+
+    extraAttrs.forPost(frame, model, jsonModel);
+    clean.post(jsonModel, frame);
+
+    if (frame.options && frame.options.withRelated) {
+        frame.options.withRelated.forEach((relation) => {
+            // @NOTE: this block also decorates primary_tag/primary_author objects as they
+            // are being passed by reference in tags/authors. Might be refactored into more explicit call
+            // in the future, but is good enough for current use-case
+            if (relation === 'tags' && jsonModel.tags) {
+                jsonModel.tags = jsonModel.tags.map(tag => mapTag(tag, frame));
+            }
+
+            if (relation === 'authors' && jsonModel.authors) {
+                jsonModel.authors = jsonModel.authors.map(author => mapUser(author, frame));
+            }
+        });
+    }
+
+    return jsonModel;
+};
+
+const mapSettings = (attrs, frame) => {
+    url.forSettings(attrs);
+    extraAttrs.forSettings(attrs, frame);
+    return attrs;
+};
+
+const mapIntegration = (model, frame) => {
+    const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
+
+    if (jsonModel.api_keys) {
+        jsonModel.api_keys.forEach((key) => {
+            if (key.type === 'admin') {
+                key.secret = `${key.id}:${key.secret}`;
+            }
+        });
+    }
+
+    return jsonModel;
+};
+
+const mapImage = (path) => {
+    return url.forImage(path);
+};
+
+const mapAction = (model, frame) => {
+    const attrs = model.toJSON(frame.options);
+    clean.action(attrs);
+    return attrs;
+};
+
+module.exports.mapPost = mapPost;
+module.exports.mapUser = mapUser;
+module.exports.mapTag = mapTag;
+module.exports.mapIntegration = mapIntegration;
+module.exports.mapSettings = mapSettings;
+module.exports.mapImage = mapImage;
+module.exports.mapAction = mapAction;

--- a/core/server/api/canary/utils/serializers/output/utils/members.js
+++ b/core/server/api/canary/utils/serializers/output/utils/members.js
@@ -1,0 +1,56 @@
+const labs = require('../../../../../../services/labs');
+const membersService = require('../../../../../../services/members');
+const MEMBER_TAG = '#members';
+const PERMIT_CONTENT = false;
+const BLOCK_CONTENT = true;
+
+// Checks if request should hide memnbers only content
+function hideMembersOnlyContent(attrs, frame) {
+    const membersEnabled = labs.isSet('members');
+    if (!membersEnabled) {
+        return PERMIT_CONTENT;
+    }
+
+    const postHasMemberTag = attrs.tags && attrs.tags.find((tag) => {
+        return (tag.name === MEMBER_TAG);
+    });
+    const requestFromMember = frame.original.context.member;
+    if (!postHasMemberTag) {
+        return PERMIT_CONTENT;
+    }
+    if (!requestFromMember) {
+        return BLOCK_CONTENT;
+    }
+
+    const memberHasPlan = !!(frame.original.context.member.plans || []).length;
+    if (!membersService.isPaymentConfigured()) {
+        return PERMIT_CONTENT;
+    }
+    if (memberHasPlan) {
+        return PERMIT_CONTENT;
+    }
+    return BLOCK_CONTENT;
+}
+
+const forPost = (attrs, frame) => {
+    const hideFormatsData = hideMembersOnlyContent(attrs, frame);
+    if (hideFormatsData) {
+        ['plaintext', 'html'].forEach((field) => {
+            attrs[field] = '';
+        });
+    }
+    if (labs.isSet('members')) {
+        // CASE: Members always adds tags, remove if the user didn't originally ask for them
+        const origQueryOrOptions = frame.original.query || frame.original.options || {};
+        const origInclude = origQueryOrOptions.include;
+
+        if (!origInclude || !origInclude.includes('tags')) {
+            delete attrs.tags;
+            attrs.primary_tag = null;
+        }
+    }
+
+    return attrs;
+};
+
+module.exports.forPost = forPost;

--- a/core/server/api/canary/utils/serializers/output/utils/url.js
+++ b/core/server/api/canary/utils/serializers/output/utils/url.js
@@ -1,0 +1,135 @@
+const _ = require('lodash');
+const urlService = require('../../../../../../../frontend/services/url');
+const urlUtils = require('../../../../../../lib/url-utils');
+const localUtils = require('../../../index');
+
+const forPost = (id, attrs, frame) => {
+    attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+
+    /**
+     * CASE: admin api should serve preview urls
+     *
+     * @NOTE
+     * The url service has no clue of the draft/scheduled concept. It only generates urls for published resources.
+     * Adding a hardcoded fallback into the url service feels wrong IMO.
+     *
+     * Imagine the site won't be part of core and core does not serve urls anymore.
+     * Core needs to offer a preview API, which returns draft posts.
+     * That means the url is no longer /p/:uuid, it's e.g. GET /api/canary/content/preview/:uuid/.
+     * /p/ is a concept of the site, not of core.
+     *
+     * The site is not aware of existing drafts. It won't be able to get the uuid.
+     *
+     * Needs further discussion.
+     */
+    if (!localUtils.isContentAPI(frame)) {
+        if (attrs.status !== 'published' && attrs.url.match(/\/404\//)) {
+            attrs.url = urlUtils.urlFor({
+                relativeUrl: urlUtils.urlJoin('/p', attrs.uuid, '/')
+            }, null, true);
+        }
+    }
+
+    if (attrs.feature_image) {
+        attrs.feature_image = urlUtils.urlFor('image', {image: attrs.feature_image}, true);
+    }
+
+    if (attrs.og_image) {
+        attrs.og_image = urlUtils.urlFor('image', {image: attrs.og_image}, true);
+    }
+
+    if (attrs.twitter_image) {
+        attrs.twitter_image = urlUtils.urlFor('image', {image: attrs.twitter_image}, true);
+    }
+
+    if (attrs.canonical_url) {
+        attrs.canonical_url = urlUtils.relativeToAbsolute(attrs.canonical_url);
+    }
+
+    if (attrs.html) {
+        const urlOptions = {
+            assetsOnly: true
+        };
+
+        if (frame.options.absolute_urls) {
+            urlOptions.assetsOnly = false;
+        }
+
+        attrs.html = urlUtils.makeAbsoluteUrls(
+            attrs.html,
+            urlUtils.urlFor('home', true),
+            attrs.url,
+            urlOptions
+        ).html();
+    }
+
+    if (frame.options.columns && !frame.options.columns.includes('url')) {
+        delete attrs.url;
+    }
+
+    return attrs;
+};
+
+const forUser = (id, attrs, options) => {
+    if (!options.columns || (options.columns && options.columns.includes('url'))) {
+        attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+    }
+
+    if (attrs.profile_image) {
+        attrs.profile_image = urlUtils.urlFor('image', {image: attrs.profile_image}, true);
+    }
+
+    if (attrs.cover_image) {
+        attrs.cover_image = urlUtils.urlFor('image', {image: attrs.cover_image}, true);
+    }
+
+    return attrs;
+};
+
+const forTag = (id, attrs, options) => {
+    if (!options.columns || (options.columns && options.columns.includes('url'))) {
+        attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
+    }
+
+    if (attrs.feature_image) {
+        attrs.feature_image = urlUtils.urlFor('image', {image: attrs.feature_image}, true);
+    }
+
+    return attrs;
+};
+
+const forSettings = (attrs) => {
+    // @TODO: https://github.com/TryGhost/Ghost/issues/10106
+    // @NOTE: Admin & Content API return a different format, need to mappers
+    if (_.isArray(attrs)) {
+        attrs.forEach((obj) => {
+            if (['cover_image', 'logo', 'icon'].includes(obj.key) && obj.value) {
+                obj.value = urlUtils.urlFor('image', {image: obj.value}, true);
+            }
+        });
+    } else {
+        if (attrs.cover_image) {
+            attrs.cover_image = urlUtils.urlFor('image', {image: attrs.cover_image}, true);
+        }
+
+        if (attrs.logo) {
+            attrs.logo = urlUtils.urlFor('image', {image: attrs.logo}, true);
+        }
+
+        if (attrs.icon) {
+            attrs.icon = urlUtils.urlFor('image', {image: attrs.icon}, true);
+        }
+    }
+
+    return attrs;
+};
+
+const forImage = (path) => {
+    return urlUtils.urlFor('image', {image: path}, true);
+};
+
+module.exports.forPost = forPost;
+module.exports.forUser = forUser;
+module.exports.forTag = forTag;
+module.exports.forSettings = forSettings;
+module.exports.forImage = forImage;

--- a/core/server/api/canary/utils/serializers/output/webhooks.js
+++ b/core/server/api/canary/utils/serializers/output/webhooks.js
@@ -1,0 +1,17 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:webhooks');
+
+module.exports = {
+    all(models, apiConfig, frame) {
+        debug('all');
+        // CASE: e.g. destroy returns null
+        if (!models) {
+            return;
+        }
+
+        frame.response = {
+            webhooks: [models.toJSON(frame.options)]
+        };
+
+        debug(frame.response);
+    }
+};

--- a/core/server/api/canary/utils/validators/index.js
+++ b/core/server/api/canary/utils/validators/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+    get input() {
+        return require('./input');
+    },
+
+    get output() {
+        return require('./output');
+    }
+};

--- a/core/server/api/canary/utils/validators/input/images.js
+++ b/core/server/api/canary/utils/validators/input/images.js
@@ -1,0 +1,81 @@
+const jsonSchema = require('../utils/json-schema');
+const config = require('../../../../../config');
+const common = require('../../../../../lib/common');
+const imageLib = require('../../../../../lib/image');
+
+const profileImage = (frame) => {
+    return imageLib.imageSize.getImageSizeFromPath(frame.file.path).then((response) => {
+        // save the image dimensions in new property for file
+        frame.file.dimensions = response;
+
+        // CASE: file needs to be a square
+        if (frame.file.dimensions.width !== frame.file.dimensions.height) {
+            return Promise.reject(new common.errors.ValidationError({
+                message: common.i18n.t('errors.api.images.isNotSquare')
+            }));
+        }
+    });
+};
+
+const icon = (frame) => {
+    const iconExtensions = (config.get('uploads').icons && config.get('uploads').icons.extensions) || [];
+
+    const validIconFileSize = (size) => {
+        return (size / 1024) <= 100;
+    };
+
+    // CASE: file should not be larger than 100kb
+    if (!validIconFileSize(frame.file.size)) {
+        return Promise.reject(new common.errors.ValidationError({
+            message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+        }));
+    }
+
+    return imageLib.blogIcon.getIconDimensions(frame.file.path).then((response) => {
+        // save the image dimensions in new property for file
+        frame.file.dimensions = response;
+
+        // CASE: file needs to be a square
+        if (frame.file.dimensions.width !== frame.file.dimensions.height) {
+            return Promise.reject(new common.errors.ValidationError({
+                message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            }));
+        }
+
+        // CASE: icon needs to be bigger than or equal to 60px
+        // .ico files can contain multiple sizes, we need at least a minimum of 60px (16px is ok, as long as 60px are present as well)
+        if (frame.file.dimensions.width < 60) {
+            return Promise.reject(new common.errors.ValidationError({
+                message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            }));
+        }
+
+        // CASE: icon needs to be smaller than or equal to 1000px
+        if (frame.file.dimensions.width > 1000) {
+            return Promise.reject(new common.errors.ValidationError({
+                message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            }));
+        }
+    });
+};
+
+module.exports = {
+    upload(apiConfig, frame) {
+        return Promise.resolve()
+            .then(() => {
+                const schema = require('./schemas/images-upload');
+                const definitions = require('./schemas/images');
+                return jsonSchema.validate(schema, definitions, frame.data);
+            })
+            .then(() => {
+                if (frame.data.purpose === 'profile_image') {
+                    return profileImage(frame);
+                }
+            })
+            .then(() => {
+                if (frame.data.purpose === 'icon') {
+                    return icon(frame);
+                }
+            });
+    }
+};

--- a/core/server/api/canary/utils/validators/input/index.js
+++ b/core/server/api/canary/utils/validators/input/index.js
@@ -1,0 +1,45 @@
+module.exports = {
+    get passwordreset() {
+        return require('./passwordreset');
+    },
+
+    get setup() {
+        return require('./setup');
+    },
+
+    get posts() {
+        return require('./posts');
+    },
+
+    get pages() {
+        return require('./pages');
+    },
+
+    get invites() {
+        return require('./invites');
+    },
+
+    get invitations() {
+        return require('./invitations');
+    },
+
+    get settings() {
+        return require('./settings');
+    },
+
+    get tags() {
+        return require('./tags');
+    },
+
+    get users() {
+        return require('./users');
+    },
+
+    get images() {
+        return require('./images');
+    },
+
+    get oembed() {
+        return require('./oembed');
+    }
+};

--- a/core/server/api/canary/utils/validators/input/invitations.js
+++ b/core/server/api/canary/utils/validators/input/invitations.js
@@ -1,0 +1,40 @@
+const Promise = require('bluebird');
+const validator = require('validator');
+const debug = require('ghost-ignition').debug('api:canary:utils:validators:input:invitation');
+const common = require('../../../../../lib/common');
+
+module.exports = {
+    acceptInvitation(apiConfig, frame) {
+        debug('acceptInvitation');
+
+        const data = frame.data.invitation[0];
+
+        if (!data.token) {
+            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noTokenProvided')}));
+        }
+
+        if (!data.email) {
+            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noEmailProvided')}));
+        }
+
+        if (!data.password) {
+            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noPasswordProvided')}));
+        }
+
+        if (!data.name) {
+            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noNameProvided')}));
+        }
+    },
+
+    isInvitation(apiConfig, frame) {
+        debug('isInvitation');
+
+        const email = frame.data.email;
+
+        if (typeof email !== 'string' || !validator.isEmail(email)) {
+            throw new common.errors.BadRequestError({
+                message: common.i18n.t('errors.api.authentication.invalidEmailReceived')
+            });
+        }
+    }
+};

--- a/core/server/api/canary/utils/validators/input/invites.js
+++ b/core/server/api/canary/utils/validators/input/invites.js
@@ -1,0 +1,16 @@
+const Promise = require('bluebird');
+const common = require('../../../../../lib/common');
+const models = require('../../../../../models');
+
+module.exports = {
+    add(apiConfig, frame) {
+        return models.User.findOne({email: frame.data.invites[0].email}, frame.options)
+            .then((user) => {
+                if (user) {
+                    return Promise.reject(new common.errors.ValidationError({
+                        message: common.i18n.t('errors.api.users.userAlreadyRegistered')
+                    }));
+                }
+            });
+    }
+};

--- a/core/server/api/canary/utils/validators/input/oembed.js
+++ b/core/server/api/canary/utils/validators/input/oembed.js
@@ -1,0 +1,12 @@
+const Promise = require('bluebird');
+const common = require('../../../../../lib/common');
+
+module.exports = {
+    read(apiConfig, frame) {
+        if (!frame.data.url || !frame.data.url.trim()) {
+            return Promise.reject(new common.errors.BadRequestError({
+                message: common.i18n.t('errors.api.oembed.noUrlProvided')
+            }));
+        }
+    }
+};

--- a/core/server/api/canary/utils/validators/input/pages.js
+++ b/core/server/api/canary/utils/validators/input/pages.js
@@ -1,0 +1,15 @@
+const jsonSchema = require('../utils/json-schema');
+
+module.exports = {
+    add(apiConfig, frame) {
+        const schema = require(`./schemas/pages-add`);
+        const definitions = require('./schemas/pages');
+        return jsonSchema.validate(schema, definitions, frame.data);
+    },
+
+    edit(apiConfig, frame) {
+        const schema = require(`./schemas/pages-edit`);
+        const definitions = require('./schemas/pages');
+        return jsonSchema.validate(schema, definitions, frame.data);
+    }
+};

--- a/core/server/api/canary/utils/validators/input/passwordreset.js
+++ b/core/server/api/canary/utils/validators/input/passwordreset.js
@@ -1,0 +1,30 @@
+const Promise = require('bluebird');
+const validator = require('validator');
+const debug = require('ghost-ignition').debug('api:canary:utils:validators:input:passwordreset');
+const common = require('../../../../../lib/common');
+
+module.exports = {
+    resetPassword(apiConfig, frame) {
+        debug('resetPassword');
+
+        const data = frame.data.passwordreset[0];
+
+        if (data.newPassword !== data.ne2Password) {
+            return Promise.reject(new common.errors.ValidationError({
+                message: common.i18n.t('errors.models.user.newPasswordsDoNotMatch')
+            }));
+        }
+    },
+
+    generateResetToken(apiConfig, frame) {
+        debug('generateResetToken');
+
+        const email = frame.data.passwordreset[0].email;
+
+        if (typeof email !== 'string' || !validator.isEmail(email)) {
+            throw new common.errors.BadRequestError({
+                message: common.i18n.t('errors.api.authentication.invalidEmailReceived')
+            });
+        }
+    }
+};

--- a/core/server/api/canary/utils/validators/input/posts.js
+++ b/core/server/api/canary/utils/validators/input/posts.js
@@ -1,0 +1,15 @@
+const jsonSchema = require('../utils/json-schema');
+
+module.exports = {
+    add(apiConfig, frame) {
+        const schema = require(`./schemas/posts-add`);
+        const definitions = require('./schemas/posts');
+        return jsonSchema.validate(schema, definitions, frame.data);
+    },
+
+    edit(apiConfig, frame) {
+        const schema = require(`./schemas/posts-edit`);
+        const definitions = require('./schemas/posts');
+        return jsonSchema.validate(schema, definitions, frame.data);
+    }
+};

--- a/core/server/api/canary/utils/validators/input/schemas/images-upload.json
+++ b/core/server/api/canary/utils/validators/input/schemas/images-upload.json
@@ -1,0 +1,8 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "images.upload",
+    "title": "images.upload",
+    "description": "Schema for images.upload",
+    "$ref": "images#/definitions/image"
+}

--- a/core/server/api/canary/utils/validators/input/schemas/images.json
+++ b/core/server/api/canary/utils/validators/input/schemas/images.json
@@ -1,0 +1,24 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "images",
+    "title": "images",
+    "description": "Base images definitions",
+    "definitions": {
+        "image": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "purpose": {
+                    "type": "string",
+                    "enum": ["image", "profile_image", "icon"],
+                    "default": "image"
+                },
+                "ref": {
+                    "type": ["string", "null"],
+                    "maxLength": 2000
+                }
+            }
+        }
+    }
+}

--- a/core/server/api/canary/utils/validators/input/schemas/pages-add.json
+++ b/core/server/api/canary/utils/validators/input/schemas/pages-add.json
@@ -1,0 +1,22 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "pages.add",
+    "title": "pages.add",
+    "description": "Schema for pages.add",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "pages": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+                "type": "object",
+                "allOf": [{"$ref": "pages#/definitions/page"}],
+                "required": ["title"]
+            }
+        }
+    },
+    "required": ["pages"]
+  }

--- a/core/server/api/canary/utils/validators/input/schemas/pages-edit.json
+++ b/core/server/api/canary/utils/validators/input/schemas/pages-edit.json
@@ -1,0 +1,22 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "pages.edit",
+    "title": "pages.edit",
+    "description": "Schema for pages.edit",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "pages": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+                "type": "object",
+                "allOf": [{"$ref": "pages#/definitions/page"}],
+                "required": ["updated_at"]
+            }
+        }
+    },
+    "required": ["pages"]
+  }

--- a/core/server/api/canary/utils/validators/input/schemas/pages.json
+++ b/core/server/api/canary/utils/validators/input/schemas/pages.json
@@ -1,0 +1,251 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "pages",
+    "title": "pages",
+    "description": "Base pages definitions",
+    "definitions": {
+        "page": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "slug": {
+                    "type": "string",
+                    "maxLength": 191
+                },
+                "mobiledoc": {
+                    "type": ["string", "null"],
+                    "maxLength": 1000000000
+                },
+                "html": {
+                    "type": ["string", "null"],
+                    "maxLength": 1000000000
+                },
+                "feature_image": {
+                    "type": ["string", "null"],
+                    "format": "uri-reference",
+                    "maxLength": 2000
+                },
+                "featured": {
+                    "type": "boolean"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["published", "draft", "scheduled"]
+                },
+                "locale": {
+                    "type": ["string", "null"],
+                    "maxLength": 6
+                },
+                "visibility": {
+                    "type": ["string", "null"],
+                    "enum": ["public"]
+                },
+                "meta_title": {
+                    "type": ["string", "null"],
+                    "maxLength": 300
+                },
+                "meta_description": {
+                    "type": ["string", "null"],
+                    "maxLength": 500
+                },
+                "updated_at": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                },
+                "published_at": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                },
+                "custom_excerpt": {
+                    "type": ["string", "null"],
+                    "maxLength": 300
+                },
+                "codeinjection_head": {
+                    "type": ["string", "null"],
+                    "maxLength": 65535
+                },
+                "codeinjection_foot": {
+                    "type": ["string", "null"],
+                    "maxLength": 65535
+                },
+                "og_image": {
+                    "type": ["string", "null"],
+                    "format": "uri-reference",
+                    "maxLength": 2000
+                },
+                "og_title": {
+                    "type": ["string", "null"],
+                    "maxLength": 300
+                },
+                "og_description": {
+                    "type": ["string", "null"],
+                    "maxLength": 500
+                },
+                "twitter_image": {
+                    "type": ["string", "null"],
+                    "format": "uri-reference",
+                    "maxLength": 2000
+                },
+                "twitter_title": {
+                    "type": ["string", "null"],
+                    "maxLength": 300
+                },
+                "twitter_description": {
+                    "type": ["string", "null"],
+                    "maxLength": 500
+                },
+                "custom_template": {
+                    "type": ["string", "null"],
+                    "maxLength": 100
+                },
+                "canonical_url": {
+                    "type": ["string", "null"],
+                    "format": "uri-reference",
+                    "maxLength": 2000
+                },
+                "authors": {
+                    "$ref": "#/definitions/page-authors"
+                },
+                "tags": {
+                    "$ref": "#/definitions/page-tags"
+                },
+                "id": {
+                    "strip": true
+                },
+                "page": {
+                    "strip": true
+                },
+                "author": {
+                    "strip": true
+                },
+                "author_id": {
+                    "strip": true
+                },
+                "created_at": {
+                    "strip": true
+                },
+                "created_by": {
+                    "strip": true
+                },
+                "updated_by": {
+                    "strip": true
+                },
+                "published_by": {
+                    "strip": true
+                },
+                "url": {
+                    "strip": true
+                },
+                "primary_tag": {
+                    "strip": true
+                },
+                "primary_author": {
+                    "strip": true
+                },
+                "excerpt": {
+                    "strip": true
+                },
+                "plaintext": {
+                    "strip": true
+                }
+            }
+        },
+        "page-authors": {
+            "description": "Authors of the page",
+            "type": "array",
+            "items": {
+                "anyOf": [{
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "maxLength": 24
+                        },
+                        "slug": {
+                            "type": "string",
+                            "maxLength": 191
+                        },
+                        "email": {
+                            "type": "string",
+                            "maxLength": 191
+                        },
+                        "roles": {
+                            "strip": true
+                        },
+                        "permissions": {
+                            "strip": true
+                        }
+                    },
+                    "anyOf": [
+                        {"required": ["id"]},
+                        {"required": ["slug"]},
+                        {"required": ["email"]}
+                    ]
+                }, {
+                    "type": "string",
+                    "maxLength": 191
+                }]
+            }
+        },
+        "page-tags": {
+            "description": "Tags of the page",
+            "type": "array",
+            "items": {
+                "anyOf": [{
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "maxLength": 24
+                        },
+                        "name": {
+                            "type": "string",
+                            "maxLength": 191
+                        },
+                        "slug": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 191
+                        },
+                        "parent": {
+                            "strip": true
+                        },
+                        "parent_id": {
+                            "strip": true
+                        },
+                        "pages": {
+                            "strip": true
+                        }
+                    },
+                    "anyOf": [
+                        {
+                            "required": [
+                                "id"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "name"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "slug"
+                            ]
+                        }
+                    ]
+                }, {
+                    "type": "string",
+                    "maxLength": 191
+                }]
+            }
+        }
+    }
+}

--- a/core/server/api/canary/utils/validators/input/schemas/posts-add.json
+++ b/core/server/api/canary/utils/validators/input/schemas/posts-add.json
@@ -1,0 +1,22 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "posts.add",
+    "title": "posts.add",
+    "description": "Schema for posts.add",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "posts": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+                "type": "object",
+                "allOf": [{"$ref": "posts#/definitions/post"}],
+                "required": ["title"]
+            }
+        }
+    },
+    "required": [ "posts" ]
+  }

--- a/core/server/api/canary/utils/validators/input/schemas/posts-edit.json
+++ b/core/server/api/canary/utils/validators/input/schemas/posts-edit.json
@@ -1,0 +1,22 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "posts.edit",
+    "title": "posts.edit",
+    "description": "Schema for posts.edit",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "posts": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+                "type": "object",
+                "allOf": [{"$ref": "posts#/definitions/post"}],
+                "required": ["updated_at"]
+            }
+        }
+    },
+    "required": [ "posts" ]
+  }

--- a/core/server/api/canary/utils/validators/input/schemas/posts.json
+++ b/core/server/api/canary/utils/validators/input/schemas/posts.json
@@ -1,0 +1,236 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "posts",
+    "title": "posts",
+    "description": "Base posts definitions",
+    "definitions": {
+        "post": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "maxLength": 2000
+                },
+                "slug": {
+                    "type": "string",
+                    "maxLength": 191
+                },
+                "mobiledoc": {
+                    "type": ["string", "null"],
+                    "maxLength": 1000000000
+                },
+                "html": {
+                    "type": ["string", "null"],
+                    "maxLength": 1000000000
+                },
+                "feature_image": {
+                    "type": ["string", "null"],
+                    "format": "uri-reference",
+                    "maxLength": 2000
+                },
+                "featured": {
+                    "type": "boolean"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["published", "draft", "scheduled"]
+                },
+                "locale": {
+                    "type": ["string", "null"],
+                    "maxLength": 6
+                },
+                "visibility": {
+                    "type": ["string", "null"],
+                    "enum": ["public"]
+                },
+                "meta_title": {
+                    "type": ["string", "null"],
+                    "maxLength": 300
+                },
+                "meta_description": {
+                    "type": ["string", "null"],
+                    "maxLength": 500
+                },
+                "updated_at": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                },
+                "published_at": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                },
+                "custom_excerpt": {
+                    "type": ["string", "null"],
+                    "maxLength": 300
+                },
+                "codeinjection_head": {
+                    "type": ["string", "null"],
+                    "maxLength": 65535
+                },
+                "codeinjection_foot": {
+                    "type": ["string", "null"],
+                    "maxLength": 65535
+                },
+                "og_image": {
+                    "type": ["string", "null"],
+                    "format": "uri-reference",
+                    "maxLength": 2000
+                },
+                "og_title": {
+                    "type": ["string", "null"],
+                    "maxLength": 300
+                },
+                "og_description": {
+                    "type": ["string", "null"],
+                    "maxLength": 500
+                },
+                "twitter_image": {
+                    "type": ["string", "null"],
+                    "format": "uri-reference",
+                    "maxLength": 2000
+                },
+                "twitter_title": {
+                    "type": ["string", "null"],
+                    "maxLength": 300
+                },
+                "twitter_description": {
+                    "type": ["string", "null"],
+                    "maxLength": 500
+                },
+                "custom_template": {
+                    "type": ["string", "null"],
+                    "maxLength": 100
+                },
+                "canonical_url": {
+                    "type": ["string", "null"],
+                    "format": "uri-reference",
+                    "maxLength": 2000
+                },
+                "authors": {
+                    "$ref": "#/definitions/post-authors"
+                },
+                "tags": {
+                    "$ref": "#/definitions/post-tags"
+                },
+                "id": {
+                    "strip": true
+                },
+                "author": {
+                    "strip": true
+                },
+                "author_id": {
+                    "strip": true
+                },
+                "page": {
+                    "strip": true
+                },
+                "created_at": {
+                    "strip": true
+                },
+                "created_by": {
+                    "strip": true
+                },
+                "updated_by": {
+                    "strip": true
+                },
+                "published_by": {
+                    "strip": true
+                },
+                "url": {
+                    "strip": true
+                },
+                "primary_tag": {
+                    "strip": true
+                },
+                "primary_author": {
+                    "strip": true
+                },
+                "excerpt": {
+                    "strip": true
+                },
+                "plaintext": {
+                    "strip": true
+                }
+            }
+        },
+        "post-authors": {
+            "description": "Authors of the post",
+            "type": "array",
+            "items": {
+                "anyOf": [{
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "maxLength": 24
+                        },
+                        "slug": {
+                            "type": "string",
+                            "maxLength": 191
+                        },
+                        "email": {
+                            "type": "string",
+                            "maxLength": 191
+                        },
+                        "roles": {
+                            "strip": true
+                        },
+                        "permissions": {
+                            "strip": true
+                        }
+                    },
+                    "anyOf": [
+                        {"required": ["id"]},
+                        {"required": ["slug"]},
+                        {"required": ["email"]}
+                    ]
+                }, {
+                    "type": "string",
+                    "maxLength": 191
+                }]
+            }
+        },
+        "post-tags": {
+            "description": "Tags of the post",
+            "type": "array",
+            "items": {
+                "anyOf": [{
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "maxLength": 24
+                        },
+                        "name": {
+                            "type": "string",
+                            "maxLength": 191
+                        },
+                        "slug": {
+                            "type": ["string", "null"],
+                            "maxLength": 191
+                        },
+                        "parent": {
+                            "strip": true
+                        },
+                        "parent_id": {
+                            "strip": true
+                        },
+                        "posts": {
+                            "strip": true
+                        }
+                    },
+                    "anyOf": [
+                        {"required": ["id"]},
+                        {"required": ["name"]},
+                        {"required": ["slug"]}
+                    ]
+                }, {
+                    "type": "string",
+                    "maxLength": 191
+                }]
+            }
+        }
+    }
+}

--- a/core/server/api/canary/utils/validators/input/schemas/tags-add.json
+++ b/core/server/api/canary/utils/validators/input/schemas/tags-add.json
@@ -1,0 +1,23 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "tags.add",
+    "title": "tags.add",
+    "description": "Schema for tags.add",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "tags": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "additionalProperties": false,
+            "items": {
+                "type": "object",
+                "allOf": [{"$ref": "tags#/definitions/tag"}],
+                "required": ["name"]
+            }
+        }
+    },
+    "required": [ "tags" ]
+  }

--- a/core/server/api/canary/utils/validators/input/schemas/tags-edit.json
+++ b/core/server/api/canary/utils/validators/input/schemas/tags-edit.json
@@ -1,0 +1,18 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "tags.edit",
+    "title": "tags.edit",
+    "description": "Schema for tags.edit",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "tags": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {"$ref": "tags#/definitions/tag"}
+        }
+    },
+    "required": [ "tags" ]
+  }

--- a/core/server/api/canary/utils/validators/input/schemas/tags.json
+++ b/core/server/api/canary/utils/validators/input/schemas/tags.json
@@ -1,0 +1,70 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "tags",
+    "title": "tags",
+    "description": "Base tags definitions",
+    "definitions": {
+        "tag": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 191,
+                    "pattern": "^([^,]|$)"
+                },
+                "slug": {
+                    "type": ["string", "null"],
+                    "maxLength": 191
+                },
+                "description": {
+                    "type": ["string", "null"],
+                    "maxLength": 500
+                },
+                "feature_image": {
+                    "type": ["string", "null"],
+                    "format": "uri-reference",
+                    "maxLength": 2000
+                },
+                "visibility": {
+                    "type": "string",
+                    "enum": ["public", "internal"]
+                },
+                "meta_title": {
+                    "type": ["string", "null"],
+                    "maxLength": 300
+                },
+                "meta_description": {
+                    "type": ["string", "null"],
+                    "maxLength": 500
+                },
+                "id": {
+                    "strip": true
+                },
+                "parent": {
+                    "strip": true
+                },
+                "parent_id": {
+                    "strip": true
+                },
+                "created_at": {
+                    "strip": true
+                },
+                "created_by": {
+                    "strip": true
+                },
+                "updated_at": {
+                    "strip": true
+                },
+                "updated_by": {
+                    "strip": true
+                },
+                "url": {
+                    "strip": true
+                }
+            }
+        }
+    }
+}

--- a/core/server/api/canary/utils/validators/input/settings.js
+++ b/core/server/api/canary/utils/validators/input/settings.js
@@ -1,0 +1,39 @@
+const Promise = require('bluebird');
+const _ = require('lodash');
+const common = require('../../../../../lib/common');
+
+module.exports = {
+    read(apiConfig, frame) {
+        // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
+        if (frame.options.key === 'permalinks') {
+            return Promise.reject(new common.errors.NotFoundError({
+                message: common.i18n.t('errors.errors.resourceNotFound')
+            }));
+        }
+    },
+
+    edit(apiConfig, frame) {
+        const errors = [];
+
+        _.each(frame.data.settings, (setting) => {
+            if (setting.key === 'active_theme') {
+                // @NOTE: active theme has to be changed via theme endpoints
+                errors.push(
+                    new common.errors.BadRequestError({
+                        message: common.i18n.t('errors.api.settings.activeThemeSetViaAPI.error'),
+                        help: common.i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
+                    })
+                );
+            } else if (setting.key === 'permalinks') {
+                // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
+                errors.push(new common.errors.NotFoundError({
+                    message: common.i18n.t('errors.api.settings.problemFindingSetting', {key: setting.key})
+                }));
+            }
+        });
+
+        if (errors.length) {
+            return Promise.reject(errors[0]);
+        }
+    }
+};

--- a/core/server/api/canary/utils/validators/input/setup.js
+++ b/core/server/api/canary/utils/validators/input/setup.js
@@ -1,0 +1,12 @@
+const debug = require('ghost-ignition').debug('api:canary:utils:validators:input:updateSetup');
+const common = require('../../../../../lib/common');
+
+module.exports = {
+    updateSetup(apiConfig, frame) {
+        debug('resetPassword');
+
+        if (!frame.options.context || !frame.options.context.user) {
+            throw new common.errors.NoPermissionError({message: common.i18n.t('errors.api.authentication.notTheBlogOwner')});
+        }
+    }
+};

--- a/core/server/api/canary/utils/validators/input/tags.js
+++ b/core/server/api/canary/utils/validators/input/tags.js
@@ -1,0 +1,15 @@
+const jsonSchema = require('../utils/json-schema');
+
+module.exports = {
+    add(apiConfig, frame) {
+        const schema = require('./schemas/tags-add');
+        const definitions = require('./schemas/tags');
+        return jsonSchema.validate(schema, definitions, frame.data);
+    },
+
+    edit(apiConfig, frame) {
+        const schema = require('./schemas/tags-edit');
+        const definitions = require('./schemas/tags');
+        return jsonSchema.validate(schema, definitions, frame.data);
+    }
+};

--- a/core/server/api/canary/utils/validators/input/users.js
+++ b/core/server/api/canary/utils/validators/input/users.js
@@ -1,0 +1,17 @@
+const Promise = require('bluebird');
+const debug = require('ghost-ignition').debug('api:canary:utils:validators:input:users');
+const common = require('../../../../../lib/common');
+
+module.exports = {
+    changePassword(apiConfig, frame) {
+        debug('changePassword');
+
+        const data = frame.data.password[0];
+
+        if (data.newPassword !== data.ne2Password) {
+            return Promise.reject(new common.errors.ValidationError({
+                message: common.i18n.t('errors.models.user.newPasswordsDoNotMatch')
+            }));
+        }
+    }
+};

--- a/core/server/api/canary/utils/validators/output/index.js
+++ b/core/server/api/canary/utils/validators/output/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/core/server/api/canary/utils/validators/utils/json-schema.js
+++ b/core/server/api/canary/utils/validators/utils/json-schema.js
@@ -1,0 +1,47 @@
+const _ = require('lodash');
+const Ajv = require('ajv');
+const stripKeyword = require('./strip-keyword');
+const common = require('../../../../../lib/common');
+
+const ajv = new Ajv({
+    allErrors: true,
+    useDefaults: true
+});
+
+stripKeyword(ajv);
+
+const getValidation = (schema, def) => {
+    if (!ajv.getSchema(def.$id)) {
+        ajv.addSchema(def);
+    }
+    return ajv.getSchema(schema.$id) || ajv.compile(schema);
+};
+
+const validate = (schema, definition, data) => {
+    const validation = getValidation(schema, definition);
+
+    validation(data);
+
+    if (validation.errors) {
+        let key;
+        const dataPath = _.get(validation, 'errors[0].dataPath');
+
+        if (dataPath) {
+            key = dataPath.split('.').pop();
+        } else {
+            key = schema.$id.split('.')[0];
+        }
+
+        return Promise.reject(new common.errors.ValidationError({
+            message: common.i18n.t('notices.data.validation.index.schemaValidationFailed', {
+                key: key
+            }),
+            property: key,
+            errorDetails: validation.errors
+        }));
+    }
+
+    return Promise.resolve();
+};
+
+module.exports.validate = validate;

--- a/core/server/api/canary/utils/validators/utils/strip-keyword.js
+++ b/core/server/api/canary/utils/validators/utils/strip-keyword.js
@@ -1,0 +1,22 @@
+/**
+ * 'strip' keyword is introduced into schemas for following behavior:
+ * properties that are 'known' but should not be present in the model
+ * should be stripped from data and not throw validation errors.
+ *
+ * An example of such property is `tag.parent` which we want to ignore
+ * but not necessarily throw a validation error as it was present in
+ * responses in previous versions of API
+ */
+module.exports = function defFunc(ajv) {
+    defFunc.definition = {
+        errors: false,
+        modifying: true,
+        valid: true,
+        validate: function (schema, data, parentSchema, dataPath, parentData, propName) {
+            delete parentData[propName];
+        }
+    };
+
+    ajv.addKeyword('strip', defFunc.definition);
+    return ajv;
+};

--- a/core/server/api/canary/webhooks.js
+++ b/core/server/api/canary/webhooks.js
@@ -1,0 +1,90 @@
+const models = require('../../models');
+const common = require('../../lib/common');
+
+module.exports = {
+    docName: 'webhooks',
+
+    add: {
+        statusCode: 201,
+        headers: {},
+        options: [],
+        data: [],
+        validation: {
+            data: {
+                event: {
+                    required: true
+                },
+                target_url: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            return models.Webhook.getByEventAndTarget(
+                frame.data.webhooks[0].event,
+                frame.data.webhooks[0].target_url,
+                frame.options
+            ).then((webhook) => {
+                if (webhook) {
+                    return Promise.reject(
+                        new common.errors.ValidationError({message: common.i18n.t('errors.api.webhooks.webhookAlreadyExists')})
+                    );
+                }
+
+                return models.Webhook.add(frame.data.webhooks[0], frame.options);
+            });
+        }
+    },
+
+    edit: {
+        permissions: true,
+        data: [
+            'name',
+            'event',
+            'target_url',
+            'secret',
+            'api_version'
+        ],
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        query({data, options}) {
+            return models.Webhook.edit(data.webhooks[0], Object.assign(options, {require: true}))
+                .catch(models.Webhook.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Webhook'
+                        })
+                    });
+                });
+        }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {},
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: true,
+        query(frame) {
+            frame.options.require = true;
+            return models.Webhook.destroy(frame.options).return(null);
+        }
+    }
+};

--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -1,4 +1,5 @@
 module.exports = require('./v0.1');
 module.exports['v0.1'] = require('./v0.1');
 module.exports.v2 = require('./v2');
+module.exports.canary = require('./canary');
 module.exports.shared = require('./shared');

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -67,7 +67,12 @@
     },
     "api": {
         "versions": {
-            "all": ["v0.1", "v2"],
+            "all": ["v0.1", "v2", "canary"],
+            "canary": {
+                "admin": "canary/admin",
+                "content": "canary/content",
+                "members": "canary/members"
+            },
             "v2": {
                 "admin": "v2/admin",
                 "content": "v2/content",

--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken');
+const url = require('url');
 const models = require('../../../models');
 const common = require('../../../lib/common');
 
@@ -90,10 +91,12 @@ const authenticate = (req, res, next) => {
         // https://github.com/auth0/node-jsonwebtoken/issues/208#issuecomment-231861138
         const secret = Buffer.from(apiKey.get('secret'), 'hex');
 
-        // @TODO When v3 api hits we should check against the api actually being used
-        // ensure the token was meant for this api
+        const {pathname} = url.parse(req.originalUrl);
+        const [hasMatch, version = 'v2', api = 'admin'] = pathname.match(/ghost\/api\/([^/]+)\/([^/]+)\/(.+)*/); // eslint-disable-line no-unused-vars
+
+        // ensure the token was meant for this api version
         const options = Object.assign({
-            audience: '/v2/admin/'
+            audience: new RegExp(`\/?${version}\/${api}\/?$`) // eslint-disable-line no-useless-escape
         }, JWT_OPTIONS);
 
         try {

--- a/core/server/web/api/canary/admin/app.js
+++ b/core/server/web/api/canary/admin/app.js
@@ -1,0 +1,41 @@
+const debug = require('ghost-ignition').debug('web:canary:admin:app');
+const boolParser = require('express-query-boolean');
+const express = require('express');
+const bodyParser = require('body-parser');
+const shared = require('../../../shared');
+const routes = require('./routes');
+
+module.exports = function setupApiApp() {
+    debug('Admin API canary setup start');
+    const apiApp = express();
+
+    // API middleware
+
+    // Body parsing
+    apiApp.use(bodyParser.json({limit: '1mb'}));
+    apiApp.use(bodyParser.urlencoded({extended: true, limit: '1mb'}));
+
+    // Query parsing
+    apiApp.use(boolParser());
+
+    // send 503 json response in case of maintenance
+    apiApp.use(shared.middlewares.maintenance);
+
+    // Check version matches for API requests, depends on res.locals.safeVersion being set
+    // Therefore must come after themeHandler.ghostLocals, for now
+    apiApp.use(shared.middlewares.api.versionMatch);
+
+    // Admin API shouldn't be cached
+    apiApp.use(shared.middlewares.cacheControl('private'));
+
+    // Routing
+    apiApp.use(routes());
+
+    // API error handling
+    apiApp.use(shared.middlewares.errorHandler.resourceNotFound);
+    apiApp.use(shared.middlewares.errorHandler.handleJSONResponseV2);
+
+    debug('Admin API canary setup end');
+
+    return apiApp;
+};

--- a/core/server/web/api/canary/admin/middleware.js
+++ b/core/server/web/api/canary/admin/middleware.js
@@ -1,0 +1,57 @@
+const common = require('../../../../lib/common');
+const auth = require('../../../../services/auth');
+const shared = require('../../../shared');
+
+const notImplemented = function (req, res, next) {
+    // CASE: user is logged in, allow
+    if (!req.api_key) {
+        return next();
+    }
+
+    // @NOTE: integrations have limited access for now
+    const whitelisted = {
+        // @NOTE: stable
+        site: ['GET'],
+        posts: ['GET', 'PUT', 'DELETE', 'POST'],
+        pages: ['GET', 'PUT', 'DELETE', 'POST'],
+        images: ['POST'],
+        // @NOTE: experimental
+        tags: ['GET', 'PUT', 'DELETE', 'POST'],
+        users: ['GET'],
+        themes: ['POST', 'PUT'],
+        subscribers: ['GET', 'PUT', 'DELETE', 'POST'],
+        config: ['GET'],
+        webhooks: ['POST', 'DELETE'],
+        schedules: ['PUT'],
+        db: ['POST']
+    };
+
+    const match = req.url.match(/^\/(\w+)\/?/);
+
+    if (match) {
+        const entity = match[1];
+
+        if (whitelisted[entity] && whitelisted[entity].includes(req.method)) {
+            return next();
+        }
+    }
+
+    next(new common.errors.GhostError({
+        errorType: 'NotImplementedError',
+        message: common.i18n.t('errors.api.common.notImplemented'),
+        statusCode: '501'
+    }));
+};
+
+/**
+ * Authentication for private endpoints
+ */
+module.exports.authAdminApi = [
+    auth.authenticate.authenticateAdminApi,
+    auth.authorize.authorizeAdminApi,
+    shared.middlewares.updateUserLastSeen,
+    shared.middlewares.api.cors,
+    shared.middlewares.urlRedirects.adminRedirect,
+    shared.middlewares.prettyUrls,
+    notImplemented
+];

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -1,0 +1,228 @@
+const express = require('express');
+const api = require('../../../../api');
+const apiCanary = require('../../../../api/canary');
+const mw = require('./middleware');
+
+const shared = require('../../../shared');
+
+// Handling uploads & imports
+const upload = shared.middlewares.upload;
+
+module.exports = function apiRoutes() {
+    const router = express.Router();
+
+    // alias delete with del
+    router.del = router.delete;
+
+    router.use(shared.middlewares.api.cors);
+
+    const http = apiCanary.http;
+
+    // ## Public
+    router.get('/site', http(apiCanary.site.read));
+
+    // ## Configuration
+    router.get('/config', mw.authAdminApi, http(apiCanary.config.read));
+
+    // ## Posts
+    router.get('/posts', mw.authAdminApi, http(apiCanary.posts.browse));
+    router.post('/posts', mw.authAdminApi, http(apiCanary.posts.add));
+    router.get('/posts/:id', mw.authAdminApi, http(apiCanary.posts.read));
+    router.get('/posts/slug/:slug', mw.authAdminApi, http(apiCanary.posts.read));
+    router.put('/posts/:id', mw.authAdminApi, http(apiCanary.posts.edit));
+    router.del('/posts/:id', mw.authAdminApi, http(apiCanary.posts.destroy));
+
+    // ## Pages
+    router.get('/pages', mw.authAdminApi, http(apiCanary.pages.browse));
+    router.post('/pages', mw.authAdminApi, http(apiCanary.pages.add));
+    router.get('/pages/:id', mw.authAdminApi, http(apiCanary.pages.read));
+    router.get('/pages/slug/:slug', mw.authAdminApi, http(apiCanary.pages.read));
+    router.put('/pages/:id', mw.authAdminApi, http(apiCanary.pages.edit));
+    router.del('/pages/:id', mw.authAdminApi, http(apiCanary.pages.destroy));
+
+    // # Integrations
+
+    router.get('/integrations', mw.authAdminApi, http(apiCanary.integrations.browse));
+    router.get('/integrations/:id', mw.authAdminApi, http(apiCanary.integrations.read));
+    router.post('/integrations', mw.authAdminApi, http(apiCanary.integrations.add));
+    router.put('/integrations/:id', mw.authAdminApi, http(apiCanary.integrations.edit));
+    router.del('/integrations/:id', mw.authAdminApi, http(apiCanary.integrations.destroy));
+
+    // ## Schedules
+    router.put('/schedules/:resource/:id', mw.authAdminApi, http(apiCanary.schedules.publish));
+
+    // ## Settings
+    router.get('/settings/routes/yaml', mw.authAdminApi, http(apiCanary.settings.download));
+    router.post('/settings/routes/yaml',
+        mw.authAdminApi,
+        upload.single('routes'),
+        shared.middlewares.validation.upload({type: 'routes'}),
+        http(apiCanary.settings.upload)
+    );
+
+    router.get('/settings', mw.authAdminApi, http(apiCanary.settings.browse));
+    router.get('/settings/:key', mw.authAdminApi, http(apiCanary.settings.read));
+    router.put('/settings', mw.authAdminApi, http(apiCanary.settings.edit));
+
+    // ## Users
+    router.get('/users', mw.authAdminApi, http(apiCanary.users.browse));
+    router.get('/users/:id', mw.authAdminApi, http(apiCanary.users.read));
+    router.get('/users/slug/:slug', mw.authAdminApi, http(apiCanary.users.read));
+    // NOTE: We don't expose any email addresses via the public api.
+    router.get('/users/email/:email', mw.authAdminApi, http(apiCanary.users.read));
+
+    router.put('/users/password', mw.authAdminApi, http(apiCanary.users.changePassword));
+    router.put('/users/owner', mw.authAdminApi, http(apiCanary.users.transferOwnership));
+    router.put('/users/:id', mw.authAdminApi, http(apiCanary.users.edit));
+    router.del('/users/:id', mw.authAdminApi, http(apiCanary.users.destroy));
+
+    // ## Tags
+    router.get('/tags', mw.authAdminApi, http(apiCanary.tags.browse));
+    router.get('/tags/:id', mw.authAdminApi, http(apiCanary.tags.read));
+    router.get('/tags/slug/:slug', mw.authAdminApi, http(apiCanary.tags.read));
+    router.post('/tags', mw.authAdminApi, http(apiCanary.tags.add));
+    router.put('/tags/:id', mw.authAdminApi, http(apiCanary.tags.edit));
+    router.del('/tags/:id', mw.authAdminApi, http(apiCanary.tags.destroy));
+
+    // ## Subscribers
+    router.get('/subscribers', shared.middlewares.labs.subscribers, mw.authAdminApi, http(apiCanary.subscribers.browse));
+    router.get('/subscribers/csv', shared.middlewares.labs.subscribers, mw.authAdminApi, http(apiCanary.subscribers.exportCSV));
+    router.post('/subscribers/csv',
+        shared.middlewares.labs.subscribers,
+        mw.authAdminApi,
+        upload.single('subscribersfile'),
+        shared.middlewares.validation.upload({type: 'subscribers'}),
+        http(apiCanary.subscribers.importCSV)
+    );
+    router.get('/subscribers/:id', shared.middlewares.labs.subscribers, mw.authAdminApi, http(apiCanary.subscribers.read));
+    router.get('/subscribers/email/:email', shared.middlewares.labs.subscribers, mw.authAdminApi, http(apiCanary.subscribers.read));
+    router.post('/subscribers', shared.middlewares.labs.subscribers, mw.authAdminApi, http(apiCanary.subscribers.add));
+    router.put('/subscribers/:id', shared.middlewares.labs.subscribers, mw.authAdminApi, http(apiCanary.subscribers.edit));
+    router.del('/subscribers/:id', shared.middlewares.labs.subscribers, mw.authAdminApi, http(apiCanary.subscribers.destroy));
+    router.del('/subscribers/email/:email', shared.middlewares.labs.subscribers, mw.authAdminApi, http(apiCanary.subscribers.destroy));
+
+    // ## Members
+    router.get('/members', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.browse));
+    router.get('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.read));
+    router.del('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.destroy));
+
+    // ## Roles
+    router.get('/roles/', mw.authAdminApi, http(apiCanary.roles.browse));
+
+    // ## Clients
+    router.get('/clients/slug/:slug', api.http(api.clients.read));
+
+    // ## Slugs
+    router.get('/slugs/:type/:name', mw.authAdminApi, http(apiCanary.slugs.generate));
+
+    // ## Themes
+    router.get('/themes/', mw.authAdminApi, http(apiCanary.themes.browse));
+
+    router.get('/themes/:name/download',
+        mw.authAdminApi,
+        http(apiCanary.themes.download)
+    );
+
+    router.post('/themes/upload',
+        mw.authAdminApi,
+        upload.single('file'),
+        shared.middlewares.validation.upload({type: 'themes'}),
+        http(apiCanary.themes.upload)
+    );
+
+    router.put('/themes/:name/activate',
+        mw.authAdminApi,
+        http(apiCanary.themes.activate)
+    );
+
+    router.del('/themes/:name',
+        mw.authAdminApi,
+        http(apiCanary.themes.destroy)
+    );
+
+    // ## Notifications
+    router.get('/notifications', mw.authAdminApi, http(apiCanary.notifications.browse));
+    router.post('/notifications', mw.authAdminApi, http(apiCanary.notifications.add));
+    router.del('/notifications/:notification_id', mw.authAdminApi, http(apiCanary.notifications.destroy));
+
+    // ## DB
+    router.get('/db', mw.authAdminApi, http(apiCanary.db.exportContent));
+    router.post('/db',
+        mw.authAdminApi,
+        upload.single('importfile'),
+        shared.middlewares.validation.upload({type: 'db'}),
+        http(apiCanary.db.importContent)
+    );
+    router.del('/db', mw.authAdminApi, http(apiCanary.db.deleteAllContent));
+    router.post('/db/backup',
+        mw.authAdminApi,
+        http(apiCanary.db.backupContent)
+    );
+
+    // ## Mail
+    router.post('/mail', mw.authAdminApi, http(apiCanary.mail.send));
+    router.post('/mail/test', mw.authAdminApi, http(apiCanary.mail.sendTest));
+
+    // ## Slack
+    router.post('/slack/test', mw.authAdminApi, http(apiCanary.slack.sendTest));
+
+    // ## Sessions
+    router.get('/session', mw.authAdminApi, api.http(apiCanary.session.read));
+    // We don't need auth when creating a new session (logging in)
+    router.post('/session',
+        shared.middlewares.brute.globalBlock,
+        shared.middlewares.brute.userLogin,
+        api.http(apiCanary.session.add)
+    );
+    router.del('/session', mw.authAdminApi, api.http(apiCanary.session.delete));
+
+    // ## Authentication
+    router.post('/authentication/passwordreset',
+        shared.middlewares.brute.globalReset,
+        shared.middlewares.brute.userReset,
+        http(apiCanary.authentication.generateResetToken)
+    );
+    router.put('/authentication/passwordreset', shared.middlewares.brute.globalBlock, http(apiCanary.authentication.resetPassword));
+    router.post('/authentication/invitation', http(apiCanary.authentication.acceptInvitation));
+    router.get('/authentication/invitation', http(apiCanary.authentication.isInvitation));
+    router.post('/authentication/setup', http(apiCanary.authentication.setup));
+    router.put('/authentication/setup', mw.authAdminApi, http(apiCanary.authentication.updateSetup));
+    router.get('/authentication/setup', http(apiCanary.authentication.isSetup));
+
+    // ## Images
+    router.post('/images/upload',
+        mw.authAdminApi,
+        upload.single('file'),
+        shared.middlewares.validation.upload({type: 'images'}),
+        shared.middlewares.image.normalize,
+        http(apiCanary.images.upload)
+    );
+
+    // ## Invites
+    router.get('/invites', mw.authAdminApi, http(apiCanary.invites.browse));
+    router.get('/invites/:id', mw.authAdminApi, http(apiCanary.invites.read));
+    router.post('/invites', mw.authAdminApi, http(apiCanary.invites.add));
+    router.del('/invites/:id', mw.authAdminApi, http(apiCanary.invites.destroy));
+
+    // ## Redirects (JSON based)
+    router.get('/redirects/json', mw.authAdminApi, http(apiCanary.redirects.download));
+    router.post('/redirects/json',
+        mw.authAdminApi,
+        upload.single('redirects'),
+        shared.middlewares.validation.upload({type: 'redirects'}),
+        http(apiCanary.redirects.upload)
+    );
+
+    // ## Webhooks (RESTHooks)
+    router.post('/webhooks', mw.authAdminApi, http(apiCanary.webhooks.add));
+    router.put('/webhooks/:id', mw.authAdminApi, http(apiCanary.webhooks.edit));
+    router.del('/webhooks/:id', mw.authAdminApi, http(apiCanary.webhooks.destroy));
+
+    // ## Oembed (fetch response from oembed provider)
+    router.get('/oembed', mw.authAdminApi, http(apiCanary.oembed.read));
+
+    // ## Actions
+    router.get('/actions/:type/:id', mw.authAdminApi, http(apiCanary.actions.browse));
+
+    return router;
+};

--- a/core/server/web/api/canary/content/app.js
+++ b/core/server/web/api/canary/content/app.js
@@ -1,0 +1,36 @@
+const debug = require('ghost-ignition').debug('web:api:canary:content:app');
+const boolParser = require('express-query-boolean');
+const bodyParser = require('body-parser');
+const express = require('express');
+const shared = require('../../../shared');
+const routes = require('./routes');
+
+module.exports = function setupApiApp() {
+    debug('Content API canary setup start');
+    const apiApp = express();
+
+    // API middleware
+
+    // @NOTE: req.body is undefined if we don't use this parser, this can trouble if components rely on req.body being present
+    apiApp.use(bodyParser.json({limit: '1mb'}));
+
+    // Query parsing
+    apiApp.use(boolParser());
+
+    // send 503 json response in case of maintenance
+    apiApp.use(shared.middlewares.maintenance);
+
+    // API shouldn't be cached
+    apiApp.use(shared.middlewares.cacheControl('private'));
+
+    // Routing
+    apiApp.use(routes());
+
+    // API error handling
+    apiApp.use(shared.middlewares.errorHandler.resourceNotFound);
+    apiApp.use(shared.middlewares.errorHandler.handleJSONResponse);
+
+    debug('Content API canary setup end');
+
+    return apiApp;
+};

--- a/core/server/web/api/canary/content/middleware.js
+++ b/core/server/web/api/canary/content/middleware.js
@@ -1,0 +1,23 @@
+const cors = require('cors');
+const auth = require('../../../../services/auth');
+const shared = require('../../../shared');
+
+/**
+ * Auth Middleware Packages
+ *
+ * IMPORTANT
+ * - cors middleware MUST happen before pretty urls, because otherwise cors header can get lost on redirect
+ * - url redirects MUST happen after cors, otherwise cors header can get lost on redirect
+ */
+
+/**
+ * Authentication for public endpoints
+ */
+module.exports.authenticatePublic = [
+    shared.middlewares.brute.contentApiKey,
+    auth.authenticate.authenticateContentApi,
+    auth.authorize.authorizeContentApi,
+    cors(),
+    shared.middlewares.urlRedirects.adminRedirect,
+    shared.middlewares.prettyUrls
+];

--- a/core/server/web/api/canary/content/routes.js
+++ b/core/server/web/api/canary/content/routes.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const cors = require('cors');
+const apiCanary = require('../../../../api/canary');
+const mw = require('./middleware');
+
+module.exports = function apiRoutes() {
+    const router = express.Router();
+
+    router.use(cors());
+
+    const http = apiCanary.http;
+
+    // ## Posts
+    router.get('/posts', mw.authenticatePublic, http(apiCanary.postsPublic.browse));
+    router.get('/posts/:id', mw.authenticatePublic, http(apiCanary.postsPublic.read));
+    router.get('/posts/slug/:slug', mw.authenticatePublic, http(apiCanary.postsPublic.read));
+
+    // ## Pages
+    router.get('/pages', mw.authenticatePublic, http(apiCanary.pagesPublic.browse));
+    router.get('/pages/:id', mw.authenticatePublic, http(apiCanary.pagesPublic.read));
+    router.get('/pages/slug/:slug', mw.authenticatePublic, http(apiCanary.pagesPublic.read));
+
+    // ## Users
+    router.get('/authors', mw.authenticatePublic, http(apiCanary.authorsPublic.browse));
+    router.get('/authors/:id', mw.authenticatePublic, http(apiCanary.authorsPublic.read));
+    router.get('/authors/slug/:slug', mw.authenticatePublic, http(apiCanary.authorsPublic.read));
+
+    // ## Tags
+    router.get('/tags', mw.authenticatePublic, http(apiCanary.tagsPublic.browse));
+    router.get('/tags/:id', mw.authenticatePublic, http(apiCanary.tagsPublic.read));
+    router.get('/tags/slug/:slug', mw.authenticatePublic, http(apiCanary.tagsPublic.read));
+
+    // ## Settings
+    router.get('/settings', mw.authenticatePublic, http(apiCanary.publicSettings.browse));
+
+    return router;
+};

--- a/core/server/web/api/canary/members/app.js
+++ b/core/server/web/api/canary/members/app.js
@@ -1,0 +1,28 @@
+const debug = require('ghost-ignition').debug('web:canary:members:app');
+const express = require('express');
+const membersService = require('../../../../services/members');
+const labs = require('../../../shared/middlewares/labs');
+const shared = require('../../../shared');
+
+module.exports = function setupMembersApiApp() {
+    debug('Members API canary setup start');
+    const apiApp = express();
+
+    // Entire app is behind labs flag
+    apiApp.use(labs.members);
+
+    // Set up the auth pages
+    apiApp.use('/static/auth', membersService.authPages);
+
+    // Set up the api endpoints and the gateway
+    // NOTE: this is wrapped in a function to ensure we always go via the getter
+    apiApp.use((req, res, next) => membersService.api(req, res, next));
+
+    // API error handling
+    apiApp.use(shared.middlewares.errorHandler.resourceNotFound);
+    apiApp.use(shared.middlewares.errorHandler.handleJSONResponseV2);
+
+    debug('Members API canary setup end');
+
+    return apiApp;
+};

--- a/core/server/web/api/index.js
+++ b/core/server/web/api/index.js
@@ -12,6 +12,9 @@ module.exports = function setupApiApp() {
     apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'content'}), require('./v2/content/app')());
     apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'admin'}), require('./v2/admin/app')());
     apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'members'}), require('./v2/members/app')());
+    apiApp.use(urlUtils.getVersionPath({version: 'canary', type: 'content'}), require('./canary/content/app')());
+    apiApp.use(urlUtils.getVersionPath({version: 'canary', type: 'admin'}), require('./canary/admin/app')());
+    apiApp.use(urlUtils.getVersionPath({version: 'canary', type: 'members'}), require('./canary/members/app')());
 
     // Error handling for requests to non-existent API versions
     apiApp.use(errorHandler.resourceNotFound);

--- a/core/server/web/shared/middlewares/uncapitalise.js
+++ b/core/server/web/shared/middlewares/uncapitalise.js
@@ -22,7 +22,7 @@ const uncapitalise = (req, res, next) => {
     let decodedURI;
 
     const isSignupOrReset = pathToTest.match(/^(.*\/ghost\/(signup|reset)\/)/i),
-        isAPI = pathToTest.match(/^(.*\/ghost\/api\/v[\d.]+\/.*?\/)/i);
+        isAPI = pathToTest.match(/^(.*\/ghost\/api\/(v[\d.]+|canary)\/.*?\/)/i);
 
     if (isSignupOrReset) {
         pathToTest = isSignupOrReset[1];

--- a/core/test/regression/api/canary/admin/authentication_spec.js
+++ b/core/test/regression/api/canary/admin/authentication_spec.js
@@ -1,0 +1,312 @@
+const should = require('should');
+const sinon = require('sinon');
+const supertest = require('supertest');
+const localUtils = require('./utils');
+const testUtils = require('../../../../utils/index');
+const models = require('../../../../../server/models/index');
+const security = require('../../../../../server/lib/security/index');
+const settingsCache = require('../../../../../server/services/settings/cache');
+const config = require('../../../../../server/config/index');
+const mailService = require('../../../../../server/services/mail/index');
+
+let ghost = testUtils.startGhost;
+let request;
+
+describe('Authentication API v3', function () {
+    let ghostServer;
+
+    describe('Blog setup', function () {
+        before(function () {
+            return ghost({forceStart: true})
+                .then(function (_ghostServer) {
+                    ghostServer = _ghostServer;
+                    request = supertest.agent(config.get('url'));
+                });
+        });
+
+        beforeEach(function () {
+            sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail is disabled');
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('is setup? no', function () {
+            return request
+                .get(localUtils.API.getApiQuery('authentication/setup'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect(200)
+                .then((res) => {
+                    res.body.setup[0].status.should.be.false();
+                });
+        });
+
+        it('complete setup', function () {
+            return request
+                .post(localUtils.API.getApiQuery('authentication/setup'))
+                .set('Origin', config.get('url'))
+                .send({
+                    setup: [{
+                        name: 'test user',
+                        email: 'test@example.com',
+                        password: 'thisissupersafe',
+                        blogTitle: 'a test blog'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect(201)
+                .then((res) => {
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.users);
+                    should.not.exist(jsonResponse.meta);
+
+                    jsonResponse.users.should.have.length(1);
+                    localUtils.API.checkResponse(jsonResponse.users[0], 'user');
+
+                    const newUser = jsonResponse.users[0];
+                    newUser.id.should.equal(testUtils.DataGenerator.Content.users[0].id);
+                    newUser.name.should.equal('test user');
+                    newUser.email.should.equal('test@example.com');
+
+                    mailService.GhostMailer.prototype.send.called.should.be.true();
+                    mailService.GhostMailer.prototype.send.args[0][0].to.should.equal('test@example.com');
+                });
+        });
+
+        it('is setup? yes', function () {
+            return request
+                .get(localUtils.API.getApiQuery('authentication/setup'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect(200)
+                .then((res) => {
+                    res.body.setup[0].status.should.be.true();
+                });
+        });
+
+        it('complete setup again', function () {
+            return request
+                .post(localUtils.API.getApiQuery('authentication/setup'))
+                .set('Origin', config.get('url'))
+                .send({
+                    setup: [{
+                        name: 'test user',
+                        email: 'test-leo@example.com',
+                        password: 'thisissupersafe',
+                        blogTitle: 'a test blog'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect(403);
+        });
+
+        it('update setup', function () {
+            return localUtils.doAuth(request)
+                .then(() => {
+                    return request
+                        .put(localUtils.API.getApiQuery('authentication/setup'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            setup: [{
+                                name: 'test user edit',
+                                email: 'test-edit@example.com',
+                                password: 'thisissupersafe',
+                                blogTitle: 'a test blog'
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect(200);
+                })
+                .then((res) => {
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.users);
+                    should.not.exist(jsonResponse.meta);
+
+                    jsonResponse.users.should.have.length(1);
+                    localUtils.API.checkResponse(jsonResponse.users[0], 'user');
+
+                    const newUser = jsonResponse.users[0];
+                    newUser.id.should.equal(testUtils.DataGenerator.Content.users[0].id);
+                    newUser.name.should.equal('test user edit');
+                    newUser.email.should.equal('test-edit@example.com');
+                });
+        });
+    });
+
+    describe('Invitation', function () {
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    ghostServer = _ghostServer;
+                    request = supertest.agent(config.get('url'));
+
+                    // simulates blog setup (initialises the owner)
+                    return localUtils.doAuth(request, 'invites');
+                });
+        });
+
+        it('check invite with invalid email', function () {
+            return request
+                .get(localUtils.API.getApiQuery('authentication/invitation?email=invalidemail'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect(400);
+        });
+
+        it('check valid invite', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`authentication/invitation?email=${testUtils.DataGenerator.forKnex.invites[0].email}`))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect(200)
+                .then((res) => {
+                    res.body.invitation[0].valid.should.equal(true);
+                });
+        });
+
+        it('check invalid invite', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`authentication/invitation?email=notinvited@example.org`))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect(200)
+                .then((res) => {
+                    res.body.invitation[0].valid.should.equal(false);
+                });
+        });
+
+        it('try to accept without invite', function () {
+            return request
+                .post(localUtils.API.getApiQuery('authentication/invitation'))
+                .set('Origin', config.get('url'))
+                .send({
+                    invitation: [{
+                        token: 'lul11111',
+                        password: 'lel123456',
+                        email: 'not-invited@example.org',
+                        name: 'not invited'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect(404);
+        });
+
+        it('try to accept with invite', function () {
+            return request
+                .post(localUtils.API.getApiQuery('authentication/invitation'))
+                .set('Origin', config.get('url'))
+                .send({
+                    invitation: [{
+                        token: testUtils.DataGenerator.forKnex.invites[0].token,
+                        password: '12345678910',
+                        email: testUtils.DataGenerator.forKnex.invites[0].email,
+                        name: 'invited'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect(200)
+                .then((res) => {
+                    res.body.invitation[0].message.should.equal('Invitation accepted.');
+                });
+        });
+    });
+
+    describe('Password reset', function () {
+        const user = testUtils.DataGenerator.forModel.users[0];
+
+        before(function () {
+            return ghost({forceStart: true})
+                .then(() =>  {
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(() => {
+                    return localUtils.doAuth(request);
+                });
+        });
+
+        beforeEach(function () {
+            sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail is disabled');
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('reset password', function (done) {
+            models.User.getOwnerUser(testUtils.context.internal)
+                .then(function (ownerUser) {
+                    var token = security.tokens.resetToken.generateHash({
+                        expires: Date.now() + (1000 * 60),
+                        email: user.email,
+                        dbHash: settingsCache.get('db_hash'),
+                        password: ownerUser.get('password')
+                    });
+
+                    request.put(localUtils.API.getApiQuery('authentication/passwordreset'))
+                        .set('Origin', config.get('url'))
+                        .set('Accept', 'application/json')
+                        .send({
+                            passwordreset: [{
+                                token: token,
+                                newPassword: 'thisissupersafe',
+                                ne2Password: 'thisissupersafe'
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            const jsonResponse = res.body;
+                            should.exist(jsonResponse.passwordreset[0].message);
+                            jsonResponse.passwordreset[0].message.should.equal('Password changed successfully.');
+                            done();
+                        });
+                })
+                .catch(done);
+        });
+
+        it('reset password: invalid token', function () {
+            return request
+                .put(localUtils.API.getApiQuery('authentication/passwordreset'))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .send({
+                    passwordreset: [{
+                        token: 'invalid',
+                        newPassword: 'thisissupersafe',
+                        ne2Password: 'thisissupersafe'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(401);
+        });
+
+        it('reset password: generate reset token', function () {
+            return request
+                .post(localUtils.API.getApiQuery('authentication/passwordreset'))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .send({
+                    passwordreset: [{
+                        email: user.email
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .then((res) => {
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.passwordreset[0].message);
+                    jsonResponse.passwordreset[0].message.should.equal('Check your email for further instructions.');
+                    mailService.GhostMailer.prototype.send.args[0][0].to.should.equal(user.email);
+                });
+        });
+    });
+});

--- a/core/test/regression/api/canary/admin/db_spec.js
+++ b/core/test/regression/api/canary/admin/db_spec.js
@@ -1,0 +1,164 @@
+const path = require('path');
+const _ = require('lodash');
+const os = require('os');
+const fs = require('fs-extra');
+const uuid = require('uuid');
+const should = require('should');
+const supertest = require('supertest');
+const sinon = require('sinon');
+const config = require('../../../../../server/config');
+const models = require('../../../../../server/models');
+const common = require('../../../../../server/lib/common');
+const testUtils = require('../../../../utils');
+const localUtils = require('./utils');
+
+let ghost = testUtils.startGhost;
+let request;
+let eventsTriggered;
+
+describe('DB API', () => {
+    let backupKey;
+    let schedulerKey;
+
+    before(() => {
+        return ghost()
+            .then(() => {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(() => {
+                return localUtils.doAuth(request);
+            })
+            .then(() => {
+                backupKey = _.find(testUtils.existingData.apiKeys, {integration: {slug: 'ghost-backup'}});
+                schedulerKey = _.find(testUtils.existingData.apiKeys, {integration: {slug: 'ghost-scheduler'}});
+            });
+    });
+
+    beforeEach(() => {
+        eventsTriggered = {};
+
+        sinon.stub(common.events, 'emit').callsFake((eventName, eventObj) => {
+            if (!eventsTriggered[eventName]) {
+                eventsTriggered[eventName] = [];
+            }
+
+            eventsTriggered[eventName].push(eventObj);
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('can export the database with more tables', () => {
+        return request.get(localUtils.API.getApiQuery('db/?include=clients,client_trusted_domains'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect(200)
+            .then((res) => {
+                const jsonResponse = res.body;
+                should.exist(jsonResponse.db);
+                jsonResponse.db.should.have.length(1);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(28);
+            });
+    });
+
+    it('can export & import', () => {
+        const exportFolder = path.join(os.tmpdir(), uuid.v4());
+        const exportPath = path.join(exportFolder, 'export.json');
+
+        return request.put(localUtils.API.getApiQuery('settings/'))
+            .set('Origin', config.get('url'))
+            .send({
+                settings: [
+                    {
+                        key: 'is_private',
+                        value: true
+                    }
+                ]
+            })
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then(() => {
+                return request.get(localUtils.API.getApiQuery('db/'))
+                    .set('Origin', config.get('url'))
+                    .expect('Content-Type', /json/)
+                    .expect(200);
+            })
+            .then((res) => {
+                const jsonResponse = res.body;
+                should.exist(jsonResponse.db);
+
+                fs.ensureDirSync(exportFolder);
+                fs.writeJSONSync(exportPath, jsonResponse);
+
+                return request.post(localUtils.API.getApiQuery('db/'))
+                    .set('Origin', config.get('url'))
+                    .set('Accept', 'application/json')
+                    .expect('Content-Type', /json/)
+                    .attach('importfile', exportPath)
+                    .expect(200);
+            })
+            .then((res) => {
+                res.body.problems.length.should.eql(3);
+                fs.removeSync(exportFolder);
+            });
+    });
+
+    it('import should fail without file', () => {
+        return request.post(localUtils.API.getApiQuery('db/'))
+            .set('Origin', config.get('url'))
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect(422);
+    });
+
+    it('import should fail with unsupported file', () => {
+        return request.post(localUtils.API.getApiQuery('db/'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .attach('importfile', path.join(__dirname, '/../../../../utils/fixtures/csv/single-column-with-header.csv'))
+            .expect(415);
+    });
+
+    it('export can be triggered by backup integration', () => {
+        const backupQuery = `?filename=test`;
+        const fsStub = sinon.stub(fs, 'writeFile').resolves();
+
+        return request.post(localUtils.API.getApiQuery(`db/backup${backupQuery}`))
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', backupKey)}`)
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect(200)
+            .then((res) => {
+                res.body.should.be.Object();
+                res.body.db[0].filename.should.match(/test\.json/);
+                fsStub.calledOnce.should.eql(true);
+            });
+    });
+
+    it('export can not be triggered by integration other than backup', () => {
+        const fsStub = sinon.stub(fs, 'writeFile').resolves();
+
+        return request.post(localUtils.API.getApiQuery(`db/backup`))
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', schedulerKey)}`)
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect(403)
+            .then((res) => {
+                should.exist(res.body.errors);
+                res.body.errors[0].type.should.eql('NoPermissionError');
+                fsStub.called.should.eql(false);
+            });
+    });
+
+    it('export can be triggered by Admin authentication', () => {
+        const fsStub = sinon.stub(fs, 'writeFile').resolves();
+
+        return request.post(localUtils.API.getApiQuery(`db/backup`))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect(200);
+    });
+});

--- a/core/test/regression/api/canary/admin/images_spec.js
+++ b/core/test/regression/api/canary/admin/images_spec.js
@@ -1,0 +1,86 @@
+const path = require('path');
+const fs = require('fs-extra');
+const should = require('should');
+const supertest = require('supertest');
+const localUtils = require('./utils');
+const testUtils = require('../../../../utils');
+const config = require('../../../../../server/config');
+
+const ghost = testUtils.startGhost;
+
+describe('Images API', function () {
+    const images = [];
+    let request;
+
+    before(function () {
+        return ghost()
+            .then(function () {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return localUtils.doAuth(request);
+            });
+    });
+
+    after(function () {
+        images.forEach(function (image) {
+            fs.removeSync(config.get('paths').appRoot + image);
+        });
+    });
+
+    it('Can\'t import fail without file', function () {
+        return request
+            .post(localUtils.API.getApiQuery('images/upload'))
+            .set('Origin', config.get('url'))
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect(422);
+    });
+
+    it('Can\'t import with unsupported file', function (done) {
+        request.post(localUtils.API.getApiQuery('images/upload'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .attach('file', path.join(__dirname, '/../../../../utils/fixtures/csv/single-column-with-header.csv'))
+            .expect(415)
+            .end(function (err) {
+                if (err) {
+                    return done(err);
+                }
+
+                done();
+            });
+    });
+
+    it('Can\'t upload incorrect extension', function (done) {
+        request.post(localUtils.API.getApiQuery('images/upload'))
+            .set('Origin', config.get('url'))
+            .set('content-type', 'image/png')
+            .expect('Content-Type', /json/)
+            .attach('file', path.join(__dirname, '/../../../../utils/fixtures/images/ghost-logo.pngx'))
+            .expect(415)
+            .end(function (err) {
+                if (err) {
+                    return done(err);
+                }
+
+                done();
+            });
+    });
+
+    it('Can\'t import if profile image is not square', function (done) {
+        request.post(localUtils.API.getApiQuery('images/upload'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .field('purpose', 'profile_image')
+            .attach('file', path.join(__dirname, '/../../../../utils/fixtures/images/favicon_not_square.png'))
+            .expect(422)
+            .end(function (err) {
+                if (err) {
+                    return done(err);
+                }
+
+                done();
+            });
+    });
+});

--- a/core/test/regression/api/canary/admin/notifications_spec.js
+++ b/core/test/regression/api/canary/admin/notifications_spec.js
@@ -1,0 +1,198 @@
+const should = require('should');
+const supertest = require('supertest');
+const testUtils = require('../../../../utils');
+const config = require('../../../../../server/config');
+const localUtils = require('./utils');
+const ghost = testUtils.startGhost;
+
+describe('Notifications API', function () {
+    describe('As Editor', function () {
+        let request;
+
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({
+                            email: 'test+editor@ghost.org'
+                        }),
+                        role: testUtils.DataGenerator.Content.roles[1].name
+                    });
+                })
+                .then((user) => {
+                    request.user = user;
+                    return localUtils.doAuth(request);
+                });
+        });
+
+        it('Add notification', function () {
+            const newNotification = {
+                type: 'info',
+                message: 'test notification',
+                custom: true
+            };
+
+            return request.post(localUtils.API.getApiQuery('notifications/'))
+                .set('Origin', config.get('url'))
+                .send({notifications: [newNotification]})
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201)
+                .then((res) => {
+                    const jsonResponse = res.body;
+
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.notifications);
+                    should.equal(jsonResponse.notifications.length, 1);
+                });
+        });
+
+        it('Read notifications', function () {
+            return request.get(localUtils.API.getApiQuery('notifications/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .then((res) => {
+                    const jsonResponse = res.body;
+
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.notifications);
+                    should.equal(jsonResponse.notifications.length, 1);
+                });
+        });
+    });
+
+    describe('As Author', function () {
+        let request;
+
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({
+                            email: 'test+author@ghost.org'
+                        }),
+                        role: testUtils.DataGenerator.Content.roles[2].name
+                    });
+                })
+                .then((user) => {
+                    request.user = user;
+                    return localUtils.doAuth(request);
+                });
+        });
+
+        it('Add notification', function () {
+            const newNotification = {
+                type: 'info',
+                message: 'test notification',
+                custom: true
+            };
+
+            return request.post(localUtils.API.getApiQuery('notifications/'))
+                .set('Origin', config.get('url'))
+                .send({notifications: [newNotification]})
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(403);
+        });
+
+        it('Read notifications', function () {
+            return request.get(localUtils.API.getApiQuery('notifications/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(403);
+        });
+    });
+
+    describe('Can view by multiple users', function () {
+        let requestEditor1;
+        let requestEditor2;
+        let notification;
+
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    requestEditor1 = supertest.agent(config.get('url'));
+                    requestEditor2 = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({
+                            email: 'test+editor1@ghost.org'
+                        }),
+                        role: testUtils.DataGenerator.Content.roles[1].name
+                    });
+                })
+                .then((user) => {
+                    requestEditor1.user = user;
+                    return localUtils.doAuth(requestEditor1);
+                })
+                .then(function () {
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({
+                            email: 'test+editor2@ghost.org'
+                        }),
+                        role: testUtils.DataGenerator.Content.roles[1].name
+                    });
+                })
+                .then((user) => {
+                    requestEditor2.user = user;
+                    return localUtils.doAuth(requestEditor2);
+                })
+                .then(() => {
+                    const newNotification = {
+                        type: 'info',
+                        message: 'multiple views',
+                        custom: true
+                    };
+
+                    return requestEditor1.post(localUtils.API.getApiQuery('notifications/'))
+                        .set('Origin', config.get('url'))
+                        .send({notifications: [newNotification]})
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(201)
+                        .then((res) => {
+                            notification = res.body.notifications[0];
+                        });
+                });
+        });
+
+        it('notification is visible and dismissible by other user', function () {
+            return requestEditor1.del(localUtils.API.getApiQuery(`notifications/${notification.id}`))
+                .set('Origin', config.get('url'))
+                .expect(204)
+                .then(() => {
+                    return requestEditor2.get(localUtils.API.getApiQuery(`notifications/`))
+                        .set('Origin', config.get('url'))
+                        .expect(200)
+                        .then(function (res) {
+                            const deleted = res.body.notifications.filter(n => n.id === notification.id);
+                            deleted.should.not.be.empty();
+                        });
+                })
+                .then(() => {
+                    return requestEditor2.del(localUtils.API.getApiQuery(`notifications/${notification.id}`))
+                        .set('Origin', config.get('url'))
+                        .expect(204);
+                })
+                .then(() => {
+                    return requestEditor2.get(localUtils.API.getApiQuery(`notifications/`))
+                        .set('Origin', config.get('url'))
+                        .expect(200)
+                        .then(function (res) {
+                            const deleted = res.body.notifications.filter(n => n.id === notification.id);
+                            deleted.should.be.empty();
+                        });
+                });
+        });
+    });
+});

--- a/core/test/regression/api/canary/admin/posts_spec.js
+++ b/core/test/regression/api/canary/admin/posts_spec.js
@@ -1,0 +1,373 @@
+const should = require('should');
+const supertest = require('supertest');
+const ObjectId = require('bson-objectid');
+const moment = require('moment-timezone');
+const testUtils = require('../../../../utils');
+const config = require('../../../../../server/config');
+const models = require('../../../../../server/models');
+const localUtils = require('./utils');
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Posts API', function () {
+    let ghostServer;
+    let ownerCookie;
+
+    before(function () {
+        return ghost()
+            .then(function (_ghostServer) {
+                ghostServer = _ghostServer;
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return localUtils.doAuth(request, 'users:extra', 'posts');
+            })
+            .then(function (cookie) {
+                ownerCookie = cookie;
+            });
+    });
+
+    describe('Browse', function () {
+        it('fields & formats combined', function (done) {
+            request.get(localUtils.API.getApiQuery('posts/?formats=mobiledoc,html&fields=id,title'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    localUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(13);
+
+                    localUtils.API.checkResponse(
+                        jsonResponse.posts[0],
+                        'post',
+                        null,
+                        null,
+                        ['mobiledoc', 'id', 'title', 'html']
+                    );
+
+                    localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+
+                    done();
+                });
+        });
+
+        it('combined fields, formats, include and non existing', function (done) {
+            request.get(localUtils.API.getApiQuery('posts/?formats=mobiledoc,html,plaintext&fields=id,title,primary_tag,doesnotexist&include=authors,tags'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    localUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(13);
+
+                    localUtils.API.checkResponse(
+                        jsonResponse.posts[0],
+                        'post',
+                        null,
+                        null,
+                        ['mobiledoc', 'plaintext', 'id', 'title', 'html', 'authors', 'tags', 'primary_tag']
+                    );
+
+                    localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+
+                    done();
+                });
+        });
+    });
+
+    describe('Read', function () {
+        it('can\'t retrieve non existent post', function (done) {
+            request.get(localUtils.API.getApiQuery(`posts/${ObjectId.generate()}/`))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    var jsonResponse = res.body;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.errors);
+                    testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                        'message',
+                        'context',
+                        'type',
+                        'details',
+                        'property',
+                        'help',
+                        'code',
+                        'id'
+                    ]);
+                    done();
+                });
+        });
+    });
+
+    describe('Add', function () {
+        it('adds default title when it is missing', function () {
+            return request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: ''
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201)
+            .then((res) => {
+                should.exist(res.body.posts);
+                should.exist(res.body.posts[0].title);
+                res.body.posts[0].title.should.equal('(Untitled)');
+            });
+        });
+    });
+
+    describe('Edit', function () {
+        it('published_at = null', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    return request
+                        .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                published_at: null,
+                                updated_at: res.body.posts[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200);
+                })
+                .then((res) => {
+                    // @NOTE: if you set published_at to null and the post is published, we set it to NOW in model layer
+                    should.exist(res.headers['x-cache-invalidate']);
+                    should.exist(res.body.posts);
+                    should.exist(res.body.posts[0].published_at);
+                });
+        });
+
+        it('html to plaintext', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    return request
+                        .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/?source=html&formats=html,plaintext'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                html: '<p>HTML Ipsum presents</p>',
+                                updated_at: res.body.posts[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200);
+                })
+                .then((res) => {
+                    return models.Post.findOne({
+                        id: res.body.posts[0].id
+                    }, testUtils.context.internal);
+                })
+                .then((model) => {
+                    model.get('plaintext').should.equal('HTML Ipsum presents');
+                });
+        });
+
+        it('canonical_url', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    return request
+                        .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                canonical_url: `/canonical/url`,
+                                updated_at: res.body.posts[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200);
+                })
+                .then((res) => {
+                    should.exist(res.body.posts);
+                    should.exist(res.body.posts[0].canonical_url);
+                    res.body.posts[0].canonical_url.should.equal(`${config.get('url')}/canonical/url`);
+                });
+        });
+
+        it('update dates & x_by', function () {
+            const post = {
+                created_by: ObjectId.generate(),
+                updated_by: ObjectId.generate(),
+                created_at: moment().add(2, 'days').format(),
+                updated_at: moment().add(2, 'days').format()
+            };
+
+            return request
+                .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/'))
+                .set('Origin', config.get('url'))
+                .send({posts: [post]})
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .then((res) => {
+                    // @NOTE: you cannot modify these fields above manually, that's why the resource won't change.
+                    should.not.exist(res.headers['x-cache-invalidate']);
+
+                    return models.Post.findOne({
+                        id: res.body.posts[0].id
+                    }, testUtils.context.internal);
+                })
+                .then((model) => {
+                    // We expect that the changed properties aren't changed, they are still the same than before.
+                    model.get('created_at').toISOString().should.not.eql(post.created_at);
+                    model.get('updated_by').should.not.eql(post.updated_by);
+                    model.get('created_by').should.not.eql(post.created_by);
+
+                    // `updated_at` is automatically set, but it's not the date we send to override.
+                    model.get('updated_at').toISOString().should.not.eql(post.updated_at);
+                });
+        });
+
+        it('Can change scheduled post', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[7].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    res.body.posts[0].status.should.eql('scheduled');
+
+                    return request
+                        .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[7].id + '/'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                title: 'change scheduled post',
+                                updated_at: res.body.posts[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200);
+                })
+                .then((res) => {
+                    should.exist(res.headers['x-cache-invalidate']);
+                });
+        });
+
+        it('trims title', function () {
+            const untrimmedTitle = '  test trimmed update title  ';
+
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    return request
+                        .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                title: untrimmedTitle,
+                                updated_at: res.body.posts[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200);
+                })
+                .then((res) => {
+                    should.exist(res.body.posts);
+                    should.exist(res.body.posts[0].title);
+                    res.body.posts[0].title.should.equal(untrimmedTitle.trim());
+                });
+        });
+
+        it('strips invisible unicode from slug', function () {
+            const slug = 'this-is\u0008-invisible';
+
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    return request
+                        .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                slug: slug,
+                                updated_at: res.body.posts[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200);
+                })
+                .then((res) => {
+                    should.exist(res.body.posts);
+                    should.exist(res.body.posts[0].slug);
+                    res.body.posts[0].slug.should.equal('this-is-invisible');
+                });
+        });
+    });
+
+    describe('Destroy', function () {
+        it('non existent post', function () {
+            return request
+                .del(localUtils.API.getApiQuery('posts/' + ObjectId.generate() + '/'))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .then((res) => {
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    should.exist(res.body);
+                    should.exist(res.body.errors);
+                    testUtils.API.checkResponseValue(res.body.errors[0], [
+                        'message',
+                        'context',
+                        'type',
+                        'details',
+                        'property',
+                        'help',
+                        'code',
+                        'id'
+                    ]);
+                });
+        });
+    });
+});

--- a/core/test/regression/api/canary/admin/redirects_spec.js
+++ b/core/test/regression/api/canary/admin/redirects_spec.js
@@ -1,0 +1,231 @@
+const should = require('should');
+const supertest = require('supertest');
+const fs = require('fs-extra');
+const Promise = require('bluebird');
+const path = require('path');
+const testUtils = require('../../../../utils');
+const localUtils = require('../../../../acceptance/old/admin/utils');
+const configUtils = require('../../../../utils/configUtils');
+const config = require('../../../../../server/config');
+
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Redirects API', () => {
+    let originalContentPath;
+
+    before(() => {
+        return ghost({redirectsFile: true})
+            .then(() => {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(() => {
+                return localUtils.doAuth(request, 'client:trusted-domain');
+            })
+            .then(() => {
+                originalContentPath = configUtils.config.get('paths:contentPath');
+            });
+    });
+
+    describe('Download', () => {
+        afterEach(() => {
+            configUtils.config.set('paths:contentPath', originalContentPath);
+        });
+
+        it('file does not exist', () => {
+            // Just set any content folder, which does not contain a redirects file.
+            configUtils.set('paths:contentPath', path.join(__dirname, '../../../utils/fixtures/data'));
+
+            return request
+                .get(localUtils.API.getApiQuery('redirects/json/?client_id=ghost-admin&client_secret=not_available'))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    res.headers['content-disposition'].should.eql('Attachment; filename="redirects.json"');
+                    res.headers['content-type'].should.eql('application/json; charset=utf-8');
+                    should.not.exist(res.headers['x-cache-invalidate']);
+
+                    // API returns an empty file with the correct file structure (empty [])
+                    res.headers['content-length'].should.eql('2');
+                });
+        });
+
+        it('file exists', () => {
+            return request
+                .get(localUtils.API.getApiQuery('redirects/json/?client_id=ghost-admin&client_secret=not_available'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /application\/json/)
+                .expect('Content-Disposition', 'Attachment; filename="redirects.json"')
+                .expect(200)
+                .then((res) => {
+                    res.headers['content-disposition'].should.eql('Attachment; filename="redirects.json"');
+                    res.headers['content-type'].should.eql('application/json; charset=utf-8');
+                    res.headers['content-length'].should.eql('698');
+
+                    res.body.should.not.be.empty();
+                    res.body.length.should.equal(12);
+                });
+        });
+    });
+
+    describe('Upload', () => {
+        describe('Error cases', () => {
+            it('syntax error', () => {
+                fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects.json'), 'something');
+
+                return request
+                    .post(localUtils.API.getApiQuery('redirects/json/?client_id=ghost-admin&client_secret=not_available'))
+                    .set('Origin', config.get('url'))
+                    .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects.json'))
+                    .expect('Content-Type', /application\/json/)
+                    .expect(400);
+            });
+
+            it('wrong format: no array', () => {
+                fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects.json'), JSON.stringify({
+                    from: 'c',
+                    to: 'd'
+                }));
+
+                return request
+                    .post(localUtils.API.getApiQuery('redirects/json/?client_id=ghost-admin&client_secret=not_available'))
+                    .set('Origin', config.get('url'))
+                    .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects.json'))
+                    .expect('Content-Type', /application\/json/)
+                    .expect(422);
+            });
+
+            it('wrong format: no from/to', () => {
+                fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects.json'), JSON.stringify([{to: 'd'}]));
+
+                return request
+                    .post(localUtils.API.getApiQuery('redirects/json/?client_id=ghost-admin&client_secret=not_available'))
+                    .set('Origin', config.get('url'))
+                    .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects.json'))
+                    .expect('Content-Type', /application\/json/)
+                    .expect(422);
+            });
+        });
+
+        describe('Ensure re-registering redirects works', () => {
+            const startGhost = (options) => {
+                return ghost(options)
+                    .then(() => {
+                        request = supertest.agent(config.get('url'));
+                    })
+                    .then(() => {
+                        return localUtils.doAuth(request, 'client:trusted-domain');
+                    });
+            };
+
+            it('no redirects file exists', () => {
+                return startGhost({redirectsFile: false, forceStart: true})
+                    .then(() => {
+                        return request
+                            .get('/my-old-blog-post/')
+                            .expect(404);
+                    })
+                    .then(() => {
+                        // Provide a redirects file in the root directory of the content test folder
+                        fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects-init.json'), JSON.stringify([{
+                            from: 'k',
+                            to: 'l'
+                        }]));
+                    })
+                    .then(() => {
+                        return request
+                            .post(localUtils.API.getApiQuery('redirects/json/?client_id=ghost-admin&client_secret=not_available'))
+                            .set('Origin', config.get('url'))
+                            .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects-init.json'))
+                            .expect('Content-Type', /application\/json/)
+                            .expect(200);
+                    })
+                    .then((res) => {
+                        res.headers['x-cache-invalidate'].should.eql('/*');
+
+                        return request
+                            .get('/k/')
+                            .expect(302);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/l');
+
+                        const dataFiles = fs.readdirSync(config.getContentPath('data'));
+                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(1);
+                    });
+            });
+
+            it('override', () => {
+                return startGhost({forceStart: true})
+                    .then(() => {
+                        return request
+                            .get('/my-old-blog-post/')
+                            .expect(301);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/revamped-url/');
+                    })
+                    .then(() => {
+                        // Provide a second redirects file in the root directory of the content test folder
+                        fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects.json'), JSON.stringify([{
+                            from: 'c',
+                            to: 'd'
+                        }]));
+                    })
+                    .then(() => {
+                        // Override redirects file
+                        return request
+                            .post(localUtils.API.getApiQuery('redirects/json/?client_id=ghost-admin&client_secret=not_available'))
+                            .set('Origin', config.get('url'))
+                            .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects.json'))
+                            .expect('Content-Type', /application\/json/)
+                            .expect(200);
+                    })
+                    .then((res) => {
+                        res.headers['x-cache-invalidate'].should.eql('/*');
+
+                        return request
+                            .get('/my-old-blog-post/')
+                            .expect(404);
+                    })
+                    .then(() => {
+                        return request
+                            .get('/c/')
+                            .expect(302);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/d');
+
+                        // check backup of redirects files
+                        const dataFiles = fs.readdirSync(config.getContentPath('data'));
+                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(2);
+
+                        // Provide another redirects file in the root directory of the content test folder
+                        fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects-something.json'), JSON.stringify([{
+                            from: 'e',
+                            to: 'b'
+                        }]));
+                    })
+                    .then(() => {
+                        // the backup is in the format HH:mm:ss, we have to wait minimum a second
+                        return new Promise((resolve) => {
+                            setTimeout(resolve, 1100);
+                        });
+                    })
+                    .then(() => {
+                        // Override redirects file again and ensure the backup file works twice
+                        return request
+                            .post(localUtils.API.getApiQuery('redirects/json/?client_id=ghost-admin&client_secret=not_available'))
+                            .set('Origin', config.get('url'))
+                            .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects-something.json'))
+                            .expect('Content-Type', /application\/json/)
+                            .expect(200);
+                    })
+                    .then(() => {
+                        const dataFiles = fs.readdirSync(config.getContentPath('data'));
+                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(3);
+                    });
+            });
+        });
+    });
+});

--- a/core/test/regression/api/canary/admin/schedules_spec.js
+++ b/core/test/regression/api/canary/admin/schedules_spec.js
@@ -1,0 +1,183 @@
+const _ = require('lodash');
+const should = require('should');
+const supertest = require('supertest');
+const Promise = require('bluebird');
+const sinon = require('sinon');
+const moment = require('moment-timezone');
+const SchedulingDefault = require('../../../../../server/adapters/scheduling/SchedulingDefault');
+const models = require('../../../../../server/models/index');
+const config = require('../../../../../server/config/index');
+const testUtils = require('../../../../utils/index');
+const localUtils = require('./utils');
+
+const ghost = testUtils.startGhost;
+
+describe('Schedules API', function () {
+    const resources = [];
+    let request;
+
+    before(function () {
+        models.init();
+
+        // @NOTE: mock the post scheduler, otherwise it will auto publish the post
+        sinon.stub(SchedulingDefault.prototype, '_pingUrl').resolves();
+    });
+
+    after(function () {
+        sinon.restore();
+    });
+
+    before(function () {
+        return ghost()
+            .then(() => {
+                request = supertest.agent(config.get('url'));
+            });
+    });
+
+    before(function () {
+        return ghost()
+            .then(function () {
+                resources.push(testUtils.DataGenerator.forKnex.createPost({
+                    created_by: testUtils.existingData.users[0].id,
+                    author_id: testUtils.existingData.users[0].id,
+                    published_by: testUtils.existingData.users[0].id,
+                    published_at: moment().add(30, 'seconds').toDate(),
+                    status: 'scheduled',
+                    slug: 'first'
+                }));
+
+                resources.push(testUtils.DataGenerator.forKnex.createPost({
+                    created_by: testUtils.existingData.users[0].id,
+                    author_id: testUtils.existingData.users[0].id,
+                    published_by: testUtils.existingData.users[0].id,
+                    published_at: moment().subtract(30, 'seconds').toDate(),
+                    status: 'scheduled',
+                    slug: 'second'
+                }));
+
+                resources.push(testUtils.DataGenerator.forKnex.createPost({
+                    created_by: testUtils.existingData.users[0].id,
+                    author_id: testUtils.existingData.users[0].id,
+                    published_by: testUtils.existingData.users[0].id,
+                    published_at: moment().add(10, 'minute').toDate(),
+                    status: 'scheduled',
+                    slug: 'third'
+                }));
+
+                resources.push(testUtils.DataGenerator.forKnex.createPost({
+                    created_by: testUtils.existingData.users[0].id,
+                    author_id: testUtils.existingData.users[0].id,
+                    published_by: testUtils.existingData.users[0].id,
+                    published_at: moment().subtract(10, 'minute').toDate(),
+                    status: 'scheduled',
+                    slug: 'fourth'
+                }));
+
+                resources.push(testUtils.DataGenerator.forKnex.createPost({
+                    created_by: testUtils.existingData.users[0].id,
+                    author_id: testUtils.existingData.users[0].id,
+                    published_by: testUtils.existingData.users[0].id,
+                    published_at: moment().add(30, 'seconds').toDate(),
+                    status: 'scheduled',
+                    slug: 'fifth',
+                    page: true
+                }));
+
+                return Promise.mapSeries(resources, function (post) {
+                    return models.Post.add(post, {context: {internal: true}});
+                }).then(function (result) {
+                    result.length.should.eql(5);
+                });
+            });
+    });
+
+    describe('publish', function () {
+        let schedulerKey;
+
+        before(() => {
+             schedulerKey = _.find(testUtils.existingData.apiKeys, {integration: {slug: 'ghost-scheduler'}});
+        });
+
+        it('publishes posts', function () {
+            return request
+                .put(localUtils.API.getApiQuery(`schedules/posts/${resources[0].id}/`))
+                .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', schedulerKey)}`)
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .then((res) => {
+                    should.exist(res.headers['x-cache-invalidate']);
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse);
+                    jsonResponse.posts[0].id.should.eql(resources[0].id);
+                    jsonResponse.posts[0].status.should.eql('published');
+                });
+        });
+
+        it('publishes page', function () {
+            return request
+                .put(localUtils.API.getApiQuery(`schedules/pages/${resources[4].id}/`))
+                .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', schedulerKey)}`)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .then((res) => {
+                    should.exist(res.headers['x-cache-invalidate']);
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse);
+                    jsonResponse.pages[0].id.should.eql(resources[4].id);
+                    jsonResponse.pages[0].status.should.eql('published');
+                });
+        });
+
+        it('no access', function () {
+            const zapierKey = _.find(testUtils.existingData.apiKeys, {integration: {slug: 'ghost-backup'}});
+            return request
+                .put(localUtils.API.getApiQuery(`schedules/posts/${resources[0].id}/`))
+                .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', zapierKey)}`)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(403);
+        });
+
+        it('should fail with invalid resource type', function () {
+            return request
+                .put(localUtils.API.getApiQuery(`schedules/this_is_invalid/${resources[0].id}/`))
+                .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', schedulerKey)}`)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(422);
+        });
+
+        it('published_at is x seconds in past, but still in tolerance', function () {
+            return request
+                .put(localUtils.API.getApiQuery(`schedules/posts/${resources[1].id}/`))
+                .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', schedulerKey)}`)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+        });
+
+        it('not found', function () {
+            return request
+                .put(localUtils.API.getApiQuery(`schedules/posts/${resources[2].id}/`))
+                .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', schedulerKey)}`)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404);
+        });
+
+        it('force publish', function () {
+            return request
+                .put(localUtils.API.getApiQuery(`schedules/posts/${resources[3].id}/`))
+                .send({
+                    force: true
+                })
+                .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', schedulerKey)}`)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+        });
+    });
+});

--- a/core/test/regression/api/canary/admin/settings_spec.js
+++ b/core/test/regression/api/canary/admin/settings_spec.js
@@ -1,0 +1,193 @@
+const should = require('should');
+const supertest = require('supertest');
+const config = require('../../../../../server/config');
+const testUtils = require('../../../../utils');
+const localUtils = require('./utils');
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Settings API', function () {
+    let ghostServer;
+
+    before(function () {
+        return ghost()
+            .then(function (_ghostServer) {
+                ghostServer = _ghostServer;
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return localUtils.doAuth(request);
+            });
+    });
+
+    after(function () {
+        return ghostServer.stop();
+    });
+
+    it('Can\'t read core setting', function () {
+        return request
+            .get(localUtils.API.getApiQuery('settings/db_hash/'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(403);
+    });
+
+    it('Can\'t read permalinks', function (done) {
+        request.get(localUtils.API.getApiQuery('settings/permalinks/'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                done();
+            });
+    });
+
+    it('can\'t read non existent setting', function (done) {
+        request.get(localUtils.API.getApiQuery('settings/testsetting/'))
+            .set('Origin', config.get('url'))
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                should.not.exist(res.headers['x-cache-invalidate']);
+                var jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.errors);
+                testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                    'message',
+                    'context',
+                    'type',
+                    'details',
+                    'property',
+                    'help',
+                    'code',
+                    'id'
+                ]);
+                done();
+            });
+    });
+
+    it('can\'t edit permalinks', function (done) {
+        const settingToChange = {
+            settings: [{key: 'permalinks', value: '/:primary_author/:slug/'}]
+        };
+
+        request.put(localUtils.API.getApiQuery('settings/'))
+            .set('Origin', config.get('url'))
+            .send(settingToChange)
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(404)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                done();
+            });
+    });
+
+    it('can\'t edit non existent setting', function (done) {
+        request.get(localUtils.API.getApiQuery('settings/'))
+            .set('Origin', config.get('url'))
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                var jsonResponse = res.body,
+                    newValue = 'new value';
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.settings);
+                jsonResponse.settings = [{key: 'testvalue', value: newValue}];
+
+                request.put(localUtils.API.getApiQuery('settings/'))
+                    .set('Origin', config.get('url'))
+                    .send(jsonResponse)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(404)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        jsonResponse = res.body;
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        should.exist(jsonResponse.errors);
+                        testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                            'message',
+                            'context',
+                            'type',
+                            'details',
+                            'property',
+                            'help',
+                            'code',
+                            'id'
+                        ]);
+                        done();
+                    });
+            });
+    });
+
+    it('Will transform "1"', function (done) {
+        request.get(localUtils.API.getApiQuery('settings/'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                const jsonResponse = res.body,
+                    settingToChange = {
+                        settings: [
+                            {
+                                key: 'is_private',
+                                value: '1'
+                            }
+                        ]
+                    };
+
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.settings);
+
+                request.put(localUtils.API.getApiQuery('settings/'))
+                    .set('Origin', config.get('url'))
+                    .send(settingToChange)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        const putBody = res.body;
+                        res.headers['x-cache-invalidate'].should.eql('/*');
+                        should.exist(putBody);
+
+                        putBody.settings[0].key.should.eql('is_private');
+                        putBody.settings[0].value.should.eql(true);
+
+                        localUtils.API.checkResponse(putBody, 'settings');
+                        done();
+                    });
+            });
+    });
+});

--- a/core/test/regression/api/canary/admin/slack_spec.js
+++ b/core/test/regression/api/canary/admin/slack_spec.js
@@ -1,0 +1,48 @@
+const should = require('should');
+const supertest = require('supertest');
+const sinon = require('sinon');
+const testUtils = require('../../../../utils');
+const localUtils = require('../../../../acceptance/old/admin/utils');
+const config = require('../../../../../server/config');
+const common = require('../../../../../server/lib/common');
+const ghost = testUtils.startGhost;
+
+let request;
+
+describe('Slack API', function () {
+    let ghostServer;
+
+    before(function () {
+        return ghost()
+            .then(function (_ghostServer) {
+                ghostServer = _ghostServer;
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return localUtils.doAuth(request);
+            });
+    });
+    after(function () {
+        sinon.restore();
+    });
+
+    it('Can post slack test', function (done) {
+        const eventSpy = sinon.spy(common.events, 'emit');
+        request.post(localUtils.API.getApiQuery('slack/test/'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                eventSpy.calledWith('slack.test').should.be.true();
+                done();
+            });
+    });
+});

--- a/core/test/regression/api/canary/admin/subscribers_spec.js
+++ b/core/test/regression/api/canary/admin/subscribers_spec.js
@@ -1,0 +1,229 @@
+const path = require('path');
+const should = require('should');
+const supertest = require('supertest');
+const sinon = require('sinon');
+const testUtils = require('../../../../utils');
+const localUtils = require('../../../../acceptance/old/admin/utils');
+const config = require('../../../../../server/config');
+const labs = require('../../../../../server/services/labs');
+
+const ghost = testUtils.startGhost;
+
+let request;
+
+describe('Subscribers API', function () {
+    before(function () {
+        sinon.stub(labs, 'isSet').withArgs('subscribers').returns(true);
+    });
+
+    after(function () {
+        sinon.restore();
+    });
+
+    before(function () {
+        return ghost()
+            .then(function () {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return localUtils.doAuth(request, 'subscriber');
+            });
+    });
+
+    it('Can browse', function () {
+        return request
+            .get(localUtils.API.getApiQuery('subscribers/'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.subscribers);
+                jsonResponse.subscribers.should.have.length(1);
+                localUtils.API.checkResponse(jsonResponse.subscribers[0], 'subscriber');
+
+                testUtils.API.isISO8601(jsonResponse.subscribers[0].created_at).should.be.true();
+                jsonResponse.subscribers[0].created_at.should.be.an.instanceof(String);
+
+                jsonResponse.meta.pagination.should.have.property('page', 1);
+                jsonResponse.meta.pagination.should.have.property('limit', 15);
+                jsonResponse.meta.pagination.should.have.property('pages', 1);
+                jsonResponse.meta.pagination.should.have.property('total', 1);
+                jsonResponse.meta.pagination.should.have.property('next', null);
+                jsonResponse.meta.pagination.should.have.property('prev', null);
+            });
+    });
+
+    it('Can read', function () {
+        return request
+            .get(localUtils.API.getApiQuery(`subscribers/${testUtils.DataGenerator.Content.subscribers[0].id}/`))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.subscribers);
+                jsonResponse.subscribers.should.have.length(1);
+                localUtils.API.checkResponse(jsonResponse.subscribers[0], 'subscriber');
+            });
+    });
+
+    it('Can add', function () {
+        const subscriber = {
+            name: 'test',
+            email: 'subscriberTestAdd@test.com'
+        };
+
+        return request
+            .post(localUtils.API.getApiQuery(`subscribers/`))
+            .send({subscribers: [subscriber]})
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.subscribers);
+                jsonResponse.subscribers.should.have.length(1);
+                // localUtils.API.checkResponse(jsonResponse.subscribers[0], 'subscriber'); // TODO: modify checked schema
+                jsonResponse.subscribers[0].name.should.equal(subscriber.name);
+                jsonResponse.subscribers[0].email.should.equal(subscriber.email);
+            });
+    });
+
+    it('Can edit by id', function () {
+        const subscriberToChange = {
+            name: 'changed',
+            email: 'subscriber1Changed@test.com'
+        };
+
+        const subscriberChanged = {
+            name: 'changed',
+            email: 'subscriber1Changed@test.com'
+        };
+
+        return request
+            .post(localUtils.API.getApiQuery(`subscribers/`))
+            .send({subscribers: [subscriberToChange]})
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.subscribers);
+                jsonResponse.subscribers.should.have.length(1);
+
+                return jsonResponse.subscribers[0];
+            })
+            .then((newSubscriber) => {
+                return request
+                    .put(localUtils.API.getApiQuery(`subscribers/${newSubscriber.id}/`))
+                    .send({subscribers:[subscriberChanged]})
+                    .set('Origin', config.get('url'))
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .then((res) => {
+                        should.not.exist(res.headers['x-cache-invalidate']);
+
+                        const jsonResponse = res.body;
+
+                        should.exist(jsonResponse);
+                        should.exist(jsonResponse.subscribers);
+                        jsonResponse.subscribers.should.have.length(1);
+                        localUtils.API.checkResponse(jsonResponse.subscribers[0], 'subscriber');
+                        jsonResponse.subscribers[0].name.should.equal(subscriberChanged.name);
+                        jsonResponse.subscribers[0].email.should.equal(subscriberChanged.email);
+                    });
+            });
+    });
+
+    it('Can destroy', function () {
+        const subscriber = {
+            name: 'test',
+            email: 'subscriberTestDestroy@test.com'
+        };
+
+        return request
+            .post(localUtils.API.getApiQuery(`subscribers/`))
+            .send({subscribers: [subscriber]})
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+
+                const jsonResponse = res.body;
+
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.subscribers);
+
+                return jsonResponse.subscribers[0];
+            })
+            .then((newSubscriber) => {
+                return request
+                    .delete(localUtils.API.getApiQuery(`subscribers/${newSubscriber.id}`))
+                    .set('Origin', config.get('url'))
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(204)
+                    .then(() => newSubscriber);
+            })
+            .then((newSubscriber) => {
+                return request
+                    .get(localUtils.API.getApiQuery(`subscribers/${newSubscriber.id}/`))
+                    .set('Origin', config.get('url'))
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(404);
+            });
+    });
+
+    it('Can export CSV', function () {
+        return request
+            .get(localUtils.API.getApiQuery(`subscribers/csv/`))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /text\/csv/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                res.headers['content-disposition'].should.match(/Attachment;\sfilename="subscribers/);
+                res.text.should.match(/id,email,created_at,deleted_at/);
+                res.text.should.match(/subscriber1@test.com/);
+            });
+    });
+
+    it('Can import CSV', function () {
+        return request
+            .post(localUtils.API.getApiQuery(`subscribers/csv/`))
+            .attach('subscribersfile', path.join(__dirname, '/../../../../utils/fixtures/csv/single-column-with-header.csv'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.meta);
+                should.exist(jsonResponse.meta.stats);
+
+                jsonResponse.meta.stats.imported.should.equal(2);
+                jsonResponse.meta.stats.duplicates.should.equal(0);
+                jsonResponse.meta.stats.invalid.should.equal(0);
+            });
+    });
+});

--- a/core/test/regression/api/canary/admin/users_spec.js
+++ b/core/test/regression/api/canary/admin/users_spec.js
@@ -1,0 +1,291 @@
+const should = require('should');
+const supertest = require('supertest');
+const ObjectId = require('bson-objectid');
+const testUtils = require('../../../../utils');
+const config = require('../../../../../server/config');
+const localUtils = require('./utils');
+const ghost = testUtils.startGhost;
+let request;
+
+describe('User API', function () {
+    let editor, author, ghostServer, otherAuthor, admin;
+
+    describe('As Owner', function () {
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    ghostServer = _ghostServer;
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    // create inactive user
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({email: 'test+3@ghost.org'}),
+                        role: testUtils.DataGenerator.Content.roles[2].name
+                    });
+                })
+                .then(function (_user) {
+                    otherAuthor = _user;
+
+                    // create admin user
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({email: 'test+admin@ghost.org', slug: 'owner'}),
+                        role: testUtils.DataGenerator.Content.roles[3].name
+                    });
+                })
+                .then(function (_user) {
+                    admin = _user;
+
+                    // by default we login with the owner
+                    return localUtils.doAuth(request);
+                });
+        });
+
+        describe('Read', function () {
+            it('can\'t retrieve non existent user by id', function (done) {
+                request.get(localUtils.API.getApiQuery('users/' + ObjectId.generate() + '/'))
+                    .set('Origin', config.get('url'))
+                    .set('Accept', 'application/json')
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(404)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse);
+                        should.exist(jsonResponse.errors);
+                        testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                            'message',
+                            'context',
+                            'type',
+                            'details',
+                            'property',
+                            'help',
+                            'code',
+                            'id'
+                        ]);
+                        done();
+                    });
+            });
+
+            it('can\'t retrieve non existent user by slug', function (done) {
+                request.get(localUtils.API.getApiQuery('users/slug/blargh/'))
+                    .set('Origin', config.get('url'))
+                    .set('Accept', 'application/json')
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(404)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse);
+                        should.exist(jsonResponse.errors);
+                        testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                            'message',
+                            'context',
+                            'type',
+                            'details',
+                            'property',
+                            'help',
+                            'code',
+                            'id'
+                        ]);
+                        done();
+                    });
+            });
+        });
+
+        describe('Edit', function () {
+            it('can change the other users password', function (done) {
+                request.put(localUtils.API.getApiQuery('users/password/'))
+                    .set('Origin', config.get('url'))
+                    .send({
+                        password: [{
+                            newPassword: 'superSecure',
+                            ne2Password: 'superSecure',
+                            user_id: otherAuthor.id
+                        }]
+                    })
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        done();
+                    });
+            });
+        });
+
+        describe('Destroy', function () {
+            it('[failure] Destroy unknown user id', function (done) {
+                request.delete(localUtils.API.getApiQuery('users/' + ObjectId.generate()))
+                    .set('Origin', config.get('url'))
+                    .expect(404)
+                    .end(function (err) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        done();
+                    });
+            });
+        });
+    });
+
+    describe('As Editor', function () {
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    ghostServer = _ghostServer;
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    // create editor
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({email: 'test+1@ghost.org'}),
+                        role: testUtils.DataGenerator.Content.roles[1].name
+                    });
+                })
+                .then(function (_user1) {
+                    editor = _user1;
+                    request.user = editor;
+
+                    // by default we login with the owner
+                    return localUtils.doAuth(request);
+                });
+        });
+
+        describe('success cases', function () {
+            it('can edit himself', function (done) {
+                request.put(localUtils.API.getApiQuery('users/' + editor.id + '/'))
+                    .set('Origin', config.get('url'))
+                    .send({
+                        users: [{id: editor.id, name: 'test'}]
+                    })
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        done();
+                    });
+            });
+        });
+
+        describe('error cases', function () {
+            it('can\'t edit the owner', function (done) {
+                request.put(localUtils.API.getApiQuery('users/' + testUtils.DataGenerator.Content.users[0].id + '/'))
+                    .set('Origin', config.get('url'))
+                    .send({
+                        users: [{
+                            id: testUtils.DataGenerator.Content.users[0].id
+                        }]
+                    })
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(403)
+                    .end(function (err) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        done();
+                    });
+            });
+
+            it('Cannot transfer ownership to any other user', function () {
+                return request
+                    .put(localUtils.API.getApiQuery('users/owner'))
+                    .set('Origin', config.get('url'))
+                    .send({
+                        owner: [{
+                            id: testUtils.existingData.users[1].id
+                        }]
+                    })
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(403);
+            });
+        });
+    });
+
+    describe('As Author', function () {
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    ghostServer = _ghostServer;
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    // create author
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({email: 'test+2@ghost.org'}),
+                        role: testUtils.DataGenerator.Content.roles[2].name
+                    });
+                })
+                .then(function (_user2) {
+                    author = _user2;
+                    request.user = author;
+
+                    // by default we login with the owner
+                    return localUtils.doAuth(request);
+                });
+        });
+
+        describe('success cases', function () {
+            it('can edit himself', function (done) {
+                request.put(localUtils.API.getApiQuery('users/' + author.id + '/'))
+                    .set('Origin', config.get('url'))
+                    .send({
+                        users: [{id: author.id, name: 'test'}]
+                    })
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        done();
+                    });
+            });
+        });
+
+        describe('error cases', function () {
+            it('can\'t edit the owner', function (done) {
+                request.put(localUtils.API.getApiQuery('users/' + testUtils.DataGenerator.Content.users[0].id + '/'))
+                    .set('Origin', config.get('url'))
+                    .send({
+                        users: [{
+                            id: testUtils.DataGenerator.Content.users[0].id
+                        }]
+                    })
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(403)
+                    .end(function (err) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        done();
+                    });
+            });
+        });
+    });
+});

--- a/core/test/regression/api/canary/admin/utils.js
+++ b/core/test/regression/api/canary/admin/utils.js
@@ -1,0 +1,122 @@
+const url = require('url');
+const _ = require('lodash');
+const testUtils = require('../../../../utils');
+const schema = require('../../../../../server/data/schema').tables;
+const API_URL = '/ghost/api/canary/admin/';
+
+const expectedProperties = {
+    // API top level
+    posts: ['posts', 'meta'],
+    tags: ['tags', 'meta'],
+    users: ['users', 'meta'],
+    settings: ['settings', 'meta'],
+    subscribers: ['subscribers', 'meta'],
+    roles: ['roles'],
+    pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
+    slugs: ['slugs'],
+    slug: ['slug'],
+    invites: ['invites', 'meta'],
+    themes: ['themes'],
+
+    post: _(schema.posts)
+        .keys()
+        // by default we only return mobiledoc
+        .without('html', 'plaintext')
+        .without('visibility')
+        .without('locale')
+        .without('page')
+        .without('author_id')
+        // always returns computed properties
+        .concat('url', 'primary_tag', 'primary_author', 'excerpt')
+        .concat('authors', 'tags')
+    ,
+    user: _(schema.users)
+        .keys()
+        .without('visibility')
+        .without('password')
+        .without('locale')
+        .without('ghost_auth_access_token')
+        .without('ghost_auth_id')
+        .concat('url')
+    ,
+    tag: _(schema.tags)
+        .keys()
+        // unused field
+        .without('parent_id')
+    ,
+    setting: _(schema.settings)
+        .keys()
+    ,
+    subscriber: _(schema.subscribers)
+        .keys()
+    ,
+    accesstoken: _(schema.accesstokens)
+        .keys()
+    ,
+    role: _(schema.roles)
+        .keys()
+    ,
+    permission: _(schema.permissions)
+        .keys()
+    ,
+    notification: ['type', 'message', 'status', 'id', 'dismissible', 'location', 'custom'],
+    theme: ['name', 'package', 'active'],
+    invite: _(schema.invites)
+        .keys()
+        .without('token')
+    ,
+    webhook: _(schema.webhooks)
+            .keys()
+};
+
+_.each(expectedProperties, (value, key) => {
+    if (!value.__wrapped__) {
+        return;
+    }
+
+    /**
+     * @deprecated: x_by
+     */
+    expectedProperties[key] = value
+        .without(
+            'created_by',
+            'updated_by',
+            'published_by'
+        )
+        .value();
+});
+
+module.exports = {
+    API: {
+        getApiQuery(route) {
+            return url.resolve(API_URL, route);
+        },
+
+        checkResponse(...args) {
+            this.expectedProperties = expectedProperties;
+            return testUtils.API.checkResponse.call(this, ...args);
+        }
+    },
+
+    doAuth(...args) {
+        return testUtils.API.doAuth(`${API_URL}session/`, ...args);
+    },
+
+    getValidAdminToken(endpoint, key) {
+        const jwt = require('jsonwebtoken');
+        key = key || testUtils.DataGenerator.Content.api_keys[0];
+
+        const JWT_OPTIONS = {
+            keyid: key.id,
+            algorithm: 'HS256',
+            expiresIn: '5m',
+            audience: endpoint
+        };
+
+        return jwt.sign(
+            {},
+            Buffer.from(key.secret, 'hex'),
+            JWT_OPTIONS
+        );
+    }
+};

--- a/core/test/regression/api/canary/content/authors_spec.js
+++ b/core/test/regression/api/canary/content/authors_spec.js
@@ -1,0 +1,41 @@
+const should = require('should');
+const supertest = require('supertest');
+const localUtils = require('./utils');
+const testUtils = require('../../../../utils');
+const configUtils = require('../../../../utils/configUtils');
+const config = require('../../../../../server/config');
+
+const ghost = testUtils.startGhost;
+
+describe('Authors Content API', function () {
+    const validKey = localUtils.getValidKey();
+    let request;
+
+    before(function () {
+        return ghost()
+            .then(function (_ghostServer) {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return testUtils.initFixtures('owner:post', 'users:no-owner', 'user:inactive', 'posts', 'api_keys');
+            });
+    });
+
+    afterEach(function () {
+        configUtils.restore();
+    });
+
+    it('can read authors with fields', function () {
+        return request.get(localUtils.API.getApiQuery(`authors/1/?key=${validKey}&fields=name`))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+
+                // We don't expose any other attrs.
+                localUtils.API.checkResponse(res.body.authors[0], 'author', null, null, ['id', 'name']);
+            });
+    });
+});

--- a/core/test/regression/api/canary/content/pages_spec.js
+++ b/core/test/regression/api/canary/content/pages_spec.js
@@ -1,0 +1,56 @@
+const should = require('should');
+const supertest = require('supertest');
+const testUtils = require('../../../../utils');
+const localUtils = require('./utils');
+const configUtils = require('../../../../utils/configUtils');
+const config = require('../../../../../server/config');
+
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Pages Content API', function () {
+    before(function () {
+        return ghost()
+            .then(function () {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return testUtils.initFixtures('users:no-owner', 'user:inactive', 'posts', 'tags:extra', 'api_keys');
+            });
+    });
+
+    afterEach(function () {
+        configUtils.restore();
+    });
+
+    it('Can browse pages with page:false', function () {
+        const key = localUtils.getValidKey();
+        return request.get(localUtils.API.getApiQuery(`pages/?key=${key}&filter=page:false`))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                res.headers.vary.should.eql('Accept-Encoding');
+                should.exist(res.headers['access-control-allow-origin']);
+                should.not.exist(res.headers['x-cache-invalidate']);
+
+                const jsonResponse = res.body;
+                should.exist(jsonResponse.pages);
+                should.exist(jsonResponse.meta);
+
+                jsonResponse.pages.should.have.length(0);
+            });
+    });
+
+    it('can\'t read post', function () {
+        const key = localUtils.getValidKey();
+
+        return request
+            .get(localUtils.API.getApiQuery(`pages/${testUtils.DataGenerator.Content.posts[0].id}/?key=${key}`))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(404);
+    });
+});

--- a/core/test/regression/api/canary/content/posts_spec.js
+++ b/core/test/regression/api/canary/content/posts_spec.js
@@ -1,0 +1,157 @@
+const should = require('should');
+const supertest = require('supertest');
+const _ = require('lodash');
+const testUtils = require('../../../../utils');
+const localUtils = require('./utils');
+const configUtils = require('../../../../utils/configUtils');
+const urlUtils = require('../../../../utils/urlUtils');
+const config = require('../../../../../server/config');
+
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Posts', function () {
+    before(function () {
+        return ghost()
+            .then(function () {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return testUtils.initFixtures('users:no-owner', 'user:inactive', 'posts', 'tags:extra', 'api_keys');
+            });
+    });
+
+    afterEach(function () {
+        configUtils.restore();
+        urlUtils.restore();
+    });
+
+    const validKey = localUtils.getValidKey();
+
+    it('browse posts with basic page filter should not return pages', function (done) {
+        request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&filter=page:true`))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+                const jsonResponse = res.body;
+
+                should.not.exist(res.headers['x-cache-invalidate']);
+                should.exist(jsonResponse.posts);
+                localUtils.API.checkResponse(jsonResponse, 'posts');
+                localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+                jsonResponse.posts.should.have.length(0);
+
+                done();
+            });
+    });
+
+    it('browse posts with basic page filter should not return pages', function (done) {
+        request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&filter=page:true,featured:true`))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+                const jsonResponse = res.body;
+
+                should.not.exist(res.headers['x-cache-invalidate']);
+                should.exist(jsonResponse.posts);
+                localUtils.API.checkResponse(jsonResponse, 'posts');
+                localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+                jsonResponse.posts.should.have.length(2);
+                jsonResponse.posts.filter(p => (p.page === true)).should.have.length(0);
+
+                done();
+            });
+    });
+
+    it('browse posts with published and draft status, should not return drafts', function (done) {
+        request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&filter=status:published,status:draft`))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+                const jsonResponse = res.body;
+
+                jsonResponse.posts.should.be.an.Array().with.lengthOf(11);
+
+                done();
+            });
+    });
+
+    it('ensure origin header on redirect is not getting lost', function (done) {
+        // NOTE: force a redirect to the admin url
+        configUtils.set('admin:url', 'http://localhost:9999');
+        urlUtils.stubUrlUtilsFromConfig();
+
+        request.get(localUtils.API.getApiQuery(`posts?key=${validKey}`))
+            .set('Origin', 'https://example.com')
+            // 301 Redirects _should_ be cached
+            .expect('Cache-Control', testUtils.cacheRules.year)
+            .expect(301)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                res.headers.vary.should.eql('Accept, Accept-Encoding');
+                res.headers.location.should.eql(`http://localhost:9999/ghost/api/canary/content/posts/?key=${validKey}`);
+                should.exist(res.headers['access-control-allow-origin']);
+                should.not.exist(res.headers['x-cache-invalidate']);
+                done();
+            });
+    });
+
+    it('browse posts, ignores staticPages', function (done) {
+        request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&staticPages=true`))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                should.not.exist(res.headers['x-cache-invalidate']);
+                var jsonResponse = res.body;
+                should.exist(jsonResponse.posts);
+                localUtils.API.checkResponse(jsonResponse, 'posts');
+                jsonResponse.posts.should.have.length(11);
+                localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+                _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+                done();
+            });
+    });
+
+    it('can\'t read page', function () {
+        return request
+            .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[5].id}/?key=${validKey}`))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(404);
+    });
+
+    it('can read post with fields', function () {
+        return request
+            .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[0].id}/?key=${validKey}&fields=title,slug`))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                localUtils.API.checkResponse(res.body.posts[0], 'post', null, null, ['id', 'title', 'slug']);
+            });
+    });
+});

--- a/core/test/regression/api/canary/content/tags_spec.js
+++ b/core/test/regression/api/canary/content/tags_spec.js
@@ -1,0 +1,39 @@
+const should = require('should');
+const supertest = require('supertest');
+const localUtils = require('./utils');
+const testUtils = require('../../../../utils');
+const configUtils = require('../../../../utils/configUtils');
+const config = require('../../../../../server/config');
+
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Tags', function () {
+    before(function () {
+        return ghost()
+            .then(function () {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return testUtils.initFixtures('users:no-owner', 'user:inactive', 'posts', 'tags:extra', 'api_keys');
+            });
+    });
+
+    afterEach(function () {
+        configUtils.restore();
+    });
+
+    const validKey = localUtils.getValidKey();
+
+    it('can read tags with fields', function () {
+        return request
+            .get(localUtils.API.getApiQuery(`tags/${testUtils.DataGenerator.Content.tags[0].id}/?key=${validKey}&fields=name,slug`))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                localUtils.API.checkResponse(res.body.tags[0], 'tag', null, null, ['id', 'name', 'slug']);
+            });
+    });
+});

--- a/core/test/regression/api/canary/content/utils.js
+++ b/core/test/regression/api/canary/content/utils.js
@@ -1,0 +1,87 @@
+const url = require('url');
+const _ = require('lodash');
+const testUtils = require('../../../../utils');
+const schema = require('../../../../../server/data/schema').tables;
+const API_URL = '/ghost/api/canary/content/';
+
+const expectedProperties = {
+    // API top level
+    posts: ['posts', 'meta'],
+    tags: ['tags', 'meta'],
+    authors: ['authors', 'meta'],
+    pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
+
+    post: _(schema.posts)
+        .keys()
+        // by default we only return html
+        .without('mobiledoc', 'plaintext')
+        // canary doesn't return author_id OR author
+        .without('author_id', 'author')
+        // and always returns computed properties: url, primary_tag, primary_author
+        .concat('url', 'primary_tag', 'primary_author')
+        // canary API doesn't return unused fields
+        .without('locale', 'visibility')
+        // These fields aren't useful as they always have known values
+        .without('status')
+        // @TODO: https://github.com/TryGhost/Ghost/issues/10335
+        // .without('page')
+        // canary returns a calculated excerpt field
+        .concat('excerpt')
+    ,
+    author: _(schema.users)
+        .keys()
+        .without(
+            'password',
+            'email',
+            'ghost_auth_access_token',
+            'ghost_auth_id',
+            'created_at',
+            'created_by',
+            'updated_at',
+            'updated_by',
+            'last_seen',
+            'status'
+        )
+        // canary API doesn't return unused fields
+        .without('accessibility', 'locale', 'tour', 'visibility')
+    ,
+    tag: _(schema.tags)
+        .keys()
+        // canary Tag API doesn't return parent_id or parent
+        .without('parent_id', 'parent')
+        // canary Tag API doesn't return date fields
+        .without('created_at', 'updated_at')
+};
+
+_.each(expectedProperties, (value, key) => {
+    if (!value.__wrapped__) {
+        return;
+    }
+
+    /**
+     * @deprecated: x_by
+     */
+    expectedProperties[key] = value
+        .without(
+            'created_by',
+            'updated_by',
+            'published_by'
+        )
+        .value();
+});
+
+module.exports = {
+    API: {
+        getApiQuery(route) {
+            return url.resolve(API_URL, route);
+        },
+
+        checkResponse(...args) {
+            this.expectedProperties = expectedProperties;
+            return testUtils.API.checkResponse.call(this, ...args);
+        }
+    },
+    getValidKey() {
+        return testUtils.DataGenerator.Content.api_keys[1].secret;
+    }
+};

--- a/core/test/regression/site/site_spec.js
+++ b/core/test/regression/site/site_spec.js
@@ -3522,4 +3522,1748 @@ describe('Integration - Web - Site', function () {
             });
         });
     });
+
+    describe('canary', function () {
+        let postSpy;
+
+        describe('default routes.yaml', function () {
+            before(function () {
+                testUtils.integrationTesting.urlService.resetGenerators();
+                testUtils.integrationTesting.defaultMocks(sinon, {amp: true, apps: true});
+                testUtils.integrationTesting.overrideGhostConfig(configUtils);
+
+                return testUtils.integrationTesting.initGhost()
+                    .then(function () {
+                        sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                        sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                        app = siteApp({start: true});
+                        return testUtils.integrationTesting.urlService.waitTillFinished();
+                    })
+                    .then(() => {
+                        return appsService.init();
+                    });
+            });
+
+            before(function () {
+                configUtils.set('url', 'http://example.com');
+                urlUtils.stubUrlUtilsFromConfig();
+            });
+
+            beforeEach(function () {
+                const postsAPI = require('../../../server/api/canary/posts-public');
+                postSpy = sinon.spy(postsAPI.browse, 'query');
+            });
+
+            afterEach(function () {
+                postSpy.restore();
+            });
+
+            after(function () {
+                configUtils.restore();
+                urlUtils.restore();
+                sinon.restore();
+            });
+
+            describe('behaviour: default cases', function () {
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('serve amp', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/amp/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.match(/amp\.hbs/);
+                            response.body.should.match(/<h1>HTML Ipsum Presents<\/h1>/);
+                        });
+                });
+
+                it('post not found', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/not-found/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('serve static page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('page');
+                        });
+                });
+
+                it('serve author', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/author/joe-bloggs/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('author');
+
+                            $('.author-bio').length.should.equal(1);
+                        });
+                });
+
+                it('serve tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/bacon/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('tag');
+
+                            postSpy.args[0][0].options.filter.should.eql('(tags:\'bacon\'+tags.visibility:public)+page:false');
+                            postSpy.args[0][0].options.page.should.eql(1);
+                            postSpy.args[0][0].options.limit.should.eql(2);
+                        });
+                });
+
+                it('serve tag rss', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/bacon/rss/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+
+                            should.exist(response.res.locals.context);
+                            should.exist(response.res.locals.version);
+                            should.exist(response.res.locals.safeVersion);
+                            should.exist(response.res.locals.safeVersion);
+                            should.exist(response.res.locals.relativeUrl);
+                            should.exist(response.res.locals.secure);
+                            should.exist(response.res.routerOptions);
+                        });
+                });
+
+                it('serve collection: page 2', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/page/2/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+
+                it('serve public asset', function () {
+                    const req = {
+                        secure: false,
+                        method: 'GET',
+                        url: '/public/ghost-sdk.js',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve theme asset', function () {
+                    //configUtils.set('url', 'https://example.com');
+
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/assets/css/screen.css',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+            });
+
+            describe('behaviour: prettify', function () {
+                it('url without slash', function () {
+                    const req = {
+                        secure: false,
+                        method: 'GET',
+                        url: '/prettify-me',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('/prettify-me/');
+                        });
+                });
+            });
+
+            describe('behaviour: url redirects', function () {
+                describe('pagination', function () {
+                    it('redirect /page/1/ to /', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/page/1/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('/');
+                            });
+                    });
+                });
+
+                describe('rss', function () {
+                    it('redirect /feed/ to /rss/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/feed/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('/rss/');
+                            });
+                    });
+
+                    it('redirect /rss/1/ to /rss/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/rss/1/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('/rss/');
+                            });
+                    });
+                });
+            });
+        });
+
+        describe('https', function () {
+            before(function () {
+                configUtils.set('url', 'https://example.com');
+                urlUtils.stubUrlUtilsFromConfig();
+            });
+
+            after(function () {
+                urlUtils.restore();
+                configUtils.restore();
+            });
+
+            describe('protocol', function () {
+                it('blog is https, request is http', function () {
+                    const req = {
+                        secure: false,
+                        host: 'example.com',
+                        method: 'GET',
+                        url: '/html-ipsum'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('https://example.com/html-ipsum/');
+                        });
+                });
+
+                it('blog is https, request is http, trailing slash exists already', function () {
+                    const req = {
+                        secure: false,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('https://example.com/html-ipsum/');
+                        });
+                });
+            });
+
+            describe('assets', function () {
+                it('blog is https, request is http', function () {
+                    const req = {
+                        secure: false,
+                        method: 'GET',
+                        url: '/public/ghost-sdk.js',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('https://example.com/public/ghost-sdk.js');
+                        });
+                });
+
+                it('blog is https, request is http', function () {
+                    const req = {
+                        secure: false,
+                        method: 'GET',
+                        url: '/favicon.png',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('https://example.com/favicon.png');
+                        });
+                });
+
+                it('blog is https, request is http', function () {
+                    const req = {
+                        secure: false,
+                        method: 'GET',
+                        url: '/assets/css/main.css',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('https://example.com/assets/css/main.css');
+                        });
+                });
+            });
+        });
+
+        describe('extended routes.yaml: collections', function () {
+            describe('2 collections', function () {
+                before(function () {
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {
+                            '/': 'home'
+                        },
+
+                        collections: {
+                            '/podcast/': {
+                                permalink: '/podcast/:slug/',
+                                filter: 'featured:true'
+                            },
+
+                            '/something/': {
+                                permalink: '/something/:slug/',
+                                filter: 'featured:false'
+                            }
+                        },
+
+                        taxonomies: {
+                            tag: '/categories/:slug/',
+                            author: '/authors/:slug/'
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sinon);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve static route', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+
+                it('serve rss', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/podcast/rss/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('serve collection: podcast', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/podcast/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+
+                it('serve collection: something', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+            });
+
+            describe('no collections', function () {
+                before(function () {
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {
+                            '/test/': 'test'
+                        },
+                        collections: {},
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sinon);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve route', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+            });
+
+            describe('static permalink route', function () {
+                before(function () {
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/podcast/': {
+                                permalink: '/featured/',
+                                filter: 'featured:true'
+                            },
+
+                            '/': {
+                                permalink: '/:slug/'
+                            }
+                        },
+
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sinon);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/featured/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            // We can't find a post with the slug "featured"
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('serve author', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/author/joe-bloggs/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('serve tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/bacon/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+            });
+
+            describe('primary author permalink', function () {
+                before(function () {
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/something/': {
+                                permalink: '/:primary_author/:slug/'
+                            }
+                        },
+
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sinon);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/joe-bloggs/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('post without author', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('page');
+                        });
+                });
+            });
+
+            describe('primary tag permalink', function () {
+                before(function () {
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/something/': {
+                                permalink: '/something/:primary_tag/:slug/'
+                            }
+                        },
+
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sinon);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/kitchen-sink/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('post without tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('post without tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('page');
+                        });
+                });
+            });
+
+            describe('collection/routes with data key', function () {
+                before(function () {
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {
+                            '/my-page/': {
+                                data: {
+                                    query: {
+                                        page: {
+                                            controller: 'pagesPublic',
+                                            resource: 'pages',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'static-page-test'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        pages: [{redirect: true, slug: 'static-page-test'}]
+                                    }
+                                }
+                            }
+                        },
+
+                        collections: {
+                            '/food/': {
+                                permalink: '/food/:slug/',
+                                filter: 'tag:bacon+tag:-chorizo',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'tagsPublic',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'bacon'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: true, slug: 'bacon'}]
+                                    }
+                                }
+                            },
+                            '/sport/': {
+                                permalink: '/sport/:slug/',
+                                filter: 'tag:chorizo+tag:-bacon',
+                                data: {
+                                    query: {
+                                        apollo: {
+                                            controller: 'tagsPublic',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'chorizo'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: false, slug: 'chorizo'}]
+                                    }
+                                }
+                            }
+                        },
+
+                        taxonomies: {
+                            tag: '/categories/:slug/',
+                            author: '/authors/:slug/'
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sinon);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve /food/', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/food/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+                        });
+                });
+
+                it('serve bacon tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/categories/bacon/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                        });
+                });
+
+                it('serve /sport/', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/sport/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+                        });
+                });
+
+                it('serve chorizo tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/categories/chorizo/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve my-page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/my-page/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+            });
+        });
+
+        describe('extended routes.yaml: templates', function () {
+            describe('default template, no template', function () {
+                before(function () {
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/',
+                                templates: ['default']
+                            },
+                            '/magic/': {
+                                permalink: '/magic/:slug/'
+                            }
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sinon);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+
+                it('serve second collectiom', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/magic/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+                        });
+                });
+            });
+
+            describe('two templates', function () {
+                before(function () {
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/',
+                                templates: ['something', 'default']
+                            }
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sinon);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+            });
+
+            describe('home.hbs priority', function () {
+                before(function () {
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/',
+                                templates: ['something', 'default']
+                            },
+                            '/magic/': {
+                                permalink: '/magic/:slug/',
+                                templates: ['something', 'default']
+                            }
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sinon, {theme: 'test-theme'});
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('home');
+                        });
+                });
+
+                it('serve second page collection: should use index.hbs', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/magic/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('something');
+                        });
+                });
+            });
+        });
+
+        describe('extended routes.yaml: routes', function () {
+            describe('channels', function () {
+                before(testUtils.integrationTesting.urlService.resetGenerators);
+                before(testUtils.teardown);
+                before(testUtils.setup('users:roles', 'posts'));
+
+                before(function () {
+                    testUtils.integrationTesting.defaultMocks(sinon, {theme: 'test-theme-channels'});
+
+                    sinon.stub(frontendSettingsService, 'get').returns({
+                        routes: {
+                            '/channel1/': {
+                                controller: 'channel',
+                                filter: 'tag:kitchen-sink',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'tagsPublic',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'kitchen-sink'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: true, slug: 'kitchen-sink'}]
+                                    }
+                                }
+                            },
+
+                            '/channel2/': {
+                                controller: 'channel',
+                                filter: 'tag:bacon',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'tagsPublic',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'bacon'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: true, slug: 'bacon'}]
+                                    }
+                                },
+                                templates: ['default']
+                            },
+
+                            '/channel3/': {
+                                controller: 'channel',
+                                filter: 'author:joe-bloggs',
+                                data: {
+                                    query: {
+                                        joe: {
+                                            controller: 'authorsPublic',
+                                            resource: 'authors',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'joe-bloggs',
+                                                redirect: false
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        authors: [{redirect: false, slug: 'joe-bloggs'}]
+                                    }
+                                }
+                            },
+
+                            '/channel4/': {
+                                controller: 'channel',
+                                filter: 'author:joe-bloggs'
+                            },
+
+                            '/channel5/': {
+                                controller: 'channel',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'authorsPublic',
+                                            resource: 'authors',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'joe-bloggs',
+                                                redirect: false
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        authors: [{redirect: false, slug: 'joe-bloggs'}]
+                                    }
+                                }
+                            },
+
+                            '/channel6/': {
+                                controller: 'channel',
+                                data: {
+                                    query: {
+                                        post: {
+                                            controller: 'postsPublic',
+                                            resource: 'posts',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'html-ipsum',
+                                                redirect: true
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        posts: [{redirect: true, slug: 'html-ipsum'}]
+                                    }
+                                }
+                            }
+                        },
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/'
+                            }
+                        },
+
+                        taxonomies: {
+                            tag: '/tag/:slug/',
+                            author: '/author/:slug/'
+                        }
+                    });
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                            sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(10);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                    urlUtils.restore();
+                });
+
+                after(function () {
+                    sinon.restore();
+                });
+
+                it('serve channel 1', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel1/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+
+                it('serve channel 1: rss', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel1/rss/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.headers['content-type'].should.eql('text/xml; charset=UTF-8');
+                        });
+                });
+
+                it('serve channel 2', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel2/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+
+                            // default tempalte does not list posts
+                            $('.post-card').length.should.equal(0);
+                        });
+                });
+
+                it('serve channel 3', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel3/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('channel3');
+                        });
+                });
+
+                it('serve channel 4', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel4/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve channel 5', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel5/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve channel 6', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel6/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve kitching-sink: redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/kitchen-sink/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('/channel1/');
+                        });
+                });
+
+                it('serve html-ipsum: redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('/channel6/');
+                        });
+                });
+
+                it('serve chorizo: no redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/chorizo/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve joe-bloggs', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/author/joe-bloggs/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+            });
+        });
+
+        describe('extended routes.yaml (5): rss override', function () {
+            before(function () {
+                sinon.stub(frontendSettingsService, 'get').returns({
+                    routes: {
+                        '/about/': 'about',
+                        '/podcast/rss/': {
+                            templates: ['podcast/rss'],
+                            content_type: 'text/xml'
+                        },
+                        '/cooking/': {
+                            controller: 'channel',
+                            rss: false
+                        },
+                        '/flat/': {
+                            controller: 'channel'
+                        }
+                    },
+
+                    collections: {
+                        '/podcast/': {
+                            permalink: '/:slug/',
+                            filter: 'featured:true',
+                            templates: ['home'],
+                            rss: false
+                        },
+                        '/music/': {
+                            permalink: '/:slug/',
+                            rss: false
+                        },
+                        '/': {
+                            permalink: '/:slug/'
+                        }
+                    },
+
+                    taxonomies: {}
+                });
+
+                testUtils.integrationTesting.urlService.resetGenerators();
+                testUtils.integrationTesting.defaultMocks(sinon, {theme: 'test-theme'});
+
+                return testUtils.integrationTesting.initGhost()
+                    .then(function () {
+                        sinon.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+                        sinon.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                        app = siteApp({start: true});
+                        return testUtils.integrationTesting.urlService.waitTillFinished();
+                    });
+            });
+
+            beforeEach(function () {
+                testUtils.integrationTesting.overrideGhostConfig(configUtils);
+            });
+
+            afterEach(function () {
+                configUtils.restore();
+                urlUtils.restore();
+            });
+
+            after(function () {
+                sinon.restore();
+            });
+
+            it('serve /rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(200);
+                    });
+            });
+
+            it('serve /music/rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/music/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(404);
+                    });
+            });
+
+            it('serve /cooking/rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/cooking/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(404);
+                    });
+            });
+
+            it('serve /flat/rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/flat/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(200);
+                    });
+            });
+
+            it('serve /podcast/rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/podcast/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(200);
+                        response.template.should.eql('podcast/rss');
+                        response.headers['content-type'].should.eql('text/xml; charset=utf-8');
+                        response.body.match(/<link>/g).length.should.eql(2);
+                    });
+            });
+
+            it('serve /podcast/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/podcast/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        const $ = cheerio.load(response.body);
+                        response.statusCode.should.eql(200);
+                        $('head link')[2].attribs.href.should.eql('https://127.0.0.1:2369/rss/');
+                    });
+            });
+        });
+    });
 });

--- a/core/test/unit/api/canary/session_spec.js
+++ b/core/test/unit/api/canary/session_spec.js
@@ -1,0 +1,142 @@
+const should = require('should');
+const sinon = require('sinon');
+
+const models = require('../../../../server/models');
+const {UnauthorizedError} = require('../../../../server/lib/common/errors');
+
+const sessionController = require('../../../../server/api/canary/session');
+const sessionServiceMiddleware = require('../../../../server/services/auth/session/middleware');
+
+describe('Session controller', function () {
+    before(function () {
+        models.init();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('exports an add method', function () {
+        should.equal(typeof sessionController.add, 'function');
+    });
+    it('exports an delete method', function () {
+        should.equal(typeof sessionController.delete, 'function');
+    });
+
+    describe('#add', function () {
+        it('throws an UnauthorizedError if the object is missing a username and password', function () {
+            return sessionController.add({}).then(() => {
+                should.fail('session.add did not throw');
+            },(err) => {
+                should.equal(err instanceof UnauthorizedError, true);
+            });
+        });
+
+        it('it checks the username and password and throws UnauthorizedError if it fails', function () {
+            const userCheckStub = sinon.stub(models.User, 'check')
+                .rejects(new Error());
+
+            return sessionController.add({
+                username: 'freddy@vodafone.com',
+                password: 'qu33nRul35'
+            }, {}).then(() => {
+                should.fail('session.add did not throw');
+            },(err) => {
+                should.equal(err instanceof UnauthorizedError, true);
+            });
+        });
+
+        it('it returns a function that calls req.brute.reset, sets req.user and calls createSession if the check works', function () {
+            const fakeReq = {
+                brute: {
+                    reset: sinon.stub().callsArg(0)
+                }
+            };
+            const fakeRes = {};
+            const fakeNext = () => {};
+            const fakeUser = models.User.forge({});
+            sinon.stub(models.User, 'check')
+                .resolves(fakeUser);
+
+            const createSessionStub = sinon.stub(sessionServiceMiddleware, 'createSession');
+
+            return sessionController.add({
+                username: 'freddy@vodafone.com',
+                password: 'qu33nRul35'
+            }, {}).then((fn) => {
+                fn(fakeReq, fakeRes, fakeNext);
+            }).then(function () {
+                should.equal(fakeReq.brute.reset.callCount, 1);
+
+                const createSessionStubCall = createSessionStub.getCall(0);
+                should.equal(fakeReq.user, fakeUser);
+                should.equal(createSessionStubCall.args[0], fakeReq);
+                should.equal(createSessionStubCall.args[1], fakeRes);
+                should.equal(createSessionStubCall.args[2], fakeNext);
+            });
+        });
+
+        it('it returns a function that calls req.brute.reset and calls next if reset errors', function () {
+            const resetError = new Error();
+            const fakeReq = {
+                brute: {
+                    reset: sinon.stub().callsArgWith(0, resetError)
+                }
+            };
+            const fakeRes = {};
+            const fakeNext = sinon.stub();
+            const fakeUser = models.User.forge({});
+            sinon.stub(models.User, 'check')
+                .resolves(fakeUser);
+
+            const createSessionStub = sinon.stub(sessionServiceMiddleware, 'createSession');
+
+            return sessionController.add({
+                username: 'freddy@vodafone.com',
+                password: 'qu33nRul35'
+            }, {}).then((fn) => {
+                fn(fakeReq, fakeRes, fakeNext);
+            }).then(function () {
+                should.equal(fakeReq.brute.reset.callCount, 1);
+                should.equal(fakeNext.callCount, 1);
+                should.equal(fakeNext.args[0][0], resetError);
+            });
+        });
+    });
+
+    describe('#delete', function () {
+        it('returns a function that calls destroySession', function () {
+            const fakeReq = {};
+            const fakeRes = {};
+            const fakeNext = () => {};
+            const destroySessionStub = sinon.stub(sessionServiceMiddleware, 'destroySession');
+
+            return sessionController.delete().then((fn) => {
+                fn(fakeReq, fakeRes, fakeNext);
+            }).then(function () {
+                const destroySessionStubCall = destroySessionStub.getCall(0);
+                should.equal(destroySessionStubCall.args[0], fakeReq);
+                should.equal(destroySessionStubCall.args[1], fakeRes);
+                should.equal(destroySessionStubCall.args[2], fakeNext);
+            });
+        });
+    });
+
+    describe('#get', function () {
+        it('returns the result of User.findOne', function () {
+            const findOneReturnVal = new Promise(() => {});
+            const findOneStub = sinon.stub(models.User, 'findOne')
+                .returns(findOneReturnVal);
+
+            const result = sessionController.read({
+                context: {
+                    user: 108
+                }
+            });
+            should.equal(result, findOneReturnVal);
+            should.deepEqual(findOneStub.args[0][0], {
+                id: 108
+            });
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/index_spec.js
+++ b/core/test/unit/api/canary/utils/index_spec.js
@@ -1,0 +1,30 @@
+const should = require('should');
+const sinon = require('sinon');
+const utils = require('../../../../../server/api/canary/utils');
+
+describe('Unit: canary/utils/index', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('isContentAPI', function () {
+        it('is true when apiType is "content"', function () {
+            const frame = {
+                apiType: 'content'
+            };
+            should(utils.isContentAPI(frame)).equal(true);
+        });
+
+        it('is false when apiType is admin', function () {
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {
+                        no: 'public'
+                    }
+                }
+            };
+            should(utils.isContentAPI(frame)).equal(false);
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/input/integrations_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/input/integrations_spec.js
@@ -1,0 +1,58 @@
+const should = require('should');
+const serializers = require('../../../../../../../server/api/canary/utils/serializers');
+
+describe('Unit: canary/utils/serializers/input/pages', function () {
+    describe('browse', function () {
+        it('default', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    context: {}
+                }
+            };
+
+            serializers.input.integrations.browse(apiConfig, frame);
+            frame.options.filter.should.eql('type:[custom,builtin]');
+        });
+
+        it('combines filters', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    filter: 'type:internal',
+                    context: {}
+                }
+            };
+
+            serializers.input.integrations.browse(apiConfig, frame);
+            frame.options.filter.should.eql('(type:internal)+type:[custom,builtin]');
+        });
+    });
+
+    describe('read', function () {
+        it('default', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    context: {}
+                }
+            };
+
+            serializers.input.integrations.read(apiConfig, frame);
+            frame.options.filter.should.eql('type:[custom,builtin]');
+        });
+
+        it('combines filters', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    filter: 'type:internal',
+                    context: {}
+                }
+            };
+
+            serializers.input.integrations.read(apiConfig, frame);
+            frame.options.filter.should.eql('(type:internal)+type:[custom,builtin]');
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/input/pages_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/input/pages_spec.js
@@ -1,0 +1,237 @@
+const should = require('should');
+const serializers = require('../../../../../../../server/api/canary/utils/serializers');
+
+describe('Unit: canary/utils/serializers/input/pages', function () {
+    describe('browse', function () {
+        it('default', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {}
+                }
+            };
+
+            serializers.input.pages.browse(apiConfig, frame);
+            frame.options.filter.should.eql('page:true');
+        });
+
+        it('combine filters', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    filter: 'status:published+tag:eins',
+                    context: {}
+                }
+            };
+
+            serializers.input.pages.browse(apiConfig, frame);
+            frame.options.filter.should.eql('(status:published+tag:eins)+page:true');
+        });
+
+        it('combine filters', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    filter: 'page:false+tag:eins',
+                    context: {}
+                }
+            };
+
+            serializers.input.pages.browse(apiConfig, frame);
+            frame.options.filter.should.eql('(page:false+tag:eins)+page:true');
+        });
+
+        it('combine filters', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    filter: 'page:false',
+                    context: {}
+                }
+            };
+
+            serializers.input.pages.browse(apiConfig, frame);
+            frame.options.filter.should.eql('(page:false)+page:true');
+        });
+
+        it('remove mobiledoc option from formats', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    formats: ['html', 'mobiledoc', 'plaintext'],
+                    context: {}
+                }
+            };
+
+            serializers.input.pages.browse(apiConfig, frame);
+            frame.options.formats.should.not.containEql('mobiledoc');
+            frame.options.formats.should.containEql('html');
+            frame.options.formats.should.containEql('plaintext');
+        });
+    });
+
+    describe('read', function () {
+        it('content api default', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {}
+                },
+                data: {}
+            };
+
+            serializers.input.pages.read(apiConfig, frame);
+            frame.options.filter.should.eql('page:true');
+        });
+
+        it('content api default', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {
+                        user: 0,
+                        api_key: {
+                            id: 1,
+                            type: 'content'
+                        }
+                    }
+                },
+                data: {}
+            };
+
+            serializers.input.pages.read(apiConfig, frame);
+            frame.options.filter.should.eql('page:true');
+        });
+
+        it('admin api default', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {
+                        user: 0,
+                        api_key: {
+                            id: 1,
+                            type: 'admin'
+                        }
+                    }
+                },
+                data: {}
+            };
+
+            serializers.input.pages.read(apiConfig, frame);
+            frame.options.filter.should.eql('(page:true)+status:[draft,published,scheduled]');
+        });
+
+        it('custom page filter', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    filter: 'page:false',
+                    context: {}
+                },
+                data: {}
+            };
+
+            serializers.input.pages.read(apiConfig, frame);
+            frame.options.filter.should.eql('(page:false)+page:true');
+        });
+
+        it('custom status filter', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    filter: 'status:draft',
+                    context: {
+                        user: 0,
+                        api_key: {
+                            id: 1,
+                            type: 'admin'
+                        }
+                    }
+                },
+                data: {}
+            };
+
+            serializers.input.pages.read(apiConfig, frame);
+            frame.options.filter.should.eql('(status:draft)+page:true');
+        });
+
+        it('remove mobiledoc option from formats', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    formats: ['html', 'mobiledoc', 'plaintext'],
+                    context: {}
+                },
+                data: {
+                    status: 'all',
+                    page: false
+                }
+            };
+
+            serializers.input.pages.read(apiConfig, frame);
+            frame.options.formats.should.not.containEql('mobiledoc');
+            frame.options.formats.should.containEql('html');
+            frame.options.formats.should.containEql('plaintext');
+        });
+    });
+
+    describe('Ensure relations format', function () {
+        it('relations is array of objects', function () {
+            const apiConfig = {};
+
+            const frame = {
+                apiType: 'content',
+                options: {},
+                data: {
+                    pages: [
+                        {
+                            id: 'id1',
+                            authors: [{id: 'id'}],
+                            tags: [{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]
+                        }
+                    ]
+                }
+            };
+
+            serializers.input.pages.edit(apiConfig, frame);
+
+            frame.data.pages[0].authors.should.eql([{id: 'id'}]);
+            frame.data.pages[0].tags.should.eql([{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
+        });
+
+        it('authors is array of strings', function () {
+            const apiConfig = {};
+
+            const frame = {
+                apiType: 'content',
+                options: {},
+                data: {
+                    pages: [
+                        {
+                            id: 'id1',
+                            authors: ['email1', 'email2'],
+                            tags: ['name1', 'name2']
+                        }
+                    ]
+                }
+            };
+
+            serializers.input.pages.edit(apiConfig, frame);
+
+            frame.data.pages[0].authors.should.eql([{email: 'email1'}, {email: 'email2'}]);
+            frame.data.pages[0].tags.should.eql([{name: 'name1'}, {name: 'name2'}]);
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/input/posts_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/input/posts_spec.js
@@ -1,0 +1,533 @@
+const should = require('should');
+const sinon = require('sinon');
+const serializers = require('../../../../../../../server/api/canary/utils/serializers');
+const urlUtils = require('../../../../../../utils/urlUtils');
+
+describe('Unit: canary/utils/serializers/input/posts', function () {
+    describe('browse', function () {
+        it('default', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {
+                        user: 0,
+                        api_key: {
+                            id: 1,
+                            type: 'content'
+                        }
+                    }
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            frame.options.filter.should.eql('page:false');
+        });
+
+        it('should not work for non public context', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {
+                        user: 1
+                    }
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            should.equal(frame.options.filter, '(page:false)+status:[draft,published,scheduled]');
+        });
+
+        it('combine filters', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {
+                        user: 0,
+                        api_key: {
+                            id: 1,
+                            type: 'content'
+                        }
+                    },
+                    filter: 'status:published+tag:eins'
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            frame.options.filter.should.eql('(status:published+tag:eins)+page:false');
+        });
+
+        it('combine filters', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {
+                        user: 0,
+                        api_key: {
+                            id: 1,
+                            type: 'content'
+                        }
+                    },
+                    filter: 'page:true+tag:eins'
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            frame.options.filter.should.eql('(page:true+tag:eins)+page:false');
+        });
+
+        it('combine filters', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {
+                        user: 0,
+                        api_key: {
+                            id: 1,
+                            type: 'content'
+                        }
+                    },
+                    filter: 'page:true'
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            frame.options.filter.should.eql('(page:true)+page:false');
+        });
+
+        it('combine filters', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {
+                        user: 0,
+                        api_key: {
+                            id: 1,
+                            type: 'content'
+                        }
+                    },
+                    filter: '(page:true,page:false)'
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            frame.options.filter.should.eql('((page:true,page:false))+page:false');
+        });
+
+        it('remove mobiledoc option from formats', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    formats: ['html', 'mobiledoc', 'plaintext'],
+                    context: {}
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            frame.options.formats.should.not.containEql('mobiledoc');
+            frame.options.formats.should.containEql('html');
+            frame.options.formats.should.containEql('plaintext');
+        });
+    });
+
+    describe('read', function () {
+        it('with apiType of "content" it forces page filter', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {},
+                data: {}
+            };
+
+            serializers.input.posts.read(apiConfig, frame);
+            frame.options.filter.should.eql('page:false');
+        });
+
+        it('with apiType of "content" it forces page false filter', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    filter: 'page:true'
+                },
+                data: {}
+            };
+
+            serializers.input.posts.read(apiConfig, frame);
+            frame.options.filter.should.eql('(page:true)+page:false');
+        });
+
+        it('with apiType of "admin" it forces page & status false filter', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {
+                        api_key: {
+                            id: 1,
+                            type: 'admin'
+                        }
+                    }
+                },
+                data: {}
+            };
+
+            serializers.input.posts.read(apiConfig, frame);
+            frame.options.filter.should.eql('(page:false)+status:[draft,published,scheduled]');
+        });
+
+        it('with apiType of "admin" it forces page filter & respects custom status filter', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {
+                        api_key: {
+                            id: 1,
+                            type: 'admin'
+                        }
+                    },
+                    filter: 'status:draft'
+                },
+                data: {}
+            };
+
+            serializers.input.posts.read(apiConfig, frame);
+            frame.options.filter.should.eql('(status:draft)+page:false');
+        });
+
+        it('remove mobiledoc option from formats', function () {
+            const apiConfig = {};
+            const frame = {
+                apiType: 'content',
+                options: {
+                    formats: ['html', 'mobiledoc', 'plaintext'],
+                    context: {}
+                },
+                data: {}
+            };
+
+            serializers.input.posts.read(apiConfig, frame);
+            frame.options.formats.should.not.containEql('mobiledoc');
+            frame.options.formats.should.containEql('html');
+            frame.options.formats.should.containEql('plaintext');
+        });
+    });
+
+    describe('edit', function () {
+        describe('Ensure relative urls are returned for standard image urls', function () {
+            describe('no subdir', function () {
+                let sandbox;
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                before(function () {
+                    sandbox = sinon.createSandbox();
+                    urlUtils.stubUrlUtils({url: 'https://mysite.com'}, sandbox);
+                });
+
+                it('when mobiledoc contains an absolute URL to image', function () {
+                    const apiConfig = {};
+                    const frame = {
+                        options: {
+                            context: {
+                                user: 0,
+                                api_key: {
+                                    id: 1,
+                                    type: 'content'
+                                }
+                            }
+                        },
+                        data: {
+                            posts: [
+                                {
+                                    id: 'id1',
+                                    mobiledoc: '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"https://mysite.com/content/images/2019/02/image.jpg"}]]}'
+                                }
+                            ]
+                        }
+                    };
+
+                    serializers.input.posts.edit(apiConfig, frame);
+
+                    let postData = frame.data.posts[0];
+                    postData.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"/content/images/2019/02/image.jpg"}]]}');
+                });
+
+                it('when mobiledoc contains multiple absolute URLs to images with different protocols', function () {
+                    const apiConfig = {};
+                    const frame = {
+                        options: {
+                            context: {
+                                user: 0,
+                                api_key: {
+                                    id: 1,
+                                    type: 'content'
+                                }
+                            }
+                        },
+                        data: {
+                            posts: [
+                                {
+                                    id: 'id1',
+                                    mobiledoc: '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"https://mysite.com/content/images/2019/02/image.jpg"}],["image",{"src":"http://mysite.com/content/images/2019/02/image.png"}]]'
+                                }
+                            ]
+                        }
+                    };
+
+                    serializers.input.posts.edit(apiConfig, frame);
+
+                    let postData = frame.data.posts[0];
+                    postData.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"/content/images/2019/02/image.jpg"}],["image",{"src":"/content/images/2019/02/image.png"}]]');
+                });
+
+                it('when blog url is without subdir', function () {
+                    const apiConfig = {};
+                    const frame = {
+                        options: {
+                            context: {
+                                user: 0,
+                                api_key: {
+                                    id: 1,
+                                    type: 'content'
+                                }
+                            },
+                            withRelated: ['tags', 'authors']
+                        },
+                        data: {
+                            posts: [
+                                {
+                                    id: 'id1',
+                                    feature_image: 'https://mysite.com/content/images/image.jpg',
+                                    og_image: 'https://mysite.com/mycustomstorage/images/image.jpg',
+                                    twitter_image: 'https://mysite.com/blog/content/images/image.jpg',
+                                    tags: [{
+                                        id: 'id3',
+                                        feature_image: 'http://mysite.com/content/images/image.jpg'
+                                    }],
+                                    authors: [{
+                                        id: 'id4',
+                                        name: 'Ghosty',
+                                        profile_image: 'https://somestorage.com/blog/images/image.jpg'
+                                    }]
+                                }
+                            ]
+                        }
+                    };
+                    serializers.input.posts.edit(apiConfig, frame);
+                    let postData = frame.data.posts[0];
+                    postData.feature_image.should.eql('/content/images/image.jpg');
+                    postData.og_image.should.eql('https://mysite.com/mycustomstorage/images/image.jpg');
+                    postData.twitter_image.should.eql('https://mysite.com/blog/content/images/image.jpg');
+                    postData.tags[0].feature_image.should.eql('/content/images/image.jpg');
+                    postData.authors[0].profile_image.should.eql('https://somestorage.com/blog/images/image.jpg');
+                });
+            });
+
+            describe('with subdir', function () {
+                let sandbox;
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                before(function () {
+                    sandbox = sinon.createSandbox();
+                    urlUtils.stubUrlUtils({url: 'https://mysite.com/blog'}, sandbox);
+                });
+
+                it('when blog url is with subdir', function () {
+                    const apiConfig = {};
+                    const frame = {
+                        options: {
+                            context: {
+                                user: 0,
+                                api_key: {
+                                    id: 1,
+                                    type: 'content'
+                                }
+                            },
+                            withRelated: ['tags', 'authors']
+                        },
+                        data: {
+                            posts: [
+                                {
+                                    id: 'id1',
+                                    feature_image: 'https://mysite.com/blog/content/images/image.jpg',
+                                    og_image: 'https://mysite.com/content/images/image.jpg',
+                                    twitter_image: 'https://mysite.com/mycustomstorage/images/image.jpg',
+                                    tags: [{
+                                        id: 'id3',
+                                        feature_image: 'http://mysite.com/blog/mycustomstorage/content/images/image.jpg'
+                                    }],
+                                    authors: [{
+                                        id: 'id4',
+                                        name: 'Ghosty',
+                                        profile_image: 'https://somestorage.com/blog/content/images/image.jpg'
+                                    }]
+                                }
+                            ]
+                        }
+                    };
+                    serializers.input.posts.edit(apiConfig, frame);
+                    let postData = frame.data.posts[0];
+                    postData.feature_image.should.eql('/blog/content/images/image.jpg');
+                    postData.og_image.should.eql('https://mysite.com/content/images/image.jpg');
+                    postData.twitter_image.should.eql('https://mysite.com/mycustomstorage/images/image.jpg');
+                    postData.tags[0].feature_image.should.eql('http://mysite.com/blog/mycustomstorage/content/images/image.jpg');
+                    postData.authors[0].profile_image.should.eql('https://somestorage.com/blog/content/images/image.jpg');
+                });
+            });
+        });
+
+        describe('Ensure html to mobiledoc conversion', function () {
+            it('no transformation when no html source option provided', function () {
+                const apiConfig = {};
+                const mobiledoc = '{"version":"0.3.1","atoms":[],"cards":[],"sections":[]}';
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                id: 'id1',
+                                html: '<p>convert me</p>',
+                                mobiledoc: mobiledoc
+                            }
+                        ]
+                    }
+                };
+
+                serializers.input.posts.edit(apiConfig, frame);
+
+                let postData = frame.data.posts[0];
+                postData.mobiledoc.should.equal(mobiledoc);
+            });
+
+            it('no transformation when html data is empty', function () {
+                const apiConfig = {};
+                const mobiledoc = '{"version":"0.3.1","atoms":[],"cards":[],"sections":[]}';
+                const frame = {
+                    options: {
+                        source: 'html'
+                    },
+                    data: {
+                        posts: [
+                            {
+                                id: 'id1',
+                                html: '',
+                                mobiledoc: mobiledoc
+                            }
+                        ]
+                    }
+                };
+
+                serializers.input.posts.edit(apiConfig, frame);
+
+                let postData = frame.data.posts[0];
+                postData.mobiledoc.should.equal(mobiledoc);
+            });
+
+            it('transforms html when html is present in data and source options', function () {
+                const apiConfig = {};
+                const mobiledoc = '{"version":"0.3.1","atoms":[],"cards":[],"sections":[]}';
+                const frame = {
+                    options: {
+                        source: 'html'
+                    },
+                    data: {
+                        posts: [
+                            {
+                                id: 'id1',
+                                html: '<p>this is great feature</p>',
+                                mobiledoc: mobiledoc
+                            }
+                        ]
+                    }
+                };
+
+                serializers.input.posts.edit(apiConfig, frame);
+
+                let postData = frame.data.posts[0];
+                postData.mobiledoc.should.not.equal(mobiledoc);
+                postData.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"this is great feature"]]]]}');
+            });
+
+            it('preserves html cards in transformed html', function () {
+                const apiConfig = {};
+                const frame = {
+                    options: {
+                        source: 'html'
+                    },
+                    data: {
+                        posts: [
+                            {
+                                id: 'id1',
+                                html: '<p>this is great feature</p>\n<!--kg-card-begin: html--><div class="custom">My Custom HTML</div><!--kg-card-end: html-->\n<p>custom html preserved!</p>'
+                            }
+                        ]
+                    }
+                };
+
+                serializers.input.posts.edit(apiConfig, frame);
+
+                let postData = frame.data.posts[0];
+                postData.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["html",{"html":"<div class=\\"custom\\">My Custom HTML</div>"}]],"markups":[],"sections":[[1,"p",[[0,[],0,"this is great feature"]]],[10,0],[1,"p",[[0,[],0,"custom html preserved!"]]]]}');
+            });
+        });
+
+        describe('Ensure relations format', function () {
+            it('relations is array of objects', function () {
+                const apiConfig = {};
+
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                id: 'id1',
+                                authors: [{id: 'id'}],
+                                tags: [{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]
+                            }
+                        ]
+                    }
+                };
+
+                serializers.input.posts.edit(apiConfig, frame);
+
+                frame.data.posts[0].authors.should.eql([{id: 'id'}]);
+                frame.data.posts[0].tags.should.eql([{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
+            });
+
+            it('authors is array of strings', function () {
+                const apiConfig = {};
+
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                id: 'id1',
+                                authors: ['email1', 'email2'],
+                                tags: ['name1', 'name2']
+                            }
+                        ]
+                    }
+                };
+
+                serializers.input.posts.edit(apiConfig, frame);
+
+                frame.data.posts[0].authors.should.eql([{email: 'email1'}, {email: 'email2'}]);
+                frame.data.posts[0].tags.should.eql([{name: 'name1'}, {name: 'name2'}]);
+            });
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/output/all_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/output/all_spec.js
@@ -1,0 +1,69 @@
+const should = require('should');
+const serializers = require('../../../../../../../server/api/canary/utils/serializers');
+
+describe('Unit: canary/utils/serializers/output/all', () => {
+    describe('after', function () {
+        it('x_by', function () {
+            const apiConfig = {};
+            let response = {
+                posts: [
+                    {
+                        created_by: 'xxx',
+                        title: 'xxx'
+                    }
+                ]
+            };
+
+            serializers.output.all.after(apiConfig, {
+                response: response
+            });
+
+            should.not.exist(response.posts[0].created_by);
+            should.exist(response.posts[0].title);
+
+            response = {
+                post:
+                    {
+                        created_by: 'xxx',
+                        updated_by: 'yyy',
+                        title: 'xxx'
+                    }
+            };
+
+            serializers.output.all.after(apiConfig, {
+                response: response
+            });
+
+            should.not.exist(response.post.created_by);
+            should.not.exist(response.post.updated_by);
+            should.exist(response.post.title);
+
+            response = {
+                pages: [
+                    {
+                        created_by: 'xxx',
+                        authors: [
+                            {
+                                updated_by: 'yyy',
+                                slug: 'ghost'
+                            }
+                        ]
+                    },
+                    {
+                        published_by: 'yyy'
+                    }
+                ]
+            };
+
+            serializers.output.all.after(apiConfig, {
+                response: response
+            });
+
+            should.not.exist(response.pages[0].created_by);
+            should.not.exist(response.pages[1].published_by);
+            should.exist(response.pages[0].authors);
+            should.exist(response.pages[0].authors[0].slug);
+            should.not.exist(response.pages[0].authors[0].updated_by);
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/output/pages_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/output/pages_spec.js
@@ -1,0 +1,52 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../../../../../utils');
+const mapper = require('../../../../../../../server/api/canary/utils/serializers/output/utils/mapper');
+const serializers = require('../../../../../../../server/api/canary/utils/serializers');
+
+describe('Unit: canary/utils/serializers/output/pages', () => {
+    let pageModel;
+
+    beforeEach(() => {
+        pageModel = (data) => {
+            return Object.assign(data, {toJSON: sinon.stub().returns(data)});
+        };
+
+        sinon.stub(mapper, 'mapPost').returns({});
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('calls the mapper', () => {
+        const apiConfig = {};
+        const frame = {
+            options: {
+                withRelated: ['tags', 'authors'],
+                context: {
+                    private: false
+                }
+            }
+        };
+
+        const ctrlResponse = {
+            data: [
+                pageModel(testUtils.DataGenerator.forKnex.createPost({
+                    id: 'id1',
+                    page: true
+                })),
+                pageModel(testUtils.DataGenerator.forKnex.createPost({
+                    id: 'id2',
+                    page: true
+                }))
+            ],
+            meta: {}
+        };
+
+        serializers.output.pages.all(ctrlResponse, apiConfig, frame);
+
+        mapper.mapPost.callCount.should.equal(2);
+        mapper.mapPost.getCall(0).args.should.eql([ctrlResponse.data[0], frame]);
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/output/posts_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/output/posts_spec.js
@@ -1,0 +1,46 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../../../../../utils');
+const mapper = require('../../../../../../../server/api/canary/utils/serializers/output/utils/mapper');
+const serializers = require('../../../../../../../server/api/canary/utils/serializers');
+
+describe('Unit: canary/utils/serializers/output/posts', () => {
+    let postModel;
+
+    beforeEach(() => {
+        postModel = (data) => {
+            return Object.assign(data, {toJSON: sinon.stub().returns(data)});
+        };
+
+        sinon.stub(mapper, 'mapPost').returns({});
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('calls the mapper', () => {
+        const apiConfig = {};
+        const frame = {
+            options: {
+                withRelated: ['tags', 'authors'],
+                context: {
+                    private: false
+                }
+            }
+        };
+
+        const ctrlResponse = {
+            data: [
+                postModel(testUtils.DataGenerator.forKnex.createPost({})),
+                postModel(testUtils.DataGenerator.forKnex.createPost({}))
+            ],
+            meta: {}
+        };
+
+        serializers.output.pages.all(ctrlResponse, apiConfig, frame);
+
+        mapper.mapPost.callCount.should.equal(2);
+        mapper.mapPost.getCall(0).args.should.eql([ctrlResponse.data[0], frame]);
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/output/tags_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/output/tags_spec.js
@@ -1,0 +1,59 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../../../../../utils');
+const mapper = require('../../../../../../../server/api/canary/utils/serializers/output/utils/mapper');
+const serializers = require('../../../../../../../server/api/canary/utils/serializers');
+
+describe('Unit: canary/utils/serializers/output/tags', () => {
+    let tagModel;
+
+    beforeEach(() => {
+        tagModel = (data) => {
+            return Object.assign(data, {toJSON: sinon.stub().returns(data)});
+        };
+
+        sinon.stub(mapper, 'mapTag').returns({});
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('calls the mapper when single tag present', () => {
+        const apiConfig = {};
+        const frame = {
+            options: {
+                context: {}
+            }
+        };
+
+        const ctrlResponse = tagModel(testUtils.DataGenerator.forKnex.createTag());
+
+        serializers.output.tags.all(ctrlResponse, apiConfig, frame);
+
+        mapper.mapTag.callCount.should.equal(1);
+        mapper.mapTag.getCall(0).args.should.eql([ctrlResponse, frame]);
+    });
+
+    it('calls the mapper with multiple tags', () => {
+        const apiConfig = {};
+        const frame = {
+            options: {
+                context: {}
+            }
+        };
+
+        const ctrlResponse = tagModel({
+            data: [
+                testUtils.DataGenerator.forKnex.createTag(),
+                testUtils.DataGenerator.forKnex.createTag()
+            ],
+            meta: {}
+        });
+
+        serializers.output.tags.all(ctrlResponse, apiConfig, frame);
+
+        mapper.mapTag.callCount.should.equal(2);
+        mapper.mapTag.getCall(0).args.should.eql([ctrlResponse.data[0], frame]);
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/output/utils/date_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/output/utils/date_spec.js
@@ -1,0 +1,24 @@
+const should = require('should');
+const sinon = require('sinon');
+const settingsCache = require('../../../../../../../../server/services/settings/cache');
+const dateUtil = require('../../../../../../../../server/api/canary/utils/serializers/output/utils/date');
+
+describe('Unit: canary/utils/serializers/output/utils/date', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('creates date strings in ISO 8601 format with UTC offset', () => {
+        const timezone = 'Europe/Oslo';
+        const testDates = [
+            {in: '2014-01-01T01:28:58.593Z', out: '2014-01-01T02:28:58.593+01:00'},
+            {in:'2014-12-31T23:28:58.123Z', out: '2015-01-01T00:28:58.123+01:00'},
+            {in:'2014-03-01T01:28:58.593Z', out: '2014-03-01T02:28:58.593+01:00'}
+        ];
+        sinon.stub(settingsCache, 'get').returns(timezone);
+
+        testDates.forEach((date) => {
+            dateUtil.format(date.in).should.equal(date.out);
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/output/utils/extra-attrs_spec.js
@@ -1,0 +1,49 @@
+const should = require('should');
+const sinon = require('sinon');
+const extraAttrsUtil = require('../../../../../../../../server/api/canary/utils/serializers/output/utils/extra-attrs');
+
+describe('Unit: canary/utils/serializers/output/utils/extra-attrs', () => {
+    const frame = {
+        options: {}
+    };
+
+    let model;
+
+    beforeEach(function () {
+        model = sinon.stub();
+        model.get = sinon.stub();
+        model.get.withArgs('plaintext').returns(new Array(5000).join('A'));
+    });
+
+    describe('for post', function () {
+        it('respects custom excerpt', () => {
+            const attrs = {custom_excerpt: 'custom excerpt'};
+
+            extraAttrsUtil.forPost(frame, model, attrs);
+            model.get.called.should.be.false();
+
+            attrs.excerpt.should.eql(attrs.custom_excerpt);
+        });
+
+        it('no custom excerpt', () => {
+            const attrs = {};
+
+            extraAttrsUtil.forPost(frame, model, attrs);
+            model.get.called.should.be.true();
+
+            attrs.excerpt.should.eql(new Array(501).join('A'));
+        });
+
+        it('has excerpt when plaintext is null', () => {
+            model.get.withArgs('plaintext').returns(null);
+
+            const attrs = {};
+
+            extraAttrsUtil.forPost(frame, model, attrs);
+            model.get.called.should.be.true();
+
+            attrs.should.have.property('excerpt');
+            (attrs.excerpt === null).should.be.true();
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/output/utils/mapper_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/output/utils/mapper_spec.js
@@ -1,0 +1,172 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../../../../../../utils');
+const dateUtil = require('../../../../../../../../server/api/canary/utils/serializers/output/utils/date');
+const urlUtil = require('../../../../../../../../server/api/canary/utils/serializers/output/utils/url');
+const cleanUtil = require('../../../../../../../../server/api/canary/utils/serializers/output/utils/clean');
+const extraAttrsUtils = require('../../../../../../../../server/api/canary/utils/serializers/output/utils/extra-attrs');
+const mapper = require('../../../../../../../../server/api/canary/utils/serializers/output/utils/mapper');
+
+describe('Unit: canary/utils/serializers/output/utils/mapper', () => {
+    beforeEach(() => {
+        sinon.stub(dateUtil, 'forPost').returns({});
+
+        sinon.stub(urlUtil, 'forPost').returns({});
+        sinon.stub(urlUtil, 'forTag').returns({});
+        sinon.stub(urlUtil, 'forUser').returns({});
+
+        sinon.stub(extraAttrsUtils, 'forPost').returns({});
+
+        sinon.stub(cleanUtil, 'post').returns({});
+        sinon.stub(cleanUtil, 'tag').returns({});
+        sinon.stub(cleanUtil, 'author').returns({});
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('mapPost', () => {
+        let postModel;
+
+        beforeEach(() => {
+            postModel = (data) => {
+                return Object.assign(data, {
+                    toJSON: sinon.stub().returns(data)
+                });
+            };
+        });
+
+        it('calls mapper on relations', () => {
+            const frame = {
+                options: {
+                    withRelated: ['tags', 'authors'],
+                    context: {}
+                },
+                apiType: 'content'
+            };
+
+            const post = postModel(testUtils.DataGenerator.forKnex.createPost({
+                id: 'id1',
+                feature_image: 'value',
+                page: true,
+                tags: [{
+                    id: 'id3',
+                    feature_image: 'value'
+                }],
+                authors: [{
+                    id: 'id4',
+                    name: 'Ghosty'
+                }]
+            }));
+
+            mapper.mapPost(post, frame);
+
+            dateUtil.forPost.callCount.should.equal(1);
+
+            extraAttrsUtils.forPost.callCount.should.equal(1);
+
+            cleanUtil.post.callCount.should.eql(1);
+            cleanUtil.tag.callCount.should.eql(1);
+            cleanUtil.author.callCount.should.eql(1);
+
+            urlUtil.forPost.callCount.should.equal(1);
+            urlUtil.forTag.callCount.should.equal(1);
+            urlUtil.forUser.callCount.should.equal(1);
+
+            urlUtil.forTag.getCall(0).args.should.eql(['id3', {id: 'id3', feature_image: 'value'}, frame.options]);
+            urlUtil.forUser.getCall(0).args.should.eql(['id4', {name: 'Ghosty', id: 'id4'}, frame.options]);
+        });
+    });
+
+    describe('mapUser', () => {
+        let userModel;
+
+        beforeEach(() => {
+            userModel = (data) => {
+                return Object.assign(data, {toJSON: sinon.stub().returns(data)});
+            };
+        });
+
+        it('calls utils', () => {
+            const frame = {
+                options: {
+                    context: {}
+                }
+            };
+
+            const user = userModel(testUtils.DataGenerator.forKnex.createUser({
+                id: 'id1',
+                name: 'Ghosty'
+            }));
+
+            mapper.mapUser(user, frame);
+
+            urlUtil.forUser.callCount.should.equal(1);
+            urlUtil.forUser.getCall(0).args.should.eql(['id1', user, frame.options]);
+        });
+    });
+
+    describe('mapTag', () => {
+        let tagModel;
+
+        beforeEach(() => {
+            tagModel = (data) => {
+                return Object.assign(data, {toJSON: sinon.stub().returns(data)});
+            };
+        });
+
+        it('calls utils', () => {
+            const frame = {
+                options: {
+                    context: {}
+                }
+            };
+
+            const tag = tagModel(testUtils.DataGenerator.forKnex.createTag({
+                id: 'id3',
+                feature_image: 'value'
+            }));
+
+            mapper.mapTag(tag, frame);
+
+            urlUtil.forTag.callCount.should.equal(1);
+            urlUtil.forTag.getCall(0).args.should.eql(['id3', tag, frame.options]);
+        });
+    });
+
+    describe('mapIntegration', () => {
+        let integrationModel;
+
+        beforeEach(() => {
+            integrationModel = (data) => {
+                return Object.assign(data, {toJSON: sinon.stub().returns(data)});
+            };
+        });
+
+        it('formats admin keys', () => {
+            const frame = {
+            };
+
+            const integration = integrationModel(testUtils.DataGenerator.forKnex.createIntegration({
+                api_keys: testUtils.DataGenerator.Content.api_keys
+            }));
+
+            const mapped = mapper.mapIntegration(integration, frame);
+
+            should.exist(mapped.api_keys);
+
+            mapped.api_keys.forEach((key) => {
+                if (key.type === 'admin') {
+                    const [id, secret] = key.secret.split(':');
+                    should.exist(id);
+                    should.exist(secret);
+                } else {
+                    const [id, secret] = key.secret.split(':');
+                    should.exist(id);
+                    should.not.exist(secret);
+                }
+            });
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/serializers/output/utils/url_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/output/utils/url_spec.js
@@ -1,0 +1,54 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../../../../../../utils');
+const urlService = require('../../../../../../../../frontend/services/url');
+const urlUtils = require('../../../../../../../../server/lib/url-utils');
+const urlUtil = require('../../../../../../../../server/api/canary/utils/serializers/output/utils/url');
+
+describe('Unit: canary/utils/serializers/output/utils/url', () => {
+    beforeEach(() => {
+        sinon.stub(urlService, 'getUrlByResourceId').returns('getUrlByResourceId');
+        sinon.stub(urlUtils, 'urlFor').returns('urlFor');
+        sinon.stub(urlUtils, 'makeAbsoluteUrls').returns({html: sinon.stub()});
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('Ensure calls url service', () => {
+        let pageModel;
+
+        beforeEach(() => {
+            pageModel = (data) => {
+                return Object.assign(data, {toJSON: sinon.stub().returns(data)});
+            };
+        });
+
+        it('meta & models & relations', () => {
+            const post = pageModel(testUtils.DataGenerator.forKnex.createPost({
+                id: 'id1',
+                feature_image: 'value'
+            }));
+
+            urlUtil.forPost(post.id, post, {options: {}});
+
+            post.hasOwnProperty('url').should.be.true();
+
+            urlUtils.urlFor.callCount.should.eql(2);
+            urlUtils.urlFor.getCall(0).args.should.eql(['image', {image: 'value'}, true]);
+            urlUtils.urlFor.getCall(1).args.should.eql(['home', true]);
+
+            urlUtils.makeAbsoluteUrls.callCount.should.eql(1);
+            urlUtils.makeAbsoluteUrls.getCall(0).args.should.eql([
+                '## markdown',
+                'urlFor',
+                'getUrlByResourceId',
+                {assetsOnly: true}
+            ]);
+
+            urlService.getUrlByResourceId.callCount.should.eql(1);
+            urlService.getUrlByResourceId.getCall(0).args.should.eql(['id1', {absolute: true}]);
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/validators/input/pages_spec.js
+++ b/core/test/unit/api/canary/utils/validators/input/pages_spec.js
@@ -1,0 +1,425 @@
+const _ = require('lodash');
+const should = require('should');
+const sinon = require('sinon');
+const Promise = require('bluebird');
+const common = require('../../../../../../../server/lib/common');
+const validators = require('../../../../../../../server/api/canary/utils/validators');
+
+describe('Unit: canary/utils/validators/input/pages', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('add', function () {
+        const apiConfig = {
+            docName: 'pages'
+        };
+
+        describe('required fields', function () {
+            it('should fail with no data', function () {
+                const frame = {
+                    options: {},
+                    data: {}
+                };
+
+                return validators.input.pages.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with no pages', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: []
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with no pages in array', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: []
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with more than page', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [],
+                        tags: []
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail without required fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [{
+                            what: 'a fail'
+                        }]
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with required fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}]
+                        }]
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame);
+            });
+
+            it('should remove `strip`able fields and leave regular fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}],
+                            id: 'strip me',
+                            created_at: 'strip me',
+                            created_by: 'strip me',
+                            updated_by: 'strip me',
+                            published_by: 'strip me'
+                        }]
+                    }
+                };
+
+                let result = validators.input.pages.add(apiConfig, frame);
+
+                should.exist(frame.data.pages[0].title);
+                should.exist(frame.data.pages[0].authors);
+                should.not.exist(frame.data.pages[0].id);
+                should.not.exist(frame.data.pages[0].created_at);
+                should.not.exist(frame.data.pages[0].created_by);
+                should.not.exist(frame.data.pages[0].updated_by);
+                should.not.exist(frame.data.pages[0].published_by);
+
+                return result;
+            });
+        });
+
+        describe('field formats', function () {
+            const fieldMap = {
+                title: [123, new Date(), _.repeat('a', 2001)],
+                slug: [123, new Date(), _.repeat('a', 192)],
+                mobiledoc: [123, new Date()],
+                feature_image: [123, new Date(), 'random words'],
+                featured: [123, new Date(), 'abc'],
+                status: [123, new Date(), 'abc'],
+                locale: [123, new Date(), _.repeat('a', 7)],
+                visibility: [123, new Date(), 'abc'],
+                meta_title: [123, new Date(), _.repeat('a', 301)],
+                meta_description: [123, new Date(), _.repeat('a', 501)]
+            };
+
+            Object.keys(fieldMap).forEach((key) => {
+                it(`should fail for bad ${key}`, function () {
+                    const badValues = fieldMap[key];
+
+                    const checks = badValues.map((value) => {
+                        const page = {};
+                        page[key] = value;
+
+                        if (key !== 'title') {
+                            page.title = 'abc';
+                        }
+
+                        const frame = {
+                            options: {},
+                            data: {
+                                pages: [page]
+                            }
+                        };
+
+                        return validators.input.pages.add(apiConfig, frame)
+                            .then(Promise.reject)
+                            .catch((err) => {
+                                (err instanceof common.errors.ValidationError).should.be.true();
+                            });
+                    });
+
+                    return Promise.all(checks);
+                });
+            });
+        });
+
+        describe('authors structure', function () {
+            it('should require properties', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [
+                            {
+                                title: 'cool',
+                                authors: {}
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should require id', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    name: 'hey'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    id: 'correct',
+                                    name: 'ja'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame);
+            });
+        });
+    });
+
+    describe('edit', function () {
+        const apiConfig = {
+            docName: 'pages'
+        };
+
+        describe('required fields', function () {
+            it('should fail with no data', function () {
+                const frame = {
+                    options: {},
+                    data: {}
+                };
+
+                return validators.input.pages.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with no pages', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: []
+                    }
+                };
+
+                return validators.input.pages.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with more than page', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [],
+                        tags: []
+                    }
+                };
+
+                return validators.input.pages.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with some fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [{
+                            title: 'pass',
+                            updated_at: new Date().toISOString()
+                        }]
+                    }
+                };
+
+                return validators.input.pages.edit(apiConfig, frame);
+            });
+        });
+
+        describe('authors structure', function () {
+            it('should require properties', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [
+                            {
+                                title: 'cool',
+                                authors: {}
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.pages.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should require id', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    name: 'hey'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.pages.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with valid authors', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [
+                            {
+                                title: 'cool',
+                                updated_at: new Date().toISOString(),
+                                authors: [{
+                                    id: 'correct',
+                                    name: 'ja'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.pages.edit(apiConfig, frame);
+            });
+
+            it('should pass without authors', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [
+                            {
+                                title: 'cool',
+                                updated_at: new Date().toISOString()
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.pages.edit(apiConfig, frame);
+            });
+
+            it('should pass with authors as array with strings', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [
+                            {
+                                authors: ['email1', 'email2'],
+                                updated_at: new Date().toISOString()
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.pages.edit(apiConfig, frame);
+            });
+
+            it('should pass with authors as array with strings & objects', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [
+                            {
+                                authors: ['email1', {email: 'email'}],
+                                updated_at: new Date().toISOString()
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.pages.edit(apiConfig, frame);
+            });
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/validators/input/posts_spec.js
+++ b/core/test/unit/api/canary/utils/validators/input/posts_spec.js
@@ -1,0 +1,425 @@
+const _ = require('lodash');
+const should = require('should');
+const sinon = require('sinon');
+const Promise = require('bluebird');
+const common = require('../../../../../../../server/lib/common');
+const validators = require('../../../../../../../server/api/canary/utils/validators');
+
+describe('Unit: canary/utils/validators/input/posts', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('add', function () {
+        const apiConfig = {
+            docName: 'posts'
+        };
+
+        describe('required fields', function () {
+            it('should fail with no data', function () {
+                const frame = {
+                    options: {},
+                    data: {}
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with no posts', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: []
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with no posts in array', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: []
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with more than post', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [],
+                        tags: []
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail without required fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            what: 'a fail'
+                        }]
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with required fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}]
+                        }]
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame);
+            });
+
+            it('should remove `strip`able fields and leave regular fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}],
+                            id: 'strip me',
+                            created_at: 'strip me',
+                            created_by: 'strip me',
+                            updated_by: 'strip me',
+                            published_by: 'strip me'
+                        }]
+                    }
+                };
+
+                let result = validators.input.posts.add(apiConfig, frame);
+
+                should.exist(frame.data.posts[0].title);
+                should.exist(frame.data.posts[0].authors);
+                should.not.exist(frame.data.posts[0].id);
+                should.not.exist(frame.data.posts[0].created_at);
+                should.not.exist(frame.data.posts[0].created_by);
+                should.not.exist(frame.data.posts[0].updated_by);
+                should.not.exist(frame.data.posts[0].published_by);
+
+                return result;
+            });
+        });
+
+        describe('field formats', function () {
+            const fieldMap = {
+                title: [123, new Date(), _.repeat('a', 2001)],
+                slug: [123, new Date(), _.repeat('a', 192)],
+                mobiledoc: [123, new Date()],
+                feature_image: [123, new Date(), 'random words'],
+                featured: [123, new Date(), 'abc'],
+                status: [123, new Date(), 'abc'],
+                locale: [123, new Date(), _.repeat('a', 7)],
+                visibility: [123, new Date(), 'abc'],
+                meta_title: [123, new Date(), _.repeat('a', 301)],
+                meta_description: [123, new Date(), _.repeat('a', 501)]
+            };
+
+            Object.keys(fieldMap).forEach((key) => {
+                it(`should fail for bad ${key}`, function () {
+                    const badValues = fieldMap[key];
+
+                    const checks = badValues.map((value) => {
+                        const post = {};
+                        post[key] = value;
+
+                        if (key !== 'title') {
+                            post.title = 'abc';
+                        }
+
+                        const frame = {
+                            options: {},
+                            data: {
+                                posts: [post]
+                            }
+                        };
+
+                        return validators.input.posts.add(apiConfig, frame)
+                            .then(Promise.reject)
+                            .catch((err) => {
+                                (err instanceof common.errors.ValidationError).should.be.true();
+                            });
+                    });
+
+                    return Promise.all(checks);
+                });
+            });
+        });
+
+        describe('authors structure', function () {
+            it('should require properties', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: {}
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should require id', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    name: 'hey'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    id: 'correct',
+                                    name: 'ja'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame);
+            });
+        });
+    });
+
+    describe('edit', function () {
+        const apiConfig = {
+            docName: 'posts'
+        };
+
+        describe('required fields', function () {
+            it('should fail with no data', function () {
+                const frame = {
+                    options: {},
+                    data: {}
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with no posts', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: []
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with more than post', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [],
+                        tags: []
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with some fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            title: 'pass',
+                            updated_at: new Date().toISOString()
+                        }]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame);
+            });
+        });
+
+        describe('authors structure', function () {
+            it('should require properties', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: {}
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should require id', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                authors: [{
+                                    name: 'hey'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with valid authors', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                updated_at: new Date().toISOString(),
+                                authors: [{
+                                    id: 'correct',
+                                    name: 'ja'
+                                }]
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame);
+            });
+
+            it('should pass without authors', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                title: 'cool',
+                                updated_at: new Date().toISOString()
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame);
+            });
+
+            it('should pass with authors as array with strings', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                authors: ['email1', 'email2'],
+                                updated_at: new Date().toISOString()
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame);
+            });
+
+            it('should pass with authors as array with strings & objects', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [
+                            {
+                                authors: ['email1', {email: 'email'}],
+                                updated_at: new Date().toISOString()
+                            }
+                        ]
+                    }
+                };
+
+                return validators.input.posts.edit(apiConfig, frame);
+            });
+        });
+    });
+});

--- a/core/test/unit/api/canary/utils/validators/input/tags_spec.js
+++ b/core/test/unit/api/canary/utils/validators/input/tags_spec.js
@@ -1,0 +1,243 @@
+const _ = require('lodash');
+const should = require('should');
+const sinon = require('sinon');
+const Promise = require('bluebird');
+const common = require('../../../../../../../server/lib/common');
+const validators = require('../../../../../../../server/api/canary/utils/validators');
+
+describe('Unit: canary/utils/validators/input/tags', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('add', function () {
+        const apiConfig = {
+            docName: 'tags'
+        };
+
+        describe('required fields', function () {
+            it('should fail with no data', function () {
+                const frame = {
+                    options: {},
+                    data: {}
+                };
+
+                return validators.input.tags.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with no tags', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: []
+                    }
+                };
+
+                return validators.input.tags.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with no tags in array', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: []
+                    }
+                };
+
+                return validators.input.tags.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with more than tags', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: [],
+                        posts: []
+                    }
+                };
+
+                return validators.input.tags.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail without required fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: [{
+                            what: 'a fail'
+                        }]
+                    }
+                };
+
+                return validators.input.tags.add(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with required fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: [{
+                            name: 'pass'
+                        }]
+                    }
+                };
+
+                return validators.input.tags.add(apiConfig, frame);
+            });
+
+            it('should remove `strip`able fields and leave regular fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: [{
+                            name: 'pass',
+                            parent: 'strip me',
+                            created_at: 'strip me',
+                            created_by: 'strip me',
+                            updated_at: 'strip me',
+                            updated_by: 'strip me'
+                        }]
+                    }
+                };
+
+                let result = validators.input.tags.add(apiConfig, frame);
+
+                should.exist(frame.data.tags[0].name);
+                should.not.exist(frame.data.tags[0].parent);
+                should.not.exist(frame.data.tags[0].created_at);
+                should.not.exist(frame.data.tags[0].created_by);
+                should.not.exist(frame.data.tags[0].updated_at);
+                should.not.exist(frame.data.tags[0].updated_by);
+
+                return result;
+            });
+        });
+
+        describe('field formats', function () {
+            const fieldMap = {
+                name: [123, new Date(), ',starts-with-coma', '', _.repeat('a', 192), null],
+                slug: [123, new Date(), _.repeat('a', 192)],
+                description: [123, new Date(), _.repeat('a', 501)],
+                feature_image: [123, new Date(), 'not uri'],
+                visibility: [123, new Date(), 'abc', null],
+                meta_title: [123, new Date(), _.repeat('a', 301)],
+                meta_description: [123, new Date(), _.repeat('a', 501)]
+            };
+
+            Object.keys(fieldMap).forEach((key) => {
+                it(`should fail for bad ${key}`, function () {
+                    const badValues = fieldMap[key];
+
+                    const checks = badValues.map((value) => {
+                        const tag = {};
+                        tag[key] = value;
+
+                        if (key !== 'name') {
+                            tag.name = 'abc';
+                        }
+
+                        const frame = {
+                            options: {},
+                            data: {
+                                tags: [tag]
+                            }
+                        };
+
+                        return validators.input.tags.add(apiConfig, frame)
+                            .then(Promise.reject)
+                            .catch((err) => {
+                                (err instanceof common.errors.ValidationError).should.be.true();
+                            });
+                    });
+
+                    return Promise.all(checks);
+                });
+            });
+        });
+    });
+
+    describe('edit', function () {
+        const apiConfig = {
+            docName: 'tags'
+        };
+
+        describe('required fields', function () {
+            it('should fail with no data', function () {
+                const frame = {
+                    options: {},
+                    data: {}
+                };
+
+                return validators.input.tags.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with no tags', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: []
+                    }
+                };
+
+                return validators.input.tags.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should fail with more than tags', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: [],
+                        posts: []
+                    }
+                };
+
+                return validators.input.tags.edit(apiConfig, frame)
+                    .then(Promise.reject)
+                    .catch((err) => {
+                        (err instanceof common.errors.ValidationError).should.be.true();
+                    });
+            });
+
+            it('should pass with some fields', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        tags: [{
+                            name: 'pass'
+                        }]
+                    }
+                };
+
+                return validators.input.tags.edit(apiConfig, frame);
+            });
+        });
+    });
+});

--- a/core/test/unit/data/meta/description_spec.js
+++ b/core/test/unit/data/meta/description_spec.js
@@ -210,4 +210,15 @@ describe('getMetaDescription', function () {
         });
         description.should.equal('Best page ever!');
     });
+
+    it('canary: should return data page meta description if on root context contains page', function () {
+        var description = getMetaDescription({
+            page: {
+                meta_description: 'Best page ever!'
+            }
+        }, {
+            context: ['page']
+        });
+        description.should.equal('Best page ever!');
+    });
 });

--- a/core/test/unit/data/meta/title_spec.js
+++ b/core/test/unit/data/meta/title_spec.js
@@ -246,6 +246,16 @@ describe('getTitle', function () {
         title.should.equal('My awesome page!');
     });
 
+    it('canary: should return page title if in page context', function () {
+        var title = getTitle({
+            page: {
+                title: 'My awesome page!'
+            }
+        }, {context: ['page']});
+
+        title.should.equal('My awesome page!');
+    });
+
     it('should return post title if in amp and page context', function () {
         var title = getTitle({
             post: {

--- a/core/test/unit/helpers/body_class_spec.js
+++ b/core/test/unit/helpers/body_class_spec.js
@@ -151,6 +151,15 @@ describe('{{body_class}} helper', function () {
             rendered.string.should.equal('page-template page-about');
         });
 
+        it('canary: a static page', function () {
+            var rendered = callBodyClassWithContext(
+                ['page'],
+                {relativeUrl: '/about', page: {page: true, slug: 'about'}}
+            );
+
+            rendered.string.should.equal('page-template page-about');
+        });
+
         it('a static page with custom template (is now the same as one without)', function () {
             var rendered = callBodyClassWithContext(
                 ['page'],

--- a/core/test/unit/helpers/get_spec.js
+++ b/core/test/unit/helpers/get_spec.js
@@ -369,6 +369,72 @@ describe('{{#get}} helper', function () {
         });
     });
 
+    describe('users canary', function () {
+        let browseUsersStub;
+        const meta = {pagination: {}};
+
+        beforeEach(function () {
+            locals = {root: {_locals: {apiVersion: 'canary'}}};
+
+            browseUsersStub = sinon.stub(api["canary"], 'authorsPublic').get(() => {
+                return {
+                    browse: sinon.stub().resolves({authors: [], meta: meta})
+                };
+            });
+        });
+
+        it('browse users', function (done) {
+            helpers.get.call(
+                {},
+                'users',
+                {hash: {}, data: locals, fn: fn, inverse: inverse}
+            ).then(function () {
+                // We don't use the labs helper for canary
+                labsStub.calledOnce.should.be.false();
+
+                fn.called.should.be.true();
+                fn.firstCall.args[0].should.be.an.Object().with.property('authors');
+                fn.firstCall.args[0].authors.should.eql([]);
+                inverse.called.should.be.false();
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('authors canary', function () {
+        let browseUsersStub;
+        const meta = {pagination: {}};
+
+        beforeEach(function () {
+            locals = {root: {_locals: {apiVersion: 'canary'}}};
+
+            browseUsersStub = sinon.stub(api["canary"], 'authorsPublic').get(() => {
+                return {
+                    browse: sinon.stub().resolves({authors: [], meta: meta})
+                };
+            });
+        });
+
+        it('browse users', function (done) {
+            helpers.get.call(
+                {},
+                'authors',
+                {hash: {}, data: locals, fn: fn, inverse: inverse}
+            ).then(function () {
+                // We don't use the labs helper for canary
+                labsStub.calledOnce.should.be.false();
+
+                fn.called.should.be.true();
+                fn.firstCall.args[0].should.be.an.Object().with.property('authors');
+                fn.firstCall.args[0].authors.should.eql([]);
+                inverse.called.should.be.false();
+
+                done();
+            }).catch(done);
+        });
+    });
+
     describe('general error handling', function () {
         it('should return an error for an unknown resource', function (done) {
             helpers.get.call(

--- a/core/test/unit/services/auth/api-key/admin_spec.js
+++ b/core/test/unit/services/auth/api-key/admin_spec.js
@@ -31,7 +31,7 @@ describe('Admin API Key Auth', function () {
         sinon.restore();
     });
 
-    it('should authenticate known+valid API key', function (done) {
+    it('should authenticate known+valid v2 API key', function (done) {
         const token = jwt.sign({
         }, this.secret, {
             keyid: this.fakeApiKey.id,
@@ -42,7 +42,32 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: '/test/',
+            originalUrl: '/ghost/api/v2/admin/',
+            headers: {
+                authorization: `Ghost ${token}`
+            }
+        };
+        const res = {};
+
+        apiKeyAuth.admin.authenticate(req, res, (err) => {
+            should.not.exist(err);
+            req.api_key.should.eql(this.fakeApiKey);
+            done();
+        });
+    });
+
+    it('should authenticate known+valid canary API key', function (done) {
+        const token = jwt.sign({
+        }, this.secret, {
+            keyid: this.fakeApiKey.id,
+            algorithm: 'HS256',
+            expiresIn: '5m',
+            audience: '/canary/admin/',
+            issuer: this.fakeApiKey.id
+        });
+
+        const req = {
+            originalUrl: '/ghost/api/canary/admin/',
             headers: {
                 authorization: `Ghost ${token}`
             }
@@ -103,7 +128,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: '/test/',
+            originalUrl: '/ghost/api/v2/admin/',
             headers: {
                 authorization: `Ghost ${token}`
             }
@@ -132,7 +157,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: '/test/',
+            originalUrl: '/ghost/api/v2/admin/',
             headers: {
                 authorization: `Ghost ${token}`
             }
@@ -162,7 +187,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: '/test/',
+            originalUrl: '/ghost/api/v2/admin/',
             headers: {
                 authorization: `Ghost ${token}`
             }
@@ -190,7 +215,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: '/test/',
+            originalUrl: '/ghost/api/v2/admin/',
             headers: {
                 authorization: `Ghost ${token}`
             }

--- a/core/test/unit/services/routing/TaxonomyRouter_spec.js
+++ b/core/test/unit/services/routing/TaxonomyRouter_spec.js
@@ -5,7 +5,8 @@ const should = require('should'),
     common = require('../../../../server/lib/common'),
     controllers = require('../../../../frontend/services/routing/controllers'),
     TaxonomyRouter = require('../../../../frontend/services/routing/TaxonomyRouter'),
-    RESOURCE_CONFIG = require('../../../../frontend/services/routing/config/v2');
+    RESOURCE_CONFIG = require('../../../../frontend/services/routing/config/v2'),
+    RESOURCE_CONFIG_CANARY = require('../../../../frontend/services/routing/config/canary');
 
 describe('UNIT - services/routing/TaxonomyRouter', function () {
     let req, res, next;
@@ -61,8 +62,26 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
         taxonomyRouter.mountRoute.args[2][1].should.eql(taxonomyRouter._redirectEditOption.bind(taxonomyRouter));
     });
 
-    it('fn: _prepareContext', function () {
+    it('v2:fn: _prepareContext', function () {
         const taxonomyRouter = new TaxonomyRouter('tag', '/tag/:slug/', RESOURCE_CONFIG);
+        taxonomyRouter._prepareContext(req, res, next);
+        next.calledOnce.should.eql(true);
+
+        res.routerOptions.should.eql({
+            type: 'channel',
+            name: 'tag',
+            permalinks: '/tag/:slug/',
+            resourceType: RESOURCE_CONFIG.QUERY.tag.resource,
+            data: {tag: RESOURCE_CONFIG.QUERY.tag},
+            filter: RESOURCE_CONFIG.TAXONOMIES.tag.filter,
+            context: ['tag'],
+            slugTemplate: true,
+            identifier: taxonomyRouter.identifier
+        });
+    });
+
+    it('canary:fn: _prepareContext', function () {
+        const taxonomyRouter = new TaxonomyRouter('tag', '/tag/:slug/', RESOURCE_CONFIG_CANARY);
         taxonomyRouter._prepareContext(req, res, next);
         next.calledOnce.should.eql(true);
 

--- a/core/test/unit/services/routing/helpers/entry-lookup_spec.js
+++ b/core/test/unit/services/routing/helpers/entry-lookup_spec.js
@@ -372,4 +372,108 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
             });
         });
     });
+
+    describe('canary', function () {
+        describe('static pages', function () {
+            const routerOptions = {
+                permalinks: '/:slug/',
+                query: {controller: 'pagesPublic', resource: 'pages'}
+            };
+
+            let pages;
+            let postsReadStub;
+            let pagesReadStub;
+
+            beforeEach(function () {
+                pages = [
+                    testUtils.DataGenerator.forKnex.createPost({url: '/test/', slug: 'test', page: true})
+                ];
+
+                postsReadStub = sinon.stub();
+                pagesReadStub = sinon.stub();
+
+                pagesReadStub//.withArgs({slug: pages[0].slug, include: 'author,authors,tags'})
+                    .resolves({
+                        pages: pages
+                    });
+
+                sinon.stub(api.canary, 'posts').get(() => {
+                    return {
+                        read: postsReadStub
+                    };
+                });
+
+                sinon.stub(api.canary, 'pagesPublic').get(() => {
+                    return {
+                        read: pagesReadStub
+                    };
+                });
+
+                locals = {apiVersion: 'canary'};
+            });
+
+            it('ensure pages controller is triggered', function () {
+                const testUrl = 'http://127.0.0.1:2369' + pages[0].url;
+
+                return helpers.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
+                    postsReadStub.called.should.be.false();
+                    pagesReadStub.calledOnce.should.be.true();
+                    should.exist(lookup.entry);
+                    lookup.entry.should.have.property('url', pages[0].url);
+                    lookup.isEditURL.should.be.false();
+                });
+            });
+        });
+
+        describe('posts', function () {
+            const routerOptions = {
+                permalinks: '/:slug/',
+                query: {controller: 'posts', resource: 'posts'}
+            };
+
+            let posts;
+            let postsReadStub;
+            let pagesReadStub;
+
+            beforeEach(function () {
+                posts = [
+                    testUtils.DataGenerator.forKnex.createPost({url: '/test/', slug: 'test'})
+                ];
+
+                postsReadStub = sinon.stub();
+                pagesReadStub = sinon.stub();
+
+                postsReadStub//.withArgs({slug: posts[0].slug, include: 'author,authors,tags'})
+                    .resolves({
+                        posts: posts
+                    });
+
+                sinon.stub(api.canary, 'posts').get(() => {
+                    return {
+                        read: postsReadStub
+                    };
+                });
+
+                sinon.stub(api.canary, 'pagesPublic').get(() => {
+                    return {
+                        read: pagesReadStub
+                    };
+                });
+
+                locals = {apiVersion: 'canary'};
+            });
+
+            it('ensure posts controller is triggered', function () {
+                const testUrl = 'http://127.0.0.1:2369' + posts[0].url;
+
+                return helpers.entryLookup(testUrl, routerOptions, locals).then(function (lookup) {
+                    postsReadStub.calledOnce.should.be.true();
+                    pagesReadStub.called.should.be.false();
+                    should.exist(lookup.entry);
+                    lookup.entry.should.have.property('url', posts[0].url);
+                    lookup.isEditURL.should.be.false();
+                });
+            });
+        });
+    });
 });

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -1574,4 +1574,777 @@ describe('UNIT: services/settings/validate', function () {
             });
         });
     });
+
+    describe('canary', function () {
+        before(function () {
+            apiVersion = 'canary';
+        });
+
+        it('no type definitions / empty yaml file', function () {
+            const object = validate({});
+
+            object.should.eql({collections: {}, routes: {}, taxonomies: {}});
+        });
+
+        it('throws error when using :\w+ notiation in collection', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '/magic/{slug}/'
+                        },
+                        '/': {
+                            permalink: '/:slug/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when using :\w+ notiation in taxonomies', function () {
+            try {
+                validate({
+                    taxonomies: {
+                        tag: '/categories/:slug/'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when using an undefined taxonomy', function () {
+            try {
+                validate({
+                    taxonomies: {
+                        sweet_baked_good: '/patisserie/{slug}'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when permalink is missing (collection)', function () {
+            try {
+                validate({
+                    collections: {
+                        permalink: '/{slug}/'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    routes: {
+                        about: 'about'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    routes: {
+                        '/about': 'about'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    routes: {
+                        'about/': 'about'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        'magic/': {
+                            permalink: '/{slug}/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        magic: {
+                            permalink: '/{slug}/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic': {
+                            permalink: '/{slug}/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '/{slug}'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '{slug}'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('no validation error for routes', function () {
+            validate({
+                routes: {
+                    '/': 'home'
+                }
+            });
+        });
+
+        it('no validation error for / collection', function () {
+            validate({
+                collections: {
+                    '/': {
+                        permalink: '/{primary_tag}/{slug}/'
+                    }
+                }
+            });
+        });
+
+        it('transforms {.*} notation into :\w+', function () {
+            const object = validate({
+                collections: {
+                    '/magic/': {
+                        permalink: '/magic/{year}/{slug}/'
+                    },
+                    '/': {
+                        permalink: '/{slug}/'
+                    }
+                },
+                taxonomies: {
+                    tag: '/tags/{slug}/',
+                    author: '/authors/{slug}/'
+                }
+            });
+
+            object.should.eql({
+                routes: {},
+                taxonomies: {
+                    tag: '/tags/:slug/',
+                    author: '/authors/:slug/'
+                },
+                collections: {
+                    '/magic/': {
+                        permalink: '/magic/:year/:slug/',
+                        templates: []
+                    },
+                    '/': {
+                        permalink: '/:slug/',
+                        templates: []
+                    }
+                }
+            });
+        });
+
+        describe('template definitions', function () {
+            it('single value', function () {
+                const object = validate({
+                    routes: {
+                        '/about/': 'about',
+                        '/me/': {
+                            template: 'me'
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/{slug}/',
+                            template: 'test'
+                        }
+                    }
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/about/': {
+                            templates: ['about']
+                        },
+                        '/me/': {
+                            templates: ['me']
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/:slug/',
+                            templates: ['test']
+                        }
+                    }
+                });
+            });
+
+            it('array', function () {
+                const object = validate({
+                    routes: {
+                        '/about/': 'about',
+                        '/me/': {
+                            template: ['me']
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/{slug}/',
+                            template: ['test']
+                        }
+                    }
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/about/': {
+                            templates: ['about']
+                        },
+                        '/me/': {
+                            templates: ['me']
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/:slug/',
+                            templates: ['test']
+                        }
+                    }
+                });
+            });
+        });
+
+        describe('data definitions', function () {
+            it('shortform', function () {
+                const object = validate({
+                    routes: {
+                        '/food/': {
+                            data: 'tag.food'
+                        },
+                        '/music/': {
+                            data: 'tag.music'
+                        },
+                        '/ghost/': {
+                            data: 'author.ghost'
+                        },
+                        '/sleep/': {
+                            data: {
+                                bed: 'tag.bed',
+                                dream: 'tag.dream'
+                            }
+                        },
+                        '/lala/': {
+                            data: 'author.carsten'
+                        }
+                    },
+                    collections: {
+                        '/more/': {
+                            permalink: '/{slug}/',
+                            data: {
+                                home: 'page.home'
+                            }
+                        },
+                        '/podcast/': {
+                            permalink: '/podcast/{slug}/',
+                            data: {
+                                something: 'tag.something'
+                            }
+                        },
+                        '/': {
+                            permalink: '/{slug}/',
+                            data: 'tag.sport'
+                        }
+                    }
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/food/': {
+                            data: {
+                                query: {
+                                    tag: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'food',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'food'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/ghost/': {
+                            data: {
+                                query: {
+                                    author: {
+                                        controller: 'authorsPublic',
+                                        resource: 'authors',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'ghost'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    authors: [{redirect: true, slug: 'ghost'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/music/': {
+                            data: {
+                                query: {
+                                    tag: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'music',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'music'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/sleep/': {
+                            data: {
+                                query: {
+                                    bed: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'bed',
+                                            visibility: 'public'
+                                        }
+                                    },
+                                    dream: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'dream',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'bed'}, {redirect: true, slug: 'dream'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/lala/': {
+                            data: {
+                                query: {
+                                    author: {
+                                        controller: 'authorsPublic',
+                                        resource: 'authors',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'carsten'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    authors: [{redirect: true, slug: 'carsten'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    },
+                    collections: {
+                        '/more/': {
+                            permalink: '/:slug/',
+                            data: {
+                                query: {
+                                    home: {
+                                        controller: 'pagesPublic',
+                                        resource: 'pages',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'home'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    pages: [{redirect: true, slug: 'home'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/podcast/': {
+                            permalink: '/podcast/:slug/',
+                            data: {
+                                query: {
+                                    something: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'something',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'something'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/': {
+                            permalink: '/:slug/',
+                            data: {
+                                query: {
+                                    tag: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'sport',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'sport'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    }
+                });
+            });
+
+            it('longform', function () {
+                const object = validate({
+                    routes: {
+                        '/food/': {
+                            data: {
+                                food: {
+                                    resource: 'posts',
+                                    type: 'browse'
+                                }
+                            }
+                        },
+                        '/wellness/': {
+                            data: {
+                                posts: {
+                                    resource: 'posts',
+                                    type: 'read',
+                                    redirect: false
+                                }
+                            }
+                        },
+                        '/partyparty/': {
+                            data: {
+                                people: {
+                                    resource: 'authors',
+                                    type: 'read',
+                                    slug: 'djgutelaune',
+                                    redirect: true
+                                }
+                            }
+                        }
+                    },
+                    collections: {
+                        '/yoga/': {
+                            permalink: '/{slug}/',
+                            data: {
+                                gym: {
+                                    resource: 'posts',
+                                    type: 'read',
+                                    slug: 'ups',
+                                    status: 'draft'
+                                }
+                            }
+                        }
+                    }
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/food/': {
+                            data: {
+                                query: {
+                                    food: {
+                                        controller: 'postsPublic',
+                                        resource: 'posts',
+                                        type: 'browse',
+                                        options: {}
+                                    }
+                                },
+                                router: {
+                                    posts: [{redirect: true}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/wellness/': {
+                            data: {
+                                query: {
+                                    posts: {
+                                        controller: 'postsPublic',
+                                        resource: 'posts',
+                                        type: 'read',
+                                        options: {
+                                            slug: '%s'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    posts: [{redirect: false}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/partyparty/': {
+                            data: {
+                                query: {
+                                    people: {
+                                        controller: 'authorsPublic',
+                                        resource: 'authors',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'djgutelaune'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    authors: [{redirect: true, slug: 'djgutelaune'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    },
+                    collections: {
+                        '/yoga/': {
+                            permalink: '/:slug/',
+                            data: {
+                                query: {
+                                    gym: {
+                                        controller: 'postsPublic',
+                                        resource: 'posts',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'ups',
+                                            status: 'draft'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    posts: [{redirect: true, slug: 'ups'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    }
+                });
+            });
+
+            it('errors: data shortform incorrect', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: 'tag:test'
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform resource is missing', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    type: 'edit'
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform type is missing', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    resource: 'subscribers'
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform name is author', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    author: {
+                                        resource: 'users'
+                                    }
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform does not use a custom name at all', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    resource: 'users'
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+        });
+    });
 });

--- a/core/test/unit/services/themes/engines/create_spec.js
+++ b/core/test/unit/services/themes/engines/create_spec.js
@@ -98,5 +98,17 @@ describe('Themes: engines', function () {
                 'ghost-api': 'v0.1'
             });
         });
+
+        it('canary', function () {
+            const engines = themeEngines.create({
+                engines: {
+                    'ghost-api': 'canary'
+                }
+            });
+
+            engines.should.eql({
+                'ghost-api': 'canary'
+            });
+        });
     });
 });

--- a/core/test/unit/web/api/canary/content/middleware_spec.js
+++ b/core/test/unit/web/api/canary/content/middleware_spec.js
@@ -1,0 +1,17 @@
+const should = require('should');
+const middleware = require('../../../../../../server/web/api/canary/content/middleware');
+
+describe('Content Api canary middleware', function () {
+    it('exports an authenticatePublic middleware', function () {
+        should.exist(middleware.authenticatePublic);
+    });
+
+    describe('authenticatePublic', function () {
+        it('uses brute content api middleware as the first middleware in the chain', function () {
+            const firstMiddleware = middleware.authenticatePublic[0];
+            const brute = require('../../../../../../server/web/shared/middlewares/brute');
+
+            should.equal(firstMiddleware, brute.contentApiKey);
+        });
+    });
+});

--- a/core/test/unit/web/middleware/uncapitalise_spec.js
+++ b/core/test/unit/web/middleware/uncapitalise_spec.js
@@ -125,7 +125,7 @@ describe('Middleware: uncapitalise', function () {
     });
 
     describe('An API request', function () {
-        ['v0.1', 'v2', 'v10'].forEach((apiVersion) => {
+        ['v0.1', 'v2', 'canary', 'v10'].forEach((apiVersion) => {
             describe(`for ${apiVersion}`, function () {
                 it('does nothing if there are no capitals', function (done) {
                     req.path = `/ghost/api/${apiVersion}/endpoint/`;


### PR DESCRIPTION
Adds new canary api endpoint based on existing v2 api
### TODO

- [x] Fix theme engine create method to work for canary
- [x] Fix admin_key auth to work with dynamic audience based on url
- [x] Add updated scheduler controller
- [x] Add updated db backup logic
- [x] Add canary unit tests
- [x] Add canary regression tests
- [x] Update capitalise logic for canary