### PR TITLE
🐛 Fixed duplication error when importing posts without slugs

### DIFF
--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -200,7 +200,7 @@ class PostsImporter extends BaseImporter {
         // For any further future duplication detection, see https://github.com/TryGhost/Ghost/issues/8717.
         let slugs = [];
         this.dataToImport = _.filter(this.dataToImport, (post) => {
-            if (slugs.indexOf(post.slug) !== -1) {
+            if (!!post.slug && slugs.indexOf(post.slug) !== -1) {
                 this.problems.push({
                     message: 'Entry was not imported and ignored. Detected duplicated entry.',
                     help: this.modelName,

--- a/core/test/regression/importer/importer_spec.js
+++ b/core/test/regression/importer/importer_spec.js
@@ -252,6 +252,31 @@ describe('Integration: Importer', function () {
                 });
         });
 
+        it('does not treat posts without slug as duplicate', function () {
+            let exportData = exportedLatestBody().db[0];
+
+            exportData.data.posts[0] = {
+                title: "duplicate title"
+            };
+
+            exportData.data.posts[1] = {
+                title: "duplicate title"
+            };
+
+            return dataImporter.doImport(exportData, importOptions)
+                .then(function (importResult) {
+                    should.exist(importResult.data.posts);
+                    importResult.data.posts.length.should.equal(2);
+                    importResult.problems.length.should.eql(0);
+
+                    importResult.data.posts[0].title.should.equal('duplicate title');
+                    importResult.data.posts[1].title.should.equal('duplicate title');
+
+                    importResult.data.posts[0].slug.should.equal('duplicate-title');
+                    importResult.data.posts[1].slug.should.equal('duplicate-title-2');
+                });
+        });
+
         it('can import user with missing allowed fields', function () {
             let exportData = exportedLatestBody().db[0];
 


### PR DESCRIPTION
refs #8717

@ErisDS duplicate detection won't take into account posts without slugs. This would allow importing all of the posts with just titles and allow generating slugs on the model layer. Let me know if such behavior makes sense for now?