### PR TITLE
Added permission restrictions to editing members flag

### DIFF
--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -83,6 +83,9 @@ module.exports = {
             cacheInvalidate: true
         },
         permissions: {
+            unsafeAttrsObject(frame) {
+                return _.find(frame.data.settings, {key: 'labs'});
+            },
             before(frame) {
                 const errors = [];
 

--- a/core/server/api/canary/utils/permissions.js
+++ b/core/server/api/canary/utils/permissions.js
@@ -26,7 +26,12 @@ const nonePublicAuth = (apiConfig, frame) => {
         permissionIdentifier = apiConfig.identifier(frame);
     }
 
-    const unsafeAttrObject = apiConfig.unsafeAttrs && _.has(frame, `data.[${apiConfig.docName}][0]`) ? _.pick(frame.data[apiConfig.docName][0], apiConfig.unsafeAttrs) : {};
+    let unsafeAttrObject = apiConfig.unsafeAttrs && _.has(frame, `data.[${apiConfig.docName}][0]`) ? _.pick(frame.data[apiConfig.docName][0], apiConfig.unsafeAttrs) : {};
+
+    if (apiConfig.unsafeAttrsObject) {
+        unsafeAttrObject = apiConfig.unsafeAttrsObject(frame);
+    }
+
     const permsPromise = permissions.canThis(frame.options.context)[apiConfig.method][singular](permissionIdentifier, unsafeAttrObject);
 
     return permsPromise.then((result) => {

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -83,6 +83,9 @@ module.exports = {
             cacheInvalidate: true
         },
         permissions: {
+            unsafeAttrsObject(frame) {
+                return _.find(frame.data.settings, {key: 'labs'});
+            },
             before(frame) {
                 const errors = [];
 

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -6,6 +6,7 @@ const Promise = require('bluebird'),
     ghostBookshelf = require('./base'),
     common = require('../lib/common'),
     validation = require('../data/validation'),
+    settingsCache = require('../services/settings/cache'),
     internalContext = {context: {internal: true}};
 
 let Settings, defaultSettings;
@@ -235,6 +236,35 @@ Settings = ghostBookshelf.Model.extend({
 
                 return allSettings;
             });
+    },
+
+    permissible: function permissible(modelId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission, hasApiKeyPermission) {
+        let isEdit = (action === 'edit');
+        let isOwner;
+
+        function isChangingMembers() {
+            if (unsafeAttrs && unsafeAttrs.key === 'labs') {
+                let editedValue = JSON.parse(unsafeAttrs.value);
+                if (editedValue.members !== undefined) {
+                    return editedValue.members !== settingsCache.get('labs').members;
+                }
+            }
+        }
+
+        isOwner = loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Owner'});
+
+        if (isEdit && isChangingMembers()) {
+            // Only allow owner to toggle members flag
+            hasUserPermission = isOwner;
+        }
+
+        if (hasUserPermission && hasApiKeyPermission && hasAppPermission) {
+            return Promise.resolve();
+        }
+
+        return Promise.reject(new common.errors.NoPermissionError({
+            message: common.i18n.t('errors.models.post.notEnoughPermission')
+        }));
     }
 });
 

--- a/core/test/acceptance/old/admin/settings_spec.js
+++ b/core/test/acceptance/old/admin/settings_spec.js
@@ -153,7 +153,7 @@ describe('Settings API', function () {
                             },
                             {
                                 key: 'labs',
-                                value: '{"subscribers":false,"members":true,"default_content_visibility":"paid"}'
+                                value: '{"subscribers":false,"members":true}'
                             }
                         ]
                     };
@@ -219,7 +219,7 @@ describe('Settings API', function () {
                         should.equal(putBody.settings[12].value, 'twitter description');
 
                         putBody.settings[13].key.should.eql('labs');
-                        should.equal(putBody.settings[13].value, '{"subscribers":false,"members":true,"default_content_visibility":"paid"}');
+                        should.equal(putBody.settings[13].value, '{"subscribers":false,"members":true}');
 
                         localUtils.API.checkResponse(putBody, 'settings');
                         done();

--- a/core/test/regression/api/canary/admin/settings_spec.js
+++ b/core/test/regression/api/canary/admin/settings_spec.js
@@ -9,185 +9,187 @@ let request;
 describe('Settings API', function () {
     let ghostServer;
 
-    before(function () {
-        return ghost()
-            .then(function (_ghostServer) {
-                ghostServer = _ghostServer;
-                request = supertest.agent(config.get('url'));
-            })
-            .then(function () {
-                return localUtils.doAuth(request);
-            });
-    });
+    describe('As Owner', function () {
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    ghostServer = _ghostServer;
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    return localUtils.doAuth(request);
+                });
+        });
 
-    after(function () {
-        return ghostServer.stop();
-    });
+        after(function () {
+            return ghostServer.stop();
+        });
 
-    it('Can\'t read core setting', function () {
-        return request
-            .get(localUtils.API.getApiQuery('settings/db_hash/'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(403);
-    });
+        it('Can\'t read core setting', function () {
+            return request
+                .get(localUtils.API.getApiQuery('settings/db_hash/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(403);
+        });
 
-    it('Can\'t read permalinks', function (done) {
-        request.get(localUtils.API.getApiQuery('settings/permalinks/'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(404)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
+        it('Can\'t read permalinks', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/permalinks/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                done();
-            });
-    });
+                    done();
+                });
+        });
 
-    it('can\'t read non existent setting', function (done) {
-        request.get(localUtils.API.getApiQuery('settings/testsetting/'))
-            .set('Origin', config.get('url'))
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(404)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
+        it('can\'t read non existent setting', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/testsetting/'))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                should.not.exist(res.headers['x-cache-invalidate']);
-                var jsonResponse = res.body;
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.errors);
-                testUtils.API.checkResponseValue(jsonResponse.errors[0], [
-                    'message',
-                    'context',
-                    'type',
-                    'details',
-                    'property',
-                    'help',
-                    'code',
-                    'id'
-                ]);
-                done();
-            });
-    });
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    var jsonResponse = res.body;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.errors);
+                    testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                        'message',
+                        'context',
+                        'type',
+                        'details',
+                        'property',
+                        'help',
+                        'code',
+                        'id'
+                    ]);
+                    done();
+                });
+        });
 
-    it('can\'t edit permalinks', function (done) {
-        const settingToChange = {
-            settings: [{key: 'permalinks', value: '/:primary_author/:slug/'}]
-        };
+        it('can\'t edit permalinks', function (done) {
+            const settingToChange = {
+                settings: [{key: 'permalinks', value: '/:primary_author/:slug/'}]
+            };
 
-        request.put(localUtils.API.getApiQuery('settings/'))
-            .set('Origin', config.get('url'))
-            .send(settingToChange)
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(404)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
+            request.put(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .send(settingToChange)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                done();
-            });
-    });
+                    done();
+                });
+        });
 
-    it('can\'t edit non existent setting', function (done) {
-        request.get(localUtils.API.getApiQuery('settings/'))
-            .set('Origin', config.get('url'))
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
+        it('can\'t edit non existent setting', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                var jsonResponse = res.body,
-                    newValue = 'new value';
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.settings);
-                jsonResponse.settings = [{key: 'testvalue', value: newValue}];
+                    var jsonResponse = res.body,
+                        newValue = 'new value';
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.settings);
+                    jsonResponse.settings = [{key: 'testvalue', value: newValue}];
 
-                request.put(localUtils.API.getApiQuery('settings/'))
-                    .set('Origin', config.get('url'))
-                    .send(jsonResponse)
-                    .expect('Content-Type', /json/)
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .end(function (err, res) {
-                        if (err) {
-                            return done(err);
-                        }
-
-                        jsonResponse = res.body;
-                        should.not.exist(res.headers['x-cache-invalidate']);
-                        should.exist(jsonResponse.errors);
-                        testUtils.API.checkResponseValue(jsonResponse.errors[0], [
-                            'message',
-                            'context',
-                            'type',
-                            'details',
-                            'property',
-                            'help',
-                            'code',
-                            'id'
-                        ]);
-                        done();
-                    });
-            });
-    });
-
-    it('Will transform "1"', function (done) {
-        request.get(localUtils.API.getApiQuery('settings/'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
-
-                const jsonResponse = res.body,
-                    settingToChange = {
-                        settings: [
-                            {
-                                key: 'is_private',
-                                value: '1'
+                    request.put(localUtils.API.getApiQuery('settings/'))
+                        .set('Origin', config.get('url'))
+                        .send(jsonResponse)
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
                             }
-                        ]
-                    };
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.settings);
+                            jsonResponse = res.body;
+                            should.not.exist(res.headers['x-cache-invalidate']);
+                            should.exist(jsonResponse.errors);
+                            testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                                'message',
+                                'context',
+                                'type',
+                                'details',
+                                'property',
+                                'help',
+                                'code',
+                                'id'
+                            ]);
+                            done();
+                        });
+                });
+        });
 
-                request.put(localUtils.API.getApiQuery('settings/'))
-                    .set('Origin', config.get('url'))
-                    .send(settingToChange)
-                    .expect('Content-Type', /json/)
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(200)
-                    .end(function (err, res) {
-                        if (err) {
-                            return done(err);
-                        }
+        it('Will transform "1"', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                        const putBody = res.body;
-                        res.headers['x-cache-invalidate'].should.eql('/*');
-                        should.exist(putBody);
+                    const jsonResponse = res.body,
+                        settingToChange = {
+                            settings: [
+                                {
+                                    key: 'is_private',
+                                    value: '1'
+                                }
+                            ]
+                        };
 
-                        putBody.settings[0].key.should.eql('is_private');
-                        putBody.settings[0].value.should.eql(true);
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.settings);
 
-                        localUtils.API.checkResponse(putBody, 'settings');
-                        done();
-                    });
-            });
+                    request.put(localUtils.API.getApiQuery('settings/'))
+                        .set('Origin', config.get('url'))
+                        .send(settingToChange)
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            const putBody = res.body;
+                            res.headers['x-cache-invalidate'].should.eql('/*');
+                            should.exist(putBody);
+
+                            putBody.settings[0].key.should.eql('is_private');
+                            putBody.settings[0].value.should.eql(true);
+
+                            localUtils.API.checkResponse(putBody, 'settings');
+                            done();
+                        });
+                });
+        });
     });
 });

--- a/core/test/regression/api/canary/admin/settings_spec.js
+++ b/core/test/regression/api/canary/admin/settings_spec.js
@@ -4,10 +4,10 @@ const config = require('../../../../../server/config');
 const testUtils = require('../../../../utils');
 const localUtils = require('./utils');
 const ghost = testUtils.startGhost;
-let request;
 
 describe('Settings API', function () {
     let ghostServer;
+    let request;
 
     describe('As Owner', function () {
         before(function () {
@@ -187,6 +187,149 @@ describe('Settings API', function () {
                             putBody.settings[0].value.should.eql(true);
 
                             localUtils.API.checkResponse(putBody, 'settings');
+                            done();
+                        });
+                });
+        });
+    });
+
+    describe('As Editor', function () {
+        let editor;
+
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    ghostServer = _ghostServer;
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    // create editor
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({email: 'test+1@ghost.org'}),
+                        role: testUtils.DataGenerator.Content.roles[1].name
+                    });
+                })
+                .then(function (_user1) {
+                    editor = _user1;
+                    request.user = editor;
+
+                    // by default we login with the owner
+                    return localUtils.doAuth(request);
+                });
+        });
+
+        it('should not be able to edit settings', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    var jsonResponse = res.body,
+                        newValue = 'new value';
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.settings);
+                    jsonResponse.settings = [{key: 'visibility', value: 'public'}];
+
+                    request.put(localUtils.API.getApiQuery('settings/'))
+                        .set('Origin', config.get('url'))
+                        .send(jsonResponse)
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(403)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            jsonResponse = res.body;
+                            should.not.exist(res.headers['x-cache-invalidate']);
+                            should.exist(jsonResponse.errors);
+                            testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                                'message',
+                                'context',
+                                'type',
+                                'details',
+                                'property',
+                                'help',
+                                'code',
+                                'id'
+                            ]);
+
+                            done();
+                        });
+                });
+        });
+    });
+
+    describe('As Author', function () {
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    ghostServer = _ghostServer;
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    // create author
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({email: 'test+2@ghost.org'}),
+                        role: testUtils.DataGenerator.Content.roles[2].name
+                    });
+                })
+                .then(function (author) {
+                    request.user = author;
+
+                    // by default we login with the owner
+                    return localUtils.doAuth(request);
+                });
+        });
+
+        it('should not be able to edit settings', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    var jsonResponse = res.body,
+                        newValue = 'new value';
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.settings);
+                    jsonResponse.settings = [{key: 'visibility', value: 'public'}];
+
+                    request.put(localUtils.API.getApiQuery('settings/'))
+                        .set('Origin', config.get('url'))
+                        .send(jsonResponse)
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(403)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            jsonResponse = res.body;
+                            should.not.exist(res.headers['x-cache-invalidate']);
+                            should.exist(jsonResponse.errors);
+                            testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                                'message',
+                                'context',
+                                'type',
+                                'details',
+                                'property',
+                                'help',
+                                'code',
+                                'id'
+                            ]);
+
                             done();
                         });
                 });

--- a/core/test/regression/api/v2/admin/settings_spec.js
+++ b/core/test/regression/api/v2/admin/settings_spec.js
@@ -24,170 +24,172 @@ describe('Settings API', function () {
         return ghostServer.stop();
     });
 
-    it('Can\'t read core setting', function () {
-        return request
-            .get(localUtils.API.getApiQuery('settings/db_hash/'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(403);
-    });
+    describe('As Owner', function () {
+        it('Can\'t read core setting', function () {
+            return request
+                .get(localUtils.API.getApiQuery('settings/db_hash/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(403);
+        });
 
-    it('Can\'t read permalinks', function (done) {
-        request.get(localUtils.API.getApiQuery('settings/permalinks/'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(404)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
+        it('Can\'t read permalinks', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/permalinks/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                done();
-            });
-    });
+                    done();
+                });
+        });
 
-    it('can\'t read non existent setting', function (done) {
-        request.get(localUtils.API.getApiQuery('settings/testsetting/'))
-            .set('Origin', config.get('url'))
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(404)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
+        it('can\'t read non existent setting', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/testsetting/'))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                should.not.exist(res.headers['x-cache-invalidate']);
-                var jsonResponse = res.body;
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.errors);
-                testUtils.API.checkResponseValue(jsonResponse.errors[0], [
-                    'message',
-                    'context',
-                    'type',
-                    'details',
-                    'property',
-                    'help',
-                    'code',
-                    'id'
-                ]);
-                done();
-            });
-    });
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    var jsonResponse = res.body;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.errors);
+                    testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                        'message',
+                        'context',
+                        'type',
+                        'details',
+                        'property',
+                        'help',
+                        'code',
+                        'id'
+                    ]);
+                    done();
+                });
+        });
 
-    it('can\'t edit permalinks', function (done) {
-        const settingToChange = {
-            settings: [{key: 'permalinks', value: '/:primary_author/:slug/'}]
-        };
+        it('can\'t edit permalinks', function (done) {
+            const settingToChange = {
+                settings: [{key: 'permalinks', value: '/:primary_author/:slug/'}]
+            };
 
-        request.put(localUtils.API.getApiQuery('settings/'))
-            .set('Origin', config.get('url'))
-            .send(settingToChange)
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(404)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
+            request.put(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .send(settingToChange)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                done();
-            });
-    });
+                    done();
+                });
+        });
 
-    it('can\'t edit non existent setting', function (done) {
-        request.get(localUtils.API.getApiQuery('settings/'))
-            .set('Origin', config.get('url'))
-            .set('Accept', 'application/json')
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
+        it('can\'t edit non existent setting', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                var jsonResponse = res.body,
-                    newValue = 'new value';
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.settings);
-                jsonResponse.settings = [{key: 'testvalue', value: newValue}];
+                    var jsonResponse = res.body,
+                        newValue = 'new value';
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.settings);
+                    jsonResponse.settings = [{key: 'testvalue', value: newValue}];
 
-                request.put(localUtils.API.getApiQuery('settings/'))
-                    .set('Origin', config.get('url'))
-                    .send(jsonResponse)
-                    .expect('Content-Type', /json/)
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .end(function (err, res) {
-                        if (err) {
-                            return done(err);
-                        }
-
-                        jsonResponse = res.body;
-                        should.not.exist(res.headers['x-cache-invalidate']);
-                        should.exist(jsonResponse.errors);
-                        testUtils.API.checkResponseValue(jsonResponse.errors[0], [
-                            'message',
-                            'context',
-                            'type',
-                            'details',
-                            'property',
-                            'help',
-                            'code',
-                            'id'
-                        ]);
-                        done();
-                    });
-            });
-    });
-
-    it('Will transform "1"', function (done) {
-        request.get(localUtils.API.getApiQuery('settings/'))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .end(function (err, res) {
-                if (err) {
-                    return done(err);
-                }
-
-                const jsonResponse = res.body,
-                    settingToChange = {
-                        settings: [
-                            {
-                                key: 'is_private',
-                                value: '1'
+                    request.put(localUtils.API.getApiQuery('settings/'))
+                        .set('Origin', config.get('url'))
+                        .send(jsonResponse)
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
                             }
-                        ]
-                    };
 
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.settings);
+                            jsonResponse = res.body;
+                            should.not.exist(res.headers['x-cache-invalidate']);
+                            should.exist(jsonResponse.errors);
+                            testUtils.API.checkResponseValue(jsonResponse.errors[0], [
+                                'message',
+                                'context',
+                                'type',
+                                'details',
+                                'property',
+                                'help',
+                                'code',
+                                'id'
+                            ]);
+                            done();
+                        });
+                });
+        });
 
-                request.put(localUtils.API.getApiQuery('settings/'))
-                    .set('Origin', config.get('url'))
-                    .send(settingToChange)
-                    .expect('Content-Type', /json/)
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(200)
-                    .end(function (err, res) {
-                        if (err) {
-                            return done(err);
-                        }
+        it('Will transform "1"', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
 
-                        const putBody = res.body;
-                        res.headers['x-cache-invalidate'].should.eql('/*');
-                        should.exist(putBody);
+                    const jsonResponse = res.body,
+                        settingToChange = {
+                            settings: [
+                                {
+                                    key: 'is_private',
+                                    value: '1'
+                                }
+                            ]
+                        };
 
-                        putBody.settings[0].key.should.eql('is_private');
-                        putBody.settings[0].value.should.eql(true);
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.settings);
 
-                        localUtils.API.checkResponse(putBody, 'settings');
-                        done();
-                    });
-            });
+                    request.put(localUtils.API.getApiQuery('settings/'))
+                        .set('Origin', config.get('url'))
+                        .send(settingToChange)
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            const putBody = res.body;
+                            res.headers['x-cache-invalidate'].should.eql('/*');
+                            should.exist(putBody);
+
+                            putBody.settings[0].key.should.eql('is_private');
+                            putBody.settings[0].value.should.eql(true);
+
+                            localUtils.API.checkResponse(putBody, 'settings');
+                            done();
+                        });
+                });
+        });
     });
 });


### PR DESCRIPTION
These changes:
- [x] verify only specific roles are able to edit settings
- [x] limits editing of `members` flag by the `Owner` role only 
- [x] clean up settings test 

@allouis let me know what you think about these. I had to create this new concept of `unsafeAttrsObject` in controllers to be able to leave the permissions layer less coupled from controller implementation. It also only checks for single `labs` key right now, but think that's fine as it's only use case we care about. Some more descriptions about the thinking in commit messages ;) 

Another thing to consider here is somehow disabling toggling members for no owner in the UI. At the moment it just drops the error in top banner and disallows toggling.