### PR TITLE
🐛Fixed incorrect url generation for post reschedule/unschedule

### DIFF
--- a/core/server/adapters/scheduling/SchedulingBase.js
+++ b/core/server/adapters/scheduling/SchedulingBase.js
@@ -1,6 +1,6 @@
 function SchedulingBase() {
     Object.defineProperty(this, 'requiredFns', {
-        value: ['schedule', 'unschedule', 'reschedule', 'run'],
+        value: ['schedule', 'unschedule', 'run'],
         writable: false
     });
 }

--- a/core/server/adapters/scheduling/SchedulingDefault.js
+++ b/core/server/adapters/scheduling/SchedulingDefault.js
@@ -59,11 +59,9 @@ SchedulingDefault.prototype.schedule = function (object) {
 };
 
 /**
- * @description Remove & schedule a job.
+ * @description Unschedule a job.
  *
- * This function is useful if the model layer detects a rescheduling event.
- * Rescheduling means: scheduled -> update published at.
- * To be able to delete the previous job we need the old published time.
+ * Unscheduling means: scheduled -> draft.
  *
  * @param {Object} object
  *                       {
@@ -79,39 +77,18 @@ SchedulingDefault.prototype.schedule = function (object) {
  *                          bootstrap: [Boolean]
  *                      }
  */
-SchedulingDefault.prototype.reschedule = function (object, options = {bootstrap: false}) {
+SchedulingDefault.prototype.unschedule = function (object, options = {bootstrap: false}) {
     /**
      * CASE:
-     * The post scheduling unit calls "reschedule" on bootstrap, because other custom scheduling implementations
+     * The post scheduling unit triggers "reschedule" on bootstrap, because other custom scheduling implementations
      * could use a database and we need to give the chance to update the job (delete + re-add).
      *
      * We receive a "bootstrap" variable to ensure that jobs are scheduled correctly for this scheduler implementation,
      * because "object.extra.oldTime" === "object.time". If we mark the job as deleted, it won't get scheduled.
      */
     if (!options.bootstrap) {
-        this._deleteJob({time: object.extra.oldTime, url: object.url});
+        this._deleteJob(object);
     }
-
-    this._addJob(object);
-};
-
-/**
- * @description Unschedule a job.
- *
- * Unscheduling means: scheduled -> draft.
- *
- * @param {Object} object
- *                       {
- *                          time: [Number] A unix timestamp
- *                          url:  [String] The full post/page API url to publish it.
- *                          extra: {
- *                              httpMethod: [String] The method of the target API endpoint.
- *                              oldTime:    [Number] The previous published time.
- *                          }
- *                       }
- */
-SchedulingDefault.prototype.unschedule = function (object) {
-    this._deleteJob(object);
 };
 
 /**

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -148,7 +148,7 @@ exports.init = function init(options = {}) {
             // and not an in-process implementation!
             Object.keys(scheduledResources).forEach((resourceType) => {
                 scheduledResources[resourceType].forEach((model) => {
-                    adapter.unschedule(_private.normalize({model, apiUrl, integration, resourceType}, 'unscheduled'));
+                    adapter.unschedule(_private.normalize({model, apiUrl, integration, resourceType}, 'unscheduled'), {bootstrap: true});
                     adapter.schedule(_private.normalize({model, apiUrl, integration, resourceType}));
                 });
             });

--- a/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
+++ b/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
@@ -74,11 +74,20 @@ describe('Scheduling Default Adapter', function () {
                 }
             });
 
-            scope.adapter.reschedule({
+            /**Reschedule is now unschedule+schedule */
+            scope.adapter.unschedule({
                 time: time,
                 url: 'something',
                 extra: {
                     oldTime: time,
+                    method: 'PUT'
+                }
+            });
+            scope.adapter.schedule({
+                time: time,
+                url: 'something',
+                extra: {
+                    oldTime: null,
                     method: 'PUT'
                 }
             });
@@ -94,7 +103,7 @@ describe('Scheduling Default Adapter', function () {
 
             const time = moment().add(20, 'milliseconds').valueOf();
 
-            scope.adapter.reschedule({
+            scope.adapter.unschedule({
                 time: time,
                 url: 'something',
                 extra: {
@@ -102,6 +111,15 @@ describe('Scheduling Default Adapter', function () {
                     method: 'PUT'
                 }
             }, {bootstrap: true});
+
+            scope.adapter.schedule({
+                time: time,
+                url: 'something',
+                extra: {
+                    oldTime: null,
+                    method: 'PUT'
+                }
+            });
 
             setTimeout(() => {
                 scope.adapter._pingUrl.calledOnce.should.eql(true);


### PR DESCRIPTION
no issue

The default scheduling generates a known, independent URL for publishing a resource. In case of resource being rescheduled or unscheduled, the adapter expects the the same URL to remove/update existing jobs. The URL includes a JWT token for API auth which is calculated from post model and appended to URL.

There was a bug in token generation which meant If we go to update or delete the job i.e. unschedule a post then a new token is used which means the existing scheduled job cannot be removed. This PR:

- removes issued at (`iat`) timestamp from token generation which lead to a different token being generated for same payload
- Fixes timestamp being used for URL calculation from resource model
- Removes `reschedule` method from default scheduler as its no longer triggered
  - `reschedule` event now calls `adapter.unschedule` + `adapter.schedule` instead of `adapter.reschedule` as different URLs are generated for the 2 tasks
- Fixes test for reschedule
