### PR TITLE
Squash integration

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -1,0 +1,26 @@
+# You need the BCrypt hash string of the plaintext password
+# You can generate the BCrypt hash string at : https://passwordhashing.com/BCrypt
+#
+# This Squash file is using the BCrypt hash string
+# ($2b$10$H3T/cnjaCIgBHwUiMMPlzuMxNFVUrAMdv67CM5S.DEPsF8RF2mWsW)
+# # of the password : Ghost@123
+# You can change the usr_email and usr_password as you wish.
+#
+# The default settings of Admin client panel:
+#   URL: /Ghost
+#   email:  ghost@example.com
+#   password:  Ghost@123
+
+deployments:
+  Ghost:
+    filename:
+      ./Dockerfile
+    environment:
+      - USR_PASSWORD=$2b$10$H3T/cnjaCIgBHwUiMMPlzuMxNFVUrAMdv67CM5S.DEPsF8RF2mWsW
+      - USR_EMAIL=ghost@example.com
+    build_options: --build-arg squash_domain=$SQUASH_DOMAIN --build-arg usr_email=$USR_EMAIL --build-arg usr_password=$USR_PASSWORD
+    vm_size:
+      1GB
+    port_forwarding:
+      80:2368
+    backend_wait: 90

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+### Get certain node image
+FROM ubuntu:18.04
+MAINTAINER Ghost
+
+# Use bash for the shell
+SHELL ["bash", "-c"]
+
+## Squash domain
+ARG squash_domain="localhost"
+ENV SQUASH_DOMAIN=$squash_domain
+
+## Default password
+ARG usr_password="$2b$10$H3T/cnjaCIgBHwUiMMPlzuMxNFVUrAMdv67CM5S.DEPsF8RF2mWsW"
+ENV USR_PASSWORD=$usr_password
+
+## Default user
+ARG usr_email="ghost@example.com"
+ENV USR_EMAIL=$usr_email
+
+## Update package lists
+RUN apt-get update -y
+
+## Init && Install dependent packages
+RUN apt-get upgrade -y
+RUN apt-get install curl git sqlite -y
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
+RUN apt-get install -y nodejs
+RUN apt-get install gcc g++ make -y
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update
+RUN apt-get install yarn -y
+
+## Then install these global packages
+RUN yarn global add knex-migrator grunt-cli ember-cli bower
+
+## configure your own reposities
+RUN mkdir -p /var/lib/ghost
+WORKDIR /var/lib/ghost/
+
+# Manual grunt init: pull private repo Admin client and themes/casper.
+RUN mkdir -p content/themes && \
+		cd content/themes && \
+		git clone https://github.com/TryGhost/Casper.git casper
+
+COPY . /var/lib/ghost/
+WORKDIR /var/lib/ghost/
+
+RUN cd core && \
+		git clone https://github.com/TryGhost/Ghost-Admin.git client
+
+
+## Turn localhost to Squash domain.
+RUN sed -i "s/http:\/\/localhost:2368/https:\/\/$SQUASH_DOMAIN/g" "core/server/config/env/config.development.json"
+
+RUN sed -i "s/http:\/\/localhost:2368/http:\/\/0.0.0.0:2368/g" "core/server/config/defaults.json"
+
+RUN sed -i "s/127.0.0.1/0.0.0.0/g" "core/server/config/defaults.json"
+
+RUN yarn setup
+
+RUN sqlite3 /var/lib/ghost/content/data/ghost-dev.db "update users set status='active', password='$USR_PASSWORD', email='$USR_EMAIL' where id='1'"
+
+EXPOSE 2368
+
+CMD grunt dev


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

---

This is a patch to integrate Squash.io with Ghost. I believe this is going to be handy to the project so any project maintainers and developers can quickly check the branch changes deployed on its own isolated VM, including the Ghost admin and theme.

Example of Ghost working with Squash: https://squash-integration-qlvhz.squash.io/

Admin area (credentials: ghost@example.com/Ghost@123): 
https://squash-integration-qlvhz.squash.io/Ghost

Squash is free for Open Source projects, maintainers just need to signup and [reach out to the support ](https://www.squash.io/support/)through the chat window and we will enable a forever free Open Source account. Once this is done, Squash will post a comment on each Pull Request [like this](https://github.com/emiquelito/Ghost/pull/3):

![squash-comment](https://user-images.githubusercontent.com/98694/69469464-4dacc580-0d4e-11ea-9396-a4b7ce26a7cd.PNG)

When you click on the Squash link in a new PR it will deploy the branch of code into a brand new VM, this process takes about 7 minutes for Ghost (most of this time is spent on "yarn setup"). 

Let me know what you think please. Thanks.
