### PR TITLE
Improve reliability of Mocha tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -117,6 +117,7 @@ const configureGrunt = function (grunt) {
                 timeout: '30000',
                 save: grunt.option('reporter-output'),
                 require: ['core/server/overrides'],
+                retries: '3',
                 exit: true
             },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,7 +114,7 @@ const configureGrunt = function (grunt) {
             options: {
                 ui: 'bdd',
                 reporter: grunt.option('reporter') || 'spec',
-                timeout: '30000',
+                timeout: '60000',
                 save: grunt.option('reporter-output'),
                 require: ['core/server/overrides'],
                 retries: '3',


### PR DESCRIPTION
no issue

retries:
- we occasionally see random errors which fail tests
- this is a problem because it's blocking us seeing which tests are
  really failing
- for now, retry the tests 3 times to overcome the intermittent problem
  until a better solution is found

timeout:
- allow for random platform delays in tests