### PR TITLE
Refactored email handling to be consistent for send email

### DIFF
--- a/core/server/api/canary/email-preview.js
+++ b/core/server/api/canary/email-preview.js
@@ -30,9 +30,7 @@ module.exports = {
                         });
                     }
 
-                    const post = model.toJSON(options);
-
-                    return mega.postEmailSerializer.serialize(post);
+                    return mega.postEmailSerializer.serialize(model, {isBrowserPreview: true});
                 });
         }
     },

--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -155,7 +155,7 @@ module.exports = {
                         let postEmail = model.relations.email;
 
                         if (!postEmail) {
-                            const email = await mega.addEmail(model.toJSON(), frame.options);
+                            const email = await mega.addEmail(model, frame.options);
                             model.set('email', email);
                         } else if (postEmail && postEmail.get('status') === 'failed') {
                             const email = await mega.retryFailedEmail(postEmail);

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -4,6 +4,7 @@ const settingsCache = require('../../services/settings/cache');
 const urlUtils = require('../../lib/url-utils');
 const moment = require('moment');
 const cheerio = require('cheerio');
+const api = require('../../api');
 
 const getSite = () => {
     return Object.assign({}, settingsCache.getPublic(), {
@@ -11,14 +12,57 @@ const getSite = () => {
     });
 };
 
-const serialize = (post) => {
+/**
+ * createUnsubscribeUrl
+ *
+ * Takes a member and returns the url that should be used to unsubscribe
+ * In case of no member, generates the preview unsubscribe url - `?preview=1`
+ *
+ * @param {object} member
+ * @param {string} member.uuid
+ */
+const createUnsubscribeUrl = (member) => {
+    const siteUrl = urlUtils.getSiteUrl();
+    const unsubscribeUrl = new URL(siteUrl);
+    unsubscribeUrl.pathname = `${unsubscribeUrl.pathname}/unsubscribe/`.replace('//', '/');
+    if (member.uuid) {
+        unsubscribeUrl.searchParams.set('uuid', member.uuid);
+    } else {
+        unsubscribeUrl.searchParams.set('preview', '1');
+    }
+
+    return unsubscribeUrl.href;
+};
+
+// NOTE: serialization is needed to make sure we are using current API and do post transformations
+//       such as image URL transformation from relative to absolute
+const serializePostModel = async (model) => {
+    const frame = {options: {context: {user: true}}};
+    const apiVersion = model.get('api_version') || 'v3';
+    const docName = 'posts';
+
+    await api.shared
+        .serializers
+        .handle
+        .output(model, {docName: docName, method: 'read'}, api[apiVersion].serializers.output, frame);
+
+    return frame.response[docName][0];
+};
+
+const serialize = async (postModel, options = {isBrowserPreview: false}) => {
+    const post = await serializePostModel(postModel);
     post.published_at = post.published_at ? moment(post.published_at).format('DD MMM YYYY') : moment().format('DD MMM YYYY');
     post.authors = post.authors && post.authors.map(author => author.name).join(',');
     post.html = post.html || '';
     if (post.posts_meta) {
         post.email_subject = post.posts_meta.email_subject;
     }
-    let juicedHtml = juice(template({post, site: getSite()}));
+    let htmlTemplate = template({post, site: getSite()});
+    if (options.isBrowserPreview) {
+        const previewUnsubscribeUrl = createUnsubscribeUrl({});
+        htmlTemplate = htmlTemplate.replace('%recipient.unsubscribe_url%', previewUnsubscribeUrl);
+    }
+    let juicedHtml = juice(htmlTemplate);
     // Force all links to open in new tab
     let _cheerio = cheerio.load(juicedHtml);
     _cheerio('a').attr('target','_blank');
@@ -31,5 +75,6 @@ const serialize = (post) => {
 };
 
 module.exports = {
-    serialize: serialize
+    serialize,
+    createUnsubscribeUrl
 };


### PR DESCRIPTION
The email generation for test/newsletter/preview was scattered and calling same methods from multiple places. This caused unexpected and different behaviours for the different use-cases. This PR refactors methods to be consistent and use common serialization for email generation for different use-cases leading to same template/html generation for email.
