### PR TITLE
🔥 Moved user email removal to API serialization layer

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -30,6 +30,7 @@ const author = (attrs, frame) => {
         delete attrs.updated_at;
         delete attrs.last_seen;
         delete attrs.status;
+        delete attrs.email;
 
         // @NOTE: used for night shift
         delete attrs.accessibility;

--- a/core/server/api/v2/utils/serializers/output/utils/clean.js
+++ b/core/server/api/v2/utils/serializers/output/utils/clean.js
@@ -30,6 +30,7 @@ const author = (attrs, frame) => {
         delete attrs.updated_at;
         delete attrs.last_seen;
         delete attrs.status;
+        delete attrs.email;
 
         // @NOTE: used for night shift
         delete attrs.accessibility;

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -216,13 +216,6 @@ User = ghostBookshelf.Model.extend({
         // remove password hash for security reasons
         delete attrs.password;
 
-        // NOTE: We don't expose the email address for for external, app and public context.
-        // @TODO: Why? External+Public is actually the same context? Was also mentioned here https://github.com/TryGhost/Ghost/issues/9043
-        // @TODO: move to api serialization when we drop v0.1
-        if (!options || !options.context || (!options.context.user && !options.context.internal && (!options.context.api_key || options.context.api_key.type === 'content'))) {
-            delete attrs.email;
-        }
-
         return attrs;
     },
 


### PR DESCRIPTION
Essentially these changes reflect similar logic to what has been done in case of similar changes - https://github.com/TryGhost/Ghost/commit/0306c397d04779d22d93c3660fdf3f594da5e756. 

@rishabhgrg @kevinansfield 	the only bit I was worried about is accidentally leaking the email field if the API is used directly (e.g. fetching resource from "frontend") but haven't found anything obvious. For example, in [webhooks](https://github.com/TryGhost/Ghost/blob/b83232b/core/server/services/webhooks/listen.js#L6-L37) we don't listen to user change events at all. Maybe you could think of a case I didn't take into account :thinking: 	