### PR TITLE
Allowed `comment_id` and `uuid` in post API input

### DIFF
--- a/core/server/api/canary/utils/validators/input/schemas/posts.json
+++ b/core/server/api/canary/utils/validators/input/schemas/posts.json
@@ -117,6 +117,12 @@
                 "id": {
                     "strip": true
                 },
+                "uuid": {
+                    "strip": true
+                },
+                "comment_id": {
+                    "strip": true
+                },
                 "author": {
                     "strip": true
                 },

--- a/core/server/api/v2/utils/validators/input/schemas/posts.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts.json
@@ -117,6 +117,12 @@
                 "id": {
                     "strip": true
                 },
+                "uuid": {
+                    "strip": true
+                },
+                "comment_id": {
+                    "strip": true
+                },
                 "author": {
                     "strip": true
                 },


### PR DESCRIPTION
no issue

Allows `comment_id` and `uuid` to be passed in post `add`/`edit` API calls instead of failing requests with validation error, though both properties are stripped out in serializer as we don't allow editing them.
