### PR TITLE
🐛  Fixed empty html/plaintext fields for narrow fields parameter

### DIFF
--- a/core/server/api/canary/utils/serializers/input/pages.js
+++ b/core/server/api/canary/utils/serializers/input/pages.js
@@ -53,6 +53,12 @@ function setDefaultOrder(frame) {
     }
 }
 
+function forceVisibilityColumn(frame) {
+    if (frame.options.columns && !frame.options.columns.includes('visibility')) {
+        frame.options.columns.push('visibility');
+    }
+}
+
 function defaultFormat(frame) {
     if (frame.options.formats) {
         return;
@@ -100,6 +106,7 @@ module.exports = {
         if (localUtils.isContentAPI(frame)) {
             removeMobiledocFormat(frame);
             setDefaultOrder(frame);
+            forceVisibilityColumn(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -119,6 +126,7 @@ module.exports = {
         if (localUtils.isContentAPI(frame)) {
             removeMobiledocFormat(frame);
             setDefaultOrder(frame);
+            forceVisibilityColumn(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/core/server/api/canary/utils/serializers/input/posts.js
+++ b/core/server/api/canary/utils/serializers/input/posts.js
@@ -53,6 +53,12 @@ function setDefaultOrder(frame) {
     }
 }
 
+function forceVisibilityColumn(frame) {
+    if (frame.options.columns && !frame.options.columns.includes('visibility')) {
+        frame.options.columns.push('visibility');
+    }
+}
+
 function defaultFormat(frame) {
     if (frame.options.formats) {
         return;
@@ -108,6 +114,7 @@ module.exports = {
             removeMobiledocFormat(frame);
 
             setDefaultOrder(frame);
+            forceVisibilityColumn(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -135,6 +142,7 @@ module.exports = {
             removeMobiledocFormat(frame);
 
             setDefaultOrder(frame);
+            forceVisibilityColumn(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -95,6 +95,10 @@ const post = (attrs, frame) => {
         if (attrs.og_description === '') {
             attrs.og_description = null;
         }
+        // NOTE: the visibility column has to be always present in Content API response to perform content gating
+        if (frame.options.columns && frame.options.columns.includes('visibility') && !frame.original.query.fields.includes('visibility')) {
+            delete attrs.visibility;
+        }
     } else {
         delete attrs.page;
     }

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -53,6 +53,12 @@ function setDefaultOrder(frame) {
     }
 }
 
+function forceVisibilityColumn(frame) {
+    if (frame.options.columns && !frame.options.columns.includes('visibility')) {
+        frame.options.columns.push('visibility');
+    }
+}
+
 function defaultFormat(frame) {
     if (frame.options.formats) {
         return;
@@ -100,6 +106,7 @@ module.exports = {
         if (localUtils.isContentAPI(frame)) {
             removeMobiledocFormat(frame);
             setDefaultOrder(frame);
+            forceVisibilityColumn(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -119,6 +126,7 @@ module.exports = {
         if (localUtils.isContentAPI(frame)) {
             removeMobiledocFormat(frame);
             setDefaultOrder(frame);
+            forceVisibilityColumn(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -53,6 +53,12 @@ function setDefaultOrder(frame) {
     }
 }
 
+function forceVisibilityColumn(frame) {
+    if (frame.options.columns && !frame.options.columns.includes('visibility')) {
+        frame.options.columns.push('visibility');
+    }
+}
+
 function defaultFormat(frame) {
     if (frame.options.formats) {
         return;
@@ -108,6 +114,7 @@ module.exports = {
             removeMobiledocFormat(frame);
 
             setDefaultOrder(frame);
+            forceVisibilityColumn(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -135,6 +142,7 @@ module.exports = {
             removeMobiledocFormat(frame);
 
             setDefaultOrder(frame);
+            forceVisibilityColumn(frame);
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/core/test/regression/api/canary/content/posts_spec.js
+++ b/core/test/regression/api/canary/content/posts_spec.js
@@ -224,6 +224,7 @@ describe('api/canary/content/posts', function () {
     });
 
     describe('content gating', function () {
+        let publicPost;
         let membersPost;
         let paidPost;
 
@@ -233,6 +234,12 @@ describe('api/canary/content/posts', function () {
         });
 
         before (function () {
+            publicPost = testUtils.DataGenerator.forKnex.createPost({
+                slug: 'free-to-see',
+                visibility: 'public',
+                published_at: moment().add(15, 'seconds').toDate() // here to ensure sorting is not modified
+            });
+
             membersPost = testUtils.DataGenerator.forKnex.createPost({
                 slug: 'thou-shalt-not-be-seen',
                 visibility: 'members',
@@ -246,9 +253,29 @@ describe('api/canary/content/posts', function () {
             });
 
             return testUtils.fixtures.insertPosts([
+                publicPost,
                 membersPost,
                 paidPost
             ]);
+        });
+
+        it('public post fields are always visible', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${publicPost.id}/?key=${validKey}&fields=slug,html,plaintext&formats=html,plaintext`))
+                .set('Origin', testUtils.API.getURL())
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .then((res) => {
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    const post = jsonResponse.posts[0];
+
+                    localUtils.API.checkResponse(post, 'post', null, null, ['id', 'slug', 'html', 'plaintext']);
+                    post.slug.should.eql('free-to-see');
+                    post.html.should.not.eql('');
+                    post.plaintext.should.not.eql('');
+                });
         });
 
         it('cannot read members only post content', function () {
@@ -319,7 +346,7 @@ describe('api/canary/content/posts', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(13);
+                    jsonResponse.posts.should.have.length(14);
                     localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
@@ -327,17 +354,19 @@ describe('api/canary/content/posts', function () {
                     // Default order 'published_at desc' check
                     jsonResponse.posts[0].slug.should.eql('thou-shalt-not-be-seen');
                     jsonResponse.posts[1].slug.should.eql('thou-shalt-be-paid-for');
-                    jsonResponse.posts[6].slug.should.eql('organising-content');
+                    jsonResponse.posts[2].slug.should.eql('free-to-see');
+                    jsonResponse.posts[7].slug.should.eql('organising-content');
 
                     jsonResponse.posts[0].html.should.eql('');
                     jsonResponse.posts[1].html.should.eql('');
-                    jsonResponse.posts[6].html.should.not.eql('');
+                    jsonResponse.posts[2].html.should.not.eql('');
+                    jsonResponse.posts[7].html.should.not.eql('');
 
                     // check meta response for this test
                     jsonResponse.meta.pagination.page.should.eql(1);
                     jsonResponse.meta.pagination.limit.should.eql(15);
                     jsonResponse.meta.pagination.pages.should.eql(1);
-                    jsonResponse.meta.pagination.total.should.eql(13);
+                    jsonResponse.meta.pagination.total.should.eql(14);
                     jsonResponse.meta.pagination.hasOwnProperty('next').should.be.true();
                     jsonResponse.meta.pagination.hasOwnProperty('prev').should.be.true();
                     should.not.exist(jsonResponse.meta.pagination.next);

--- a/core/test/regression/api/v3/content/posts_spec.js
+++ b/core/test/regression/api/v3/content/posts_spec.js
@@ -224,6 +224,7 @@ describe('api/v3/content/posts', function () {
     });
 
     describe('content gating', function () {
+        let publicPost;
         let membersPost;
         let paidPost;
 
@@ -233,6 +234,12 @@ describe('api/v3/content/posts', function () {
         });
 
         before (function () {
+            publicPost = testUtils.DataGenerator.forKnex.createPost({
+                slug: 'free-to-see',
+                visibility: 'public',
+                published_at: moment().add(15, 'seconds').toDate() // here to ensure sorting is not modified
+            });
+
             membersPost = testUtils.DataGenerator.forKnex.createPost({
                 slug: 'thou-shalt-not-be-seen',
                 visibility: 'members',
@@ -246,9 +253,29 @@ describe('api/v3/content/posts', function () {
             });
 
             return testUtils.fixtures.insertPosts([
+                publicPost,
                 membersPost,
                 paidPost
             ]);
+        });
+
+        it('public post fields are always visible', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${publicPost.id}/?key=${validKey}&fields=slug,html,plaintext&formats=html,plaintext`))
+                .set('Origin', testUtils.API.getURL())
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .then((res) => {
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    const post = jsonResponse.posts[0];
+
+                    localUtils.API.checkResponse(post, 'post', null, null, ['id', 'slug', 'html', 'plaintext']);
+                    post.slug.should.eql('free-to-see');
+                    post.html.should.not.eql('');
+                    post.plaintext.should.not.eql('');
+                });
         });
 
         it('cannot read members only post content', function () {
@@ -319,7 +346,7 @@ describe('api/v3/content/posts', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(13);
+                    jsonResponse.posts.should.have.length(14);
                     localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
@@ -327,17 +354,19 @@ describe('api/v3/content/posts', function () {
                     // Default order 'published_at desc' check
                     jsonResponse.posts[0].slug.should.eql('thou-shalt-not-be-seen');
                     jsonResponse.posts[1].slug.should.eql('thou-shalt-be-paid-for');
-                    jsonResponse.posts[6].slug.should.eql('organising-content');
+                    jsonResponse.posts[2].slug.should.eql('free-to-see');
+                    jsonResponse.posts[7].slug.should.eql('organising-content');
 
                     jsonResponse.posts[0].html.should.eql('');
                     jsonResponse.posts[1].html.should.eql('');
-                    jsonResponse.posts[6].html.should.not.eql('');
+                    jsonResponse.posts[2].html.should.not.eql('');
+                    jsonResponse.posts[7].html.should.not.eql('');
 
                     // check meta response for this test
                     jsonResponse.meta.pagination.page.should.eql(1);
                     jsonResponse.meta.pagination.limit.should.eql(15);
                     jsonResponse.meta.pagination.pages.should.eql(1);
-                    jsonResponse.meta.pagination.total.should.eql(13);
+                    jsonResponse.meta.pagination.total.should.eql(14);
                     jsonResponse.meta.pagination.hasOwnProperty('next').should.be.true();
                     jsonResponse.meta.pagination.hasOwnProperty('prev').should.be.true();
                     should.not.exist(jsonResponse.meta.pagination.next);


### PR DESCRIPTION
The issue has been first spotted in https://forum.ghost.org/t/plaintext-value-is-empty-using-the-api/10537. TLDR: when `?fields` query parameter only fetches content gated fields they are always empty. This is happening because `visibility` attribute is expected to be present.

@allouis would love your opinion on the placement/approach for the field filtering logic. It's a bit ugly to compare `frame.columns` with `frame.original.fields`, but that was the best way I could think of to achieve this kind of logic without doing internal reshuffles (more in commit messages). 

