### PR TITLE
Improve visibility's default handling

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -194,6 +194,9 @@
         "members_session_secret": {
             "defaultValue": null
         },
+        "default_content_visibility": {
+            "defaultValue": "public"
+        },
         "members_subscription_settings": {
             "defaultValue": "{\"isPaid\":false,\"paymentProcessors\":[{\"adapter\":\"stripe\",\"config\":{\"secret_token\":\"\",\"public_token\":\"\",\"product\":{\"name\":\"Ghost Subscription\"},\"plans\":[{\"name\":\"Monthly\",\"currency\":\"usd\",\"interval\":\"month\",\"amount\":\"\"},{\"name\":\"Yearly\",\"currency\":\"usd\",\"interval\":\"year\",\"amount\":\"\"}]}}]}"
         }

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -43,8 +43,8 @@ Post = ghostBookshelf.Model.extend({
     defaults: function defaults() {
         let visibility = 'public';
 
-        if (settingsCache.get('labs') && (settingsCache.get('labs').members === true) && settingsCache.get('labs').default_content_visibility) {
-            visibility = settingsCache.get('labs').default_content_visibility;
+        if (settingsCache.get('labs') && (settingsCache.get('labs').members === true) && settingsCache.get('default_content_visibility')) {
+            visibility = settingsCache.get('default_content_visibility');
         }
 
         return {

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -113,7 +113,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(78);
+                    eventSpy.callCount.should.equal(80);
 
                     eventSpy.args[1][0].should.equal('settings.db_hash.added');
                     eventSpy.args[1][1].attributes.type.should.equal('core');
@@ -122,7 +122,8 @@ describe('Unit: models/settings', function () {
                     eventSpy.args[13][1].attributes.type.should.equal('blog');
                     eventSpy.args[13][1].attributes.value.should.equal('The professional publishing platform');
 
-                    eventSpy.args[77][0].should.equal('settings.members_subscription_settings.added');
+                    eventSpy.args[77][0].should.equal('settings.default_content_visibility.added');
+                    eventSpy.args[79][0].should.equal('settings.members_subscription_settings.added');
                 });
         });
 
@@ -136,7 +137,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(76);
+                    eventSpy.callCount.should.equal(78);
 
                     eventSpy.args[13][0].should.equal('settings.logo.added');
                 });


### PR DESCRIPTION
no issue

Changes:
- [x] ~Accept's `null` as a default (a bit ugly, non-DRY handing in serializers)~
- [x] Adds default setting value (and moves it out of labs flag)
- [x] Discuss if `null` value should be handled this way (think it's fine but we haven't done anything similar in the API). The alternative could be forcing the client to send `undefined` value for `visibility`. 
	- [x] Disallow null value. Set `undefined` on client-side to keep existing convention
