### PR TITLE
Whitelisted members endpoints for v2 and canary Admin APIs

### DIFF
--- a/core/server/web/api/canary/admin/middleware.js
+++ b/core/server/web/api/canary/admin/middleware.js
@@ -20,6 +20,7 @@ const notImplemented = function (req, res, next) {
         tags: ['GET', 'PUT', 'DELETE', 'POST'],
         users: ['GET'],
         themes: ['POST', 'PUT'],
+        members: ['GET', 'PUT', 'DELETE', 'POST'],
         subscribers: ['GET', 'PUT', 'DELETE', 'POST'],
         config: ['GET'],
         webhooks: ['POST', 'DELETE'],

--- a/core/server/web/api/v2/admin/middleware.js
+++ b/core/server/web/api/v2/admin/middleware.js
@@ -19,6 +19,7 @@ const notImplemented = function (req, res, next) {
         tags: ['GET', 'PUT', 'DELETE', 'POST'],
         users: ['GET'],
         themes: ['POST', 'PUT'],
+        members: ['GET', 'PUT', 'DELETE', 'POST'],
         subscribers: ['GET', 'PUT', 'DELETE', 'POST'],
         config: ['GET'],
         webhooks: ['POST', 'DELETE'],


### PR DESCRIPTION
no issue

- http verbs needed to be whitelisted for the members endpoint to avoid `NotImplementedError`s when accessing