### PR TITLE
Passed partner_id in stripe appInfo

### DIFF
--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -106,6 +106,7 @@ function getStripePaymentConfig() {
         plans: stripePaymentProcessor.config.plans,
         appInfo: {
             name: 'Ghost',
+            partner_id: 'pp_partner_DKmRVtTs4j9pwZ',
             version: ghostVersion.original,
             url: 'https://ghost.org/'
         }


### PR DESCRIPTION
no-issue

This correctly configures stripe to use our partner integration
