### PR TITLE
Migrated redirects.json into the settings table.

### DIFF
--- a/core/frontend/services/redirects/index.js
+++ b/core/frontend/services/redirects/index.js
@@ -1,8 +1,4 @@
 module.exports = {
-    init: function () {
-        return this.settings.migrate();
-    },
-
     get settings() {
         return require('./settings');
     },

--- a/core/frontend/services/redirects/index.js
+++ b/core/frontend/services/redirects/index.js
@@ -1,4 +1,8 @@
 module.exports = {
+    init: function () {
+        return this.settings.migrate();
+    },
+
     get settings() {
         return require('./settings');
     },

--- a/core/frontend/services/redirects/settings.js
+++ b/core/frontend/services/redirects/settings.js
@@ -1,10 +1,8 @@
 const fs = require('fs-extra');
-const path = require('path');
 const Promise = require('bluebird');
 
 const validation = require('./validation');
 
-const config = require('../../../server/config');
 const common = require('../../../server/lib/common');
 const models = require('../../../server/models');
 const settingsCache = require('../../../server/services/settings/cache');
@@ -52,37 +50,5 @@ const get = () => {
     return settingsCache.get('redirects');
 };
 
-const REDIRECTS_DEPRECATION_NOTICE = 
-`Editing the redirects.json file directly is no longer supported.
-To make redirect.json changes, please download it from the Ghost Admin panel, instead.
-Once your changes are done, you will need to upload it to the Admin panel for the changes to take effect.
-TODO: link PR/issue here.`;
-
-// redirects used to be stored in a redirects.json file on disc. we migrated it to the 'settings' table.
-// if we are coming from an older version of Ghost, we want to read it into that table, and also
-// write a notice file to make those rare few that edit the file directly aware that we no longer read it.
-// in any case, redirects should probably be done in the NGINX layer. see https://github.com/TryGhost/Ghost/issues/7707
-const migrate = () => {
-    const redirectsPath = path.join(config.getContentPath('data'), 'redirects.json');
-    const warningPath = path.join(config.getContentPath('data'), 'REDIRECTS_DEPRECATION_NOTICE.txt');
-
-    return fs.pathExists(redirectsPath)
-        .then((exists) => {
-            if (!exists) {
-                return null;
-            }
-
-            return readRedirectsFile(redirectsPath)
-                .then((redirects) => {
-                    return models.Settings.edit({
-                        key: 'redirects',
-                        value: JSON.stringify(redirects)
-                    });
-                })
-                .then(fs.writeFile(warningPath, REDIRECTS_DEPRECATION_NOTICE));
-        });
-};
-
 module.exports.get = get;
-module.exports.migrate = migrate;
 module.exports.setFromFilePath = setFromFilePath;

--- a/core/frontend/services/redirects/settings.js
+++ b/core/frontend/services/redirects/settings.js
@@ -1,12 +1,13 @@
 const fs = require('fs-extra');
 const path = require('path');
 const Promise = require('bluebird');
-const moment = require('moment-timezone');
 
 const validation = require('./validation');
 
 const config = require('../../../server/config');
 const common = require('../../../server/lib/common');
+const models = require('../../../server/models');
+const settingsCache = require('../../../server/services/settings/cache');
 
 const readRedirectsFile = (redirectsPath) => {
     return fs.readFile(redirectsPath, 'utf-8')
@@ -37,8 +38,33 @@ const readRedirectsFile = (redirectsPath) => {
 };
 
 const setFromFilePath = (filePath) => {
+    return readRedirectsFile(filePath)
+        .then((content) => {
+            validation.validate(content);
+            return models.Settings.edit({
+                key: 'redirects',
+                value: JSON.stringify(content)
+            });
+        });
+};
+
+const get = () => {
+    return settingsCache.get('redirects');
+};
+
+const REDIRECTS_DEPRECATION_NOTICE = 
+`Editing the redirects.json file directly is no longer supported.
+To make redirect.json changes, please download it from the Ghost Admin panel, instead.
+Once your changes are done, you will need to upload it to the Admin panel for the changes to take effect.
+TODO: link PR/issue here.`;
+
+// redirects used to be stored in a redirects.json file on disc. we migrated it to the 'settings' table.
+// if we are coming from an older version of Ghost, we want to read it into that table, and also
+// write a notice file to make those rare few that edit the file directly aware that we no longer read it.
+// in any case, redirects should probably be done in the NGINX layer. see https://github.com/TryGhost/Ghost/issues/7707
+const migrate = () => {
     const redirectsPath = path.join(config.getContentPath('data'), 'redirects.json');
-    const backupRedirectsPath = path.join(config.getContentPath('data'), `redirects-${moment().format('YYYY-MM-DD-HH-mm-ss')}.json`);
+    const warningPath = path.join(config.getContentPath('data'), 'REDIRECTS_DEPRECATION_NOTICE.txt');
 
     return fs.pathExists(redirectsPath)
         .then((exists) => {
@@ -46,30 +72,17 @@ const setFromFilePath = (filePath) => {
                 return null;
             }
 
-            return fs.pathExists(backupRedirectsPath)
-                .then((exists) => {
-                    if (!exists) {
-                        return null;
-                    }
-
-                    return fs.unlink(backupRedirectsPath);
+            return readRedirectsFile(redirectsPath)
+                .then((redirects) => {
+                    return models.Settings.edit({
+                        key: 'redirects',
+                        value: JSON.stringify(redirects)
+                    });
                 })
-                .then(() => {
-                    return fs.move(redirectsPath, backupRedirectsPath);
-                });
-        })
-        .then(() => {
-            return readRedirectsFile(filePath)
-                .then((content) => {
-                    validation.validate(content);
-                    return fs.writeFile(redirectsPath, JSON.stringify(content), 'utf-8');
-                });
+                .then(fs.writeFile(warningPath, REDIRECTS_DEPRECATION_NOTICE));
         });
 };
 
-const get = () => {
-    return readRedirectsFile(path.join(config.getContentPath('data'), 'redirects.json'));
-};
-
 module.exports.get = get;
+module.exports.migrate = migrate;
 module.exports.setFromFilePath = setFromFilePath;

--- a/core/server/data/migrations/versions/3.4/01-move-redirects-json-to-settings-table.js
+++ b/core/server/data/migrations/versions/3.4/01-move-redirects-json-to-settings-table.js
@@ -1,0 +1,68 @@
+const fs = require('fs-extra');
+const path = require('path');
+const common = require('../../../../lib/common');
+const config = require('../../../../config');
+const models = require('../../../../models');
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+    up() {
+        const contentDataPath = config.getContentPath('data');
+        const redirectsPath = path.join(contentDataPath, 'redirects.json');
+        const backupPath = path.join(contentDataPath, 'redirects-backup.json');
+
+        common.logging.info('Migrating redirects.json into \'settings\' database table.');
+
+        return fs.readFile(redirectsPath, 'utf8')
+            .then((content) => {
+                let parsedContent;
+                try {
+                    parsedContent = JSON.parse(content);
+                } catch (err) {
+                    common.logging.warn('Failed to parse existing redirects.json, skipping migration.');
+                }
+
+                if (parsedContent) {
+                    return models.Settings.edit({
+                        key: 'redirects',
+                        value: JSON.stringify(parsedContent)
+                    });
+                }
+            })
+            .then(() => {
+                return fs.copy(redirectsPath, backupPath);
+            })
+            .then(() => {
+                return fs.remove(redirectsPath);
+            })
+            .catch({code: 'ENOENT'}, () => {
+                common.logging.info('No redirects.json found, skipping migration.');
+            })
+            .catch(() => {
+                common.logging.warn('Error migrating redirects.json, please verify redirect settings are correct via Admin panel after this upgrade.');
+            });
+    },
+    down() {
+        const contentDataPath = config.getContentPath('data');
+        const redirectsPath = path.join(contentDataPath, 'redirects.json');
+        const backupPath = path.join(contentDataPath, 'redirects-backup.json');
+
+        common.logging.info('Rollback: re-creating redirects.json from backup.');
+
+        return fs.readFile(backupPath, 'utf8')
+            .then(() => {
+                return fs.copy(backupPath, redirectsPath);
+            })
+            .then(() => {
+                return fs.remove(backupPath);
+            })
+            .catch({code: 'ENOENT'}, () => {
+                common.logging.info('Skipping rollback: no redirects-backup.json found');
+            })
+            .catch(() => {
+                common.logging.warn('Trouble re-creating redirects.json, please ensure redirects are correct after rollback.');
+            });
+    }
+};

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -101,7 +101,7 @@
             "defaultValue": "[]"
         },
         "redirects": {
-            "defaultValue": null
+            "defaultValue": "[]"
         },
         "slack": {
             "defaultValue": "[{\"url\":\"\", \"username\":\"Ghost\"}]"

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -100,6 +100,9 @@
         "secondary_navigation": {
             "defaultValue": "[]"
         },
+        "redirects": {
+            "defaultValue": null
+        },
         "slack": {
             "defaultValue": "[{\"url\":\"\", \"username\":\"Ghost\"}]"
         },

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -84,6 +84,7 @@ const minimalRequiredSetupToStartGhost = (dbState) => {
 
     // Frontend
     const frontendSettings = require('../frontend/services/settings');
+    const frontendRedirects = require('../frontend/services/redirects');
 
     let ghostServer;
 
@@ -97,11 +98,14 @@ const minimalRequiredSetupToStartGhost = (dbState) => {
     return settings.init()
         .then(() => {
             debug('Settings done');
-
             return frontendSettings.init();
         })
         .then(() => {
             debug('Frontend settings done');
+            return frontendRedirects.init();
+        })
+        .then(() => {
+            debug('Frontend redirects done');
             return themeService.init();
         })
         .then(() => {

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -84,7 +84,6 @@ const minimalRequiredSetupToStartGhost = (dbState) => {
 
     // Frontend
     const frontendSettings = require('../frontend/services/settings');
-    const frontendRedirects = require('../frontend/services/redirects');
 
     let ghostServer;
 
@@ -102,10 +101,6 @@ const minimalRequiredSetupToStartGhost = (dbState) => {
         })
         .then(() => {
             debug('Frontend settings done');
-            return frontendRedirects.init();
-        })
-        .then(() => {
-            debug('Frontend redirects done');
             return themeService.init();
         })
         .then(() => {

--- a/core/test/unit/models/settings_spec.js
+++ b/core/test/unit/models/settings_spec.js
@@ -114,7 +114,7 @@ describe('Unit: models/settings', function () {
             return models.Settings.populateDefaults()
                 .then(() => {
                     // 2 events per item - settings.added and settings.[name].added
-                    eventSpy.callCount.should.equal(88);
+                    eventSpy.callCount.should.equal(90);
                     const eventsEmitted = eventSpy.args.map(args => args[0]);
                     const checkEventEmitted = event => should.ok(eventsEmitted.includes(event), `${event} event should be emitted`);
 
@@ -137,7 +137,7 @@ describe('Unit: models/settings', function () {
             return models.Settings.populateDefaults()
                 .then(() => {
                     // 2 events per item - settings.added and settings.[name].added
-                    eventSpy.callCount.should.equal(86);
+                    eventSpy.callCount.should.equal(88);
 
                     eventSpy.args[13][0].should.equal('settings.logo.added');
                 });


### PR DESCRIPTION
## Template
no issue (currently)

See https://forum.ghost.org/t/request-for-maintainer-feedback-towards-stateless-ghost/11665. We move the redirects.json into the settings table to allow Ghost to be run in a more stateless fashion.

- [X] There's a clear use-case for this code change
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `yarn test` and `yarn lint`)

## Approach
In the changes here, I migrate the `redirects.json`, migrating at startup the first time these new changes are deployed, via the existing schema migration framework, which has previously been used for similar data migrations (see `4-permalink-settings.js`). I do this partly because #7707 mentioned wanting to move towards that when `redirects.json` was originally added.