### PR TITLE
Exposed member uuid to themes under `@member.uuid`

### DIFF
--- a/core/frontend/services/themes/middleware.js
+++ b/core/frontend/services/themes/middleware.js
@@ -114,6 +114,7 @@ function updateLocalTemplateOptions(req, res, next) {
     };
 
     const member = req.member ? {
+        uuid: req.member.uuid,
         email: req.member.email,
         name: req.member.name,
         firstname: req.member.name && req.member.name.split(' ')[0],


### PR DESCRIPTION
no-issue

Ronseal. Exposes's uuid for use in third party tracking/linking of
members, e.g. google tag manager

refs: https://forum.ghost.org/t/ghost-and-member-id-for-google-tag-manager/12317