### PR TITLE
Fixed preview access in 3.0, where preview is broken in members theme

### DIFF
--- a/core/frontend/services/routing/controllers/preview.js
+++ b/core/frontend/services/routing/controllers/preview.js
@@ -53,6 +53,10 @@ module.exports = function previewController(req, res, next) {
                 return urlUtils.redirect301(res, urlService.getUrlByResourceId(post.id, {withSubdirectory: true}));
             }
 
+            if (res.locals.apiVersion !== 'v0.1' && res.locals.apiVersion !== 'v2') {
+                post.access = !!post.html;
+            }
+
             // @TODO: See helpers/secure
             helpers.secure(req, post);
 


### PR DESCRIPTION
Currently, if you use the Lyra theme with members enabled on v3.0, you _cannot_ use the preview.

Ghost gates any post not published, and requires an access level of paid. This renders preview completely broken in 3.0 with the Lyra theme.

Accordingly, this pull request fixes the issue. As a note, an [issue on the Lyra theme repository](https://github.com/TryGhost/Lyra/issues/4) has been started.