### PR TITLE
🐛 Fixed 3.0 migration for SQLite

### DIFF
--- a/core/server/data/migrations/versions/3.0/05-populate-posts-meta-table.js
+++ b/core/server/data/migrations/versions/3.0/05-populate-posts-meta-table.js
@@ -42,7 +42,11 @@ module.exports.up = (options) => {
                     postsMetaEntry.id = ObjectId.generate();
                     return postsMetaEntry;
                 });
-                return localOptions.transacting('posts_meta').insert(postsMetaEntries);
+
+                // NOTE: iterative method is needed to prevent from `SQLITE_ERROR: too many variables` error
+                return Promise.map(postsMetaEntries, (postsMeta) => {
+                    return localOptions.transacting('posts_meta').insert(postsMeta);
+                });
             } else {
                 common.logging.info('Skipping populating posts_meta table: found 0 posts with metadata');
                 return Promise.resolve();


### PR DESCRIPTION
closes #11263

- The issue here is with hitting SQLite's internal SQLITE_LIMIT_VARIABLE_NUMBER limit when updating with large amount of posts having metadata fields set (ref.: https://sqlite.org/limits.html#max_variable_number)
- Transforming migration to iterative method avoided inserting lots of records at once

It's touching migration code :building_construction: I would love your 2 :heavy_check_mark:  for this. Thaaanks!