### PR TITLE
Added image_sizes configuration to /settings endpoint

### DIFF
--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -92,6 +92,12 @@ module.exports = {
                             message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                         }));
                     }
+
+                    if (setting.key === 'image_sizes' && !(frame.options.context && frame.options.context.internal)) {
+                        errors.push(new common.errors.NoPermissionError({
+                            message: common.i18n.t('errors.api.settings.noPermissionToEditSettings')
+                        }));
+                    }
                 });
 
                 if (errors.length) {

--- a/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
@@ -73,6 +73,20 @@ module.exports.forSettings = (attrs, frame) => {
             ghostFoot.key = 'codeinjection_foot';
             attrs.push(ghostFoot);
         }
+
+        const imageSizes = _.find(attrs, {key: 'image_sizes'});
+
+        if (imageSizes && imageSizes.value) {
+            const sizes = JSON.parse(imageSizes.value);
+
+            Object.keys(sizes).forEach((key) => {
+                if (sizes[key].type !== 'core') {
+                    sizes[key].type = 'api';
+                }
+            });
+
+            imageSizes.value = JSON.stringify(sizes);
+        }
     } else {
         attrs.codeinjection_head = attrs.ghost_head;
         attrs.codeinjection_foot = attrs.ghost_foot;

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -92,6 +92,12 @@ module.exports = {
                             message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                         }));
                     }
+
+                    if (setting.key === 'image_sizes' && !(frame.options.context && frame.options.context.internal)) {
+                        errors.push(new common.errors.NoPermissionError({
+                            message: common.i18n.t('errors.api.settings.noPermissionToEditSettings')
+                        }));
+                    }
                 });
 
                 if (errors.length) {

--- a/core/server/api/v2/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/v2/utils/serializers/output/utils/extra-attrs.js
@@ -73,6 +73,20 @@ module.exports.forSettings = (attrs, frame) => {
             ghostFoot.key = 'codeinjection_foot';
             attrs.push(ghostFoot);
         }
+
+        const imageSizes = _.find(attrs, {key: 'image_sizes'});
+
+        if (imageSizes && imageSizes.value) {
+            const sizes = JSON.parse(imageSizes.value);
+
+            Object.keys(sizes).forEach((key) => {
+                if (sizes[key].type !== 'core') {
+                    sizes[key].type = 'api';
+                }
+            });
+
+            imageSizes.value = JSON.stringify(sizes);
+        }
     } else {
         attrs.codeinjection_head = attrs.ghost_head;
         attrs.codeinjection_foot = attrs.ghost_foot;

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -163,6 +163,9 @@
                     "max": 300
                 }
             }
+        },
+        "image_sizes": {
+            "defaultValue": "{\"publisher_logo\":{\"width\":600,\"height\":60,\"type\":\"core\"},\"amp_feature_image\":{\"width\":600,\"height\":400,\"type\":\"core\"}}"
         }
     },
     "theme": {

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -127,6 +127,16 @@ Settings = ghostBookshelf.Model.extend({
             }
         });
 
+        // CASE: "theme" type overrides ALL previous "theme" sizes
+        const hasThemeSizes = !!(_.find(parsedIncoming, {type: 'theme'}));
+        if (hasThemeSizes) {
+            Object.keys(parsedOriginal).forEach((key) => {
+                if (parsedOriginal[key].type === 'theme'){
+                    delete parsedOriginal[key];
+                }
+            });
+        }
+
         Object.keys(parsedOriginal).forEach((key) => {
             if (parsedOriginal[key].type !== 'core' && parsedIncoming[key]){
                 delete parsedOriginal[key];

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -115,6 +115,21 @@ Settings = ghostBookshelf.Model.extend({
             });
     },
 
+    mergeImageSizes: function mergeImageSizes(original, attrs) {
+        const parsedOriginal = JSON.parse(original);
+        const parsedIncoming = JSON.parse(attrs);
+        let merged;
+
+        Object.keys(parsedOriginal).forEach((key) => {
+            if (parsedOriginal[key].type !== 'core' && parsedIncoming[key]){
+                delete parsedOriginal[key];
+            }
+        });
+
+        merged = Object.assign({}, parsedIncoming, parsedOriginal);
+        return JSON.stringify(merged);
+    },
+
     format() {
         const attrs = ghostBookshelf.Model.prototype.format.apply(this, arguments);
 
@@ -182,7 +197,13 @@ Settings = ghostBookshelf.Model.extend({
                     } else {
                         // If we have a value, set it.
                         if (Object.prototype.hasOwnProperty.call(item, 'value')) {
-                            setting.set('value', item.value);
+                            let value = item.value;
+
+                            if (setting.get('key') === 'image_sizes') {
+                                value = this.mergeImageSizes(setting.get('value'), value);
+                            }
+
+                            setting.set('value', value);
                         }
                         // Internal context can overwrite type (for fixture migrations)
                         if (options.context && options.context.internal && Object.prototype.hasOwnProperty.call(item, 'type')) {

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -120,7 +120,7 @@ Settings = ghostBookshelf.Model.extend({
         const parsedIncoming = JSON.parse(attrs);
         let merged;
 
-        // don't allow modifications with "core" sizes
+        // CASE: don't allow modifications to "core" sizes
         Object.keys(parsedIncoming).forEach((key) => {
             if (parsedIncoming[key].type === 'core'){
                 delete parsedIncoming[key];

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -120,6 +120,13 @@ Settings = ghostBookshelf.Model.extend({
         const parsedIncoming = JSON.parse(attrs);
         let merged;
 
+        // don't allow modifications with "core" sizes
+        Object.keys(parsedIncoming).forEach((key) => {
+            if (parsedIncoming[key].type === 'core'){
+                delete parsedIncoming[key];
+            }
+        });
+
         Object.keys(parsedOriginal).forEach((key) => {
             if (parsedOriginal[key].type !== 'core' && parsedIncoming[key]){
                 delete parsedOriginal[key];

--- a/core/server/services/settings/public.js
+++ b/core/server/services/settings/public.js
@@ -26,5 +26,6 @@ module.exports = {
     og_description: 'og_description',
     twitter_image: 'twitter_image',
     twitter_title: 'twitter_title',
-    twitter_description: 'twitter_description'
+    twitter_description: 'twitter_description',
+    image_sizes: 'image_sizes'
 };

--- a/core/test/acceptance/old/content/settings_spec.js
+++ b/core/test/acceptance/old/content/settings_spec.js
@@ -43,7 +43,7 @@ describe('Settings Content API', function () {
 
                 // Verify we have the right keys for settings
                 settings.should.have.properties(_.values(publicSettings));
-                Object.keys(settings).length.should.equal(23);
+                Object.keys(settings).length.should.equal(24);
 
                 // Verify that we are returning the defaults for each value
                 _.forEach(settings, (value, key) => {
@@ -72,7 +72,7 @@ describe('Settings Content API', function () {
                     // Convert empty strings to null
                     defaultValue = defaultValue || null;
 
-                    if (defaultKey === 'navigation') {
+                    if (defaultKey === 'navigation' || defaultKey === 'image_sizes') {
                         defaultValue = JSON.parse(defaultValue);
                     }
 

--- a/core/test/regression/api/canary/admin/settings_spec.js
+++ b/core/test/regression/api/canary/admin/settings_spec.js
@@ -25,7 +25,7 @@ describe('Settings API', function () {
         return ghostServer.stop();
     });
 
-    it('Can\'t read core setting', function () {
+    it('can\'t read core setting', function () {
         return request
             .get(localUtils.API.getApiQuery('settings/db_hash/'))
             .set('Origin', config.get('url'))
@@ -34,7 +34,7 @@ describe('Settings API', function () {
             .expect(403);
     });
 
-    it('Can\'t read permalinks', function (done) {
+    it('can\'t read permalinks', function (done) {
         request.get(localUtils.API.getApiQuery('settings/permalinks/'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
@@ -145,6 +145,36 @@ describe('Settings API', function () {
             });
     });
 
+    it('can read default image_sizes', function (done) {
+        request.get(localUtils.API.getApiQuery('settings/image_sizes/'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                var jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.settings);
+
+                const imageSizesJSON = JSON.parse(jsonResponse.settings[0].value);
+
+                Object.keys(imageSizesJSON).length.should.equal(8);
+                // core image sizes
+                should.exist(imageSizesJSON.publisher_logo);
+                should.exist(imageSizesJSON.amp_feature_image);
+
+                // casper image sizes
+                should.exist(imageSizesJSON.s);
+                should.exist(imageSizesJSON.xs);
+
+                done();
+            });
+    });
+
     it('can\'t edit image_sizes', function (done) {
         request.get(localUtils.API.getApiQuery('settings/'))
             .set('Origin', config.get('url'))
@@ -192,7 +222,7 @@ describe('Settings API', function () {
             });
     });
 
-    it('Will transform "1"', function (done) {
+    it('will transform "1"', function (done) {
         request.get(localUtils.API.getApiQuery('settings/'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)

--- a/core/test/regression/api/canary/admin/settings_spec.js
+++ b/core/test/regression/api/canary/admin/settings_spec.js
@@ -163,6 +163,7 @@ describe('Settings API', function () {
                 const imageSizesJSON = JSON.parse(jsonResponse.settings[0].value);
 
                 Object.keys(imageSizesJSON).length.should.equal(8);
+
                 // core image sizes
                 should.exist(imageSizesJSON.publisher_logo);
                 should.exist(imageSizesJSON.amp_feature_image);
@@ -170,6 +171,15 @@ describe('Settings API', function () {
                 // casper image sizes
                 should.exist(imageSizesJSON.s);
                 should.exist(imageSizesJSON.xs);
+
+                // TODO: image sizes should be checked by 'checkObject' test helper
+                imageSizesJSON.publisher_logo.width.should.equal(600);
+                imageSizesJSON.publisher_logo.height.should.equal(60);
+                imageSizesJSON.publisher_logo.type.should.equal('core');
+
+                imageSizesJSON.s.width.should.equal(300);
+                should.not.exist(imageSizesJSON.s.height);
+                imageSizesJSON.s.type.should.equal('api');
 
                 done();
             });

--- a/core/test/regression/api/v2/admin/settings_spec.js
+++ b/core/test/regression/api/v2/admin/settings_spec.js
@@ -25,7 +25,7 @@ describe('Settings API', function () {
         return ghostServer.stop();
     });
 
-    it('Can\'t read core setting', function () {
+    it('can\'t read core setting', function () {
         return request
             .get(localUtils.API.getApiQuery('settings/db_hash/'))
             .set('Origin', config.get('url'))
@@ -34,7 +34,7 @@ describe('Settings API', function () {
             .expect(403);
     });
 
-    it('Can\'t read permalinks', function (done) {
+    it('can\'t read permalinks', function (done) {
         request.get(localUtils.API.getApiQuery('settings/permalinks/'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
@@ -145,6 +145,36 @@ describe('Settings API', function () {
             });
     });
 
+    it('can read default image_sizes', function (done) {
+        request.get(localUtils.API.getApiQuery('settings/image_sizes/'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                var jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.settings);
+
+                const imageSizesJSON = JSON.parse(jsonResponse.settings[0].value);
+
+                Object.keys(imageSizesJSON).length.should.equal(8);
+                // core image sizes
+                should.exist(imageSizesJSON.publisher_logo);
+                should.exist(imageSizesJSON.amp_feature_image);
+
+                // casper image sizes
+                should.exist(imageSizesJSON.s);
+                should.exist(imageSizesJSON.xs);
+
+                done();
+            });
+    });
+
     it('can\'t edit image_sizes', function (done) {
         request.get(localUtils.API.getApiQuery('settings/'))
             .set('Origin', config.get('url'))
@@ -192,7 +222,7 @@ describe('Settings API', function () {
             });
     });
 
-    it('Will transform "1"', function (done) {
+    it('will transform "1"', function (done) {
         request.get(localUtils.API.getApiQuery('settings/'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)

--- a/core/test/regression/api/v2/admin/settings_spec.js
+++ b/core/test/regression/api/v2/admin/settings_spec.js
@@ -163,6 +163,7 @@ describe('Settings API', function () {
                 const imageSizesJSON = JSON.parse(jsonResponse.settings[0].value);
 
                 Object.keys(imageSizesJSON).length.should.equal(8);
+
                 // core image sizes
                 should.exist(imageSizesJSON.publisher_logo);
                 should.exist(imageSizesJSON.amp_feature_image);
@@ -170,6 +171,15 @@ describe('Settings API', function () {
                 // casper image sizes
                 should.exist(imageSizesJSON.s);
                 should.exist(imageSizesJSON.xs);
+
+                // TODO: image sizes should be checked by 'checkObject' test helper
+                imageSizesJSON.publisher_logo.width.should.equal(600);
+                imageSizesJSON.publisher_logo.height.should.equal(60);
+                imageSizesJSON.publisher_logo.type.should.equal('core');
+
+                imageSizesJSON.s.width.should.equal(300);
+                should.not.exist(imageSizesJSON.s.height);
+                imageSizesJSON.s.type.should.equal('api');
 
                 done();
             });

--- a/core/test/regression/api/v2/admin/themes_spec.js
+++ b/core/test/regression/api/v2/admin/themes_spec.js
@@ -1,0 +1,53 @@
+const _ = require('lodash');
+const should = require('should');
+const supertest = require('supertest');
+const config = require('../../../../../server/config');
+const testUtils = require('../../../../utils');
+const localUtils = require('./utils');
+const ghost = testUtils.startGhost;
+
+describe('Themes API', function () {
+    let request;
+
+    before(function () {
+        return ghost();
+    });
+
+    before(function () {
+        request = supertest.agent(config.get('url'));
+        return localUtils.doAuth(request);
+    });
+
+    it('Activating a v2 theme reads in image_size settings', function () {
+        return request
+            .put(localUtils.API.getApiQuery('themes/test-theme/activate'))
+            .set('Origin', config.get('url'))
+            .expect(200)
+            .then(() => {
+                return testUtils.integrationTesting.urlService.waitTillFinished();
+            })
+            .then(() => {
+                return request
+                    .get(localUtils.API.getApiQuery('settings/image_sizes/'))
+                    .set('Origin', config.get('url'))
+                    .expect(200);
+            })
+            .then((res) => {
+                const jsonResponse = res.body;
+                should.exist(jsonResponse.settings);
+                should.exist(jsonResponse.settings[0]);
+                jsonResponse.settings[0].key.should.equal('image_sizes');
+
+                const imageSizesJSON = JSON.parse(jsonResponse.settings[0].value);
+
+                Object.keys(imageSizesJSON).length.should.equal(4);
+                // core image sizes
+                should.exist(imageSizesJSON.publisher_logo);
+                should.exist(imageSizesJSON.amp_feature_image);
+
+                // just loaded image sizes
+                should.exist(imageSizesJSON.test_theme_s);
+                should.exist(imageSizesJSON.test_theme_xs);
+            });
+    });
+});

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -217,5 +217,28 @@ describe('Unit: models/settings', function () {
 
             should.equal(merged, defaultSettings);
         });
+
+        it('incoming "theme" values should overwrite all existing "theme" values', function () {
+            const setting = models.Settings.forge();
+            const existingThemeValue = JSON.stringify({xl: {width: 2000, type: 'theme'}});
+            const incomingThemeValue = JSON.stringify({m: {width: 333, type: 'theme'}});
+
+            const merged = setting.mergeImageSizes(existingThemeValue, incomingThemeValue);
+
+            should.equal(merged, incomingThemeValue);
+        });
+
+        it('existing "theme" values stay untouched if no new "theme" values are incoming', function () {
+            const setting = models.Settings.forge();
+            const existingThemeValue = {xl: {width: 2000, type: 'theme'}};
+            const incomingThemeValue = {m: {width: 333, type: 'api'}};
+
+            const merged = setting.mergeImageSizes(JSON.stringify(existingThemeValue), JSON.stringify(incomingThemeValue));
+
+            should.equal(merged, JSON.stringify({
+                m: {width: 333, type: 'api'},
+                xl: {width: 2000, type: 'theme'}
+            }));
+        });
     });
 });

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -208,5 +208,14 @@ describe('Unit: models/settings', function () {
 
             should.equal(merged, incomingNonCoreValue);
         });
+
+        it('incoming values should not be able to define new "core" values', function () {
+            const setting = models.Settings.forge();
+            const incomingNonCoreValue = JSON.stringify({xl: {width: 333, type: 'core'}});
+
+            const merged = setting.mergeImageSizes(defaultSettings, incomingNonCoreValue);
+
+            should.equal(merged, defaultSettings);
+        });
     });
 });

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -113,7 +113,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(78);
+                    eventSpy.callCount.should.equal(80);
 
                     eventSpy.args[1][0].should.equal('settings.db_hash.added');
                     eventSpy.args[1][1].attributes.type.should.equal('core');
@@ -122,7 +122,10 @@ describe('Unit: models/settings', function () {
                     eventSpy.args[13][1].attributes.type.should.equal('blog');
                     eventSpy.args[13][1].attributes.value.should.equal('The professional publishing platform');
 
-                    eventSpy.args[77][0].should.equal('settings.members_subscription_settings.added');
+                    eventSpy.args[62][0].should.equal('settings.added');
+                    eventSpy.args[62][1].attributes.key.should.equal('image_sizes');
+
+                    eventSpy.args[79][0].should.equal('settings.members_subscription_settings.added');
                 });
         });
 
@@ -136,7 +139,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(76);
+                    eventSpy.callCount.should.equal(78);
 
                     eventSpy.args[13][0].should.equal('settings.logo.added');
                 });

--- a/core/test/utils/fixtures/themes/casper/package.json
+++ b/core/test/utils/fixtures/themes/casper/package.json
@@ -4,7 +4,8 @@
     "demo": "https://demo.ghost.io",
     "version": "2.4.2",
     "engines": {
-        "ghost": ">=2.0.0"
+        "ghost": ">=2.0.0",
+        "ghost-api": "v2"
     },
     "license": "MIT",
     "screenshots": {
@@ -52,6 +53,26 @@
         "postcss-easy-import": "1.0.1"
     },
     "config": {
-        "posts_per_page": 25
+        "posts_per_page": 25,
+        "image_sizes": {
+            "xxs": {
+                "width": 30
+            },
+            "xs": {
+                "width": 100
+            },
+            "s": {
+                "width": 300
+            },
+            "m": {
+                "width": 600
+            },
+            "l": {
+                "width": 1000
+            },
+            "xl": {
+                "width": 2000
+            }
+        }
     }
 }

--- a/core/test/utils/fixtures/themes/test-theme/package.json
+++ b/core/test/utils/fixtures/themes/test-theme/package.json
@@ -4,7 +4,8 @@
     "demo": "https://demo.ghost.io",
     "version": "2.4.2",
     "engines": {
-        "ghost": ">=2.0.0"
+        "ghost": ">=2.0.0",
+        "ghost-api": "v2"
     },
     "license": "MIT",
     "screenshots": {
@@ -52,6 +53,14 @@
         "postcss-easy-import": "1.0.1"
     },
     "config": {
-        "posts_per_page": 25
+        "posts_per_page": 25,
+        "image_sizes": {
+            "test_theme_s": {
+                "width": 33
+            },
+            "test_theme_xs": {
+                "width": 111
+            }
+        }
     }
 }


### PR DESCRIPTION
@allouis it's a heavy WIP but the skeleton of what's going to be introduced in terms of `image_sizes` is there. Let me know if you have any clarification questions or feedback on the approach so far. More to come tomorrow morning :wink: 

TODO:
- [x] Intoduce public property `image_sizes` in `/settings` endpoint for v2/canary Admin/Content APIs
- [x] Internal API accessible only by theme layer to load image_sizes
- [x] `image_sizes` fixtures for settings
- [x] Prevent from editting "core" sizes
- [ ] Flushing of old image_size configuration when theme is reloaded (:warning: check if we should flush out image_sizes when loaded theme doesn't contain any configuration)
- [ ] Use site.config.image_sizes in theme helpers instead of theme config
- [ ] Finalize which sizes go into "core"
- [ ] Migrations for "core" image_size values  in settings table
- [ ] Check context internal use pointed out in https://github.com/TryGhost/Ghost/pull/11007#discussion_r313185881