### PR TITLE
🐛 Fixed crash on pasting unknown url in bookmark card

### DIFF
--- a/core/server/lib/mobiledoc/cards/bookmark.js
+++ b/core/server/lib/mobiledoc/cards/bookmark.js
@@ -93,13 +93,17 @@ module.exports = createCard({
     },
 
     absoluteToRelative(urlUtils, payload, options) {
-        payload.metadata.url = payload.metadata.url && urlUtils.absoluteToRelative(payload.metadata.url, options);
+        if (payload.metadata) {
+            payload.metadata.url = payload.metadata.url && urlUtils.absoluteToRelative(payload.metadata.url, options);
+        }
         payload.caption = payload.caption && urlUtils.htmlAbsoluteToRelative(payload.caption, options);
         return payload;
     },
 
     relativeToAbsolute(urlUtils, payload, options) {
-        payload.metadata.url = payload.metadata.url && urlUtils.relativeToAbsolute(payload.metadata.url, options);
+        if (payload.metadata) {
+            payload.metadata.url = payload.metadata && payload.metadata.url && urlUtils.relativeToAbsolute(payload.metadata.url, options);
+        }
         payload.caption = payload.caption && urlUtils.htmlRelativeToAbsolute(payload.caption, options);
         return payload;
     }

--- a/core/server/lib/mobiledoc/cards/bookmark.js
+++ b/core/server/lib/mobiledoc/cards/bookmark.js
@@ -102,7 +102,7 @@ module.exports = createCard({
 
     relativeToAbsolute(urlUtils, payload, options) {
         if (payload.metadata) {
-            payload.metadata.url = payload.metadata && payload.metadata.url && urlUtils.relativeToAbsolute(payload.metadata.url, options);
+            payload.metadata.url = payload.metadata.url && urlUtils.relativeToAbsolute(payload.metadata.url, options);
         }
         payload.caption = payload.caption && urlUtils.htmlRelativeToAbsolute(payload.caption, options);
         return payload;


### PR DESCRIPTION
no issue

Adds check on `metadata.url` on bookmark card payload for relative/absolute url conversions to avoid failure in case of invalid/unknown url added in the card.
