### PR TITLE
Added back name column to members table

### DIFF
--- a/core/server/data/migrations/versions/2.32/1-add-name-to-members-table.js
+++ b/core/server/data/migrations/versions/2.32/1-add-name-to-members-table.js
@@ -9,13 +9,7 @@ module.exports = {
             return hasColumn === true;
         },
         operation: commands.addColumn,
-        operationVerb: 'Adding',
-        columnDefinition: {
-            type: 'string',
-            maxlength: 191,
-            nullable: false,
-            defaultTo: ''
-        }
+        operationVerb: 'Adding'
     }),
 
     down: commands.createColumnMigration({

--- a/core/server/data/migrations/versions/2.32/1-add-name-to-members-table.js
+++ b/core/server/data/migrations/versions/2.32/1-add-name-to-members-table.js
@@ -1,0 +1,34 @@
+const commands = require('../../../schema').commands;
+
+module.exports = {
+
+    up: commands.createColumnMigration({
+        table: 'members',
+        column: 'name',
+        dbIsInCorrectState(hasColumn) {
+            return hasColumn === true;
+        },
+        operation: commands.addColumn,
+        operationVerb: 'Adding',
+        columnDefinition: {
+            type: 'string',
+            maxlength: 191,
+            nullable: false,
+            defaultTo: ''
+        }
+    }),
+
+    down: commands.createColumnMigration({
+        table: 'members',
+        column: 'name',
+        dbIsInCorrectState(hasColumn) {
+            return hasColumn === false;
+        },
+        operation: commands.dropColumn,
+        operationVerb: 'Dropping'
+    }),
+
+    config: {
+        transaction: true
+    }
+};

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -385,6 +385,7 @@ module.exports = {
     members: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         email: {type: 'string', maxlength: 191, nullable: false, unique: true, validations: {isEmail: true}},
+        name: {type: 'string', maxlength: 191, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,7 +19,7 @@ var should = require('should'),
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '988ec6aa45840b4d15e16d5b1d2a9976';
+    const currentSchemaHash = 'a503d46e2333202f00fa2bc835b064d2';
     const currentFixturesHash = 'c7b485fe2f16517295bd35c761129729';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/294f3769cb59cd04478122896ad7743a991337aa

- We have a need for name field now :)
- This time `name` is nullable!

Migrations are present, so need :eyes:  on them :smiley: 