### PR TITLE
Fixed 500 error when deleting items that don't exist

### DIFF
--- a/core/server/api/canary/integrations.js
+++ b/core/server/api/canary/integrations.js
@@ -134,11 +134,11 @@ module.exports = {
         query({options}) {
             return models.Integration.destroy(Object.assign(options, {require: true}))
                 .catch(models.Integration.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
+                    return Promise.reject(new common.errors.NotFoundError({
                         message: common.i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Integration'
                         })
-                    });
+                    }));
                 });
         }
     }

--- a/core/server/api/canary/invites.js
+++ b/core/server/api/canary/invites.js
@@ -77,7 +77,12 @@ module.exports = {
             frame.options.require = true;
 
             return models.Invite.destroy(frame.options)
-                .then(() => null);
+                .then(() => null)
+                .catch(models.Invite.NotFoundError, () => {
+                    return Promise.reject(new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.invites.inviteNotFound')
+                    }));
+                });
         }
     },
 

--- a/core/server/api/canary/labels.js
+++ b/core/server/api/canary/labels.js
@@ -139,7 +139,13 @@ module.exports = {
         },
         permissions: true,
         query(frame) {
-            return models.Label.destroy(frame.options).then(() => null);
+            return models.Label.destroy(frame.options)
+                .then(() => null)
+                .catch(models.Label.NotFoundError, () => {
+                    return Promise.reject(new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.labels.labelNotFound')
+                    }));
+                });
         }
     }
 };

--- a/core/server/api/canary/pages.js
+++ b/core/server/api/canary/pages.js
@@ -198,9 +198,9 @@ module.exports = {
             return models.Post.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Post.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
+                    return Promise.reject(new common.errors.NotFoundError({
                         message: common.i18n.t('errors.api.pages.pageNotFound')
-                    });
+                    }));
                 });
         }
     }

--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -233,9 +233,9 @@ module.exports = {
             return models.Post.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Post.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
+                    return Promise.reject(new common.errors.NotFoundError({
                         message: common.i18n.t('errors.api.posts.postNotFound')
-                    });
+                    }));
                 });
         }
     }

--- a/core/server/api/canary/tags.js
+++ b/core/server/api/canary/tags.js
@@ -142,7 +142,13 @@ module.exports = {
         },
         permissions: true,
         query(frame) {
-            return models.Tag.destroy(frame.options).then(() => null);
+            return models.Tag.destroy(frame.options)
+                .then(() => null)
+                .catch(models.Tag.NotFoundError, () => {
+                    return Promise.reject(new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.tags.tagNotFound')
+                    }));
+                });
         }
     }
 };

--- a/core/server/api/canary/webhooks.js
+++ b/core/server/api/canary/webhooks.js
@@ -84,7 +84,16 @@ module.exports = {
         permissions: true,
         query(frame) {
             frame.options.require = true;
-            return models.Webhook.destroy(frame.options).then(() => null);
+
+            return models.Webhook.destroy(frame.options)
+                .then(() => null)
+                .catch(models.Webhook.NotFoundError, () => {
+                    return Promise.reject(new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Webhook'
+                        })
+                    }));
+                });
         }
     }
 };

--- a/core/server/api/v2/integrations.js
+++ b/core/server/api/v2/integrations.js
@@ -134,11 +134,11 @@ module.exports = {
         query({options}) {
             return models.Integration.destroy(Object.assign(options, {require: true}))
                 .catch(models.Integration.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
+                    return Promise.reject(new common.errors.NotFoundError({
                         message: common.i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Integration'
                         })
-                    });
+                    }));
                 });
         }
     }

--- a/core/server/api/v2/invites.js
+++ b/core/server/api/v2/invites.js
@@ -77,7 +77,12 @@ module.exports = {
             frame.options.require = true;
 
             return models.Invite.destroy(frame.options)
-                .then(() => null);
+                .then(() => null)
+                .catch(models.Invite.NotFoundError, () => {
+                    return Promise.reject(new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.invites.inviteNotFound')
+                    }));
+                });
         }
     },
 

--- a/core/server/api/v2/pages.js
+++ b/core/server/api/v2/pages.js
@@ -198,9 +198,9 @@ module.exports = {
             return models.Post.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Post.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
+                    return Promise.reject(new common.errors.NotFoundError({
                         message: common.i18n.t('errors.api.pages.pageNotFound')
-                    });
+                    }));
                 });
         }
     }

--- a/core/server/api/v2/posts.js
+++ b/core/server/api/v2/posts.js
@@ -193,9 +193,9 @@ module.exports = {
             return models.Post.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Post.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
+                    return Promise.reject(new common.errors.NotFoundError({
                         message: common.i18n.t('errors.api.posts.postNotFound')
-                    });
+                    }));
                 });
         }
     }

--- a/core/server/api/v2/tags.js
+++ b/core/server/api/v2/tags.js
@@ -142,7 +142,13 @@ module.exports = {
         },
         permissions: true,
         query(frame) {
-            return models.Tag.destroy(frame.options).then(() => null);
+            return models.Tag.destroy(frame.options)
+                .then(() => null)
+                .catch(models.Tag.NotFoundError, () => {
+                    return Promise.reject(new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.tags.tagNotFound')
+                    }));
+                });
         }
     }
 };

--- a/core/server/api/v2/webhooks.js
+++ b/core/server/api/v2/webhooks.js
@@ -84,7 +84,15 @@ module.exports = {
         permissions: true,
         query(frame) {
             frame.options.require = true;
-            return models.Webhook.destroy(frame.options).then(() => null);
+            return models.Webhook.destroy(frame.options)
+                .then(() => null)
+                .catch(models.Webhook.NotFoundError, () => {
+                    return Promise.reject(new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Webhook'
+                        })
+                    }));
+                });
         }
     }
 };

--- a/core/server/models/label.js
+++ b/core/server/models/label.js
@@ -107,6 +107,10 @@ Label = ghostBookshelf.Model.extend({
         return this.forge({id: options.id})
             .fetch(options)
             .then(function destroyLabelsAndMember(label) {
+                if (!label) {
+                    return Promise.reject();
+                }
+
                 return label.related('members')
                     .detach(null, options)
                     .then(function destroyLabels() {

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -117,6 +117,10 @@ Tag = ghostBookshelf.Model.extend({
         return this.forge({id: options.id})
             .fetch(options)
             .then(function destroyTagsAndPost(tag) {
+                if (!tag) {
+                    return Promise.reject();
+                }
+
                 return tag.related('posts')
                     .detach(null, options)
                     .then(function destroyTags() {


### PR DESCRIPTION
fixes #11723

- when deleting an invite/label/tag/webhook that doesn't
  exist, Ghost would throw a 500 error
- this commit catches the NotFoundError
- also rejects from model if nothing was found
- spotted in Sentry

also brings other code in line with these changes