### PR TITLE
Added support for token session to /ghost

### DIFF
--- a/core/server/services/auth/session/express-session.js
+++ b/core/server/services/auth/session/express-session.js
@@ -1,0 +1,37 @@
+const session = require('express-session');
+const constants = require('../../../lib/constants');
+const config = require('../../../config');
+const settingsCache = require('../../settings/cache');
+const models = require('../../../models');
+const urlUtils = require('../../../lib/url-utils');
+
+const SessionStore = require('./store');
+
+const expressSessionMiddleware = session({
+    store: new SessionStore(models.Session),
+    secret: settingsCache.get('session_secret'),
+    resave: false,
+    saveUninitialized: false,
+    name: 'ghost-admin-api-session',
+    cookie: {
+        maxAge: constants.SIX_MONTH_MS,
+        httpOnly: true,
+        path: urlUtils.getSubdir() + '/ghost',
+        sameSite: 'lax',
+        secure: urlUtils.isSSL(config.get('url'))
+    }
+});
+
+exports.getSession = async function getSession(req, res) {
+    if (req.session) {
+        return req.session;
+    }
+    return new Promise((resolve, reject) => {
+        expressSessionMiddleware(req, res, function (err) {
+            if (err) {
+                return reject(err);
+            }
+            resolve(req.session);
+        });
+    });
+};

--- a/core/server/services/auth/session/index.js
+++ b/core/server/services/auth/session/index.js
@@ -12,7 +12,7 @@ const SessionStore = require('./store');
 
 function getOriginOfRequest(req) {
     const origin = req.get('origin');
-    const referrer = req.get('referrer');
+    const referrer = req.get('referrer') || urlUtils.getAdminUrl() || urlUtils.getSiteUrl();
 
     if (!origin && !referrer) {
         return null;

--- a/core/server/services/auth/session/index.js
+++ b/core/server/services/auth/session/index.js
@@ -1,10 +1,11 @@
+const createSessionService = require('@tryghost/session-service');
+const createSessionMiddleware = require('./middleware');
+
+const expressSession = require('./express-session');
+
 const models = require('../../../models');
 const urlUtils = require('../../../lib/url-utils');
 const url = require('url');
-
-const SessionService = require('@tryghost/session-service');
-const SessionMiddleware = require('./middleware');
-const expressSession = require('./express-session');
 
 function getOriginOfRequest(req) {
     const origin = req.get('origin');
@@ -25,18 +26,12 @@ function getOriginOfRequest(req) {
     return null;
 }
 
-function findUserById({id}) {
-    return models.User.findOne({id});
-}
-
-const sessionService = SessionService({
+const sessionService = createSessionService({
     getOriginOfRequest,
     getSession: expressSession.getSession,
-    findUserById
+    findUserById({id}) {
+        return models.User.findOne({id});
+    }
 });
 
-const sessionMiddleware = SessionMiddleware({
-    sessionService
-});
-
-module.exports = sessionMiddleware;
+module.exports = createSessionMiddleware({sessionService});

--- a/core/server/services/auth/session/index.js
+++ b/core/server/services/auth/session/index.js
@@ -1,4 +1,6 @@
+const adapterManager = require('../../adapter-manager');
 const createSessionService = require('@tryghost/session-service');
+const sessionFromToken = require('@tryghost/mw-session-from-token');
 const createSessionMiddleware = require('./middleware');
 
 const expressSession = require('./express-session');
@@ -35,3 +37,13 @@ const sessionService = createSessionService({
 });
 
 module.exports = createSessionMiddleware({sessionService});
+
+const ssoAdapter = adapterManager.getAdapter('sso');
+// Looks funky but this is a "custom" piece of middleware
+module.exports.createSessionFromToken = sessionFromToken({
+    callNextWithError: false,
+    createSession: sessionService.createSessionForUser,
+    findUserByLookup: ssoAdapter.getUserForIdentity,
+    getLookupFromToken: ssoAdapter.getIdentityFromCredentials,
+    getTokenFromRequest: ssoAdapter.getRequestCredentials
+});

--- a/core/server/services/auth/session/index.js
+++ b/core/server/services/auth/session/index.js
@@ -1,14 +1,10 @@
-const session = require('express-session');
-const constants = require('../../../lib/constants');
-const config = require('../../../config');
-const settingsCache = require('../../settings/cache');
 const models = require('../../../models');
 const urlUtils = require('../../../lib/url-utils');
 const url = require('url');
 
 const SessionService = require('@tryghost/session-service');
 const SessionMiddleware = require('./middleware');
-const SessionStore = require('./store');
+const expressSession = require('./express-session');
 
 function getOriginOfRequest(req) {
     const origin = req.get('origin');
@@ -29,42 +25,13 @@ function getOriginOfRequest(req) {
     return null;
 }
 
-async function getSession(req, res) {
-    if (req.session) {
-        return req.session;
-    }
-    return new Promise((resolve, reject) => {
-        expressSessionMiddleware(req, res, function (err) {
-            if (err) {
-                return reject(err);
-            }
-            resolve(req.session);
-        });
-    });
-}
-
 function findUserById({id}) {
     return models.User.findOne({id});
 }
 
-const expressSessionMiddleware = session({
-    store: new SessionStore(models.Session),
-    secret: settingsCache.get('session_secret'),
-    resave: false,
-    saveUninitialized: false,
-    name: 'ghost-admin-api-session',
-    cookie: {
-        maxAge: constants.SIX_MONTH_MS,
-        httpOnly: true,
-        path: urlUtils.getSubdir() + '/ghost',
-        sameSite: 'lax',
-        secure: urlUtils.isSSL(config.get('url'))
-    }
-});
-
 const sessionService = SessionService({
     getOriginOfRequest,
-    getSession,
+    getSession: expressSession.getSession,
     findUserById
 });
 

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -59,7 +59,7 @@ module.exports = function setupParentApp(options = {}) {
     adminApp.enable('trust proxy'); // required to respect x-forwarded-proto in admin requests
     adminApp.use('/ghost/api', require('./api')());
     adminApp.use('/ghost/.well-known', require('./well-known')());
-    adminApp.use('/ghost', require('./admin')());
+    adminApp.use('/ghost', require('../services/auth/session').createSessionFromToken, require('./admin')());
 
     // TODO: remove {admin url}/content/* once we're sure the API is not returning relative asset URLs anywhere
     // only register this route if the admin is separate so we're not overriding the {site}/content/* route

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tryghost/kg-markdown-html-renderer": "1.0.2",
     "@tryghost/members-api": "0.18.0",
     "@tryghost/members-ssr": "0.7.4",
+    "@tryghost/mw-session-from-token": "^0.1.0",
     "@tryghost/session-service": "^0.1.0",
     "@tryghost/social-urls": "0.1.8",
     "@tryghost/string": "0.1.8",

--- a/test/unit/api/canary/session_spec.js
+++ b/test/unit/api/canary/session_spec.js
@@ -5,7 +5,7 @@ const models = require('../../../../core/server/models');
 const {UnauthorizedError} = require('../../../../core/server/lib/common/errors');
 
 const sessionController = require('../../../../core/server/api/canary/session');
-const sessionServiceMiddleware = require('../../../../core/server/services/auth/session').middleware;
+const sessionServiceMiddleware = require('../../../../core/server/services/auth/session');
 
 describe('Session controller', function () {
     before(function () {

--- a/test/unit/api/v2/session_spec.js
+++ b/test/unit/api/v2/session_spec.js
@@ -5,7 +5,7 @@ const models = require('../../../../core/server/models');
 const {UnauthorizedError} = require('../../../../core/server/lib/common/errors');
 
 const sessionController = require('../../../../core/server/api/v2/session');
-const sessionServiceMiddleware = require('../../../../core/server/services/auth/session').middleware;
+const sessionServiceMiddleware = require('../../../../core/server/services/auth/session');
 
 describe('v2 Session controller', function () {
     before(function () {

--- a/test/unit/api/v3/session_spec.js
+++ b/test/unit/api/v3/session_spec.js
@@ -5,7 +5,7 @@ const models = require('../../../../core/server/models');
 const {UnauthorizedError} = require('../../../../core/server/lib/common/errors');
 
 const sessionController = require('../../../../core/server/api/canary/session');
-const sessionServiceMiddleware = require('../../../../core/server/services/auth/session').middleware;
+const sessionServiceMiddleware = require('../../../../core/server/services/auth/session');
 
 describe('v3 Session controller', function () {
     before(function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -435,6 +435,11 @@
     mobiledoc-dom-renderer "0.7.0"
     mobiledoc-text-renderer "0.4.0"
 
+"@tryghost/mw-session-from-token@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/mw-session-from-token/-/mw-session-from-token-0.1.0.tgz#ad73da936d3cc3abdfc7753a5098e76ae5dc271e"
+  integrity sha512-t6a9YMMHaQ2Uypl+WaGLc4mFKjwhfyfA+l7V9H5DwFeAFIYWcRssy/D3e+gTT3rbLC39W0vqkmZFNE2JQZuuEQ==
+
 "@tryghost/pretty-cli@1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@tryghost/pretty-cli/-/pretty-cli-1.2.3.tgz#06fc84e4659ffde7166ca2a9ebe17c3951438a6c"


### PR DESCRIPTION
no-issue

There's a few changes here, mostly refactoring.

- Session service refactored into sub modules (mw-session-from-token, session-service)
- Adapters refactored to remove duplication
- New middleware added to /ghost route - which will allow sessions to be generated
- New SSO Adapter added which will control how the above session are created.
- Default SSO Adapter added which does nothing.

All in all should contain no functionality changes out of the box