### PR TITLE
💡 Added typographer option to the markdown converter

### DIFF
--- a/core/server/lib/mobiledoc/converters/markdown-converter.js
+++ b/core/server/lib/mobiledoc/converters/markdown-converter.js
@@ -2,7 +2,8 @@ var MarkdownIt = require('markdown-it'),
     converter = new MarkdownIt({
         html: true,
         breaks: true,
-        linkify: true
+        linkify: true,
+        typographer: true
     })
         .use(require('markdown-it-footnote'))
         .use(require('markdown-it-lazy-headers'))


### PR DESCRIPTION
This PR sets the Markdown-it option `typographer` for rendering markdown, which performs [certain symbol replacements](https://github.com/markdown-it/markdown-it/blob/master/lib/rules_core/replacements.js), along with converting straight quotes into curly quotes.

There's no current issue that this is addressing, but the problem of not having smart quotes specifically has been raised multiple times in the past, including back in [#1795](https://github.com/TryGhost/Ghost/issues/1795)

Additionally, I've opened a pull request for the editor ([#1301](https://github.com/TryGhost/Ghost-Admin/pull/1301)) which would perform a certain subset of these conversions as text expansions (similarly to how many other editors would).