### PR TITLE
Fixed permission to only fetch for active users

### DIFF
--- a/core/server/services/permissions/providers.js
+++ b/core/server/services/permissions/providers.js
@@ -5,7 +5,7 @@ var _ = require('lodash'),
 
 module.exports = {
     user: function (id) {
-        return models.User.findOne({id: id, status: 'all'}, {withRelated: ['permissions', 'roles', 'roles.permissions']})
+        return models.User.findOne({id: id, status: 'active'}, {withRelated: ['permissions', 'roles', 'roles.permissions']})
             .then(function (foundUser) {
                 // CASE: {context: {user: id}} where the id is not in our database
                 if (!foundUser) {


### PR DESCRIPTION
no-issue

Essentially only active users should have their permissions loaded, this
means that suspended or inactive users are stripped of all permissions
until their status is changed.