### PR TITLE
Add randomization option to foreach

### DIFF
--- a/core/frontend/helpers/foreach.js
+++ b/core/frontend/helpers/foreach.js
@@ -21,7 +21,7 @@ module.exports = function foreach(items, options) {
 
     // Initial values set based on parameters sent through. If nothing sent, set to defaults
     const {fn, inverse, hash, data, ids} = options;
-    let {columns, limit, from, to} = hash;
+    let {columns, limit, from, to, random} = hash;
     let length = _.size(items);
     let output = '';
     let frame;
@@ -70,6 +70,10 @@ module.exports = function foreach(items, options) {
     function iterateCollection(context) {
         // Context is all posts on the blog
         let current = 1;
+
+        if (random) {
+            context = context.sort(() => 0.5 - Math.random());
+        }
 
         // For each post, if it is a post number that fits within the from and to
         // send the key to execIteration to set to be added to the page


### PR DESCRIPTION
A simple change that adds an option ``random`` to the ``foreach`` helper.  When ``random`` is enabled results are randomized.  For example, to get 6 random posts:

```
{{#get "posts" limit="all"}}
  {{#foreach posts random=1 limit=6}}
    . . .
  {{/foreach}}
{{/get}}
```

The ``random`` option is truthy.  I.e. any value that evaluates to true in Javascript will turn it on.

It is true that Web caching may prevent a random result from appearing on every page reload.  But if this is used to show articles at the bottom of each post, you will get different results on each post page.  The cache will also eventually time out.

I think this is the simplest and least intrusive way to implement this feature and I know many people have asked for it so please consider accepting this PR.