### PR TITLE
Fix the data logo structuration

### DIFF
--- a/core/frontend/meta/schema.js
+++ b/core/frontend/meta/schema.js
@@ -29,10 +29,7 @@ function schemaPublisherObject(metaDataVal) {
         '@type': 'Organization',
         name: escapeExpression(metaDataVal.site.title),
         url: metaDataVal.site.url || null,
-        logo: {
-            '@type': 'ImageObject',
-            url: schemaImageObject(metaDataVal.site.logo) || null
-        }
+        logo: schemaImageObject(metaDataVal.site.logo) || null
     };
 
     return publisherObject;


### PR DESCRIPTION
The logo should not be embeded int another shemaObject.
Issue : https://github.com/TryGhost/Ghost/issues/11746

Not Well structured : 
``
 "logo": {
            "@type": "ImageObject",
            "url": {
                "@type": "ImageObject",
                "url": "https://www.geeek.org/content/images/2019/05/logo-small.png",
                "width": 175,
                "height": 60
            }
        }
``
Well structured : 
``
"logo": {
            "@type": "ImageObject",
            "url": "https://www.geeek.org/content/images/2019/05/logo-small.png",
            "width": 175,
            "height": 60
     }
``