### PR TITLE
Added 'visibility' property check to {{#has}} helper

### DIFF
--- a/core/frontend/helpers/has.js
+++ b/core/frontend/helpers/has.js
@@ -8,7 +8,7 @@ const proxy = require('./proxy');
 const _ = require('lodash');
 const logging = proxy.logging;
 const i18n = proxy.i18n;
-const validAttrs = ['tag', 'author', 'slug', 'id', 'number', 'index', 'any', 'all'];
+const validAttrs = ['tag', 'author', 'slug','visibility', 'id', 'number', 'index', 'any', 'all'];
 
 function handleCount(ctxAttr, data) {
     if (!data || !_.isFinite(data.length)) {
@@ -135,6 +135,9 @@ module.exports = function has(options) {
             },
             index: function () {
                 return attrs.index && evaluateIntegerMatch(attrs.index, options.data.index) || false;
+            },
+            visibility: function () {
+                return attrs.visibility && evaluateStringMatch(attrs.visibility, self.visibility, true) || false;
             },
             slug: function () {
                 return attrs.slug && evaluateStringMatch(attrs.slug, self.slug, true) || false;

--- a/core/test/unit/helpers/has_spec.js
+++ b/core/test/unit/helpers/has_spec.js
@@ -528,6 +528,38 @@ describe('{{#has}} helper', function () {
         });
     });
 
+    describe('visibility match', function () {
+        it('matches on an exact visibility (pass)', function () {
+            thisCtx = {visibility: 'paid'};
+
+            // {{#has visibility="paid"}}
+            callHasHelper(thisCtx, {visibility: 'paid'});
+
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('matches on an exact visibility (fail)', function () {
+            thisCtx = {visibility: 'paid'};
+
+            // {{#has visibility="members"}}
+            callHasHelper(thisCtx, {visibility: 'members'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+
+        it('fails gracefully if there is no visibility (fail)', function () {
+            thisCtx = {};
+
+            // {{#has visibility="welcome-to-ghost"}}
+            callHasHelper(thisCtx, {visibility: 'paid'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+    });
+
     describe('id match', function () {
         it('matches on an exact id (pass)', function () {
             thisCtx = {id: '5981fbed98141579627e9a5a'};


### PR DESCRIPTION
no issue

- Allows for syntax like `{{#has visibility="paid"}}` to be used on Content API resources