### PR TITLE
Added raw helper

### DIFF
--- a/core/frontend/helpers/index.js
+++ b/core/frontend/helpers/index.js
@@ -38,6 +38,7 @@ coreHelpers.post_class = require('./post_class');
 coreHelpers.prev_post = require('./prev_next');
 coreHelpers.price = require('./price');
 coreHelpers.next_post = require('./prev_next');
+coreHelpers.raw = require('./raw');
 coreHelpers.reading_time = require('./reading_time');
 coreHelpers.t = require('./t');
 coreHelpers.tags = require('./tags');
@@ -86,6 +87,7 @@ registerAllCoreHelpers = function registerAllCoreHelpers() {
     registerThemeHelper('plural', coreHelpers.plural);
     registerThemeHelper('post_class', coreHelpers.post_class);
     registerThemeHelper('price', coreHelpers.price);
+    registerThemeHelper('raw', coreHelpers.raw);
     registerThemeHelper('reading_time', coreHelpers.reading_time);
     registerThemeHelper('t', coreHelpers.t);
     registerThemeHelper('tags', coreHelpers.tags);

--- a/core/frontend/helpers/raw.js
+++ b/core/frontend/helpers/raw.js
@@ -1,0 +1,8 @@
+// # Raw helper
+// Usage: `{{{{raw}}}}...{{{{/raw}}}}`
+//
+// Returns raw contents unprocessed by handlebars.
+
+module.exports = function raw(options) {
+    return options.fn(this);
+};

--- a/core/test/unit/helpers/raw_spec.js
+++ b/core/test/unit/helpers/raw_spec.js
@@ -1,0 +1,40 @@
+const should = require('should');
+const helpers = require.main.require('core/frontend/helpers');
+const handlebars = require.main.require('core/frontend/services/themes/engine').handlebars;
+
+let defaultGlobals;
+
+function compile(templateString) {
+    const template = handlebars.compile(templateString);
+    template.with = (locals = {}, globals) => {
+        globals = globals || defaultGlobals;
+
+        return template(locals, globals);
+    };
+
+    return template;
+}
+
+describe('{{raw}} helper', function () {
+    before(function () {
+        handlebars.registerHelper('raw', helpers.raw);
+    });
+
+    it('can correctly compile space', function () {
+        compile('{{{{raw}}}} {{{{/raw}}}}')
+            .with({})
+            .should.eql(' ');
+    });
+
+    it('can correctly ignore handlebars', function () {
+        compile('{{{{raw}}}}{{test}}{{{{/raw}}}}')
+            .with({tag: {}})
+            .should.eql('{{test}}');
+    });
+
+    it('can correctly compile recursive', function () {
+        compile('{{{{raw}}}}{{{{raw}}}}{{{{/raw}}}}{{{{/raw}}}}')
+            .with({tag: {}})
+            .should.eql('{{{{raw}}}}{{{{/raw}}}}');
+    });
+});

--- a/test/unit/helpers/index_spec.js
+++ b/test/unit/helpers/index_spec.js
@@ -10,7 +10,7 @@ describe('Helpers', function () {
         ghostHelpers = [
             'asset', 'author', 'authors', 'body_class', 'cancel_link', 'concat', 'content', 'date', 'encode', 'excerpt', 'facebook_url', 'foreach', 'get',
             'ghost_foot', 'ghost_head', 'has', 'img_url', 'is', 'lang', 'link', 'link_class', 'meta_description', 'meta_title', 'navigation',
-            'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'price', 'reading_time', 't', 'tags', 'title', 'twitter_url',
+            'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'price', 'raw', 'reading_time', 't', 'tags', 'title', 'twitter_url',
             'url'
         ],
         expectedHelpers = _.concat(hbsHelpers, ghostHelpers);


### PR DESCRIPTION
Adds raw helper.  This makes it possible to include content containing ``{{}}`` without it being interpreted by handlebars on the server.  This is useful for including things that will be rendered client-side such as client-side handlebars templates or vue.js templates.  It can also be used to include unprocessed inline html, css or JavaScript all of which may contain handlebars that could lead to conflicts.

Example usage:

```
{{{{raw}}}}
Here's how you use handlbars:
<pre><code>
{{#get "posts" include="tags,authors"}}
    {{#foreach posts}}
        {{title}}
    {{/foreach}}
{{/get}}
</code></pre>
{{{{/raw}}}}
```