### PR TITLE
Optimized posts_meta table join when meta columns are not requested

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -803,7 +803,14 @@ Post = ghostBookshelf.Model.extend({
         if (['edit', 'add', 'destroy'].indexOf(methodName) !== -1) {
             options.withRelated = _.union(['authors', 'tags'], options.withRelated || []);
         }
-        options.withRelated = _.union(['posts_meta'], options.withRelated || []);
+
+        const META_ATTRIBUTES = _.without(ghostBookshelf.model('PostsMeta').prototype.permittedAttributes(), 'id', 'post_id');
+
+        // NOTE: only include post_meta relation when requested in 'columns' or by default
+        //       optimization is needed to be able to perform .findAll on large SQLite datasets
+        if (!options.columns || (options.columns && _.intersection(META_ATTRIBUTES, options.columns).length)) {
+            options.withRelated = _.union(['posts_meta'], options.withRelated || []);
+        }
 
         return options;
     },


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/11270

This PR is focused on allowing migrations for SQLite users with large amounts of posts (>999).

As described in the commit message:
> The main problem is in the `SELECT` statement which is generated for `findAll` method in Bookshelf which creates `WHERE IN(post_ids_here)` statement with all posts in the database

^such `WHERE IN` fails when there are more than 999 posts in the database due to [this SQLite restriction](https://sqlite.org/limits.html#max_variable_number).

:warning: The implication is that we do not support `.findAll` method for `Post` model on `SQLite` with more than 999 records :scream_cat: Would need a separate investigation into it and possibly some optimization on Bookshelf relation level :thinking: 

Below was moved to https://github.com/TryGhost/Ghost/pull/11302
~As this PR if focused only on the migration bit, have considered multiple approaches:~
~1. Rearrange migrations so that `11-update-posts-html.js` runs before we introduce `posts_meta` table/relation. Didn't work as the relationship is already in the codebase and could only work if it was on separate minors :disappointed:~ 
~2. Iterative post-by-post migration. This method would require introducing temporary storage (table or flag) for already migrated posts so that we could iteratively fetch&migrate posts one-by-one until we can verify that all of them were migrated. Didn't go with it as considered it over complicated.~
~3. `posts_meta` relation fetching optimization (only in cases when we pass `options.column` to the query). This is the solution I went with in the PR. It solves the issue and introduces a little speed-up in cases when none of the columns from `posts_meta` table are needed. One possible danger is that it's overoptimizing and misses some use-cases for fetching this relation.~ 

@kevinansfield @rishabhgrg would really appreciate your thoughts on this one! Danke! 