### PR TITLE
Updated oembed metadata icon rule

### DIFF
--- a/core/server/api/canary/oembed.js
+++ b/core/server/api/canary/oembed.js
@@ -10,8 +10,8 @@ const metascraper = require('metascraper')([
     require('metascraper-author')(),
     require('metascraper-publisher')(),
     require('metascraper-image')(),
-    require('metascraper-logo')(),
-    require('metascraper-logo-favicon')()
+    require('metascraper-logo-favicon')(),
+    require('metascraper-logo')()
 ]);
 
 async function fetchBookmarkData(url, html) {


### PR DESCRIPTION
no issue

Current metascraper rule for fetching page metadata in case of bookmark card gives preference to publisher logo over icon tags. This PR updates the order by giving first preference to icon link tags followed by logo.
