### PR TITLE
Added tagging support to bulk email service

### DIFF
--- a/core/server/services/bulk-email/index.js
+++ b/core/server/services/bulk-email/index.js
@@ -63,6 +63,13 @@ module.exports = {
                 from: fromAddress,
                 'recipient-variables': recipientData
             });
+
+            if (config.mailgun.tag) {
+                Object.assign(messageData, {
+                    'o:tag': config.mailgun.tag
+                });
+            }
+
             await mailgunInstance.messages().send(messageData);
         } catch (err) {
             common.logging.error({err});


### PR DESCRIPTION
Was thinking of adding this would make sense in mega service instead, but went with bulk-email one as that utilizes the config closer and leaves mega less coupled with email-provider-specific configs.  