### PR TITLE
Cached post serialization

### DIFF
--- a/core/server/api/canary/utils/serializers/output/posts.js
+++ b/core/server/api/canary/utils/serializers/output/posts.js
@@ -1,5 +1,7 @@
 const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:posts');
 const mapper = require('./utils/mapper');
+const moment = require('moment');
+const postsCache = {};
 
 module.exports = {
     all(models, apiConfig, frame) {
@@ -12,7 +14,15 @@ module.exports = {
 
         if (models.meta) {
             frame.response = {
-                posts: models.data.map(model => mapper.mapPost(model, frame)),
+                posts: models.data.map((model) => {
+                    var key = model.id + '_' + JSON.stringify(frame);
+
+                    if (!postsCache[key] || moment(new Date(postsCache[key].updated_at)).diff(new Date(model.updated_at)) < 0) {
+                        postsCache[key] = mapper.mapPost(model, frame);
+                    }
+
+                    return postsCache[key];
+                }),
                 meta: models.meta
             };
 


### PR DESCRIPTION
no issue

Something I noticed at the retreat, but finally had a chance to have a good look... :eyes: Post serialization is a huge chunk of each request (~35%-ish for me). A single request takes ~150ms with ~55ms for the serialization. The serialization *should* be cacheable, so this PR implements that. This potentially avoids the need to rewrite `htmlRelativeToAbsolute` because it's not a big deal any more.

(My local setup is `NODE_ENV=production` but sqlite, so YMMV with MySQL etc. I also used the default `wrk` options for benchmarking. The request time seems to fluctuate on filesystem cache anyway.)

Before:
* 20.57 req/s
* ~150ms individual request

After:
* 29.46 req/s
* ~95ms individual request

= ~43% higher throughput

(EDIT: Single threaded `wrk` (`wrk -t 1...`) goes from 35 req/s to 52req/s (+48%)).

Questions:
* I think the idea works & the tests pass but am I forgetting anything?
* I hate the key I ended up using, but `frame` needs to be taken into account. Any better ideas? Is this good enough to be unique?
* Is the `updated_at` check OK? I copied it from the AMP code, but it should be fine.