### PR TITLE
Excluded `mobiledoc_revisions` table from exports

### DIFF
--- a/core/server/data/exporter/index.js
+++ b/core/server/data/exporter/index.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
     common = require('../../lib/common'),
     security = require('../../lib/security'),
     models = require('../../models'),
-    EXCLUDED_TABLES = ['accesstokens', 'refreshtokens', 'clients', 'client_trusted_domains', 'sessions'],
+    EXCLUDED_TABLES = ['accesstokens', 'refreshtokens', 'clients', 'client_trusted_domains', 'sessions', 'mobiledoc_revisions'],
     EXCLUDED_FIELDS_CONDITIONS = {
         settings: [{
             operator: 'whereNot',

--- a/core/test/acceptance/old/admin/db_spec.js
+++ b/core/test/acceptance/old/admin/db_spec.js
@@ -66,7 +66,7 @@ describe('DB API', () => {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(26);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(25);
             });
     });
 


### PR DESCRIPTION
no issue

- the `mobiledoc_revisions` table can grow very large in certain circumstances which can result in Out-Of-Memory errors when performing backups, resulting in failed upgrades
- adds `mobiledoc_revisions` to the exporter excluded tables list as a temporary solution until we have safer export creation and/or improved revision handling