### PR TITLE
Added actions to the User and Tag models

### DIFF
--- a/core/server/api/canary/actions.js
+++ b/core/server/api/canary/actions.js
@@ -7,31 +7,12 @@ module.exports = {
         options: [
             'page',
             'limit',
-            'fields'
+            'fields',
+            'include',
+            'filter'
         ],
-        data: [
-            'id',
-            'type'
-        ],
-        validation: {
-            id: {
-                required: true
-            },
-            type: {
-                required: true,
-                values: ['resource', 'actor']
-            }
-        },
         permissions: true,
         query(frame) {
-            if (frame.data.type === 'resource') {
-                frame.options.withRelated = ['actor'];
-                frame.options.filter = `resource_id:${frame.data.id}`;
-            } else {
-                frame.options.withRelated = ['resource'];
-                frame.options.filter = `actor_id:${frame.data.id}`;
-            }
-
             return models.Action.findPage(frame.options);
         }
     }

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -233,35 +233,18 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             }
         });
 
-        [
-            'fetching',
-            'fetching:collection',
-            'fetched',
-            'fetched:collection',
-            'creating',
-            'created',
-            'updating',
-            'updated',
-            'destroying',
-            'destroyed',
-            'saving',
-            'saved'
-        ].forEach(function (eventName) {
-            var functionName = 'on' + eventName[0].toUpperCase() + eventName.slice(1);
-
-            if (functionName.indexOf(':') !== -1) {
-                functionName = functionName.slice(0, functionName.indexOf(':'))
-                    + functionName[functionName.indexOf(':') + 1].toUpperCase()
-                    + functionName.slice(functionName.indexOf(':') + 2);
-                functionName = functionName.replace(':', '');
-            }
-
-            if (!self[functionName]) {
-                return;
-            }
-
-            self.on(eventName, self[functionName]);
-        });
+        self.on('fetched', self.onFetched);
+        self.on('fetching', self.onFetching);
+        self.on('fetched:collection', self.onFetchedCollection);
+        self.on('fetching:collection', self.onFetchingCollection);
+        self.on('creating', self.onCreating);
+        self.on('created', self.onCreated);
+        self.on('updating', self.onUpdating);
+        self.on('updated', self.onUpdated);
+        self.on('destroying', self.onDestroying);
+        self.on('destroyed', self.onDestroyed);
+        self.on('saving', self.onSaving);
+        self.on('saved', self.onSaved);
 
         // @NOTE: Please keep here. If we don't initialize the parent, bookshelf-relations won't work.
         proto.initialize.call(this);
@@ -276,6 +259,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         return validation.validateSchema(this.tableName, this, options);
     },
 
+    onFetched() {},
+
     /**
      * http://knexjs.org/#Builder-forUpdate
      * https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
@@ -289,18 +274,17 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         }
     },
 
+    onFetchedCollection() {},
+
     onFetchingCollection: function onFetchingCollection(model, columns, options) {
         if (options.forUpdate && options.transacting) {
             options.query.forUpdate();
         }
     },
 
-    onSaving: function onSaving() {
-        // Remove any properties which don't belong on the model
-        this.attributes = this.pick(this.permittedAttributes());
+    onCreated(model, attrs, options) {
+        addAction(model, 'added', options);
     },
-
-    onDestroying() {},
 
     /**
      * Adding resources implies setting these properties on the server side
@@ -359,6 +343,10 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             });
     },
 
+    onUpdated(model, attrs, options) {
+        addAction(model, 'edited', options);
+    },
+
     /**
      * Changing resources implies setting these properties on the server side
      * - set `updated_by` based on the context
@@ -413,13 +401,14 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         return Promise.resolve(this.onValidate(model, attr, options));
     },
 
-    onCreated(model, attrs, options) {
-        addAction(model, 'added', options);
+    onSaved() {},
+
+    onSaving: function onSaving() {
+        // Remove any properties which don't belong on the model
+        this.attributes = this.pick(this.permittedAttributes());
     },
 
-    onUpdated(model, attrs, options) {
-        addAction(model, 'edited', options);
-    },
+    onDestroying() {},
 
     onDestroyed(model, options) {
         if (!model._changed) {
@@ -433,8 +422,6 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         addAction(model, 'deleted', options);
     },
-
-    onSaved() {},
 
     /**
      * before we insert dates into the database, we have to normalize

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -659,7 +659,7 @@ Post = ghostBookshelf.Model.extend({
         return {
             event: event,
             resource_id: this.id || this.previous('id'),
-            resource_type: this.tableName.replace(/s$/, ''),
+            resource_type: 'post',
             actor_id: actor.id,
             actor_type: actor.type
         };

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -68,6 +68,24 @@ Tag = ghostBookshelf.Model.extend({
         delete attrs.parent_id;
 
         return attrs;
+    },
+
+    getAction(event, options) {
+        const actor = this.getActor(options);
+
+        // @NOTE: we ignore internal updates (`options.context.internal`) for now
+        if (!actor) {
+            return;
+        }
+
+        // @TODO: implement context
+        return {
+            event: event,
+            resource_id: this.id || this.previous('id'),
+            resource_type: 'tag',
+            actor_id: actor.id,
+            actor_type: actor.type
+        };
     }
 }, {
     orderDefaultOptions: function orderDefaultOptions() {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -322,6 +322,24 @@ User = ghostBookshelf.Model.extend({
         delete options.status;
 
         return filter;
+    },
+
+    getAction(event, options) {
+        const actor = this.getActor(options);
+
+        // @NOTE: we ignore internal updates (`options.context.internal`) for now
+        if (!actor) {
+            return;
+        }
+
+        // @TODO: implement context
+        return {
+            event: event,
+            resource_id: this.id || this.previous('id'),
+            resource_type: 'user',
+            actor_id: actor.id,
+            actor_type: actor.type
+        };
     }
 }, {
     orderDefaultOptions: function orderDefaultOptions() {

--- a/core/server/web/api/canary/admin/middleware.js
+++ b/core/server/web/api/canary/admin/middleware.js
@@ -16,6 +16,7 @@ const notImplemented = function (req, res, next) {
         pages: ['GET', 'PUT', 'DELETE', 'POST'],
         images: ['POST'],
         // @NOTE: experimental
+        actions: ['GET'],
         tags: ['GET', 'PUT', 'DELETE', 'POST'],
         users: ['GET'],
         themes: ['POST', 'PUT'],

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -222,7 +222,7 @@ module.exports = function apiRoutes() {
     router.get('/oembed', mw.authAdminApi, http(apiCanary.oembed.read));
 
     // ## Actions
-    router.get('/actions/:type/:id', mw.authAdminApi, http(apiCanary.actions.browse));
+    router.get('/actions', mw.authAdminApi, http(apiCanary.actions.browse));
 
     return router;
 };


### PR DESCRIPTION
This includes some minor refactors to the Base and Post model to increase readability.

All that was needed to add the actions was the `getAction` method to the appropriate model.

It is worth noting that none of the actions include any `context` - unsure if that's a requirement atm

Also of note is that deleting a user will generate a deleted action for the user, but also a deleted action for each post created by the deleted user.