### PR TITLE
redirects.yaml Logic

### DIFF
--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -22,15 +22,15 @@ _private.registerRoutes = () => {
     try {
         if (fs.existsSync(path.join(config.getContentPath('data'), 'redirects.yaml'))) {
             let configYaml = yaml.safeLoad(fs.readFileSync(path.join(config.getContentPath('data'), 'redirects.yaml'), 'utf-8'));
-            console.log(configYaml);
+            
             /**
              * 302: Temporary redirects
              */
             for (const redirect in configYaml['302']) {
                 redirects.push({
-                    "from": redirect,
-                    "to": configYaml['302'][redirect],
-                    "permanent": false
+                    from: redirect,
+                    to: configYaml['302'][redirect],
+                    permanent: false
                 });
             }
 
@@ -39,9 +39,9 @@ _private.registerRoutes = () => {
              */
             for (const redirect in configYaml['301']) {
                 redirects.push({
-                    "from": redirect,
-                    "to": configYaml['301'][redirect],
-                    "permanent": true
+                    from: redirect,
+                    to: configYaml['301'][redirect],
+                    permanent: true
                 });
             }
         } else {


### PR DESCRIPTION
Per #11085, custom-redirects.js will now attempt to read from a redirects.yaml file with the structure described in that issue. Also per that issue, it's intended to be backwards compatible; if there's no redirects.yaml file, it should read any redirects.json file that's present as expected.

Linted and tested. Some `Local File System Storage` tests apparently failed but I think that has more to do with my environment.

This is sort of my first PR on a project of this size so feedback is extremely appreciated!