### PR TITLE
Switched scheduler to use API v3

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -47,7 +47,7 @@ function initialiseServices() {
             active: config.get('scheduling').active,
             // NOTE: When changing API version need to consider how to migrate custom scheduling adapters
             //       that rely on URL to lookup persisted scheduled records (jobs, etc.). Ref: https://github.com/TryGhost/Ghost/pull/10726#issuecomment-489557162
-            apiUrl: urlUtils.urlFor('api', {version: 'v2', versionType: 'admin'}, true),
+            apiUrl: urlUtils.urlFor('api', {version: 'v3', versionType: 'admin'}, true),
             internalPath: config.get('paths').internalSchedulingPath,
             contentPath: config.getContentPath('scheduling')
         })


### PR DESCRIPTION
- Switch is needed so that mailinglist work when posts are scheduled
- v3 API is the default stable API that should be preferably used by all clients (including Scheduler)