### PR TITLE
Added content gating based on visibility flag

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/members.js
+++ b/core/server/api/canary/utils/serializers/output/utils/members.js
@@ -14,13 +14,13 @@ function hideMembersOnlyContent({visibility}, frame) {
 
     if (!requestFromMember) {
         return BLOCK_CONTENT;
+    } else if (visibility === 'members') {
+        return PERMIT_CONTENT;
     }
 
     const memberHasPlan = !!(_.get(frame, 'original.context.member.stripe.subscriptions', [])).length;
 
-    if (visibility === 'members' && requestFromMember) {
-        return PERMIT_CONTENT;
-    } else if (visibility === 'paid' && memberHasPlan) {
+    if (visibility === 'paid' && memberHasPlan) {
         return PERMIT_CONTENT;
     }
 

--- a/core/server/api/canary/utils/serializers/output/utils/members.js
+++ b/core/server/api/canary/utils/serializers/output/utils/members.js
@@ -1,45 +1,42 @@
+const _ = require('lodash');
 const labs = require('../../../../../../services/labs');
-const membersService = require('../../../../../../services/members');
-const MEMBER_TAG = '#members';
-const PERMIT_CONTENT = false;
-const BLOCK_CONTENT = true;
 
-// Checks if request should hide memnbers only content
-function hideMembersOnlyContent(attrs, frame) {
-    const membersEnabled = labs.isSet('members');
-    if (!membersEnabled) {
+// Checks if request should hide members only content
+function hideMembersOnlyContent({visibility}, frame) {
+    const PERMIT_CONTENT = false;
+    const BLOCK_CONTENT = true;
+
+    if (visibility === 'public') {
         return PERMIT_CONTENT;
     }
 
-    const postHasMemberTag = attrs.tags && attrs.tags.find((tag) => {
-        return (tag.name === MEMBER_TAG);
-    });
     const requestFromMember = frame.original.context.member;
-    if (!postHasMemberTag) {
-        return PERMIT_CONTENT;
-    }
+
     if (!requestFromMember) {
         return BLOCK_CONTENT;
     }
 
-    const memberHasPlan = !!(frame.original.context.member.stripe.subscriptions || []).length;
-    if (!membersService.isPaymentConfigured()) {
+    const memberHasPlan = !!(_.get(frame, 'original.context.member.stripe.subscriptions', [])).length;
+
+    if (visibility === 'members' && requestFromMember) {
+        return PERMIT_CONTENT;
+    } else if (visibility === 'paid' && memberHasPlan) {
         return PERMIT_CONTENT;
     }
-    if (memberHasPlan) {
-        return PERMIT_CONTENT;
-    }
+
     return BLOCK_CONTENT;
 }
 
 const forPost = (attrs, frame) => {
-    const hideFormatsData = hideMembersOnlyContent(attrs, frame);
-    if (hideFormatsData) {
-        ['plaintext', 'html'].forEach((field) => {
-            attrs[field] = '';
-        });
-    }
     if (labs.isSet('members')) {
+        const hideFormatsData = hideMembersOnlyContent(attrs, frame);
+
+        if (hideFormatsData) {
+            ['plaintext', 'html'].forEach((field) => {
+                attrs[field] = '';
+            });
+        }
+
         // CASE: Members always adds tags, remove if the user didn't originally ask for them
         const origQueryOrOptions = frame.original.query || frame.original.options || {};
         const origInclude = origQueryOrOptions.include;

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -14,13 +14,13 @@ function hideMembersOnlyContent({visibility}, frame) {
 
     if (!requestFromMember) {
         return BLOCK_CONTENT;
+    } else if (visibility === 'members') {
+        return PERMIT_CONTENT;
     }
 
     const memberHasPlan = !!(_.get(frame, 'original.context.member.stripe.subscriptions', [])).length;
 
-    if (visibility === 'members' && requestFromMember) {
-        return PERMIT_CONTENT;
-    } else if (visibility === 'paid' && memberHasPlan) {
+    if (visibility === 'paid' && memberHasPlan) {
         return PERMIT_CONTENT;
     }
 

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -1,45 +1,42 @@
+const _ = require('lodash');
 const labs = require('../../../../../../services/labs');
-const membersService = require('../../../../../../services/members');
-const MEMBER_TAG = '#members';
-const PERMIT_CONTENT = false;
-const BLOCK_CONTENT = true;
 
-// Checks if request should hide memnbers only content
-function hideMembersOnlyContent(attrs, frame) {
-    const membersEnabled = labs.isSet('members');
-    if (!membersEnabled) {
+// Checks if request should hide members only content
+function hideMembersOnlyContent({visibility}, frame) {
+    const PERMIT_CONTENT = false;
+    const BLOCK_CONTENT = true;
+
+    if (visibility === 'public') {
         return PERMIT_CONTENT;
     }
 
-    const postHasMemberTag = attrs.tags && attrs.tags.find((tag) => {
-        return (tag.name === MEMBER_TAG);
-    });
     const requestFromMember = frame.original.context.member;
-    if (!postHasMemberTag) {
-        return PERMIT_CONTENT;
-    }
+
     if (!requestFromMember) {
         return BLOCK_CONTENT;
     }
 
-    const memberHasPlan = !!(frame.original.context.member.stripe.subscriptions).length;
-    if (!membersService.isPaymentConfigured()) {
+    const memberHasPlan = !!(_.get(frame, 'original.context.member.stripe.subscriptions', [])).length;
+
+    if (visibility === 'members' && requestFromMember) {
+        return PERMIT_CONTENT;
+    } else if (visibility === 'paid' && memberHasPlan) {
         return PERMIT_CONTENT;
     }
-    if (memberHasPlan) {
-        return PERMIT_CONTENT;
-    }
+
     return BLOCK_CONTENT;
 }
 
 const forPost = (attrs, frame) => {
-    const hideFormatsData = hideMembersOnlyContent(attrs, frame);
-    if (hideFormatsData) {
-        ['plaintext', 'html'].forEach((field) => {
-            attrs[field] = '';
-        });
-    }
     if (labs.isSet('members')) {
+        const hideFormatsData = hideMembersOnlyContent(attrs, frame);
+
+        if (hideFormatsData) {
+            ['plaintext', 'html'].forEach((field) => {
+                attrs[field] = '';
+            });
+        }
+
         // CASE: Members always adds tags, remove if the user didn't originally ask for them
         const origQueryOrOptions = frame.original.query || frame.original.options || {};
         const origInclude = origQueryOrOptions.include;

--- a/core/test/unit/api/canary/utils/serializers/output/utils/members_spec.js
+++ b/core/test/unit/api/canary/utils/serializers/output/utils/members_spec.js
@@ -1,0 +1,136 @@
+const should = require('should');
+const sinon = require('sinon');
+const labs = require('../../../../../../../../server/services/labs');
+const members = require('../../../../../../../../server/api/canary/utils/serializers/output/utils/members');
+
+describe('Unit: canary/utils/serializers/output/utils/members', function () {
+    describe('for post', function () {
+        it('does not modify attributes when members is disabled', function () {
+            const attrs = {
+                plaintext: 'no touching',
+                html: '<p>I am here to stay</p>'
+            };
+
+            const frame = {
+                options: {}
+            };
+            members.forPost(attrs, frame);
+
+            attrs.plaintext.should.eql('no touching');
+        });
+
+        describe('labs.members enabled', function () {
+            before(function () {
+                sinon.stub(labs, 'isSet').returns(true);
+            });
+
+            it('should NOT hide content attributes when visibility is public', function () {
+                const attrs = {
+                    visibility: 'public',
+                    plaintext: 'no touching',
+                    html: '<p>I am here to stay</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {}
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('no touching');
+            });
+
+            it('should hide content attributes when visibility is "members"', function () {
+                const attrs = {
+                    visibility: 'members',
+                    plaintext: 'no touching. secret stuff',
+                    html: '<p>I am here to stay</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {}
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('');
+                attrs.html.should.eql('');
+            });
+
+            it('should NOT hide content attributes when visibility is "members" and member is present', function () {
+                const attrs = {
+                    visibility: 'members',
+                    plaintext: 'I see dead people',
+                    html: '<p>What\'s the matter?</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {
+                            member: {}
+                        }
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('I see dead people');
+                attrs.html.should.eql('<p>What\'s the matter?</p>');
+            });
+
+            it('should hide content attributes when visibility is "paid" and member has no subscription', function () {
+                const attrs = {
+                    visibility: 'paid',
+                    plaintext: 'I see dead people',
+                    html: '<p>What\'s the matter?</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {
+                            member: {
+                                stripe: {
+                                    subscriptions: []
+                                }
+                            }
+                        }
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('');
+                attrs.html.should.eql('');
+            });
+
+            it('should NOT hide content attributes when visibility is "paid" and member has a subscription', function () {
+                const attrs = {
+                    visibility: 'paid',
+                    plaintext: 'Secret paid content',
+                    html: '<p>Can read this</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {
+                            member: {
+                                stripe: {
+                                    subscriptions: ['I pay money dollaz']
+                                }
+                            }
+                        }
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('Secret paid content');
+                attrs.html.should.eql('<p>Can read this</p>');
+            });
+        });
+    });
+});

--- a/core/test/unit/api/v2/utils/serializers/output/utils/members_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/output/utils/members_spec.js
@@ -1,0 +1,136 @@
+const should = require('should');
+const sinon = require('sinon');
+const labs = require('../../../../../../../../server/services/labs');
+const members = require('../../../../../../../../server/api/v2/utils/serializers/output/utils/members');
+
+describe('Unit: v2/utils/serializers/output/utils/members', function () {
+    describe('for post', function () {
+        it('does not modify attributes when members is disabled', function () {
+            const attrs = {
+                plaintext: 'no touching',
+                html: '<p>I am here to stay</p>'
+            };
+
+            const frame = {
+                options: {}
+            };
+            members.forPost(attrs, frame);
+
+            attrs.plaintext.should.eql('no touching');
+        });
+
+        describe('labs.members enabled', function () {
+            before(function () {
+                sinon.stub(labs, 'isSet').returns(true);
+            });
+
+            it('should NOT hide content attributes when visibility is public', function () {
+                const attrs = {
+                    visibility: 'public',
+                    plaintext: 'no touching',
+                    html: '<p>I am here to stay</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {}
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('no touching');
+            });
+
+            it('should hide content attributes when visibility is "members"', function () {
+                const attrs = {
+                    visibility: 'members',
+                    plaintext: 'no touching. secret stuff',
+                    html: '<p>I am here to stay</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {}
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('');
+                attrs.html.should.eql('');
+            });
+
+            it('should NOT hide content attributes when visibility is "members" and member is present', function () {
+                const attrs = {
+                    visibility: 'members',
+                    plaintext: 'I see dead people',
+                    html: '<p>What\'s the matter?</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {
+                            member: {}
+                        }
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('I see dead people');
+                attrs.html.should.eql('<p>What\'s the matter?</p>');
+            });
+
+            it('should hide content attributes when visibility is "paid" and member has no subscription', function () {
+                const attrs = {
+                    visibility: 'paid',
+                    plaintext: 'I see dead people',
+                    html: '<p>What\'s the matter?</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {
+                            member: {
+                                stripe: {
+                                    subscriptions: []
+                                }
+                            }
+                        }
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('');
+                attrs.html.should.eql('');
+            });
+
+            it('should NOT hide content attributes when visibility is "paid" and member has a subscription', function () {
+                const attrs = {
+                    visibility: 'paid',
+                    plaintext: 'Secret paid content',
+                    html: '<p>Can read this</p>'
+                };
+
+                const frame = {
+                    original: {
+                        context: {
+                            member: {
+                                stripe: {
+                                    subscriptions: ['I pay money dollaz']
+                                }
+                            }
+                        }
+                    }
+                };
+
+                members.forPost(attrs, frame);
+
+                attrs.plaintext.should.eql('Secret paid content');
+                attrs.html.should.eql('<p>Can read this</p>');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Hides content based on combinations of posts visibility options: `public`, `members`, `paid` and respective member's status.

@allouis wanted to check on the format of the `subscribtions` attribute. Should we check for some specific value in `subscriptions` or regular check if it's non-falsy value is enough?