### PR TITLE
✨ Added complimentary member subscription

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -131,6 +131,19 @@ const members = {
         async query(frame) {
             const member = await models.Member.edit(frame.data.members[0], frame.options);
 
+            const subscriptions = await membersService.api.members.getStripeSubscriptions(member);
+            const compedSubscriptions = subscriptions.filter(sub => (sub.plan.nickname === 'Complimentary'));
+
+            if (frame.data.members[0].comped !== undefined && (frame.data.members[0].comped !== compedSubscriptions)) {
+                const hasCompedSubscription = !!(compedSubscriptions.length);
+
+                if (frame.data.members[0].comped && !hasCompedSubscription) {
+                    await membersService.api.members.setComplimentarySubscription(member);
+                } else if (!(frame.data.members[0].comped) && hasCompedSubscription) {
+                    await membersService.api.members.cancelComplimentarySubscription(member);
+                }
+            }
+
             return member;
         }
     },

--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -20,14 +20,14 @@ const decorateWithSubscriptions = async function (member) {
 
 const listMembers = async function (options) {
     const res = (await models.Member.findPage(options));
-    const members = res.data.map(model => model.toJSON(options));
+    const memberModels = res.data.map(model => model.toJSON(options));
 
-    const membersWithSubscriptions = await Promise.all(members.map(async function (member) {
-        decorateWithSubscriptions(member);
+    const members = await Promise.all(memberModels.map(async function (member) {
+        return decorateWithSubscriptions(member);
     }));
 
     return {
-        members: membersWithSubscriptions,
+        members: members,
         meta: res.meta
     };
 };
@@ -59,25 +59,17 @@ const members = {
         validation: {},
         permissions: true,
         async query(frame) {
-            let member = await models.Member.findOne(frame.data, frame.options);
+            let model = await models.Member.findOne(frame.data, frame.options);
 
-            if (!member) {
+            if (!model) {
                 throw new common.errors.NotFoundError({
                     message: common.i18n.t('errors.api.members.memberNotFound')
                 });
             }
 
-            // NOTE: this logic is here until relations between Members/MemberStripeCustomer/StripeCustomerSubscription
-            //       are in place
-            const subscriptions = await membersService.api.members.getStripeSubscriptions(member);
-            member = member.toJSON(frame.options);
-            Object.assign(member, {
-                stripe: {
-                    subscriptions
-                }
-            });
+            const member = model.toJSON(frame.options);
 
-            return member;
+            return decorateWithSubscriptions(member);
         }
     },
 
@@ -101,13 +93,15 @@ const members = {
         permissions: true,
         async query(frame) {
             try {
-                const member = await models.Member.add(frame.data.members[0], frame.options);
+                const model = await models.Member.add(frame.data.members[0], frame.options);
 
                 if (frame.options.send_email) {
-                    await membersService.api.sendEmailWithMagicLink(member.get('email'), frame.options.email_type);
+                    await membersService.api.sendEmailWithMagicLink(model.get('email'), frame.options.email_type);
                 }
 
-                return member;
+                const member = model.toJSON(frame.options);
+
+                return decorateWithSubscriptions(member);
             } catch (error) {
                 if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
                     throw new common.errors.ValidationError({message: common.i18n.t('errors.api.members.memberAlreadyExists')});
@@ -133,22 +127,24 @@ const members = {
         },
         permissions: true,
         async query(frame) {
-            const member = await models.Member.edit(frame.data.members[0], frame.options);
+            const model = await models.Member.edit(frame.data.members[0], frame.options);
 
-            const subscriptions = await membersService.api.members.getStripeSubscriptions(member);
+            const subscriptions = await membersService.api.members.getStripeSubscriptions(model);
             const compedSubscriptions = subscriptions.filter(sub => (sub.plan.nickname === 'Complimentary'));
 
             if (frame.data.members[0].comped !== undefined && (frame.data.members[0].comped !== compedSubscriptions)) {
                 const hasCompedSubscription = !!(compedSubscriptions.length);
 
                 if (frame.data.members[0].comped && !hasCompedSubscription) {
-                    await membersService.api.members.setComplimentarySubscription(member);
+                    await membersService.api.members.setComplimentarySubscription(model);
                 } else if (!(frame.data.members[0].comped) && hasCompedSubscription) {
-                    await membersService.api.members.cancelComplimentarySubscription(member);
+                    await membersService.api.members.cancelComplimentarySubscription(model);
                 }
             }
 
-            return member;
+            const member = model.toJSON(frame.options);
+
+            return decorateWithSubscriptions(member);
         }
     },
 

--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -129,20 +129,20 @@ const members = {
         async query(frame) {
             const model = await models.Member.edit(frame.data.members[0], frame.options);
 
-            const subscriptions = await membersService.api.members.getStripeSubscriptions(model);
+            const member = model.toJSON(frame.options);
+
+            const subscriptions = await membersService.api.members.getStripeSubscriptions(member);
             const compedSubscriptions = subscriptions.filter(sub => (sub.plan.nickname === 'Complimentary'));
 
             if (frame.data.members[0].comped !== undefined && (frame.data.members[0].comped !== compedSubscriptions)) {
                 const hasCompedSubscription = !!(compedSubscriptions.length);
 
                 if (frame.data.members[0].comped && !hasCompedSubscription) {
-                    await membersService.api.members.setComplimentarySubscription(model);
+                    await membersService.api.members.setComplimentarySubscription(member);
                 } else if (!(frame.data.members[0].comped) && hasCompedSubscription) {
-                    await membersService.api.members.cancelComplimentarySubscription(model);
+                    await membersService.api.members.cancelComplimentarySubscription(member);
                 }
             }
-
-            const member = model.toJSON(frame.options);
 
             return decorateWithSubscriptions(member);
         }

--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -6,7 +6,10 @@ module.exports = {
     browse(data, apiConfig, frame) {
         debug('browse');
 
-        frame.response = mapper.mapMember(data, frame);
+        frame.response = {
+            members: data.members.map(member => mapper.mapMember(member, frame)),
+            meta: data.meta
+        };
     },
 
     add(data, apiConfig, frame) {

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -142,6 +142,18 @@ const mapAction = (model, frame) => {
 
 const mapMember = (model, frame) => {
     const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
+
+    if (_.get(jsonModel, 'stripe.subscriptions')) {
+        let compedSubscriptions = _.get(jsonModel, 'stripe.subscriptions').filter(sub => (sub.plan.nickname === 'Complimentary'));
+        const hasCompedSubscription = !!(compedSubscriptions.length);
+
+        // NOTE: `frame.options.fields` has to be taken into account in the same way as for `stripe.subscriptions`
+        //       at the moment of implementation fields were not fully supported by members endpoints
+        Object.assign(jsonModel, {
+            comped: hasCompedSubscription
+        });
+    }
+
     return jsonModel;
 };
 

--- a/core/server/api/canary/utils/validators/input/schemas/members-edit.json
+++ b/core/server/api/canary/utils/validators/input/schemas/members-edit.json
@@ -28,6 +28,9 @@
                 "subscribed": {
                     "type": "boolean"
                 },
+                "comped": {
+                    "type": "boolean"
+                },
                 "id": {
                     "strip": true
                 },

--- a/core/server/api/canary/utils/validators/input/schemas/members.json
+++ b/core/server/api/canary/utils/validators/input/schemas/members.json
@@ -28,6 +28,9 @@
                 "subscribed": {
                     "type": "boolean"
                 },
+                "comped": {
+                    "strip": "true"
+                },
                 "id": {
                     "strip": true
                 },

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -5,6 +5,13 @@ const crypto = require('crypto');
 const common = require('../../lib/common');
 const urlUtils = require('../../lib/url-utils');
 
+const COMPLIMENTARY_PLAN = {
+    name: 'Complimentary',
+    currency: 'usd',
+    interval: 'year',
+    amount: '0'
+};
+
 // NOTE: the function is an exact duplicate of one in GhostMailer should be extracted
 //       into a common lib once it needs to be reused anywhere else again
 function getDomain() {
@@ -43,6 +50,8 @@ function getStripePaymentConfig() {
     if (!stripePaymentProcessor.config.public_token || !stripePaymentProcessor.config.secret_token) {
         return null;
     }
+
+    stripePaymentProcessor.config.plans.push(COMPLIMENTARY_PLAN);
 
     const webhookHandlerUrl = new URL('/members/webhooks/stripe', siteUrl);
 

--- a/core/test/regression/api/canary/admin/members_spec.js
+++ b/core/test/regression/api/canary/admin/members_spec.js
@@ -166,7 +166,7 @@ describe('Members API', function () {
                         should.exist(jsonResponse);
                         should.exist(jsonResponse.members);
                         jsonResponse.members.should.have.length(1);
-                        localUtils.API.checkResponse(jsonResponse.members[0], 'member');
+                        localUtils.API.checkResponse(jsonResponse.members[0], 'member', 'stripe');
                         jsonResponse.members[0].name.should.equal(memberChanged.name);
                         jsonResponse.members[0].email.should.not.equal(memberChanged.email);
                         jsonResponse.members[0].email.should.equal(memberToChange.email);
@@ -175,7 +175,7 @@ describe('Members API', function () {
     });
 
     // NOTE: this test should be enabled and expanded once test suite fully supports Stripe mocking
-    it.skp('Can set a "Complimentary" subscription', function () {
+    it.skip('Can set a "Complimentary" subscription', function () {
         const memberToChange = {
             name: 'Comped Member',
             email: 'member2comp@test.com'
@@ -217,7 +217,7 @@ describe('Members API', function () {
                         should.exist(jsonResponse);
                         should.exist(jsonResponse.members);
                         jsonResponse.members.should.have.length(1);
-                        localUtils.API.checkResponse(jsonResponse.members[0], 'member');
+                        localUtils.API.checkResponse(jsonResponse.members[0], 'member', 'stripe');
                         jsonResponse.members[0].name.should.equal(memberToChange.name);
                         jsonResponse.members[0].email.should.equal(memberToChange.email);
                         jsonResponse.members[0].comped.should.equal(memberToChange.comped);

--- a/core/test/regression/api/canary/admin/utils.js
+++ b/core/test/regression/api/canary/admin/utils.js
@@ -55,6 +55,7 @@ const expectedProperties = {
     ,
     member: _(schema.members)
         .keys()
+        .concat('comped')
     ,
     role: _(schema.roles)
         .keys()

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nexes/nql": "0.3.0",
     "@sentry/node": "5.11.1",
     "@tryghost/helpers": "1.1.22",
-    "@tryghost/members-api": "0.11.2",
+    "@tryghost/members-api": "0.12.0",
     "@tryghost/members-ssr": "0.7.4",
     "@tryghost/social-urls": "0.1.5",
     "@tryghost/string": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,10 +316,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.11.2.tgz#7cb957792231fadcb4e01520a57fbe8865cc10db"
-  integrity sha512-ntFfYJK3E2WJtJDlgUFOZ/7TKR1u71iNcV3lBfIkj/rpxfXGvW/SnU08sLxxieTFmYK/xJAWdrIE9vYJmuTlhw==
+"@tryghost/members-api@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.12.0.tgz#f3b32d8216a5bfc6c4c5404634ff661a86848548"
+  integrity sha512-qQAFr+QcedQDWWUaxuDC1XI3Kgcq28fj0bCOY+FqkXgSmec0A6x6glps+GY/gzQF6FfH7GBrRByJ0a+wriIqog==
   dependencies:
     "@tryghost/magic-link" "^0.3.3"
     bluebird "^3.5.4"


### PR DESCRIPTION
refs https://github.com/TryGhost/Members/pull/118

TODO:
- [x] "Complimentary" plan migrations
  - [x] review from 2 people!
  - [x] put "Complimentary" plan into https://github.com/TryGhost/Ghost/blob/90d582c/core/server/services/members/config.js#L32 method instead of migration
- [x] accept&handle `comped` flag to set/unset "Complimentary" subscriptions
- [x] return `comped` flag from members endpoints
- [x] protection from cancelling/setting Complimentary subscription from public enpoints
- [x] bump @tryghost/members-api version to support `members.setComplimentarySubscription` & `members.cancelComplimentarySubscription` methods
