### PR TITLE
Supported `update` and `destroy` for members

### DIFF
--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -47,6 +47,10 @@ async function getMemberMetadata(member, module) {
     return metadata.toJSON();
 }
 
+function updateMember({name}, options) {
+    return models.Member.edit({name}, options);
+}
+
 function deleteMember(options) {
     options = options || {};
     return models.Member.destroy(options).catch(models.Member.NotFoundError, () => {
@@ -168,6 +172,7 @@ function createApiInstance() {
         setMemberMetadata,
         getMemberMetadata,
         createMember,
+        updateMember,
         getMember,
         deleteMember,
         listMembers,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@nexes/nql": "0.3.0",
     "@tryghost/helpers": "1.1.11",
-    "@tryghost/members-api": "0.7.2",
+    "@tryghost/members-api": "0.7.4",
     "@tryghost/members-ssr": "0.5.2",
     "@tryghost/social-urls": "0.1.2",
     "@tryghost/string": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,10 +237,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.7.2.tgz#5e1abb455cf18ee5d1bf6fe5e2459dd59879dae0"
-  integrity sha512-t1nQ8+uCzbam90gSsvlTUdje0/0A7UWCl2OCOb2m3tEGgVJoCPjkcKHH+wD0tskYWjwuMSeDgaLLzT12MaEZHg==
+"@tryghost/members-api@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.7.4.tgz#f635fccba5e0026c714a19a2ab03b367930440c5"
+  integrity sha512-jixKn+WKefLKsiyEj4DD9FKqxZ7ejGoVVCG/KO6l3JxzvUG7s36hLX3AYq1OngdmwxtdMUBP/QuYcHAvU2d1mw==
   dependencies:
     "@tryghost/magic-link" "^0.2.0"
     bluebird "^3.5.4"


### PR DESCRIPTION
no-issue

This fixes the `destroy` and `update` methods for `membersService.api.members` object