### PR TITLE
Enforced proper Node versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: [ 10, 12 ]
+        node: [ '10.13.0', '12.10.0' ]
         env:
           - DB: sqlite3
             NODE_ENV: testing
@@ -60,7 +60,7 @@ jobs:
           submodules: true
       - uses: actions/setup-node@v1
         with:
-          node-version: '10'
+          node-version: '10.13.0'
       - run: npm install -g ghost-cli@next
       - run: zip -r ghost.zip .
 


### PR DESCRIPTION
no issue

- a recent regression was not caught by CI because we only specify major
  versions
- this change will temporarily fail in CI until the fix for the
  regression is implemented