### PR TITLE
Disable pool by default for production server

### DIFF
--- a/core/server/config/env/config.production.json
+++ b/core/server/config/env/config.production.json
@@ -6,6 +6,9 @@
             "user"     : "root",
             "password" : "",
             "database" : "ghost"
+        },
+        "pool" : {
+            "min":0
         }
     },
     "paths": {


### PR DESCRIPTION
Without this config, we get ECONNRESET after 10 minutes of inactivity on docker based setup.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x ] There's a clear use-case for this code change
- [x ] Commit message has a short title & references relevant issues
- [x ] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
