### PR TITLE
Batching support for bulk email service + metadata for emails

### DIFF
--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -389,6 +389,7 @@ module.exports = {
             validations: {isIn: [['pending', 'submitting', 'submitted', 'failed']]}
         },
         error: {type: 'string', maxlength: 2000, nullable: true},
+        meta: {type: 'text', maxlength: 65535, nullable: true},
         stats: {type: 'text', maxlength: 65535, nullable: true},
         email_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         subject: {type: 'string', maxlength: 300, nullable: true},

--- a/core/server/services/bulk-email/index.js
+++ b/core/server/services/bulk-email/index.js
@@ -88,17 +88,5 @@ module.exports = {
         } catch (err) {
             common.logging.error({err});
         }
-    },
-
-    async getStats(messageId) {
-        try {
-            let filter = {
-                'message-id': messageId
-            };
-
-            return await mailgunInstance.events().get(filter);
-        } catch (err) {
-            common.logging.error({err});
-        }
     }
 };

--- a/core/server/services/bulk-email/index.js
+++ b/core/server/services/bulk-email/index.js
@@ -47,7 +47,7 @@ module.exports = {
      * @param {Email} message - The message to send
      * @param {[EmailAddress]} recipients - the recipients to send the email to
      * @param {[object]} recipientData - list of data keyed by email to inject into the email
-     * @returns {Array{Promise<boolean>}} An array of promises representing the success of the batch email sending
+     * @returns {Promise<Array<object>>} An array of promises representing the success of the batch email sending
      */
     async send(message, recipients, recipientData) {
         let BATCH_SIZE = 1000;
@@ -85,6 +85,18 @@ module.exports = {
 
                 return mailgunInstance.messages().send(messageData);
             });
+        } catch (err) {
+            common.logging.error({err});
+        }
+    },
+
+    async getStats(messageId) {
+        try {
+            let filter = {
+                'message-id': messageId
+            };
+
+            return await mailgunInstance.events().get(filter);
         } catch (err) {
             common.logging.error({err});
         }

--- a/core/server/services/bulk-email/index.js
+++ b/core/server/services/bulk-email/index.js
@@ -72,7 +72,7 @@ module.exports = {
                 });
 
                 const messageData = Object.assign({}, message, {
-                    to: toAddresses.join(', '),
+                    to: toAddresses,
                     from: fromAddress,
                     'recipient-variables': recipientVariables
                 });

--- a/core/server/services/bulk-email/index.js
+++ b/core/server/services/bulk-email/index.js
@@ -1,8 +1,11 @@
 const {URL} = require('url');
+const _ = require('lodash');
 const mailgun = require('mailgun-js');
 const configService = require('../../config');
 const common = require('../../lib/common');
 let mailgunInstance;
+
+const BATCH_SIZE = 2;
 
 function createMailgun(config) {
     const baseUrl = new URL(config.baseUrl);
@@ -46,31 +49,47 @@ module.exports = {
      * @param {Email} message - The message to send
      * @param {[EmailAddress]} recipients - the recipients to send the email to
      * @param {[object]} recipientData - list of data keyed by email to inject into the email
-     * @returns {Promise<boolean>} A promise representing the success of the email sending
+     * @returns {Array{Promise<boolean>}} An array of promises representing the success of the batch email sending
      */
     async send(message, recipients, recipientData) {
         if (!mailgunInstance) {
             return;
         }
         let fromAddress = message.from;
-        if (/@localhost$/.test(message.from)) {
+        if (/@localhost$/.test(message.from) || /@ghost.local$/.test(message.from)) {
             fromAddress = 'localhost@example.com';
             common.logging.warn(`Rewriting bulk email from address ${message.from} to ${fromAddress}`);
         }
         try {
-            const messageData = Object.assign({}, message, {
-                to: recipients.join(', '),
-                from: fromAddress,
-                'recipient-variables': recipientData
-            });
+            let chunks = _.chunk(recipients, BATCH_SIZE);
 
-            if (config.mailgun.tag) {
-                Object.assign(messageData, {
-                    'o:tag': config.mailgun.tag
+            return chunks.map((chunk) => {
+                const messageData = Object.assign({}, message, {
+                    to: chunk.join(', '),
+                    from: fromAddress,
+                    'recipient-variables': recipientData
                 });
-            }
 
-            await mailgunInstance.messages().send(messageData);
+                if (config.mailgun.tag) {
+                    Object.assign(messageData, {
+                        'o:tag': config.mailgun.tag
+                    });
+                }
+
+                return mailgunInstance.messages().send(messageData);
+            });
+        } catch (err) {
+            common.logging.error({err});
+        }
+    },
+
+    async getStats(messageId) {
+        try {
+            let filter = {
+                'message-id': messageId
+            };
+
+            return await mailgunInstance.events().get(filter);
         } catch (err) {
             common.logging.error({err});
         }

--- a/core/server/services/bulk-email/index.js
+++ b/core/server/services/bulk-email/index.js
@@ -63,13 +63,18 @@ module.exports = {
             BATCH_SIZE = 2;
         }
         try {
-            let chunks = _.chunk(recipients, BATCH_SIZE);
+            const chunkedRecipients = _.chunk(recipients, BATCH_SIZE);
 
-            return Promise.map(chunks, (chunk) => {
+            return Promise.map(chunkedRecipients, (toAddresses) => {
+                const recipientVariables = {};
+                toAddresses.forEach((email) => {
+                    recipientVariables[email] = recipientData[email];
+                });
+
                 const messageData = Object.assign({}, message, {
-                    to: chunk.join(', '),
+                    to: toAddresses.join(', '),
                     from: fromAddress,
-                    'recipient-variables': recipientData
+                    'recipient-variables': recipientVariables
                 });
 
                 if (config.mailgun.tag) {

--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -179,10 +179,11 @@ async function listener(emailModel, options) {
         id: emailModel.id
     });
 
-    await sendEmail(post, members);
+    const meta = await sendEmail(post, members);
 
     await models.Email.edit({
-        status: 'submitted'
+        status: 'submitted',
+        meta: JSON.stringify(meta)
     }, {
         id: emailModel.id
     });

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,7 +19,7 @@ var should = require('should'),
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '34f9620db05fc136fa9abb7133e21615';
+    const currentSchemaHash = '1bfb322b4eeb5275cb1baa0df69d3ada';
     const currentFixturesHash = 'b1787330f042f3954d73c43aa8bfa915';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
Implemented basic batching support along with metadata returned with each batch saving to emails table. Can be split into 2 separate commits/PRs if needed 

The pooling service will come in as a separate PR as there will be a lot more logic involved.