### PR TITLE
Added new `requirePaymentForSignup` setting for members

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -198,7 +198,7 @@
             "defaultValue": "public"
         },
         "members_subscription_settings": {
-            "defaultValue": "{\"isPaid\":false,\"paymentProcessors\":[{\"adapter\":\"stripe\",\"config\":{\"secret_token\":\"\",\"public_token\":\"\",\"product\":{\"name\":\"Ghost Subscription\"},\"plans\":[{\"name\":\"Monthly\",\"currency\":\"usd\",\"interval\":\"month\",\"amount\":\"\"},{\"name\":\"Yearly\",\"currency\":\"usd\",\"interval\":\"year\",\"amount\":\"\"}]}}]}"
+            "defaultValue": "{\"isPaid\":false,\"requirePaymentForSignup\":false,\"paymentProcessors\":[{\"adapter\":\"stripe\",\"config\":{\"secret_token\":\"\",\"public_token\":\"\",\"product\":{\"name\":\"Ghost Subscription\"},\"plans\":[{\"name\":\"Monthly\",\"currency\":\"usd\",\"interval\":\"month\",\"amount\":\"\"},{\"name\":\"Yearly\",\"currency\":\"usd\",\"interval\":\"year\",\"amount\":\"\"}]}}]}"
         }
     }
 }

--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -119,6 +119,11 @@ function getStripePaymentConfig() {
     };
 }
 
+function getRequirePaymentSetting() {
+    const subscriptionSettings = settingsCache.get('members_subscription_settings');
+    return !!subscriptionSettings.requirePaymentForSignup;
+}
+
 module.exports = createApiInstance;
 
 function createApiInstance() {
@@ -134,7 +139,8 @@ function createApiInstance() {
                 signinURL.searchParams.set('token', token);
                 signinURL.searchParams.set('action', type);
                 return signinURL.href;
-            }
+            },
+            allowSelfSignup: !getRequirePaymentSetting()
         },
         mail: {
             transporter: {


### PR DESCRIPTION
no issue

- Adds new `requirePaymentForSignup` setting flag for members, set `false` by default. 
- Wires `auth.allowSelfSignup` of members-api to above flag, allowing admin to control if self-signups are allowed on publication
