### PR TITLE
Updated create member method

### DIFF
--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -7,9 +7,10 @@ const ghostVersion = require('../../lib/ghost-version');
 const mail = require('../mail');
 const models = require('../../models');
 
-function createMember({email}) {
+function createMember({email, name}) {
     return models.Member.add({
-        email
+        email,
+        name
     }).then((member) => {
         return member.toJSON();
     });

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@nexes/nql": "0.3.0",
     "@tryghost/helpers": "1.1.10",
-    "@tryghost/members-api": "0.6.0",
+    "@tryghost/members-api": "0.6.1",
     "@tryghost/members-ssr": "0.5.0",
     "@tryghost/social-urls": "0.1.2",
     "@tryghost/string": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,10 +199,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.6.0.tgz#24ab1129bc3c09a35ab52c760e184caa917f6023"
-  integrity sha512-uinR3QoZM2ylQzB+OC9ZlhYwRc9gqDsAd1R+1ogVMIuIw+3jO5G+dh0SU905JssiRaR9TcY+o5PSeyehomGO6Q==
+"@tryghost/members-api@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.6.1.tgz#ab8130f547ed60a35c83a10b9d1c2bcca27a8d6a"
+  integrity sha512-aZSDE5MW0kbHZWgKSK3LkQRZKQG4LmBeHeifMwW51LJypHirFoWAqCjDSD8ssjxULO11XuMqUwzpgH9YwhkzNA==
   dependencies:
     "@tryghost/magic-link" "^0.1.3"
     bluebird "^3.5.4"


### PR DESCRIPTION
no-issue

This allows member creation to be passed a name, and also for a `sendEmail` and `emailType` flag to be passed as options.

Example usage:

```js
const membersService = require('./core/server/services/members');

const member = await membersService.api.members.create({
  email: 'egg@ghost.org',
  name: 'egg'
}, {
  sendEmail: true,
  emailType: 'signup'
})
```