### PR TITLE
🐛 Fixed structured data issue for publisher logo

### DIFF
--- a/core/frontend/meta/schema.js
+++ b/core/frontend/meta/schema.js
@@ -5,19 +5,19 @@ const _ = require('lodash');
 
 function schemaImageObject(metaDataVal) {
     let imageObject;
-    if (!metaDataVal) {
+    if (!metaDataVal || !metaDataVal.url) {
         return null;
-    }
-    if (!metaDataVal.dimensions) {
-        return metaDataVal.url;
     }
 
     imageObject = {
         '@type': 'ImageObject',
-        url: metaDataVal.url,
-        width: metaDataVal.dimensions.width,
-        height: metaDataVal.dimensions.height
+        url: metaDataVal.url
     };
+
+    if (metaDataVal.dimensions) {
+        imageObject.width = metaDataVal.dimensions.width;
+        imageObject.height = metaDataVal.dimensions.height;
+    }
 
     return imageObject;
 }

--- a/test/unit/data/meta/schema_spec.js
+++ b/test/unit/data/meta/schema_spec.js
@@ -430,7 +430,10 @@ describe('getSchema', function () {
             author: {
                 '@type': 'Person',
                 description: 'My author bio.',
-                image: 'http://mysite.com/author/image/url/me.jpg',
+                image: {
+                    '@type': 'ImageObject',
+                    url: 'http://mysite.com/author/image/url/me.jpg'
+                },
                 name: 'Post Author',
                 sameAs: [
                     'http://myblogsite.com/',
@@ -443,7 +446,10 @@ describe('getSchema', function () {
             datePublished: '2015-12-25T05:35:01.234Z',
             description: 'Post meta description',
             headline: 'Post Title',
-            image: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            image: {
+                '@type': 'ImageObject',
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg'
+            },
             keywords: 'one, two, tag',
             mainEntityOfPage: {
                 '@type': 'WebPage',
@@ -453,7 +459,10 @@ describe('getSchema', function () {
                 '@type': 'Organization',
                 name: 'Site Title',
                 url: 'http://mysite.com',
-                logo: 'http://mysite.com/author/image/url/logo.jpg'
+                logo: {
+                    '@type': 'ImageObject',
+                    url: 'http://mysite.com/author/image/url/logo.jpg'
+                }
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });

--- a/test/unit/helpers/ghost_head_spec.js
+++ b/test/unit/helpers/ghost_head_spec.js
@@ -371,7 +371,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"@type": "WebSite"/);
                 rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/site-cover.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/site-cover.png"\n/);
                 rendered.string.should.match(/"description": "site description"/);
 
                 done();
@@ -419,7 +419,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"@type": "WebSite"/);
                 rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/site-cover.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/site-cover.png"\n/);
                 rendered.string.should.match(/"description": "site SEO description"/);
 
                 done();
@@ -467,8 +467,8 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"name": "Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/about\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image-about.png"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/test-image-about.png"\n/);
+                rendered.string.should.match(/"image": {\n            "@type": "ImageObject",\n            "url": "http:\/\/localhost:65530\/content\/images\/test-author-image.png"\n/);
                 rendered.string.should.match(/"description": "all about our site"/);
 
                 done();
@@ -516,8 +516,8 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"name": "Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/about\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image-about.png"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/test-image-about.png"/);
+                rendered.string.should.match(/"image": {\n            "@type": "ImageObject",\n            "url": "http:\/\/localhost:65530\/content\/images\/test-author-image.png"\n/);
                 rendered.string.should.match(/"description": "all about our site"/);
 
                 done();
@@ -574,7 +574,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"author": {/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"image": {\n            "@type": "ImageObject",\n            "url": "http:\/\/localhost:65530\/content\/images\/test-author-image.png"\n/);
                 rendered.string.should.match(/"url": "https:\/\/mysite.com\/fakeauthor\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.not.match(/"description": "Author bio"/);
@@ -582,7 +582,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
                 rendered.string.should.match(re3);
                 rendered.string.should.match(re4);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/test-image.png"\n/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "site description"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
@@ -638,13 +638,13 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"author": {/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"image": {\n            "@type": "ImageObject",\n            "url": "http:\/\/localhost:65530\/content\/images\/test-author-image.png"/);
                 rendered.string.should.match(/"url": "https:\/\/mysite.com\/fakeauthor\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.not.match(/"description": "Author bio"/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "post custom excerpt"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
@@ -751,13 +751,13 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"author": {/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"image": {\n            "@type": "ImageObject",\n            "url": "http:\/\/localhost:65530\/content\/images\/test-author-image.png"/);
                 rendered.string.should.match(/"url": "https:\/\/mysite.com\/fakeauthor\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.not.match(/"description": "Author bio"/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "site description"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
@@ -813,13 +813,13 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"author": {/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"image": {\n            "@type": "ImageObject",\n            "url": "http:\/\/localhost:65530\/content\/images\/test-author-image.png"/);
                 rendered.string.should.match(/"url": "https:\/\/mysite.com\/fakeauthor\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost &quot;test&quot;"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "site &quot;test&quot; description"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
@@ -870,13 +870,13 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"author": {/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"image": {\n            "@type": "ImageObject",\n            "url": "http:\/\/localhost:65530\/content\/images\/test-author-image.png"/);
                 rendered.string.should.match(/"url": "https:\/\/mysite.com\/fakeauthor\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
                 rendered.string.should.not.match(/"keywords":/);
                 rendered.string.should.match(/"description": "site description"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
@@ -1077,7 +1077,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"@type": "Series"/);
                 rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/tag\/tagtitle\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/tag-image.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/tag-image.png"/);
                 rendered.string.should.match(/"name": "tagtitle"/);
                 rendered.string.should.match(/"description": "tag meta description"/);
 
@@ -1120,7 +1120,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"@type": "Series"/);
                 rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:65530\/tag\/tagtitle\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/tag-image.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/tag-image.png"/);
                 rendered.string.should.match(/"name": "tagtitle"/);
 
                 done();
@@ -1210,7 +1210,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"sameAs": \[\n        "http:\/\/authorwebsite.com",\n        "https:\/\/www.facebook.com\/testuser",\n        "https:\/\/twitter.com\/testuser"\n    \]/);
                 rendered.string.should.match(/"url": "https:\/\/mysite.com\/fakeauthor\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/author-cover-image.png"/);
+                rendered.string.should.match(/"image": {\n        "@type": "ImageObject",\n        "url": "http:\/\/localhost:65530\/content\/images\/author-cover-image.png"/);
                 rendered.string.should.match(/"name": "Author name"/);
 
                 done();


### PR DESCRIPTION
closes #11304

- Google requires an `ImageObject` to be always returned for `publisher.logo` (https://developers.google.com/search/docs/data-types/article)
- The previous fix https://github.com/TryGhost/Ghost/commit/3f5daa60c82205b8538a6584b24a9d7ceda593c6 added a second nested `url` error and got therefore reverted with https://github.com/tryghost/ghost/commit/7ac614030d80a3c172a117f44b7736dec197dba2
- This commit updates the image object generation fn to **always** return an `ImageObject` with minimum of `url` and `@type` properties. If dimensions are available, we'll pass those in there as well