### PR TITLE
Added transaction support to pagination plugin

### DIFF
--- a/core/server/models/plugins/pagination.js
+++ b/core/server/models/plugins/pagination.js
@@ -144,11 +144,18 @@ pagination = function pagination(bookshelf) {
             // Get the table name and idAttribute for this model
             var tableName = _.result(this.constructor.prototype, 'tableName'),
                 idAttribute = _.result(this.constructor.prototype, 'idAttribute'),
-                self = this,
+                self = this;
+
+            let countPromise;
+            if (options.transacting) {
+                countPromise = this.query().clone().transacting(options.transacting).select(
+                    bookshelf.knex.raw('count(distinct ' + tableName + '.' + idAttribute + ') as aggregate')
+                );
+            } else {
                 countPromise = this.query().clone().select(
                     bookshelf.knex.raw('count(distinct ' + tableName + '.' + idAttribute + ') as aggregate')
                 );
-
+            }
             // #### Pre count clauses
             // Add any where or join clauses which need to be included with the aggregate query
 

--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -51,17 +51,12 @@ const sendTestEmail = async (postModel, toEmails) => {
  *
  * @param {object} postModel Post Model Object
  */
-const addEmail = async (postModel, options) => {
+
+const addEmail = async (post, options) => {
     const knexOptions = _.pick(options, ['transacting', 'forUpdate']);
 
-    // TODO: this is using the Member model directly rather than the members
-    // service because the service is hardcoded to Member.findPage and our
-    // pagination plugin does not currently work with transactions
-    const members = await models.Member
-        .findAll(Object.assign({filter: 'subscribed:true'}, knexOptions))
-        .map(member => member.toJSON(options));
-
-    const {emailTmpl, emails} = await getEmailData(postModel, members);
+    const {members} = await membersService.api.members.list(Object.assign(knexOptions, {filter: 'subscribed:true'}, {limit: 'all'}));
+    const {emailTmpl, emails} = await getEmailData(post, members);
 
     // NOTE: don't create email object when there's nobody to send the email to
     if (!emails.length) {

--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -52,11 +52,11 @@ const sendTestEmail = async (postModel, toEmails) => {
  * @param {object} postModel Post Model Object
  */
 
-const addEmail = async (post, options) => {
+const addEmail = async (postModel, options) => {
     const knexOptions = _.pick(options, ['transacting', 'forUpdate']);
 
     const {members} = await membersService.api.members.list(Object.assign(knexOptions, {filter: 'subscribed:true'}, {limit: 'all'}));
-    const {emailTmpl, emails} = await getEmailData(post, members);
+    const {emailTmpl, emails} = await getEmailData(postModel, members);
 
     // NOTE: don't create email object when there's nobody to send the email to
     if (!emails.length) {


### PR DESCRIPTION
Adds transaction support to `fetchPage` method. This is needed to be able to count members during the post publish transaction. 

This is the next iteration over initial quick-fix: 90905b02125b138db18898b02bc305f20392f0b0
