### PR TITLE
Fixed importer not handling post.page->post.type conversion

### DIFF
--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -1,9 +1,9 @@
-const debug = require('ghost-ignition').debug('importer:posts'),
-    _ = require('lodash'),
-    uuid = require('uuid'),
-    BaseImporter = require('./base'),
-    converters = require('../../../../lib/mobiledoc/converters'),
-    validation = require('../../../validation');
+const debug = require('ghost-ignition').debug('importer:posts');
+const _ = require('lodash');
+const uuid = require('uuid');
+const BaseImporter = require('./base');
+const converters = require('../../../../lib/mobiledoc/converters');
+const validation = require('../../../validation');
 
 class PostsImporter extends BaseImporter {
     constructor(allDataFromFile) {
@@ -20,6 +20,16 @@ class PostsImporter extends BaseImporter {
         _.each(this.dataToImport, (obj) => {
             if (!validation.validator.isUUID(obj.uuid || '')) {
                 obj.uuid = uuid.v4();
+            }
+
+            // we used to have post.page=true/false
+            // we now have post.type='page'/'post'
+            // give precedence to post.type if both are present
+            if (_.has(obj, 'page')) {
+                if (_.isEmpty(obj.type)) {
+                    obj.type = obj.page ? 'page' : 'post';
+                }
+                delete obj.page;
             }
         });
     }

--- a/core/test/unit/data/importer/importers/data/posts_spec.js
+++ b/core/test/unit/data/importer/importers/data/posts_spec.js
@@ -1,0 +1,91 @@
+const should = require('should');
+const find = require('lodash/find');
+const PostsImporter = require('../../../../../../server/data/importer/importers/data/posts');
+
+describe.only('PostsImporter', function () {
+    describe('#beforeImport', function () {
+        it('converts post.page to post.type', function () {
+            const fakePosts = [{
+                slug: 'page-false',
+                page: false
+            }, {
+                slug: 'page-true',
+                page: true
+            }, {
+                slug: 'type-post',
+                type: 'post'
+            }, {
+                slug: 'type-page',
+                type: 'page'
+            }];
+
+            const importer = new PostsImporter({posts: fakePosts});
+
+            importer.beforeImport();
+
+            const pageFalse = find(importer.dataToImport, {slug: 'page-false'});
+            should.exist(pageFalse);
+            should.not.exist(pageFalse.page, 'pageFalse.page should not exist');
+            should.exist(pageFalse.type, 'pageFalse.type should exist');
+            pageFalse.type.should.equal('post');
+
+            const pageTrue = find(importer.dataToImport, {slug: 'page-true'});
+            should.exist(pageTrue);
+            should.not.exist(pageTrue.page, 'pageTrue.page should not exist');
+            should.exist(pageTrue.type, 'pageTrue.type should exist');
+            pageTrue.type.should.equal('page');
+
+            const typePost = find(importer.dataToImport, {slug: 'type-post'});
+            should.exist(typePost);
+            should.not.exist(typePost.page, 'typePost.page should not exist');
+            should.exist(typePost.type, 'typePost.type should exist');
+            typePost.type.should.equal('post');
+
+            const typePage = find(importer.dataToImport, {slug: 'type-page'});
+            should.exist(typePage);
+            should.not.exist(typePage.page, 'typePage.page should not exist');
+            should.exist(typePage.type, 'typePage.type should exist');
+            typePage.type.should.equal('page');
+        });
+
+        it('gives precedence to post.type when post.page is also present', function () {
+            const fakePosts = [{
+                slug: 'page-false-type-page',
+                page: false,
+                type: 'page'
+            }, {
+                slug: 'page-true-type-page',
+                page: true,
+                type: 'page'
+            }, {
+                slug: 'page-false-type-post',
+                page: false,
+                type: 'post'
+            }, {
+                slug: 'page-true-type-post',
+                page: true,
+                type: 'post'
+            }];
+
+            const importer = new PostsImporter({posts: fakePosts});
+
+            importer.beforeImport();
+
+            const pageFalseTypePage = find(importer.dataToImport, {slug: 'page-false-type-page'});
+            should.exist(pageFalseTypePage);
+            pageFalseTypePage.type.should.equal('page', 'pageFalseTypePage.type');
+
+            const pageTrueTypePage = find(importer.dataToImport, {slug: 'page-true-type-page'});
+            should.exist(pageTrueTypePage);
+            pageTrueTypePage.type.should.equal('page', 'pageTrueTypePage.type');
+
+            const pageFalseTypePost = find(importer.dataToImport, {slug: 'page-false-type-post'});
+            should.exist(pageFalseTypePost);
+            pageFalseTypePost.type.should.equal('post', 'pageFalseTypePost.type');
+
+            const pageTrueTypePost = find(importer.dataToImport, {slug: 'page-true-type-post'});
+            should.exist(pageTrueTypePost);
+            pageTrueTypePost.type.should.equal('post', 'pageTrueTypePost.type');
+        });
+    });
+});


### PR DESCRIPTION
no issue

- updates the attribute sanitiser of the posts importer to convert `post.page=true/false` to `post.type='page'/'post'`
- gives precedence to `post.type` if an imported post somehow has both `post.page` and `post.type` attributes