### PR TITLE
Fixed post meta migration for 3.x

### DIFF
--- a/core/server/data/migrations/versions/3.0/05-populate-posts-meta-table.js
+++ b/core/server/data/migrations/versions/3.0/05-populate-posts-meta-table.js
@@ -35,7 +35,7 @@ module.exports.up = (options) => {
                 let postsMetaEntries = _.map(posts, (post) => {
                     let postsMetaEntry = metaAttrs.reduce(function (obj, entry) {
                         return Object.assign(obj, {
-                            [entry]: post.get(entry)
+                            [entry]: post.get(entry) || null
                         });
                     }, {});
                     postsMetaEntry.post_id = post.get('id');


### PR DESCRIPTION
no issue

Since we added `email_subject` to `posts_meta` table in `3.1`, the migration tries to add `email_subject` column from post table, which does not exist and thus tries adding `undefined` value for column. Since sqlite expects default values while inserting new columns, this breaks any migration directly from `1.x`/`2.x` to 3.x.

The fix adds a default `null` value for any post_schema entry which doesn't has a value.
