### PR TITLE
Fixed truncated URL for password reset email

### DIFF
--- a/core/server/services/auth/passwordreset.js
+++ b/core/server/services/auth/passwordreset.js
@@ -123,12 +123,10 @@ async function sendResetNotification(data, mailAPI) {
     const adminUrl = urlUtils.urlFor('admin', true);
     const resetToken = security.url.encodeBase64(data.resetToken);
     const resetUrl = urlUtils.urlJoin(adminUrl, 'reset', resetToken, '/');
-    const resetLink = urlUtils.urlJoin(adminUrl, 'reset', `${resetToken.slice(0, 5)}...`);
 
     const content = await mail.utils.generateContent({
         data: {
-            resetUrl,
-            resetLink
+            resetUrl
         },
         template: 'reset-password'
     });

--- a/core/server/services/mail/templates/reset-password.html
+++ b/core/server/services/mail/templates/reset-password.html
@@ -23,7 +23,7 @@
                                         <!-- START OF EMAIL CONTENT -->
                                         <p style="color: #808284; font-family: sans-serif; font-size: 15px; font-weight: normal; line-height: 1.5em; margin: 0; padding: 0 0 1.5em 0;"><strong>Hey there!</strong></p>
                                         <p style="color: #808284; font-family: sans-serif; font-size: 15px; font-weight: normal; line-height: 1.5em; margin: 0; padding: 0 0 1.5em 0;">You can use this link to create a new password for your account on <strong>{{siteTitle}}</strong>:</p>
-                                        <p style="color: #808284; font-family: sans-serif; font-size: 15px; font-weight: normal; line-height: 1.5em; margin: 0; padding: 0 0 1.5em 0;"><a href="{{resetUrl}}" style="color: #5ba4e5;">{{resetLink}}</a></p>
+                                        <p style="color: #808284; font-family: sans-serif; font-size: 15px; font-weight: normal; line-height: 1.5em; margin: 0; padding: 0 0 1.5em 0; word-break: break-all;"><a href="{{resetUrl}}" style="color: #5ba4e5;">{{resetUrl}}</a></p>
                                         <p style="color: #808284; font-family: sans-serif; font-size: 15px; font-weight: normal; line-height: 1.5em; margin: 0; padding: 0 0 1.5em 0;">If you have any trouble, you should contact your site administrator for help.</p>
                                         <!-- END OF EMAIL CONTENT -->
 


### PR DESCRIPTION
no refs.
- shows the full URL instead of a truncated link in password reset email body. This is required for security and usability reasons (copy/paste)