### PR TITLE
Renamed login middleware to getIdentityToken

### DIFF
--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -77,7 +77,7 @@ module.exports = {
             constants.ONE_HOUR_S
         )
     ],
-    authentication: [
+    createSessionFromToken: [
         getMemberDataFromSession,
         exchangeTokenForSession,
         decorateResponse

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -16,7 +16,7 @@ const getIdentityToken = async function (req, res) {
     }
 };
 
-const logout = async function (req, res) {
+const deleteSession = async function (req, res) {
     try {
         await membersService.ssr.deleteSession(req, res);
         res.writeHead(204);
@@ -86,9 +86,9 @@ module.exports = {
         shared.middlewares.labs.members,
         getIdentityToken
     ],
-    logout: [
+    deleteSession: [
         shared.middlewares.labs.members,
-        logout
+        deleteSession
     ],
     stripeWebhooks: [
         shared.middlewares.labs.members,

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -4,7 +4,7 @@ const shared = require('../../web/shared');
 const labsService = require('../labs');
 const membersService = require('./index');
 
-const login = async function (req, res) {
+const getIdentityToken = async function (req, res) {
     try {
         const token = await membersService.ssr.getIdentityTokenForMemberFromSession(req, res);
         res.writeHead(200);
@@ -82,9 +82,9 @@ module.exports = {
         exchangeTokenForSession,
         decorateResponse
     ],
-    login: [
+    getIdentityToken: [
         shared.middlewares.labs.members,
-        login
+        getIdentityToken
     ],
     logout: [
         shared.middlewares.labs.members,

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -120,7 +120,7 @@ module.exports = function setupSiteApp(options = {}) {
     // Members middleware
     // Initializes members specific routes as well as assigns members specific data to the req/res objects
     siteApp.get('/members/ssr', membersMiddleware.getIdentityToken);
-    siteApp.delete('/members/ssr', membersMiddleware.logout);
+    siteApp.delete('/members/ssr', membersMiddleware.deleteSession);
     siteApp.post('/members/webhooks/stripe', membersMiddleware.stripeWebhooks);
 
     siteApp.use(membersMiddleware.authentication);

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -119,7 +119,7 @@ module.exports = function setupSiteApp(options = {}) {
 
     // Members middleware
     // Initializes members specific routes as well as assigns members specific data to the req/res objects
-    siteApp.get('/members/ssr', membersMiddleware.login);
+    siteApp.get('/members/ssr', membersMiddleware.getIdentityToken);
     siteApp.delete('/members/ssr', membersMiddleware.logout);
     siteApp.post('/members/webhooks/stripe', membersMiddleware.stripeWebhooks);
 

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -123,7 +123,7 @@ module.exports = function setupSiteApp(options = {}) {
     siteApp.delete('/members/ssr', membersMiddleware.deleteSession);
     siteApp.post('/members/webhooks/stripe', membersMiddleware.stripeWebhooks);
 
-    siteApp.use(membersMiddleware.authentication);
+    siteApp.use(membersMiddleware.createSessionFromToken);
 
     // Theme middleware
     // This should happen AFTER any shared assets are served, as it only changes things to do with templates


### PR DESCRIPTION
no-issue

This name `login` was misleading as this middleware didn't login
members, that was handled by the `authentication` middleware,
specifically `exchangeTokenForSession`

It's also possible we'd want to split the `authentication` middleware into two explicit pieces - but not sure :man_shrugging: 