### PR TITLE
Fixed meta title for pages

### DIFF
--- a/core/frontend/meta/title.js
+++ b/core/frontend/meta/title.js
@@ -47,6 +47,14 @@ function getTitle(data, root, options) {
         } else {
             title = data.post.meta_title || data.post.title;
         }
+    // Page title dependent on legacy object formatting (https://github.com/TryGhost/Ghost/issues/10042)
+    } else if (_.includes(context, 'page') && data.post) {
+        if (options && options.property) {
+            postSdTitle = options.property + '_title';
+            title = data.post[postSdTitle] || '';
+        } else {
+            title = data.post.meta_title || data.post.title;
+        }
     // Page title v2
     } else if (_.includes(context, 'page') && data.page) {
         if (options && options.property) {

--- a/core/test/regression/site/frontend_spec.js
+++ b/core/test/regression/site/frontend_spec.js
@@ -351,7 +351,7 @@ describe('Frontend Routing', function () {
                         should.not.exist(res.headers['set-cookie']);
                         should.exist(res.headers.date);
 
-                        $('title').text().should.equal('Ghost');
+                        $('title').text().should.equal('This is static page');
                         $('body.page-template').length.should.equal(1);
                         $('article.post').length.should.equal(1);
 

--- a/core/test/unit/helpers/meta_title_spec.js
+++ b/core/test/unit/helpers/meta_title_spec.js
@@ -61,7 +61,7 @@ describe('{{meta_title}} helper', function () {
 
         it('returns correct title for a page with meta_title set', function () {
             var rendered = helpers.meta_title.call(
-                {page: {title: 'About Page', meta_title: 'All about my awesomeness', page: true}},
+                {post: {title: 'About Page', meta_title: 'All about my awesomeness', page: true}},
                 {data: {root: {context: ['page']}}}
             );
 


### PR DESCRIPTION
closes #11357
refs ##10042

Change that introduced a bug was made in cbca480. The condition could be removed once #10042 is resolved, it is currently not dependent on the API version rather the object form used in the frontend.