### PR TITLE
Updated travis notifications config logic for slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,11 @@ script: |
   else
     yarn ci
   fi
-after_failure: |
-  if [ "${TRAVIS_EVENT_TYPE}" == "cron" ]; then
-    curl -X POST --data-urlencode "payload={\"attachments\": [{\"color\": \"danger\", \"fallback\": \"Build Failure: $TRAVIS_JOB_WEB_URL\", \"title\": \"Build Failure\", \"text\": \"$TRAVIS_JOB_WEB_URL\"}]}" $SLACK_URL
-  fi
+notifications:
+  slack:
+    if: type = cron
+    rooms:
+      - secure: KzvGpf6RFHgQ3BkppKM4OejFjJYxH60KkDDShet0a0v+j/03HF5Nx0S0Vl9O/F2dPt2qWvblKb3j9EKgB7RsoFSdZuOk7ijA9Duvn+p9RrLom0C9JxOA3ob065WAGyE0OGRm1P5H98loX/L+6oOHC4/qqGKXgz6gUdBtZBn/yo8=
+    on_success: change
+    on_failure: always
+    on_pull_requests: false


### PR DESCRIPTION
no issue

Uses travis conditionals to push slack notifications only for cron run on master
