### PR TITLE
Added localhost check for Ghost Mailer

### DIFF
--- a/core/server/services/mail/GhostMailer.js
+++ b/core/server/services/mail/GhostMailer.js
@@ -27,7 +27,7 @@ function getFromAddress(requestedFromAddress) {
     }
 
     // If we do have a from address, and it's just an email
-    if (validator.isEmail(address)) {
+    if (validator.isEmail(address, {require_tld: false})) {
         const defaultBlogTitle = settingsCache.get('title') ? settingsCache.get('title').replace(/"/g, '\\"') : common.i18n.t('common.mail.title', {domain: getDomain()});
         return `"${defaultBlogTitle}" <${address}>`;
     }


### PR DESCRIPTION
no issue

Allow localhost mails to bypass validator email check and assign blog title as email name when missing. Uses same logic as used for sending bulk emails [here](https://github.com/TryGhost/Ghost/blob/master/core/server/services/bulk-email/index.js#L64)