### PR TITLE
🎨 Optimized loading stripe scripts only when it is needed

### DIFF
--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -44,10 +44,17 @@ function finaliseStructuredData(metaData) {
 }
 
 function getMembersHelper() {
-    return `
-        <script src="https://js.stripe.com/v3/"></script>
-        <script defer src="${getAssetUrl('public/members.js')}"></script>
-    `;
+    const stripePaymentProcessor = settingsCache.get('members_subscription_settings').paymentProcessors.find(
+        paymentProcessor => paymentProcessor.adapter === 'stripe'
+    );
+    const stripeSecretToken = stripePaymentProcessor.config.secret_token;
+    const stripePublicToken = stripePaymentProcessor.config.public_token;
+
+    var membersHelper = `<script defer src="${getAssetUrl('public/members.js')}"></script>`;
+    if (!!stripeSecretToken && stripeSecretToken !== '' && !!stripePublicToken && stripePublicToken !== '') {
+        membersHelper += '<script src="https://js.stripe.com/v3/"></script>';
+    }
+    return membersHelper;
 }
 
 /**


### PR DESCRIPTION
closes #11463

Ghost used to always load stripe.js into the frontend of all pages when memberships are enabled, even when Stripe isn't configured / memberships to a page are free.

This meant that some people's site were unnecessarily loading stripe.js, leading to unnecessarily long loading times & potentially even privacy issues (the stripe.js script sets cookies that might be problematic under GDPR, especially if the people running the site don't expect Stripe to be loaded because they haven't configured it).

This change changes Ghost's behaviour to only load stripe.js when both stripe API tokens are present & not empty (the quickets way to verify that Stripe is fully configured &  operational on a blog).