### PR TITLE
Removed redundant member manipulation proxy methods

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -1,6 +1,7 @@
 // NOTE: We must not cache references to membersService.api
 // as it is a getter and may change during runtime.
 const Promise = require('bluebird');
+const models = require('../../models');
 const membersService = require('../../services/members');
 const common = require('../../lib/common');
 const fsLib = require('../../lib/fs');
@@ -113,7 +114,15 @@ const members = {
         permissions: true,
         async query(frame) {
             frame.options.require = true;
-            await membersService.api.members.destroy(frame.options);
+            await membersService.api.members.destroy(frame.options)
+                .catch(models.Member.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Member'
+                        })
+                    });
+                });
+
             return null;
         }
     },

--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -8,28 +8,6 @@ const signupEmail = require('./emails/signup');
 const subscribeEmail = require('./emails/subscribe');
 const config = require('./config');
 
-async function createMember({email, name, note}, options = {}) {
-    const model = await models.Member.add({
-        email,
-        name: name || null,
-        note: note || null
-    });
-    const member = model.toJSON(options);
-    return member;
-}
-
-async function getMember(data, options = {}) {
-    if (!data.email && !data.id && !data.uuid) {
-        return Promise.resolve(null);
-    }
-    const model = await models.Member.findOne(data, options);
-    if (!model) {
-        return null;
-    }
-    const member = model.toJSON(options);
-    return member;
-}
-
 async function setMetadata(module, metadata) {
     if (module !== 'stripe') {
         return;
@@ -70,42 +48,6 @@ async function getMetadata(module, member) {
         customers: customers,
         subscriptions: subscriptions
     };
-}
-
-async function updateMember({name, note, subscribed}, options = {}) {
-    const attrs = {
-        name: name || null,
-        note: note || null
-    };
-
-    if (subscribed !== undefined) {
-        attrs.subscribed = subscribed;
-    }
-
-    const model = await models.Member.edit(attrs, options);
-
-    const member = model.toJSON(options);
-    return member;
-}
-
-function deleteMember(options) {
-    options = options || {};
-    return models.Member.destroy(options).catch(models.Member.NotFoundError, () => {
-        throw new common.errors.NotFoundError({
-            message: common.i18n.t('errors.api.resource.resourceNotFound', {
-                resource: 'Member'
-            })
-        });
-    });
-}
-
-function listMembers(options) {
-    return models.Member.findPage(options).then((models) => {
-        return {
-            members: models.data.map(model => model.toJSON(options)),
-            meta: models.meta
-        };
-    });
 }
 
 const ghostMailer = new mail.GhostMailer();
@@ -225,11 +167,7 @@ function createApiInstance() {
         },
         setMetadata,
         getMetadata,
-        createMember,
-        updateMember,
-        getMember,
-        deleteMember,
-        listMembers,
+        memberModel: models.Member,
         logger: common.logging
     });
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@nexes/nql": "0.3.0",
     "@tryghost/helpers": "1.1.19",
-    "@tryghost/members-api": "0.9.0",
+    "@tryghost/members-api": "0.10.0",
     "@tryghost/members-ssr": "0.7.3",
     "@tryghost/social-urls": "0.1.4",
     "@tryghost/string": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,10 +237,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.9.0.tgz#8fc227b9b6f536093f67a68d47687830de2c1748"
-  integrity sha512-8nfaI2CAi+B3DToLrxUwSYVaBX/gX+mLnBJW3cIml/sBXokno4Sr08HX7OpTnTNXLroLHa/+QYivhtMRAOxjQQ==
+"@tryghost/members-api@0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.10.0.tgz#4666faa6e215255ac682a45edbdee8d95aa99175"
+  integrity sha512-Y3vVQnrB0EHmYSxGNnm7XLXJcleUlYxW6fdjv7663D3FjxM0s4+PkDpEPA/JW18Z9jUS1zOvZoASNM0WTA0ddw==
   dependencies:
     "@tryghost/magic-link" "^0.3.2"
     bluebird "^3.5.4"


### PR DESCRIPTION
TODO:
- [x] bump members package once https://github.com/TryGhost/Members/pull/105 is merged and new version is out
- [x] test!

These methods have been moved ton @tryghost/members-api in favor of using the model directly (ref: https://github.com/TryGhost/Members/pull/105)
