### PR TITLE
Permission restrictions for `post.visibility` modifications

### DIFF
--- a/core/server/api/canary/pages.js
+++ b/core/server/api/canary/pages.js
@@ -2,7 +2,7 @@ const models = require('../../models');
 const common = require('../../lib/common');
 const urlUtils = require('../../lib/url-utils');
 const ALLOWED_INCLUDES = ['tags', 'authors', 'authors.roles'];
-const UNSAFE_ATTRS = ['status', 'authors'];
+const UNSAFE_ATTRS = ['status', 'authors', 'visibility'];
 
 module.exports = {
     docName: 'pages',

--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -2,7 +2,7 @@ const models = require('../../models');
 const common = require('../../lib/common');
 const urlUtils = require('../../lib/url-utils');
 const allowedIncludes = ['tags', 'authors', 'authors.roles'];
-const unsafeAttrs = ['status', 'authors'];
+const unsafeAttrs = ['status', 'authors', 'visibility'];
 
 module.exports = {
     docName: 'posts',

--- a/core/server/api/v2/pages.js
+++ b/core/server/api/v2/pages.js
@@ -2,7 +2,7 @@ const models = require('../../models');
 const common = require('../../lib/common');
 const urlUtils = require('../../lib/url-utils');
 const ALLOWED_INCLUDES = ['tags', 'authors', 'authors.roles'];
-const UNSAFE_ATTRS = ['status', 'authors'];
+const UNSAFE_ATTRS = ['status', 'authors', 'visibility'];
 
 module.exports = {
     docName: 'pages',

--- a/core/server/api/v2/posts.js
+++ b/core/server/api/v2/posts.js
@@ -2,7 +2,7 @@ const models = require('../../models');
 const common = require('../../lib/common');
 const urlUtils = require('../../lib/url-utils');
 const allowedIncludes = ['tags', 'authors', 'authors.roles'];
-const unsafeAttrs = ['status', 'authors'];
+const unsafeAttrs = ['status', 'authors', 'visibility'];
 
 module.exports = {
     docName: 'posts',

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -397,6 +397,36 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     });
                 });
 
+                it('rejects if changing visibility', function (done) {
+                    var mockPostObj = {
+                            get: sinon.stub(),
+                            related: sinon.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {visibility: 'public'};
+
+                    mockPostObj.get.withArgs('visibility').returns('paid');
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.contributor,
+                        false,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.called).be.false();
+                        should(mockPostObj.related.calledOnce).be.true();
+                        done();
+                    });
+                });
+
                 it('rejects if changing author id', function (done) {
                     var mockPostObj = {
                             get: sinon.stub(),
@@ -869,6 +899,36 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     });
                 });
 
+                it('rejects if changing visibility', function (done) {
+                    var mockPostObj = {
+                            get: sinon.stub(),
+                            related: sinon.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {visibility: 'public'};
+
+                    mockPostObj.get.withArgs('visibility').returns('paid');
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.author,
+                        false,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.called).be.false();
+                        should(mockPostObj.related.calledOnce).be.true();
+                        done();
+                    });
+                });
+
                 it('rejects if editing another\'s post (using `authors`)', function (done) {
                     var mockPostObj = {
                             get: sinon.stub(),
@@ -1172,6 +1232,32 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     true
                 ).then(() => {
                     should(mockPostObj.get.called).be.false();
+                });
+            });
+
+            it('resolves if changing visibility', function (done) {
+                var mockPostObj = {
+                        get: sinon.stub(),
+                        related: sinon.stub()
+                    },
+                    context = {user: 1},
+                    unsafeAttrs = {visibility: 'public'};
+
+                mockPostObj.get.withArgs('visibility').returns('paid');
+                mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                models.Post.permissible(
+                    mockPostObj,
+                    'edit',
+                    context,
+                    unsafeAttrs,
+                    testUtils.permissions.editor,
+                    false,
+                    true,
+                    true
+                ).then(() => {
+                    should(mockPostObj.get.called).be.false();
+                    should(mockPostObj.related.calledOnce).be.true()
                 });
             });
         });

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -1235,7 +1235,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 });
             });
 
-            it('resolves if changing visibility', function (done) {
+            it('resolves if changing visibility', function () {
                 var mockPostObj = {
                         get: sinon.stub(),
                         related: sinon.stub()
@@ -1257,7 +1257,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     true
                 ).then(() => {
                     should(mockPostObj.get.called).be.false();
-                    should(mockPostObj.related.calledOnce).be.true()
+                    should(mockPostObj.related.calledOnce).be.true();
                 });
             });
         });


### PR DESCRIPTION
This set of changes makes sure only "editor-and-higher" roles + admin integration can modify the `visiblity` property on posts model.

There were no good test suites for integrations modifying posts specifically, so have written a little suite on the side which will not be included with this PR - https://gist.github.com/gargol/3160d35ea81df49c7656a9889a5d2987. The reason why it's not included - it doesn't fit anywhere yet and was just a small sanity check while writing code.

@rishabhgrg @kevinansfield the changes have to do with permissions, wanted to get a second pair of eyes on them for that reason :)