### PR TITLE
Added migrations to drop v0.1 auth tables

### DIFF
--- a/core/server/data/migrations/versions/3.0.0/2-drop-token-auth-tables.js
+++ b/core/server/data/migrations/versions/3.0.0/2-drop-token-auth-tables.js
@@ -1,0 +1,30 @@
+const common = require('../../../../lib/common');
+const commands = require('../../../schema').commands;
+
+const tables = [
+    'accesstokens',
+    'refreshtokens'
+];
+
+module.exports.up = (options) => {
+    const connection = options.connection;
+
+    return Promise.each(tables, function (table) {
+        return connection.schema.hasTable(table)
+            .then(function (exists) {
+                if (!exists) {
+                    common.logging.warn(`Dropping table: ${table}`);
+                    return;
+                }
+
+                common.logging.info(`Dropping table: ${table}`);
+                return commands.deleteTable(table, connection);
+            });
+    });
+};
+
+// the schemas for the deleted tables no longer exist so there's nothing for
+// `commands.createTable` to draw from for the table structure
+module.exports.down = () => {
+    return Promise.resolve();
+};

--- a/core/server/data/migrations/versions/3.0.0/3-drop-client-auth-tables.js
+++ b/core/server/data/migrations/versions/3.0.0/3-drop-client-auth-tables.js
@@ -1,0 +1,30 @@
+const common = require('../../../../lib/common');
+const commands = require('../../../schema').commands;
+
+const tables = [
+    'client_trusted_domains', // first due to foreign key constraint on client_id
+    'clients'
+];
+
+module.exports.up = (options) => {
+    const connection = options.connection;
+
+    return Promise.each(tables, function (table) {
+        return connection.schema.hasTable(table)
+            .then(function (exists) {
+                if (!exists) {
+                    common.logging.warn(`Dropping table: ${table}`);
+                    return;
+                }
+
+                common.logging.info(`Dropping table: ${table}`);
+                return commands.deleteTable(table, connection);
+            });
+    });
+};
+
+// the schemas for the deleted tables no longer exist so there's nothing for
+// `commands.createTable` to draw from for the table structure
+module.exports.down = () => {
+    return Promise.resolve();
+};


### PR DESCRIPTION
no issue

- drops now-unused `accesstokens`, `refreshtokens`, `clients`, and `client_trusted_domains` tables
- no rollback because the db schema for the tables no longer exists