### PR TITLE
Exposed visibility prop for posts on canary api

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -98,8 +98,6 @@ const post = (attrs, frame) => {
         if (attrs.og_description === '') {
             attrs.og_description = null;
         }
-
-        delete attrs.visibility;
     } else {
         delete attrs.page;
 


### PR DESCRIPTION
no-issue

This is required by the theme layer to style member only posts
differently