### PR TITLE
Fixed member.deleted webhook having an empty payload

### DIFF
--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -1,18 +1,19 @@
 const common = require('../../../../../lib/common');
 const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:members');
+const mapper = require('./utils/mapper');
 
 module.exports = {
     browse(data, apiConfig, frame) {
         debug('browse');
 
-        frame.response = data;
+        frame.response = mapper.mapMember(data, frame);
     },
 
     add(data, apiConfig, frame) {
         debug('add');
 
         frame.response = {
-            members: [data]
+            members: [mapper.mapMember(data, frame)]
         };
     },
 
@@ -20,7 +21,7 @@ module.exports = {
         debug('edit');
 
         frame.response = {
-            members: [data]
+            members: [mapper.mapMember(data, frame)]
         };
     },
 
@@ -34,7 +35,7 @@ module.exports = {
         }
 
         frame.response = {
-            members: [data]
+            members: [mapper.mapMember(data, frame)]
         };
     },
 

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -119,6 +119,11 @@ const mapAction = (model, frame) => {
     return attrs;
 };
 
+const mapMember = (model, frame) => {
+    const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
+    return jsonModel;
+};
+
 module.exports.mapPost = mapPost;
 module.exports.mapUser = mapUser;
 module.exports.mapTag = mapTag;
@@ -126,3 +131,4 @@ module.exports.mapIntegration = mapIntegration;
 module.exports.mapSettings = mapSettings;
 module.exports.mapImage = mapImage;
 module.exports.mapAction = mapAction;
+module.exports.mapMember = mapMember;


### PR DESCRIPTION
no issue

- the members output serializer was passing model objects through on `frame.response` but the webhooks serializer doesn't know how to deal with those
- adjusting the output serializer to use a mapper as per the other serializers means that POJOs are being passed through which allows the webhook serializer to correctly pick out the changed attributes