### PR TITLE
Extracted members-specific middleware from site app module

### DIFF
--- a/core/server/services/members/index.js
+++ b/core/server/services/members/index.js
@@ -49,3 +49,4 @@ const membersService = {
 };
 
 module.exports = membersService;
+module.exports.middleware = require('./middleware');

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -4,81 +4,94 @@ const shared = require('../../web/shared');
 const labsService = require('../labs');
 const membersService = require('./index');
 
-module.exports.public = (siteApp) => {
-    siteApp.get('/public/members.js',
+const login = async function (req, res) {
+    try {
+        const token = await membersService.ssr.getIdentityTokenForMemberFromSession(req, res);
+        res.writeHead(200);
+        res.end(token);
+    } catch (err) {
+        common.logging.warn(err.message);
+        res.writeHead(err.statusCode);
+        res.end(err.message);
+    }
+};
+
+const logout = async function (req, res) {
+    try {
+        await membersService.ssr.deleteSession(req, res);
+        res.writeHead(204);
+        res.end();
+    } catch (err) {
+        common.logging.warn(err.message);
+        res.writeHead(err.statusCode);
+        res.end(err.message);
+    }
+};
+
+const getMemberDataFromSession = async function (req, res, next) {
+    if (!labsService.isSet('members')) {
+        req.member = null;
+        return next();
+    }
+    try {
+        const member = await membersService.ssr.getMemberDataFromSession(req, res);
+        Object.assign(req, {member});
+        next();
+    } catch (err) {
+        common.logging.warn(err.message);
+        Object.assign(req, {member: null});
+        next();
+    }
+};
+
+const exchangeTokenForSession = async function (req, res, next) {
+    if (!labsService.isSet('members')) {
+        return next();
+    }
+    if (!req.url.includes('token=')) {
+        return next();
+    }
+    try {
+        const member = await membersService.ssr.exchangeTokenForSession(req, res);
+        Object.assign(req, {member});
+        next();
+    } catch (err) {
+        common.logging.warn(err.message);
+        return next();
+    }
+};
+
+const decorateResponse = function (req, res, next) {
+    res.locals.member = req.member;
+    next();
+};
+
+// @TODO only loads this stuff if members is enabled
+// Set req.member & res.locals.member if a cookie is set
+module.exports = {
+    public: [
         shared.middlewares.labs.members,
         shared.middlewares.servePublicFile.createPublicFileMiddleware(
             'public/members.js',
             'application/javascript',
             constants.ONE_HOUR_S
         )
-    );
-};
-
-module.exports.use = (siteApp) => {
-    // @TODO only loads this stuff if members is enabled
-    // Set req.member & res.locals.member if a cookie is set
-    siteApp.get('/members/ssr', shared.middlewares.labs.members, async function (req, res) {
-        try {
-            const token = await membersService.ssr.getIdentityTokenForMemberFromSession(req, res);
-            res.writeHead(200);
-            res.end(token);
-        } catch (err) {
-            common.logging.warn(err.message);
-            res.writeHead(err.statusCode);
-            res.end(err.message);
-        }
-    });
-
-    siteApp.delete('/members/ssr', shared.middlewares.labs.members, async function (req, res) {
-        try {
-            await membersService.ssr.deleteSession(req, res);
-            res.writeHead(204);
-            res.end();
-        } catch (err) {
-            common.logging.warn(err.message);
-            res.writeHead(err.statusCode);
-            res.end(err.message);
-        }
-    });
-
-    siteApp.post('/members/webhooks/stripe', shared.middlewares.labs.members, (req, res, next) => membersService.api.middleware.handleStripeWebhook(req, res, next));
-
-    siteApp.use(async function (req, res, next) {
-        if (!labsService.isSet('members')) {
-            req.member = null;
-            return next();
-        }
-        try {
-            const member = await membersService.ssr.getMemberDataFromSession(req, res);
-            Object.assign(req, {member});
-            next();
-        } catch (err) {
-            common.logging.warn(err.message);
-            Object.assign(req, {member: null});
-            next();
-        }
-    });
-
-    siteApp.use(async function (req, res, next) {
-        if (!labsService.isSet('members')) {
-            return next();
-        }
-        if (!req.url.includes('token=')) {
-            return next();
-        }
-        try {
-            const member = await membersService.ssr.exchangeTokenForSession(req, res);
-            Object.assign(req, {member});
-            next();
-        } catch (err) {
-            common.logging.warn(err.message);
-            return next();
-        }
-    });
-
-    siteApp.use(function (req, res, next) {
-        res.locals.member = req.member;
-        next();
-    });
+    ],
+    authentication: [
+        getMemberDataFromSession,
+        exchangeTokenForSession,
+        decorateResponse
+    ],
+    login: [
+        shared.middlewares.labs.members,
+        login
+    ],
+    logout: [
+        shared.middlewares.labs.members,
+        logout
+    ],
+    stripeWebhooks: [
+        shared.middlewares.labs.members,
+        membersService.api.middleware.handleStripeWebhook
+    ]
 };

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -51,7 +51,9 @@ module.exports.use = (siteApp) => {
         }
     });
 
+    // NOTE: this route needs a clear note why (if intentional) is it skipping shared.middlewares.labs.members middleware
     siteApp.post('/members/webhooks/stripe', (req, res, next) => membersService.api.middleware.handleStripeWebhook(req, res, next));
+
     siteApp.use(async function (req, res, next) {
         if (!labsService.isSet('members')) {
             req.member = null;

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -1,7 +1,28 @@
 const common = require('../../lib/common');
+const constants = require('../../lib/constants');
 const shared = require('../../web/shared');
 const labsService = require('../labs');
 const membersService = require('./index');
+
+module.exports.public = (siteApp) => {
+    siteApp.get('/public/members-theme-bindings.js',
+        shared.middlewares.labs('members'),
+        shared.middlewares.servePublicFile.createPublicFileMiddleware(
+            'public/members-theme-bindings.js',
+            'application/javascript',
+            constants.ONE_HOUR_S
+        )
+    );
+
+    siteApp.get('/public/members.js',
+        shared.middlewares.labs('members'),
+        shared.middlewares.servePublicFile.createPublicFileMiddleware(
+            'public/members.js',
+            'application/javascript',
+            constants.ONE_HOUR_S
+        )
+    );
+};
 
 module.exports.use = (siteApp) => {
     // @TODO only loads this stuff if members is enabled

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -92,6 +92,6 @@ module.exports = {
     ],
     stripeWebhooks: [
         shared.middlewares.labs.members,
-        membersService.api.middleware.handleStripeWebhook
+        (req, res, next) => membersService.api.middleware.handleStripeWebhook(req, res, next)
     ]
 };

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -1,0 +1,71 @@
+const common = require('../../lib/common');
+const shared = require('../../web/shared');
+const labsService = require('../labs');
+const membersService = require('./index');
+
+module.exports.use = (siteApp) => {
+    // @TODO only loads this stuff if members is enabled
+    // Set req.member & res.locals.member if a cookie is set
+    siteApp.get('/members/ssr', shared.middlewares.labs.members, async function (req, res) {
+        try {
+            const token = await membersService.ssr.getIdentityTokenForMemberFromSession(req, res);
+            res.writeHead(200);
+            res.end(token);
+        } catch (err) {
+            common.logging.warn(err.message);
+            res.writeHead(err.statusCode);
+            res.end(err.message);
+        }
+    });
+
+    siteApp.delete('/members/ssr', shared.middlewares.labs.members, async function (req, res) {
+        try {
+            await membersService.ssr.deleteSession(req, res);
+            res.writeHead(204);
+            res.end();
+        } catch (err) {
+            common.logging.warn(err.message);
+            res.writeHead(err.statusCode);
+            res.end(err.message);
+        }
+    });
+
+    siteApp.post('/members/webhooks/stripe', (req, res, next) => membersService.api.middleware.handleStripeWebhook(req, res, next));
+    siteApp.use(async function (req, res, next) {
+        if (!labsService.isSet('members')) {
+            req.member = null;
+            return next();
+        }
+        try {
+            const member = await membersService.ssr.getMemberDataFromSession(req, res);
+            Object.assign(req, {member});
+            next();
+        } catch (err) {
+            common.logging.warn(err.message);
+            Object.assign(req, {member: null});
+            next();
+        }
+    });
+
+    siteApp.use(async function (req, res, next) {
+        if (!labsService.isSet('members')) {
+            return next();
+        }
+        if (!req.url.includes('token=')) {
+            return next();
+        }
+        try {
+            const member = await membersService.ssr.exchangeTokenForSession(req, res);
+            Object.assign(req, {member});
+            next();
+        } catch (err) {
+            common.logging.warn(err.message);
+            return next();
+        }
+    });
+
+    siteApp.use(function (req, res, next) {
+        res.locals.member = req.member;
+        next();
+    });
+};

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -6,7 +6,7 @@ const membersService = require('./index');
 
 module.exports.public = (siteApp) => {
     siteApp.get('/public/members-theme-bindings.js',
-        shared.middlewares.labs('members'),
+        shared.middlewares.labs.members,
         shared.middlewares.servePublicFile.createPublicFileMiddleware(
             'public/members-theme-bindings.js',
             'application/javascript',
@@ -15,7 +15,7 @@ module.exports.public = (siteApp) => {
     );
 
     siteApp.get('/public/members.js',
-        shared.middlewares.labs('members'),
+        shared.middlewares.labs.members,
         shared.middlewares.servePublicFile.createPublicFileMiddleware(
             'public/members.js',
             'application/javascript',

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -42,8 +42,7 @@ module.exports.use = (siteApp) => {
         }
     });
 
-    // NOTE: this route needs a clear note why (if intentional) is it skipping shared.middlewares.labs.members middleware
-    siteApp.post('/members/webhooks/stripe', (req, res, next) => membersService.api.middleware.handleStripeWebhook(req, res, next));
+    siteApp.post('/members/webhooks/stripe', shared.middlewares.labs.members, (req, res, next) => membersService.api.middleware.handleStripeWebhook(req, res, next));
 
     siteApp.use(async function (req, res, next) {
         if (!labsService.isSet('members')) {

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -5,15 +5,6 @@ const labsService = require('../labs');
 const membersService = require('./index');
 
 module.exports.public = (siteApp) => {
-    siteApp.get('/public/members-theme-bindings.js',
-        shared.middlewares.labs.members,
-        shared.middlewares.servePublicFile.createPublicFileMiddleware(
-            'public/members-theme-bindings.js',
-            'application/javascript',
-            constants.ONE_HOUR_S
-        )
-    );
-
     siteApp.get('/public/members.js',
         shared.middlewares.labs.members,
         shared.middlewares.servePublicFile.createPublicFileMiddleware(

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -6,17 +6,16 @@ const {URL} = require('url');
 
 // App requires
 const config = require('../../config');
-const common = require('../../lib/common');
 const apps = require('../../services/apps');
 const constants = require('../../lib/constants');
 const storage = require('../../adapters/storage');
 const urlService = require('../../../frontend/services/url');
-const labsService = require('../../services/labs');
 const urlUtils = require('../../lib/url-utils');
 const sitemapHandler = require('../../../frontend/services/sitemap/handler');
 const themeService = require('../../../frontend/services/themes');
 const themeMiddleware = themeService.middleware;
 const membersService = require('../../services/members');
+const membersMiddleware = membersService.middleware;
 const siteRoutes = require('./routes');
 const shared = require('../shared');
 
@@ -133,67 +132,9 @@ module.exports = function setupSiteApp(options = {}) {
     require('../../../frontend/helpers').loadCoreHelpers();
     debug('Helpers done');
 
-    // @TODO only loads this stuff if members is enabled
-    // Set req.member & res.locals.member if a cookie is set
-    siteApp.get('/members/ssr', shared.middlewares.labs.members, async function (req, res) {
-        try {
-            const token = await membersService.ssr.getIdentityTokenForMemberFromSession(req, res);
-            res.writeHead(200);
-            res.end(token);
-        } catch (err) {
-            common.logging.warn(err.message);
-            res.writeHead(err.statusCode);
-            res.end(err.message);
-        }
-    });
-
-    siteApp.delete('/members/ssr', shared.middlewares.labs.members, async function (req, res) {
-        try {
-            await membersService.ssr.deleteSession(req, res);
-            res.writeHead(204);
-            res.end();
-        } catch (err) {
-            common.logging.warn(err.message);
-            res.writeHead(err.statusCode);
-            res.end(err.message);
-        }
-    });
-    siteApp.post('/members/webhooks/stripe', (req, res, next) => membersService.api.middleware.handleStripeWebhook(req, res, next));
-    siteApp.use(async function (req, res, next) {
-        if (!labsService.isSet('members')) {
-            req.member = null;
-            return next();
-        }
-        try {
-            const member = await membersService.ssr.getMemberDataFromSession(req, res);
-            Object.assign(req, {member});
-            next();
-        } catch (err) {
-            common.logging.warn(err.message);
-            Object.assign(req, {member: null});
-            next();
-        }
-    });
-    siteApp.use(async function (req, res, next) {
-        if (!labsService.isSet('members')) {
-            return next();
-        }
-        if (!req.url.includes('token=')) {
-            return next();
-        }
-        try {
-            const member = await membersService.ssr.exchangeTokenForSession(req, res);
-            Object.assign(req, {member});
-            next();
-        } catch (err) {
-            common.logging.warn(err.message);
-            return next();
-        }
-    });
-    siteApp.use(function (req, res, next) {
-        res.locals.member = req.member;
-        next();
-    });
+    // Members middleware
+    // Initializes members specific routes as well as assigns members specific data to the req/res objects
+    membersMiddleware.use(siteApp);
 
     // Theme middleware
     // This should happen AFTER any shared assets are served, as it only changes things to do with templates

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -94,7 +94,7 @@ module.exports = function setupSiteApp(options = {}) {
     siteApp.use(shared.middlewares.serveFavicon());
 
     // /public/members.js
-    membersMiddleware.public(siteApp);
+    siteApp.get('/public/members.js', membersMiddleware.public);
 
     // Serve sitemap.xsl file
     siteApp.use(shared.middlewares.servePublicFile('sitemap.xsl', 'text/xsl', constants.ONE_DAY_S));
@@ -119,7 +119,11 @@ module.exports = function setupSiteApp(options = {}) {
 
     // Members middleware
     // Initializes members specific routes as well as assigns members specific data to the req/res objects
-    membersMiddleware.use(siteApp);
+    siteApp.get('/members/ssr', membersMiddleware.login);
+    siteApp.delete('/members/ssr', membersMiddleware.logout);
+    siteApp.post('/members/webhooks/stripe', membersMiddleware.stripeWebhooks);
+
+    siteApp.use(membersMiddleware.authentication);
 
     // Theme middleware
     // This should happen AFTER any shared assets are served, as it only changes things to do with templates

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -94,22 +94,7 @@ module.exports = function setupSiteApp(options = {}) {
     siteApp.use(shared.middlewares.serveFavicon());
 
     // /public/members.js
-    siteApp.get('/public/members-theme-bindings.js',
-        shared.middlewares.labs('members'),
-        shared.middlewares.servePublicFile.createPublicFileMiddleware(
-            'public/members-theme-bindings.js',
-            'application/javascript',
-            constants.ONE_HOUR_S
-        )
-    );
-    siteApp.get('/public/members.js',
-        shared.middlewares.labs('members'),
-        shared.middlewares.servePublicFile.createPublicFileMiddleware(
-            'public/members.js',
-            'application/javascript',
-            constants.ONE_HOUR_S
-        )
-    );
+    membersMiddleware.public(siteApp);
 
     // Serve sitemap.xsl file
     siteApp.use(shared.middlewares.servePublicFile('sitemap.xsl', 'text/xsl', constants.ONE_DAY_S));

--- a/core/test/regression/site/members_spec.js
+++ b/core/test/regression/site/members_spec.js
@@ -1,0 +1,49 @@
+const should = require('should');
+const sinon = require('sinon');
+const supertest = require('supertest');
+const testUtils = require('../../utils');
+const configUtils = require('../../utils/configUtils');
+const settingsCache = require('../../../server/services/settings/cache');
+
+const ghost = testUtils.startGhost;
+
+describe('Integration - Web - Members', function () {
+    let request;
+
+    before(function () {
+        return ghost()
+            .then(function () {
+                request = supertest.agent(configUtils.config.get('url'));
+            });
+    });
+
+    describe('Members enabled', function () {
+        before(function () {
+            const originalSettingsCacheGetFn = settingsCache.get;
+
+            sinon.stub(settingsCache, 'get').callsFake(function (key, options) {
+                if (key === 'labs') {
+                    return {members: true};
+                }
+
+                return originalSettingsCacheGetFn(key, options);
+            });
+        });
+
+        after(function () {
+            sinon.restore();
+        });
+
+        it('should not serve members js file', function () {
+            return request.get('/public/members.js')
+                .expect(200);
+        });
+    });
+
+    describe('Members disabled', function () {
+        it('should not serve members js file', function () {
+            return request.get('/public/members.js')
+                .expect(404);
+        });
+    });
+});

--- a/core/test/regression/site/members_spec.js
+++ b/core/test/regression/site/members_spec.js
@@ -7,6 +7,9 @@ const settingsCache = require('../../../server/services/settings/cache');
 
 const ghost = testUtils.startGhost;
 
+// NOTE: if only this suite is run some of the tests will fail due to
+//       wrong template loading issues which would need to be investigated
+//       As a workaround run it with some of other tests e.g. "frontend_spec"
 describe('Integration - Web - Members', function () {
     let request;
 
@@ -34,16 +37,70 @@ describe('Integration - Web - Members', function () {
             sinon.restore();
         });
 
-        it('should not serve members js file', function () {
-            return request.get('/public/members.js')
-                .expect(200);
+        describe('Static files', function () {
+            it('should serve members.js file', function () {
+                return request.get('/public/members.js')
+                    .expect(200);
+            });
+        });
+
+        describe('Routes', function () {
+            it('should error when invalid member token is passed in to ssr', function () {
+                return request.get('/members/ssr')
+                    .expect(400);
+            });
+
+            it('should return no content when removing member sessions', function () {
+                return request.del('/members/ssr')
+                    .expect(204);
+            });
+
+            it('should error serving webhook endpoint without any parameters', function () {
+                return request.post('/members/webhooks/stripe')
+                    .expect(400);
+            });
         });
     });
 
     describe('Members disabled', function () {
-        it('should not serve members js file', function () {
-            return request.get('/public/members.js')
-                .expect(404);
+        before(function () {
+            const originalSettingsCacheGetFn = settingsCache.get;
+
+            sinon.stub(settingsCache, 'get').callsFake(function (key, options) {
+                if (key === 'labs') {
+                    return {members: false};
+                }
+
+                return originalSettingsCacheGetFn(key, options);
+            });
+        });
+
+        after(function () {
+            sinon.restore();
+        });
+
+        describe('Static files', function () {
+            it('should not serve members js file', function () {
+                return request.get('/public/members.js')
+                    .expect(404);
+            });
+        });
+
+        describe('Routes', function () {
+            it('should not serve ssr endpoint', function () {
+                return request.get('/members/ssr')
+                    .expect(404);
+            });
+
+            it('should not serve ssr removal endpoint', function () {
+                return request.del('/members/ssr')
+                    .expect(404);
+            });
+
+            it('should not serve webhook endpoint', function () {
+                return request.post('/members/webhooks/stripe')
+                    .expect(404);
+            });
         });
     });
 });


### PR DESCRIPTION
This changeset gets members related code out of `site/app.js` and cleans up how member flags are used.

Todos:
- [x] Add tests for the routes and public files
- [x] ~Maybe take care of https://github.com/TryGhost/Ghost/blob/9a2719a/core/server/web/site/app.js#L136~ 
  - [x] ~if this is done follow up on [forum](https://forum.ghost.org/t/how-to-remove-members-related-js/9819)~
  - [x] to load this middleware dynamically in a similar fashion as `customRedirects` middleware we'd need to hook into settings cache change event  (which don't exist yet) and would be too much trickery comparing to current approach with middleware I think  