### PR TITLE
Added new endpoint for refreshing api key secret

### DIFF
--- a/core/server/api/canary/integrations.js
+++ b/core/server/api/canary/integrations.js
@@ -85,11 +85,16 @@ module.exports = {
                                 })
                             });
                         }
-                        await models.ApiKey.refreshSecret(model.toJSON(), Object.assign({}, options, {id: options.keyid}));
-                        // TODO: Throw error if changing secret fails
-                        return models.Integration.findOne({id: options.id}, {
-                            withRelated: ['api_keys', 'webhooks']
-                        });
+                        try {
+                            await models.ApiKey.refreshSecret(model.toJSON(), Object.assign({}, options, {id: options.keyid}));
+                            return models.Integration.findOne({id: options.id}, {
+                                withRelated: ['api_keys', 'webhooks']
+                            });
+                        } catch (err) {
+                            throw new common.errors.GhostError({
+                                err: err
+                            });
+                        }
                     });
             }
             return models.Integration.edit(data, Object.assign(options, {require: true}))

--- a/core/server/models/api-key.js
+++ b/core/server/models/api-key.js
@@ -114,7 +114,7 @@ const ApiKey = ghostBookshelf.Model.extend({
             }
         }
     },
-    onSaved(model, attrs, options) {
+    onUpdated(model, attrs, options) {
         if (this.previous('secret') !== this.get('secret')) {
             addAction(model, 'refreshed', options);
         }

--- a/core/server/models/api-key.js
+++ b/core/server/models/api-key.js
@@ -1,4 +1,6 @@
 const omit = require('lodash/omit');
+const common = require('../lib/common');
+const _ = require('lodash');
 const crypto = require('crypto');
 const ghostBookshelf = require('./base');
 const {Role} = require('./role');
@@ -24,6 +26,50 @@ const {Role} = require('./role');
 const createSecret = (type) => {
     const bytes = type === 'content' ? 13 : 32;
     return crypto.randomBytes(bytes).toString('hex');
+};
+
+const addAction = (model, event, options) => {
+    if (!model.wasChanged()) {
+        return;
+    }
+
+    // CASE: model does not support actions at all
+    if (!model.getAction) {
+        return;
+    }
+
+    const action = model.getAction(event, options);
+
+    // CASE: model does not support action for target event
+    if (!action) {
+        return;
+    }
+
+    const insert = (action) => {
+        ghostBookshelf.model('Action')
+            .add(action)
+            .catch((err) => {
+                if (_.isArray(err)) {
+                    err = err[0];
+                }
+
+                common.logging.error(new common.errors.InternalServerError({
+                    err
+                }));
+            });
+    };
+
+    if (options.transacting) {
+        options.transacting.once('committed', (committed) => {
+            if (!committed) {
+                return;
+            }
+
+            insert(action);
+        });
+    } else {
+        insert(action);
+    }
 };
 
 const ApiKey = ghostBookshelf.Model.extend({
@@ -67,6 +113,29 @@ const ApiKey = ghostBookshelf.Model.extend({
                 this.set('role_id', null);
             }
         }
+    },
+    onSaved(model, attrs, options) {
+        if (this.previous('secret') !== this.get('secret')) {
+            addAction(model, 'refreshed', options);
+        }
+    },
+
+    getAction(event, options) {
+        const actor = this.getActor(options);
+
+        // @NOTE: we ignore internal updates (`options.context.internal`) for now
+        if (!actor) {
+            return;
+        }
+
+        // @TODO: implement context
+        return {
+            event: event,
+            resource_id: this.id || this.previous('id'),
+            resource_type: 'api_key',
+            actor_id: actor.id,
+            actor_type: actor.type
+        };
     }
 }, {
     refreshSecret(data, options) {

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -42,6 +42,7 @@ module.exports = function apiRoutes() {
     router.get('/integrations', mw.authAdminApi, http(apiCanary.integrations.browse));
     router.get('/integrations/:id', mw.authAdminApi, http(apiCanary.integrations.read));
     router.post('/integrations', mw.authAdminApi, http(apiCanary.integrations.add));
+    router.post('/integrations/:id/api_key/:keyid/refresh', mw.authAdminApi, http(apiCanary.integrations.edit));
     router.put('/integrations/:id', mw.authAdminApi, http(apiCanary.integrations.edit));
     router.del('/integrations/:id', mw.authAdminApi, http(apiCanary.integrations.destroy));
 

--- a/test/api-acceptance/admin/integrations_spec.js
+++ b/test/api-acceptance/admin/integrations_spec.js
@@ -312,7 +312,19 @@ describe('Integrations API', function () {
                                 const updatedAdminApiKey = updatedIntegration.api_keys.find(key => key.type === 'admin');
                                 should.equal(updatedIntegration.id, createdIntegration.id);
                                 updatedAdminApiKey.secret.should.not.eql(adminApiKey.secret);
-                                done();
+                                request.get(localUtils.API.getApiQuery(`actions/?filter=resource_id:${adminApiKey.id}&include=actor`))
+                                    .set('Origin', config.get('url'))
+                                    .expect('Content-Type', /json/)
+                                    .expect('Cache-Control', testUtils.cacheRules.private)
+                                    .expect(200)
+                                    .end(function (err, {body}) {
+                                        const actions = body.actions;
+                                        const refreshedAction = actions.find((action) => {
+                                            return action.event === 'refreshed';
+                                        });
+                                        should.exist(refreshedAction);
+                                        done();
+                                    });
                             });
                     });
             });


### PR DESCRIPTION
no issue

- Adds new endpoint on integration to refresh admin/content api keys
- Allows owner/admin to refresh their content or admin API keys for an integration via Ghost Admin
- Adds a new `refreshed` event to actions table for `api_key` everytime an api secret is refreshed