### PR TITLE
Serialized email data on post add/edit

### DIFF
--- a/core/server/api/canary/utils/validators/input/schemas/posts.json
+++ b/core/server/api/canary/utils/validators/input/schemas/posts.json
@@ -159,6 +159,9 @@
                 },
                 "plaintext": {
                     "strip": true
+                },
+                "email": {
+                    "strip": true
                 }
             }
         },


### PR DESCRIPTION
no issue

Removes post email data from edit/add requests as we don't want to edit email object directly as part of post
