### PR TITLE
🐛 Fixed 404s when using a proxy setup

### DIFF
--- a/core/server/web/admin/app.js
+++ b/core/server/web/admin/app.js
@@ -11,6 +11,10 @@ module.exports = function setupAdminApp() {
     debug('Admin setup start');
     const adminApp = express();
 
+    // Make sure 'req.secure' and `req.hostname` is valid for proxied requests
+    // (X-Forwarded-Proto header will be checked, if present)
+    adminApp.enable('trust proxy');
+
     // Admin assets
     // @TODO ensure this gets a local 404 error handler
     const configMaxAge = config.get('caching:admin:maxAge');

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -1,6 +1,6 @@
 const debug = require('ghost-ignition').debug('web:parent');
 const express = require('express');
-const vhost = require('vhost');
+const vhost = require('@tryghost/vhost-middleware');
 const config = require('../config');
 const compress = require('compression');
 const netjet = require('netjet');

--- a/core/server/web/shared/middlewares/url-redirects.js
+++ b/core/server/web/shared/middlewares/url-redirects.js
@@ -96,7 +96,7 @@ _private.getBlogRedirectUrl = (options) => {
  */
 _private.redirect = (req, res, next, redirectFn) => {
     const redirectUrl = redirectFn({
-        requestedHost: req.get('host'),
+        requestedHost: req.hostname,
         requestedUrl: url.parse(req.originalUrl || req.url).pathname,
         queryParameters: req.query,
         secure: req.secure

--- a/core/test/unit/web/middleware/url-redirects_spec.js
+++ b/core/test/unit/web/middleware/url-redirects_spec.js
@@ -13,7 +13,7 @@ describe('UNIT: url redirects', function () {
 
     beforeEach(function () {
         req = {
-            get: function get() {
+            get hostname() {
                 return host;
             }
         };

--- a/core/test/unit/web/parent-app_spec.js
+++ b/core/test/unit/web/parent-app_spec.js
@@ -30,7 +30,7 @@ describe('parent app', function () {
 
         parentApp = proxyquire('../../../server/web/parent-app', {
             express: expressStub,
-            vhost: vhostSpy,
+            '@tryghost/vhost-middleware': vhostSpy,
             './api': apiSpy,
             './admin': adminSpy,
             './site': siteSpy,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@tryghost/social-urls": "0.1.4",
     "@tryghost/string": "^0.1.3",
     "@tryghost/url-utils": "0.6.11",
+    "@tryghost/vhost-middleware": "1.0.0",
     "ajv": "6.10.2",
     "amperize": "0.6.0",
     "analytics-node": "3.3.0",
@@ -124,7 +125,6 @@
     "simple-html-tokenizer": "0.5.8",
     "uuid": "3.3.3",
     "validator": "6.3.0",
-    "vhost": "3.0.2",
     "xml": "1.0.1"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,6 +334,15 @@
     remark "^11.0.1"
     unist-util-visit "^2.0.0"
 
+"@tryghost/vhost-middleware@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/vhost-middleware/-/vhost-middleware-1.0.0.tgz#b9318b837054e87c35b27a31961847ad8bf70868"
+  integrity sha512-F+rSk4YmquxjfSPvRc4s20NuOQfnQluK6drvttkPybKWTMoRvs5/uDfVdyil3lTVZC5COh7sSBCCM3Fin7FYGA==
+  dependencies:
+    bluebird "^3.7.1"
+    ghost-ignition "^3.1.0"
+    lodash "^4.17.15"
+
 "@types/bluebird@^3.5.26", "@types/bluebird@^3.5.27":
   version "3.5.27"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.27.tgz#61eb4d75dc6bfbce51cf49ee9bbebe941b2cb5d0"
@@ -913,6 +922,11 @@ bluebird@^3.0.5, bluebird@^3.4.1, bluebird@^3.4.3, bluebird@^3.4.6, bluebird@^3.
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.0.tgz#56a6a886e03f6ae577cffedeb524f8f2450293cf"
   integrity sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==
+
+bluebird@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
+  integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
 
 body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
@@ -8970,11 +8984,6 @@ vfile@^4.0.0:
     replace-ext "1.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
-
-vhost@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/vhost/-/vhost-3.0.2.tgz#2fb1decd4c466aa88b0f9341af33dc1aff2478d5"
-  integrity sha1-L7HezUxGaqiLD5NBrzPcGv8keNU=
 
 video-extensions@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
no issue

When using certain proxy setups that result in `host` and `x-forwarded-host` being different, it became impossible to access Ghost because all routes showed generic 404 pages.

- `vhost` module that we are using to separate front-end and admin urls does not use express' `req.hostname` so it does not pick up the `x-forwarded-host` url that express' `'trust proxy'` config gives us
- switched to the forked `@tryghost/vhost-middleware` package which has a one-line change to use `req.hostname || req.host`
- added `'trust proxy'` config to the admin express app and switched to using `req.hostname` in our redirect code to avoid infinite redirect loops