### PR TITLE
Added excerpt fallback when html & custom_excerpt fields are empty

### DIFF
--- a/core/frontend/helpers/excerpt.js
+++ b/core/frontend/helpers/excerpt.js
@@ -18,12 +18,16 @@ var proxy = require('./proxy'),
  * We have not touched this helper yet, we will revisit later.
  */
 module.exports = function excerpt(options) {
-    var truncateOptions = (options || {}).hash || {},
-        excerptText = this.custom_excerpt
-            ? String(this.custom_excerpt)
-            : this.html
-                ? String(this.html)
-                : '';
+    let truncateOptions = (options || {}).hash || {};
+    let excerptText;
+
+    if (this.custom_excerpt) {
+        excerptText = String(this.custom_excerpt);
+    } else if (this.html) {
+        excerptText = String(this.html);
+    } else {
+        excerptText = '';
+    }
 
     truncateOptions = _.pick(truncateOptions, ['words', 'characters']);
     _.keys(truncateOptions).map(function (key) {

--- a/core/frontend/helpers/excerpt.js
+++ b/core/frontend/helpers/excerpt.js
@@ -10,13 +10,6 @@ var proxy = require('./proxy'),
     SafeString = proxy.SafeString,
     getMetaDataExcerpt = proxy.metaData.getMetaDataExcerpt;
 
-/**
- * @NOTE:
- *
- * Content API v2 returns a calculated `post.excerpt` field.
- * See https://github.com/TryGhost/Ghost/issues/10062.
- * We have not touched this helper yet, we will revisit later.
- */
 module.exports = function excerpt(options) {
     let truncateOptions = (options || {}).hash || {};
     let excerptText;

--- a/core/frontend/helpers/excerpt.js
+++ b/core/frontend/helpers/excerpt.js
@@ -25,6 +25,8 @@ module.exports = function excerpt(options) {
         excerptText = String(this.custom_excerpt);
     } else if (this.html) {
         excerptText = String(this.html);
+    } else if (this.excerpt) {
+        excerptText = String(this.excerpt);
     } else {
         excerptText = '';
     }

--- a/core/test/unit/helpers/excerpt_spec.js
+++ b/core/test/unit/helpers/excerpt_spec.js
@@ -16,7 +16,7 @@ describe('{{excerpt}} Helper', function () {
         rendered.string.should.equal('');
     });
 
-    it('can render excerpt', function () {
+    it('can render custom_excerpt', function () {
         const html = 'Hello World',
             rendered = helpers.excerpt.call({
                 html: html,
@@ -119,7 +119,7 @@ describe('{{excerpt}} Helper', function () {
         rendered.string.should.equal(expected);
     });
 
-    it('uses custom excerpt if provided instead of truncating html', function () {
+    it('uses custom_excerpt if provided instead of truncating html', function () {
         const html = '<p>Hello <strong>World! It\'s me!</strong></p>',
             customExcerpt = 'My Custom Excerpt wins!',
             expected = 'My Custom Excerpt wins!',
@@ -136,7 +136,7 @@ describe('{{excerpt}} Helper', function () {
         rendered.string.should.equal(expected);
     });
 
-    it('does not truncate custom excerpt if characters options is provided', function () {
+    it('does not truncate custom_excerpt if characters options is provided', function () {
         const html = '<p>Hello <strong>World! It\'s me!</strong></p>',
             customExcerpt = 'This is a custom excerpt. It should always be rendered in full length and not being cut ' +
                        'off. The maximum length of a custom excerpt is 300 characters. Enough to tell a bit about ' +
@@ -160,7 +160,7 @@ describe('{{excerpt}} Helper', function () {
         rendered.string.should.equal(expected);
     });
 
-    it('does not truncate custom excerpt if words options is provided', function () {
+    it('does not truncate custom_excerpt if words options is provided', function () {
         const html = '<p>Hello <strong>World! It\'s me!</strong></p>',
             customExcerpt = 'This is a custom excerpt. It should always be rendered in full length and not being cut ' +
                        'off. The maximum length of a custom excerpt is 300 characters. Enough to tell a bit about ' +

--- a/core/test/unit/helpers/excerpt_spec.js
+++ b/core/test/unit/helpers/excerpt_spec.js
@@ -1,22 +1,23 @@
-var should = require('should'),
+const should = require('should'),
 
     // Stuff we are testing
     helpers = require('../../../frontend/helpers');
 
 describe('{{excerpt}} Helper', function () {
-    it('renders empty string when html and excerpt are null', function () {
-        var html = null,
-            rendered = helpers.excerpt.call({
-                html: html,
-                custom_excerpt: null
-            });
+    it('renders empty string when html, excerpt, and custom_excerpt are null', function () {
+        const html = null;
+        const rendered = helpers.excerpt.call({
+            html: html,
+            custom_excerpt: null,
+            excerpt: null
+        });
 
         should.exist(rendered);
         rendered.string.should.equal('');
     });
 
     it('can render excerpt', function () {
-        var html = 'Hello World',
+        const html = 'Hello World',
             rendered = helpers.excerpt.call({
                 html: html,
                 custom_excerpt: ''
@@ -27,7 +28,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('does not output HTML', function () {
-        var html = '<p>There are <br />10<br> types<br/> of people in <img src="a">the world:' +
+        const html = '<p>There are <br />10<br> types<br/> of people in <img src="a">the world:' +
                 '<img src=b alt="c"> those who <img src="@" onclick="javascript:alert(\'hello\');">' +
                 'understand trinary,</p> those who don\'t <div style="" class=~/\'-,._?!|#>and' +
                 '< test > those<<< test >>> who mistake it &lt;for&gt; binary.',
@@ -43,7 +44,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('strips multiple inline footnotes', function () {
-        var html = '<p>Testing<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup>, my footnotes. And stuff. Footnote<sup id="fnref:2"><a href="#fn:2" rel="footnote">2</a></sup><a href="http://google.com">with a link</a> right after.',
+        const html = '<p>Testing<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup>, my footnotes. And stuff. Footnote<sup id="fnref:2"><a href="#fn:2" rel="footnote">2</a></sup><a href="http://google.com">with a link</a> right after.',
             expected = 'Testing, my footnotes. And stuff. Footnotewith a link right after.',
             rendered = helpers.excerpt.call({
                 html: html,
@@ -55,7 +56,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('strips inline and bottom footnotes', function () {
-        var html = '<p>Testing<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup> a very short post with a single footnote.</p>\n' +
+        const html = '<p>Testing<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup> a very short post with a single footnote.</p>\n' +
                 '<div class="footnotes"><ol><li class="footnote" id="fn:1"><p><a href="https://ghost.org">https://ghost.org</a> <a href="#fnref:1" title="return to article">↩</a></p></li></ol></div>',
             expected = 'Testing a very short post with a single footnote.',
             rendered = helpers.excerpt.call({
@@ -68,7 +69,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('can truncate html by word', function () {
-        var html = '<p>Hello <strong>World! It\'s me!</strong></p>',
+        const html = '<p>Hello <strong>World! It\'s me!</strong></p>',
             expected = 'Hello World!',
             rendered = (
                 helpers.excerpt.call(
@@ -85,7 +86,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('can truncate html with non-ascii characters by word', function () {
-        var html = '<p>Едквюэ опортэат <strong>праэчынт ючю но, квуй эю</strong></p>',
+        const html = '<p>Едквюэ опортэат <strong>праэчынт ючю но, квуй эю</strong></p>',
             expected = 'Едквюэ опортэат',
             rendered = (
                 helpers.excerpt.call(
@@ -102,7 +103,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('can truncate html by character', function () {
-        var html = '<p>Hello <strong>World! It\'s me!</strong></p>',
+        const html = '<p>Hello <strong>World! It\'s me!</strong></p>',
             expected = 'Hello Wo',
             rendered = (
                 helpers.excerpt.call(
@@ -119,7 +120,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('uses custom excerpt if provided instead of truncating html', function () {
-        var html = '<p>Hello <strong>World! It\'s me!</strong></p>',
+        const html = '<p>Hello <strong>World! It\'s me!</strong></p>',
             customExcerpt = 'My Custom Excerpt wins!',
             expected = 'My Custom Excerpt wins!',
             rendered = (
@@ -136,7 +137,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('does not truncate custom excerpt if characters options is provided', function () {
-        var html = '<p>Hello <strong>World! It\'s me!</strong></p>',
+        const html = '<p>Hello <strong>World! It\'s me!</strong></p>',
             customExcerpt = 'This is a custom excerpt. It should always be rendered in full length and not being cut ' +
                        'off. The maximum length of a custom excerpt is 300 characters. Enough to tell a bit about ' +
                        'your story and make a nice summary for your readers. It\s only allowed to truncate anything ' +
@@ -160,7 +161,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('does not truncate custom excerpt if words options is provided', function () {
-        var html = '<p>Hello <strong>World! It\'s me!</strong></p>',
+        const html = '<p>Hello <strong>World! It\'s me!</strong></p>',
             customExcerpt = 'This is a custom excerpt. It should always be rendered in full length and not being cut ' +
                        'off. The maximum length of a custom excerpt is 300 characters. Enough to tell a bit about ' +
                        'your story and make a nice summary for your readers. It\s only allowed to truncate anything ' +
@@ -184,7 +185,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('puts additional space after closing paragraph', function () {
-        var html = '<p>Testing.</p><p>Space before this text.</p><p>And this as well!</p>',
+        const html = '<p>Testing.</p><p>Space before this text.</p><p>And this as well!</p>',
             expected = 'Testing. Space before this text. And this as well!',
             rendered = (
                 helpers.excerpt.call(
@@ -200,7 +201,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('puts additional space instead of <br> tag', function () {
-        var html = '<p>Testing.<br>Space before this text.<br>And this as well!</p>',
+        const html = '<p>Testing.<br>Space before this text.<br>And this as well!</p>',
             expected = 'Testing. Space before this text. And this as well!',
             rendered = (
                 helpers.excerpt.call(
@@ -216,7 +217,7 @@ describe('{{excerpt}} Helper', function () {
     });
 
     it('puts additional space between paragraph in markup generated by Ghost', function () {
-        var html = '<p>put space in excerpt.</p><p></p><p>before this paragraph.</p>' +
+        const html = '<p>put space in excerpt.</p><p></p><p>before this paragraph.</p>' +
                 '<figure class="kg-card kg-image-card"><img src="/content/images/2019/08/photo.jpg" class="kg-image"></figure>' +
                 '<p>and skip the image.</p><p></p>',
             expected = 'put space in excerpt.  before this paragraph. and skip the image.',

--- a/core/test/unit/helpers/excerpt_spec.js
+++ b/core/test/unit/helpers/excerpt_spec.js
@@ -27,6 +27,18 @@ describe('{{excerpt}} Helper', function () {
         rendered.string.should.equal(html);
     });
 
+    it('can render excerpt when other fields are empty', function () {
+        const html = '',
+            rendered = helpers.excerpt.call({
+                html: html,
+                custom_excerpt: '',
+                excerpt: 'Regular excerpt'
+            });
+
+        should.exist(rendered);
+        rendered.string.should.equal('Regular excerpt');
+    });
+
     it('does not output HTML', function () {
         const html = '<p>There are <br />10<br> types<br/> of people in <img src="a">the world:' +
                 '<img src=b alt="c"> those who <img src="@" onclick="javascript:alert(\'hello\');">' +


### PR DESCRIPTION
Adds fallback to `excerpt` fields available since Content API v2 for cases when content gating returns empty `html` field and `custom_excerpt` is not provided.