### PR TITLE
Removed token param on page load for members

### DIFF
--- a/core/server/public/members.js
+++ b/core/server/public/members.js
@@ -138,3 +138,9 @@ Array.prototype.forEach.call(document.querySelectorAll('[data-members-signout]')
     }
     el.addEventListener('click', clickHandler);
 });
+
+var url = new URL(window.location);
+if (url.searchParams.get('token')) {
+    url.searchParams.delete('token');
+    window.history.replaceState({}, document.title, url.href);
+}


### PR DESCRIPTION
no-issue

This adds a bit of protection from accidentally sharing the url, and
also makes the url look cleaner
