### PR TITLE
🐛 Fixed "View site" screen in admin on private sites with separate admin url

### DIFF
--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -1,6 +1,8 @@
 const debug = require('ghost-ignition').debug('web:site:app');
 const path = require('path');
 const express = require('express');
+const cors = require('cors');
+const {URL} = require('url');
 
 // App requires
 const config = require('../../config');
@@ -20,6 +22,39 @@ const STATIC_IMAGE_URL_PREFIX = `/${urlUtils.STATIC_IMAGE_URL_PREFIX}`;
 
 let router;
 
+const corsOptionsDelegate = function corsOptionsDelegate(req, callback) {
+    const origin = req.header('Origin');
+    const corsOptions = {
+        origin: false, // disallow cross-origin requests by default
+        credentials: true // required to allow admin-client to login to private sites
+    };
+
+    if (origin) {
+        const originUrl = new URL(origin);
+
+        // allow all localhost and 127.0.0.1 requests no matter the port
+        if (originUrl.hostname === 'localhost' || originUrl.hostname === '127.0.0.1') {
+            corsOptions.origin = true;
+        }
+
+        // allow the configured host through on any protocol
+        const siteUrl = new URL(config.get('url'));
+        if (originUrl.host === siteUrl.host) {
+            corsOptions.origin = true;
+        }
+
+        // allow the configured admin:url host through on any protocol
+        if (config.get('admin:url')) {
+            const adminUrl = new URL(config.get('admin:url'));
+            if (originUrl.host === adminUrl.host) {
+                corsOptions.origin = true;
+            }
+        }
+    }
+
+    callback(null, corsOptions);
+};
+
 function SiteRouter(req, res, next) {
     router(req, res, next);
 }
@@ -32,6 +67,9 @@ module.exports = function setupSiteApp(options = {}) {
     // ## App - specific code
     // set the view engine
     siteApp.set('view engine', 'hbs');
+
+    // enable CORS headers (allows admin client to hit front-end when configured on separate URLs)
+    siteApp.use(cors(corsOptionsDelegate));
 
     // you can extend Ghost with a custom redirects file
     // see https://github.com/TryGhost/Ghost/issues/7707


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/11078

Problem:
- the admin client makes an XHR request to the `/private/` endpoint when a private site is configured
- when a separate admin URL is configured this was causing 500 errors in the admin client because missing CORS headers on the endpoint was causing browsers to abort the request
- browsers will also look at the CORS headers on any resources that are the result of a redirect and abort the request if they do not allow cross-origin requests, this means allowing all requests on `/private/` is not enough

Solution:
- uses the `cors` middleware with a dynamic options function for the whole of the front-end site app
- dynamic options function allows the following requests through:
  - same-origin (browsers and non-browser agents will not send an `Origin` header)
  - origin is `localhost` or `127.0.0.1` with any protocol and port
  - origin matches the configured `url` hostname+port on any protocol
  - origin matches the configured `admin:url` hostname+port on any protocol