### PR TITLE
✨ Deleted all but active sessions on password change

### DIFF
--- a/core/server/api/canary/users.js
+++ b/core/server/api/canary/users.js
@@ -160,6 +160,7 @@ module.exports = {
             }
         },
         query(frame) {
+            frame.options.skipSessionID = frame.original.session.id;
             return models.User.changePassword(frame.data.password[0], frame.options);
         }
     },

--- a/core/server/api/shared/http.js
+++ b/core/server/api/shared/http.js
@@ -40,6 +40,7 @@ const http = (apiImpl) => {
             query: req.query,
             params: req.params,
             user: req.user,
+            session: req.session,
             context: {
                 api_key: apiKey,
                 user: user,

--- a/core/server/api/v2/users.js
+++ b/core/server/api/v2/users.js
@@ -155,6 +155,7 @@ module.exports = {
             }
         },
         query(frame) {
+            frame.options.skipSessionID = frame.original.session.id;
             return models.User.changePassword(frame.data.password[0], frame.options);
         }
     },

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -864,31 +864,27 @@ User = ghostBookshelf.Model.extend({
      * @param {Object} object
      * @param {Object} unfilteredOptions
      */
-    changePassword: function changePassword(object, unfilteredOptions) {
-        var options = this.filterOptions(unfilteredOptions, 'changePassword'),
-            self = this,
-            newPassword = object.newPassword,
-            userId = object.user_id,
-            oldPassword = object.oldPassword,
-            isLoggedInUser = userId === options.context.user,
-            user;
+    changePassword: async function changePassword(object, unfilteredOptions) {
+        const options = this.filterOptions(unfilteredOptions, 'changePassword');
+        const newPassword = object.newPassword;
+        const userId = object.user_id;
+        const oldPassword = object.oldPassword;
+        const isLoggedInUser = userId === options.context.user;
 
         options.require = true;
 
-        return self.forge({id: userId}).fetch(options)
-            .then(function then(_user) {
-                user = _user;
+        const user = await this.forge({id: userId}).fetch(options);
 
-                if (isLoggedInUser) {
-                    return self.isPasswordCorrect({
-                        plainPassword: oldPassword,
-                        hashedPassword: user.get('password')
-                    });
-                }
-            })
-            .then(function then() {
-                return user.save({password: newPassword});
+        if (isLoggedInUser) {
+            await this.isPasswordCorrect({
+                plainPassword: oldPassword,
+                hashedPassword: user.get('password')
             });
+        }
+
+        const updatedUser = await user.save({password: newPassword});
+
+        return updatedUser;
     },
 
     transferOwnership: function transferOwnership(object, unfilteredOptions) {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -870,8 +870,10 @@ User = ghostBookshelf.Model.extend({
         const userId = object.user_id;
         const oldPassword = object.oldPassword;
         const isLoggedInUser = userId === options.context.user;
+        const skipSessionID = unfilteredOptions.skipSessionID;
 
         options.require = true;
+        options.withRelated = ['sessions'];
 
         const user = await this.forge({id: userId}).fetch(options);
 
@@ -883,6 +885,13 @@ User = ghostBookshelf.Model.extend({
         }
 
         const updatedUser = await user.save({password: newPassword});
+
+        const sessions = user.related('sessions');
+        for (const session of sessions) {
+            if (session.get('session_id') !== skipSessionID) {
+                await session.destroy(options);
+            }
+        }
 
         return updatedUser;
     },

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -235,7 +235,7 @@ User = ghostBookshelf.Model.extend({
     },
 
     sessions: function sessions() {
-        return this.hasMany('Sessions');
+        return this.hasMany('Session');
     },
 
     roles: function roles() {

--- a/core/test/acceptance/admin/users_spec.js
+++ b/core/test/acceptance/admin/users_spec.js
@@ -310,8 +310,8 @@ describe('User API', function () {
             });
     });
 
-    it('Can change password', function () {
-        return request
+    it('Can change password and retain the session', async function () {
+        await request
             .put(localUtils.API.getApiQuery('users/password'))
             .set('Origin', config.get('url'))
             .send({
@@ -329,5 +329,10 @@ describe('User API', function () {
                 should.exist(res.body.password);
                 should.exist(res.body.password[0].message);
             });
+
+        await request
+            .get(localUtils.API.getApiQuery('session/'))
+            .set('Origin', config.get('url'))
+            .expect(200);
     });
 });


### PR DESCRIPTION
refs #10323 

This changes the model to delete ALL sessions for a user from the session store when their password is changed

The session middleware is updated to "resave" the session at end of each request - this keeps the active session alive when changing passwords