### PR TITLE
🐛 Fixed incorrect email data for post email

### DIFF
--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -57,7 +57,10 @@ const addEmail = async (postModel, options) => {
     const knexOptions = _.pick(options, ['transacting', 'forUpdate']);
 
     const {members} = await membersService.api.members.list(Object.assign(knexOptions, {filter: 'subscribed:true'}, {limit: 'all'}));
-    const {emailTmpl, emails} = await getEmailData(postModel, members);
+    const membersToSendTo = members.filter((member) => {
+        return membersService.contentGating.checkPostAccess(postModel.toJSON(), member);
+    });
+    const {emailTmpl, emails} = await getEmailData(postModel, membersToSendTo);
 
     // NOTE: don't create email object when there's nobody to send the email to
     if (!emails.length) {


### PR DESCRIPTION
no issue

The email data attached to a post when published with send email flag was not filtered on member access, and picked up the whole member list for email data. This resulted in incorrect data stored in  emails table even in case of paid-members-only publish, and also incorrect count of "emails sent" being displayed on Admin. 

NOTE: The actual emails being sent are still gated by member access, so no emails were sent to anyone without access, this only affected the associated email data and count. Also, the fix here will show correct email sent status for any future post, but will still show incorrect data for any already published posts as the email data in DB is already wrong and will probably need a migration

