### PR TITLE
Fix for validator preventing requests without tld

### DIFF
--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -75,7 +75,7 @@ validator.extend('isTimezone', function isTimezone(str) {
 });
 
 validator.extend('isEmptyOrURL', function isEmptyOrURL(str) {
-    return (_.isEmpty(str) || validator.isURL(str, {require_protocol: false}));
+    return (_.isEmpty(str) || validator.isURL(str, {require_protocol: false, require_tld: false}));
 });
 
 validator.extend('isSlug', function isSlug(str) {

--- a/core/server/lib/request.js
+++ b/core/server/lib/request.js
@@ -11,7 +11,7 @@ var defaultOptions = {
 };
 
 module.exports = function request(url, options) {
-    if (_.isEmpty(url) || !validator.isURL(url)) {
+    if (_.isEmpty(url) || !validator.isURL(url, {require_protocol: false, require_tld: false})) {
         return Promise.reject(new common.errors.InternalServerError({
             message: 'URL empty or invalid.',
             code: 'URL_MISSING_INVALID',


### PR DESCRIPTION
Use the require_tld: false option in the package validator.

Per https://forum.ghost.org/t/scheduled-posts-wont-publish/8924/7