### PR TITLE
🐛 Fixed error from has helper w/o dependent data

### DIFF
--- a/core/frontend/helpers/has.js
+++ b/core/frontend/helpers/has.js
@@ -11,6 +11,9 @@ var proxy = require('./proxy'),
     validAttrs = ['tag', 'author', 'slug', 'id', 'number', 'index', 'any', 'all'];
 
 function handleCount(ctxAttr, data) {
+    if (!data || !_.isFinite(data.length)) {
+        return false;
+    }
     let count;
 
     if (ctxAttr.match(/count:\d+/)) {

--- a/core/frontend/helpers/has.js
+++ b/core/frontend/helpers/has.js
@@ -4,11 +4,11 @@
 //
 // Checks if a post has a particular property
 
-var proxy = require('./proxy'),
-    _ = require('lodash'),
-    logging = proxy.logging,
-    i18n = proxy.i18n,
-    validAttrs = ['tag', 'author', 'slug', 'id', 'number', 'index', 'any', 'all'];
+const proxy = require('./proxy');
+const _ = require('lodash');
+const logging = proxy.logging;
+const i18n = proxy.i18n;
+const validAttrs = ['tag', 'author', 'slug', 'id', 'number', 'index', 'any', 'all'];
 
 function handleCount(ctxAttr, data) {
     if (!data || !_.isFinite(data.length)) {


### PR DESCRIPTION
no-issue

Usage of the has helper like `{{#has 'author:count>1'}}` when the
current context does not have the dependent data (in this case
`authors`) would error, because it could not read property length of
undefined.