### PR TITLE
Allow theme variables in package.json config object

### DIFF
--- a/core/frontend/services/themes/config/index.js
+++ b/core/frontend/services/themes/config/index.js
@@ -1,6 +1,6 @@
 var _ = require('lodash'),
     defaultConfig = require('./defaults'),
-    allowedKeys = ['posts_per_page', 'image_sizes'];
+    allowedKeys = ['posts_per_page', 'image_sizes', 'theme'];
 
 module.exports.create = function configLoader(packageJson) {
     var config = _.cloneDeep(defaultConfig);

--- a/core/frontend/services/themes/middleware.js
+++ b/core/frontend/services/themes/middleware.js
@@ -47,7 +47,8 @@ function updateGlobalTemplateOptions(req, res, next) {
     const labsData = _.cloneDeep(settingsCache.get('labs'));
     const themeData = {
         posts_per_page: activeTheme.get().config('posts_per_page'),
-        image_sizes: activeTheme.get().config('image_sizes')
+        image_sizes: activeTheme.get().config('image_sizes'),
+        theme: activeTheme.get().config('theme')
     };
 
     // @TODO: only do this if something changed?

--- a/core/test/unit/services/themes/middleware_spec.js
+++ b/core/test/unit/services/themes/middleware_spec.js
@@ -112,7 +112,7 @@ describe('Themes middleware', function () {
     });
 
     it('calls updateTemplateOptions with correct data', function (done) {
-        const themeDataExpectedProps = ['posts_per_page', 'image_sizes'];
+        const themeDataExpectedProps = ['posts_per_page', 'image_sizes', 'theme'];
 
         executeMiddleware(middleware, req, res, function next(err) {
             should.not.exist(err);


### PR DESCRIPTION
Allows theme variables in package.json's config for global config handlebars access. 
https://ghost.org/docs/api/v2/handlebars-themes/helpers/config/

```{
  "name": "my-theme",
  "version": 1.0.0,
  "author": {
    "email": "my@address.here"
  }
  "config": {
    "theme":{
        "custom-user-defined-variable": 42
    }
  }
}```

For example,
`<div class="{{@config.theme.custom-user-defined-variable}}">...</div>`