### PR TITLE
🐛 Fixed regex match replacement when dealing with external URLs

### DIFF
--- a/test/regression/api/canary/admin/redirects_spec.js
+++ b/test/regression/api/canary/admin/redirects_spec.js
@@ -60,10 +60,10 @@ describe('Redirects API', function () {
                 .then((res) => {
                     res.headers['content-disposition'].should.eql('Attachment; filename="redirects.json"');
                     res.headers['content-type'].should.eql('application/json; charset=utf-8');
-                    res.headers['content-length'].should.eql('698');
+                    res.headers['content-length'].should.eql('756');
 
                     res.body.should.not.be.empty();
-                    res.body.length.should.equal(12);
+                    res.body.length.should.equal(13);
                 });
         });
     });

--- a/test/regression/api/v2/admin/redirects_spec.js
+++ b/test/regression/api/v2/admin/redirects_spec.js
@@ -60,10 +60,10 @@ describe('Redirects API', function () {
                 .then((res) => {
                     res.headers['content-disposition'].should.eql('Attachment; filename="redirects.json"');
                     res.headers['content-type'].should.eql('application/json; charset=utf-8');
-                    res.headers['content-length'].should.eql('698');
+                    res.headers['content-length'].should.eql('756');
 
                     res.body.should.not.be.empty();
-                    res.body.length.should.equal(12);
+                    res.body.length.should.equal(13);
                 });
         });
     });

--- a/test/regression/api/v3/admin/redirects_spec.js
+++ b/test/regression/api/v3/admin/redirects_spec.js
@@ -60,10 +60,10 @@ describe('Redirects API', function () {
                 .then((res) => {
                     res.headers['content-disposition'].should.eql('Attachment; filename="redirects.json"');
                     res.headers['content-type'].should.eql('application/json; charset=utf-8');
-                    res.headers['content-length'].should.eql('698');
+                    res.headers['content-length'].should.eql('756');
 
                     res.body.should.not.be.empty();
-                    res.body.length.should.equal(12);
+                    res.body.length.should.equal(13);
                 });
         });
     });

--- a/test/regression/site/frontend_spec.js
+++ b/test/regression/site/frontend_spec.js
@@ -768,6 +768,60 @@ describe('Frontend Routing', function () {
                         doEnd(done)(err, res);
                     });
             });
+
+            it('with capturing group', function (done) {
+                request.get('/external-url/docs')
+                    .expect(302)
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .end(function (err, res) {
+                        res.headers.location.should.eql('https://ghost.org/docs');
+                        doEnd(done)(err, res);
+                    });
+            });
+        });
+    });
+
+    describe('Subdirectory redirects (use redirects.json from test/utils/fixtures/data)', function () {
+        var ghostServer;
+
+        before(function () {
+            configUtils.set('url', 'http://localhost:2370/blog/');
+            urlUtils.stubUrlUtilsFromConfig();
+
+            return ghost({forceStart: true})
+                .then(function (_ghostServer) {
+                    ghostServer = _ghostServer;
+                    request = supertest.agent(config.get('server:host') + ':' + config.get('server:port'));
+                });
+        });
+
+        after(function () {
+            configUtils.restore();
+            urlUtils.restore();
+        });
+
+        describe('internal url redirect', function () {
+            it('shold include the subdirectory', function (done) {
+                request.get('/blog/my-old-blog-post/')
+                    .expect(302)
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .end(function (err, res) {
+                        res.headers.location.should.eql('/blog/revamped-url/');
+                        doEnd(done)(err, res);
+                    });
+            });
+        });
+
+        describe('external url redirect', function () {
+            it('shold not include the subdirectory', function (done) {
+                request.get('/blog/external-url/docs')
+                    .expect(302)
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .end(function (err, res) {
+                        res.headers.location.should.eql('https://ghost.org/docs');
+                        doEnd(done)(err, res);
+                    });
+            });
         });
     });
 });

--- a/test/utils/fixtures/data/redirects.json
+++ b/test/utils/fixtures/data/redirects.json
@@ -46,5 +46,9 @@
     {
         "from": "/external-url",
         "to": "https://ghost.org"
+    },
+    {
+        "from": "/external-url/(.*)",
+        "to": "https://ghost.org/$1"
     }
 ]


### PR DESCRIPTION
refs #10898
- Execute string replacement on external paths
- Take non-top-level base URLs into consideration (to avoid #10776 dups)
- Added tests for all of the above cases

---

- [x] There's a clear use-case for this code change
Both [this comment](https://github.com/TryGhost/Ghost/issues/10898#issuecomment-516246531) and [this thread on the forum](https://forum.ghost.org/t/problem-with-redirect-regex-after-upgrade-3-0/13745)
- [x] Commit message has a short title & references relevant issues
I hope so. I tried my best to stay under 80 characters 😃
- [x] The build will pass (run `yarn test` and `yarn lint`)
Yep