### PR TITLE
Cleaned up members `isPaid` flag in settings table

### DIFF
--- a/core/server/data/migrations/versions/3.11/02-remove-legacy-is-paid-flag-from-settings.js
+++ b/core/server/data/migrations/versions/3.11/02-remove-legacy-is-paid-flag-from-settings.js
@@ -1,0 +1,63 @@
+const _ = require('lodash');
+const Promise = require('bluebird');
+const common = require('../../../../lib/common');
+const debug = require('ghost-ignition').debug('migrations');
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    let localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+    const settingsKey = 'members_subscription_settings';
+
+    return localOptions
+        .transacting('settings')
+        .then((response) => {
+            if (!response) {
+                common.logging.warn('Cannot find settings.');
+                return;
+            }
+
+            let subscriptionSettingsEntry = response.find((entry) => {
+                return entry.key === settingsKey;
+            });
+
+            if (!subscriptionSettingsEntry) {
+                common.logging.warn('Cannot find members subscription settings.');
+                return;
+            }
+
+            let subscriptionSettings = JSON.parse(subscriptionSettingsEntry.value);
+
+            debug('before cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            const hasIsPaid = Object.prototype.hasOwnProperty.call(subscriptionSettings, 'isPaid');
+
+            if (hasIsPaid) {
+                debug('Removing legacy isPaid flag from members settings');
+                delete subscriptionSettings.isPaid;
+            }
+
+            debug('after cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            return localOptions
+                .transacting('settings')
+                .where('key', settingsKey)
+                .update({
+                    value: JSON.stringify(subscriptionSettings)
+                });
+        });
+};
+
+// `up` is only run to fix a problem that is introduced with 3.10.0,
+// it doesn't make sense to "reintroduced" broken state with down migration
+module.exports.down = () => Promise.resolve();
+
+module.exports.config = {
+    transaction: true
+};

--- a/core/server/data/migrations/versions/3.12/01-remove-legacy-is-paid-flag-from-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-legacy-is-paid-flag-from-settings.js
@@ -35,17 +35,17 @@ module.exports.up = (options) => {
             if (hasIsPaid) {
                 debug('Removing legacy isPaid flag from members settings');
                 delete subscriptionSettings.isPaid;
+
+                debug('after cleanup');
+                debug(JSON.stringify(subscriptionSettings, null, 2));
+
+                return options
+                    .transacting('settings')
+                    .where('key', settingsKey)
+                    .update({
+                        value: JSON.stringify(subscriptionSettings)
+                    });
             }
-
-            debug('after cleanup');
-            debug(JSON.stringify(subscriptionSettings, null, 2));
-
-            return options
-                .transacting('settings')
-                .where('key', settingsKey)
-                .update({
-                    value: JSON.stringify(subscriptionSettings)
-                });
         });
 };
 

--- a/core/server/data/migrations/versions/3.12/01-remove-legacy-is-paid-flag-from-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-legacy-is-paid-flag-from-settings.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const Promise = require('bluebird');
 const common = require('../../../../lib/common');
 const debug = require('ghost-ignition').debug('migrations');
 
@@ -54,9 +53,57 @@ module.exports.up = (options) => {
         });
 };
 
-// `up` is only run to fix a problem that is introduced with 3.10.0,
-// it doesn't make sense to "reintroduced" broken state with down migration
-module.exports.down = () => Promise.resolve();
+module.exports.down = (options) => {
+    let localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+    const settingsKey = 'members_subscription_settings';
+
+    return localOptions
+        .transacting('settings')
+        .then((response) => {
+            if (!response) {
+                common.logging.warn('Cannot find settings.');
+                return;
+            }
+
+            let subscriptionSettingsEntry = response.find((entry) => {
+                return entry.key === settingsKey;
+            });
+
+            if (!subscriptionSettingsEntry) {
+                common.logging.warn('Cannot find members subscription settings.');
+                return;
+            }
+
+            let subscriptionSettings = JSON.parse(subscriptionSettingsEntry.value);
+
+            debug('before cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            let isPaid = false;
+
+            const stripePaymentProcessor = subscriptionSettings.paymentProcessors.find(
+                paymentProcessor => paymentProcessor.adapter === 'stripe'
+            );
+
+            if (stripePaymentProcessor && stripePaymentProcessor.config.public_token && stripePaymentProcessor.config.secret_token) {
+                isPaid = true;
+            }
+
+            subscriptionSettings.isPaid = isPaid;
+
+            debug('after cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            return localOptions
+                .transacting('settings')
+                .where('key', settingsKey)
+                .update({
+                    value: JSON.stringify(subscriptionSettings)
+                });
+        });
+};
 
 module.exports.config = {
     transaction: true

--- a/core/server/data/migrations/versions/3.12/01-remove-legacy-is-paid-flag-from-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-legacy-is-paid-flag-from-settings.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const common = require('../../../../lib/common');
 const debug = require('ghost-ignition').debug('migrations');
 
@@ -7,12 +6,9 @@ module.exports.config = {
 };
 
 module.exports.up = (options) => {
-    let localOptions = _.merge({
-        context: {internal: true}
-    }, options);
     const settingsKey = 'members_subscription_settings';
 
-    return localOptions
+    return options
         .transacting('settings')
         .then((response) => {
             if (!response) {
@@ -44,7 +40,7 @@ module.exports.up = (options) => {
             debug('after cleanup');
             debug(JSON.stringify(subscriptionSettings, null, 2));
 
-            return localOptions
+            return options
                 .transacting('settings')
                 .where('key', settingsKey)
                 .update({
@@ -54,12 +50,9 @@ module.exports.up = (options) => {
 };
 
 module.exports.down = (options) => {
-    let localOptions = _.merge({
-        context: {internal: true}
-    }, options);
     const settingsKey = 'members_subscription_settings';
 
-    return localOptions
+    return options
         .transacting('settings')
         .then((response) => {
             if (!response) {
@@ -96,7 +89,7 @@ module.exports.down = (options) => {
             debug('after cleanup');
             debug(JSON.stringify(subscriptionSettings, null, 2));
 
-            return localOptions
+            return options
                 .transacting('settings')
                 .where('key', settingsKey)
                 .update({

--- a/core/server/data/migrations/versions/3.12/01-remove-legacy-is-paid-flag-from-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-legacy-is-paid-flag-from-settings.js
@@ -10,18 +10,13 @@ module.exports.up = (options) => {
 
     return options
         .transacting('settings')
-        .then((response) => {
-            if (!response) {
-                common.logging.warn('Cannot find settings.');
-                return;
-            }
-
-            let subscriptionSettingsEntry = response.find((entry) => {
-                return entry.key === settingsKey;
-            });
-
+        .where('key', settingsKey)
+        .select('value')
+        .first()
+        .then((subscriptionSettingsEntry) => {
+            debug(subscriptionSettingsEntry);
             if (!subscriptionSettingsEntry) {
-                common.logging.warn('Cannot find members subscription settings.');
+                common.logging.warn(`Cannot find ${settingsKey} settings.`);
                 return;
             }
 
@@ -54,18 +49,13 @@ module.exports.down = (options) => {
 
     return options
         .transacting('settings')
-        .then((response) => {
-            if (!response) {
-                common.logging.warn('Cannot find settings.');
-                return;
-            }
-
-            let subscriptionSettingsEntry = response.find((entry) => {
-                return entry.key === settingsKey;
-            });
-
+        .where('key', settingsKey)
+        .select('value')
+        .first()
+        .then((subscriptionSettingsEntry) => {
+            debug(subscriptionSettingsEntry);
             if (!subscriptionSettingsEntry) {
-                common.logging.warn('Cannot find members subscription settings.');
+                common.logging.warn(`Cannot find ${settingsKey} settings.`);
                 return;
             }
 

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -207,7 +207,7 @@
             "defaultValue": "public"
         },
         "members_subscription_settings": {
-            "defaultValue": "{\"isPaid\":false,\"fromAddress\":\"noreply\",\"allowSelfSignup\":true,\"paymentProcessors\":[{\"adapter\":\"stripe\",\"config\":{\"secret_token\":\"\",\"public_token\":\"\",\"product\":{\"name\":\"Ghost Subscription\"},\"plans\":[{\"name\":\"Monthly\",\"currency\":\"usd\",\"interval\":\"month\",\"amount\":\"\"},{\"name\":\"Yearly\",\"currency\":\"usd\",\"interval\":\"year\",\"amount\":\"\"}]}}]}"
+            "defaultValue": "{\"fromAddress\":\"noreply\",\"allowSelfSignup\":true,\"paymentProcessors\":[{\"adapter\":\"stripe\",\"config\":{\"secret_token\":\"\",\"public_token\":\"\",\"product\":{\"name\":\"Ghost Subscription\"},\"plans\":[{\"name\":\"Monthly\",\"currency\":\"usd\",\"interval\":\"month\",\"amount\":\"\"},{\"name\":\"Yearly\",\"currency\":\"usd\",\"interval\":\"year\",\"amount\":\"\"}]}}]}"
         }
     },
     "bulk_email": {


### PR DESCRIPTION
While working on https://github.com/TryGhost/Ghost/pull/11650 spotted this flag and decided to do a lil cleanup while in the area.

The `isPaid` flag is no longer used and can be removed to make the settings JSON easier to read

TODO:
- [ ] if this change goes through merge in respective Admin-Client changes - https://github.com/TryGhost/Ghost-Admin/compare/master...gargol:members-clean-up-is-paid-flag?expand=1