### PR TITLE
💡 Removed list of reserved slugs

### DIFF
--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -20,10 +20,7 @@
         ]
     },
     "slugs": {
-        "reserved": ["admin", "app", "apps", "categories",
-            "category", "dashboard", "feed", "ghost-admin", "login", "logout",
-            "page", "pages", "post", "posts", "public", "register", "setup",
-            "signin", "signout", "signup", "user", "users", "wp-admin", "wp-login"],
+        "reserved": [],
         "protected": ["ghost", "rss", "amp"]
     },
     "uploads": {


### PR DESCRIPTION
no issue

- reserved slugs get in the way of creating pages such as `/signin/` which do not currently exist and are useful for members
- the reserved slugs concept is a little meaningless because if there are any route clashes then our own routes should always win out over a post slug