### PR TITLE
🐛 Fixed blog setup crashing for falsy email config

### DIFF
--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -110,6 +110,7 @@ function sendWelcomeEmail(email, mailAPI) {
                     });
             });
     }
+    return Promise.resolve();
 }
 
 module.exports = {


### PR DESCRIPTION
closes #11040

- In case of falsy `sendWelcomeEmail` config, the blog setup crashed as the setup method implicitly returned undefined instead of promise. This handles the falsy config correctly by returning a resolved promise and allowing setup to progress.

- Adds new regression test for blog setup with custom config
