### PR TITLE
alternate support for amp-youtube re: #10972

### DIFF
--- a/core/frontend/apps/amp/lib/helpers/amp_components.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_components.js
@@ -27,6 +27,10 @@ function ampComponents() {
         components.push('<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>');
     }
 
+    if (html.indexOf('youtube.com/embed') !== -1) {
+        components.push('<script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>');
+    }
+
     if (html.indexOf('<audio') !== -1) {
         components.push('<script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>');
     }

--- a/core/frontend/apps/amp/lib/helpers/amp_components.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_components.js
@@ -23,12 +23,15 @@ function ampComponents() {
         components.push('<script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>');
     }
 
-    if (html.indexOf('<iframe') !== -1) {
-        components.push('<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>');
+    let count_iframe = (html.match(/<iframe/g) || []).length,
+        count_youtube = (html.match(/youtube.com\/embed/g) || []).length;
+
+    if (count_youtube) {
+        components.push('<script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>');
     }
 
-    if (html.indexOf('youtube.com/embed') !== -1) {
-        components.push('<script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>');
+    if (count_iframe > count_youtube) {
+        components.push('<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>');
     }
 
     if (html.indexOf('<audio') !== -1) {

--- a/core/frontend/apps/amp/lib/helpers/amp_components.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_components.js
@@ -23,14 +23,14 @@ function ampComponents() {
         components.push('<script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>');
     }
 
-    let count_iframe = (html.match(/<iframe/g) || []).length,
-        count_youtube = (html.match(/youtube.com\/embed/g) || []).length;
+    let iframeCount = (html.match(/<iframe/g) || []).length,
+        youtubeCount = (html.match(/youtube.com\/embed/g) || []).length;
 
-    if (count_youtube) {
+    if (youtubeCount) {
         components.push('<script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>');
     }
 
-    if (count_iframe > count_youtube) {
+    if (iframeCount > youtubeCount) {
         components.push('<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>');
     }
 

--- a/core/frontend/apps/amp/lib/helpers/amp_components.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_components.js
@@ -23,8 +23,8 @@ function ampComponents() {
         components.push('<script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>');
     }
 
-    let iframeCount = (html.match(/<iframe/g) || []).length,
-        youtubeCount = (html.match(/(youtu.be\/|youtube(-nocookie)?.com\/(v\/|.*u\/\w\/|embed\/|.*v=))/g) || []).length;
+    let iframeCount = (html.match(/(<iframe)(.*?)(<\/iframe>)/gi) || []).length,
+        youtubeCount = (html.match(/(<iframe)(.*?)(youtu.be\/|youtube(-nocookie)?.com\/(v\/|.*u\/\w\/|embed\/|.*v=))(.*?)(<\/iframe>)/gi) || []).length;
 
     if (youtubeCount) {
         components.push('<script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>');

--- a/core/frontend/apps/amp/lib/helpers/amp_components.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_components.js
@@ -24,7 +24,7 @@ function ampComponents() {
     }
 
     let iframeCount = (html.match(/<iframe/g) || []).length,
-        youtubeCount = (html.match(/youtube.com\/embed/g) || []).length;
+        youtubeCount = (html.match(/(youtu.be\/|youtube(-nocookie)?.com\/(v\/|.*u\/\w\/|embed\/|.*v=))/g) || []).length;
 
     if (youtubeCount) {
         components.push('<script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>');

--- a/core/frontend/apps/amp/lib/helpers/amp_content.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_content.js
@@ -36,8 +36,8 @@ allowedAMPTags = ['html', 'body', 'article', 'section', 'nav', 'aside', 'h1', 'h
     'table', 'caption', 'colgroup', 'col', 'tbody', 'thead', 'tfoot', 'tr', 'td',
     'th', 'button', 'noscript', 'acronym', 'center', 'dir', 'hgroup', 'listing',
     'multicol', 'nextid', 'nobr', 'spacer', 'strike', 'tt', 'xmp', 'amp-img',
-    'amp-video', 'amp-ad', 'amp-embed', 'amp-anim', 'amp-iframe', 'amp-pixel',
-    'amp-audio', 'O:P'];
+    'amp-video', 'amp-ad', 'amp-embed', 'amp-anim', 'amp-iframe', 'amp-youtube',
+    'amp-pixel', 'amp-audio', 'O:P'];
 
 allowedAMPAttributes = {
     '*': ['itemid', 'itemprop', 'itemref', 'itemscope', 'itemtype', 'accesskey', 'class', 'dir', 'draggable',
@@ -110,7 +110,8 @@ allowedAMPAttributes = {
     'amp-anim': ['media', 'noloading', 'alt', 'attribution', 'placeholder', 'src', 'srcset', 'width', 'height', 'layout'],
     'amp-audio': ['src', 'width', 'height', 'autoplay', 'loop', 'muted', 'controls'],
     'amp-iframe': ['src', 'srcdoc', 'width', 'height', 'layout', 'frameborder', 'allowfullscreen', 'allowtransparency',
-        'sandbox', 'referrerpolicy']
+        'sandbox', 'referrerpolicy'],
+    'amp-youtube': ['src', 'width', 'height', 'layout', 'frameborder', 'autoplay', 'loop', 'data-videoid', 'data-live-channelid']
 };
 
 function getAmperizeHTML(html, post) {

--- a/core/test/unit/apps/amp/amp_components_spec.js
+++ b/core/test/unit/apps/amp/amp_components_spec.js
@@ -31,7 +31,21 @@ describe('{{amp_components}} helper', function () {
         should.exist(rendered);
         rendered.should.match(/<script async custom-element="amp-iframe" src="https:\/\/cdn.ampproject.org\/v0\/amp-iframe-0.1.js"><\/script>/);
     });
+    
+    it('adds script tag for a youtube embed', function () {
+        var post = {
+                html: '<iframe src="https://www.youtube.com/embed/zqNTltOGh5c" frameborder="0"></iframe>'
+            },
+            rendered;
 
+        rendered = ampComponentsHelper.call(
+            {relativeUrl: '/post/amp/', safeVersion: '0.3', context: ['amp', 'post'], post: post},
+            {data: {root: {context: ['amp', 'post']}}});
+
+        should.exist(rendered);
+        rendered.should.match(/<script async custom-element="amp-youtube" src="https:\/\/cdn.ampproject.org\/v0\/amp-youtube-0.1.js"><\/script>/);
+    });
+    
     it('adds script tag for an audio tag', function () {
         var post = {
                 html: '<audio src="myaudiofile.mp3"/>'

--- a/core/test/unit/apps/amp/amp_components_spec.js
+++ b/core/test/unit/apps/amp/amp_components_spec.js
@@ -31,7 +31,7 @@ describe('{{amp_components}} helper', function () {
         should.exist(rendered);
         rendered.should.match(/<script async custom-element="amp-iframe" src="https:\/\/cdn.ampproject.org\/v0\/amp-iframe-0.1.js"><\/script>/);
     });
-    
+
     it('adds script tag for a youtube embed', function () {
         var post = {
                 html: '<iframe src="https://www.youtube.com/embed/zqNTltOGh5c" frameborder="0"></iframe>'
@@ -45,7 +45,25 @@ describe('{{amp_components}} helper', function () {
         should.exist(rendered);
         rendered.should.match(/<script async custom-element="amp-youtube" src="https:\/\/cdn.ampproject.org\/v0\/amp-youtube-0.1.js"><\/script>/);
     });
-    
+
+    it('adds scripts for youtube embeds and iframes', function () {
+        var post = {
+                html: `
+                    <iframe src="https://www.youtube.com/embed/zqNTltOGh5c" frameborder="0"></iframe>
+                    <iframe src="//giphy.com/embed/o0vwzuFwCGAFO" width="480" height="480" frameBorder="0" class="giphy-embed" allowFullScreen></iframe>
+                `
+            },
+            rendered;
+
+        rendered = ampComponentsHelper.call(
+            {relativeUrl: '/post/amp/', safeVersion: '0.3', context: ['amp', 'post'], post: post},
+            {data: {root: {context: ['amp', 'post']}}});
+
+        should.exist(rendered);
+        rendered.should.match(/<script async custom-element="amp-youtube" src="https:\/\/cdn.ampproject.org\/v0\/amp-youtube-0.1.js"><\/script>/);
+        rendered.should.match(/<script async custom-element="amp-iframe" src="https:\/\/cdn.ampproject.org\/v0\/amp-iframe-0.1.js"><\/script>/);
+    });
+
     it('adds script tag for an audio tag', function () {
         var post = {
                 html: '<audio src="myaudiofile.mp3"/>'


### PR DESCRIPTION
See issue [#10972](https://github.com/TryGhost/Ghost/issues/10972).

Sorry, not sure the right protocol here. I made a different version of PR [#11054](https://github.com/TryGhost/Ghost/pull/11054). I count the number of references to iframe or youtube embeds and use that to determine which script tag to include.

[#11054](https://github.com/TryGhost/Ghost/pull/11054) includes both tags instead of differentiating, which may be faster/more efficient.