### PR TITLE
🐛 Fixed "Unable to update nested relation" error when adding labels to members

### DIFF
--- a/core/server/data/migrations/versions/3.7/01-fix-incorrect-member-labels-foreign-keys.js
+++ b/core/server/data/migrations/versions/3.7/01-fix-incorrect-member-labels-foreign-keys.js
@@ -1,0 +1,46 @@
+const logging = require('../../../../lib/common/logging');
+const commands = require('../../../schema').commands;
+
+const table = 'members_labels';
+const message1 = 'Adding table: ' + table;
+const message2 = 'Dropping table: ' + table;
+
+// 3.6.0 had an incorrect schema definition that created foreign key constraints for the wrong table.
+//
+// The schema.js is correct as of 3.7.0 and members_labels has not been used at this point
+// so it's safe to drop and recreate the table to let knex do it's thing.
+
+const dropTable = function (connection) {
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (!exists) {
+                logging.warn(message2);
+                return;
+            }
+
+            logging.info(message2);
+            return commands.deleteTable(table, connection);
+        });
+};
+
+const addTable = function (connection) {
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (exists) {
+                logging.warn(message1);
+                return;
+            }
+
+            logging.info(message1);
+            return commands.createTable(table, connection);
+        });
+};
+
+module.exports.up = ({connection}) => {
+    return dropTable(connection).then(() => addTable(connection));
+};
+
+// noop
+module.exports.down = () => {
+    return Promise.resolve();
+};

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -344,8 +344,8 @@ module.exports = {
     },
     members_labels: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id'},
-        label_id: {type: 'string', maxlength: 24, nullable: false, references: 'tags.id'},
+        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id'},
+        label_id: {type: 'string', maxlength: 24, nullable: false, references: 'labels.id'},
         sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
     },
     members_stripe_customers: {

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,7 +19,7 @@ var should = require('should'),
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '07054c5c99b34da68c362f7431dedba4';
+    const currentSchemaHash = '4d65d73126e314a8c05e98990a992201';
     const currentFixturesHash = '0ca1c9a6d3dab21d8a1e0b6a988fd83f';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
no issue

- 3.6.0 contained incorrect references in the `schema.js` file for the `members_label` table that was added in that version. On MySQL knex created a foreign key constraint for that reference which stopped member label relationships from being createable
- this commit fixes the schema file and has a migration to drop and recreate the table. Knex handles removal and addition of foreign keys during table drop/create