### PR TITLE
🏗  Migrated subscribers data to members

### DIFF
--- a/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
+++ b/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
@@ -28,7 +28,7 @@ module.exports.up = (options) => {
         .fetch(localOptions)
         .then(({models: subscribers}) => {
             if (subscribers.length > 0) {
-                common.logging.info(`Adding ${subscribers.length} entries to subscribers`);
+                common.logging.info(`Adding ${subscribers.length} entries to members`);
 
                 let members = _.map(subscribers, (subscriber) => {
                     let member = memberAttrs.reduce(function (obj, prop) {

--- a/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
+++ b/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
@@ -1,6 +1,5 @@
 const ObjectId = require('bson-objectid');
 const _ = require('lodash');
-const membersSchema = require('../../../schema').tables.members;
 const models = require('../../../../models');
 const common = require('../../../../lib/common');
 
@@ -15,7 +14,14 @@ module.exports.up = (options) => {
         migrating: true
     }, options);
 
-    const memberAttrs = _.keys(membersSchema);
+    const memberAttrs = [
+        'name',
+        'email',
+        'created_at',
+        'created_by',
+        'updated_at',
+        'updated_by'
+    ];
 
     return models.Subscribers
         .forge()
@@ -25,9 +31,9 @@ module.exports.up = (options) => {
                 common.logging.info(`Adding ${subscribers.length} entries to subscribers`);
 
                 let members = _.map(subscribers, (subscriber) => {
-                    let member = memberAttrs.reduce(function (obj, entry) {
+                    let member = memberAttrs.reduce(function (obj, prop) {
                         return Object.assign(obj, {
-                            [entry]: subscriber.get(entry)
+                            [prop]: subscriber.get(prop)
                         });
                     }, {});
                     member.id = ObjectId.generate();

--- a/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
+++ b/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
@@ -5,7 +5,8 @@ const models = require('../../../../models');
 const common = require('../../../../lib/common');
 
 module.exports.config = {
-    transaction: true
+    transaction: true,
+    irreversible: true
 };
 
 module.exports.up = (options) => {

--- a/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
+++ b/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
@@ -1,0 +1,46 @@
+const ObjectId = require('bson-objectid');
+const _ = require('lodash');
+const membersSchema = require('../../../schema').tables.members;
+const models = require('../../../../models');
+const common = require('../../../../lib/common');
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    const localOptions = _.merge({
+        context: {internal: true},
+        migrating: true
+    }, options);
+
+    const memberAttrs = _.keys(membersSchema);
+
+    return models.Subscribers
+        .forge()
+        .fetch(localOptions)
+        .then(({models: subscribers}) => {
+            if (subscribers.length > 0) {
+                common.logging.info(`Adding ${subscribers.length} entries to subscribers`);
+
+                let members = _.map(subscribers, (subscriber) => {
+                    let member = memberAttrs.reduce(function (obj, entry) {
+                        return Object.assign(obj, {
+                            [entry]: subscriber.get(entry)
+                        });
+                    }, {});
+                    member.id = ObjectId.generate();
+
+                    return member;
+                });
+                return localOptions.transacting('members').insert(members);
+            } else {
+                common.logging.info('Skipping populating members table: found 0 subscribers');
+                return Promise.resolve();
+            }
+        });
+};
+
+module.exports.down = () => {
+    return Promise.reject();
+};


### PR DESCRIPTION
subscribers be dead :skull: part uno

Heavily inspired (aka total rip-off) from https://github.com/TryGhost/Ghost/commit/8ec12d9eeed7fb4aa0ce7022cfc802063fd8c4fa#diff-d8134e2685be7aa74ca7fda95443c6ef. As a follow up will be the removal of all subscriber related code (schema, app, flags, templates etc.)

Migration need :eyes: on this. Thx!
