### PR TITLE
Fixed member posts not appearing in theme after restart

### DIFF
--- a/core/frontend/services/url/configs/canary.js
+++ b/core/frontend/services/url/configs/canary.js
@@ -8,7 +8,7 @@ module.exports = [
         type: 'posts',
         modelOptions: {
             modelName: 'Post',
-            filter: 'visibility:public+status:published+type:post',
+            filter: 'status:published+type:post',
             exclude: [
                 'title',
                 'mobiledoc',
@@ -79,7 +79,7 @@ module.exports = [
                 'primary_tag',
                 'primary_author'
             ],
-            filter: 'visibility:public+status:published+type:page'
+            filter: 'status:published+type:page'
         },
         events: {
             add: 'page.published',

--- a/core/frontend/services/url/configs/v2.js
+++ b/core/frontend/services/url/configs/v2.js
@@ -8,7 +8,7 @@ module.exports = [
         type: 'posts',
         modelOptions: {
             modelName: 'Post',
-            filter: 'visibility:public+status:published+type:post',
+            filter: 'status:published+type:post',
             exclude: [
                 'title',
                 'mobiledoc',
@@ -79,7 +79,7 @@ module.exports = [
                 'primary_tag',
                 'primary_author'
             ],
-            filter: 'visibility:public+status:published+type:page'
+            filter: 'status:published+type:page'
         },
         events: {
             add: 'page.published',

--- a/core/frontend/services/url/configs/v3.js
+++ b/core/frontend/services/url/configs/v3.js
@@ -8,7 +8,7 @@ module.exports = [
         type: 'posts',
         modelOptions: {
             modelName: 'Post',
-            filter: 'visibility:public+status:published+type:post',
+            filter: 'status:published+type:post',
             exclude: [
                 'title',
                 'mobiledoc',
@@ -79,7 +79,7 @@ module.exports = [
                 'primary_tag',
                 'primary_author'
             ],
-            filter: 'visibility:public+status:published+type:page'
+            filter: 'status:published+type:page'
         },
         events: {
             add: 'page.published',


### PR DESCRIPTION
no issue

We currently use `visibility:public` filter for post url config for all API versions in `v3`, which causes any post with non-public visibility to not get added in resource list on bootup. This means every time on server start/restart, fetching posts in theme will exclude any existing post not having `visibility:public` as it won't have a corresponding url resource added.

This fix was previously committed to master here - https://github.com/TryGhost/Ghost/commit/ff13821b27acfc7a5ce9758cc0b7d38f365f3054 - but got overwritten during `master -> v3` merge somewhere(most likely  at https://github.com/TryGhost/Ghost/commit/e57e19ec31e4bdebbf0873689fa911d79029fb88) causing weird behavior with member posts on v3.

This PR brings back the fix from original commit by removing `visibility:public` filter from post/page url config, which allows all posts including `members` and `paid` to load correctly in theme.