### PR TITLE
Added initial multiple email templates support

### DIFF
--- a/core/server/public/members.js
+++ b/core/server/public/members.js
@@ -9,6 +9,11 @@ Array.prototype.forEach.call(document.querySelectorAll('form[data-members-form]'
         form.classList.remove('success', 'invalid', 'error');
         var input = event.target.querySelector('input[data-members-email]');
         var email = input.value;
+        var emailType = undefined;
+
+        if (form.dataset.membersForm) {
+            emailType = form.dataset.membersForm;
+        }
 
         if (!email.includes('@')) {
             form.classList.add('invalid')
@@ -23,7 +28,8 @@ Array.prototype.forEach.call(document.querySelectorAll('form[data-members-form]'
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                email: email
+                email: email,
+                emailType: emailType
             })
         }).then(function (res) {
             form.addEventListener('submit', submitHandler);

--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -122,9 +122,10 @@ function createApiInstance() {
             privateKey: settingsCache.get('members_private_key')
         },
         auth: {
-            getSigninURL(token) {
+            getSigninURL(token, type) {
                 const signinURL = new URL(siteUrl);
                 signinURL.searchParams.set('token', token);
+                signinURL.searchParams.set('action', type);
                 return signinURL.href;
             }
         },
@@ -135,6 +136,28 @@ function createApiInstance() {
                         common.logging.warn(message.text);
                     }
                     return ghostMailer.send(Object.assign({subject: 'Signin'}, message));
+                }
+            },
+            getText(url, type) {
+                switch (type) {
+                case 'subscribe':
+                    return `Click here to confirm your subscription ${url}`;
+                case 'signup':
+                    return `Click here to confirm your email address and sign up ${url}`;
+                case 'signin':
+                default:
+                    return `Click here to sign in ${url}`;
+                }
+            },
+            getHTML(url, type) {
+                switch (type) {
+                case 'subscribe':
+                    return `<a href="${url}">Click here to confirm your subscription</a>`;
+                case 'signup':
+                    return `<a href="${url}">Click here to confirm your email address and sign up</a>`;
+                case 'signin':
+                default:
+                    return `<a href="${url}">Click here to sign in</a>`;
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@nexes/nql": "0.3.0",
     "@tryghost/helpers": "1.1.11",
-    "@tryghost/members-api": "0.6.2",
+    "@tryghost/members-api": "0.7.0",
     "@tryghost/members-ssr": "0.5.2",
     "@tryghost/social-urls": "0.1.2",
     "@tryghost/string": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,22 +227,22 @@
   dependencies:
     "@tryghost/kg-clean-basic-html" "^0.1.3"
 
-"@tryghost/magic-link@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@tryghost/magic-link/-/magic-link-0.1.4.tgz#9e8812ba918726370b6ce881f53bf2435c993948"
-  integrity sha512-FROmFRgzYKAOTA3QkeS3G4qNrdgBFt9+gUGwVn0sR/JKnHPaELtlDlRHeUJsQeytJdnuU3FEkKpKYlqd2Ecb+w==
+"@tryghost/magic-link@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/magic-link/-/magic-link-0.2.0.tgz#77b6fac7d83fdff0543a1506be63601f1ec9f742"
+  integrity sha512-vYj48P7RKLMfdkRCdYQ6bGv5J168ce621ZuBhEbGKf6kIiiRfNQDno+FOjiOBBKn3AS+FkIulc3z48qz/0U+Jg==
   dependencies:
     bluebird "^3.5.5"
     ghost-ignition "^3.1.0"
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.6.2.tgz#265d6d196157892d0774db9e1126f61003a845ef"
-  integrity sha512-m6Zjyp8wUfTyTGi9ECXzvB4lhF5gALLE14c4N10SXshL15jzXGhPat7WBrpylguaCNkfuPIJiUOX8Q2B1z57zg==
+"@tryghost/members-api@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.7.0.tgz#6cb4170d406f0fb654b0c5c849f4740528c5cad8"
+  integrity sha512-tAoNKu5fWbJdU9lUr34ZUpXk0qCyKu0MKXaGpCFlEwLd2KprKcPrtXrtL0ky3lLz6/8Hd/vInvcXcww6XsUMbw==
   dependencies:
-    "@tryghost/magic-link" "^0.1.4"
+    "@tryghost/magic-link" "^0.2.0"
     bluebird "^3.5.4"
     body-parser "^1.19.0"
     cookies "^0.7.3"


### PR DESCRIPTION
no-issue

This adds the initial support for multiple email templates. They can be driven in the frontend buy changing `data-members-form` to have a value of either `"signup"`, `"signin"` or `"subscribe"` for example: `data-members-form="subscribe"` 