### PR TITLE
Custom redirects

### DIFF
--- a/core/server/public/members.js
+++ b/core/server/public/members.js
@@ -54,6 +54,18 @@ Array.prototype.forEach.call(document.querySelectorAll('[data-members-plan]'), f
         event.preventDefault();
 
         var plan = el.dataset.membersPlan;
+        var successUrl = el.dataset.membersSuccess;
+        var cancelUrl = el.dataset.membersCancel;
+        var checkoutSuccessUrl;
+        var checkoutCancelUrl;
+
+        if (successUrl) {
+            checkoutSuccessUrl = (new URL(successUrl, window.location.href)).href;
+        }
+
+        if (cancelUrl) {
+            checkoutCancelUrl = (new URL(cancelUrl, window.location.href)).href;
+        }
 
         if (errorEl) {
             errorEl.innerText = '';
@@ -74,7 +86,9 @@ Array.prototype.forEach.call(document.querySelectorAll('[data-members-plan]'), f
                 },
                 body: JSON.stringify({
                     plan: plan,
-                    identity: identity
+                    identity: identity,
+                    successUrl: checkoutSuccessUrl,
+                    cancelUrl: checkoutCancelUrl
                 })
             }).then(function (res) {
                 if (!res.ok) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@nexes/nql": "0.3.0",
     "@tryghost/helpers": "1.1.11",
-    "@tryghost/members-api": "0.7.5",
+    "@tryghost/members-api": "0.7.6",
     "@tryghost/members-ssr": "0.6.0",
     "@tryghost/social-urls": "0.1.2",
     "@tryghost/string": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,10 +237,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.7.5.tgz#1b9e833b8098ea925b3f0ce3d2716934f0053290"
-  integrity sha512-84DEv/xTf5MrMdVpIq8jVXAT2e8PEFQiCqZWd4mTjYd+fNZlkd+WBg9DGM2qc1M21tYIXdMdwOmXQo9rzqhgdQ==
+"@tryghost/members-api@0.7.6":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.7.6.tgz#915c0fda3d46b4618be3045f0324d273fd7b8383"
+  integrity sha512-HQxgxveVqr+RXmliqikzIRwFReKur/4g0u73zvTpweoVCWX5nDPqWaPqvxfxMWh1wqOu1lskMp3pOi2v8p6EjQ==
   dependencies:
     "@tryghost/magic-link" "^0.2.0"
     bluebird "^3.5.4"


### PR DESCRIPTION
no-issue

You can now use `data-members-success` and `data-members-cancel` on any
element which also has a valid `data-members-plan` attribute to set the
cancel and success redirects for stripe checkout.

The value will be used similar to how a `href` attribute would be.

e.g.

On a page site.com/membership

An attribute of "/success" would redirect to site.com/success
An attribute of "success" would redirect to site.com/membership/success
An attribute of "site.com/whatever" would redirect to site.com/whatever