### PR TITLE
✨  Allowed pages to accept HTML as a source

### DIFF
--- a/core/server/api/canary/pages.js
+++ b/core/server/api/canary/pages.js
@@ -85,12 +85,16 @@ module.exports = {
         statusCode: 201,
         headers: {},
         options: [
-            'include'
+            'include',
+            'source'
         ],
         validation: {
             options: {
                 include: {
                     values: ALLOWED_INCLUDES
+                },
+                source: {
+                    values: ['html']
                 }
             }
         },
@@ -117,6 +121,7 @@ module.exports = {
         options: [
             'include',
             'id',
+            'source',
             // NOTE: only for internal context
             'forUpdate',
             'transacting'
@@ -128,6 +133,9 @@ module.exports = {
                 },
                 id: {
                     required: true
+                },
+                source: {
+                    values: ['html']
                 }
             }
         },

--- a/core/server/api/v2/pages.js
+++ b/core/server/api/v2/pages.js
@@ -85,12 +85,16 @@ module.exports = {
         statusCode: 201,
         headers: {},
         options: [
-            'include'
+            'include',
+            'source'
         ],
         validation: {
             options: {
                 include: {
                     values: ALLOWED_INCLUDES
+                },
+                source: {
+                    values: ['html']
                 }
             }
         },
@@ -117,6 +121,7 @@ module.exports = {
         options: [
             'include',
             'id',
+            'source',
             // NOTE: only for internal context
             'forUpdate',
             'transacting'
@@ -128,6 +133,9 @@ module.exports = {
                 },
                 id: {
                     required: true
+                },
+                source: {
+                    values: ['html']
                 }
             }
         },

--- a/core/test/regression/api/canary/admin/pages_spec.js
+++ b/core/test/regression/api/canary/admin/pages_spec.js
@@ -1,0 +1,47 @@
+const should = require('should');
+const supertest = require('supertest');
+const testUtils = require('../../../../utils');
+const config = require('../../../../../server/config');
+const localUtils = require('./utils');
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Pages API', function () {
+    before(function () {
+        return ghost()
+            .then(function (_ghostServer) {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return localUtils.doAuth(request, 'posts');
+            });
+    });
+
+    describe('Edit', function () {
+        it('accepts html source', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`pages/${testUtils.DataGenerator.Content.posts[5].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    res.body.pages[0].slug.should.equal('static-page-test');
+
+                    return request
+                        .put(localUtils.API.getApiQuery('pages/' + testUtils.DataGenerator.Content.posts[5].id + '/?source=html'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            pages: [{
+                                html: '<p>HTML Ipsum presents</p>',
+                                updated_at: res.body.pages[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200);
+                })
+                .then((res) => {
+                    res.body.pages[0].mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"HTML Ipsum presents"]]]]}');
+                });
+        });
+    });
+});

--- a/core/test/regression/api/v2/admin/pages_spec.js
+++ b/core/test/regression/api/v2/admin/pages_spec.js
@@ -1,0 +1,47 @@
+const should = require('should');
+const supertest = require('supertest');
+const testUtils = require('../../../../utils');
+const config = require('../../../../../server/config');
+const localUtils = require('./utils');
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Pages API', function () {
+    before(function () {
+        return ghost()
+            .then(function (_ghostServer) {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(function () {
+                return localUtils.doAuth(request, 'posts');
+            });
+    });
+
+    describe('Edit', function () {
+        it('accepts html source', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`pages/${testUtils.DataGenerator.Content.posts[5].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    res.body.pages[0].slug.should.equal('static-page-test');
+
+                    return request
+                        .put(localUtils.API.getApiQuery('pages/' + testUtils.DataGenerator.Content.posts[5].id + '/?source=html'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            pages: [{
+                                html: '<p>HTML Ipsum presents</p>',
+                                updated_at: res.body.pages[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200);
+                })
+                .then((res) => {
+                    res.body.pages[0].mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"HTML Ipsum presents"]]]]}');
+                });
+        });
+    });
+});


### PR DESCRIPTION
Allow pages to be created using html as source. 
Adds parity for the /pages/ 'add' and 'edit' methods, to their /posts/ counterparts both of which use a common implementation. 

POSTing to the Posts endpoint is documented to accept source=html
https://ghost.org/docs/api/v3/admin/#source-html
However this does not work with the Pages endpoint. 

Previously adding a Page via API would only accept mobiledoc as source. With this change HTML can be provided when specifying 'html' as the source on the querystring. 
For example, via the AdminClient SDK:
```GhostAdminAPI.posts.add({ title: 'my title', html: '<p>Hi!</p>' }, {source: 'html'})```

Documentation for the Admin API Client Library generally indicate a similar treatment of pages and posts but does not cover the topic of HTML source. 
https://ghost.org/docs/api/v3/javascript/admin/#endpoints
...Except, in the Publishing example which shows html source format, but only for Posts
https://ghost.org/docs/api/v3/javascript/admin/#publishing-example

Doing the same with the Pages API results in a document with only a title and no content, silently ignoring the source html.

My use case for this was in using the SDK to communicate with the API in a headless manner to create pages. While posts and pages API endpoints share an implementation that already implements a conversion from html to mobile doc, the endpoint for /pages was not configured the same as the posts endpoint. It was missing the ability to accept the source types. Only HTML has been added as a source type. 
