### PR TITLE
Fixed double builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ services:
 - mysql
 # Don't run builds for renovate PRs
 if: NOT head_branch =~ ^renovate
+branches:
+  only:
+    - master
+    - 2.x
 env:
   matrix:
   - DB=sqlite3 NODE_ENV=testing


### PR DESCRIPTION
no issue

- Travis builds were being run twice on a PR: once for the PR and once
  for the branch
- this commit whitelists the branches that Travis can run on