### PR TITLE
Email model + endpoints

### DIFF
--- a/core/server/api/canary/email.js
+++ b/core/server/api/canary/email.js
@@ -1,0 +1,33 @@
+const models = require('../../models');
+const common = require('../../lib/common');
+
+module.exports = {
+    docName: 'emails',
+
+    read: {
+        options: [
+            'fields'
+        ],
+        validation: {
+            options: {
+                fields: ['html', 'plaintext', 'subject']
+            }
+        },
+        data: [
+            'id'
+        ],
+        permissions: true,
+        query(frame) {
+            return models.Email.findOne(frame.data, frame.options)
+                .then((model) => {
+                    if (!model) {
+                        throw new common.errors.NotFoundError({
+                            message: common.i18n.t('errors.api.email.emailNotFound')
+                        });
+                    }
+
+                    return model.toJSON(frame.options);
+                });
+        }
+    }
+};

--- a/core/server/api/canary/index.js
+++ b/core/server/api/canary/index.js
@@ -111,6 +111,10 @@ module.exports = {
         return shared.pipeline(require('./email-preview'), localUtils);
     },
 
+    get emails() {
+        return shared.pipeline(require('./email'), localUtils);
+    },
+
     get site() {
         return shared.pipeline(require('./site'), localUtils);
     },

--- a/core/server/api/canary/utils/serializers/output/emails.js
+++ b/core/server/api/canary/utils/serializers/output/emails.js
@@ -1,0 +1,7 @@
+module.exports = {
+    read(email, apiConfig, frame) {
+        frame.response = {
+            emails: [email]
+        };
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/index.js
+++ b/core/server/api/canary/utils/serializers/output/index.js
@@ -105,5 +105,9 @@ module.exports = {
 
     get email_preview() {
         return require('./email-preview');
+    },
+
+    get emails() {
+        return require('./emails');
     }
 };

--- a/core/server/data/migrations/versions/3.1/06-add-emails-table.js
+++ b/core/server/data/migrations/versions/3.1/06-add-emails-table.js
@@ -1,0 +1,35 @@
+const common = require('../../../../lib/common');
+const commands = require('../../../schema').commands;
+const table = 'emails';
+const message1 = 'Adding table: ' + table;
+const message2 = 'Dropping table: ' + table;
+
+module.exports.up = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (exists) {
+                common.logging.warn(message1);
+                return;
+            }
+
+            common.logging.info(message1);
+            return commands.createTable(table, connection);
+        });
+};
+
+module.exports.down = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (!exists) {
+                common.logging.warn(message2);
+                return;
+            }
+
+            common.logging.info(message2);
+            return commands.deleteTable(table, connection);
+        });
+};

--- a/core/server/data/migrations/versions/3.1/07-add-email-permissions.js
+++ b/core/server/data/migrations/versions/3.1/07-add-email-permissions.js
@@ -31,7 +31,7 @@ module.exports.up = (options) => {
         const modelToAdd = _private.getPermissions(resource);
 
         return utils.addFixturesForModel(modelToAdd, localOptions)
-            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}s`))
+            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}`))
             .then(() => permissions.init(localOptions));
     });
 };

--- a/core/server/data/migrations/versions/3.1/07-add-email-permissions.js
+++ b/core/server/data/migrations/versions/3.1/07-add-email-permissions.js
@@ -1,0 +1,51 @@
+const _ = require('lodash');
+const utils = require('../../../schema/fixtures/utils');
+const permissions = require('../../../../services/permissions');
+const logging = require('../../../../lib/common/logging');
+
+const resources = ['emails'];
+const _private = {};
+
+_private.getPermissions = function getPermissions(resource) {
+    return utils.findModelFixtures('Permission', {object_type: resource});
+};
+
+_private.printResult = function printResult(result, message) {
+    if (result.done === result.expected) {
+        logging.info(message);
+    } else {
+        logging.warn(`(${result.done}/${result.expected}) ${message}`);
+    }
+};
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    const localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+
+    return Promise.map(resources, (resource) => {
+        const modelToAdd = _private.getPermissions(resource);
+
+        return utils.addFixturesForModel(modelToAdd, localOptions)
+            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}s`))
+            .then(() => permissions.init(localOptions));
+    });
+};
+
+module.exports.down = (options) => {
+    const localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+
+    return Promise.map(resources, (resource) => {
+        const modelToRemove = _private.getPermissions(resource);
+
+        // permission model automatically cleans up permissions_roles on .destroy()
+        return utils.removeFixturesForModel(modelToRemove, localOptions)
+            .then(result => _private.printResult(result, `Removing permissions fixtures for ${resource}s`));
+    });
+};

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -372,6 +372,11 @@
                     "name": "Send test email",
                     "action_type": "sendTestEmail",
                     "object_type": "email_preview"
+                },
+                {
+                    "name": "Email",
+                    "action_type": "read",
+                    "object_type": "email"
                 }
             ]
         },
@@ -567,7 +572,8 @@
                     "api_key": "all",
                     "action": "all",
                     "member": "all",
-                    "email_preview": "all"
+                    "email_preview": "all",
+                    "email": "all"
                 },
                 "DB Backup Integration": {
                     "db": "all"
@@ -590,7 +596,8 @@
                     "webhook": "all",
                     "action": "all",
                     "member": "all",
-                    "email_preview": "all"
+                    "email_preview": "all",
+                    "email": "all"
                 },
                 "Editor": {
                     "notification": "all",
@@ -602,7 +609,8 @@
                     "role": "all",
                     "invite": "all",
                     "theme": ["browse"],
-                    "email_preview": "all"
+                    "email_preview": "all",
+                    "email": "all"
                 },
                 "Author": {
                     "post": ["browse", "read", "add"],
@@ -612,7 +620,8 @@
                     "user": ["browse", "read"],
                     "role": ["browse"],
                     "theme": ["browse"],
-                    "email_preview": "read"
+                    "email_preview": "read",
+                    "email": "read"
                 },
                 "Contributor": {
                     "post": ["browse", "read", "add"],
@@ -622,7 +631,8 @@
                     "user": ["browse", "read"],
                     "role": ["browse"],
                     "theme": ["browse"],
-                    "email_preview": "read"
+                    "email_preview": "read",
+                    "email": "read"
                 }
             }
         },

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -376,5 +376,28 @@ module.exports = {
         // @NOTE: The context object can be used to store information about an action e.g. diffs, meta
         context: {type: 'text', maxlength: 1000000000, nullable: true},
         created_at: {type: 'dateTime', nullable: false}
+    },
+    emails: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', unique: true},
+        uuid: {type: 'string', maxlength: 36, nullable: false, validations: {isUUID: true}},
+        status: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'sending',
+            validations: {isIn: [['sending', 'sent', 'failed']]}
+        },
+        error: {type: 'string', maxlength: 2000, nullable: true},
+        stats: {type: 'text', maxlength: 65535, nullable: true},
+        email_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
+        subject: {type: 'string', maxlength: 300, nullable: true},
+        html: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+        plaintext: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+        submitted_at: {type: 'dateTime', nullable: false},
+        created_at: {type: 'dateTime', nullable: false},
+        created_by: {type: 'string', maxlength: 24, nullable: false},
+        updated_at: {type: 'dateTime', nullable: true},
+        updated_by: {type: 'string', maxlength: 24, nullable: true}
     }
 };

--- a/core/server/models/email.js
+++ b/core/server/models/email.js
@@ -1,0 +1,37 @@
+const ghostBookshelf = require('./base');
+
+const Email = ghostBookshelf.Model.extend({
+    tableName: 'emails',
+
+    emitChange: function emitChange(event, options) {
+        const eventToTrigger = 'email' + '.' + event;
+        ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
+    },
+
+    onCreated: function onCreated(model, attrs, options) {
+        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+
+        model.emitChange('added', options);
+    },
+
+    onUpdated: function onUpdated(model, attrs, options) {
+        ghostBookshelf.Model.prototype.onUpdated.apply(this, arguments);
+
+        model.emitChange('edited', options);
+    },
+
+    onDestroyed: function onDestroyed(model, options) {
+        ghostBookshelf.Model.prototype.onDestroyed.apply(this, arguments);
+
+        model.emitChange('deleted', options);
+    }
+});
+
+const Emails = ghostBookshelf.Collection.extend({
+    model: Email
+});
+
+module.exports = {
+    Email: ghostBookshelf.model('Email', Email),
+    Emails: ghostBookshelf.collection('Emails', Emails)
+};

--- a/core/server/models/email.js
+++ b/core/server/models/email.js
@@ -1,7 +1,15 @@
+const uuid = require('uuid');
 const ghostBookshelf = require('./base');
 
 const Email = ghostBookshelf.Model.extend({
     tableName: 'emails',
+
+    defaults: function defaults() {
+        return {
+            uuid: uuid.v4(),
+            status: 'sending'
+        };
+    },
 
     emitChange: function emitChange(event, options) {
         const eventToTrigger = 'email' + '.' + event;

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -36,7 +36,8 @@ models = [
     'action',
     'posts-meta',
     'member-stripe-customer',
-    'stripe-customer-subscription'
+    'stripe-customer-subscription',
+    'email'
 ];
 
 function init() {

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -255,6 +255,9 @@
             "api_key": {
                 "apiKeyNotFound": "API Key not found"
             },
+            "email": {
+                "emailNotFound": "Email not found."
+            },
             "base": {
                 "index": {
                     "missingContext": "missing context"

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -215,9 +215,12 @@ module.exports = function apiRoutes() {
     // ## Actions
     router.get('/actions', mw.authAdminApi, http(apiCanary.actions.browse));
 
-    // ## Emails
+    // ## Email Preview
     router.get('/email_preview/posts/:id', mw.authAdminApi, http(apiCanary.email_preview.read));
     router.post('/email_preview/posts/:id', mw.authAdminApi, http(apiCanary.email_preview.sendTestEmail));
+
+    // ## Emails
+    router.get('/emails/:id', mw.authAdminApi, http(apiCanary.emails.read));
 
     return router;
 };

--- a/core/test/acceptance/admin/db_spec.js
+++ b/core/test/acceptance/admin/db_spec.js
@@ -55,7 +55,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(27);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(28);
             });
     });
 

--- a/core/test/acceptance/admin/emails_spec.js
+++ b/core/test/acceptance/admin/emails_spec.js
@@ -1,0 +1,38 @@
+const should = require('should');
+const supertest = require('supertest');
+const testUtils = require('../../utils');
+const config = require('../../../server/config');
+const localUtils = require('./utils');
+
+const ghost = testUtils.startGhost;
+
+describe('Email API', function () {
+    let request;
+
+    before(function () {
+        return ghost()
+            .then(function () {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return localUtils.doAuth(request, 'posts', 'emails');
+            });
+    });
+
+    it('Can read an email', function () {
+        return request
+            .get(localUtils.API.getApiQuery(`emails/${testUtils.DataGenerator.Content.emails[0].id}/`))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.emails);
+                jsonResponse.emails.should.have.length(1);
+                localUtils.API.checkResponse(jsonResponse.emails[0], 'email');
+            });
+    });
+});

--- a/core/test/acceptance/admin/utils.js
+++ b/core/test/acceptance/admin/utils.js
@@ -101,6 +101,9 @@ const expectedProperties = {
     ,
     webhook: _(schema.webhooks)
         .keys()
+    ,
+    email: _(schema.emails)
+        .keys()
 };
 
 _.each(expectedProperties, (value, key) => {

--- a/core/test/acceptance/admin/utils.js
+++ b/core/test/acceptance/admin/utils.js
@@ -63,9 +63,9 @@ const expectedProperties = {
         // returns meta fields from `posts_meta` schema
         .concat(
             ..._(schema.posts_meta).keys()
-            .without('post_id', 'id')
-            // pages are not sent as emails
-            .without('email_subject')
+                .without('post_id', 'id')
+                // pages are not sent as emails
+                .without('email_subject')
         )
     ,
 

--- a/core/test/unit/data/schema/fixtures/utils_spec.js
+++ b/core/test/unit/data/schema/fixtures/utils_spec.js
@@ -150,19 +150,19 @@ describe('Migration Fixture Utils', function () {
             fixtureUtils.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
-                result.should.have.property('expected', 61);
-                result.should.have.property('done', 61);
+                result.should.have.property('expected', 66);
+                result.should.have.property('done', 66);
 
                 // Permissions & Roles
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(61);
+                dataMethodStub.filter.callCount.should.eql(66);
                 dataMethodStub.find.callCount.should.eql(7);
-                baseUtilAttachStub.callCount.should.eql(61);
+                baseUtilAttachStub.callCount.should.eql(66);
 
-                fromItem.related.callCount.should.eql(61);
-                fromItem.findWhere.callCount.should.eql(61);
-                toItem[0].get.callCount.should.eql(122);
+                fromItem.related.callCount.should.eql(66);
+                fromItem.findWhere.callCount.should.eql(66);
+                toItem[0].get.callCount.should.eql(132);
 
                 done();
             }).catch(done);

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,7 +19,7 @@ var should = require('should'),
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'd7af2f707b0221871d27d9387e0de2e2';
+    const currentSchemaHash = 'ee3406c46cb779fa73c5c86a4e676973';
     const currentFixturesHash = '84005b6e8f62231b6fd0fc261ce893db';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,8 +19,8 @@ var should = require('should'),
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'ee3406c46cb779fa73c5c86a4e676973';
-    const currentFixturesHash = '84005b6e8f62231b6fd0fc261ce893db';
+    const currentSchemaHash = '986b3a9c8a5c00e5230f8bfb1133006a';
+    const currentFixturesHash = '7462de0f3d5879c328161e0c98039aec';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -418,6 +418,32 @@ DataGenerator.Content = {
             type: 'admin',
             integration_id: undefined // "internal"
         }
+    ],
+
+    emails: [
+        {
+            id: ObjectId.generate(),
+            uuid: '6b6afda6-4b5e-4893-bff6-f16859e8349a',
+            status: 'sending',
+            stats: '',
+            email_count: 2,
+            subject: 'You got mailed!',
+            html: '<p>Look! I\'m an email</p>',
+            plaintext: 'Waba-daba-dab-da',
+            submitted_at: moment().toDate()
+        },
+        {
+            id: ObjectId.generate(),
+            uuid: '365daa11-4bf0-4614-ad43-6346387ffa00',
+            status: 'failed',
+            error: 'Everything went south',
+            stats: '',
+            email_count: 3,
+            subject: 'You got mailed! Again!',
+            html: '<p>What\'s that? Another email!</p>',
+            plaintext: 'yes this is an email',
+            submitted_at: moment().toDate()
+        }
     ]
 };
 
@@ -425,6 +451,8 @@ DataGenerator.Content = {
 DataGenerator.Content.subscribers[0].post_id = DataGenerator.Content.posts[0].id;
 DataGenerator.Content.api_keys[0].integration_id = DataGenerator.Content.integrations[0].id;
 DataGenerator.Content.api_keys[1].integration_id = DataGenerator.Content.integrations[0].id;
+DataGenerator.Content.emails[0].post_id = DataGenerator.Content.posts[0].id;
+DataGenerator.Content.emails[1].post_id = DataGenerator.Content.posts[1].id;
 
 DataGenerator.forKnex = (function () {
     function createBasic(overrides) {
@@ -904,6 +932,11 @@ DataGenerator.forKnex = (function () {
         createBasic(DataGenerator.Content.api_keys[2])
     ];
 
+    const emails = [
+        createBasic(DataGenerator.Content.emails[0]),
+        createBasic(DataGenerator.Content.emails[1])
+    ];
+
     return {
         createPost: createPost,
         createGenericPost: createGenericPost,
@@ -940,7 +973,8 @@ DataGenerator.forKnex = (function () {
         roles_users: roles_users,
         webhooks: webhooks,
         integrations: integrations,
-        api_keys: api_keys
+        api_keys: api_keys,
+        emails: emails
     };
 }());
 

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -464,6 +464,12 @@ fixtures = {
         return Promise.map(DataGenerator.forKnex.api_keys, function (api_key) {
             return models.ApiKey.add(api_key, module.exports.context.internal);
         });
+    },
+
+    insertEmails: function insertEmails() {
+        return Promise.map(DataGenerator.forKnex.emails, function (email) {
+            return models.Email.add(email, module.exports.context.internal);
+        });
     }
 };
 
@@ -613,6 +619,9 @@ toDoList = {
     },
     api_keys: function insertApiKeys() {
         return fixtures.insertApiKeys();
+    },
+    emails: function insertEmails() {
+        return fixtures.insertEmails();
     }
 };
 


### PR DESCRIPTION
This PR introduces new `email` model with the following properties:
- `post_id` - reference to post table
- `uuid` - for e.g. for tracking stats from mailing provider/API
- `status` - [sending, sent, failed]
- `error` - store just an error string from email provider (no extensive details)
- `stats` - JSON with whatever email provider gives us (deal with serialization/normalization of this data later, for now store as is)
- `email_count` - stores how many emails were attempted to be delivered
- `plaintext`/`html`/`subject` - copies from post model
- `submitted_at` - to track when the 'last attempt' to send email was

It also introduces basic `GET /emails/:id` Admin API v3 which returns all the above fields with standard updated/created timestamps/fields.

Left todo:
- [x] defaults like uuid generation in email model
- [x] migrations for permissions