### PR TITLE
Fixed MySQL port mapping in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: ghost_testing
         ports:
-          - 3306
+          - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     name: Node ${{ matrix.node }} - ${{ matrix.env.DB }}
     steps:


### PR DESCRIPTION
no issue

- turns out the exposed port is randomly assigned, but this worked for
  us so far
- this commit enforces the use of 3306 for the MySQL port