### PR TITLE
Fixed settings cache reset when migration modifies settings table

### DIFF
--- a/core/server/data/migrations/versions/3.11/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.11/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -1,67 +1,11 @@
-const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
-const settings = require('../../../../services/settings');
-const debug = require('ghost-ignition').debug('migrations');
 
 module.exports.config = {
     transaction: true
 };
 
-module.exports.up = (options) => {
-    let localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-    const settingsKey = 'members_subscription_settings';
-
-    return localOptions
-        .transacting('settings')
-        .then((response) => {
-            if (!response) {
-                common.logging.warn('Cannot find settings.');
-                return;
-            }
-
-            let subscriptionSettingsEntry = response.find((entry) => {
-                return entry.key === settingsKey;
-            });
-
-            if (!subscriptionSettingsEntry) {
-                common.logging.warn('Cannot find members subscription settings.');
-                return;
-            }
-
-            let subscriptionSettings = JSON.parse(subscriptionSettingsEntry.value);
-
-            debug('before cleanup');
-            debug(JSON.stringify(subscriptionSettings, null, 2));
-
-            const stripePaymentProcessor = subscriptionSettings.paymentProcessors.find(
-                paymentProcessor => paymentProcessor.adapter === 'stripe'
-            );
-
-            // Remove "broken" complimentary plans that were introduced with 3.10.0, they didn't have
-            // interval property defined unlike regular plans
-            if (stripePaymentProcessor && stripePaymentProcessor.config.public_token && stripePaymentProcessor.config.secret_token) {
-                stripePaymentProcessor.config.plans = stripePaymentProcessor.config.plans.filter((plan) => {
-                    return plan.interval !== undefined;
-                });
-            }
-
-            debug('after cleanup');
-            debug(JSON.stringify(subscriptionSettings, null, 2));
-
-            return localOptions
-                .transacting('settings')
-                .where('key', settingsKey)
-                .update({
-                    value: JSON.stringify(subscriptionSettings)
-                });
-        })
-        .then(() => {
-            return settings.init();
-        });
-};
+// no-op'd because migration has been fixed and will be available in 3.12.0
+module.exports.up = () => Promise.resolve();
 
 // `up` is only run to fix a problem that is introduced with 3.10.0,
 // it doesn't make sense to "reintroduced" broken state with down migration

--- a/core/server/data/migrations/versions/3.11/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.11/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const common = require('../../../../lib/common');
+const settings = require('../../../../services/settings');
 const debug = require('ghost-ignition').debug('migrations');
 
 module.exports.config = {
@@ -56,6 +57,9 @@ module.exports.up = (options) => {
                 .update({
                     value: JSON.stringify(subscriptionSettings)
                 });
+        })
+        .then(() => {
+            return settings.init();
         });
 };
 

--- a/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const common = require('../../../../lib/common');
-const settingsCache = require('../../../../services/settings/cache');
 const debug = require('ghost-ignition').debug('migrations');
 
 module.exports.config = {

--- a/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -1,0 +1,72 @@
+const _ = require('lodash');
+const Promise = require('bluebird');
+const common = require('../../../../lib/common');
+const settings = require('../../../../services/settings');
+const debug = require('ghost-ignition').debug('migrations');
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    let localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+    const settingsKey = 'members_subscription_settings';
+
+    return localOptions
+        .transacting('settings')
+        .then((response) => {
+            if (!response) {
+                common.logging.warn('Cannot find settings.');
+                return;
+            }
+
+            let subscriptionSettingsEntry = response.find((entry) => {
+                return entry.key === settingsKey;
+            });
+
+            if (!subscriptionSettingsEntry) {
+                common.logging.warn('Cannot find members subscription settings.');
+                return;
+            }
+
+            let subscriptionSettings = JSON.parse(subscriptionSettingsEntry.value);
+
+            debug('before cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            const stripePaymentProcessor = subscriptionSettings.paymentProcessors.find(
+                paymentProcessor => paymentProcessor.adapter === 'stripe'
+            );
+
+            // Remove "broken" complimentary plans that were introduced with 3.10.0, they didn't have
+            // interval property defined unlike regular plans
+            if (stripePaymentProcessor && stripePaymentProcessor.config.public_token && stripePaymentProcessor.config.secret_token) {
+                stripePaymentProcessor.config.plans = stripePaymentProcessor.config.plans.filter((plan) => {
+                    return plan.interval !== undefined;
+                });
+            }
+
+            debug('after cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            return localOptions
+                .transacting('settings')
+                .where('key', settingsKey)
+                .update({
+                    value: JSON.stringify(subscriptionSettings)
+                });
+        })
+        .then(() => {
+            return settings.init();
+        });
+};
+
+// `up` is only run to fix a problem that is introduced with 3.10.0,
+// it doesn't make sense to "reintroduced" broken state with down migration
+module.exports.down = () => Promise.resolve();
+
+module.exports.config = {
+    transaction: true
+};

--- a/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -78,16 +78,22 @@ module.exports.up = (options) => {
                 })
                 .then(() => {
                     const settingModel = Object.assign({}, subscriptionSettingsEntry, {value: JSON.stringify(subscriptionSettings)});
-                    settingsCache.set(settingsKey, settingModel);
 
-                    // need to make sure members-api gets reinitialized below is a hacky way to trigger it as we don't use model's in migration
-                    const settingsModelImitation = {
+                    // need to make sure 2 places that depend on settings update themselves
+                    // 1. members-api gets reinitialized below is a hacky way to trigger it as we don't use model's in migration
+                    // 2. settings cache listens on changes and needs toJSON method to function
+                    const settingsModelMock = {
+                        // getter for members-api initialization
                         get() {
                             return settingsKey;
+                        },
+                        // for settings cache
+                        toJSON() {
+                            return settingModel;
                         }
                     };
 
-                    common.events.emit('settings.edited', settingsModelImitation);
+                    common.events.emit('settings.edited', settingsModelMock);
                 });
         });
 };

--- a/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -79,6 +79,15 @@ module.exports.up = (options) => {
                 .then(() => {
                     const settingModel = Object.assign({}, subscriptionSettingsEntry, {value: JSON.stringify(subscriptionSettings)});
                     settingsCache.set(settingsKey, settingModel);
+
+                    // need to make sure members-api gets reinitialized below is a hacky way to trigger it as we don't use model's in migration
+                    const settingsModelImitation = {
+                        get() {
+                            return settingsKey;
+                        }
+                    };
+
+                    common.events.emit('settings.edited', settingsModelImitation);
                 });
         });
 };

--- a/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const common = require('../../../../lib/common');
-const settings = require('../../../../services/settings');
+const settingsCache = require('../../../../services/settings/cache');
 const debug = require('ghost-ignition').debug('migrations');
 
 module.exports.config = {
@@ -56,10 +56,11 @@ module.exports.up = (options) => {
                 .where('key', settingsKey)
                 .update({
                     value: JSON.stringify(subscriptionSettings)
+                })
+                .then(() => {
+                    const settingModel = Object.assign({}, subscriptionSettingsEntry, {value: JSON.stringify(subscriptionSettings)});
+                    settingsCache.set(settingsKey, settingModel);
                 });
-        })
-        .then(() => {
-            return settings.init();
         });
 };
 

--- a/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.12/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -46,6 +46,25 @@ module.exports.up = (options) => {
                 stripePaymentProcessor.config.plans = stripePaymentProcessor.config.plans.filter((plan) => {
                     return plan.interval !== undefined;
                 });
+
+                const complimentaryPlan = stripePaymentProcessor.config.plans.find(plan => (plan.name === 'Complimentary' && plan.currency === stripePaymentProcessor.config.currency));
+
+                if (!complimentaryPlan && stripePaymentProcessor.config.currency) {
+                    const complimentaryInCurrentCurrency = {
+                        name: 'Complimentary',
+                        currency: stripePaymentProcessor.config.currency,
+                        interval: 'year',
+                        amount: '0'
+                    };
+
+                    debug('no complimentary plan found in plans');
+                    debug(JSON.stringify(stripePaymentProcessor.config.plans, null, 2));
+
+                    debug('inserting complimentary plan');
+                    debug(JSON.stringify(complimentaryInCurrentCurrency, null, 2));
+
+                    stripePaymentProcessor.config.plans.push(complimentaryInCurrentCurrency);
+                }
             }
 
             debug('after cleanup');

--- a/core/server/services/settings/cache.js
+++ b/core/server/services/settings/cache.js
@@ -117,11 +117,6 @@ module.exports = {
         // First, reset the cache
         settingsCache = {};
 
-        // Remove listeners if there were any registered
-        common.events.removeListener('settings.edited', updateSettingFromModel);
-        common.events.removeListener('settings.added', updateSettingFromModel);
-        common.events.removeListener('settings.deleted', updateSettingFromModel);
-
         // // if we have been passed a collection of settings, use this to populate the cache
         if (settingsCollection && settingsCollection.models) {
             _.each(settingsCollection.models, updateSettingFromModel);

--- a/core/server/services/settings/cache.js
+++ b/core/server/services/settings/cache.js
@@ -117,6 +117,11 @@ module.exports = {
         // First, reset the cache
         settingsCache = {};
 
+        // Remove listeners if there were any registered
+        common.events.removeListener('settings.edited', updateSettingFromModel);
+        common.events.removeListener('settings.added', updateSettingFromModel);
+        common.events.removeListener('settings.deleted', updateSettingFromModel);
+
         // // if we have been passed a collection of settings, use this to populate the cache
         if (settingsCollection && settingsCollection.models) {
             _.each(settingsCollection.models, updateSettingFromModel);


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/11649
refs https://github.com/TryGhost/Ghost/pull/11650 - this PR is expansion upon this migration fixing the prolem of triggering settings cache reset and adding correct complimentary plan.
refs https://github.com/TryGhost/Ghost/pull/11650

After migrations are run through Ghost-CLI the instance needs to catch up with potential changes that were done in settings table. Otherwise it ends up in obsolete state after version update. 2 places that are effected by the changes are: settings cache and members service. 

Additionally a corrected "Complimentary" plan was missed to be added in previous migration instead of the broken ones, so this migration fixes this problem as well.
