### PR TITLE
🐛Fix generic 500 response

### DIFF
--- a/core/server/services/auth/api-key/content.js
+++ b/core/server/services/auth/api-key/content.js
@@ -7,6 +7,13 @@ const authenticateContentApiKey = function authenticateContentApiKey(req, res, n
         return next();
     }
 
+    if (req.query.key.constructor === Array) {
+        return next(new common.errors.BadRequestError({
+            message: common.i18n.t('errors.middleware.auth.invalidRequest'),
+            code: 'INVALID_REQUEST'
+        }));
+    }
+
     let key = req.query.key;
 
     models.ApiKey.findOne({secret: key}).then((apiKey) => {

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -75,6 +75,7 @@
                 "unknownContentApiKey": "Unknown Content API Key",
                 "adminApiKidMissing": "Admin API kid missing.",
                 "invalidApiKeyType": "Invalid API Key type",
+                "invalidRequest": "Invalid Request",
                 "invalidToken": "Invalid token",
                 "invalidTokenWithMessage": "Invalid token: {message}",
                 "incorrectAuthHeaderFormat": "Authorization header format is \"Authorization: Ghost [token]\""

--- a/core/test/regression/api/v2/content/posts_spec.js
+++ b/core/test/regression/api/v2/content/posts_spec.js
@@ -154,4 +154,13 @@ describe('Posts', function () {
                 localUtils.API.checkResponse(res.body.posts[0], 'post', null, null, ['id', 'title', 'slug']);
             });
     });
+
+    it('can\'t read page with multiple keys', function () {
+        return request
+            .get(localUtils.API.getApiQuery(`posts?key=${validKey}&key=&fields=title,slug`))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(400);
+    });
 });

--- a/core/test/unit/services/auth/api-key/content_spec.js
+++ b/core/test/unit/services/auth/api-key/content_spec.js
@@ -78,4 +78,21 @@ describe('Content API Key Auth', function () {
             done();
         });
     });
+
+    it('shouldn\'t authenticate with invalid request', function (done) {
+        const req = {
+            query: {
+                key: [this.fakeApiKey.secret, '']
+            }
+        };
+        const res = {};
+
+        authenticateContentApiKey(req, res, function next(err) {
+            should.exist(err);
+            should.equal(err instanceof common.errors.BadRequestError, true);
+            err.code.should.eql('INVALID_REQUEST');
+            should.not.exist(req.api_key);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
closes #10948 

- Throws 400 when request has multiple key-query values