### PR TITLE
Migrated default scheduler to work with v2 API

### DIFF
--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -1,19 +1,18 @@
-const Promise = require('bluebird'),
-    moment = require('moment'),
-    jwt = require('jsonwebtoken'),
-    localUtils = require('../utils'),
-    common = require('../../../lib/common'),
-    models = require('../../../models'),
-    urlUtils = require('../../../lib/url-utils'),
-    _private = {};
-
+const Promise = require('bluebird');
+const moment = require('moment');
+const jwt = require('jsonwebtoken');
+const localUtils = require('../utils');
+const common = require('../../../lib/common');
+const models = require('../../../models');
+const urlUtils = require('../../../lib/url-utils');
+const _private = {};
  
 /**
  * @description Load the internal scheduler integration
  *
  * @return {Promise}
  */
-_private.getSchedulerIntegration = function() {
+_private.getSchedulerIntegration = function () {
     return models.Integration.findOne({slug: 'ghost-scheduler'}, {withRelated: 'api_keys'})
         .then((integration) => {
             if (!integration) {
@@ -23,11 +22,9 @@ _private.getSchedulerIntegration = function() {
                     })
                 });
             }
-            let apiKeys = integration.toJSON().api_keys;
             return integration.toJSON();
         });
 };
-
 
 /**
  * @description Get signed admin token for making authenticated requests
@@ -59,7 +56,7 @@ _private.getSignedAdminToken = function (options) {
         Buffer.from(key.secret, 'hex'),
         JWT_OPTIONS
     );
-}
+};
 
 /**
  * @description Normalize model data into scheduler notation.
@@ -68,7 +65,7 @@ _private.getSignedAdminToken = function (options) {
  */
 _private.normalize = function normalize(options) {
     const {model, apiUrl, resourceType} = options;
-    const resource = `${resourceType}s`
+    const resource = `${resourceType}s`;
     const signedAdminToken = _private.getSignedAdminToken(options);
     let url = `${urlUtils.urlJoin(apiUrl, 'schedules', resource, model.get('id'))}/?token=${signedAdminToken}`;
     return {

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -42,12 +42,13 @@ _private.getSignedAdminToken = function (options) {
         audience: apiUrl
     };
 
-    // Default token expiry is till 10 minutes after scheduled time
-    // or if published_at is in past then till 10 minutes after blog start
+    // Default token expiry is till 6 hours after scheduled time
+    // or if published_at is in past then till 6 hours after blog start
+    // to allow for retries in case of network issues
     // and never before 10 mins to publish time
-    let tokenExpiry = moment(model.get('published_at')).add(10, 'm');
+    let tokenExpiry = moment(model.get('published_at')).add(6, 'h');
     if (tokenExpiry.isBefore(moment())) {
-        tokenExpiry = moment().add(10, 'm');
+        tokenExpiry = moment().add(6, 'h');
     }
 
     return jwt.sign(

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -54,7 +54,7 @@ _private.getSignedAdminToken = function (options) {
     return jwt.sign(
         {
             exp: tokenExpiry.unix(),
-            nbf: moment(model.get('published_at')).subtract(5, 'm').unix()
+            nbf: moment(model.get('published_at')).subtract(10, 'm').unix()
         },
         Buffer.from(key.secret, 'hex'),
         JWT_OPTIONS

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -88,12 +88,22 @@ _private.normalize = function normalize(options) {
  */
 _private.loadScheduledResources = function () {
     const apiv2 = require('../../../api').v2;
-    return apiv2.schedules.getScheduled.query({
-        options: {
-            context: {internal: true}
-        }
-    }).then((result) => {
-        return result || {};
+    const resources = ['post', 'page'];
+    return Promise.mapSeries(resources, (resourceType) => {
+        return apiv2.schedules.getScheduled.query({
+            options: {
+                context: {internal: true},
+                resource: resourceType
+            }
+        }).then((result) => {
+            return result[resourceType];
+        });
+    }).then((results) => {
+        return resources.reduce(function (obj, entry, index) {
+            return Object.assign(obj, {
+                [entry]: results[index]
+            });
+        }, {});
     });
 };
 

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -91,7 +91,6 @@ _private.loadScheduledResources = function () {
     return Promise.mapSeries(SCHEDULED_RESOURCES, (resourceType) => {
         return api.schedules.getScheduled.query({
             options: {
-                context: {internal: true},
                 resource: resourceType
             }
         }).then((result) => {

--- a/core/server/api/canary/schedules.js
+++ b/core/server/api/canary/schedules.js
@@ -111,18 +111,16 @@ module.exports = {
             }
         },
         query(frame) {
-            const resourceType = frame.options.resource;
-            const resourceModel = (resourceType === 'posts') ? 'Post' : 'Page';
-
+            const resourceModel = 'Post';
+            const resourceType = (frame.options.resource === 'post') ? 'post' : 'page';
             const cleanOptions = {};
-            cleanOptions.filter = 'status:scheduled';
-            cleanOptions.columns = ['id', 'published_at', 'created_at'];
+            cleanOptions.filter = `status:scheduled+type:${resourceType}`;
+            cleanOptions.columns = ['id', 'published_at', 'created_at', 'type'];
 
             return models[resourceModel].findAll(cleanOptions)
                 .then((result) => {
                     let response = {};
                     response[resourceType] = result;
-
                     return response;
                 });
         }

--- a/core/server/api/v2/schedules.js
+++ b/core/server/api/v2/schedules.js
@@ -102,24 +102,25 @@ module.exports = {
         // NOTE: this method is for internal use only by DefaultScheduler
         //       it is not exposed anywhere!
         permissions: false,
+        validation: {
+            options: {
+                resource: {
+                    required: true,
+                    values: ['posts', 'pages']
+                }
+            }
+        },
         query(frame) {
             const resourceModel = 'Post';
+            const resourceType = (frame.options.resource === 'post') ? 'post' : 'page';
             const cleanOptions = {};
-            cleanOptions.filter = 'status:scheduled';
+            cleanOptions.filter = `status:scheduled+type:${resourceType}`;
             cleanOptions.columns = ['id', 'published_at', 'created_at', 'type'];
 
             return models[resourceModel].findAll(cleanOptions)
-                .then((result = []) => {
+                .then((result) => {
                     let response = {};
-                    result.forEach((model) => {
-                        let type = model.get('type') || 'post';
-                        if (response[type]) {
-                            response[type].push(model);
-                        } else {
-                            response[type] = [model];
-                        }
-                    })
-
+                    response[resourceType] = result;
                     return response;
                 });
         }

--- a/core/server/api/v2/schedules.js
+++ b/core/server/api/v2/schedules.js
@@ -102,26 +102,23 @@ module.exports = {
         // NOTE: this method is for internal use only by DefaultScheduler
         //       it is not exposed anywhere!
         permissions: false,
-        validation: {
-            options: {
-                resource: {
-                    required: true,
-                    values: ['posts', 'pages']
-                }
-            }
-        },
         query(frame) {
-            const resourceType = frame.options.resource;
-            const resourceModel = (resourceType === 'posts') ? 'Post' : 'Page';
-
+            const resourceModel = 'Post';
             const cleanOptions = {};
             cleanOptions.filter = 'status:scheduled';
-            cleanOptions.columns = ['id', 'published_at', 'created_at'];
+            cleanOptions.columns = ['id', 'published_at', 'created_at', 'type'];
 
             return models[resourceModel].findAll(cleanOptions)
-                .then((result) => {
+                .then((result = []) => {
                     let response = {};
-                    response[resourceType] = result;
+                    result.forEach((model) => {
+                        let type = model.get('type') || 'post';
+                        if (response[type]) {
+                            response[type].push(model);
+                        } else {
+                            response[type] = [model];
+                        }
+                    })
 
                     return response;
                 });

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -45,7 +45,7 @@ function initialiseServices() {
             active: config.get('scheduling').active,
             // NOTE: When changing API version need to consider how to migrate custom scheduling adapters
             //       that rely on URL to lookup persisted scheduled records (jobs, etc.). Ref: https://github.com/TryGhost/Ghost/pull/10726#issuecomment-489557162
-            apiUrl: urlUtils.urlFor('api', {version: 'v2', versionType: 'content'}, true),
+            apiUrl: urlUtils.urlFor('api', {version: 'v2', versionType: 'admin'}, true),
             internalPath: config.get('paths').internalSchedulingPath,
             contentPath: config.getContentPath('scheduling')
         })

--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -3,8 +3,7 @@ const url = require('url');
 const models = require('../../../models');
 const common = require('../../../lib/common');
 
-const JWT_OPTIONS = {
-    maxAge: '5m',
+let JWT_OPTIONS = {
     algorithms: ['HS256']
 };
 
@@ -39,11 +38,13 @@ const authenticate = (req, res, next) => {
         return next();
     }
     const token = _extractTokenFromHeader(req.headers.authorization);
+    JWT_OPTIONS['maxAge'] = '5m';
     return authenticateWithToken(req, res, next, token);
 }
 
 const authenticateInternal = (req, res, next) => {
     const token = _extractTokenFromUrl(req.originalUrl);
+    delete JWT_OPTIONS['maxAge'];
     return authenticateWithToken(req, res, next, token);
 }
 

--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -150,5 +150,5 @@ const authenticateWithToken = (req, res, next, token) => {
 
 module.exports = {
     authenticate,
-    authenticateWithUrl: authenticateWithUrl
+    authenticateWithUrl
 };

--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -50,7 +50,7 @@ const authenticateInternal = (req, res, next) => {
 
 /**
  * Admin API key authentication flow:
- * 1. extract the JWT token from the `Authorization: Ghost xxxx` header
+ * 1. extract the JWT token from the `Authorization: Ghost xxxx` header or from URL(for schedules)
  * 2. decode the JWT to extract the api_key id from the "key id" header claim
  * 3. find a matching api_key record
  * 4. verify the JWT (matching secret, matching URL path, not expired)

--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -78,7 +78,6 @@ const authenticateWithUrl = (req, res, next) => {
  *   https://tools.ietf.org/html/rfc7519#section-4.1.3
  */
 const authenticateWithToken = (req, res, next, token) => {
-
     const decoded = jwt.decode(token, {complete: true});
 
     if (!decoded || !decoded.header) {

--- a/core/server/services/auth/api-key/admin.js
+++ b/core/server/services/auth/api-key/admin.js
@@ -38,15 +38,15 @@ const authenticate = (req, res, next) => {
         return next();
     }
     const token = _extractTokenFromHeader(req.headers.authorization);
-    JWT_OPTIONS['maxAge'] = '5m';
+    JWT_OPTIONS.maxAge = '5m';
     return authenticateWithToken(req, res, next, token);
-}
+};
 
 const authenticateInternal = (req, res, next) => {
     const token = _extractTokenFromUrl(req.originalUrl);
-    delete JWT_OPTIONS['maxAge'];
+    delete JWT_OPTIONS.maxAge;
     return authenticateWithToken(req, res, next, token);
-}
+};
 
 /**
  * Admin API key authentication flow:
@@ -63,7 +63,6 @@ const authenticateInternal = (req, res, next) => {
  *   https://tools.ietf.org/html/rfc7519#section-4.1.3
  */
 const authenticateWithToken = (req, res, next, token) => {
-
     if (!token) {
         return next(new common.errors.UnauthorizedError({
             message: common.i18n.t('errors.middleware.auth.incorrectAuthHeaderFormat'),

--- a/core/server/services/auth/authenticate.js
+++ b/core/server/services/auth/authenticate.js
@@ -4,6 +4,7 @@ const members = require('./members');
 
 const authenticate = {
     authenticateAdminApi: [apiKeyAuth.admin.authenticate, session.authenticate],
+    authenticateAdminApiInternal: [apiKeyAuth.admin.authenticateInternal, session.authenticate],
 
     authenticateContentApi: [apiKeyAuth.content.authenticateContentApiKey, members.authenticateMembersToken]
 };

--- a/core/server/services/auth/authenticate.js
+++ b/core/server/services/auth/authenticate.js
@@ -4,7 +4,7 @@ const members = require('./members');
 
 const authenticate = {
     authenticateAdminApi: [apiKeyAuth.admin.authenticate, session.authenticate],
-    authenticateAdminApiInternal: [apiKeyAuth.admin.authenticateInternal, session.authenticate],
+    authenticateAdminApiWithUrl: [apiKeyAuth.admin.authenticateWithUrl],
 
     authenticateContentApi: [apiKeyAuth.content.authenticateContentApiKey, members.authenticateMembersToken]
 };

--- a/core/server/web/api/canary/admin/middleware.js
+++ b/core/server/web/api/canary/admin/middleware.js
@@ -58,6 +58,20 @@ module.exports.authAdminApi = [
 ];
 
 /**
+ * Authentication for private endpoints with token in URL
+ * Ex.: For scheduler publish endpoint
+ */
+module.exports.authAdminApiWithUrl = [
+    auth.authenticate.authenticateAdminApiWithUrl,
+    auth.authorize.authorizeAdminApi,
+    shared.middlewares.updateUserLastSeen,
+    shared.middlewares.api.cors,
+    shared.middlewares.urlRedirects.adminRedirect,
+    shared.middlewares.prettyUrls,
+    notImplemented
+];
+
+/**
  * Middleware for public admin endpoints
  */
 module.exports.publicAdminApi = [

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -48,7 +48,7 @@ module.exports = function apiRoutes() {
     router.del('/integrations/:id', mw.authAdminApi, http(apiCanary.integrations.destroy));
 
     // ## Schedules
-    router.put('/schedules/:resource/:id', mw.authAdminApi, http(apiCanary.schedules.publish));
+    router.put('/schedules/:resource/:id', mw.authAdminApiWithUrl, http(apiCanary.schedules.publish));
 
     // ## Settings
     router.get('/settings/routes/yaml', mw.authAdminApi, http(apiCanary.settings.download));

--- a/core/server/web/api/v2/admin/middleware.js
+++ b/core/server/web/api/v2/admin/middleware.js
@@ -57,6 +57,19 @@ module.exports.authAdminApi = [
 ];
 
 /**
+ * Authentication for internal endpoints
+ */
+module.exports.authInternalAdminApi = [
+    auth.authenticate.authenticateAdminApiInternal,
+    auth.authorize.authorizeAdminApi,
+    shared.middlewares.updateUserLastSeen,
+    shared.middlewares.api.cors,
+    shared.middlewares.urlRedirects.adminRedirect,
+    shared.middlewares.prettyUrls,
+    notImplemented
+];
+
+/**
  * Middleware for public admin endpoints
  */
 module.exports.publicAdminApi = [

--- a/core/server/web/api/v2/admin/middleware.js
+++ b/core/server/web/api/v2/admin/middleware.js
@@ -57,10 +57,11 @@ module.exports.authAdminApi = [
 ];
 
 /**
- * Authentication for internal endpoints
+ * Authentication for private endpoints with token in URL
+ * Ex.: For scheduler publish endpoint
  */
-module.exports.authInternalAdminApi = [
-    auth.authenticate.authenticateAdminApiInternal,
+module.exports.authAdminApiWithUrl = [
+    auth.authenticate.authenticateAdminApiWithUrl,
     auth.authorize.authorizeAdminApi,
     shared.middlewares.updateUserLastSeen,
     shared.middlewares.api.cors,

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -48,7 +48,7 @@ module.exports = function apiRoutes() {
     router.del('/integrations/:id', mw.authAdminApi, http(apiv2.integrations.destroy));
 
     // ## Schedules
-    router.put('/schedules/:resource/:id', mw.authAdminApi, http(apiv2.schedules.publish));
+    router.put('/schedules/:resource/:id', mw.authInternalAdminApi, http(apiv2.schedules.publish));
 
     // ## Settings
     router.get('/settings/routes/yaml', mw.authAdminApi, http(apiv2.settings.download));

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -48,7 +48,7 @@ module.exports = function apiRoutes() {
     router.del('/integrations/:id', mw.authAdminApi, http(apiv2.integrations.destroy));
 
     // ## Schedules
-    router.put('/schedules/:resource/:id', mw.authInternalAdminApi, http(apiv2.schedules.publish));
+    router.put('/schedules/:resource/:id', mw.authAdminApiWithUrl, http(apiv2.schedules.publish));
 
     // ## Settings
     router.get('/settings/routes/yaml', mw.authAdminApi, http(apiv2.settings.download));


### PR DESCRIPTION
The v2 API previously broke the fundamental concept of how the scheduler works - having a known, independent URL for publishing a resource later. Also, previously scheduler worked using client id/secret for an authenticated URL to publish resources. We replaced concept of `client id/secret` from v2 onwards to have `integrations` which have `api_key` to generate valid tokens. 

The default scheduler needs to be updated to be able to generate a known independent URL for publishing resources from v2 API onwards.

This PR -

- updates resource scheduling logic to work with v2/v3/canary APIs by working with integrations instead of client id/secret
- creates a signed JWT Admin token with a limited duration validity using `never before` and `expiry` claims
- creates a `v2` publish URL with above signed JWT in URL query for scheduler to make authenticated publish requests using just URLs
- adds new admin auth middleware which can read a token from URL query and authenticate requests for publishing
- updates `schedules/publish` endpoint to use the new admin auth middleware allowing tokens in URL query