### PR TITLE
Drop primary_autor/primary_tag fields in Content API v3

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -100,14 +100,14 @@ const post = (attrs, frame) => {
         }
     } else {
         delete attrs.page;
+    }
 
-        if (!attrs.tags) {
-            delete attrs.primary_tag;
-        }
+    if (!attrs.tags) {
+        delete attrs.primary_tag;
+    }
 
-        if (!attrs.authors) {
-            delete attrs.primary_author;
-        }
+    if (!attrs.authors) {
+        delete attrs.primary_author;
     }
 
     delete attrs.locale;

--- a/core/test/regression/api/canary/admin/utils.js
+++ b/core/test/regression/api/canary/admin/utils.js
@@ -27,6 +27,8 @@ const expectedProperties = {
         .without('page')
         .without('author_id')
         // always returns computed properties
+        // primary_tag and primary_author properties are included
+        // only because authors and tags are always included
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         .concat('authors', 'tags')
     ,

--- a/core/test/regression/api/canary/content/utils.js
+++ b/core/test/regression/api/canary/content/utils.js
@@ -18,7 +18,7 @@ const expectedProperties = {
         // canary doesn't return author_id OR author
         .without('author_id', 'author')
         // and always returns computed properties: url, primary_tag, primary_author
-        .concat('url', 'primary_tag', 'primary_author')
+        .concat('url')
         // canary API doesn't return unused fields
         .without('locale', 'visibility')
         // These fields aren't useful as they always have known values


### PR DESCRIPTION
no issue

PR here mostly for CI checks and a reference point. Details explained in the commit message