### PR TITLE
Extract post metadata in new post_meta table

### DIFF
--- a/core/server/api/canary/utils/serializers/input/pages.js
+++ b/core/server/api/canary/utils/serializers/input/pages.js
@@ -3,6 +3,7 @@ const debug = require('ghost-ignition').debug('api:canary:utils:serializers:inpu
 const converters = require('../../../../../lib/mobiledoc/converters');
 const url = require('./utils/url');
 const localUtils = require('../../index');
+const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -43,6 +44,12 @@ function defaultFormat(frame) {
     }
 
     frame.options.formats = 'mobiledoc';
+}
+
+function handlePostsMeta(frame) {
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    let meta = _.pick(frame.data.pages[0], metaAttrs);
+    frame.data.pages[0].posts_meta = meta;
 }
 
 /**
@@ -147,6 +154,7 @@ module.exports = {
             });
         }
 
+        handlePostsMeta(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -156,6 +164,7 @@ module.exports = {
 
         debug('edit');
 
+        handlePostsMeta(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/canary/utils/serializers/input/posts.js
+++ b/core/server/api/canary/utils/serializers/input/posts.js
@@ -4,6 +4,7 @@ const url = require('./utils/url');
 const localUtils = require('../../index');
 const labs = require('../../../../../services/labs');
 const converters = require('../../../../../lib/mobiledoc/converters');
+const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -52,6 +53,12 @@ function defaultFormat(frame) {
     }
 
     frame.options.formats = 'mobiledoc';
+}
+
+function handlePostsMeta(frame) {
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    let meta = _.pick(frame.data.posts[0], metaAttrs);
+    frame.data.posts[0].posts_meta = meta;
 }
 
 /**
@@ -182,6 +189,7 @@ module.exports = {
             });
         }
 
+        handlePostsMeta(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -189,6 +197,7 @@ module.exports = {
     edit(apiConfig, frame) {
         this.add(apiConfig, frame, {add: false});
 
+        handlePostsMeta(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -58,7 +58,6 @@ const mapPost = (model, frame) => {
         });
     }
 
-
     // Transforms post/page metadata to flat structure
     let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
     _(metaAttrs).filter((k) => {

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -5,6 +5,7 @@ const date = require('./date');
 const members = require('./members');
 const clean = require('./clean');
 const extraAttrs = require('./extra-attrs');
+const postsMetaSchema = require('../../../../../../data/schema').tables.posts_meta;
 
 const mapUser = (model, frame) => {
     const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
@@ -56,6 +57,17 @@ const mapPost = (model, frame) => {
             }
         });
     }
+
+    // Transforms post/page metadata to flat structure
+    let postsMeta = Object.assign({}, _.mapValues(postsMetaSchema, () => null), jsonModel.posts_meta);
+    delete postsMeta.id;
+    delete postsMeta.post_id;
+    _.each(postsMeta, (v, k) => {
+        if (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k))) {
+            jsonModel[k] = v;
+        }
+    });
+    delete jsonModel.posts_meta;
 
     return jsonModel;
 };

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -58,8 +58,10 @@ const mapPost = (model, frame) => {
         });
     }
 
+
     // Transforms post/page metadata to flat structure
-    _.keys(_.omit(postsMetaSchema, ['id', 'post_id'])).filter((k) => {
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    _(metaAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
         jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -63,7 +63,7 @@ const mapPost = (model, frame) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
         jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
-    })
+    });
     delete jsonModel.posts_meta;
 
     return jsonModel;

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -59,14 +59,11 @@ const mapPost = (model, frame) => {
     }
 
     // Transforms post/page metadata to flat structure
-    let postsMeta = Object.assign({}, _.mapValues(postsMetaSchema, () => null), jsonModel.posts_meta);
-    delete postsMeta.id;
-    delete postsMeta.post_id;
-    _.each(postsMeta, (v, k) => {
-        if (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k))) {
-            jsonModel[k] = v;
-        }
-    });
+    _.keys(_.omit(postsMetaSchema, ['id', 'post_id'])).filter((k) => {
+        return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
+    }).each((attr) => {
+        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+    })
     delete jsonModel.posts_meta;
 
     return jsonModel;

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -3,6 +3,7 @@ const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:pa
 const converters = require('../../../../../lib/mobiledoc/converters');
 const url = require('./utils/url');
 const localUtils = require('../../index');
+const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -43,6 +44,12 @@ function defaultFormat(frame) {
     }
 
     frame.options.formats = 'mobiledoc';
+}
+
+function handlePostsMeta(frame) {
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    let meta = _.pick(frame.data.pages[0], metaAttrs);
+    frame.data.pages[0].posts_meta = meta;
 }
 
 /**
@@ -147,6 +154,7 @@ module.exports = {
             });
         }
 
+        handlePostsMeta(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -156,6 +164,7 @@ module.exports = {
 
         debug('edit');
 
+        handlePostsMeta(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -4,6 +4,7 @@ const url = require('./utils/url');
 const localUtils = require('../../index');
 const labs = require('../../../../../services/labs');
 const converters = require('../../../../../lib/mobiledoc/converters');
+const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -52,6 +53,12 @@ function defaultFormat(frame) {
     }
 
     frame.options.formats = 'mobiledoc';
+}
+
+function handlePostsMeta(frame) {
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    let meta = _.pick(frame.data.posts[0], metaAttrs);
+    frame.data.posts[0].posts_meta = meta;
 }
 
 /**
@@ -182,6 +189,7 @@ module.exports = {
             });
         }
 
+        handlePostsMeta(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -189,6 +197,7 @@ module.exports = {
     edit(apiConfig, frame) {
         this.add(apiConfig, frame, {add: false});
 
+        handlePostsMeta(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -5,6 +5,7 @@ const date = require('./date');
 const members = require('./members');
 const clean = require('./clean');
 const extraAttrs = require('./extra-attrs');
+const postsMetaSchema = require('../../../../../../data/schema').tables.posts_meta;
 
 const mapUser = (model, frame) => {
     const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
@@ -56,6 +57,17 @@ const mapPost = (model, frame) => {
             }
         });
     }
+
+    // Transforms post/page metadata to flat structure
+    let postsMeta = Object.assign({}, _.mapValues(postsMetaSchema, () => null), jsonModel.posts_meta);
+    delete postsMeta.id;
+    delete postsMeta.post_id;
+    _.each(postsMeta, (v, k) => {
+        if (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k))) {
+            jsonModel[k] = v;
+        }
+    });
+    delete jsonModel.posts_meta;
 
     return jsonModel;
 };

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -63,7 +63,7 @@ const mapPost = (model, frame) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
         jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
-    })
+    });
     delete jsonModel.posts_meta;
 
     return jsonModel;

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -59,14 +59,11 @@ const mapPost = (model, frame) => {
     }
 
     // Transforms post/page metadata to flat structure
-    let postsMeta = Object.assign({}, _.mapValues(postsMetaSchema, () => null), jsonModel.posts_meta);
-    delete postsMeta.id;
-    delete postsMeta.post_id;
-    _.each(postsMeta, (v, k) => {
-        if (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k))) {
-            jsonModel[k] = v;
-        }
-    });
+    _.keys(_.omit(postsMetaSchema, ['id', 'post_id'])).filter((k) => {
+        return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
+    }).each((attr) => {
+        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+    })
     delete jsonModel.posts_meta;
 
     return jsonModel;

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -59,7 +59,8 @@ const mapPost = (model, frame) => {
     }
 
     // Transforms post/page metadata to flat structure
-    _.keys(_.omit(postsMetaSchema, ['id', 'post_id'])).filter((k) => {
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    _(metaAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
         jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;

--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -29,7 +29,7 @@ class PostsImporter extends BaseImporter {
     /**
      * Sanitizes post metadata, picking data from sepearate table(for >= v3) or post itself(for < v3)
      */
-    santizePostsMeta(model) {
+    sanitizePostsMeta(model) {
         let postsMetaFromFile = _.find(this.requiredFromFile.posts_meta, {post_id: model.id}) || _.pick(model, metaAttrs);
         let postsMetaData = Object.assign({}, _.mapValues(postsMetaSchema, () => null), postsMetaFromFile);
         model.posts_meta = postsMetaData;

--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -216,7 +216,7 @@ class PostsImporter extends BaseImporter {
                 model.mobiledoc = JSON.stringify(mobiledoc);
                 model.html = converters.mobiledocConverter.render(JSON.parse(model.mobiledoc));
             }
-            this.santizePostsMeta(model);
+            this.sanitizePostsMeta(model);
         });
 
         // NOTE: We only support removing duplicate posts within the file to import.

--- a/core/server/data/migrations/versions/3.0.0/2-add-posts-meta-table.js
+++ b/core/server/data/migrations/versions/3.0.0/2-add-posts-meta-table.js
@@ -1,0 +1,35 @@
+const common = require('../../../../lib/common');
+const commands = require('../../../schema').commands;
+const table = 'posts_meta';
+const message1 = `Adding table: ${table}`;
+const message2 = `Dropping table: ${table}`;
+
+module.exports.up = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (exists) {
+                common.logging.warn(message1);
+                return;
+            }
+
+            common.logging.info(message1);
+            return commands.createTable(table, connection);
+        });
+};
+
+module.exports.down = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (!exists) {
+                common.logging.warn(message2);
+                return;
+            }
+
+            common.logging.info(message2);
+            return commands.deleteTable(table, connection);
+        });
+};

--- a/core/server/data/migrations/versions/3.0.0/3-populate-posts-meta-table.js
+++ b/core/server/data/migrations/versions/3.0.0/3-populate-posts-meta-table.js
@@ -1,0 +1,78 @@
+const postsMetaSchema = require('../../../schema').tables.posts_meta;
+const ObjectId = require('bson-objectid');
+const _ = require('lodash');
+const models = require('../../../../models');
+const common = require('../../../../lib/common');
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    const localOptions = _.merge({
+        context: {internal: true},
+        migrating: true
+    }, options);
+    const metaAttrs = _.keys(postsMetaSchema);
+
+    return models.Posts
+        .forge()
+        .query((qb) => {
+            // We only want to add entries in new table for posts which have any metadata
+            qb.whereNotNull('meta_title');
+            qb.orWhereNotNull('meta_description');
+            qb.orWhereNotNull('twitter_title');
+            qb.orWhereNotNull('twitter_description');
+            qb.orWhereNotNull('twitter_image');
+            qb.orWhereNotNull('og_description');
+            qb.orWhereNotNull('og_title');
+            qb.orWhereNotNull('og_image');
+        })
+        .fetch(localOptions)
+        .then(({models: posts}) => {
+            if (posts.length > 0) {
+                common.logging.info(`Adding ${posts.length} entries to posts_meta`);
+                let postsMetaEntries = _.map(posts, (post) => {
+                    let postsMetaEntry = metaAttrs.reduce(function (obj, entry) {
+                        return Object.assign(obj, {
+                            [entry]: post.get(entry)
+                        });
+                    }, {});
+                    postsMetaEntry.post_id = post.get('id');
+                    postsMetaEntry.id = ObjectId.generate();
+                    return postsMetaEntry;
+                });
+                return localOptions.transacting('posts_meta').insert(postsMetaEntries);
+            } else {
+                common.logging.info('Skipping populating posts_meta table: found 0 posts with metadata');
+                return Promise.resolve();
+            }
+        });
+};
+
+module.exports.down = function (options) {
+    let localOptions = _.merge({
+        context: {internal: true},
+        migrating: true
+    }, options);
+    const metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+
+    return models.PostsMeta
+        .findAll(localOptions)
+        .then(({models: postsMeta}) => {
+            if (postsMeta.length > 0) {
+                common.logging.info(`Adding metadata for ${postsMeta.length} posts from posts_meta table`);
+                return Promise.map(postsMeta, (postsMeta) => {
+                    let data = metaAttrs.reduce(function (obj, entry) {
+                        return Object.assign(obj, {
+                            [entry]: postsMeta.get(entry)
+                        });
+                    }, {});
+                    return localOptions.transacting('posts').where({id: postsMeta.get('post_id')}).update(data);
+                });
+            } else {
+                common.logging.info('Skipping populating meta fields from posts_meta: found 0 entries');
+                return Promise.resolve();
+            }
+        });
+};

--- a/core/server/data/migrations/versions/3.0.0/4-remove-posts-meta-columns.js
+++ b/core/server/data/migrations/versions/3.0.0/4-remove-posts-meta-columns.js
@@ -1,0 +1,191 @@
+const commands = require('../../../schema').commands;
+
+module.exports.up = commands.createColumnMigration({
+    table: 'posts',
+    column: 'meta_title',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === false;
+    },
+    operation: commands.dropColumn,
+    operationVerb: 'Dropping'
+},
+{
+    table: 'posts',
+    column: 'meta_description',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === false;
+    },
+    operation: commands.dropColumn,
+    operationVerb: 'Dropping'
+},
+{
+    table: 'posts',
+    column: 'og_image',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === false;
+    },
+    operation: commands.dropColumn,
+    operationVerb: 'Dropping'
+},
+{
+    table: 'posts',
+    column: 'og_title',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === false;
+    },
+    operation: commands.dropColumn,
+    operationVerb: 'Dropping'
+},
+{
+    table: 'posts',
+    column: 'og_description',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === false;
+    },
+    operation: commands.dropColumn,
+    operationVerb: 'Dropping'
+},
+{
+    table: 'posts',
+    column: 'twitter_image',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === false;
+    },
+    operation: commands.dropColumn,
+    operationVerb: 'Dropping'
+},
+{
+    table: 'posts',
+    column: 'twitter_title',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === false;
+    },
+    operation: commands.dropColumn,
+    operationVerb: 'Dropping'
+},
+{
+    table: 'posts',
+    column: 'twitter_description',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === false;
+    },
+    operation: commands.dropColumn,
+    operationVerb: 'Dropping'
+});
+
+module.exports.down = commands.createColumnMigration({
+    table: 'posts',
+    column: 'meta_title',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === true;
+    },
+    operation: commands.addColumn,
+    operationVerb: 'Adding',
+    columnDefinition: {
+        type: 'string',
+        nullable: true,
+        maxlength: 2000
+    }
+},
+{
+    table: 'posts',
+    column: 'meta_description',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === true;
+    },
+    operation: commands.addColumn,
+    operationVerb: 'Adding',
+    columnDefinition: {
+        type: 'string',
+        nullable: true,
+        maxlength: 2000
+    }
+},
+{
+    table: 'posts',
+    column: 'og_image',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === true;
+    },
+    operation: commands.addColumn,
+    operationVerb: 'Adding',
+    columnDefinition: {
+        type: 'string',
+        nullable: true,
+        maxlength: 2000
+    }
+},
+{
+    table: 'posts',
+    column: 'og_title',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === true;
+    },
+    operation: commands.addColumn,
+    operationVerb: 'Adding',
+    columnDefinition: {
+        type: 'string',
+        nullable: true,
+        maxlength: 300
+    }
+},
+{
+    table: 'posts',
+    column: 'og_description',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === true;
+    },
+    operation: commands.addColumn,
+    operationVerb: 'Adding',
+    columnDefinition: {
+        type: 'string',
+        nullable: true,
+        maxlength: 500
+    }
+},
+{
+    table: 'posts',
+    column: 'twitter_image',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === true;
+    },
+    operation: commands.addColumn,
+    operationVerb: 'Adding',
+    columnDefinition: {
+        type: 'string',
+        nullable: true,
+        maxlength: 2000
+    }
+},
+{
+    table: 'posts',
+    column: 'twitter_title',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === true;
+    },
+    operation: commands.addColumn,
+    operationVerb: 'Adding',
+    columnDefinition: {
+        type: 'string',
+        nullable: true,
+        maxlength: 300
+    }
+},
+{
+    table: 'posts',
+    column: 'twitter_description',
+    dbIsInCorrectState(columnExists) {
+        return columnExists === true;
+    },
+    operation: commands.addColumn,
+    operationVerb: 'Adding',
+    columnDefinition: {
+        type: 'string',
+        nullable: true,
+        maxlength: 500
+    }
+});
+
+module.exports.config = {
+    transaction: true
+};

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -29,8 +29,6 @@ module.exports = {
             defaultTo: 'public',
             validations: {isIn: [['public']]}
         },
-        meta_title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
-        meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
         /**
          * @deprecated: `author_id`, might be removed in Ghost 3.0
          * If we keep it, then only, because you can easier query post.author_id than posts_authors[*].sort_order.
@@ -50,14 +48,20 @@ module.exports = {
         custom_excerpt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
         codeinjection_head: {type: 'text', maxlength: 65535, nullable: true},
         codeinjection_foot: {type: 'text', maxlength: 65535, nullable: true},
+        custom_template: {type: 'string', maxlength: 100, nullable: true},
+        canonical_url: {type: 'text', maxlength: 2000, nullable: true}
+    },
+    posts_meta: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', unique: true},
         og_image: {type: 'string', maxlength: 2000, nullable: true},
         og_title: {type: 'string', maxlength: 300, nullable: true},
         og_description: {type: 'string', maxlength: 500, nullable: true},
         twitter_image: {type: 'string', maxlength: 2000, nullable: true},
         twitter_title: {type: 'string', maxlength: 300, nullable: true},
         twitter_description: {type: 'string', maxlength: 500, nullable: true},
-        custom_template: {type: 'string', maxlength: 100, nullable: true},
-        canonical_url: {type: 'text', maxlength: 2000, nullable: true}
+        meta_title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
+        meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}}
     },
     users: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -585,6 +585,15 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         const options = ghostBookshelf.Model.filterOptions(unfilteredOptions, 'toJSON');
         options.omitPivot = true;
 
+        /**
+         * removes null relations coming from `hasOne` - https://bookshelfjs.org/api.html#Model-instance-hasOne
+         * Based on https://github.com/bookshelf/bookshelf/issues/72#issuecomment-25164617
+         */
+        _.each(this.relations, (value, key) => {
+            if (_.isEmpty(value)) {
+                delete this.relations[key];
+            }
+        });
         // CASE: get JSON of previous attrs
         if (options.previous) {
             const clonedModel = _.cloneDeep(this);
@@ -742,7 +751,13 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             }
 
             if (this.prototype.relationships && this.prototype.relationships.indexOf(property) !== -1) {
-                _.each(data[property], (relation, indexInArr) => {
+                let relations = data[property];
+
+                // CASE: 1:1 relation will have single data point
+                if (!_.isArray(data[property])) {
+                    relations = [data[property]];
+                }
+                _.each(relations, (relation, indexInArr) => {
                     _.each(relation, (value, relationProperty) => {
                         if (value !== null
                             && Object.prototype.hasOwnProperty.call(schema.tables[this.prototype.relationshipBelongsTo[property]], relationProperty)

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -34,7 +34,8 @@ models = [
     'api-key',
     'mobiledoc-revision',
     'member',
-    'action'
+    'action',
+    'posts-meta'
 ];
 
 function init() {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -233,18 +233,6 @@ Post = ghostBookshelf.Model.extend({
                 authors.forEach(author => author.emitChange('attached', options));
             });
         });
-        
-        model.related('posts_meta').once('detaching', function onDetached(collection, postsMeta) {
-            model.related('posts_meta').once('detached', function onDetached(detachedCollection, response, options) {
-                postsMeta.emitChange('detached', options);
-            });
-        });
-
-        model.related('posts_meta').once('attaching', function onAttached(collection, postsMeta) {
-            model.related('posts_meta').once('attached', function onAttached(detachedCollection, response, options) {
-                postsMeta.emitChange('attached', options);
-            });
-        });
     },
 
     /**

--- a/core/server/models/posts-meta.js
+++ b/core/server/models/posts-meta.js
@@ -1,0 +1,18 @@
+const ghostBookshelf = require('./base');
+
+const PostsMeta = ghostBookshelf.Model.extend({
+    tableName: 'posts_meta'
+}, {
+    emitChange: function emitChange(event, options) {
+        const eventToTrigger = 'posts_meta' + '.' + event;
+        ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
+    },
+
+    post() {
+        return this.belongsTo('Post');
+    }
+});
+
+module.exports = {
+    PostsMeta: ghostBookshelf.model('PostsMeta', PostsMeta)
+};

--- a/core/server/models/posts-meta.js
+++ b/core/server/models/posts-meta.js
@@ -3,11 +3,6 @@ const ghostBookshelf = require('./base');
 const PostsMeta = ghostBookshelf.Model.extend({
     tableName: 'posts_meta'
 }, {
-    emitChange: function emitChange(event, options) {
-        const eventToTrigger = 'posts_meta' + '.' + event;
-        ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
-    },
-
     post() {
         return this.belongsTo('Post');
     }

--- a/core/test/acceptance/old/admin/db_spec.js
+++ b/core/test/acceptance/old/admin/db_spec.js
@@ -58,7 +58,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(25);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(26);
             });
     });
 

--- a/core/test/acceptance/old/admin/utils.js
+++ b/core/test/acceptance/old/admin/utils.js
@@ -37,6 +37,10 @@ const expectedProperties = {
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         // returned by default
         .concat('tags', 'authors')
+        // returns meta fields from `posts_meta` schema
+        .concat(
+            ..._(schema.posts_meta).keys().without('post_id', 'id')
+        )
     ,
 
     page: _(schema.posts)
@@ -52,6 +56,10 @@ const expectedProperties = {
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         // returned by default
         .concat('tags', 'authors')
+        // returns meta fields from `posts_meta` schema
+        .concat(
+            ..._(schema.posts_meta).keys().without('post_id', 'id')
+        )
     ,
 
     user: _(schema.users)

--- a/core/test/acceptance/old/content/utils.js
+++ b/core/test/acceptance/old/content/utils.js
@@ -27,6 +27,10 @@ const expectedProperties = {
         // .without('page')
         // v2 returns a calculated excerpt field
         .concat('excerpt')
+        // returns meta fields from `posts_meta` schema
+        .concat(
+            ..._(schema.posts_meta).keys().without('post_id', 'id')
+        )
     ,
     author: _(schema.users)
         .keys()

--- a/core/test/regression/api/canary/admin/db_spec.js
+++ b/core/test/regression/api/canary/admin/db_spec.js
@@ -60,7 +60,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(27);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(28);
             });
     });
 

--- a/core/test/regression/api/canary/admin/utils.js
+++ b/core/test/regression/api/canary/admin/utils.js
@@ -31,6 +31,10 @@ const expectedProperties = {
         // only because authors and tags are always included
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         .concat('authors', 'tags')
+        // returns meta fields from `posts_meta` schema
+        .concat(
+            ..._(schema.posts_meta).keys().without('post_id', 'id')
+        )
     ,
     user: _(schema.users)
         .keys()

--- a/core/test/regression/api/canary/content/utils.js
+++ b/core/test/regression/api/canary/content/utils.js
@@ -27,6 +27,10 @@ const expectedProperties = {
         // .without('page')
         // canary returns a calculated excerpt field
         .concat('excerpt')
+        // returns meta fields from `posts_meta` schema
+        .concat(
+            ..._(schema.posts_meta).keys().without('post_id', 'id')
+        )
     ,
     author: _(schema.users)
         .keys()

--- a/core/test/regression/api/v2/admin/db_spec.js
+++ b/core/test/regression/api/v2/admin/db_spec.js
@@ -60,7 +60,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(27);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(28);
             });
     });
 

--- a/core/test/regression/api/v2/admin/utils.js
+++ b/core/test/regression/api/v2/admin/utils.js
@@ -29,6 +29,10 @@ const expectedProperties = {
         // always returns computed properties
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         .concat('authors', 'tags')
+        // returns meta fields from `posts_meta` schema
+        .concat(
+            ..._(schema.posts_meta).keys().without('post_id', 'id')
+        )
     ,
     user: _(schema.users)
         .keys()

--- a/core/test/regression/api/v2/content/utils.js
+++ b/core/test/regression/api/v2/content/utils.js
@@ -27,6 +27,10 @@ const expectedProperties = {
         // .without('page')
         // v2 returns a calculated excerpt field
         .concat('excerpt')
+        // returns meta fields from `posts_meta` schema
+        .concat(
+            ..._(schema.posts_meta).keys().without('post_id', 'id')
+        )
     ,
     author: _(schema.users)
         .keys()

--- a/core/test/regression/api/v3/admin/db_spec.js
+++ b/core/test/regression/api/v3/admin/db_spec.js
@@ -60,7 +60,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(27);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(28);
             });
     });
 

--- a/core/test/regression/api/v3/admin/utils.js
+++ b/core/test/regression/api/v3/admin/utils.js
@@ -31,6 +31,10 @@ const expectedProperties = {
         // only because authors and tags are always included
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         .concat('authors', 'tags')
+        // returns meta fields from `posts_meta` schema
+        .concat(
+            ..._(schema.posts_meta).keys().without('post_id', 'id')
+        )
     ,
     user: _(schema.users)
         .keys()

--- a/core/test/regression/api/v3/content/utils.js
+++ b/core/test/regression/api/v3/content/utils.js
@@ -27,6 +27,10 @@ const expectedProperties = {
         // .without('page')
         // v3 returns a calculated excerpt field
         .concat('excerpt')
+        // returns meta fields from `posts_meta` schema
+        .concat(
+            ..._(schema.posts_meta).keys().without('post_id', 'id')
+        )
     ,
     author: _(schema.users)
         .keys()

--- a/core/test/regression/models/model_posts_spec.js
+++ b/core/test/regression/models/model_posts_spec.js
@@ -750,8 +750,6 @@ describe('Post Model', function () {
 
                     // testing for nulls
                     (createdPost.get('feature_image') === null).should.equal(true);
-                    (createdPost.get('meta_title') === null).should.equal(true);
-                    (createdPost.get('meta_description') === null).should.equal(true);
 
                     createdPost.get('created_at').should.be.above(new Date(0).getTime());
                     createdPost.get('created_by').should.equal(testUtils.DataGenerator.Content.users[0].id);

--- a/core/test/unit/data/exporter/index_spec.js
+++ b/core/test/unit/data/exporter/index_spec.js
@@ -51,6 +51,7 @@ describe('Exporter', function () {
 
                 should.exist(exportData);
 
+                //TODO: Update when 3.0.0 is released
                 exportData.meta.version.should.eql('2.0.0');
 
                 tablesStub.calledOnce.should.be.true();
@@ -62,20 +63,21 @@ describe('Exporter', function () {
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
 
                 knexMock.getCall(0).args[0].should.eql('posts');
-                knexMock.getCall(1).args[0].should.eql('users');
-                knexMock.getCall(2).args[0].should.eql('posts_authors');
-                knexMock.getCall(3).args[0].should.eql('roles');
-                knexMock.getCall(4).args[0].should.eql('roles_users');
-                knexMock.getCall(5).args[0].should.eql('permissions');
-                knexMock.getCall(6).args[0].should.eql('permissions_users');
-                knexMock.getCall(7).args[0].should.eql('permissions_roles');
-                knexMock.getCall(8).args[0].should.eql('permissions_apps');
-                knexMock.getCall(9).args[0].should.eql('settings');
-                knexMock.getCall(10).args[0].should.eql('tags');
-                knexMock.getCall(11).args[0].should.eql('posts_tags');
-                knexMock.getCall(12).args[0].should.eql('apps');
-                knexMock.getCall(13).args[0].should.eql('app_settings');
-                knexMock.getCall(14).args[0].should.eql('app_fields');
+                knexMock.getCall(1).args[0].should.eql('posts_meta');
+                knexMock.getCall(2).args[0].should.eql('users');
+                knexMock.getCall(3).args[0].should.eql('posts_authors');
+                knexMock.getCall(4).args[0].should.eql('roles');
+                knexMock.getCall(5).args[0].should.eql('roles_users');
+                knexMock.getCall(6).args[0].should.eql('permissions');
+                knexMock.getCall(7).args[0].should.eql('permissions_users');
+                knexMock.getCall(8).args[0].should.eql('permissions_roles');
+                knexMock.getCall(9).args[0].should.eql('permissions_apps');
+                knexMock.getCall(10).args[0].should.eql('settings');
+                knexMock.getCall(11).args[0].should.eql('tags');
+                knexMock.getCall(12).args[0].should.eql('posts_tags');
+                knexMock.getCall(13).args[0].should.eql('apps');
+                knexMock.getCall(14).args[0].should.eql('app_settings');
+                knexMock.getCall(15).args[0].should.eql('app_fields');
 
                 done();
             }).catch(done);
@@ -103,22 +105,23 @@ describe('Exporter', function () {
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
 
                 knexMock.getCall(0).args[0].should.eql('posts');
-                knexMock.getCall(1).args[0].should.eql('users');
-                knexMock.getCall(2).args[0].should.eql('posts_authors');
-                knexMock.getCall(3).args[0].should.eql('roles');
-                knexMock.getCall(4).args[0].should.eql('roles_users');
-                knexMock.getCall(5).args[0].should.eql('permissions');
-                knexMock.getCall(6).args[0].should.eql('permissions_users');
-                knexMock.getCall(7).args[0].should.eql('permissions_roles');
-                knexMock.getCall(8).args[0].should.eql('permissions_apps');
-                knexMock.getCall(9).args[0].should.eql('settings');
-                knexMock.getCall(10).args[0].should.eql('tags');
-                knexMock.getCall(11).args[0].should.eql('posts_tags');
-                knexMock.getCall(12).args[0].should.eql('apps');
-                knexMock.getCall(13).args[0].should.eql('app_settings');
-                knexMock.getCall(14).args[0].should.eql('app_fields');
-                knexMock.getCall(15).args[0].should.eql('clients');
-                knexMock.getCall(16).args[0].should.eql('client_trusted_domains');
+                knexMock.getCall(1).args[0].should.eql('posts_meta');
+                knexMock.getCall(2).args[0].should.eql('users');
+                knexMock.getCall(3).args[0].should.eql('posts_authors');
+                knexMock.getCall(4).args[0].should.eql('roles');
+                knexMock.getCall(5).args[0].should.eql('roles_users');
+                knexMock.getCall(6).args[0].should.eql('permissions');
+                knexMock.getCall(7).args[0].should.eql('permissions_users');
+                knexMock.getCall(8).args[0].should.eql('permissions_roles');
+                knexMock.getCall(9).args[0].should.eql('permissions_apps');
+                knexMock.getCall(10).args[0].should.eql('settings');
+                knexMock.getCall(11).args[0].should.eql('tags');
+                knexMock.getCall(12).args[0].should.eql('posts_tags');
+                knexMock.getCall(13).args[0].should.eql('apps');
+                knexMock.getCall(14).args[0].should.eql('app_settings');
+                knexMock.getCall(15).args[0].should.eql('app_fields');
+                knexMock.getCall(16).args[0].should.eql('clients');
+                knexMock.getCall(17).args[0].should.eql('client_trusted_domains');
 
                 done();
             }).catch(done);

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,7 +19,7 @@ var should = require('should'),
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '03cc85e710d3b421c71066afc7c25b39';
+    const currentSchemaHash = '964bf174df19bf563602b6c194f34cfe';
     const currentFixturesHash = '4e08bb27bf16338b6eebad1f92a247d1';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
**NOTE: The post metadata table split is purely an internal optimization for v3 and doesn't require or expect any external actions including related API usage in v3**

We keep running into issues adding new fields to the post table because there are too many fields making the post table "too wide". We have also hit MySQL limitations in how many bytes can be in a row (64kb) with post table.

For v3, the idea is to split the 8 post fields (meta, twitter and og) used for meta data into a `posts_meta` table as these 8 fields are all "problem" varchar fields and make sense logically grouped together. The API layer is unaffected by the split as input/output serializers ensure the data flow works the same way as it was in v2. This PR -

- [x] Creates new `post_meta` schema/table with 8 fields (2 `meta_* `,  3 `twitter_*` and 3 `og_*`) 
- [x] Update relations between `post` and `post_meta` table
- [x] Update input/output serializers to keep existing API behavior 
- [x] Avoids new entry in `post_meta` table for post where all meta fields are null
- [x] Updates `1:1` table relation handling in base model
- [x] Keeps the current fields API param behavior
- [x] Handles migration of existing posts to new table structure
  - [x] Adds new `post_meta` table
  - [x] Populates metadata entries for all posts which have non-null meta fields
  - [x] Removes 8 meta fields from `post` table
- [x] Updates tests
- [x] Updates importer/exporter to work seamlessly with table changes
- [ ] Makes the filter API parameters behave as intended (non-blocking edge-case, skipped for now)