### PR TITLE
Updated default from-address for system emails

### DIFF
--- a/core/server/services/mail/GhostMailer.js
+++ b/core/server/services/mail/GhostMailer.js
@@ -24,8 +24,8 @@ GhostMailer.prototype.from = function () {
 
     // If we don't have a from address at all
     if (!from) {
-        // Default to ghost@[blog.url]
-        from = 'ghost@' + this.getDomain();
+        // Default to noreply@[blog.url]
+        from = 'noreply@' + this.getDomain();
     }
 
     // If we do have a from address, and it's just an email

--- a/core/test/unit/services/mail/GhostMailer_spec.js
+++ b/core/test/unit/services/mail/GhostMailer_spec.js
@@ -177,7 +177,7 @@ describe('Mail: Ghostmailer', function () {
             mailer.from().should.equal('"Blog Title" <static@example.com>');
         });
 
-        describe('should fall back to [blog.title] <ghost@[blog.url]>', function () {
+        describe('should fall back to [blog.title] <noreply@[blog.url]>', function () {
             let mailer;
 
             beforeEach(function () {
@@ -189,20 +189,20 @@ describe('Mail: Ghostmailer', function () {
                 sinon.stub(urlUtils, 'urlFor').returns('http://default.com');
                 configUtils.set({mail: {from: null}});
 
-                mailer.from().should.equal('"Test" <ghost@default.com>');
+                mailer.from().should.equal('"Test" <noreply@default.com>');
             });
 
             it('trailing slash', function () {
                 sinon.stub(urlUtils, 'urlFor').returns('http://default.com/');
                 configUtils.set({mail: {from: null}});
 
-                mailer.from().should.equal('"Test" <ghost@default.com>');
+                mailer.from().should.equal('"Test" <noreply@default.com>');
             });
 
             it('strip port', function () {
                 sinon.stub(urlUtils, 'urlFor').returns('http://default.com:2368/');
                 configUtils.set({mail: {from: null}});
-                mailer.from().should.equal('"Test" <ghost@default.com>');
+                mailer.from().should.equal('"Test" <noreply@default.com>');
             });
 
             it('Escape title', function () {
@@ -211,7 +211,7 @@ describe('Mail: Ghostmailer', function () {
 
                 sinon.stub(urlUtils, 'urlFor').returns('http://default.com:2368/');
                 configUtils.set({mail: {from: null}});
-                mailer.from().should.equal('"Test\\"" <ghost@default.com>');
+                mailer.from().should.equal('"Test\\"" <noreply@default.com>');
             });
         });
 
@@ -256,7 +256,7 @@ describe('Mail: Ghostmailer', function () {
 
             mailer = new mail.GhostMailer();
 
-            mailer.from().should.equal('"Ghost at default.com" <ghost@default.com>');
+            mailer.from().should.equal('"Ghost at default.com" <noreply@default.com>');
         });
     });
 });


### PR DESCRIPTION
Until now, we've used `ghost@siteurl.com` as the default `from` address for system emails, like user invitations and password resets. This was fine, because all system emails were going to people who would interact with "ghost" the app in some way, so the naming made sense.

Now we're introducing members, which will send emails on behalf of of the site owner, to their readers. If all goes to plan, they should be able to set a custom `from` address, however our default mail config will still be the fallback if no other value is available.

If you run "magazine.com" and you send someone a link to "login to magazine.com" then it's pretty weird for that email to come from "ghost@magazine.com" - so this PR changes the default value from `ghost` to `noreply` for an equally generic, but less opinionated default. 

Thanks for reading this 4 paragraph description of a 7 character PR 

xoxo