### PR TITLE
Added custom `json-string` format to ajv validator

### DIFF
--- a/core/server/api/canary/utils/validators/input/schemas/pages.json
+++ b/core/server/api/canary/utils/validators/input/schemas/pages.json
@@ -19,6 +19,7 @@
                 },
                 "mobiledoc": {
                     "type": ["string", "null"],
+                    "format": "json-string",
                     "maxLength": 1000000000
                 },
                 "html": {

--- a/core/server/api/canary/utils/validators/input/schemas/posts.json
+++ b/core/server/api/canary/utils/validators/input/schemas/posts.json
@@ -19,6 +19,7 @@
                 },
                 "mobiledoc": {
                     "type": ["string", "null"],
+                    "format": "json-string",
                     "maxLength": 1000000000
                 },
                 "html": {

--- a/core/server/api/canary/utils/validators/utils/json-schema.js
+++ b/core/server/api/canary/utils/validators/utils/json-schema.js
@@ -5,7 +5,17 @@ const common = require('../../../../../lib/common');
 
 const ajv = new Ajv({
     allErrors: true,
-    useDefaults: true
+    useDefaults: true,
+    formats: {
+        'json-string': (data) => {
+            try {
+                JSON.parse(data);
+                return true;
+            } catch (e) {
+                return false;
+            }
+        }
+    }
 });
 
 stripKeyword(ajv);

--- a/core/server/api/v2/utils/validators/input/schemas/pages.json
+++ b/core/server/api/v2/utils/validators/input/schemas/pages.json
@@ -19,6 +19,7 @@
                 },
                 "mobiledoc": {
                     "type": ["string", "null"],
+                    "format": "json-string",
                     "maxLength": 1000000000
                 },
                 "html": {

--- a/core/server/api/v2/utils/validators/input/schemas/posts.json
+++ b/core/server/api/v2/utils/validators/input/schemas/posts.json
@@ -19,6 +19,7 @@
                 },
                 "mobiledoc": {
                     "type": ["string", "null"],
+                    "format": "json-string",
                     "maxLength": 1000000000
                 },
                 "html": {

--- a/core/server/api/v2/utils/validators/utils/json-schema.js
+++ b/core/server/api/v2/utils/validators/utils/json-schema.js
@@ -5,7 +5,17 @@ const common = require('../../../../../lib/common');
 
 const ajv = new Ajv({
     allErrors: true,
-    useDefaults: true
+    useDefaults: true,
+    formats: {
+        'json-string': (data) => {
+            try {
+                JSON.parse(data);
+                return true;
+            } catch (e) {
+                return false;
+            }
+        }
+    }
 });
 
 stripKeyword(ajv);

--- a/test/unit/api/canary/utils/validators/input/pages_spec.js
+++ b/test/unit/api/canary/utils/validators/input/pages_spec.js
@@ -140,7 +140,7 @@ describe('Unit: canary/utils/validators/input/pages', function () {
             const fieldMap = {
                 title: [123, new Date(), _.repeat('a', 2001)],
                 slug: [123, new Date(), _.repeat('a', 192)],
-                mobiledoc: [123, new Date()],
+                mobiledoc: [123, new Date(), 'a'],
                 feature_image: [123, new Date(), 'random words'],
                 featured: [123, new Date(), 'abc'],
                 status: [123, new Date(), 'abc'],

--- a/test/unit/api/canary/utils/validators/input/posts_spec.js
+++ b/test/unit/api/canary/utils/validators/input/posts_spec.js
@@ -140,7 +140,7 @@ describe('Unit: canary/utils/validators/input/posts', function () {
             const fieldMap = {
                 title: [123, new Date(), _.repeat('a', 2001)],
                 slug: [123, new Date(), _.repeat('a', 192)],
-                mobiledoc: [123, new Date()],
+                mobiledoc: [123, new Date(), 'a'],
                 feature_image: [123, new Date(), 'random words'],
                 featured: [123, new Date(), 'abc'],
                 status: [123, new Date(), 'abc'],

--- a/test/unit/api/v2/utils/validators/input/pages_spec.js
+++ b/test/unit/api/v2/utils/validators/input/pages_spec.js
@@ -140,7 +140,7 @@ describe('Unit: v2/utils/validators/input/pages', function () {
             const fieldMap = {
                 title: [123, new Date(), _.repeat('a', 2001)],
                 slug: [123, new Date(), _.repeat('a', 192)],
-                mobiledoc: [123, new Date()],
+                mobiledoc: [123, new Date(), 'a'],
                 feature_image: [123, new Date(), 'random words'],
                 featured: [123, new Date(), 'abc'],
                 status: [123, new Date(), 'abc'],

--- a/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -140,7 +140,7 @@ describe('Unit: v2/utils/validators/input/posts', function () {
             const fieldMap = {
                 title: [123, new Date(), _.repeat('a', 2001)],
                 slug: [123, new Date(), _.repeat('a', 192)],
-                mobiledoc: [123, new Date()],
+                mobiledoc: [123, new Date(), 'a'],
                 feature_image: [123, new Date(), 'random words'],
                 featured: [123, new Date(), 'abc'],
                 status: [123, new Date(), 'abc'],

--- a/test/unit/api/v3/utils/validators/input/pages_spec.js
+++ b/test/unit/api/v3/utils/validators/input/pages_spec.js
@@ -140,7 +140,7 @@ describe('Unit: v3/utils/validators/input/pages', function () {
             const fieldMap = {
                 title: [123, new Date(), _.repeat('a', 2001)],
                 slug: [123, new Date(), _.repeat('a', 192)],
-                mobiledoc: [123, new Date()],
+                mobiledoc: [123, new Date(), 'a'],
                 feature_image: [123, new Date(), 'random words'],
                 featured: [123, new Date(), 'abc'],
                 status: [123, new Date(), 'abc'],

--- a/test/unit/api/v3/utils/validators/input/posts_spec.js
+++ b/test/unit/api/v3/utils/validators/input/posts_spec.js
@@ -140,7 +140,7 @@ describe('Unit: v3/utils/validators/input/posts', function () {
             const fieldMap = {
                 title: [123, new Date(), _.repeat('a', 2001)],
                 slug: [123, new Date(), _.repeat('a', 192)],
-                mobiledoc: [123, new Date()],
+                mobiledoc: [123, new Date(), 'a'],
                 feature_image: [123, new Date(), 'random words'],
                 featured: [123, new Date(), 'abc'],
                 status: [123, new Date(), 'abc'],


### PR DESCRIPTION
no issue

- the value of `mobiledoc` when submitting a page/post via the API must
  be JSON, but we don't validate this
- this results in url-utils throwing an error, which ends up being a 500
- this commit adds a custom format to AJV to validate it is valid JSON