### PR TITLE
🐛 Fix issues with importer not updating post content to point to new …

### DIFF
--- a/core/server/data/importer/handlers/image.js
+++ b/core/server/data/importer/handlers/image.js
@@ -1,9 +1,7 @@
 var _ = require('lodash'),
     Promise = require('bluebird'),
-    path = require('path'),
     config = require('../../../config'),
     urlUtils = require('../../../lib/url-utils'),
-    storage = require('../../../adapters/storage'),
 
     ImageHandler;
 
@@ -14,14 +12,13 @@ ImageHandler = {
     directories: ['images', 'content'],
 
     loadFile: function (files, baseDir) {
-        var store = storage.getStorage(),
-            baseDirRegex = baseDir ? new RegExp('^' + baseDir + '/') : new RegExp(''),
+        var baseDirRegex = baseDir ? new RegExp('^' + baseDir + '/') : new RegExp(''),
             imageFolderRegexes = _.map(urlUtils.STATIC_IMAGE_URL_PREFIX.split('/'), function (dir) {
                 return new RegExp('^' + dir + '/');
             });
 
         // normalize the directory structure
-        files = _.map(files, function (file) {
+        return Promise.map(files, function (file) {
             var noBaseDir = file.name.replace(baseDirRegex, ''),
                 noGhostDirs = noBaseDir;
 
@@ -31,17 +28,7 @@ ImageHandler = {
 
             file.originalPath = noBaseDir;
             file.name = noGhostDirs;
-            file.targetDir = path.join(config.getContentPath('images'), path.dirname(noGhostDirs));
             return file;
-        });
-
-        return Promise.map(files, function (image) {
-            return store.getUniqueFileName(image, image.targetDir).then(function (targetFilename) {
-                image.newPath = urlUtils.urlJoin('/', urlUtils.getSubdir(), urlUtils.STATIC_IMAGE_URL_PREFIX,
-                    path.relative(config.getContentPath('images'), targetFilename));
-
-                return image;
-            });
         });
     }
 };

--- a/test/unit/data/importer/index_spec.js
+++ b/test/unit/data/importer/index_spec.js
@@ -353,8 +353,6 @@ describe('Importer', function () {
     });
 
     describe('ImageHandler', function () {
-        var store = storage.getStorage();
-
         it('has the correct interface', function () {
             ImageHandler.type.should.eql('images');
             ImageHandler.extensions.should.be.instanceof(Array).and.have.lengthOf(7);
@@ -380,16 +378,11 @@ describe('Importer', function () {
                 file = [{
                     path: '/my/test/' + filename,
                     name: filename
-                }],
-                storeSpy = sinon.spy(store, 'getUniqueFileName'),
-                storageSpy = sinon.spy(storage, 'getStorage');
+                }];
 
-            ImageHandler.loadFile(_.clone(file)).then(function () {
-                storageSpy.calledOnce.should.be.true();
-                storeSpy.calledOnce.should.be.true();
-                storeSpy.firstCall.args[0].originalPath.should.equal('test-image.jpeg');
-                storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-                storeSpy.firstCall.args[0].newPath.should.eql('/content/images/test-image.jpeg');
+            ImageHandler.loadFile(_.clone(file)).then(function (files) {
+                should(files[0].originalPath).equal('test-image.jpeg');
+                should(files[0].name).equal('test-image.jpeg');
 
                 done();
             }).catch(done);
@@ -400,16 +393,11 @@ describe('Importer', function () {
                 file = [{
                     path: '/my/test/' + filename,
                     name: filename
-                }],
-                storeSpy = sinon.spy(store, 'getUniqueFileName'),
-                storageSpy = sinon.spy(storage, 'getStorage');
+                }];
 
-            ImageHandler.loadFile(_.clone(file)).then(function () {
-                storageSpy.calledOnce.should.be.true();
-                storeSpy.calledOnce.should.be.true();
-                storeSpy.firstCall.args[0].originalPath.should.equal('photos/my-cat.jpeg');
-                storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images(\/|\\)photos$/);
-                storeSpy.firstCall.args[0].newPath.should.eql('/content/images/photos/my-cat.jpeg');
+            ImageHandler.loadFile(_.clone(file)).then(function (files) {
+                should(files[0].originalPath).equal('photos/my-cat.jpeg');
+                should(files[0].name).equal('photos/my-cat.jpeg');
 
                 done();
             }).catch(done);
@@ -420,16 +408,11 @@ describe('Importer', function () {
                 file = [{
                     path: '/my/test/content/images/' + filename,
                     name: filename
-                }],
-                storeSpy = sinon.spy(store, 'getUniqueFileName'),
-                storageSpy = sinon.spy(storage, 'getStorage');
+                }];
 
-            ImageHandler.loadFile(_.clone(file)).then(function () {
-                storageSpy.calledOnce.should.be.true();
-                storeSpy.calledOnce.should.be.true();
-                storeSpy.firstCall.args[0].originalPath.should.equal('content/images/my-cat.jpeg');
-                storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-                storeSpy.firstCall.args[0].newPath.should.eql('/content/images/my-cat.jpeg');
+            ImageHandler.loadFile(_.clone(file)).then(function (result) {
+                should(result[0].originalPath).equal('content/images/my-cat.jpeg');
+                should(result[0].name).equal('my-cat.jpeg');
 
                 done();
             }).catch(done);
@@ -442,16 +425,11 @@ describe('Importer', function () {
                 file = [{
                     path: '/my/test/' + filename,
                     name: filename
-                }],
-                storeSpy = sinon.spy(store, 'getUniqueFileName'),
-                storageSpy = sinon.spy(storage, 'getStorage');
+                }];
 
-            ImageHandler.loadFile(_.clone(file)).then(function () {
-                storageSpy.calledOnce.should.be.true();
-                storeSpy.calledOnce.should.be.true();
-                storeSpy.firstCall.args[0].originalPath.should.equal('test-image.jpeg');
-                storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-                storeSpy.firstCall.args[0].newPath.should.eql('/subdir/content/images/test-image.jpeg');
+            ImageHandler.loadFile(_.clone(file)).then(function (files) {
+                should(files[0].originalPath).equal('test-image.jpeg');
+                should(files[0].name).equal('test-image.jpeg');
 
                 done();
             }).catch(done);
@@ -459,39 +437,31 @@ describe('Importer', function () {
 
         it('can load multiple files', function (done) {
             var files = [{
-                    path: '/my/test/testing.png',
-                    name: 'testing.png'
-                },
-                {
-                    path: '/my/test/photo/kitten.jpg',
-                    name: 'photo/kitten.jpg'
-                },
-                {
-                    path: '/my/test/content/images/animated/bunny.gif',
-                    name: 'content/images/animated/bunny.gif'
-                },
-                {
-                    path: '/my/test/images/puppy.jpg',
-                    name: 'images/puppy.jpg'
-                }],
-                storeSpy = sinon.spy(store, 'getUniqueFileName'),
-                storageSpy = sinon.spy(storage, 'getStorage');
+                path: '/my/test/testing.png',
+                name: 'testing.png'
+            },
+            {
+                path: '/my/test/photo/kitten.jpg',
+                name: 'photo/kitten.jpg'
+            },
+            {
+                path: '/my/test/content/images/animated/bunny.gif',
+                name: 'content/images/animated/bunny.gif'
+            },
+            {
+                path: '/my/test/images/puppy.jpg',
+                name: 'images/puppy.jpg'
+            }];
 
-            ImageHandler.loadFile(_.clone(files)).then(function () {
-                storageSpy.calledOnce.should.be.true();
-                storeSpy.callCount.should.eql(4);
-                storeSpy.firstCall.args[0].originalPath.should.equal('testing.png');
-                storeSpy.firstCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-                storeSpy.firstCall.args[0].newPath.should.eql('/content/images/testing.png');
-                storeSpy.secondCall.args[0].originalPath.should.equal('photo/kitten.jpg');
-                storeSpy.secondCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images(\/|\\)photo$/);
-                storeSpy.secondCall.args[0].newPath.should.eql('/content/images/photo/kitten.jpg');
-                storeSpy.thirdCall.args[0].originalPath.should.equal('content/images/animated/bunny.gif');
-                storeSpy.thirdCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images(\/|\\)animated$/);
-                storeSpy.thirdCall.args[0].newPath.should.eql('/content/images/animated/bunny.gif');
-                storeSpy.lastCall.args[0].originalPath.should.equal('images/puppy.jpg');
-                storeSpy.lastCall.args[0].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
-                storeSpy.lastCall.args[0].newPath.should.eql('/content/images/puppy.jpg');
+            ImageHandler.loadFile(_.clone(files)).then(function (files) {
+                should(files[0].originalPath).equal('testing.png');
+                should(files[0].name).equal('testing.png');
+                should(files[1].originalPath).equal('photo/kitten.jpg');
+                should(files[1].name).equal('photo/kitten.jpg');
+                should(files[2].originalPath).equal('content/images/animated/bunny.gif');
+                should(files[2].name).equal('animated/bunny.gif');
+                should(files[3].originalPath).equal('images/puppy.jpg');
+                should(files[3].name).equal('puppy.jpg');
 
                 done();
             }).catch(done);
@@ -669,47 +639,71 @@ describe('Importer', function () {
             ImageImporter.doImport.should.be.instanceof(Function);
         });
 
-        it('does preprocess posts, users and tags correctly', function () {
-            var inputData = require('../../../utils/fixtures/import/import-data-1.json'),
-                outputData = ImageImporter.preProcess(_.cloneDeep(inputData));
+        it('does preprocess posts, users and tags correctly', function (done) {
+            var inputData = require('../../../utils/fixtures/import/import-data-1.json');
+            var store = storage.getStorage();
+            var storeSpy = sinon.stub(store, 'save');
+            storeSpy.withArgs(inputData.images[0]).returns(Promise.resolve('/content/images/my-image.png'));
+            storeSpy.withArgs(inputData.images[1]).returns(Promise.resolve('/content/images/photos/cat.jpg'));
 
-            inputData = inputData.data.data;
-            outputData = outputData.data.data;
-
-            inputData.posts[0].markdown.should.not.containEql('/content/images/my-image.png');
-            inputData.posts[0].html.should.not.containEql('/content/images/my-image.png');
-            outputData.posts[0].markdown.should.containEql('/content/images/my-image.png');
-            outputData.posts[0].html.should.containEql('/content/images/my-image.png');
-
-            inputData.posts[0].markdown.should.not.containEql('/content/images/photos/cat.jpg');
-            inputData.posts[0].html.should.not.containEql('/content/images/photos/cat.jpg');
-            outputData.posts[0].markdown.should.containEql('/content/images/photos/cat.jpg');
-            outputData.posts[0].html.should.containEql('/content/images/photos/cat.jpg');
-
-            inputData.posts[0].feature_image.should.eql('/images/my-image.png');
-            outputData.posts[0].feature_image.should.eql('/content/images/my-image.png');
-
-            inputData.tags[0].feature_image.should.eql('/images/my-image.png');
-            outputData.tags[0].feature_image.should.eql('/content/images/my-image.png');
-
-            inputData.users[0].profile_image.should.eql('/images/my-image.png');
-            inputData.users[0].cover_image.should.eql('/images/photos/cat.jpg');
-            outputData.users[0].profile_image.should.eql('/content/images/my-image.png');
-            outputData.users[0].cover_image.should.eql('/content/images/photos/cat.jpg');
+            ImageImporter.preProcess(_.cloneDeep(inputData)).then(function (outputData) {
+                inputData = inputData.data.data;
+                outputData = outputData.data.data;
+    
+                inputData.posts[0].markdown.should.not.containEql('/content/images/my-image.png');
+                inputData.posts[0].html.should.not.containEql('/content/images/my-image.png');
+                outputData.posts[0].markdown.should.containEql('/content/images/my-image.png');
+                outputData.posts[0].html.should.containEql('/content/images/my-image.png');
+    
+                inputData.posts[0].markdown.should.not.containEql('/content/images/photos/cat.jpg');
+                inputData.posts[0].html.should.not.containEql('/content/images/photos/cat.jpg');
+                outputData.posts[0].markdown.should.containEql('/content/images/photos/cat.jpg');
+                outputData.posts[0].html.should.containEql('/content/images/photos/cat.jpg');
+    
+                inputData.posts[0].feature_image.should.eql('/images/my-image.png');
+                outputData.posts[0].feature_image.should.eql('/content/images/my-image.png');
+    
+                inputData.tags[0].feature_image.should.eql('/images/my-image.png');
+                outputData.tags[0].feature_image.should.eql('/content/images/my-image.png');
+    
+                inputData.users[0].profile_image.should.eql('/images/my-image.png');
+                inputData.users[0].cover_image.should.eql('/images/photos/cat.jpg');
+                outputData.users[0].profile_image.should.eql('/content/images/my-image.png');
+                outputData.users[0].cover_image.should.eql('/content/images/photos/cat.jpg');
+                
+                done();
+            });
         });
 
-        it('does import the images correctly', function () {
-            var inputData = require('../../../utils/fixtures/import/import-data-1.json'),
-                storageApi = {
-                    save: sinon.stub().returns(Promise.resolve())
-                },
-                storageSpy = sinon.stub(storage, 'getStorage').callsFake(function () {
-                    return storageApi;
-                });
+        it('does preprocess posts, users and tags correctly (external host storage adapter)', function (done) {
+            var inputData = require('../../../utils/fixtures/import/import-data-1.json');
+            var store = storage.getStorage();
+            var storeSpy = sinon.stub(store, 'save');
+            storeSpy.withArgs(inputData.images[0]).returns(Promise.resolve('https://cdn.example.com/my-image.png'));
+            storeSpy.withArgs(inputData.images[1]).returns(Promise.resolve('https://cdn.example.com/photos/cat.png'));
 
-            ImageImporter.doImport(inputData.images).then(function () {
-                storageSpy.calledOnce.should.be.true();
-                storageApi.save.calledTwice.should.be.true();
+            ImageImporter.preProcess(_.cloneDeep(inputData)).then(function (outputData) {
+                inputData = inputData.data.data;
+                outputData = outputData.data.data;
+    
+                outputData.posts[0].markdown.should.containEql('https://cdn.example.com/my-image.png');
+                outputData.posts[0].html.should.containEql('https://cdn.example.com/my-image.png');
+    
+                outputData.posts[0].markdown.should.containEql('https://cdn.example.com/photos/cat.png');
+                outputData.posts[0].html.should.containEql('https://cdn.example.com/photos/cat.png');
+    
+                inputData.posts[0].feature_image.should.eql('/images/my-image.png');
+                outputData.posts[0].feature_image.should.eql('https://cdn.example.com/my-image.png');
+    
+                inputData.tags[0].feature_image.should.eql('/images/my-image.png');
+                outputData.tags[0].feature_image.should.eql('https://cdn.example.com/my-image.png');
+    
+                inputData.users[0].profile_image.should.eql('/images/my-image.png');
+                inputData.users[0].cover_image.should.eql('/images/photos/cat.jpg');
+                outputData.users[0].profile_image.should.eql('https://cdn.example.com/my-image.png');
+                outputData.users[0].cover_image.should.eql('https://cdn.example.com/photos/cat.png');
+                
+                done();
             });
         });
     });

--- a/test/utils/fixtures/import/import-data-1.json
+++ b/test/utils/fixtures/import/import-data-1.json
@@ -3,16 +3,12 @@
         {
             "name": "my-image.png",
             "path": "/tmp/test/path/images/my-image.png",
-            "originalPath": "images/my-image.png",
-            "targetDir": "/test/content/images",
-            "newPath": "/content/images/my-image.png"
+            "originalPath": "images/my-image.png"
         },
         {
             "name": "photos/cat.jpg",
             "path": "/tmp/test/path/images/photos/cat.jpg",
-            "originalPath": "images/photos/cat.jpg",
-            "targetDir": "/test/content/images/photos",
-            "newPath": "/content/images/photos/cat.jpg"
+            "originalPath": "images/photos/cat.jpg"
         }
     ],
     "data": {


### PR DESCRIPTION
…image url or path.

fixes #11763

Previously we imported zips by computing the unique file path ahead of time, replacing in the posts all references to the new paths, and then saving. This failed to work if there was any mobiledoc that referenced images, as we did not do the replacement there. It also failed to take into account the fact that a storage adapter may return an externally hosted URL for e.g., CDN purposes. 

To fix that, we updated the importer to replace the mobiledoc text and also to save all images to find the new url in the preprocess stage, so that the custom paths of all storage adapters are taken into account.
