### PR TITLE
Updated post model url transforms for posts/posts_meta split

### DIFF
--- a/core/server/models/posts-meta.js
+++ b/core/server/models/posts-meta.js
@@ -1,7 +1,32 @@
 const ghostBookshelf = require('./base');
+const urlUtils = require('../lib/url-utils');
 
 const PostsMeta = ghostBookshelf.Model.extend({
-    tableName: 'posts_meta'
+    tableName: 'posts_meta',
+
+    onSaving: function onSaving() {
+        const urlTransformMap = {
+            og_image: 'absoluteToRelative',
+            twitter_image: 'absoluteToRelative'
+        };
+
+        Object.entries(urlTransformMap).forEach(([attr, transform]) => {
+            let method = transform;
+            let methodOptions = {};
+
+            if (typeof transform === 'object') {
+                method = transform.method;
+                methodOptions = transform.options || {};
+            }
+
+            if (this.hasChanged(attr) && this.get(attr)) {
+                const transformedValue = urlUtils[method](this.get(attr), methodOptions);
+                this.set(attr, transformedValue);
+            }
+        });
+
+        ghostBookshelf.Model.prototype.onSaving.apply(this, arguments);
+    }
 }, {
     post() {
         return this.belongsTo('Post');

--- a/core/test/regression/models/model_posts_spec.js
+++ b/core/test/regression/models/model_posts_spec.js
@@ -1123,9 +1123,11 @@ describe('Post Model', function () {
                     codeinjection_head: '<script src="http://127.0.0.1:2369/assets/head.js"></script>',
                     codeinjection_foot: '<script src="http://127.0.0.1:2369/assets/foot.js"></script>',
                     feature_image: 'http://127.0.0.1:2369/content/images/feature.png',
-                    og_image: 'http://127.0.0.1:2369/content/images/og.png',
-                    twitter_image: 'http://127.0.0.1:2369/content/images/twitter.png',
-                    canonical_url: 'http://127.0.0.1:2369/canonical'
+                    canonical_url: 'http://127.0.0.1:2369/canonical',
+                    posts_meta: {
+                        og_image: 'http://127.0.0.1:2369/content/images/og.png',
+                        twitter_image: 'http://127.0.0.1:2369/content/images/twitter.png'
+                    }
                 };
 
                 models.Post.add(post, context).then((createdPost) => {
@@ -1135,9 +1137,12 @@ describe('Post Model', function () {
                     createdPost.get('codeinjection_head').should.equal('<script src="/assets/head.js"></script>');
                     createdPost.get('codeinjection_foot').should.equal('<script src="/assets/foot.js"></script>');
                     createdPost.get('feature_image').should.equal('/content/images/feature.png');
-                    createdPost.get('og_image').should.equal('/content/images/og.png');
-                    createdPost.get('twitter_image').should.equal('/content/images/twitter.png');
                     createdPost.get('canonical_url').should.equal('/canonical');
+
+                    const postMeta = createdPost.relations.posts_meta;
+
+                    postMeta.get('og_image').should.equal('/content/images/og.png');
+                    postMeta.get('twitter_image').should.equal('/content/images/twitter.png');
 
                     // ensure canonical_url is not transformed when protocol does not match
                     return createdPost.save({


### PR DESCRIPTION
no issue

- `og_image` and `twitter_image` fields are now located in a separate model so the transform functionality for those fields needed to move accordingly