### PR TITLE
Redirect members on token error

### DIFF
--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -93,26 +93,26 @@ const getMemberSiteData = async function (req, res) {
 };
 
 const createSessionFromMagicLink = async function (req, res, next) {
-    let redirectPath = `${urlUtils.getSubdir()}${req.path}`;
-
     if (!req.url.includes('token=')) {
         return next();
     }
 
+    // req.query is a plain object, copy it to a URLSearchParams object so we can call toString()
+    const searchParams = new URLSearchParams('');
+    Object.keys(req.query).forEach((param) => {
+        // don't copy the token param
+        if (param !== 'token') {
+            searchParams.set(param, req.query[param]);
+        }
+    });
+
+    // We need to include the subdirectory,
+    // members is already removed from the path by express because it's a mount path
+    const redirectPath = `${urlUtils.getSubdir()}${req.path}?${searchParams.toString()}`;
+
     try {
         await membersService.ssr.exchangeTokenForSession(req, res);
 
-        // req.query is a plain object, copy it to a URLSearchParams object so we can call toString()
-        const searchParams = new URLSearchParams('');
-        Object.keys(req.query).forEach((param) => {
-            // don't copy the token param
-            if (param !== 'token') {
-                searchParams.set(param, req.query[param]);
-            }
-        });
-
-        // We need to include the subdirectory, but members is already removed from the path
-        redirectPath = `${redirectPath}?${searchParams.toString()}`;
         // Do a standard 302 redirect
         return res.redirect(redirectPath);
     } catch (err) {

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -93,9 +93,12 @@ const getMemberSiteData = async function (req, res) {
 };
 
 const createSessionFromMagicLink = async function (req, res, next) {
+    let redirectPath = `${urlUtils.getSubdir()}${req.path}`;
+
     if (!req.url.includes('token=')) {
         return next();
     }
+
     try {
         await membersService.ssr.exchangeTokenForSession(req, res);
 
@@ -109,13 +112,12 @@ const createSessionFromMagicLink = async function (req, res, next) {
         });
 
         // We need to include the subdirectory, but members is already removed from the path
-        let redirectPath = `${urlUtils.getSubdir()}${req.path}?${searchParams.toString()}`;
-
+        redirectPath = `${redirectPath}?${searchParams.toString()}`;
         // Do a standard 302 redirect
-        res.redirect(redirectPath);
+        return res.redirect(redirectPath);
     } catch (err) {
         logging.warn(err.message);
-        return next();
+        return res.redirect(redirectPath);
     }
 };
 


### PR DESCRIPTION
In 3.15 invalid tokens result in a 404 being rendered as an API-style JSON error. There are 2 issues, first the error should be a theme error - this was addressed by https://github.com/TryGhost/Ghost/pull/11795.

Secondly, this was a divergence on the original behaviour which redirected to home.

This restores the functionality from 3.14 as follows:

`/members/` -> (with no route) rendered 404 error
`/members/` -> (with route) renders members template
`/members/?token=invalidtoken&foo=bar` -> redirects to `/?foo=bar`
`/members/?token=validtoken&foo=bar` -> redirects to `/?foo=bar`