### PR TITLE
Added new member subscription settings

### DIFF
--- a/core/server/data/migrations/versions/2.37/01-add-self-signup-and-from address-to-members-settings.js
+++ b/core/server/data/migrations/versions/2.37/01-add-self-signup-and-from address-to-members-settings.js
@@ -1,0 +1,67 @@
+const _ = require('lodash');
+const Promise = require('bluebird');
+const common = require('../../../../lib/common');
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    let localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+    const settingsKey = 'members_subscription_settings';
+    return localOptions
+        .transacting('settings')
+        .then((response) => {
+            if (!response) {
+                common.logging.warn('Cannot find settings.');
+                return;
+            }
+            let subscriptionSettingsEntry = response.find((entry) => {
+                return entry.key === settingsKey;
+            });
+
+            if (!subscriptionSettingsEntry) {
+                common.logging.warn('Cannot find members subscription settings.');
+                return;
+            }
+            let subscriptionSettings = JSON.parse(subscriptionSettingsEntry.value);
+
+            let hasRequirePaymentProperty = Object.prototype.hasOwnProperty.call(subscriptionSettings, 'requirePaymentForSignup');
+            let hasSelfSignupProperty = Object.prototype.hasOwnProperty.call(subscriptionSettings, 'allowSelfSignup');
+            let hasFromAddressProperty = Object.prototype.hasOwnProperty.call(subscriptionSettings, 'fromAddress');
+
+            if (!hasFromAddressProperty) {
+                subscriptionSettings.fromAddress = 'noreply';
+            }
+
+            if (!hasRequirePaymentProperty && !hasSelfSignupProperty) {
+                subscriptionSettings.allowSelfSignup = true;
+            }
+            
+            if (hasRequirePaymentProperty) {
+                if (!hasSelfSignupProperty) {
+                    common.logging.info(`Adding allowSelfSignup property from requirePaymentForSignup in member settings`);
+                    subscriptionSettings.allowSelfSignup = !subscriptionSettings.requirePaymentForSignup;
+                }
+                common.logging.info(`Removing requirePaymentForSignup property in member settings`);
+                delete subscriptionSettings.requirePaymentForSignup;
+            }
+
+            return localOptions
+                .transacting('settings')
+                .where('key', settingsKey)
+                .update({
+                    value: JSON.stringify(subscriptionSettings)
+                });
+        });
+};
+
+// `up` only runs in order to normalize member subscription settings which was added
+// no need for down migration as its non-breaking up migration for future versions only
+module.exports.down = () => Promise.resolve();
+
+module.exports.config = {
+    transaction: true
+};


### PR DESCRIPTION
no issue

We added 2 new member subscription settings in last release- `allowSelfSignup` and `fromAddress`- with defaults as `true` and `noreply`. This migration -

-  Sets default values for both settings for users migrating from previous version 
- Cleans up intermediate naming(`requirePaymentForSignup`) previously used for `allowSelfSignup`
