### PR TITLE
 🐛 Fixed 3.0 SQLite subscribers migration

### DIFF
--- a/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
+++ b/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
@@ -37,7 +37,10 @@ module.exports.up = (options) => {
 
                     return member;
                 });
-                return localOptions.transacting('members').insert(members);
+
+                return Promise.map(members, (member) => {
+                    return localOptions.transacting('members').insert(member);
+                });
             } else {
                 common.logging.info('Skipping populating members table: found 0 subscribers');
                 return Promise.resolve();


### PR DESCRIPTION
closes #11349

- The main reason for failure was SQLite's 999 variable limit
- More details here https://github.com/TryGhost/Ghost/pull/11270

Contains a migration. @allouis & @rishabhgrg it's a pretty straight forward fix should be quick to check. Also, will go through other 3.x migrations just in search of similar migrations.
