### PR TITLE
Added missing db.backupContent permission

### DIFF
--- a/core/server/data/migrations/versions/2.28/1-add-db-backup-content-permission.js
+++ b/core/server/data/migrations/versions/2.28/1-add-db-backup-content-permission.js
@@ -1,0 +1,61 @@
+const logging = require('../../../../lib/common/logging');
+const models = require('../../../../models');
+const utils = require('../../../schema/fixtures/utils');
+
+const fixtureBackupContentPerm = utils.findModelFixtureEntry('Permission', {
+    object_type: 'db',
+    action_type: 'backupContent'
+});
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up(options) {
+        try {
+            const existingBackupContentPerm = await models.Permission.findOne(
+                fixtureBackupContentPerm,
+                options
+            );
+
+            if (existingBackupContentPerm) {
+                return logging.warn('Issue adding db.backupContent (already exists)');
+            }
+
+            const result = await utils.addFixturesForModel({
+                name: 'Permission',
+                entries: [fixtureBackupContentPerm]
+            }, options);
+
+            const success = result.done === result.expected;
+
+            if (!success) {
+                return logging.warn('Issue adding db.backupContent permission (did not insert)');
+            }
+
+            return logging.info('Completed adding db.backupContent permission');
+        } catch (err) {
+            return logging.error('Errored when adding db.backupContent permission');
+        }
+    },
+
+    async down(options) {
+        try {
+            const existingBackupContentPerm = await models.Permission.findOne(
+                fixtureBackupContentPerm,
+                options
+            );
+
+            if (!existingBackupContentPerm) {
+                return logging.warn('Issue removing db.backupContent (already removed)');
+            }
+
+            await existingBackupContentPerm.destroy(options);
+
+            return logging.info('Completed removing db.backupContent permission');
+        } catch (err) {
+            return logging.error('Errored when removing db.backupContent permission');
+        }
+    }
+};

--- a/core/server/data/migrations/versions/2.28/2-add-db-backup-content-permission-to-roles.js
+++ b/core/server/data/migrations/versions/2.28/2-add-db-backup-content-permission-to-roles.js
@@ -1,0 +1,46 @@
+const logging = require('../../../../lib/common/logging');
+const utils = require('../../../schema/fixtures/utils');
+
+const relationFixtures = {
+    from: {
+        model: 'Role',
+        match: 'name',
+        relation: 'permissions'
+    },
+    to: {
+        model: 'Permission',
+        match: ['object_type', 'action_type']
+    },
+    entries: {
+        Administrator: {
+            db: 'backupContent'
+        },
+        'DB Backup Integration': {
+            db: 'backupContent'
+        }
+    }
+};
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up(options) {
+        try {
+            await utils.addFixturesForRelation(relationFixtures, options);
+            return logging.info('Completed adding db.backupContent permission to roles');
+        } catch (err) {
+            return logging.warn('Issue adding db.backupContent permission to roles');
+        }
+    },
+
+    async down(options) {
+        try {
+            await utils.removeFixturesForRelation(relationFixtures, options);
+            return logging.info('Completed removing db.backupContent permission from roles');
+        } catch (err) {
+            return logging.warn('Issue removing db.backupContent permission from roles');
+        }
+    }
+};

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -77,6 +77,11 @@
             "name": "Permission",
             "entries": [
                 {
+                    "name": "Backup database",
+                    "action_type": "backupContent",
+                    "object_type": "db"
+                },
+                {
                     "name": "Export database",
                     "action_type": "exportContent",
                     "object_type": "db"

--- a/core/server/web/api/v2/admin/middleware.js
+++ b/core/server/web/api/v2/admin/middleware.js
@@ -53,17 +53,3 @@ module.exports.authAdminApi = [
     shared.middlewares.prettyUrls,
     notImplemented
 ];
-
-/**
- * Authentication for client endpoints
- */
-module.exports.authenticateClient = function authenticateClient(client) {
-    return [
-        auth.authenticate.authenticateClient,
-        auth.authenticate.authenticateUser,
-        auth.authorize.requiresAuthorizedClient(client),
-        shared.middlewares.api.cors,
-        shared.middlewares.urlRedirects.adminRedirect,
-        shared.middlewares.prettyUrls
-    ];
-};

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -159,7 +159,7 @@ module.exports = function apiRoutes() {
     );
     router.del('/db', mw.authAdminApi, http(apiv2.db.deleteAllContent));
     router.post('/db/backup',
-        mw.authenticateClient('Ghost Backup'),
+        mw.authAdminApi,
         http(apiv2.db.backupContent)
     );
 

--- a/core/test/unit/data/schema/fixtures/utils_spec.js
+++ b/core/test/unit/data/schema/fixtures/utils_spec.js
@@ -258,10 +258,10 @@ describe('Migration Fixture Utils', function () {
         it('should fetch a fixture with multiple entries', function () {
             var foundFixture = fixtureUtils.findModelFixtures('Permission', {object_type: 'db'});
             foundFixture.should.be.an.Object();
-            foundFixture.entries.should.be.an.Array().with.lengthOf(3);
+            foundFixture.entries.should.be.an.Array().with.lengthOf(4);
             foundFixture.entries[0].should.eql({
-                name: 'Export database',
-                action_type: 'exportContent',
+                name: 'Backup database',
+                action_type: 'backupContent',
                 object_type: 'db'
             });
         });

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -20,7 +20,7 @@ var should = require('should'),
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'fda0398e93a74b2dc435cb4c026679ba';
-    const currentFixturesHash = '06771caf35c48fd69cb209a988237c33';
+    const currentFixturesHash = 'c61a52e138abb31de3a58c7728ca3d79';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
We were missing the backupContent permission for the db object. This PR adds it to both the Administrator and the Ghost Backup roles.