### PR TITLE
Updated public site data and member's session data endpoints

### DIFF
--- a/core/server/api/canary/site.js
+++ b/core/server/api/canary/site.js
@@ -16,7 +16,7 @@ const site = {
                 brand: settingsCache.get('brand'),
                 url: urlUtils.urlFor('home', true),
                 plans: membersService.config.getPublicPlans(),
-                allowSelfSignup: membersService.config.getPublicPlans(),
+                allowSelfSignup: membersService.config.getAllowSelfSignup(),
                 version: ghostVersion.safe
             };
         }

--- a/core/server/api/canary/site.js
+++ b/core/server/api/canary/site.js
@@ -1,6 +1,7 @@
 const ghostVersion = require('../../lib/ghost-version');
 const settingsCache = require('../../services/settings/cache');
 const urlUtils = require('../../lib/url-utils');
+const membersService = require('../../services/members');
 
 const site = {
     docName: 'site',
@@ -10,7 +11,12 @@ const site = {
         query() {
             return {
                 title: settingsCache.get('title'),
+                description: settingsCache.get('description'),
+                logo: settingsCache.get('logo'),
+                brand: settingsCache.get('brand'),
                 url: urlUtils.urlFor('home', true),
+                plans: membersService.config.getPublicPlans(),
+                allowSelfSignup: membersService.config.getPublicPlans(),
                 version: ghostVersion.safe
             };
         }

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -139,6 +139,7 @@ module.exports = function setupSiteApp(options = {}) {
 
     // Members middleware
     // Initializes members specific routes as well as assigns members specific data to the req/res objects
+    siteApp.get('/members/ssr/member', shared.middlewares.labs.members, membersMiddleware.getMemberData);
     siteApp.get('/members/ssr', shared.middlewares.labs.members, membersMiddleware.getIdentityToken);
     siteApp.delete('/members/ssr', shared.middlewares.labs.members, membersMiddleware.deleteSession);
     siteApp.post('/members/webhooks/stripe', shared.middlewares.labs.members, membersMiddleware.stripeWebhooks);


### PR DESCRIPTION
This PR 

- extends admin site endpoint with new public settings - `description`, `logo`, `brand` and public member settings - `plans`, `allowSelfSignup` for members.s script and other clients
- exposes an endpoint on site url (`/members/ssr/member`) to get member's data in exchange for their session/identity on a theme when they are logged in

Refs - https://github.com/TryGhost/members.js/issues/6