### PR TITLE
Switched to mocha-github-actions-reporter for CI

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,10 @@ const configureGrunt = function (grunt) {
     grunt.loadNpmTasks('grunt-subgrunt');
     grunt.loadNpmTasks('grunt-update-submodules');
 
+    if (process.env.CI) {
+        grunt.option('reporter', 'mocha-github-actions-reporter');
+    }
+
     var cfg = {
         // #### Common paths used by tasks
         paths: {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "grunt-update-submodules": "0.4.1",
     "jwks-rsa": "1.8.0",
     "mocha": "7.1.2",
+    "mocha-github-actions-reporter": "0.2.1",
     "mock-knex": "0.4.8",
     "nock": "12.0.3",
     "proxyquire": "2.1.3",

--- a/test/api-acceptance/admin/actions_spec.js
+++ b/test/api-acceptance/admin/actions_spec.js
@@ -34,7 +34,7 @@ describe('Actions API', function () {
             })
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(201)
+            .expect(200)
             .then((res) => {
                 postId = res.body.posts[0].id;
                 postUpdatedAt = res.body.posts[0].updated_at;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@actions/core@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.3.tgz#e844b4fa0820e206075445079130868f95bfca95"
+  integrity sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w==
+
 "@babel/code-frame@^7.0.0":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -6031,6 +6036,13 @@ mobiledoc-text-renderer@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mobiledoc-text-renderer/-/mobiledoc-text-renderer-0.4.0.tgz#473fbe50aa6cde2c3b449752f3b984834dc824d2"
   integrity sha512-+Tzfo0hhUFxS0n5FWZ0nf6WUrvnVmsxaIdq0CyeLYD1lk8oW2ml+6WLdeLlzKM5OYYi3PWV6NR9HCUG01cdvWQ==
+
+mocha-github-actions-reporter@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/mocha-github-actions-reporter/-/mocha-github-actions-reporter-0.2.1.tgz#ba55fd4e50551ba9404dad1bcb63f2bed6a7d6e8"
+  integrity sha512-/r7mLNSr9a994PTB5D/l9ev4QtOyoiZNxGZanh66tn2OmePlE8EG6acD5Y8Aja3jqdHOAQ3rQBdAzotA3zuLDQ==
+  dependencies:
+    "@actions/core" "1.2.3"
 
 mocha@7.1.2:
   version "7.1.2"


### PR DESCRIPTION
no issue

- this should highlight errors within the GitHub interface