### PR TITLE
Added reading_time property to post/page resources in Canary Content API

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
@@ -1,3 +1,5 @@
+const readingMinutes = require('@tryghost/helpers').utils.readingMinutes;
+
 module.exports.forPost = (frame, model, attrs) => {
     const _ = require('lodash');
 
@@ -13,6 +15,19 @@ module.exports.forPost = (frame, model, attrs) => {
             }
         } else {
             attrs.excerpt = attrs.custom_excerpt;
+        }
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') ||
+    (frame.options.columns.includes('reading_time'))) {
+        if (attrs.html) {
+            let additionalImages = 0;
+
+            if (attrs.feature_image) {
+                additionalImages += 1;
+            }
+
+            attrs.reading_time = readingMinutes(attrs.html, additionalImages);
         }
     }
 };

--- a/core/test/regression/api/canary/content/utils.js
+++ b/core/test/regression/api/canary/content/utils.js
@@ -27,6 +27,7 @@ const expectedProperties = {
         // .without('page')
         // canary returns a calculated excerpt field
         .concat('excerpt')
+        .concat('reading_time')
     ,
     author: _(schema.users)
         .keys()

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@nexes/nql": "0.3.0",
-    "@tryghost/helpers": "1.1.14",
+    "@tryghost/helpers": "1.1.15",
     "@tryghost/members-api": "0.8.0",
     "@tryghost/members-ssr": "0.7.0",
     "@tryghost/social-urls": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@nexes/nql": "0.3.0",
-    "@tryghost/helpers": "1.1.12",
+    "@tryghost/helpers": "1.1.14",
     "@tryghost/members-api": "0.8.0",
     "@tryghost/members-ssr": "0.7.0",
     "@tryghost/social-urls": "0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,10 +199,10 @@
     mkdirp "0.5.0"
     yauzl "2.4.1"
 
-"@tryghost/helpers@1.1.14":
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/@tryghost/helpers/-/helpers-1.1.14.tgz#89fe706660b256eb8caba6a5d0bbe468f5d1dced"
-  integrity sha512-7BKhOTkfGAE+OHsO2NXNvAR2sWQNo3vXa4k9HqGjWAvabLOYCpn47kobte3suSD8Myk9/eqwZ9MgTyC+kJajDw==
+"@tryghost/helpers@1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@tryghost/helpers/-/helpers-1.1.15.tgz#8a8e53af47630707aeb328fc949ce37464f7d447"
+  integrity sha512-llve/Ha+uUnqrqP4TlGIXf+W5nDRv6XsiqLWoUFARtciP42kMQLQY+ABC4Fmc0N1daD1P020jTjd7eX+9fdVFw==
   dependencies:
     lodash-es "^4.17.11"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,10 +199,10 @@
     mkdirp "0.5.0"
     yauzl "2.4.1"
 
-"@tryghost/helpers@1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@tryghost/helpers/-/helpers-1.1.12.tgz#ca77aa2649abd2d12760b36af2d6779619202971"
-  integrity sha512-9ns/YTXfUb+UOmILQq071qZ8Y6eIEvNQFLZtFiguhOzXqSHC+rKg45aNCcoP8G9opG7vmm7bkxeE/hiQ205qpw==
+"@tryghost/helpers@1.1.14":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@tryghost/helpers/-/helpers-1.1.14.tgz#89fe706660b256eb8caba6a5d0bbe468f5d1dced"
+  integrity sha512-7BKhOTkfGAE+OHsO2NXNvAR2sWQNo3vXa4k9HqGjWAvabLOYCpn47kobte3suSD8Myk9/eqwZ9MgTyC+kJajDw==
   dependencies:
     lodash-es "^4.17.11"
 


### PR DESCRIPTION
Changes:
- [x] `reading_time` property in posts/pages resource in Canary Content API
- [x] `reading_time` helper fallback to resource property when it's present (https://github.com/TryGhost/Ghost-SDK/pull/167)