### PR TITLE
Updated members-api to get shorter magic-links

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -194,6 +194,9 @@
         "members_session_secret": {
             "defaultValue": null
         },
+        "members_email_auth_secret": {
+            "defaultValue": null
+        },
         "default_content_visibility": {
             "defaultValue": "public"
         },

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -37,7 +37,8 @@ function parseDefaultSettings() {
             members_session_secret: () => crypto.randomBytes(32).toString('hex'),
             theme_session_secret: () => crypto.randomBytes(32).toString('hex'),
             members_public_key: () => getMembersKey('public'),
-            members_private_key: () => getMembersKey('private')
+            members_private_key: () => getMembersKey('private'),
+            members_email_auth_secret: () => crypto.randomBytes(64).toString('hex')
         };
 
     _.each(defaultSettingsInCategories, function each(settings, categoryName) {

--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -171,9 +171,9 @@ function getAuthSecret() {
     return secret;
 }
 
-function getRequirePaymentSetting() {
+function getAllowSelfSignup() {
     const subscriptionSettings = settingsCache.get('members_subscription_settings');
-    return !!subscriptionSettings.requirePaymentForSignup;
+    return !subscriptionSettings.requirePaymentForSignup;
 }
 
 // NOTE: the function is an exact duplicate of one in GhostMailer should be extracted
@@ -199,7 +199,7 @@ function createApiInstance() {
                 signinURL.searchParams.set('action', type);
                 return signinURL.href;
             },
-            allowSelfSignup: !getRequirePaymentSetting(),
+            allowSelfSignup: getAllowSelfSignup(),
             secret: getAuthSecret()
         },
         mail: {

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -113,7 +113,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(80);
+                    eventSpy.callCount.should.equal(82);
 
                     eventSpy.args[1][0].should.equal('settings.db_hash.added');
                     eventSpy.args[1][1].attributes.type.should.equal('core');
@@ -137,7 +137,7 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    eventSpy.callCount.should.equal(78);
+                    eventSpy.callCount.should.equal(80);
 
                     eventSpy.args[13][0].should.equal('settings.logo.added');
                 });

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -114,16 +114,14 @@ describe('Unit: models/settings', function () {
             return models.Settings.populateDefaults()
                 .then(() => {
                     eventSpy.callCount.should.equal(82);
+                    const eventsEmitted = eventSpy.args.map(args => args[0]);
+                    const checkEventEmitted = event => should.ok(eventsEmitted.includes(event), `${event} event should be emitted`);
 
-                    eventSpy.args[1][0].should.equal('settings.db_hash.added');
-                    eventSpy.args[1][1].attributes.type.should.equal('core');
+                    checkEventEmitted('settings.db_hash.added');
+                    checkEventEmitted('settings.description.added');
 
-                    eventSpy.args[13][0].should.equal('settings.description.added');
-                    eventSpy.args[13][1].attributes.type.should.equal('blog');
-                    eventSpy.args[13][1].attributes.value.should.equal('The professional publishing platform');
-
-                    eventSpy.args[77][0].should.equal('settings.default_content_visibility.added');
-                    eventSpy.args[79][0].should.equal('settings.members_subscription_settings.added');
+                    checkEventEmitted('settings.default_content_visibility.added');
+                    checkEventEmitted('settings.members_subscription_settings.added');
                 });
         });
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@nexes/nql": "0.3.0",
     "@tryghost/helpers": "1.1.15",
-    "@tryghost/members-api": "0.8.1",
+    "@tryghost/members-api": "0.8.2",
     "@tryghost/members-ssr": "0.7.0",
     "@tryghost/social-urls": "0.1.2",
     "@tryghost/string": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,22 +227,22 @@
   dependencies:
     "@tryghost/kg-clean-basic-html" "^0.1.3"
 
-"@tryghost/magic-link@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/magic-link/-/magic-link-0.2.2.tgz#fa4dbe58d0389db558fee70ac065ce0a78cb29e7"
-  integrity sha512-5OdnC1sEDGA1ioF7NJpTT14p1nlnaHOr/EPtiDxhgND1+vd09LQe+EB6JoefLPonzSEvSexdIYRGj1Gh+zfj6A==
+"@tryghost/magic-link@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/magic-link/-/magic-link-0.3.0.tgz#52e4326efba5756a39d219990d8fcbcbd3ba813a"
+  integrity sha512-Ahd4KG8Hz/zndRjx0MQt6cY8Lq8TL3UQEXbNIhEO1zOzgyq7FKGpBoSfaVzYb6aSx1pAG/EP60VuBKetHBmUSw==
   dependencies:
     bluebird "^3.5.5"
     ghost-ignition "^3.1.0"
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.8.1.tgz#45453acbbe8f464e8bd45273d2e74902b150bce5"
-  integrity sha512-6lQbr47xR/bJHlOXTpU2dipjKWKX6pUA48rvpdJRA6xvRYQHGezXg8Ebg1K08llJgTEjpA/oFrOnA0FAf1i/vA==
+"@tryghost/members-api@0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.8.2.tgz#2d72cb80909c571fb2e6c9de868d438b5319e54d"
+  integrity sha512-maqhvyNpvw0kWG20UpSG0637YXteO5cc/ts+KWiSk4oIDuaH1sycgNXQ98q4Z+MAKzMye0iGoom7NcXQOFh8/Q==
   dependencies:
-    "@tryghost/magic-link" "^0.2.2"
+    "@tryghost/magic-link" "^0.3.0"
     bluebird "^3.5.4"
     body-parser "^1.19.0"
     cookies "^0.7.3"


### PR DESCRIPTION
no-issue

This updates members-api to 0.8.2 which uses HS256 for signatures and also removes some fluff from magic-link tokens.

We add a new members_email_auth_secret setting with a dynamicDefault and pass that into the members-api

We also add checks for if the secret is missing and gracefully fallback with warnings in the console 