### PR TITLE
docs: Fix simple typo, tempalte -> template

### DIFF
--- a/test/regression/site/site_spec.js
+++ b/test/regression/site/site_spec.js
@@ -1424,7 +1424,7 @@ describe('Integration - Web - Site', function () {
                             response.statusCode.should.eql(200);
                             response.template.should.eql('default');
 
-                            // default tempalte does not list posts
+                            // default template does not list posts
                             $('.post-card').length.should.equal(0);
                         });
                 });
@@ -3124,7 +3124,7 @@ describe('Integration - Web - Site', function () {
                             response.statusCode.should.eql(200);
                             response.template.should.eql('default');
 
-                            // default tempalte does not list posts
+                            // default template does not list posts
                             $('.post-card').length.should.equal(0);
                         });
                 });
@@ -4824,7 +4824,7 @@ describe('Integration - Web - Site', function () {
                             response.statusCode.should.eql(200);
                             response.template.should.eql('default');
 
-                            // default tempalte does not list posts
+                            // default template does not list posts
                             $('.post-card').length.should.equal(0);
                         });
                 });


### PR DESCRIPTION
There is a small typo in test/regression/site/site_spec.js.

Should read `template` rather than `tempalte`.

