### PR TITLE
Enabled export on user deletion and fetching of export files

### DIFF
--- a/core/server/api/canary/db.js
+++ b/core/server/api/canary/db.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const backupDatabase = require('../../data/db/backup');
+const dbBackup = require('../../data/db/backup');
 const exporter = require('../../data/exporter');
 const importer = require('../../data/importer');
 const common = require('../../lib/common');
@@ -25,7 +25,7 @@ module.exports = {
             // NOTE: we need to have `include` property available as backupDatabase uses it internally
             Object.assign(frame.options, {include: frame.options.withRelated});
 
-            return backupDatabase(frame.options);
+            return dbBackup.backup(frame.options);
         }
     },
 
@@ -114,7 +114,7 @@ module.exports = {
                 });
             }
 
-            return backupDatabase().then(deleteContent);
+            return dbBackup.backup().then(deleteContent);
         }
     }
 };

--- a/core/server/api/canary/db.js
+++ b/core/server/api/canary/db.js
@@ -31,7 +31,8 @@ module.exports = {
 
     exportContent: {
         options: [
-            'include'
+            'include',
+            'filename'
         ],
         validation: {
             options: {
@@ -47,7 +48,17 @@ module.exports = {
             }
         },
         permissions: true,
-        query(frame) {
+        async query(frame) {
+            if (frame.options.filename) {
+                let backup = await dbBackup.readBackup(frame.options.filename);
+
+                if (!backup) {
+                    return new common.errors.NotFoundError();
+                }
+
+                return backup;
+            }
+
             return Promise.resolve()
                 .then(() => exporter.doExport({include: frame.options.withRelated}))
                 .catch((err) => {

--- a/core/server/api/canary/db.js
+++ b/core/server/api/canary/db.js
@@ -53,7 +53,7 @@ module.exports = {
                 let backup = await dbBackup.readBackup(frame.options.filename);
 
                 if (!backup) {
-                    return new common.errors.NotFoundError();
+                    throw new common.errors.NotFoundError();
                 }
 
                 return backup;

--- a/core/server/api/canary/users.js
+++ b/core/server/api/canary/users.js
@@ -1,6 +1,6 @@
 const Promise = require('bluebird');
 const common = require('../../lib/common');
-const backupDatabase = require('../../data/db/backup');
+const dbBackup = require('../../data/db/backup');
 const models = require('../../models');
 const permissionsService = require('../../services/permissions');
 const ALLOWED_INCLUDES = ['count.posts', 'permissions', 'roles', 'roles.permissions'];
@@ -122,7 +122,7 @@ module.exports = {
         },
         permissions: true,
         async query(frame) {
-            const filename = await backupDatabase();
+            const filename = await dbBackup.backup();
 
             return models.Base.transaction((t) => {
                 frame.options.transacting = t;

--- a/core/server/api/canary/users.js
+++ b/core/server/api/canary/users.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const Promise = require('bluebird');
 const common = require('../../lib/common');
 const dbBackup = require('../../data/db/backup');
@@ -122,7 +123,9 @@ module.exports = {
         },
         permissions: true,
         async query(frame) {
-            const filename = await dbBackup.backup();
+            const backupPath = await dbBackup.backup();
+            const parsedFileName = path.parse(backupPath);
+            const filename = `${parsedFileName.name}${parsedFileName.ext}`;
 
             return models.Base.transaction((t) => {
                 frame.options.transacting = t;

--- a/core/server/api/canary/utils/serializers/output/users.js
+++ b/core/server/api/canary/utils/serializers/output/users.js
@@ -25,6 +25,16 @@ module.exports = {
         this.read(...arguments);
     },
 
+    destroy(filename, apiConfig, frame) {
+        debug('destroy');
+
+        frame.response = {
+            meta: {
+                filename: filename
+            }
+        };
+    },
+
     changePassword(models, apiConfig, frame) {
         debug('changePassword');
 

--- a/core/server/api/v2/db.js
+++ b/core/server/api/v2/db.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const backupDatabase = require('../../data/db/backup');
+const dbBackup = require('../../data/db/backup');
 const exporter = require('../../data/exporter');
 const importer = require('../../data/importer');
 const common = require('../../lib/common');
@@ -25,7 +25,7 @@ module.exports = {
             // NOTE: we need to have `include` property available as backupDatabase uses it internally
             Object.assign(frame.options, {include: frame.options.withRelated});
 
-            return backupDatabase(frame.options);
+            return dbBackup.backup(frame.options);
         }
     },
 
@@ -114,7 +114,7 @@ module.exports = {
                 });
             }
 
-            return backupDatabase().then(deleteContent);
+            return dbBackup.backup().then(deleteContent);
         }
     }
 };

--- a/core/server/data/db/backup.js
+++ b/core/server/data/db/backup.js
@@ -39,4 +39,6 @@ backup = function backup(options) {
         });
 };
 
-module.exports = backup;
+module.exports = {
+    backup
+};

--- a/core/server/data/db/backup.js
+++ b/core/server/data/db/backup.js
@@ -17,6 +17,20 @@ writeExportFile = function writeExportFile(exportResult) {
     return fs.writeFile(filename, JSON.stringify(exportResult.data)).return(filename);
 };
 
+const readBackup = async (filename) => {
+    // TODO: prevent from directory traversal - need to sanitize the filename probably on validation layer
+    var backupPath = path.resolve(urlUtils.urlJoin(config.get('paths').contentPath, 'data', filename));
+
+    const exists = await fs.pathExists(backupPath);
+
+    if (exists) {
+        const backup = await fs.readFile(backupPath);
+        return JSON.parse(backup);
+    } else {
+        return null;
+    }
+};
+
 /**
  * ## Backup
  * does an export, and stores this in a local file
@@ -40,5 +54,6 @@ backup = function backup(options) {
 };
 
 module.exports = {
-    backup
+    backup,
+    readBackup
 };

--- a/core/server/data/db/backup.js
+++ b/core/server/data/db/backup.js
@@ -18,8 +18,9 @@ writeExportFile = function writeExportFile(exportResult) {
 };
 
 const readBackup = async (filename) => {
-    // TODO: prevent from directory traversal - need to sanitize the filename probably on validation layer
-    var backupPath = path.resolve(urlUtils.urlJoin(config.get('paths').contentPath, 'data', filename));
+    const parsedFileName = path.parse(filename);
+    const sanitized = `${parsedFileName.name}${parsedFileName.ext}`;
+    const backupPath = path.resolve(urlUtils.urlJoin(config.get('paths').contentPath, 'data', sanitized));
 
     const exists = await fs.pathExists(backupPath);
 

--- a/core/test/acceptance/admin/users_spec.js
+++ b/core/test/acceptance/admin/users_spec.js
@@ -250,9 +250,11 @@ describe('User API', function () {
                 return request
                     .delete(localUtils.API.getApiQuery(`users/${userId}`))
                     .set('Origin', config.get('url'))
-                    .expect(204);
+                    .expect(200);
             })
-            .then(() => {
+            .then((res) => {
+                should.exist(res.body.meta.filename);
+
                 return request
                     .get(localUtils.API.getApiQuery(`users/${userId}/`))
                     .set('Origin', config.get('url'))

--- a/core/test/acceptance/admin/users_spec.js
+++ b/core/test/acceptance/admin/users_spec.js
@@ -256,6 +256,12 @@ describe('User API', function () {
                 should.exist(res.body.meta.filename);
 
                 return request
+                    .get(localUtils.API.getApiQuery(`db/?filename=${res.body.meta.filename}/`))
+                    .set('Origin', config.get('url'))
+                    .expect(200);
+            })
+            .then(() => {
+                return request
                     .get(localUtils.API.getApiQuery(`users/${userId}/`))
                     .set('Origin', config.get('url'))
                     .expect(404);

--- a/core/test/regression/api/v3/admin/db_spec.js
+++ b/core/test/regression/api/v3/admin/db_spec.js
@@ -107,6 +107,14 @@ describe('DB API', function () {
             });
     });
 
+    it('fails when triggering an export from unknown filename ', function () {
+        return request.get(localUtils.API.getApiQuery('db/?filename=this_file_is_not_here.json'))
+            .set('Origin', config.get('url'))
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect(404);
+    });
+
     it('import should fail without file', function () {
         return request.post(localUtils.API.getApiQuery('db/'))
             .set('Origin', config.get('url'))
@@ -123,7 +131,7 @@ describe('DB API', function () {
             .expect(415);
     });
 
-    it('export can be triggered by backup integration', function () {
+    it('backup can be triggered by backup integration', function () {
         const backupQuery = `?filename=test`;
         const fsStub = sinon.stub(fs, 'writeFile').resolves();
 
@@ -139,7 +147,7 @@ describe('DB API', function () {
             });
     });
 
-    it('export can not be triggered by integration other than backup', function () {
+    it('backup can not be triggered by integration other than backup', function () {
         const fsStub = sinon.stub(fs, 'writeFile').resolves();
 
         return request.post(localUtils.API.getApiQuery(`db/backup`))
@@ -154,7 +162,7 @@ describe('DB API', function () {
             });
     });
 
-    it('export can be triggered by Admin authentication', function () {
+    it('backup can be triggered by Admin authentication', function () {
         const fsStub = sinon.stub(fs, 'writeFile').resolves();
 
         return request.post(localUtils.API.getApiQuery(`db/backup`))

--- a/core/test/unit/data/db/backup_spec.js
+++ b/core/test/unit/data/db/backup_spec.js
@@ -1,11 +1,10 @@
 var should = require('should'),
     sinon = require('sinon'),
-    rewire = require('rewire'),
     _ = require('lodash'),
     fs = require('fs-extra'),
     models = require('../../../../server/models'),
     exporter = require('../../../../server/data/exporter'),
-    backupDatabase = rewire('../../../../server/data/db/backup');
+    backupDatabase = require('../../../../server/data/db/backup');
 
 describe('Backup', function () {
     var exportStub, filenameStub, fsStub;
@@ -25,7 +24,7 @@ describe('Backup', function () {
     });
 
     it('should create a backup JSON file', function (done) {
-        backupDatabase().then(function () {
+        backupDatabase.backup().then(function () {
             exportStub.calledOnce.should.be.true();
             filenameStub.calledOnce.should.be.true();
             fsStub.calledOnce.should.be.true();


### PR DESCRIPTION
Two main changes come into Admin API v3:
- Returns a filename of the export file when removing a user
  - The `filename` property comes in as a part of `meta` object
- Allows for the API consumer to fetch DB exports by filename
  - Needed to complete the flow of fetching DB export after the user has been removed. 
  - The export file can now be fetched by providing `?filename=${export_name.json}` as a query parameter.