### PR TITLE
✨ Added member signin link generation option

### DIFF
--- a/core/server/api/canary/index.js
+++ b/core/server/api/canary/index.js
@@ -71,6 +71,10 @@ module.exports = {
         return shared.pipeline(require('./members'), localUtils);
     },
 
+    get membersSigninUrl() {
+        return shared.pipeline(require('./membersSigninUrl.js'), localUtils);
+    },
+
     get labels() {
         return shared.pipeline(require('./labels'), localUtils);
     },

--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -110,6 +110,9 @@ const members = {
 
     read: {
         headers: {},
+        options: [
+            'magic_link'
+        ],
         data: [
             'id',
             'email'

--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -133,13 +133,17 @@ const members = {
                 }
             }
         },
-        permissions: (frame) => {
-            return models.User.findOne({role: 'Owner', status: 'all'})
-                .then((owner) => {
-                    if (owner.id !== frame.options.context.user) {
-                        throw new common.errors.NoPermissionError({message: common.i18n.t('errors.api.authentication.notTheBlogOwner')});
-                    }
-                });
+        permissions: {
+            before: (frame) => {
+                if ((_.get(frame, 'original.query.include') || '').includes('signin_url')) {
+                    return models.User.findOne({role: 'Owner', status: 'all'})
+                        .then((owner) => {
+                            if (owner.id !== frame.options.context.user) {
+                                throw new common.errors.NoPermissionError({message: common.i18n.t('errors.api.authentication.notTheBlogOwner')});
+                            }
+                        });
+                }
+            }
         },
         async query(frame) {
             let model = await models.Member.findOne(frame.data, frame.options);

--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -110,9 +110,6 @@ const members = {
 
     read: {
         headers: {},
-        options: [
-            'magic_link'
-        ],
         data: [
             'id',
             'email'

--- a/core/server/api/canary/membersSigninUrl.js
+++ b/core/server/api/canary/membersSigninUrl.js
@@ -1,0 +1,29 @@
+const models = require('../../models');
+const common = require('../../lib/common');
+const membersService = require('../../services/members');
+
+module.exports = {
+    docName: 'member_signins',
+    permissions: true,
+    read: {
+        data: [
+            'id'
+        ],
+        permissions: true,
+        async query(frame) {
+            let model = await models.Member.findOne(frame.data, frame.options);
+
+            if (!model) {
+                throw new common.errors.NotFoundError({
+                    message: common.i18n.t('errors.api.members.memberNotFound')
+                });
+            }
+
+            const magicLink = membersService.api.getMagicLink(model.get('email'));
+
+            return {
+                url: magicLink
+            };
+        }
+    }
+};

--- a/core/server/api/canary/utils/serializers/input/members.js
+++ b/core/server/api/canary/utils/serializers/input/members.js
@@ -13,9 +13,19 @@ function defaultRelations(frame) {
     frame.options.withRelated = ['labels'];
 }
 
+function removeSigninLinkRelation(frame) {
+    if (!frame.options.withRelated) {
+        return;
+    }
+
+    frame.options.withRelated = frame.options.withRelated.filter(relation => (relation === 'signin_link'));
+}
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
+
+        removeSigninLinkRelation(frame);
         defaultRelations(frame);
     },
 
@@ -36,11 +46,13 @@ module.exports = {
                 }
             });
         }
+
+        removeSigninLinkRelation(frame);
         defaultRelations(frame);
     },
 
-    edit(apiConfig, frame) {
+    edit() {
         debug('edit');
-        this.add(apiConfig, frame);
+        this.add(...arguments);
     }
 };

--- a/core/server/api/canary/utils/serializers/output/index.js
+++ b/core/server/api/canary/utils/serializers/output/index.js
@@ -63,6 +63,10 @@ module.exports = {
         return require('./members');
     },
 
+    get member_signins() {
+        return require('./member-signins');
+    },
+
     get images() {
         return require('./images');
     },

--- a/core/server/api/canary/utils/serializers/output/member-signins.js
+++ b/core/server/api/canary/utils/serializers/output/member-signins.js
@@ -1,0 +1,7 @@
+module.exports = {
+    read(data, apiConfig, frame) {
+        frame.response = {
+            member_signins: [data]
+        };
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -50,7 +50,7 @@ module.exports = {
         const fields = ['id', 'email', 'name', 'note', 'subscribed_to_emails', 'complimentary_plan', 'stripe_customer_id', 'created_at', 'deleted_at', 'labels'];
 
         models.members = models.members.map((member) => {
-            member = mapper.mapMember(member);
+            member = mapper.mapMember(member, frame);
             let stripeCustomerId;
 
             if (member.stripe) {

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -154,7 +154,7 @@ const mapMember = (model, frame) => {
         });
     }
 
-    if (frame.options && frame.options.magic_link) {
+    if (!utils.isContentAPI(frame)) {
         const membersService = require('../../../../../../services/members');
 
         const magicLink = membersService.api.getMagicLink(jsonModel.email);

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -154,6 +154,15 @@ const mapMember = (model, frame) => {
         });
     }
 
+    if (frame.options && frame.options.magic_link) {
+        const membersService = require('../../../../../../services/members');
+
+        const magicLink = membersService.api.getMagicLink(jsonModel.email);
+        Object.assign(jsonModel, {
+            magic_link: magicLink
+        });
+    }
+
     return jsonModel;
 };
 

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -154,7 +154,7 @@ const mapMember = (model, frame) => {
         });
     }
 
-    if (!utils.isContentAPI(frame)) {
+    if (!utils.isContentAPI(frame) && (_.get(frame, 'original.query.include') || '').includes('signin_url')) {
         const membersService = require('../../../../../../services/members');
 
         const magicLink = membersService.api.getMagicLink(jsonModel.email);

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -159,7 +159,7 @@ const mapMember = (model, frame) => {
 
         const magicLink = membersService.api.getMagicLink(jsonModel.email);
         Object.assign(jsonModel, {
-            magic_link: magicLink
+            signin_url: magicLink
         });
     }
 

--- a/core/server/api/canary/utils/validators/input/schemas/members-edit.json
+++ b/core/server/api/canary/utils/validators/input/schemas/members-edit.json
@@ -40,7 +40,7 @@
                 "labels": {
                     "$ref": "members#/definitions/member-labels"
                 },
-                "magic_link": {
+                "signin_url": {
                     "strip": "true"
                 },
                 "created_at": {

--- a/core/server/api/canary/utils/validators/input/schemas/members-edit.json
+++ b/core/server/api/canary/utils/validators/input/schemas/members-edit.json
@@ -40,6 +40,9 @@
                 "labels": {
                     "$ref": "members#/definitions/member-labels"
                 },
+                "magic_link": {
+                    "strip": "true"
+                },
                 "created_at": {
                     "strip": true
                 },

--- a/core/server/api/canary/utils/validators/input/schemas/members.json
+++ b/core/server/api/canary/utils/validators/input/schemas/members.json
@@ -34,7 +34,7 @@
                 "comped": {
                     "strip": "true"
                 },
-                "magic_link": {
+                "signin_url": {
                     "strip": "true"
                 },
                 "id": {

--- a/core/server/api/canary/utils/validators/input/schemas/members.json
+++ b/core/server/api/canary/utils/validators/input/schemas/members.json
@@ -34,6 +34,9 @@
                 "comped": {
                     "strip": "true"
                 },
+                "magic_link": {
+                    "strip": "true"
+                },
                 "id": {
                     "strip": true
                 },

--- a/core/server/data/migrations/versions/3.8/1-add-member-sigin-url-permissions.js
+++ b/core/server/data/migrations/versions/3.8/1-add-member-sigin-url-permissions.js
@@ -1,0 +1,58 @@
+const _ = require('lodash');
+const utils = require('../../../schema/fixtures/utils');
+const permissions = require('../../../../services/permissions');
+const logging = require('../../../../lib/common/logging');
+
+const resources = ['member_signin'];
+const _private = {};
+
+_private.getPermissions = function getPermissions(resource) {
+    return utils.findModelFixtures('Permission', {object_type: resource});
+};
+
+_private.getRelations = function getRelations(resource) {
+    return utils.findPermissionRelationsForObject(resource);
+};
+
+_private.printResult = function printResult(result, message) {
+    if (result.done === result.expected) {
+        logging.info(message);
+    } else {
+        logging.warn(`(${result.done}/${result.expected}) ${message}`);
+    }
+};
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    const localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+
+    return Promise.map(resources, (resource) => {
+        const modelToAdd = _private.getPermissions(resource);
+        const relationToAdd = _private.getRelations(resource);
+
+        return utils.addFixturesForModel(modelToAdd, localOptions)
+            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}s`))
+            .then(() => utils.addFixturesForRelation(relationToAdd, localOptions))
+            .then(result => _private.printResult(result, `Adding permissions_roles fixtures for ${resource}s`))
+            .then(() => permissions.init(localOptions));
+    });
+};
+
+module.exports.down = (options) => {
+    const localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+
+    return Promise.map(resources, (resource) => {
+        const modelToRemove = _private.getPermissions(resource);
+
+        // permission model automatically cleans up permissions_roles on .destroy()
+        return utils.removeFixturesForModel(modelToRemove, localOptions)
+            .then(result => _private.printResult(result, `Removing permissions fixtures for ${resource}s`));
+    });
+};

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -412,6 +412,11 @@
                     "name": "Delete labels",
                     "action_type": "destroy",
                     "object_type": "label"
+                },
+                {
+                    "name": "Read member signin url",
+                    "action_type": "read",
+                    "object_type": "member_signin"
                 }
             ]
         },

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -100,6 +100,8 @@ module.exports = function apiRoutes() {
     router.put('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.edit));
     router.del('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.destroy));
 
+    router.get('/members/:id/signin_url', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.membersSigninUrl.read));
+
     // ## Labels
     router.get('/labels', mw.authAdminApi, http(apiCanary.labels.browse));
     router.get('/labels/:id', mw.authAdminApi, http(apiCanary.labels.read));

--- a/core/test/regression/api/canary/admin/members_spec.js
+++ b/core/test/regression/api/canary/admin/members_spec.js
@@ -74,6 +74,23 @@ describe('Members API', function () {
             });
     });
 
+    it('Can read with a magic_link', function () {
+        return request
+            .get(localUtils.API.getApiQuery(`members/${testUtils.DataGenerator.Content.members[0].id}/?magic_link=true`))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.members);
+                jsonResponse.members.should.have.length(1);
+                localUtils.API.checkResponse(jsonResponse.members[0], 'member', ['stripe', 'magic_link']);
+            });
+    });
+
     it('Can add', function () {
         const member = {
             name: 'test',

--- a/core/test/regression/api/canary/admin/members_spec.js
+++ b/core/test/regression/api/canary/admin/members_spec.js
@@ -74,6 +74,23 @@ describe('Members API', function () {
             });
     });
 
+    it('Can read member with signin_url', function () {
+        return request
+            .get(localUtils.API.getApiQuery(`members/${testUtils.DataGenerator.Content.members[0].id}/?include=signin_url`))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.members);
+                jsonResponse.members.should.have.length(1);
+                localUtils.API.checkResponse(jsonResponse.members[0], 'member', ['stripe', 'signin_url'], ['labels']);
+            });
+    });
+
     it('Can add', function () {
         const member = {
             name: 'test',

--- a/core/test/regression/api/canary/admin/members_spec.js
+++ b/core/test/regression/api/canary/admin/members_spec.js
@@ -74,23 +74,6 @@ describe('Members API', function () {
             });
     });
 
-    it('Can read with a magic_link', function () {
-        return request
-            .get(localUtils.API.getApiQuery(`members/${testUtils.DataGenerator.Content.members[0].id}/?magic_link=true`))
-            .set('Origin', config.get('url'))
-            .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(200)
-            .then((res) => {
-                should.not.exist(res.headers['x-cache-invalidate']);
-                const jsonResponse = res.body;
-                should.exist(jsonResponse);
-                should.exist(jsonResponse.members);
-                jsonResponse.members.should.have.length(1);
-                localUtils.API.checkResponse(jsonResponse.members[0], 'member', ['stripe', 'magic_link']);
-            });
-    });
-
     it('Can add', function () {
         const member = {
             name: 'test',

--- a/core/test/regression/api/canary/admin/utils.js
+++ b/core/test/regression/api/canary/admin/utils.js
@@ -58,6 +58,7 @@ const expectedProperties = {
         .concat('avatar_image')
         .concat('comped')
         .concat('labels')
+        .concat('magic_link')
     ,
     role: _(schema.roles)
         .keys()

--- a/core/test/regression/api/canary/admin/utils.js
+++ b/core/test/regression/api/canary/admin/utils.js
@@ -58,7 +58,6 @@ const expectedProperties = {
         .concat('avatar_image')
         .concat('comped')
         .concat('labels')
-        .concat('signin_url')
     ,
     role: _(schema.roles)
         .keys()

--- a/core/test/regression/api/canary/admin/utils.js
+++ b/core/test/regression/api/canary/admin/utils.js
@@ -58,7 +58,7 @@ const expectedProperties = {
         .concat('avatar_image')
         .concat('comped')
         .concat('labels')
-        .concat('magic_link')
+        .concat('signin_url')
     ,
     role: _(schema.roles)
         .keys()

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -20,7 +20,7 @@ var should = require('should'),
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '4d65d73126e314a8c05e98990a992201';
-    const currentFixturesHash = '0ca1c9a6d3dab21d8a1e0b6a988fd83f';
+    const currentFixturesHash = 'c827723ec992dca8c9878af205aac591';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
- Adds an option to member resource to be fetched with a signin link that could be useful to generate links for Admins
- ~Adds `?signin_url=true` flag support on `GET /members/:id` endpoint~
- Adds `GET /members/:id/sigin_url` endpoint serving new `signin_url` resource

TODO:
- [x] fix validation error when `signin_url` property is posted to `/members/:id` endpoint
- [x] bump @tryghost/members-api package to support new methods