### PR TITLE
🐛 Removed overcealous menu and menu items from navigation template.

### DIFF
--- a/core/frontend/helpers/tpl/navigation.hbs
+++ b/core/frontend/helpers/tpl/navigation.hbs
@@ -1,5 +1,5 @@
-<ul class="nav" role="menu">
+<ul class="nav">
     {{#foreach navigation}}
-    <li class="{{link_class for=(url) class=(concat "nav-" slug)}}" role="menuitem"><a href="{{url absolute="true"}}">{{label}}</a></li>
+    <li class="{{link_class for=(url) class=(concat "nav-" slug)}}"><a href="{{url absolute="true"}}">{{label}}</a></li>
     {{/foreach}}
 </ul>


### PR DESCRIPTION
closes #11832.
These hide the actual links from accessibility aids and are not appropriate to use in this context.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
