### PR TITLE
build: use oembed-spec dependency

### DIFF
--- a/core/server/api/canary/oembed.js
+++ b/core/server/api/canary/oembed.js
@@ -45,7 +45,7 @@ async function fetchBookmarkData(url, html) {
 
 const findUrlWithProvider = url => ({
     url,
-    provider: oEmbed.hasProvider(url)
+    provider: oEmbed.findProvider(url)
 });
 
 const getOembedUrlFromHTML = (html) => {

--- a/core/server/api/v2/oembed.js
+++ b/core/server/api/v2/oembed.js
@@ -6,7 +6,7 @@ const cheerio = require('cheerio');
 
 const findUrlWithProvider = url => ({
     url,
-    provider: oEmbed.hasProvider(url)
+    provider: oEmbed.findProvider(url)
 });
 
 const getOembedUrlFromHTML = (html) => {

--- a/core/server/overrides.js
+++ b/core/server/overrides.js
@@ -8,14 +8,6 @@ process.env.BLUEBIRD_DEBUG = 0;
 const moment = require('moment-timezone');
 
 /**
- * oembed-parser uses promise-wtf to extend the global Promise with .finally
- *   - require it before global Bluebird Promise override so that promise-wtf
- *     doesn't error due to Bluebird's Promise already having a .finally
- *   - https://github.com/ndaidong/promise-wtf/issues/25
- */
-const {extract, hasProvider} = require('oembed-parser'); // eslint-disable-line
-
-/**
  * force UTC
  *   - you can require moment or moment-timezone, both is configured to UTC
  *   - you are allowed to use new Date() to instantiate datetime values for models, because they are transformed into UTC in the model layer

--- a/core/server/services/mega/template.js
+++ b/core/server/services/mega/template.js
@@ -677,7 +677,7 @@ figure blockquote p {
     table[class=body] .kg-bookmark-thumbnail {
         display: none !important;
     }
-    
+
     table[class=body] .kg-bookmark-metadata span {
         font-size: 13px !important;
     }
@@ -726,7 +726,7 @@ figure blockquote p {
     table[class=body] blockquote + * {
         margin-top: 1.5em !important;
     }
-    
+
     table[class=body] hr {
         margin: 2em 0 !important;
     }
@@ -822,25 +822,23 @@ figure blockquote p {
                                             <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
                                                 <tr>
                                                     <td class="post-meta">
-                                                        By ${post.authors} – 
-                                                        ${post.published_at} – 
+                                                        By ${post.authors} –
+                                                        ${post.published_at} –
                                                         <a href="${post.url}" class="view-online-link">View online →</a>
                                                     </td>
                                                 </tr>
                                             </table>
-                                            
+
                                         </td>
                                     </tr>
-                                    ${
-                                        post.feature_image ? `
+                                    ${post.feature_image ? `
                                         <tr>
                                             <td class="feature-image"><img src="${post.feature_image}"></td>
                                         </tr>
-                                        ` : ``
-                                    }
+                                        ` : ``}
                                     <tr>
                                         <td class="post-content">
-                                            
+
                                             <!-- POST CONTENT START -->
                                             ${post.html}
                                             <!-- POST CONTENT END -->
@@ -857,7 +855,7 @@ figure blockquote p {
                             <td class="wrapper" align="center">
                                 <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
                                     <tr>
-                                        <td class="footer">${site.title} &copy; ${date.getFullYear()} – <a href="%recipient.unsubscribe_url%">Unsubscribe</a></td>
+                                        <td class="footer">${site.title} &copy; ${date.getFullYear()} – <a href="%recipient.unsubscribe_url%">Unsubscribe</a></td>
                                     </tr>
                                 </table>
                             </td>

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "node-jose": "1.1.3",
     "nodemailer": "0.7.1",
     "oauth2orize": "1.11.0",
-    "oembed-spec": "1.1.1",
+    "oembed-spec": "1.1.7",
     "path-match": "1.2.4",
     "probe-image-size": "5.0.0",
     "rss": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "node-jose": "1.1.3",
     "nodemailer": "0.7.1",
     "oauth2orize": "1.11.0",
-    "oembed-parser": "1.3.7",
+    "oembed-spec": "1.1.1",
     "path-match": "1.2.4",
     "probe-image-size": "5.0.0",
     "rss": "1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6176,11 +6176,6 @@ node-environment-flags@1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
 node-forge@^0.8.1:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"
@@ -6439,12 +6434,13 @@ object.pick@^1.2.0, object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-oembed-parser@1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/oembed-parser/-/oembed-parser-1.3.7.tgz#3741c238a383f595e84dc4f4f3f9c5f6f8d95c53"
-  integrity sha512-u+zIINgVUTMJ5wqs2dpoJhWZ+0yLmChB3wV4NDIT81cZtHlm0xcgR3JuvXdtgJDJK/1diHk3DQtv2zsjhdeEkA==
+oembed-spec@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/oembed-spec/-/oembed-spec-1.1.7.tgz#061359ac2d9043eef1e22b65e28851b030c2880c"
+  integrity sha512-55lwSvDkGdrxtkfDLBgrH3z9LCj+8JhpwBrJMWOrArebKxxMIoYlrg+3q9nkYvp1TAON85gnO6m+N6t3U/bu2w==
   dependencies:
-    node-fetch "^2.6.0"
+    got "~9.6.0"
+    tldts "~5.6.3"
 
 on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
@@ -8759,6 +8755,18 @@ tlds@^1.203.0:
   version "1.203.1"
   resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.203.1.tgz#4dc9b02f53de3315bc98b80665e13de3edfc1dfc"
   integrity sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw==
+
+tldts-core@^5.6.3:
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-5.6.3.tgz#d80ce1e93b58ba0614701c28450360fc6986aaf1"
+  integrity sha512-E7Jtwgy5ZKXuKm3tb2Z73t0AgiGTnGnVrGfBAJj0nS2tENCclb/Ym5yt+wOdDW+8uJg0bI/BxHmbvUyLAYpcPQ==
+
+tldts@~5.6.3:
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-5.6.3.tgz#89159b2180bf18d807bcf38438ef6e35fafa8d9f"
+  integrity sha512-h17D3Q9iRTeEdqncCR5MfRvwPxRbGFwx/g51ky2s6+2i9BicZOPFikc5FE2jG0Se+0bAPaaoZLytQ1kGhH1U0g==
+  dependencies:
+    tldts-core "^5.6.3"
 
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
Hello,

This PR introduces [oembed-spec](https://github.com/microlinkhq/oembed-spec) as oEmbed parser because:

- It keeps oEmbed providers on sync (as npm postinstall hook).
- Handle http/https & www/non-www URLs variations.
- Built for speed on mind.

It's based on the same principles as your previous library but it solves some of the lacks in the original library.