### PR TITLE
✨ Exposed image_sizes through Content API /settings endpoint

### DIFF
--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -92,6 +92,12 @@ module.exports = {
                             message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                         }));
                     }
+
+                    if (setting.key === 'image_sizes') {
+                        errors.push(new common.errors.NoPermissionError({
+                            message: common.i18n.t('errors.api.settings.noPermissionToEditSettings')
+                        }));
+                    }
                 });
 
                 if (errors.length) {

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -92,6 +92,12 @@ module.exports = {
                             message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                         }));
                     }
+
+                    if (setting.key === 'image_sizes') {
+                        errors.push(new common.errors.NoPermissionError({
+                            message: common.i18n.t('errors.api.settings.noPermissionToEditSettings')
+                        }));
+                    }
                 });
 
                 if (errors.length) {

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -163,6 +163,9 @@
                     "max": 300
                 }
             }
+        },
+        "image_sizes": {
+            "defaultValue": "{\"amp_publisher_logo\":{\"width\":600,\"height\":60,\"type\":\"core\"},\"amp_feature_image\":{\"width\":600,\"height\":400,\"type\":\"core\"}}"
         }
     },
     "theme": {

--- a/core/server/services/settings/public.js
+++ b/core/server/services/settings/public.js
@@ -26,5 +26,6 @@ module.exports = {
     og_description: 'og_description',
     twitter_image: 'twitter_image',
     twitter_title: 'twitter_title',
-    twitter_description: 'twitter_description'
+    twitter_description: 'twitter_description',
+    image_sizes: 'image_sizes'
 };

--- a/core/test/acceptance/old/content/settings_spec.js
+++ b/core/test/acceptance/old/content/settings_spec.js
@@ -43,7 +43,7 @@ describe('Settings Content API', function () {
 
                 // Verify we have the right keys for settings
                 settings.should.have.properties(_.values(publicSettings));
-                Object.keys(settings).length.should.equal(23);
+                Object.keys(settings).length.should.equal(24);
 
                 // Verify that we are returning the defaults for each value
                 _.forEach(settings, (value, key) => {
@@ -72,7 +72,7 @@ describe('Settings Content API', function () {
                     // Convert empty strings to null
                     defaultValue = defaultValue || null;
 
-                    if (defaultKey === 'navigation') {
+                    if (defaultKey === 'navigation' || defaultKey === 'image_sizes') {
                         defaultValue = JSON.parse(defaultValue);
                     }
 

--- a/core/test/regression/api/canary/admin/settings_spec.js
+++ b/core/test/regression/api/canary/admin/settings_spec.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const should = require('should');
 const supertest = require('supertest');
 const config = require('../../../../../server/config');
@@ -75,6 +76,53 @@ describe('Settings API', function () {
                     'id'
                 ]);
                 done();
+            });
+    });
+
+    it('can\'t edit image_sizes', function (done) {
+        request.get(localUtils.API.getApiQuery('settings/'))
+            .set('Origin', config.get('url'))
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                var jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.settings);
+                should.exist(_.find(jsonResponse.settings, {key: 'image_sizes'}));
+
+                jsonResponse.settings = [{key: 'image_sizes', value: 'test value'}];
+
+                request.put(localUtils.API.getApiQuery('settings/'))
+                    .set('Origin', config.get('url'))
+                    .send(jsonResponse)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(403)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        jsonResponse = res.body;
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        should.exist(jsonResponse.errors);
+                        testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                            'message',
+                            'context',
+                            'type',
+                            'details',
+                            'property',
+                            'help',
+                            'code',
+                            'id'
+                        ]);
+                        done();
+                    });
             });
     });
 

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -113,7 +113,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(78);
+                    eventSpy.callCount.should.equal(80);
 
                     eventSpy.args[1][0].should.equal('settings.db_hash.added');
                     eventSpy.args[1][1].attributes.type.should.equal('core');
@@ -122,7 +122,10 @@ describe('Unit: models/settings', function () {
                     eventSpy.args[13][1].attributes.type.should.equal('blog');
                     eventSpy.args[13][1].attributes.value.should.equal('The professional publishing platform');
 
-                    eventSpy.args[77][0].should.equal('settings.members_subscription_settings.added');
+                    eventSpy.args[62][0].should.equal('settings.added');
+                    eventSpy.args[62][1].attributes.key.should.equal('image_sizes');
+
+                    eventSpy.args[79][0].should.equal('settings.members_subscription_settings.added');
                 });
         });
 
@@ -136,7 +139,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(76);
+                    eventSpy.callCount.should.equal(78);
 
                     eventSpy.args[13][0].should.equal('settings.logo.added');
                 });


### PR DESCRIPTION
refs #11011

@allouis @kevinansfield this is an extraction from https://github.com/TryGhost/Ghost/pull/11007 which introduces the following:
- [x] Exposes only "core" image size types through Content API in v2 and canary 
- [x] Makes sure the settings cannot be edited through Admin API

In the [public issue](https://github.com/TryGhost/Ghost/issues/11011), it would tick off the first point:
> Expose core image sizes through Content API

There is no need for migrations as data in settings is [pupulated automatically](https://github.com/TryGhost/Ghost/blob/db53ac0/core/server/models/settings.js#L206) when not present. 

The "management" bit will come in once we agree upon approach :+1: 	