### PR TITLE
🐛 Fixed migration path from 2.28.x to 3.0.0

### DIFF
--- a/core/server/data/migrations/versions/2.29/1-add-post-page-column.js
+++ b/core/server/data/migrations/versions/2.29/1-add-post-page-column.js
@@ -13,7 +13,15 @@ function createColumnMigration({table, column, dbIsInCorrectState, operation, op
                 log(`${operationVerb} ${table}.${column}`);
 
                 if (!isInCorrectState) {
-                    return operation(table, column, transacting);
+                    // has to be passed directly in case of migration to 3.0
+                    // ref: https://github.com/TryGhost/Ghost/commit/9d7190d69255ac011848c6bf654886be81abeedc#diff-c20cac44dad77922cf53ffd7b094cd8cL22
+                    const columnSpec = {
+                        type: 'bool',
+                        nullable: false,
+                        defaultTo: false
+                    };
+
+                    return operation(table, column, transacting, columnSpec);
                 }
             });
     };


### PR DESCRIPTION
This fix has to do with a migration :building_construction: would appreciate second pair of :eyes: 

Todo: 
- [x] test other migration paths (for now tested 2.28.0/1 -> 3.0)
  - Only people who were on 2.28.x version of Ghost were affected.
- [x] ping forum to confirm the fix before rollout?