### PR TITLE
Defaults handling for email property in posts

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -60,6 +60,10 @@ const mapPost = (model, frame) => {
             if (relation === 'authors' && jsonModel.authors) {
                 jsonModel.authors = jsonModel.authors.map(author => mapUser(author, frame));
             }
+
+            if (relation === 'email' && _.isEmpty(jsonModel.email)) {
+                jsonModel.email = null;
+            }
         });
     }
 

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -379,7 +379,7 @@ module.exports = {
     },
     emails: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', unique: true},
+        post_id: {type: 'string', maxlength: 24, nullable: false, index: true, unique: true},
         uuid: {type: 'string', maxlength: 36, nullable: false, validations: {isUUID: true}},
         status: {
             type: 'string',

--- a/core/test/acceptance/admin/posts_spec.js
+++ b/core/test/acceptance/admin/posts_spec.js
@@ -22,7 +22,7 @@ describe('Posts API', function () {
                 request = supertest.agent(config.get('url'));
             })
             .then(function () {
-                return localUtils.doAuth(request, 'users:extra', 'posts');
+                return localUtils.doAuth(request, 'users:extra', 'posts', 'emails');
             })
             .then(function (cookie) {
                 ownerCookie = cookie;
@@ -95,7 +95,7 @@ describe('Posts API', function () {
             });
     });
 
-    it('Can includes single relation', function (done) {
+    it('Can include single relation', function (done) {
         request.get(localUtils.API.getApiQuery('posts/?include=tags'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
@@ -115,7 +115,7 @@ describe('Posts API', function () {
                     jsonResponse.posts[0],
                     'post',
                     null,
-                    ['authors', 'primary_author']
+                    ['authors', 'primary_author', 'email']
                 );
 
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
@@ -232,7 +232,7 @@ describe('Posts API', function () {
 
     it('Can include relations for a single post', function (done) {
         request
-            .get(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/?include=authors,tags'))
+            .get(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/?include=authors,tags,email'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
@@ -254,6 +254,9 @@ describe('Posts API', function () {
 
                 jsonResponse.posts[0].tags[0].should.be.an.Object();
                 localUtils.API.checkResponse(jsonResponse.posts[0].tags[0], 'tag', ['url']);
+
+                jsonResponse.posts[0].email.should.be.an.Object();
+                localUtils.API.checkResponse(jsonResponse.posts[0].email, 'email');
                 done();
             });
     });

--- a/core/test/acceptance/admin/utils.js
+++ b/core/test/acceptance/admin/utils.js
@@ -37,7 +37,7 @@ const expectedProperties = {
         // always returns computed properties
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         // returned by default
-        .concat('tags', 'authors')
+        .concat('tags', 'authors', 'email')
         // returns meta fields from `posts_meta` schema
         .concat(
             ..._(schema.posts_meta).keys().without('post_id', 'id')

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,7 +19,7 @@ var should = require('should'),
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'ffc16afc9264ba20a0d8346387c163fb';
+    const currentSchemaHash = '34f9620db05fc136fa9abb7133e21615';
     const currentFixturesHash = 'b1787330f042f3954d73c43aa8bfa915';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
The main purpose of this PR is to unify how `email` property is served as a part of `post` resource to be `null` whenever there is no related record (similar convention to how `primary_tag` is handled). 

@kevinansfield @rishabhgrg wanted to double-check around the change in the `emails` schema with this PR - removed `references` to `posts` table and added an index in its place. The issue that came up- was not being able to remove posts when it had a reference from emails. We had a discussion at some point that emails are meant to be an independent resource and stay no matter if the post has been deleted. Lmk if you think this might be handled differently :)

TODO:
- [x] go through regression tests and make sure email fixtures are used/tested there as well
