### PR TITLE
🔥 Dropped Node v8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
 - '12'
 - '10'
-- '8'
 cache: yarn
 services:
 - mysql

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fixmodulenotdefined": "yarn cache clean && cd core/client && rm -rf node_modules tmp dist && yarn && cd ../../"
   },
   "engines": {
-    "node": "^8.16.0 || ^10.13.0 || ^12.10.0",
+    "node": "^10.13.0 || ^12.10.0",
     "cli": "^1.12.0"
   },
   "dependencies": {


### PR DESCRIPTION
PRing to check if CI build kicks in properly.

Node v8 has come to EOL as of 2019-12-31 (ref. https://github.com/nodejs/Release#end-of-life-releases)
![Screenshot from 2020-01-09 14-25-44](https://user-images.githubusercontent.com/675397/72071398-fce83080-32eb-11ea-9846-fc7b8db69dae.png)
