### PR TITLE
🐛 Fixed publisher logo meta schema

### DIFF
--- a/core/frontend/meta/schema.js
+++ b/core/frontend/meta/schema.js
@@ -22,6 +22,22 @@ function schemaImageObject(metaDataVal) {
     return imageObject;
 }
 
+function schemaPublisherObject(metaDataVal) {
+    var publisherObject;
+
+    publisherObject = {
+        '@type': 'Organization',
+        name: escapeExpression(metaDataVal.site.title),
+        url: metaDataVal.site.url || null,
+        logo: {
+            '@type': 'ImageObject',
+            url: schemaImageObject(metaDataVal.site.logo) || null
+        }
+    };
+
+    return publisherObject;
+}
+
 // Creates the final schema object with values that are not null
 function trimSchema(schema) {
     var schemaObject = {};
@@ -74,11 +90,7 @@ function getPostSchema(metaData, data) {
     schema = {
         '@context': 'https://schema.org',
         '@type': 'Article',
-        publisher: {
-            '@type': 'Organization',
-            name: escapeExpression(metaData.site.title),
-            logo: schemaImageObject(metaData.site.logo) || null
-        },
+        publisher: schemaPublisherObject(metaData),
         author: {
             '@type': 'Person',
             name: escapeExpression(data[context].primary_author.name),
@@ -110,11 +122,7 @@ function getHomeSchema(metaData) {
     var schema = {
         '@context': 'https://schema.org',
         '@type': 'WebSite',
-        publisher: {
-            '@type': 'Organization',
-            name: escapeExpression(metaData.site.title),
-            logo: schemaImageObject(metaData.site.logo) || null
-        },
+        publisher: schemaPublisherObject(metaData),
         url: metaData.url,
         image: schemaImageObject(metaData.coverImage),
         mainEntityOfPage: {
@@ -132,11 +140,7 @@ function getTagSchema(metaData, data) {
     var schema = {
         '@context': 'https://schema.org',
         '@type': 'Series',
-        publisher: {
-            '@type': 'Organization',
-            name: escapeExpression(metaData.site.title),
-            logo: schemaImageObject(metaData.site.logo) || null
-        },
+        publisher: schemaPublisherObject(metaData),
         url: metaData.url,
         image: schemaImageObject(metaData.coverImage),
         name: data.tag.name,

--- a/core/test/unit/data/meta/schema_spec.js
+++ b/core/test/unit/data/meta/schema_spec.js
@@ -90,11 +90,15 @@ describe('getSchema', function () {
             publisher: {
                 '@type': 'Organization',
                 name: 'Site Title',
+                url: 'http://mysite.com',
                 logo: {
                     '@type': 'ImageObject',
-                    url: 'http://mysite.com/author/image/url/logo.jpg',
-                    width: 500,
-                    height: 500
+                    url: {
+                        '@type': 'ImageObject',
+                        url: 'http://mysite.com/author/image/url/logo.jpg',
+                        width: 500,
+                        height: 500
+                    }
                 }
             },
             url: 'http://mysite.com/post/my-post-slug/'
@@ -190,11 +194,15 @@ describe('getSchema', function () {
             publisher: {
                 '@type': 'Organization',
                 name: 'Site Title',
+                url: 'http://mysite.com',
                 logo: {
                     '@type': 'ImageObject',
-                    url: 'http://mysite.com/author/image/url/logo.jpg',
-                    width: 500,
-                    height: 500
+                    url: {
+                        '@type': 'ImageObject',
+                        url: 'http://mysite.com/author/image/url/logo.jpg',
+                        width: 500,
+                        height: 500
+                    }
                 }
             },
             url: 'http://mysite.com/post/my-page-slug/'
@@ -293,11 +301,15 @@ describe('getSchema', function () {
             publisher: {
                 '@type': 'Organization',
                 name: 'Site Title',
+                url: 'http://mysite.com',
                 logo: {
                     '@type': 'ImageObject',
-                    url: 'http://mysite.com/author/image/url/logo.jpg',
-                    width: 500,
-                    height: 500
+                    url: {
+                        '@type': 'ImageObject',
+                        url: 'http://mysite.com/author/image/url/logo.jpg',
+                        width: 500,
+                        height: 500
+                    }
                 }
             },
             url: 'http://mysite.com/post/my-amp-post-slug/'
@@ -355,7 +367,11 @@ describe('getSchema', function () {
             publisher: {
                 '@type': 'Organization',
                 name: 'Site Title',
-                logo: null
+                url: null,
+                logo: {
+                    '@type': 'ImageObject',
+                    url: null
+                }
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });
@@ -429,7 +445,11 @@ describe('getSchema', function () {
             publisher: {
                 '@type': 'Organization',
                 name: 'Site Title',
-                logo: 'http://mysite.com/author/image/url/logo.jpg'
+                url: 'http://mysite.com',
+                logo: {
+                    '@type': 'ImageObject',
+                    url: 'http://mysite.com/author/image/url/logo.jpg'
+                }
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });
@@ -471,7 +491,11 @@ describe('getSchema', function () {
             publisher: {
                 '@type': 'Organization',
                 name: 'Site Title',
-                logo: null
+                url: null,
+                logo: {
+                    '@type': 'ImageObject',
+                    url: null
+                }
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });
@@ -516,7 +540,11 @@ describe('getSchema', function () {
             publisher: {
                 '@type': 'Organization',
                 name: 'Site Title',
-                logo: null
+                url: null,
+                logo: {
+                    '@type': 'ImageObject',
+                    url: null
+                }
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });


### PR DESCRIPTION
refs #11304
- Previously the schema publisher logo attribute was incorrectly given the logo url
- schema.org and Google's docs show the logo needing it's own type and url attributes
- I added the correct @type and moved the metaData.site.logo to the new url attribute
- This change now clears the error in Google's Structured Data tester
- A future improvement would be to size the site logo to 60px in height per Google's recommendation