### PR TITLE
Cleaned up broken complimentary plan

### DIFF
--- a/core/server/data/migrations/versions/3.11/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.11/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -1,0 +1,68 @@
+const _ = require('lodash');
+const Promise = require('bluebird');
+const common = require('../../../../lib/common');
+const debug = require('ghost-ignition').debug('migrations');
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    let localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+    const settingsKey = 'members_subscription_settings';
+
+    return localOptions
+        .transacting('settings')
+        .then((response) => {
+            if (!response) {
+                common.logging.warn('Cannot find settings.');
+                return;
+            }
+
+            let subscriptionSettingsEntry = response.find((entry) => {
+                return entry.key === settingsKey;
+            });
+
+            if (!subscriptionSettingsEntry) {
+                common.logging.warn('Cannot find members subscription settings.');
+                return;
+            }
+
+            let subscriptionSettings = JSON.parse(subscriptionSettingsEntry.value);
+
+            debug('before cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            const stripePaymentProcessor = subscriptionSettings.paymentProcessors.find(
+                paymentProcessor => paymentProcessor.adapter === 'stripe'
+            );
+
+            // Remove "broken" complimentary plans that were introduced with 3.10.0, they didn't have
+            // interval property defined unlike regular plans
+            if (stripePaymentProcessor && stripePaymentProcessor.config.public_token && stripePaymentProcessor.config.secret_token) {
+                stripePaymentProcessor.config.plans = stripePaymentProcessor.config.plans.filter((plan) => {
+                    return plan.interval !== undefined;
+                });
+            }
+
+            debug('after cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            return localOptions
+                .transacting('settings')
+                .where('key', settingsKey)
+                .update({
+                    value: JSON.stringify(subscriptionSettings)
+                });
+        });
+};
+
+// `up` is only run to fix a problem that is introduced with 3.10.0,
+// it doesn't make sense to "reintroduced" broken state with down migration
+module.exports.down = () => Promise.resolve();
+
+module.exports.config = {
+    transaction: true
+};


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/11648

- Removes Stripe plan entries from settings that are not formatted correctly.
- Incorrect formatting was caused by a bug in 3.10.0 Admin-Client where it wasn't able to find complimentary plan. Related fix for this here - https://github.com/TryGhost/Ghost-Admin/commit/9e7a6b801ac4188de8ff38125983c834a68a7927

To ease testing a little you can use `ghost:migrations` debug flag when checking the migration execution, e.g:
`DEBUG=ghost:migrations knex-migrator migrate --v 3.11 --force`