### PR TITLE
Fixed DELETE method for members on admin

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -54,9 +54,10 @@ const members = {
             }
         },
         permissions: true,
-        query(frame) {
+        async query(frame) {
             frame.options.require = true;
-            return membersService.api.members.destroy(frame.options).return(null);
+            await membersService.api.members.destroy(frame.options);
+            return null;
         }
     }
 };

--- a/core/server/api/v2/members.js
+++ b/core/server/api/v2/members.js
@@ -54,9 +54,10 @@ const members = {
             }
         },
         permissions: true,
-        query(frame) {
+        async query(frame) {
             frame.options.require = true;
-            return membersService.api.members.destroy(frame.options).return(null);
+            await membersService.api.members.destroy(frame.options);
+            return null;
         }
     }
 };


### PR DESCRIPTION
no-issue

members-api uses async functions internally which return non-bluebird
promises, so the `return` method wasn't availiable.
