### PR TITLE
DB backup regression test fixes

### DIFF
--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -81,11 +81,6 @@
             "name": "Permission",
             "entries": [
                 {
-                    "name": "Backup database",
-                    "action_type": "backupContent",
-                    "object_type": "db"
-                },
-                {
                     "name": "Export database",
                     "action_type": "exportContent",
                     "object_type": "db"
@@ -439,6 +434,11 @@
                     "name": "Publish posts",
                     "action_type": "publish",
                     "object_type": "post"
+                },
+                {
+                    "name": "Backup database",
+                    "action_type": "backupContent",
+                    "object_type": "db"
                 }
             ]
         },

--- a/core/server/web/api/v2/admin/middleware.js
+++ b/core/server/web/api/v2/admin/middleware.js
@@ -22,7 +22,8 @@ const notImplemented = function (req, res, next) {
         subscribers: ['GET', 'PUT', 'DELETE', 'POST'],
         config: ['GET'],
         webhooks: ['POST', 'DELETE'],
-        schedules: ['PUT']
+        schedules: ['PUT'],
+        db: ['POST']
     };
 
     const match = req.url.match(/^\/(\w+)\/?/);

--- a/core/test/regression/migrations/migration_spec.js
+++ b/core/test/regression/migrations/migration_spec.js
@@ -209,6 +209,10 @@ describe('Database Migration (special functions)', function () {
             // Posts
             permissions[70].name.should.eql('Publish posts');
             permissions[70].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration', 'Scheduler Integration']);
+
+            // DB
+            permissions[71].name.should.eql('Backup database');
+            permissions[71].should.be.AssignedToRoles(['Administrator', 'DB Backup Integration']);
         });
 
         describe('Populate', function () {

--- a/core/test/unit/data/schema/fixtures/utils_spec.js
+++ b/core/test/unit/data/schema/fixtures/utils_spec.js
@@ -260,6 +260,11 @@ describe('Migration Fixture Utils', function () {
             foundFixture.should.be.an.Object();
             foundFixture.entries.should.be.an.Array().with.lengthOf(4);
             foundFixture.entries[0].should.eql({
+                name: 'Export database',
+                action_type: 'exportContent',
+                object_type: 'db'
+            });
+            foundFixture.entries[3].should.eql({
                 name: 'Backup database',
                 action_type: 'backupContent',
                 object_type: 'db'

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -20,7 +20,7 @@ var should = require('should'),
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'fda0398e93a74b2dc435cb4c026679ba';
-    const currentFixturesHash = 'd0ee1deaea406f78e1f2145384196b48';
+    const currentFixturesHash = 'c7b485fe2f16517295bd35c761129729';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -1027,7 +1027,7 @@ startGhost = function startGhost(options) {
                 .then((tags) => {
                     module.exports.existingData.tags = tags.toJSON();
 
-                    return models.ApiKey.findAll({columns: ['id', 'secret']});
+                    return models.ApiKey.findAll({withRelated: 'integration'});
                 })
                 .then((keys) => {
                     module.exports.existingData.apiKeys = keys.toJSON();


### PR DESCRIPTION
no issue 

@allouis this should fix currently failing regression suites. Had to put db permission in a different order to avoid too many unnecessary changes in the test suite (would need to update all the lookups). Also allowed making requests to `POST /db/backup` which I'm almost sure had to be put in place :grimacing: Feel free to reshuffle/merge this stuff in case you need to continue your integration with backup service :wink: 	