### PR TITLE
Refactored `common` lib import to use destructuring

### DIFF
--- a/core/frontend/apps/amp/lib/router.js
+++ b/core/frontend/apps/amp/lib/router.js
@@ -3,7 +3,8 @@ const express = require('../../../../shared/express');
 const ampRouter = express.Router('amp');
 
 // Dirty requires
-const common = require('../../../../server/lib/common');
+const {i18n} = require('../../../../server/lib/common');
+const errors = require('@tryghost/errors');
 
 const urlService = require('../../../services/url');
 const helpers = require('../../../services/routing/helpers');
@@ -22,7 +23,7 @@ function _renderer(req, res, next) {
 
     // CASE: we only support amp pages for posts that are not static pages
     if (!data.post || data.post.page) {
-        return next(new common.errors.NotFoundError({message: common.i18n.t('errors.errors.pageNotFound')}));
+        return next(new errors.NotFoundError({message: i18n.t('errors.errors.pageNotFound')}));
     }
 
     // Render Call
@@ -59,8 +60,8 @@ function getPostData(req, res, next) {
     const permalinks = urlService.getPermalinkByUrl(urlWithoutSubdirectoryWithoutAmp, {withUrlOptions: true});
 
     if (!permalinks) {
-        return next(new common.errors.NotFoundError({
-            message: common.i18n.t('errors.errors.pageNotFound')
+        return next(new errors.NotFoundError({
+            message: i18n.t('errors.errors.pageNotFound')
         }));
     }
 

--- a/core/frontend/apps/private-blogging/index.js
+++ b/core/frontend/apps/private-blogging/index.js
@@ -1,5 +1,6 @@
 const urlUtils = require('../../../server/lib/url-utils');
-const common = require('../../../server/lib/common');
+const {logging, i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const middleware = require('./lib/middleware');
 const router = require('./lib/router');
 const registerHelpers = require('./lib/helpers');
@@ -14,10 +15,10 @@ let checkSubdir = function checkSubdir() {
         paths = urlUtils.getSubdir().split('/');
 
         if (paths.pop() === PRIVATE_KEYWORD) {
-            common.logging.error(new common.errors.GhostError({
-                message: common.i18n.t('errors.config.urlCannotContainPrivateSubdir.error'),
-                context: common.i18n.t('errors.config.urlCannotContainPrivateSubdir.description'),
-                help: common.i18n.t('errors.config.urlCannotContainPrivateSubdir.help')
+            logging.error(new errors.GhostError({
+                message: i18n.t('errors.config.urlCannotContainPrivateSubdir.error'),
+                context: i18n.t('errors.config.urlCannotContainPrivateSubdir.description'),
+                help: i18n.t('errors.config.urlCannotContainPrivateSubdir.help')
             }));
 
             // @TODO: why

--- a/core/frontend/apps/private-blogging/lib/middleware.js
+++ b/core/frontend/apps/private-blogging/lib/middleware.js
@@ -6,7 +6,8 @@ const path = require('path');
 const config = require('../../../../server/config');
 const urlUtils = require('../../../../server/lib/url-utils');
 const constants = require('../../../../server/lib/constants');
-const common = require('../../../../server/lib/common');
+const {i18n} = require('../../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const settingsCache = require('../../../../server/services/settings/cache');
 // routeKeywords.private: 'private'
 const privateRoute = '/private/';
@@ -81,8 +82,8 @@ const privateBlogging = {
         privateBlogging.authenticatePrivateSession(req, res, function onSessionVerified() {
             // CASE: RSS is disabled for private blogging e.g. they create overhead
             if (req.path.match(/\/rss(\/?|\/\d+\/?)$/)) {
-                return next(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.errors.pageNotFound')
+                return next(new errors.NotFoundError({
+                    message: i18n.t('errors.errors.pageNotFound')
                 }));
             }
 
@@ -143,7 +144,7 @@ const privateBlogging = {
             return res.redirect(urlUtils.urlFor({relativeUrl: forward}));
         } else {
             res.error = {
-                message: common.i18n.t('errors.middleware.privateblogging.wrongPassword')
+                message: i18n.t('errors.middleware.privateblogging.wrongPassword')
             };
             return next();
         }

--- a/core/frontend/meta/index.js
+++ b/core/frontend/meta/index.js
@@ -1,7 +1,7 @@
 const Promise = require('bluebird');
 const settingsCache = require('../../server/services/settings/cache');
 const urlUtils = require('../../server/lib/url-utils');
-const common = require('../../server/lib/common');
+const {logging} = require('../../server/lib/common');
 const getUrl = require('./url');
 const getImageDimensions = require('./image-dimensions');
 const getCanonicalUrl = require('./canonical_url');
@@ -103,7 +103,7 @@ function getMetaData(data, root) {
 
         return metaData;
     }).catch(function (err) {
-        common.logging.error(err);
+        logging.error(err);
         return metaData;
     });
 }

--- a/core/frontend/services/apps/index.js
+++ b/core/frontend/services/apps/index.js
@@ -1,6 +1,7 @@
 const debug = require('ghost-ignition').debug('services:apps');
 const Promise = require('bluebird');
-const common = require('../../../server/lib/common');
+const {logging, i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const config = require('../../../server/config');
 const loader = require('./loader');
 
@@ -11,10 +12,10 @@ module.exports = {
 
         return Promise.map(appsToLoad, appName => loader.activateAppByName(appName))
             .catch(function (err) {
-                common.logging.error(new common.errors.GhostError({
+                logging.error(new errors.GhostError({
                     err: err,
-                    context: common.i18n.t('errors.apps.appWillNotBeLoaded.error'),
-                    help: common.i18n.t('errors.apps.appWillNotBeLoaded.help')
+                    context: i18n.t('errors.apps.appWillNotBeLoaded.error'),
+                    help: i18n.t('errors.apps.appWillNotBeLoaded.help')
                 }));
             });
     }

--- a/core/frontend/services/apps/loader.js
+++ b/core/frontend/services/apps/loader.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../server/lib/common');
+const {i18n} = require('../../../server/lib/common');
 const config = require('../../../server/config');
 const Proxy = require('./proxy');
 
@@ -35,7 +35,7 @@ module.exports = {
 
         // Check for an activate() method on the app.
         if (!_.isFunction(app.activate)) {
-            return Promise.reject(new Error(common.i18n.t('errors.apps.noActivateMethodLoadingApp.error', {name: name})));
+            return Promise.reject(new Error(i18n.t('errors.apps.noActivateMethodLoadingApp.error', {name: name})));
         }
 
         // Wrapping the activate() with a when because it's possible

--- a/core/frontend/services/redirects/settings.js
+++ b/core/frontend/services/redirects/settings.js
@@ -6,7 +6,8 @@ const moment = require('moment-timezone');
 const validation = require('./validation');
 
 const config = require('../../../server/config');
-const common = require('../../../server/lib/common');
+const {i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 
 const readRedirectsFile = (redirectsPath) => {
     return fs.readFile(redirectsPath, 'utf-8')
@@ -14,8 +15,8 @@ const readRedirectsFile = (redirectsPath) => {
             try {
                 content = JSON.parse(content);
             } catch (err) {
-                throw new common.errors.BadRequestError({
-                    message: common.i18n.t('errors.general.jsonParse', {context: err.message})
+                throw new errors.BadRequestError({
+                    message: i18n.t('errors.general.jsonParse', {context: err.message})
                 });
             }
 
@@ -26,11 +27,11 @@ const readRedirectsFile = (redirectsPath) => {
                 return Promise.resolve([]);
             }
 
-            if (common.errors.utils.isIgnitionError(err)) {
+            if (errors.utils.isIgnitionError(err)) {
                 throw err;
             }
 
-            throw new common.errors.NotFoundError({
+            throw new errors.NotFoundError({
                 err: err
             });
         });

--- a/core/frontend/services/redirects/validation.js
+++ b/core/frontend/services/redirects/validation.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
-const common = require('../../../server/lib/common');
+const {i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 
 /**
  * Redirects are file based at the moment, but they will live in the database in the future.
@@ -7,16 +8,16 @@ const common = require('../../../server/lib/common');
  */
 const validate = (redirects) => {
     if (!_.isArray(redirects)) {
-        throw new common.errors.ValidationError({
-            message: common.i18n.t('errors.utils.redirectsWrongFormat'),
+        throw new errors.ValidationError({
+            message: i18n.t('errors.utils.redirectsWrongFormat'),
             help: 'https://ghost.org/docs/api/handlebars-themes/routing/redirects/'
         });
     }
 
     _.each(redirects, function (redirect) {
         if (!redirect.from || !redirect.to) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.utils.redirectsWrongFormat'),
+            throw new errors.ValidationError({
+                message: i18n.t('errors.utils.redirectsWrongFormat'),
                 context: redirect,
                 help: 'https://ghost.org/docs/api/handlebars-themes/routing/redirects/'
             });

--- a/core/frontend/services/routing/CollectionRouter.js
+++ b/core/frontend/services/routing/CollectionRouter.js
@@ -1,5 +1,5 @@
 const debug = require('ghost-ignition').debug('services:routing:collection-router');
-const common = require('../../../server/lib/common');
+const {events} = require('../../../server/lib/common');
 const urlUtils = require('../../../server/lib/url-utils');
 const ParentRouter = require('./ParentRouter');
 
@@ -90,7 +90,7 @@ class CollectionRouter extends ParentRouter {
         // REGISTER: permalinks e.g. /:slug/, /podcast/:slug
         this.mountRoute(this.permalinks.getValue({withUrlOptions: true}), controllers.entry);
 
-        common.events.emit('router.created', this);
+        events.emit('router.created', this);
     }
 
     /**
@@ -138,7 +138,7 @@ class CollectionRouter extends ParentRouter {
          * e.g. /:year/:month/:day/:slug/ or /:day/:slug/
          */
         this._onTimezoneEditedListener = this._onTimezoneEdited.bind(this);
-        common.events.on('settings.active_timezone.edited', this._onTimezoneEditedListener);
+        events.on('settings.active_timezone.edited', this._onTimezoneEditedListener);
     }
 
     /**
@@ -197,7 +197,7 @@ class CollectionRouter extends ParentRouter {
 
     reset() {
         if (this._onTimezoneEditedListener) {
-            common.events.removeListener('settings.active_timezone.edited', this._onTimezoneEditedListener);
+            events.removeListener('settings.active_timezone.edited', this._onTimezoneEditedListener);
         }
     }
 }

--- a/core/frontend/services/routing/StaticPagesRouter.js
+++ b/core/frontend/services/routing/StaticPagesRouter.js
@@ -2,7 +2,7 @@ const debug = require('ghost-ignition').debug('services:routing:static-pages-rou
 const urlUtils = require('../../../server/lib/url-utils');
 const ParentRouter = require('./ParentRouter');
 const controllers = require('./controllers');
-const common = require('../../../server/lib/common');
+const {events} = require('../../../server/lib/common');
 
 /**
  * @description Resource: pages
@@ -48,7 +48,7 @@ class StaticPagesRouter extends ParentRouter {
         // REGISTER: permalink for static pages
         this.mountRoute(this.permalinks.getValue({withUrlOptions: true}), controllers.entry);
 
-        common.events.emit('router.created', this);
+        events.emit('router.created', this);
     }
 
     /**

--- a/core/frontend/services/routing/StaticRoutesRouter.js
+++ b/core/frontend/services/routing/StaticRoutesRouter.js
@@ -1,5 +1,6 @@
 const debug = require('ghost-ignition').debug('services:routing:static-routes-router');
-const common = require('../../../server/lib/common');
+const {events} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const urlUtils = require('../../../server/lib/url-utils');
 const RSSRouter = require('./RSSRouter');
 const controllers = require('./controllers');
@@ -61,7 +62,7 @@ class StaticRoutesRouter extends ParentRouter {
         this.router().param('page', middlewares.pageParam);
         this.mountRoute(urlUtils.urlJoin(this.route.value, 'page', ':page(\\d+)'), controllers[this.controller]);
 
-        common.events.emit('router.created', this);
+        events.emit('router.created', this);
     }
 
     /**
@@ -97,7 +98,7 @@ class StaticRoutesRouter extends ParentRouter {
         // REGISTER: static route
         this.mountRoute(this.route.value, controllers.static);
 
-        common.events.emit('router.created', this);
+        events.emit('router.created', this);
     }
 
     /**
@@ -112,7 +113,7 @@ class StaticRoutesRouter extends ParentRouter {
             type: 'custom',
             templates: this.templates,
             defaultTemplate: () => {
-                throw new common.errors.IncorrectUsageError({
+                throw new errors.IncorrectUsageError({
                     message: `Missing template ${res.routerOptions.templates.map(x => `${x}.hbs`).join(', ')} for route "${req.originalUrl}".`
                 });
             },

--- a/core/frontend/services/routing/TaxonomyRouter.js
+++ b/core/frontend/services/routing/TaxonomyRouter.js
@@ -1,6 +1,6 @@
 const debug = require('ghost-ignition').debug('services:routing:taxonomy-router');
 const config = require('../../../server/config');
-const common = require('../../../server/lib/common');
+const {events} = require('../../../server/lib/common');
 const ParentRouter = require('./ParentRouter');
 const RSSRouter = require('./RSSRouter');
 const urlUtils = require('../../../server/lib/url-utils');
@@ -58,7 +58,7 @@ class TaxonomyRouter extends ParentRouter {
             this.mountRoute(urlUtils.urlJoin(this.permalinks.value, 'edit'), this._redirectEditOption.bind(this));
         }
 
-        common.events.emit('router.created', this);
+        events.emit('router.created', this);
     }
 
     /**

--- a/core/frontend/services/routing/bootstrap.js
+++ b/core/frontend/services/routing/bootstrap.js
@@ -1,6 +1,6 @@
 const debug = require('ghost-ignition').debug('services:routing:bootstrap');
 const _ = require('lodash');
-const common = require('../../../server/lib/common');
+const {events} = require('../../../server/lib/common');
 const settingsService = require('../settings');
 const StaticRoutesRouter = require('./StaticRoutesRouter');
 const StaticPagesRouter = require('./StaticPagesRouter');
@@ -34,7 +34,7 @@ module.exports.init = (options = {start: false}) => {
     registry.resetAllRouters();
     registry.resetAllRoutes();
 
-    common.events.emit('routers.reset');
+    events.emit('routers.reset');
 
     siteRouter = new ParentRouter('SiteRouter');
     registry.setRouter('siteRouter', siteRouter);

--- a/core/frontend/services/routing/controllers/channel.js
+++ b/core/frontend/services/routing/controllers/channel.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('services:routing:controllers:channel');
-const common = require('../../../../server/lib/common');
+const {i18n} = require('../../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const security = require('../../../../server/lib/security');
 const themes = require('../../themes');
 const helpers = require('../helpers');
@@ -49,8 +50,8 @@ module.exports = function channelController(req, res, next) {
         .then(function handleResult(result) {
             // CASE: requested page is greater than number of pages we have
             if (pathOptions.page > result.meta.pagination.pages) {
-                return next(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.errors.pageNotFound')
+                return next(new errors.NotFoundError({
+                    message: i18n.t('errors.errors.pageNotFound')
                 }));
             }
 

--- a/core/frontend/services/routing/controllers/collection.js
+++ b/core/frontend/services/routing/controllers/collection.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('services:routing:controllers:collection');
-const common = require('../../../../server/lib/common');
+const {i18n} = require('../../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const security = require('../../../../server/lib/security');
 const urlService = require('../../url');
 const themes = require('../../themes');
@@ -48,8 +49,8 @@ module.exports = function collectionController(req, res, next) {
         .then(function handleResult(result) {
             // CASE: requested page is greater than number of pages we have
             if (pathOptions.page > result.meta.pagination.pages) {
-                return next(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.errors.pageNotFound')
+                return next(new errors.NotFoundError({
+                    message: i18n.t('errors.errors.pageNotFound')
                 }));
             }
 

--- a/core/frontend/services/routing/middlewares/page-param.js
+++ b/core/frontend/services/routing/middlewares/page-param.js
@@ -1,4 +1,5 @@
-const common = require('../../../../server/lib/common');
+const {i18n} = require('../../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const urlUtils = require('../../../../server/lib/url-utils');
 
 /**
@@ -19,8 +20,8 @@ module.exports = function handlePageParam(req, res, next, page) {
         // CASE: page 1 is an alias for the collection index, do a permanent 301 redirect
         return urlUtils.redirect301(res, req.originalUrl.replace(pageRegex, '/'));
     } else if (page < 1 || isNaN(page)) {
-        return next(new common.errors.NotFoundError({
-            message: common.i18n.t('errors.errors.pageNotFound')
+        return next(new errors.NotFoundError({
+            message: i18n.t('errors.errors.pageNotFound')
         }));
     } else {
         req.params.page = page;

--- a/core/frontend/services/routing/settings.js
+++ b/core/frontend/services/routing/settings.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const urlService = require('../url');
 
-const common = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const config = require('../../../server/config');
 
 /**
@@ -56,7 +56,7 @@ const setFromFilePath = (filePath) => {
                     .then(() => {
                         if (!urlService.hasFinished()) {
                             if (tries > 5) {
-                                throw new common.errors.InternalServerError({
+                                throw new errors.InternalServerError({
                                     message: 'Could not load routes.yaml file.'
                                 });
                             }
@@ -86,11 +86,11 @@ const get = () => {
                 return Promise.resolve([]);
             }
 
-            if (common.errors.utils.isIgnitionError(err)) {
+            if (errors.utils.isIgnitionError(err)) {
                 throw err;
             }
 
-            throw new common.errors.NotFoundError({
+            throw new errors.NotFoundError({
                 err: err
             });
         });

--- a/core/frontend/services/settings/ensure-settings.js
+++ b/core/frontend/services/settings/ensure-settings.js
@@ -2,7 +2,8 @@ const fs = require('fs-extra');
 const Promise = require('bluebird');
 const path = require('path');
 const debug = require('ghost-ignition').debug('frontend:services:settings:ensure-settings');
-const common = require('../../../server/lib/common');
+const {i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const config = require('../../../server/config');
 
 /**
@@ -35,8 +36,8 @@ module.exports = function ensureSettingsFiles(knownSettings) {
                 });
             }).catch((error) => {
                 // CASE: we might have a permission error, as we can't access the directory
-                throw new common.errors.GhostError({
-                    message: common.i18n.t('errors.services.settings.ensureSettings', {path: contentPath}),
+                throw new errors.GhostError({
+                    message: i18n.t('errors.services.settings.ensureSettings', {path: contentPath}),
                     err: error,
                     context: error.path
                 });

--- a/core/frontend/services/settings/index.js
+++ b/core/frontend/services/settings/index.js
@@ -3,7 +3,7 @@ const debug = require('ghost-ignition').debug('frontend:services:settings:index'
 const SettingsLoader = require('./loader');
 const ensureSettingsFiles = require('./ensure-settings');
 
-const common = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     init: function () {
@@ -39,7 +39,7 @@ module.exports = {
         // CASE: this should be an edge case and only if internal usage of the
         // getter is incorrect.
         if (!setting || _.indexOf(knownSettings, setting) < 0) {
-            throw new common.errors.IncorrectUsageError({
+            throw new errors.IncorrectUsageError({
                 message: `Requested setting is not supported: '${setting}'.`,
                 help: `Please use only the supported settings: ${knownSettings}.`
             });

--- a/core/frontend/services/settings/loader.js
+++ b/core/frontend/services/settings/loader.js
@@ -1,7 +1,8 @@
 const fs = require('fs-extra');
 const path = require('path');
 const debug = require('ghost-ignition').debug('frontend:services:settings:settings-loader');
-const common = require('../../../server/lib/common');
+const {i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const config = require('../../../server/config');
 const yamlParser = require('./yaml-parser');
 const validate = require('./validate');
@@ -25,12 +26,12 @@ module.exports = function loadSettings(setting) {
         const object = yamlParser(file, fileName);
         return validate(object);
     } catch (err) {
-        if (common.errors.utils.isIgnitionError(err)) {
+        if (errors.utils.isIgnitionError(err)) {
             throw err;
         }
 
-        throw new common.errors.GhostError({
-            message: common.i18n.t('errors.services.settings.loader', {setting: setting, path: contentPath}),
+        throw new errors.GhostError({
+            message: i18n.t('errors.services.settings.loader', {setting: setting, path: contentPath}),
             context: filePath,
             err: err
         });

--- a/core/frontend/services/settings/validate.js
+++ b/core/frontend/services/settings/validate.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('frontend:services:settings:validate');
-const common = require('../../../server/lib/common');
+const {i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const themeService = require('../themes');
 const _private = {};
 let RESOURCE_CONFIG;
@@ -40,8 +41,8 @@ _private.validateData = function validateData(object) {
         };
 
         if (!shortForm.match(/.*\..*/)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: shortForm,
                     reason: 'Incorrect Format. Please use e.g. tag.recipes'
                 })
@@ -52,7 +53,7 @@ _private.validateData = function validateData(object) {
 
         if (!RESOURCE_CONFIG.QUERY[resourceKey] ||
             (Object.prototype.hasOwnProperty.call(RESOURCE_CONFIG.QUERY[resourceKey], 'internal') && RESOURCE_CONFIG.QUERY[resourceKey].internal === true)) {
-            throw new common.errors.ValidationError({
+            throw new errors.ValidationError({
                 message: `Resource key not supported. ${resourceKey}`,
                 help: 'Please use: tag, user, post or page.'
             });
@@ -96,7 +97,7 @@ _private.validateData = function validateData(object) {
         _.each(object.data, (value, key) => {
             // CASE: a name is required to define the data longform
             if (['resource', 'type', 'limit', 'order', 'include', 'filter', 'status', 'visibility', 'slug', 'redirect'].indexOf(key) !== -1) {
-                throw new common.errors.ValidationError({
+                throw new errors.ValidationError({
                     message: 'Please wrap the data definition into a custom name.',
                     help: 'Example:\n data:\n  my-tag:\n    resource: tags\n    ...\n'
                 });
@@ -104,7 +105,7 @@ _private.validateData = function validateData(object) {
 
             // @NOTE: We disallow author, because {{author}} is deprecated.
             if (key === 'author') {
-                throw new common.errors.ValidationError({
+                throw new errors.ValidationError({
                     message: 'Please choose a different name. We recommend not using author.'
                 });
             }
@@ -131,8 +132,8 @@ _private.validateData = function validateData(object) {
 
             _.each(requiredQueryFields, (option) => {
                 if (!Object.prototype.hasOwnProperty.call(object.data[key], option)) {
-                    throw new common.errors.ValidationError({
-                        message: common.i18n.t('errors.services.settings.yaml.validate', {
+                    throw new errors.ValidationError({
+                        message: i18n.t('errors.services.settings.yaml.validate', {
                             at: JSON.stringify(object.data[key]),
                             reason: `${option} is required.`
                         })
@@ -140,8 +141,8 @@ _private.validateData = function validateData(object) {
                 }
 
                 if (allowedQueryValues[option] && allowedQueryValues[option].indexOf(object.data[key][option]) === -1) {
-                    throw new common.errors.ValidationError({
-                        message: common.i18n.t('errors.services.settings.yaml.validate', {
+                    throw new errors.ValidationError({
+                        message: i18n.t('errors.services.settings.yaml.validate', {
                             at: JSON.stringify(object.data[key]),
                             reason: `${object.data[key][option]} not supported. Please use ${_.uniq(allowedQueryValues[option])}.`
                         })
@@ -184,8 +185,8 @@ _private.validateData = function validateData(object) {
 
 _private.validateRoutes = function validateRoutes(routes) {
     if (routes.constructor !== Object) {
-        throw new common.errors.ValidationError({
-            message: common.i18n.t('errors.services.settings.yaml.validate', {
+        throw new errors.ValidationError({
+            message: i18n.t('errors.services.settings.yaml.validate', {
                 at: routes,
                 reason: '`routes` must be a YAML map.'
             })
@@ -195,8 +196,8 @@ _private.validateRoutes = function validateRoutes(routes) {
     _.each(routes, (routingTypeObject, routingTypeObjectKey) => {
         // CASE: we hard-require trailing slashes for the index route
         if (!routingTypeObjectKey.match(/\/$/)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObjectKey,
                     reason: 'A trailing slash is required.'
                 })
@@ -205,8 +206,8 @@ _private.validateRoutes = function validateRoutes(routes) {
 
         // CASE: we hard-require leading slashes for the index route
         if (!routingTypeObjectKey.match(/^\//)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObjectKey,
                     reason: 'A leading slash is required.'
                 })
@@ -215,8 +216,8 @@ _private.validateRoutes = function validateRoutes(routes) {
 
         // CASE: you define /about/:
         if (!routingTypeObject) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObjectKey,
                     reason: 'Please define a template.'
                 }),
@@ -233,8 +234,8 @@ _private.validateRoutes = function validateRoutes(routes) {
 
 _private.validateCollections = function validateCollections(collections) {
     if (collections.constructor !== Object) {
-        throw new common.errors.ValidationError({
-            message: common.i18n.t('errors.services.settings.yaml.validate', {
+        throw new errors.ValidationError({
+            message: i18n.t('errors.services.settings.yaml.validate', {
                 at: collections,
                 reason: '`collections` must be a YAML map.'
             })
@@ -244,8 +245,8 @@ _private.validateCollections = function validateCollections(collections) {
     _.each(collections, (routingTypeObject, routingTypeObjectKey) => {
         // CASE: we hard-require trailing slashes for the collection index route
         if (!routingTypeObjectKey.match(/\/$/)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObjectKey,
                     reason: 'A trailing slash is required.'
                 })
@@ -254,8 +255,8 @@ _private.validateCollections = function validateCollections(collections) {
 
         // CASE: we hard-require leading slashes for the collection index route
         if (!routingTypeObjectKey.match(/^\//)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObjectKey,
                     reason: 'A leading slash is required.'
                 })
@@ -263,8 +264,8 @@ _private.validateCollections = function validateCollections(collections) {
         }
 
         if (!Object.prototype.hasOwnProperty.call(routingTypeObject, 'permalink')) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObjectKey,
                     reason: 'Please define a permalink route.'
                 }),
@@ -275,8 +276,8 @@ _private.validateCollections = function validateCollections(collections) {
         // CASE: validate permalink key
 
         if (!routingTypeObject.permalink) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObjectKey,
                     reason: 'Please define a permalink route.'
                 }),
@@ -286,8 +287,8 @@ _private.validateCollections = function validateCollections(collections) {
 
         // CASE: we hard-require trailing slashes for the value/permalink route
         if (!routingTypeObject.permalink.match(/\/$/)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObject.permalink,
                     reason: 'A trailing slash is required.'
                 })
@@ -296,8 +297,8 @@ _private.validateCollections = function validateCollections(collections) {
 
         // CASE: we hard-require leading slashes for the value/permalink route
         if (!routingTypeObject.permalink.match(/^\//)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObject.permalink,
                     reason: 'A leading slash is required.'
                 })
@@ -306,8 +307,8 @@ _private.validateCollections = function validateCollections(collections) {
 
         // CASE: notation /:slug/ or /:primary_author/ is not allowed. We only accept /{{...}}/.
         if (routingTypeObject.permalink && routingTypeObject.permalink.match(/\/:\w+/)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObject.permalink,
                     reason: 'Please use the following notation e.g. /{slug}/.'
                 })
@@ -329,8 +330,8 @@ _private.validateCollections = function validateCollections(collections) {
 
 _private.validateTaxonomies = function validateTaxonomies(taxonomies) {
     if (taxonomies.constructor !== Object) {
-        throw new common.errors.ValidationError({
-            message: common.i18n.t('errors.services.settings.yaml.validate', {
+        throw new errors.ValidationError({
+            message: i18n.t('errors.services.settings.yaml.validate', {
                 at: taxonomies,
                 reason: '`taxonomies` must be a YAML map.'
             })
@@ -340,8 +341,8 @@ _private.validateTaxonomies = function validateTaxonomies(taxonomies) {
     const validRoutingTypeObjectKeys = Object.keys(RESOURCE_CONFIG.TAXONOMIES);
     _.each(taxonomies, (routingTypeObject, routingTypeObjectKey) => {
         if (!routingTypeObject) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObjectKey,
                     reason: 'Please define a taxonomy permalink route.'
                 }),
@@ -350,8 +351,8 @@ _private.validateTaxonomies = function validateTaxonomies(taxonomies) {
         }
 
         if (!validRoutingTypeObjectKeys.includes(routingTypeObjectKey)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObjectKey,
                     reason: 'Unknown taxonomy.'
                 })
@@ -360,8 +361,8 @@ _private.validateTaxonomies = function validateTaxonomies(taxonomies) {
 
         // CASE: we hard-require trailing slashes for the taxonomie permalink route
         if (!routingTypeObject.match(/\/$/)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObject,
                     reason: 'A trailing slash is required.'
                 })
@@ -370,8 +371,8 @@ _private.validateTaxonomies = function validateTaxonomies(taxonomies) {
 
         // CASE: we hard-require leading slashes for the value/permalink route
         if (!routingTypeObject.match(/^\//)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObject,
                     reason: 'A leading slash is required.'
                 })
@@ -380,8 +381,8 @@ _private.validateTaxonomies = function validateTaxonomies(taxonomies) {
 
         // CASE: notation /:slug/ or /:primary_author/ is not allowed. We only accept /{{...}}/.
         if (routingTypeObject && routingTypeObject.match(/\/:\w+/)) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.services.settings.yaml.validate', {
+            throw new errors.ValidationError({
+                message: i18n.t('errors.services.settings.yaml.validate', {
                     at: routingTypeObject,
                     reason: 'Please use the following notation e.g. /{slug}/.'
                 })

--- a/core/frontend/services/settings/yaml-parser.js
+++ b/core/frontend/services/settings/yaml-parser.js
@@ -1,6 +1,7 @@
 const yaml = require('js-yaml');
 const debug = require('ghost-ignition').debug('frontend:services:settings:yaml-parser');
-const common = require('../../../server/lib/common');
+const {i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 
 /**
  * Takes a YAML file, parses it and returns a JSON Object
@@ -19,12 +20,12 @@ module.exports = function parseYaml(file, fileName) {
         // CASE: parsing failed, `js-yaml` tells us exactly what and where in the
         // `reason` property as well as in the message.
         // As the file uploaded is invalid, the person uploading must fix this - it's a 4xx error
-        throw new common.errors.IncorrectUsageError({
-            message: common.i18n.t('errors.services.settings.yaml.error', {file: fileName, context: error.reason}),
+        throw new errors.IncorrectUsageError({
+            message: i18n.t('errors.services.settings.yaml.error', {file: fileName, context: error.reason}),
             code: 'YAML_PARSER_ERROR',
             context: error.message,
             err: error,
-            help: common.i18n.t('errors.services.settings.yaml.help', {file: fileName})
+            help: i18n.t('errors.services.settings.yaml.help', {file: fileName})
         });
     }
 };

--- a/core/frontend/services/sitemap/manager.js
+++ b/core/frontend/services/sitemap/manager.js
@@ -1,4 +1,4 @@
-const common = require('../../../server/lib/common');
+const {events} = require('../../../server/lib/common');
 const IndexMapGenerator = require('./index-generator');
 const PagesMapGenerator = require('./page-generator');
 const PostsMapGenerator = require('./post-generator');
@@ -15,7 +15,7 @@ class SiteMapManager {
         this.tags = options.tags || this.createTagsGenerator(options);
         this.index = options.index || this.createIndexGenerator(options);
 
-        common.events.on('router.created', (router) => {
+        events.on('router.created', (router) => {
             if (router.name === 'StaticRoutesRouter') {
                 this.pages.addUrl(router.getRoute({absolute: true}), {id: router.identifier, staticRoute: true});
             }
@@ -25,15 +25,15 @@ class SiteMapManager {
             }
         });
 
-        common.events.on('url.added', (obj) => {
+        events.on('url.added', (obj) => {
             this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
         });
 
-        common.events.on('url.removed', (obj) => {
+        events.on('url.removed', (obj) => {
             this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
         });
 
-        common.events.on('routers.reset', () => {
+        events.on('routers.reset', () => {
             this.pages && this.pages.reset();
             this.posts && this.posts.reset();
             this.users && this.users.reset();

--- a/core/frontend/services/themes/activate.js
+++ b/core/frontend/services/themes/activate.js
@@ -1,4 +1,5 @@
-const common = require('../../../server/lib/common');
+const {events, logging, i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const active = require('./active');
 
 function activate(loadedTheme, checkedTheme, error) {
@@ -14,16 +15,16 @@ function activate(loadedTheme, checkedTheme, error) {
         active.set(loadedTheme, checkedTheme, error);
         const currentGhostAPI = active.get().engine('ghost-api');
 
-        common.events.emit('services.themes.activated');
+        events.emit('services.themes.activated');
 
         if (previousGhostAPI !== undefined && (previousGhostAPI !== currentGhostAPI)) {
-            common.events.emit('services.themes.api.changed');
+            events.emit('services.themes.api.changed');
             const siteApp = require('../../../server/web/site/app');
             siteApp.reload();
         }
     } catch (err) {
-        common.logging.error(new common.errors.InternalServerError({
-            message: common.i18n.t('errors.middleware.themehandler.activateFailed', {theme: loadedTheme.name}),
+        logging.error(new errors.InternalServerError({
+            message: i18n.t('errors.middleware.themehandler.activateFailed', {theme: loadedTheme.name}),
             err: err
         }));
     }

--- a/core/frontend/services/themes/index.js
+++ b/core/frontend/services/themes/index.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('themes');
-const common = require('../../../server/lib/common');
+const {events, i18n: commonI18n, logging} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const themeLoader = require('./loader');
 const active = require('./active');
 const activate = require('./activate');
@@ -21,7 +22,7 @@ module.exports = {
         debug('init themes', activeThemeName);
 
         // Register a listener for server-start to load all themes
-        common.events.on('server.start', function readAllThemesOnServerStart() {
+        events.on('server.start', function readAllThemesOnServerStart() {
             themeLoader.loadAllThemes();
         });
 
@@ -34,8 +35,8 @@ module.exports = {
                     .check(theme)
                     .then(function validationSuccess(checkedTheme) {
                         if (!validate.canActivate(checkedTheme)) {
-                            const checkError = new common.errors.ThemeValidationError({
-                                message: common.i18n.t('errors.middleware.themehandler.invalidTheme', {theme: activeThemeName}),
+                            const checkError = new errors.ThemeValidationError({
+                                message: commonI18n.t('errors.middleware.themehandler.invalidTheme', {theme: activeThemeName}),
                                 errorDetails: Object.assign(
                                     _.pick(checkedTheme, ['checkedVersion', 'name', 'path', 'version']), {
                                         errors: checkedTheme.results.error
@@ -43,15 +44,15 @@ module.exports = {
                                 )
                             });
 
-                            common.logging.error(checkError);
+                            logging.error(checkError);
 
                             activate(theme, checkedTheme, checkError);
                         } else {
                             // CASE: inform that the theme has errors, but not fatal (theme still works)
                             if (checkedTheme.results.error.length) {
-                                common.logging.warn(new common.errors.ThemeValidationError({
+                                logging.warn(new errors.ThemeValidationError({
                                     errorType: 'ThemeWorksButHasErrors',
-                                    message: common.i18n.t('errors.middleware.themehandler.themeHasErrors', {theme: activeThemeName}),
+                                    message: commonI18n.t('errors.middleware.themehandler.themeHasErrors', {theme: activeThemeName}),
                                     errorDetails: Object.assign(
                                         _.pick(checkedTheme, ['checkedVersion', 'name', 'path', 'version']), {
                                             errors: checkedTheme.results.error
@@ -66,15 +67,15 @@ module.exports = {
                         }
                     });
             })
-            .catch(common.errors.NotFoundError, function (err) {
+            .catch(errors.NotFoundError, function (err) {
                 // CASE: active theme is missing, we don't want to exit because the admin panel will still work
-                err.message = common.i18n.t('errors.middleware.themehandler.missingTheme', {theme: activeThemeName});
-                common.logging.error(err);
+                err.message = commonI18n.t('errors.middleware.themehandler.missingTheme', {theme: activeThemeName});
+                logging.error(err);
             })
             .catch(function (err) {
                 // CASE: theme threw an odd error, we don't want to exit because the admin panel will still work
                 // This is the absolute catch-all, at this point, we do not know what went wrong!
-                common.logging.error(err);
+                logging.error(err);
             });
     },
     getJSON: require('./to-json'),
@@ -90,8 +91,8 @@ module.exports = {
         const loadedTheme = list.get(themeName);
 
         if (!loadedTheme) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('notices.data.validation.index.themeCannotBeActivated', {themeName: themeName}),
+            return Promise.reject(new errors.ValidationError({
+                message: commonI18n.t('notices.data.validation.index.themeCannotBeActivated', {themeName: themeName}),
                 errorDetails: themeName
             }));
         }

--- a/core/frontend/services/themes/middleware.js
+++ b/core/frontend/services/themes/middleware.js
@@ -2,7 +2,8 @@ const _ = require('lodash');
 const hbs = require('./engine');
 const urlUtils = require('../../../server/lib/url-utils');
 const config = require('../../../server/config');
-const common = require('../../../server/lib/common');
+const {i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const settingsCache = require('../../../server/services/settings/cache');
 const labs = require('../../../server/services/labs');
 const activeTheme = require('./active');
@@ -15,19 +16,19 @@ function ensureActiveTheme(req, res, next) {
     // CASE: this means that the theme hasn't been loaded yet i.e. there is no active theme
     if (!activeTheme.get()) {
         // This is the one place we ACTUALLY throw an error for a missing theme as it's a request we cannot serve
-        return next(new common.errors.InternalServerError({
+        return next(new errors.InternalServerError({
             // We use the settingsCache here, because the setting will be set,
             // even if the theme itself is not usable because it is invalid or missing.
-            message: common.i18n.t('errors.middleware.themehandler.missingTheme', {theme: settingsCache.get('active_theme')})
+            message: i18n.t('errors.middleware.themehandler.missingTheme', {theme: settingsCache.get('active_theme')})
         }));
     }
 
     // CASE: bootstrap theme validation failed, we would like to show the errors on the site [only production]
     if (activeTheme.get().error && config.get('env') === 'production') {
-        return next(new common.errors.InternalServerError({
+        return next(new errors.InternalServerError({
             // We use the settingsCache here, because the setting will be set,
             // even if the theme itself is not usable because it is invalid or missing.
-            message: common.i18n.t('errors.middleware.themehandler.invalidTheme', {theme: settingsCache.get('active_theme')}),
+            message: i18n.t('errors.middleware.themehandler.invalidTheme', {theme: settingsCache.get('active_theme')}),
             errorDetails: activeTheme.get().error.errorDetails
         }));
     }

--- a/core/frontend/services/themes/storage.js
+++ b/core/frontend/services/themes/storage.js
@@ -8,7 +8,8 @@ const themeLoader = require('./loader');
 const toJSON = require('./to-json');
 
 const settingsCache = require('../../../server/services/settings/cache');
-const common = require('../../../server/lib/common');
+const {i18n, logging} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const debug = require('ghost-ignition').debug('api:themes');
 
 let themeStorage;
@@ -24,8 +25,8 @@ module.exports = {
         const theme = list.get(themeName);
 
         if (!theme) {
-            return Promise.reject(new common.errors.BadRequestError({
-                message: common.i18n.t('errors.api.themes.invalidThemeName')
+            return Promise.reject(new errors.BadRequestError({
+                message: i18n.t('errors.api.themes.invalidThemeName')
             }));
         }
 
@@ -38,8 +39,8 @@ module.exports = {
 
         // check if zip name is casper.zip
         if (zip.name === 'casper.zip') {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.themes.overrideCasper')
+            throw new errors.ValidationError({
+                message: i18n.t('errors.api.themes.overrideCasper')
             });
         }
 
@@ -89,29 +90,29 @@ module.exports = {
                 if (checkedTheme) {
                     fs.remove(checkedTheme.path)
                         .catch((err) => {
-                            common.logging.error(new common.errors.GhostError({err: err}));
+                            logging.error(new errors.GhostError({err: err}));
                         });
                 }
             });
     },
     destroy: function (themeName) {
         if (themeName === 'casper') {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.themes.destroyCasper')
+            throw new errors.ValidationError({
+                message: i18n.t('errors.api.themes.destroyCasper')
             });
         }
 
         if (themeName === settingsCache.get('active_theme')) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.themes.destroyActive')
+            throw new errors.ValidationError({
+                message: i18n.t('errors.api.themes.destroyActive')
             });
         }
 
         const theme = list.get(themeName);
 
         if (!theme) {
-            throw new common.errors.NotFoundError({
-                message: common.i18n.t('errors.api.themes.themeDoesNotExist')
+            throw new errors.NotFoundError({
+                message: i18n.t('errors.api.themes.themeDoesNotExist')
             });
         }
 

--- a/core/frontend/services/themes/validate.js
+++ b/core/frontend/services/themes/validate.js
@@ -2,7 +2,8 @@ const _ = require('lodash');
 const Promise = require('bluebird');
 const fs = require('fs-extra');
 const config = require('../../../server/config');
-const common = require('../../../server/lib/common');
+const {i18n} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 
 const canActivate = function canActivate(checkedTheme) {
     // CASE: production and no fatal errors
@@ -54,8 +55,8 @@ const checkSafe = function checkSafe(theme, isZip) {
                 fs.remove(checkedTheme.path);
             }
 
-            return Promise.reject(new common.errors.ThemeValidationError({
-                message: common.i18n.t('errors.api.themes.invalidTheme'),
+            return Promise.reject(new errors.ThemeValidationError({
+                message: i18n.t('errors.api.themes.invalidTheme'),
                 errorDetails: Object.assign(
                     _.pick(checkedTheme, ['checkedVersion', 'name', 'path', 'version']), {
                         errors: checkedTheme.results.error

--- a/core/frontend/services/url/Queue.js
+++ b/core/frontend/services/url/Queue.js
@@ -1,7 +1,8 @@
 const debug = require('ghost-ignition').debug('services:url:queue');
 const EventEmitter = require('events').EventEmitter;
 const _ = require('lodash');
-const common = require('../../../server/lib/common');
+const {logging} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 
 /**
  * ### Purpose of this queue
@@ -129,7 +130,7 @@ class Queue extends EventEmitter {
             } catch (err) {
                 debug('error', err.message);
 
-                common.logging.error(new common.errors.InternalServerError({
+                logging.error(new errors.InternalServerError({
                     message: 'Something bad happened.',
                     code: 'SERVICES_URL_QUEUE',
                     err: err

--- a/core/frontend/services/url/Resource.js
+++ b/core/frontend/services/url/Resource.js
@@ -1,5 +1,6 @@
 const EventEmitter = require('events').EventEmitter;
-const common = require('../../../server/lib/common');
+const {logging} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 
 /**
  * Resource cache.
@@ -35,7 +36,7 @@ class Resource extends EventEmitter {
         if (!this.config.reserved) {
             this.config.reserved = true;
         } else {
-            common.logging.error(new common.errors.InternalServerError({
+            logging.error(new errors.InternalServerError({
                 message: 'Resource is already taken. This should not happen.',
                 code: 'URLSERVICE_RESERVE_RESOURCE'
             }));

--- a/core/frontend/services/url/Resources.js
+++ b/core/frontend/services/url/Resources.js
@@ -4,7 +4,7 @@ const debug = require('ghost-ignition').debug('services:url:resources');
 const Resource = require('./Resource');
 const config = require('../../../server/config');
 const models = require('../../../server/models');
-const common = require('../../../server/lib/common');
+const {events} = require('../../../server/lib/common');
 
 /**
  * @description At the moment the resources class is directly responsible for data population
@@ -38,7 +38,7 @@ class Resources {
             listener: listener
         });
 
-        common.events.on(eventName, listener);
+        events.on(eventName, listener);
     }
 
     /**
@@ -447,7 +447,7 @@ class Resources {
                 return;
             }
 
-            common.events.removeListener(obj.eventName, obj.listener);
+            events.removeListener(obj.eventName, obj.listener);
         });
 
         this.listeners = [];

--- a/core/frontend/services/url/UrlService.js
+++ b/core/frontend/services/url/UrlService.js
@@ -1,7 +1,8 @@
 const _debug = require('ghost-ignition').debug._base;
 const debug = _debug('ghost:services:url:service');
 const _ = require('lodash');
-const common = require('../../../server/lib/common');
+const {events} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 const UrlGenerator = require('./UrlGenerator');
 const Queue = require('./Queue');
 const Urls = require('./Urls');
@@ -33,10 +34,10 @@ class UrlService {
      */
     _listeners() {
         this._onRouterAddedListener = this._onRouterAddedType.bind(this);
-        common.events.on('router.created', this._onRouterAddedListener);
+        events.on('router.created', this._onRouterAddedListener);
 
         this._onThemeChangedListener = this._onThemeChangedListener.bind(this);
-        common.events.on('services.themes.api.changed', this._onThemeChangedListener);
+        events.on('services.themes.api.changed', this._onThemeChangedListener);
 
         this._onQueueStartedListener = this._onQueueStarted.bind(this);
         this.queue.addListener('started', this._onQueueStartedListener);
@@ -131,7 +132,7 @@ class UrlService {
 
         if (!objects.length) {
             if (!this.hasFinished()) {
-                throw new common.errors.InternalServerError({
+                throw new errors.InternalServerError({
                     message: 'UrlService is processing.',
                     code: 'URLSERVICE_NOT_READY'
                 });
@@ -174,7 +175,7 @@ class UrlService {
         const object = this.urls.getByResourceId(resourceId);
 
         if (!object) {
-            throw new common.errors.NotFoundError({
+            throw new errors.NotFoundError({
                 message: 'Resource not found.',
                 code: 'URLSERVICE_RESOURCE_NOT_FOUND'
             });
@@ -304,8 +305,8 @@ class UrlService {
         if (!options.keepListeners) {
             this._onQueueStartedListener && this.queue.removeListener('started', this._onQueueStartedListener);
             this._onQueueEndedListener && this.queue.removeListener('ended', this._onQueueEndedListener);
-            this._onRouterAddedListener && common.events.removeListener('router.created', this._onRouterAddedListener);
-            this._onThemeChangedListener && common.events.removeListener('services.themes.api.changed', this._onThemeChangedListener);
+            this._onRouterAddedListener && events.removeListener('router.created', this._onRouterAddedListener);
+            this._onThemeChangedListener && events.removeListener('services.themes.api.changed', this._onThemeChangedListener);
         }
     }
 

--- a/core/frontend/services/url/Urls.js
+++ b/core/frontend/services/url/Urls.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('services:url:urls');
 const urlUtils = require('../../../server/lib/url-utils');
-const common = require('../../../server/lib/common');
+const {logging, events} = require('../../../server/lib/common');
+const errors = require('@tryghost/errors');
 
 /**
  * This class keeps track of all urls in the system.
@@ -32,7 +33,7 @@ class Urls {
         debug('cache', url);
 
         if (this.urls[resource.data.id]) {
-            common.logging.error(new common.errors.InternalServerError({
+            logging.error(new errors.InternalServerError({
                 message: 'This should not happen.',
                 code: 'URLSERVICE_RESOURCE_DUPLICATE'
             }));
@@ -47,7 +48,7 @@ class Urls {
         };
 
         // @NOTE: Notify the whole system. Currently used for sitemaps service.
-        common.events.emit('url.added', {
+        events.emit('url.added', {
             url: {
                 relative: url,
                 absolute: urlUtils.createUrl(url, true)
@@ -113,7 +114,7 @@ class Urls {
 
         debug('removed', this.urls[id].url, this.urls[id].generatorId);
 
-        common.events.emit('url.removed', {
+        events.emit('url.removed', {
             url: this.urls[id].url,
             resource: this.urls[id].resource
         });

--- a/core/server/adapters/scheduling/SchedulingDefault.js
+++ b/core/server/adapters/scheduling/SchedulingDefault.js
@@ -2,7 +2,8 @@ const util = require('util');
 const moment = require('moment');
 const debug = require('ghost-ignition').debug('scheduling-default');
 const SchedulingBase = require('./SchedulingBase');
-const common = require('../../lib/common');
+const {logging} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const request = require('../../lib/request');
 
 /**
@@ -314,7 +315,7 @@ SchedulingDefault.prototype._pingUrl = function (object) {
                 this._pingUrl(object);
             }, this.retryTimeoutInMs);
 
-            common.logging.error(new common.errors.GhostError({
+            logging.error(new errors.GhostError({
                 err,
                 context: 'Retrying...',
                 level: 'normal'
@@ -323,7 +324,7 @@ SchedulingDefault.prototype._pingUrl = function (object) {
             return;
         }
 
-        common.logging.error(new common.errors.GhostError({
+        logging.error(new errors.GhostError({
             err,
             level: 'critical'
         }));

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -2,7 +2,8 @@ const Promise = require('bluebird');
 const moment = require('moment');
 const jwt = require('jsonwebtoken');
 const localUtils = require('../utils');
-const common = require('../../../lib/common');
+const {i18n, events} = require('../../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../../models');
 const urlUtils = require('../../../lib/url-utils');
 const _private = {};
@@ -17,8 +18,8 @@ _private.getSchedulerIntegration = function () {
     return models.Integration.findOne({slug: 'ghost-scheduler'}, {withRelated: 'api_keys'})
         .then((integration) => {
             if (!integration) {
-                throw new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                throw new errors.NotFoundError({
+                    message: i18n.t('errors.api.resource.resourceNotFound', {
                         resource: 'Integration'
                     })
                 });
@@ -117,11 +118,11 @@ exports.init = function init(options = {}) {
     let integration = null;
 
     if (!Object.keys(options).length) {
-        return Promise.reject(new common.errors.IncorrectUsageError({message: 'post-scheduling: no config was provided'}));
+        return Promise.reject(new errors.IncorrectUsageError({message: 'post-scheduling: no config was provided'}));
     }
 
     if (!apiUrl) {
-        return Promise.reject(new common.errors.IncorrectUsageError({message: 'post-scheduling: no apiUrl was provided'}));
+        return Promise.reject(new errors.IncorrectUsageError({message: 'post-scheduling: no apiUrl was provided'}));
     }
 
     return _private.getSchedulerIntegration()
@@ -158,7 +159,7 @@ exports.init = function init(options = {}) {
         })
         .then(() => {
             SCHEDULED_RESOURCES.forEach((resource) => {
-                common.events.on(`${resource}.scheduled`, (model) => {
+                events.on(`${resource}.scheduled`, (model) => {
                     adapter.schedule(_private.normalize({model, apiUrl, integration, resourceType: resource}));
                 });
 
@@ -166,12 +167,12 @@ exports.init = function init(options = {}) {
                  * We want to first remove existing schedule by generating a matching token(+url)
                  * followed by generating a new token(+url) for the new schedule
                 */
-                common.events.on(`${resource}.rescheduled`, (model) => {
+                events.on(`${resource}.rescheduled`, (model) => {
                     adapter.unschedule(_private.normalize({model, apiUrl, integration, resourceType: resource}, 'unscheduled'));
                     adapter.schedule(_private.normalize({model, apiUrl, integration, resourceType: resource}));
                 });
 
-                common.events.on(`${resource}.unscheduled`, (model) => {
+                events.on(`${resource}.unscheduled`, (model) => {
                     adapter.unschedule(_private.normalize({model, apiUrl, integration, resourceType: resource}, 'unscheduled'));
                 });
             });

--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -7,7 +7,8 @@ const path = require('path');
 const Promise = require('bluebird');
 const moment = require('moment');
 const config = require('../../config');
-const common = require('../../lib/common');
+const {logging, i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const constants = require('../../lib/constants');
 const urlUtils = require('../../lib/url-utils');
 const StorageBase = require('ghost-storage-base');
@@ -110,28 +111,28 @@ class LocalFileStore extends StorageBase {
                     maxAge: constants.ONE_YEAR_MS,
                     fallthrough: false,
                     onEnd: () => {
-                        common.logging.info('LocalFileStorage.serve', req.path, moment().diff(startedAtMoment, 'ms') + 'ms');
+                        logging.info('LocalFileStorage.serve', req.path, moment().diff(startedAtMoment, 'ms') + 'ms');
                     }
                 }
             )(req, res, (err) => {
                 if (err) {
                     if (err.statusCode === 404) {
-                        return next(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.errors.imageNotFound'),
+                        return next(new errors.NotFoundError({
+                            message: i18n.t('errors.errors.imageNotFound'),
                             code: 'STATIC_FILE_NOT_FOUND',
                             property: err.path
                         }));
                     }
 
                     if (err.statusCode === 400) {
-                        return next(new common.errors.BadRequestError({err: err}));
+                        return next(new errors.BadRequestError({err: err}));
                     }
 
                     if (err.statusCode === 403) {
-                        return next(new common.errors.NoPermissionError({err: err}));
+                        return next(new errors.NoPermissionError({err: err}));
                     }
 
-                    return next(new common.errors.GhostError({err: err}));
+                    return next(new errors.GhostError({err: err}));
                 }
 
                 next();
@@ -165,23 +166,23 @@ class LocalFileStore extends StorageBase {
             fs.readFile(targetPath, (err, bytes) => {
                 if (err) {
                     if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
-                        return reject(new common.errors.NotFoundError({
+                        return reject(new errors.NotFoundError({
                             err: err,
-                            message: common.i18n.t('errors.errors.imageNotFoundWithRef', {img: options.path})
+                            message: i18n.t('errors.errors.imageNotFoundWithRef', {img: options.path})
                         }));
                     }
 
                     if (err.code === 'ENAMETOOLONG') {
-                        return reject(new common.errors.BadRequestError({err: err}));
+                        return reject(new errors.BadRequestError({err: err}));
                     }
 
                     if (err.code === 'EACCES') {
-                        return reject(new common.errors.NoPermissionError({err: err}));
+                        return reject(new errors.NoPermissionError({err: err}));
                     }
 
-                    return reject(new common.errors.GhostError({
+                    return reject(new errors.GhostError({
                         err: err,
-                        message: common.i18n.t('errors.errors.cannotReadImage', {img: options.path})
+                        message: i18n.t('errors.errors.cannotReadImage', {img: options.path})
                     }));
                 }
 

--- a/core/server/api/canary/authentication.js
+++ b/core/server/api/canary/authentication.js
@@ -1,6 +1,7 @@
 const api = require('./index');
 const config = require('../../config');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const web = require('../../web');
 const models = require('../../models');
 const auth = require('../../services/auth');
@@ -46,7 +47,7 @@ module.exports = {
             return models.User.findOne({role: 'Owner', status: 'all'})
                 .then((owner) => {
                     if (owner.id !== frame.options.context.user) {
-                        throw new common.errors.NoPermissionError({message: common.i18n.t('errors.api.authentication.notTheBlogOwner')});
+                        throw new errors.NoPermissionError({message: i18n.t('errors.api.authentication.notTheBlogOwner')});
                     }
                 });
         },

--- a/core/server/api/canary/authors-public.js
+++ b/core/server/api/canary/authors-public.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 const ALLOWED_INCLUDES = ['count.posts'];
 
@@ -52,8 +53,8 @@ module.exports = {
             return models.Author.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.authors.notFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.authors.notFound')
                         }));
                     }
 

--- a/core/server/api/canary/db.js
+++ b/core/server/api/canary/db.js
@@ -2,7 +2,7 @@ const Promise = require('bluebird');
 const dbBackup = require('../../data/db/backup');
 const exporter = require('../../data/exporter');
 const importer = require('../../data/importer');
-const common = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 module.exports = {
@@ -53,7 +53,7 @@ module.exports = {
                 let backup = await dbBackup.readBackup(frame.options.filename);
 
                 if (!backup) {
-                    throw new common.errors.NotFoundError();
+                    throw new errors.NotFoundError();
                 }
 
                 return backup;
@@ -62,7 +62,7 @@ module.exports = {
             return Promise.resolve()
                 .then(() => exporter.doExport({include: frame.options.withRelated}))
                 .catch((err) => {
-                    return Promise.reject(new common.errors.GhostError({err: err}));
+                    return Promise.reject(new errors.GhostError({err: err}));
                 });
         }
     },
@@ -118,7 +118,7 @@ module.exports = {
                             }, {concurrency: 100});
                         })
                         .catch((err) => {
-                            throw new common.errors.GhostError({
+                            throw new errors.GhostError({
                                 err: err
                             });
                         });

--- a/core/server/api/canary/email-preview.js
+++ b/core/server/api/canary/email-preview.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const mega = require('../../services/mega');
 
 module.exports = {
@@ -25,8 +26,8 @@ module.exports = {
             return models.Post.findOne(data, options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.posts.postNotFound')
                         });
                     }
 
@@ -62,14 +63,14 @@ module.exports = {
             const options = Object.assign(frame.options, {status: 'all'});
             let model = await models.Post.findOne(options, {withRelated: ['authors']});
             if (!model) {
-                throw new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.posts.postNotFound')
+                throw new errors.NotFoundError({
+                    message: i18n.t('errors.api.posts.postNotFound')
                 });
             }
             const {emails = []} = frame.data;
             const response = await mega.mega.sendTestEmail(model, emails);
             if (response && response[0] && response[0].error) {
-                throw new common.errors.EmailError({
+                throw new errors.EmailError({
                     message: response[0].error.message
                 });
             }

--- a/core/server/api/canary/email.js
+++ b/core/server/api/canary/email.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const megaService = require('../../services/mega');
 
 module.exports = {
@@ -22,8 +23,8 @@ module.exports = {
             return models.Email.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.models.email.emailNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.models.email.emailNotFound')
                         });
                     }
 
@@ -41,14 +42,14 @@ module.exports = {
             return models.Email.findOne(frame.data, frame.options)
                 .then(async (model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.models.email.emailNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.models.email.emailNotFound')
                         });
                     }
 
                     if (model.get('status') !== 'failed') {
-                        throw new common.errors.IncorrectUsageError({
-                            message: common.i18n.t('errors.models.email.retryNotAllowed')
+                        throw new errors.IncorrectUsageError({
+                            message: i18n.t('errors.models.email.retryNotAllowed')
                         });
                     }
 

--- a/core/server/api/canary/integrations.js
+++ b/core/server/api/canary/integrations.js
@@ -1,4 +1,5 @@
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 module.exports = {
@@ -43,8 +44,8 @@ module.exports = {
         query({data, options}) {
             return models.Integration.findOne(data, Object.assign(options, {require: true}))
                 .catch(models.Integration.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Integration'
                         })
                     });
@@ -79,8 +80,8 @@ module.exports = {
                 return models.ApiKey.findOne({id: options.keyid})
                     .then(async (model) => {
                         if (!model) {
-                            throw new common.errors.NotFoundError({
-                                message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            throw new errors.NotFoundError({
+                                message: i18n.t('errors.api.resource.resourceNotFound', {
                                     resource: 'ApiKey'
                                 })
                             });
@@ -91,7 +92,7 @@ module.exports = {
                                 withRelated: ['api_keys', 'webhooks']
                             });
                         } catch (err) {
-                            throw new common.errors.GhostError({
+                            throw new errors.GhostError({
                                 err: err
                             });
                         }
@@ -99,8 +100,8 @@ module.exports = {
             }
             return models.Integration.edit(data, Object.assign(options, {require: true}))
                 .catch(models.Integration.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Integration'
                         })
                     });
@@ -157,8 +158,8 @@ module.exports = {
         query({options}) {
             return models.Integration.destroy(Object.assign(options, {require: true}))
                 .catch(models.Integration.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Integration'
                         })
                     }));

--- a/core/server/api/canary/invites.js
+++ b/core/server/api/canary/invites.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n, logging} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const security = require('../../lib/security');
 const mailService = require('../../services/mail');
 const urlUtils = require('../../lib/url-utils');
@@ -51,8 +52,8 @@ module.exports = {
             return models.Invite.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.invites.inviteNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.invites.inviteNotFound')
                         }));
                     }
 
@@ -79,8 +80,8 @@ module.exports = {
             return models.Invite.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Invite.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.invites.inviteNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.invites.inviteNotFound')
                     }));
                 });
         }
@@ -143,7 +144,7 @@ module.exports = {
                         mail: [{
                             message: {
                                 to: invite.get('email'),
-                                subject: common.i18n.t('common.api.users.mail.invitedByName', {
+                                subject: i18n.t('common.api.users.mail.invitedByName', {
                                     invitedByName: emailData.invitedByName,
                                     blogName: emailData.blogName
                                 }),
@@ -166,12 +167,12 @@ module.exports = {
                 })
                 .catch((err) => {
                     if (err && err.errorType === 'EmailError') {
-                        const errorMessage = common.i18n.t('errors.api.invites.errorSendingEmail.error', {
+                        const errorMessage = i18n.t('errors.api.invites.errorSendingEmail.error', {
                             message: err.message
                         });
-                        const helpText = common.i18n.t('errors.api.invites.errorSendingEmail.help');
+                        const helpText = i18n.t('errors.api.invites.errorSendingEmail.help');
                         err.message = `${errorMessage} ${helpText}`;
-                        common.logging.warn(err.message);
+                        logging.warn(err.message);
                     }
 
                     return Promise.reject(err);

--- a/core/server/api/canary/labels.js
+++ b/core/server/api/canary/labels.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.members'];
@@ -51,8 +52,8 @@ module.exports = {
             return models.Label.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.labels.labelNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.labels.labelNotFound')
                         }));
                     }
 
@@ -103,8 +104,8 @@ module.exports = {
             return models.Label.edit(frame.data.labels[0], frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.labels.labelNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.labels.labelNotFound')
                         }));
                     }
 
@@ -142,8 +143,8 @@ module.exports = {
             return models.Label.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Label.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.labels.labelNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.labels.labelNotFound')
                     }));
                 });
         }

--- a/core/server/api/canary/mail.js
+++ b/core/server/api/canary/mail.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
 const mailService = require('../../services/mail');
 const api = require('./');
 let mailer;
@@ -17,8 +17,8 @@ _private.sendMail = (object) => {
                     notifications: [{
                         type: 'warn',
                         message: [
-                            common.i18n.t('warnings.index.unableToSendEmail'),
-                            common.i18n.t('common.seeLinkForInstructions', {link: 'https://ghost.org/docs/concepts/config/#mail'})
+                            i18n.t('warnings.index.unableToSendEmail'),
+                            i18n.t('common.seeLinkForInstructions', {link: 'https://ghost.org/docs/concepts/config/#mail'})
                         ].join(' ')
                     }]
                 },
@@ -47,7 +47,7 @@ module.exports = {
                     mail: [{
                         message: {
                             to: frame.user.get('email'),
-                            subject: common.i18n.t('common.api.mail.testGhostEmail'),
+                            subject: i18n.t('common.api.mail.testGhostEmail'),
                             html: content.html,
                             text: content.text
                         }

--- a/core/server/api/canary/memberSigninUrls.js
+++ b/core/server/api/canary/memberSigninUrls.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const membersService = require('../../services/members');
 
 module.exports = {
@@ -14,8 +15,8 @@ module.exports = {
             let model = await models.Member.findOne(frame.data, frame.options);
 
             if (!model) {
-                throw new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.members.memberNotFound')
+                throw new errors.NotFoundError({
+                    message: i18n.t('errors.api.members.memberNotFound')
                 });
             }
 

--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -3,7 +3,8 @@
 const Promise = require('bluebird');
 const models = require('../../models');
 const membersService = require('../../services/members');
-const common = require('../../lib/common');
+const {i18n, logging} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const fsLib = require('../../lib/fs');
 const _ = require('lodash');
 
@@ -120,8 +121,8 @@ const members = {
             let model = await models.Member.findOne(frame.data, frame.options);
 
             if (!model) {
-                throw new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.members.memberNotFound')
+                throw new errors.NotFoundError({
+                    message: i18n.t('errors.api.members.memberNotFound')
                 });
             }
 
@@ -172,7 +173,7 @@ const members = {
                 return decorateWithSubscriptions(member);
             } catch (error) {
                 if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
-                    throw new common.errors.ValidationError({message: common.i18n.t('errors.api.members.memberAlreadyExists')});
+                    throw new errors.ValidationError({message: i18n.t('errors.api.members.memberAlreadyExists')});
                 }
 
                 // NOTE: failed to link Stripe customer/plan/subscription
@@ -248,8 +249,8 @@ const members = {
             let member = await models.Member.findOne(frame.options);
 
             if (!member) {
-                throw new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                throw new errors.NotFoundError({
+                    message: i18n.t('errors.api.resource.resourceNotFound', {
                         resource: 'Member'
                     })
                 });
@@ -260,8 +261,8 @@ const members = {
 
             await models.Member.destroy(frame.options)
                 .catch(models.Member.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Member'
                         })
                     });
@@ -377,15 +378,15 @@ const members = {
                         if (inspection.isFulfilled()) {
                             fulfilled = fulfilled + 1;
                         } else {
-                            if (inspection.reason() instanceof common.errors.ValidationError) {
+                            if (inspection.reason() instanceof errors.ValidationError) {
                                 duplicates = duplicates + 1;
                             } else {
                                 // NOTE: if the error happens as a result of pure API call it doesn't get logged anywhere
                                 //       for this reason we have to make sure any unexpected errors are logged here
                                 if (Array.isArray(inspection.reason())) {
-                                    common.logging.error(inspection.reason()[0]);
+                                    logging.error(inspection.reason()[0]);
                                 } else {
-                                    common.logging.error(inspection.reason());
+                                    logging.error(inspection.reason());
                                 }
 
                                 invalid = invalid + 1;

--- a/core/server/api/canary/notifications.js
+++ b/core/server/api/canary/notifications.js
@@ -4,7 +4,8 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 const settingsCache = require('../../services/settings/cache');
 const ghostVersion = require('../../lib/ghost-version');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const ObjectId = require('bson-objectid');
 const api = require('./index');
 const internalContext = {context: {internal: true}};
@@ -170,14 +171,14 @@ module.exports = {
             });
 
             if (notificationToMarkAsSeenIndex > -1 && !notificationToMarkAsSeen.dismissible) {
-                return Promise.reject(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.api.notifications.noPermissionToDismissNotif')
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.api.notifications.noPermissionToDismissNotif')
                 }));
             }
 
             if (notificationToMarkAsSeenIndex < 0) {
-                return Promise.reject(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.notifications.notificationDoesNotExist')
+                return Promise.reject(new errors.NotFoundError({
+                    message: i18n.t('errors.api.notifications.notificationDoesNotExist')
                 }));
             }
 

--- a/core/server/api/canary/oembed.js
+++ b/core/server/api/canary/oembed.js
@@ -1,4 +1,5 @@
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const {extract, hasProvider} = require('oembed-parser');
 const Promise = require('bluebird');
 const request = require('../../lib/request');
@@ -76,15 +77,15 @@ const findUrlWithProvider = (url) => {
 };
 
 function unknownProvider(url) {
-    return Promise.reject(new common.errors.ValidationError({
-        message: common.i18n.t('errors.api.oembed.unknownProvider'),
+    return Promise.reject(new errors.ValidationError({
+        message: i18n.t('errors.api.oembed.unknownProvider'),
         context: url
     }));
 }
 
 function knownProvider(url) {
     return extract(url, {maxwidth: 1280}).catch((err) => {
-        return Promise.reject(new common.errors.InternalServerError({
+        return Promise.reject(new errors.InternalServerError({
             message: err.message
         }));
     });

--- a/core/server/api/canary/pages-public.js
+++ b/core/server/api/canary/pages-public.js
@@ -1,4 +1,5 @@
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 const ALLOWED_INCLUDES = ['tags', 'authors'];
 
@@ -61,8 +62,8 @@ module.exports = {
             return models.Post.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.pages.pageNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.pages.pageNotFound')
                         });
                     }
 

--- a/core/server/api/canary/pages.js
+++ b/core/server/api/canary/pages.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const urlUtils = require('../../lib/url-utils');
 const ALLOWED_INCLUDES = ['tags', 'authors', 'authors.roles'];
 const UNSAFE_ATTRS = ['status', 'authors', 'visibility'];
@@ -71,8 +72,8 @@ module.exports = {
             return models.Post.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.pages.pageNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.pages.pageNotFound')
                         });
                     }
 
@@ -198,8 +199,8 @@ module.exports = {
             return models.Post.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Post.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.pages.pageNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.pages.pageNotFound')
                     }));
                 });
         }

--- a/core/server/api/canary/posts-public.js
+++ b/core/server/api/canary/posts-public.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const allowedIncludes = ['tags', 'authors'];
 
 module.exports = {
@@ -61,8 +62,8 @@ module.exports = {
             return models.Post.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.posts.postNotFound')
                         });
                     }
 

--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const urlUtils = require('../../lib/url-utils');
 const {mega} = require('../../services/mega');
 const membersService = require('../../services/members');
@@ -73,8 +74,8 @@ module.exports = {
             return models.Post.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.posts.postNotFound')
                         });
                     }
 
@@ -154,7 +155,7 @@ module.exports = {
                 const knexOptions = _.pick(frame.options, ['transacting', 'forUpdate']);
                 const {members} = await membersService.api.members.list(Object.assign(knexOptions, {filter: 'subscribed:true'}, {limit: 'all'}));
                 if (members.length > allowedMembersLimit) {
-                    throw new common.errors.HostLimitError({
+                    throw new errors.HostLimitError({
                         message: `Your current plan allows you to send email to up to ${allowedMembersLimit} members, but you currently have ${members.length} members`,
                         help: hostUpgradeLink,
                         errorDetails: {
@@ -233,8 +234,8 @@ module.exports = {
             return models.Post.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Post.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.posts.postNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.posts.postNotFound')
                     }));
                 });
         }

--- a/core/server/api/canary/preview.js
+++ b/core/server/api/canary/preview.js
@@ -1,4 +1,5 @@
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 const ALLOWED_INCLUDES = ['authors', 'tags'];
 
@@ -29,8 +30,8 @@ module.exports = {
             return models.Post.findOne(Object.assign({status: 'all'}, frame.data), frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.posts.postNotFound')
                         });
                     }
 

--- a/core/server/api/canary/schedules.js
+++ b/core/server/api/canary/schedules.js
@@ -3,7 +3,8 @@ const moment = require('moment');
 const config = require('../../config');
 const models = require('../../models');
 const urlUtils = require('../../lib/url-utils');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const api = require('./index');
 
 module.exports = {
@@ -53,11 +54,11 @@ module.exports = {
                         const publishedAtMoment = moment(resource.published_at);
 
                         if (publishedAtMoment.diff(moment(), 'minutes') > publishAPostBySchedulerToleranceInMinutes) {
-                            return Promise.reject(new common.errors.NotFoundError({message: common.i18n.t('errors.api.job.notFound')}));
+                            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.job.notFound')}));
                         }
 
                         if (publishedAtMoment.diff(moment(), 'minutes') < publishAPostBySchedulerToleranceInMinutes * -1 && frame.data.force !== true) {
-                            return Promise.reject(new common.errors.NotFoundError({message: common.i18n.t('errors.api.job.publishInThePast')}));
+                            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.job.publishInThePast')}));
                         }
 
                         const editedResource = {};

--- a/core/server/api/canary/session.js
+++ b/core/server/api/canary/session.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 const auth = require('../../services/auth');
 const api = require('./index');
@@ -18,8 +19,8 @@ const session = {
         const object = frame.data;
 
         if (!object || !object.username || !object.password) {
-            return Promise.reject(new common.errors.UnauthorizedError({
-                message: common.i18n.t('errors.middleware.auth.accessDenied')
+            return Promise.reject(new errors.UnauthorizedError({
+                message: i18n.t('errors.middleware.auth.accessDenied')
             }));
         }
 
@@ -37,9 +38,9 @@ const session = {
                 });
             });
         }).catch(async (err) => {
-            if (!common.errors.utils.isIgnitionError(err)) {
-                throw new common.errors.UnauthorizedError({
-                    message: common.i18n.t('errors.middleware.auth.accessDenied'),
+            if (!errors.utils.isIgnitionError(err)) {
+                throw new errors.UnauthorizedError({
+                    message: i18n.t('errors.middleware.auth.accessDenied'),
                     err
                 });
             }

--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -2,7 +2,8 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 const models = require('../../models');
 const routing = require('../../../frontend/services/routing');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const settingsCache = require('../../services/settings/cache');
 
 const SETTINGS_BLACKLIST = [
@@ -58,8 +59,8 @@ module.exports = {
             let setting = settingsCache.get(frame.options.key, {resolve: false});
 
             if (!setting) {
-                return Promise.reject(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+                return Promise.reject(new errors.NotFoundError({
+                    message: i18n.t('errors.api.settings.problemFindingSetting', {
                         key: frame.options.key
                     })
                 }));
@@ -67,8 +68,8 @@ module.exports = {
 
             // @TODO: handle in settings model permissible fn
             if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
-                return Promise.reject(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                 }));
             }
 
@@ -91,8 +92,8 @@ module.exports = {
 
                 frame.data.settings.map((setting) => {
                     if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
-                        errors.push(new common.errors.NoPermissionError({
-                            message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                        errors.push(new errors.NoPermissionError({
+                            message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                         }));
                     }
                 });
@@ -121,15 +122,15 @@ module.exports = {
                 const settingFromCache = settingsCache.get(setting.key, {resolve: false});
 
                 if (!settingFromCache) {
-                    errors.push(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+                    errors.push(new errors.NotFoundError({
+                        message: i18n.t('errors.api.settings.problemFindingSetting', {
                             key: setting.key
                         })
                     }));
                 } else if (settingFromCache.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
                     // @TODO: handle in settings model permissible fn
-                    errors.push(new common.errors.NoPermissionError({
-                        message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                    errors.push(new errors.NoPermissionError({
+                        message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                     }));
                 }
             });

--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const models = require('../../models');
 const routing = require('../../../frontend/services/routing');
 const {i18n} = require('../../lib/common');
-const errors = require('@tryghost/errors');
+const {NoPermissionError, NotFoundError} = require('@tryghost/errors');
 const settingsCache = require('../../services/settings/cache');
 
 const SETTINGS_BLACKLIST = [
@@ -59,7 +59,7 @@ module.exports = {
             let setting = settingsCache.get(frame.options.key, {resolve: false});
 
             if (!setting) {
-                return Promise.reject(new errors.NotFoundError({
+                return Promise.reject(new NotFoundError({
                     message: i18n.t('errors.api.settings.problemFindingSetting', {
                         key: frame.options.key
                     })
@@ -68,7 +68,7 @@ module.exports = {
 
             // @TODO: handle in settings model permissible fn
             if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
-                return Promise.reject(new errors.NoPermissionError({
+                return Promise.reject(new NoPermissionError({
                     message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                 }));
             }
@@ -92,7 +92,7 @@ module.exports = {
 
                 frame.data.settings.map((setting) => {
                     if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
-                        errors.push(new errors.NoPermissionError({
+                        errors.push(new NoPermissionError({
                             message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                         }));
                     }
@@ -122,14 +122,14 @@ module.exports = {
                 const settingFromCache = settingsCache.get(setting.key, {resolve: false});
 
                 if (!settingFromCache) {
-                    errors.push(new errors.NotFoundError({
+                    errors.push(new NotFoundError({
                         message: i18n.t('errors.api.settings.problemFindingSetting', {
                             key: setting.key
                         })
                     }));
                 } else if (settingFromCache.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
                     // @TODO: handle in settings model permissible fn
-                    errors.push(new errors.NoPermissionError({
+                    errors.push(new NoPermissionError({
                         message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                     }));
                 }

--- a/core/server/api/canary/slack.js
+++ b/core/server/api/canary/slack.js
@@ -1,11 +1,11 @@
-const common = require('../../lib/common');
+const {events} = require('../../lib/common');
 
 module.exports = {
     docName: 'slack',
     sendTest: {
         permissions: false,
         query() {
-            common.events.emit('slack.test');
+            events.emit('slack.test');
         }
     }
 };

--- a/core/server/api/canary/slugs.js
+++ b/core/server/api/canary/slugs.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 
 const allowedTypes = {
     post: models.Post,
@@ -35,8 +36,8 @@ module.exports = {
             return models.Base.Model.generateSlug(allowedTypes[frame.options.type], frame.data.name, {status: 'all'})
                 .then((slug) => {
                     if (!slug) {
-                        return Promise.reject(new common.errors.GhostError({
-                            message: common.i18n.t('errors.api.slugs.couldNotGenerateSlug')
+                        return Promise.reject(new errors.GhostError({
+                            message: i18n.t('errors.api.slugs.couldNotGenerateSlug')
                         }));
                     }
                     return slug;

--- a/core/server/api/canary/tags-public.js
+++ b/core/server/api/canary/tags-public.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.posts'];
@@ -54,8 +55,8 @@ module.exports = {
             return models.TagPublic.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.tags.tagNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.tags.tagNotFound')
                         }));
                     }
 

--- a/core/server/api/canary/tags.js
+++ b/core/server/api/canary/tags.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.posts'];
@@ -54,8 +55,8 @@ module.exports = {
             return models.Tag.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.tags.tagNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.tags.tagNotFound')
                         }));
                     }
 
@@ -106,8 +107,8 @@ module.exports = {
             return models.Tag.edit(frame.data.tags[0], frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.tags.tagNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.tags.tagNotFound')
                         }));
                     }
 
@@ -145,8 +146,8 @@ module.exports = {
             return models.Tag.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Tag.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.tags.tagNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.tags.tagNotFound')
                     }));
                 });
         }

--- a/core/server/api/canary/themes.js
+++ b/core/server/api/canary/themes.js
@@ -1,4 +1,4 @@
-const common = require('../../lib/common');
+const {events} = require('../../lib/common');
 const themeService = require('../../../frontend/services/themes');
 const models = require('../../models');
 
@@ -66,7 +66,7 @@ module.exports = {
                         // CASE: clear cache
                         this.headers.cacheInvalidate = true;
                     }
-                    common.events.emit('theme.uploaded');
+                    events.emit('theme.uploaded');
                     return theme;
                 });
         }

--- a/core/server/api/canary/users.js
+++ b/core/server/api/canary/users.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const dbBackup = require('../../data/db/backup');
 const models = require('../../models');
 const permissionsService = require('../../services/permissions');
@@ -58,8 +59,8 @@ module.exports = {
             return models.User.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.users.userNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.users.userNotFound')
                         }));
                     }
 
@@ -91,8 +92,8 @@ module.exports = {
             return models.User.edit(frame.data.users[0], frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.users.userNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.users.userNotFound')
                         }));
                     }
 
@@ -136,7 +137,7 @@ module.exports = {
                     })
                     .then(() => filename);
             }).catch((err) => {
-                return Promise.reject(new common.errors.NoPermissionError({
+                return Promise.reject(new errors.NoPermissionError({
                     err: err
                 }));
             });

--- a/core/server/api/canary/utils/permissions.js
+++ b/core/server/api/canary/utils/permissions.js
@@ -2,7 +2,8 @@ const debug = require('ghost-ignition').debug('api:canary:utils:permissions');
 const Promise = require('bluebird');
 const _ = require('lodash');
 const permissions = require('../../../services/permissions');
-const common = require('../../../lib/common');
+const {i18n} = require('../../../lib/common');
+const errors = require('@tryghost/errors');
 
 /**
  * @description Handle requests, which need authentication.
@@ -53,19 +54,19 @@ const nonePublicAuth = (apiConfig, frame) => {
             frame.data[apiConfig.docName][0] = _.omit(frame.data[apiConfig.docName][0], result.excludedAttrs);
         }
     }).catch((err) => {
-        if (err instanceof common.errors.NoPermissionError) {
-            err.message = common.i18n.t('errors.api.utils.noPermissionToCall', {
+        if (err instanceof errors.NoPermissionError) {
+            err.message = i18n.t('errors.api.utils.noPermissionToCall', {
                 method: apiConfig.method,
                 docName: apiConfig.docName
             });
             return Promise.reject(err);
         }
 
-        if (common.errors.utils.isIgnitionError(err)) {
+        if (errors.utils.isIgnitionError(err)) {
             return Promise.reject(err);
         }
 
-        return Promise.reject(new common.errors.GhostError({
+        return Promise.reject(new errors.GhostError({
             err: err
         }));
     });

--- a/core/server/api/canary/utils/serializers/output/authentication.js
+++ b/core/server/api/canary/utils/serializers/output/authentication.js
@@ -1,4 +1,4 @@
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
 const mapper = require('./utils/mapper');
 const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:authentication');
 
@@ -28,7 +28,7 @@ module.exports = {
     generateResetToken(data, apiConfig, frame) {
         frame.response = {
             passwordreset: [{
-                message: common.i18n.t('common.api.authentication.mail.checkEmailForInstructions')
+                message: i18n.t('common.api.authentication.mail.checkEmailForInstructions')
             }]
         };
     },
@@ -36,7 +36,7 @@ module.exports = {
     resetPassword(data, apiConfig, frame) {
         frame.response = {
             passwordreset: [{
-                message: common.i18n.t('common.api.authentication.mail.passwordChanged')
+                message: i18n.t('common.api.authentication.mail.passwordChanged')
             }]
         };
     },
@@ -46,7 +46,7 @@ module.exports = {
 
         frame.response = {
             invitation: [
-                {message: common.i18n.t('common.api.authentication.mail.invitationAccepted')}
+                {message: i18n.t('common.api.authentication.mail.invitationAccepted')}
             ]
         };
     },

--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:members');
 const mapper = require('./utils/mapper');
 const {formatCSV} = require('../../../../../lib/fs');
@@ -34,8 +35,8 @@ module.exports = {
         debug('read');
 
         if (!data) {
-            return Promise.reject(new common.errors.NotFoundError({
-                message: common.i18n.t('errors.api.members.memberNotFound')
+            return Promise.reject(new errors.NotFoundError({
+                message: i18n.t('errors.api.members.memberNotFound')
             }));
         }
 

--- a/core/server/api/canary/utils/serializers/output/users.js
+++ b/core/server/api/canary/utils/serializers/output/users.js
@@ -1,5 +1,5 @@
 const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:users');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
 const mapper = require('./utils/mapper');
 
 module.exports = {
@@ -39,7 +39,7 @@ module.exports = {
         debug('changePassword');
 
         frame.response = {
-            password: [{message: common.i18n.t('notices.api.users.pwdChangedSuccessfully')}]
+            password: [{message: i18n.t('notices.api.users.pwdChangedSuccessfully')}]
         };
     },
 

--- a/core/server/api/canary/utils/validators/input/images.js
+++ b/core/server/api/canary/utils/validators/input/images.js
@@ -1,6 +1,7 @@
 const jsonSchema = require('../utils/json-schema');
 const config = require('../../../../../config');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 const imageLib = require('../../../../../lib/image');
 
 const profileImage = (frame) => {
@@ -10,8 +11,8 @@ const profileImage = (frame) => {
 
         // CASE: file needs to be a square
         if (frame.file.dimensions.width !== frame.file.dimensions.height) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.images.isNotSquare')
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.api.images.isNotSquare')
             }));
         }
     });
@@ -26,8 +27,8 @@ const icon = (frame) => {
 
     // CASE: file should not be larger than 100kb
     if (!validIconFileSize(frame.file.size)) {
-        return Promise.reject(new common.errors.ValidationError({
-            message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+        return Promise.reject(new errors.ValidationError({
+            message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
         }));
     }
 
@@ -37,23 +38,23 @@ const icon = (frame) => {
 
         // CASE: file needs to be a square
         if (frame.file.dimensions.width !== frame.file.dimensions.height) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
             }));
         }
 
         // CASE: icon needs to be bigger than or equal to 60px
         // .ico files can contain multiple sizes, we need at least a minimum of 60px (16px is ok, as long as 60px are present as well)
         if (frame.file.dimensions.width < 60) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
             }));
         }
 
         // CASE: icon needs to be smaller than or equal to 1000px
         if (frame.file.dimensions.width > 1000) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
             }));
         }
     });

--- a/core/server/api/canary/utils/validators/input/invitations.js
+++ b/core/server/api/canary/utils/validators/input/invitations.js
@@ -1,7 +1,8 @@
 const Promise = require('bluebird');
 const validator = require('validator');
 const debug = require('ghost-ignition').debug('api:canary:utils:validators:input:invitation');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     acceptInvitation(apiConfig, frame) {
@@ -10,19 +11,19 @@ module.exports = {
         const data = frame.data.invitation[0];
 
         if (!data.token) {
-            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noTokenProvided')}));
+            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noTokenProvided')}));
         }
 
         if (!data.email) {
-            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noEmailProvided')}));
+            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noEmailProvided')}));
         }
 
         if (!data.password) {
-            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noPasswordProvided')}));
+            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noPasswordProvided')}));
         }
 
         if (!data.name) {
-            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noNameProvided')}));
+            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noNameProvided')}));
         }
     },
 
@@ -32,8 +33,8 @@ module.exports = {
         const email = frame.data.email;
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
-            throw new common.errors.BadRequestError({
-                message: common.i18n.t('errors.api.authentication.invalidEmailReceived')
+            throw new errors.BadRequestError({
+                message: i18n.t('errors.api.authentication.invalidEmailReceived')
             });
         }
     }

--- a/core/server/api/canary/utils/validators/input/invites.js
+++ b/core/server/api/canary/utils/validators/input/invites.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../../../../models');
 
 module.exports = {
@@ -7,8 +8,8 @@ module.exports = {
         return models.User.findOne({email: frame.data.invites[0].email}, frame.options)
             .then((user) => {
                 if (user) {
-                    return Promise.reject(new common.errors.ValidationError({
-                        message: common.i18n.t('errors.api.users.userAlreadyRegistered')
+                    return Promise.reject(new errors.ValidationError({
+                        message: i18n.t('errors.api.users.userAlreadyRegistered')
                     }));
                 }
             });

--- a/core/server/api/canary/utils/validators/input/oembed.js
+++ b/core/server/api/canary/utils/validators/input/oembed.js
@@ -1,11 +1,12 @@
 const Promise = require('bluebird');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     read(apiConfig, frame) {
         if (!frame.data.url || !frame.data.url.trim()) {
-            return Promise.reject(new common.errors.BadRequestError({
-                message: common.i18n.t('errors.api.oembed.noUrlProvided')
+            return Promise.reject(new errors.BadRequestError({
+                message: i18n.t('errors.api.oembed.noUrlProvided')
             }));
         }
     }

--- a/core/server/api/canary/utils/validators/input/passwordreset.js
+++ b/core/server/api/canary/utils/validators/input/passwordreset.js
@@ -1,7 +1,8 @@
 const Promise = require('bluebird');
 const validator = require('validator');
 const debug = require('ghost-ignition').debug('api:canary:utils:validators:input:passwordreset');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     resetPassword(apiConfig, frame) {
@@ -10,8 +11,8 @@ module.exports = {
         const data = frame.data.passwordreset[0];
 
         if (data.newPassword !== data.ne2Password) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.models.user.newPasswordsDoNotMatch')
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.models.user.newPasswordsDoNotMatch')
             }));
         }
     },
@@ -22,8 +23,8 @@ module.exports = {
         const email = frame.data.passwordreset[0].email;
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
-            throw new common.errors.BadRequestError({
-                message: common.i18n.t('errors.api.authentication.invalidEmailReceived')
+            throw new errors.BadRequestError({
+                message: i18n.t('errors.api.authentication.invalidEmailReceived')
             });
         }
     }

--- a/core/server/api/canary/utils/validators/input/settings.js
+++ b/core/server/api/canary/utils/validators/input/settings.js
@@ -1,13 +1,13 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 const {i18n} = require('../../../../../lib/common');
-const errors = require('@tryghost/errors');
+const {BadRequestError, NotFoundError} = require('@tryghost/errors');
 
 module.exports = {
     read(apiConfig, frame) {
         // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
         if (frame.options.key === 'permalinks') {
-            return Promise.reject(new errors.NotFoundError({
+            return Promise.reject(new NotFoundError({
                 message: i18n.t('errors.api.settings.problemFindingSetting', {
                     key: frame.options.key
                 })
@@ -16,7 +16,7 @@ module.exports = {
 
         // @NOTE: was removed https://github.com/TryGhost/Ghost/issues/10373
         if (frame.options.key === 'ghost_head' || frame.options.key === 'ghost_foot') {
-            return Promise.reject(new errors.NotFoundError({
+            return Promise.reject(new NotFoundError({
                 message: i18n.t('errors.api.settings.problemFindingSetting', {
                     key: frame.options.key
                 })
@@ -31,21 +31,21 @@ module.exports = {
             if (setting.key === 'active_theme') {
                 // @NOTE: active theme has to be changed via theme endpoints
                 errors.push(
-                    new errors.BadRequestError({
+                    new BadRequestError({
                         message: i18n.t('errors.api.settings.activeThemeSetViaAPI.error'),
                         help: i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
                     })
                 );
             } else if (setting.key === 'permalinks') {
                 // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
-                errors.push(new errors.NotFoundError({
+                errors.push(new NotFoundError({
                     message: i18n.t('errors.api.settings.problemFindingSetting', {
                         key: setting.key
                     })
                 }));
             } else if (setting.key === 'ghost_head' || setting.key === 'ghost_foot') {
                 // @NOTE: was removed https://github.com/TryGhost/Ghost/issues/10373
-                errors.push(new errors.NotFoundError({
+                errors.push(new NotFoundError({
                     message: i18n.t('errors.api.settings.problemFindingSetting', {
                         key: setting.key
                     })

--- a/core/server/api/canary/utils/validators/input/settings.js
+++ b/core/server/api/canary/utils/validators/input/settings.js
@@ -1,13 +1,14 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     read(apiConfig, frame) {
         // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
         if (frame.options.key === 'permalinks') {
-            return Promise.reject(new common.errors.NotFoundError({
-                message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+            return Promise.reject(new errors.NotFoundError({
+                message: i18n.t('errors.api.settings.problemFindingSetting', {
                     key: frame.options.key
                 })
             }));
@@ -15,8 +16,8 @@ module.exports = {
 
         // @NOTE: was removed https://github.com/TryGhost/Ghost/issues/10373
         if (frame.options.key === 'ghost_head' || frame.options.key === 'ghost_foot') {
-            return Promise.reject(new common.errors.NotFoundError({
-                message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+            return Promise.reject(new errors.NotFoundError({
+                message: i18n.t('errors.api.settings.problemFindingSetting', {
                     key: frame.options.key
                 })
             }));
@@ -30,22 +31,22 @@ module.exports = {
             if (setting.key === 'active_theme') {
                 // @NOTE: active theme has to be changed via theme endpoints
                 errors.push(
-                    new common.errors.BadRequestError({
-                        message: common.i18n.t('errors.api.settings.activeThemeSetViaAPI.error'),
-                        help: common.i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
+                    new errors.BadRequestError({
+                        message: i18n.t('errors.api.settings.activeThemeSetViaAPI.error'),
+                        help: i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
                     })
                 );
             } else if (setting.key === 'permalinks') {
                 // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
-                errors.push(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+                errors.push(new errors.NotFoundError({
+                    message: i18n.t('errors.api.settings.problemFindingSetting', {
                         key: setting.key
                     })
                 }));
             } else if (setting.key === 'ghost_head' || setting.key === 'ghost_foot') {
                 // @NOTE: was removed https://github.com/TryGhost/Ghost/issues/10373
-                errors.push(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+                errors.push(new errors.NotFoundError({
+                    message: i18n.t('errors.api.settings.problemFindingSetting', {
                         key: setting.key
                     })
                 }));

--- a/core/server/api/canary/utils/validators/input/setup.js
+++ b/core/server/api/canary/utils/validators/input/setup.js
@@ -1,12 +1,13 @@
 const debug = require('ghost-ignition').debug('api:canary:utils:validators:input:updateSetup');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     updateSetup(apiConfig, frame) {
         debug('resetPassword');
 
         if (!frame.options.context || !frame.options.context.user) {
-            throw new common.errors.NoPermissionError({message: common.i18n.t('errors.api.authentication.notTheBlogOwner')});
+            throw new errors.NoPermissionError({message: i18n.t('errors.api.authentication.notTheBlogOwner')});
         }
     }
 };

--- a/core/server/api/canary/utils/validators/input/users.js
+++ b/core/server/api/canary/utils/validators/input/users.js
@@ -1,6 +1,7 @@
 const Promise = require('bluebird');
 const debug = require('ghost-ignition').debug('api:canary:utils:validators:input:users');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     changePassword(apiConfig, frame) {
@@ -9,8 +10,8 @@ module.exports = {
         const data = frame.data.password[0];
 
         if (data.newPassword !== data.ne2Password) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.models.user.newPasswordsDoNotMatch')
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.models.user.newPasswordsDoNotMatch')
             }));
         }
     }

--- a/core/server/api/canary/utils/validators/utils/json-schema.js
+++ b/core/server/api/canary/utils/validators/utils/json-schema.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
 const Ajv = require('ajv');
 const stripKeyword = require('./strip-keyword');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 const ajv = new Ajv({
     allErrors: true,
@@ -42,8 +43,8 @@ const validate = (schema, definition, data) => {
             key = schema.$id.split('.')[0];
         }
 
-        return Promise.reject(new common.errors.ValidationError({
-            message: common.i18n.t('notices.data.validation.index.schemaValidationFailed', {
+        return Promise.reject(new errors.ValidationError({
+            message: i18n.t('notices.data.validation.index.schemaValidationFailed', {
                 key: key
             }),
             property: key,

--- a/core/server/api/canary/webhooks.js
+++ b/core/server/api/canary/webhooks.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     docName: 'webhooks',
@@ -28,7 +29,7 @@ module.exports = {
             ).then((webhook) => {
                 if (webhook) {
                     return Promise.reject(
-                        new common.errors.ValidationError({message: common.i18n.t('errors.api.webhooks.webhookAlreadyExists')})
+                        new errors.ValidationError({message: i18n.t('errors.api.webhooks.webhookAlreadyExists')})
                     );
                 }
 
@@ -59,8 +60,8 @@ module.exports = {
         query({data, options}) {
             return models.Webhook.edit(data.webhooks[0], Object.assign(options, {require: true}))
                 .catch(models.Webhook.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Webhook'
                         })
                     });
@@ -88,8 +89,8 @@ module.exports = {
             return models.Webhook.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Webhook.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Webhook'
                         })
                     }));

--- a/core/server/api/shared/pipeline.js
+++ b/core/server/api/shared/pipeline.js
@@ -2,7 +2,7 @@ const debug = require('ghost-ignition').debug('api:shared:pipeline');
 const Promise = require('bluebird');
 const _ = require('lodash');
 const shared = require('../shared');
-const common = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const sequence = require('../../lib/promise/sequence');
 
 const STAGES = {
@@ -106,7 +106,7 @@ const STAGES = {
 
         // CASE: it's required to put the permission key to avoid security holes
         if (!Object.prototype.hasOwnProperty.call(apiImpl, 'permissions')) {
-            return Promise.reject(new common.errors.IncorrectUsageError());
+            return Promise.reject(new errors.IncorrectUsageError());
         }
 
         // CASE: handle permissions completely yourself
@@ -150,7 +150,7 @@ const STAGES = {
         debug('stages: query');
 
         if (!apiImpl.query) {
-            return Promise.reject(new common.errors.IncorrectUsageError());
+            return Promise.reject(new errors.IncorrectUsageError());
         }
 
         return apiImpl.query(frame);

--- a/core/server/api/shared/serializers/handle.js
+++ b/core/server/api/shared/serializers/handle.js
@@ -1,7 +1,7 @@
 const debug = require('ghost-ignition').debug('api:shared:serializers:handle');
 const Promise = require('bluebird');
 const sequence = require('../../../lib/promise/sequence');
-const common = require('../../../lib/common');
+const errors = require('@tryghost/errors');
 
 /**
  * @description Shared input serialization handler.
@@ -22,11 +22,11 @@ module.exports.input = (apiConfig, apiSerializers, frame) => {
     const sharedSerializers = require('./input');
 
     if (!apiSerializers) {
-        return Promise.reject(new common.errors.IncorrectUsageError());
+        return Promise.reject(new errors.IncorrectUsageError());
     }
 
     if (!apiConfig) {
-        return Promise.reject(new common.errors.IncorrectUsageError());
+        return Promise.reject(new errors.IncorrectUsageError());
     }
 
     // ##### SHARED ALL SERIALIZATION
@@ -86,11 +86,11 @@ module.exports.output = (response = {}, apiConfig, apiSerializers, frame) => {
     const tasks = [];
 
     if (!apiConfig) {
-        return Promise.reject(new common.errors.IncorrectUsageError());
+        return Promise.reject(new errors.IncorrectUsageError());
     }
 
     if (!apiSerializers) {
-        return Promise.reject(new common.errors.IncorrectUsageError());
+        return Promise.reject(new errors.IncorrectUsageError());
     }
 
     // ##### API VERSION RESOURCE SERIALIZATION

--- a/core/server/api/shared/validators/handle.js
+++ b/core/server/api/shared/validators/handle.js
@@ -1,6 +1,6 @@
 const debug = require('ghost-ignition').debug('api:shared:validators:handle');
 const Promise = require('bluebird');
-const common = require('../../../lib/common');
+const errors = require('@tryghost/errors');
 const sequence = require('../../../lib/promise/sequence');
 
 /**
@@ -22,11 +22,11 @@ module.exports.input = (apiConfig, apiValidators, frame) => {
     const sharedValidators = require('./input');
 
     if (!apiValidators) {
-        return Promise.reject(new common.errors.IncorrectUsageError());
+        return Promise.reject(new errors.IncorrectUsageError());
     }
 
     if (!apiConfig) {
-        return Promise.reject(new common.errors.IncorrectUsageError());
+        return Promise.reject(new errors.IncorrectUsageError());
     }
 
     // ##### SHARED ALL VALIDATION

--- a/core/server/api/shared/validators/input/all.js
+++ b/core/server/api/shared/validators/input/all.js
@@ -1,7 +1,8 @@
 const debug = require('ghost-ignition').debug('api:shared:validators:input:all');
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {i18n} = require('../../../../lib/common');
+const {BadRequestError, ValidationError} = require('@tryghost/errors');
 const validation = require('../../../../data/validation');
 
 const GLOBAL_VALIDATORS = {
@@ -29,8 +30,8 @@ const validate = (config, attrs) => {
 
     _.each(config, (value, key) => {
         if (value.required && !attrs[key]) {
-            errors.push(new common.errors.ValidationError({
-                message: common.i18n.t('notices.data.validation.index.validationFailed', {
+            errors.push(new ValidationError({
+                message: i18n.t('notices.data.validation.index.validationFailed', {
                     validationName: 'FieldIsRequired',
                     key: key
                 })
@@ -69,8 +70,8 @@ const validate = (config, attrs) => {
                         return;
                     }
 
-                    errors.push(new common.errors.ValidationError({
-                        message: common.i18n.t('notices.data.validation.index.validationFailed', {
+                    errors.push(new ValidationError({
+                        message: i18n.t('notices.data.validation.index.validationFailed', {
                             validationName: 'AllowedValues',
                             key: key
                         })
@@ -122,8 +123,8 @@ module.exports = {
         //       are introduced for all of the endpoints
         if (!['posts', 'tags'].includes(apiConfig.docName)) {
             if (_.isEmpty(frame.data) || _.isEmpty(frame.data[apiConfig.docName]) || _.isEmpty(frame.data[apiConfig.docName][0])) {
-                return Promise.reject(new common.errors.BadRequestError({
-                    message: common.i18n.t('errors.api.utils.noRootKeyProvided', {docName: apiConfig.docName})
+                return Promise.reject(new BadRequestError({
+                    message: i18n.t('errors.api.utils.noRootKeyProvided', {docName: apiConfig.docName})
                 }));
             }
         }
@@ -143,8 +144,8 @@ module.exports = {
             });
 
             if (missedDataProperties.length) {
-                return Promise.reject(new common.errors.ValidationError({
-                    message: common.i18n.t('notices.data.validation.index.validationFailed', {
+                return Promise.reject(new ValidationError({
+                    message: i18n.t('notices.data.validation.index.validationFailed', {
                         validationName: 'FieldIsRequired',
                         key: JSON.stringify(missedDataProperties)
                     })
@@ -152,8 +153,8 @@ module.exports = {
             }
 
             if (nilDataProperties.length) {
-                return Promise.reject(new common.errors.ValidationError({
-                    message: common.i18n.t('notices.data.validation.index.validationFailed', {
+                return Promise.reject(new ValidationError({
+                    message: i18n.t('notices.data.validation.index.validationFailed', {
                         validationName: 'FieldIsInvalid',
                         key: JSON.stringify(nilDataProperties)
                     })
@@ -177,8 +178,8 @@ module.exports = {
         if (!['posts', 'tags'].includes(apiConfig.docName)) {
             if (frame.options.id && frame.data[apiConfig.docName][0].id
                 && frame.options.id !== frame.data[apiConfig.docName][0].id) {
-                return Promise.reject(new common.errors.BadRequestError({
-                    message: common.i18n.t('errors.api.utils.invalidIdProvided')
+                return Promise.reject(new BadRequestError({
+                    message: i18n.t('errors.api.utils.invalidIdProvided')
                 }));
             }
         }

--- a/core/server/api/v2/authentication.js
+++ b/core/server/api/v2/authentication.js
@@ -1,6 +1,7 @@
 const api = require('./index');
 const config = require('../../config');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const web = require('../../web');
 const models = require('../../models');
 const auth = require('../../services/auth');
@@ -46,7 +47,7 @@ module.exports = {
             return models.User.findOne({role: 'Owner', status: 'all'})
                 .then((owner) => {
                     if (owner.id !== frame.options.context.user) {
-                        throw new common.errors.NoPermissionError({message: common.i18n.t('errors.api.authentication.notTheBlogOwner')});
+                        throw new errors.NoPermissionError({message: i18n.t('errors.api.authentication.notTheBlogOwner')});
                     }
                 });
         },

--- a/core/server/api/v2/authors-public.js
+++ b/core/server/api/v2/authors-public.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 const ALLOWED_INCLUDES = ['count.posts'];
 
@@ -52,8 +53,8 @@ module.exports = {
             return models.Author.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.authors.notFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.authors.notFound')
                         }));
                     }
 

--- a/core/server/api/v2/db.js
+++ b/core/server/api/v2/db.js
@@ -2,7 +2,7 @@ const Promise = require('bluebird');
 const dbBackup = require('../../data/db/backup');
 const exporter = require('../../data/exporter');
 const importer = require('../../data/importer');
-const common = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 module.exports = {
@@ -51,7 +51,7 @@ module.exports = {
             return Promise.resolve()
                 .then(() => exporter.doExport({include: frame.options.withRelated}))
                 .catch((err) => {
-                    return Promise.reject(new common.errors.GhostError({err: err}));
+                    return Promise.reject(new errors.GhostError({err: err}));
                 });
         }
     },
@@ -107,7 +107,7 @@ module.exports = {
                             }, {concurrency: 100});
                         })
                         .catch((err) => {
-                            throw new common.errors.GhostError({
+                            throw new errors.GhostError({
                                 err: err
                             });
                         });

--- a/core/server/api/v2/integrations.js
+++ b/core/server/api/v2/integrations.js
@@ -1,4 +1,5 @@
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 module.exports = {
@@ -43,8 +44,8 @@ module.exports = {
         query({data, options}) {
             return models.Integration.findOne(data, Object.assign(options, {require: true}))
                 .catch(models.Integration.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Integration'
                         })
                     });
@@ -76,8 +77,8 @@ module.exports = {
         query({data, options}) {
             return models.Integration.edit(data, Object.assign(options, {require: true}))
                 .catch(models.Integration.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Integration'
                         })
                     });
@@ -134,8 +135,8 @@ module.exports = {
         query({options}) {
             return models.Integration.destroy(Object.assign(options, {require: true}))
                 .catch(models.Integration.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Integration'
                         })
                     }));

--- a/core/server/api/v2/invites.js
+++ b/core/server/api/v2/invites.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n, logging} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const security = require('../../lib/security');
 const mailService = require('../../services/mail');
 const urlUtils = require('../../lib/url-utils');
@@ -51,8 +52,8 @@ module.exports = {
             return models.Invite.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.invites.inviteNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.invites.inviteNotFound')
                         }));
                     }
 
@@ -79,8 +80,8 @@ module.exports = {
             return models.Invite.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Invite.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.invites.inviteNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.invites.inviteNotFound')
                     }));
                 });
         }
@@ -143,7 +144,7 @@ module.exports = {
                         mail: [{
                             message: {
                                 to: invite.get('email'),
-                                subject: common.i18n.t('common.api.users.mail.invitedByName', {
+                                subject: i18n.t('common.api.users.mail.invitedByName', {
                                     invitedByName: emailData.invitedByName,
                                     blogName: emailData.blogName
                                 }),
@@ -166,12 +167,12 @@ module.exports = {
                 })
                 .catch((err) => {
                     if (err && err.errorType === 'EmailError') {
-                        const errorMessage = common.i18n.t('errors.api.invites.errorSendingEmail.error', {
+                        const errorMessage = i18n.t('errors.api.invites.errorSendingEmail.error', {
                             message: err.message
                         });
-                        const helpText = common.i18n.t('errors.api.invites.errorSendingEmail.help');
+                        const helpText = i18n.t('errors.api.invites.errorSendingEmail.help');
                         err.message = `${errorMessage} ${helpText}`;
-                        common.logging.warn(err.message);
+                        logging.warn(err.message);
                     }
 
                     return Promise.reject(err);

--- a/core/server/api/v2/mail.js
+++ b/core/server/api/v2/mail.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
 const mailService = require('../../services/mail');
 const api = require('./');
 let mailer;
@@ -17,8 +17,8 @@ _private.sendMail = (object) => {
                     notifications: [{
                         type: 'warn',
                         message: [
-                            common.i18n.t('warnings.index.unableToSendEmail'),
-                            common.i18n.t('common.seeLinkForInstructions', {link: 'https://ghost.org/docs/concepts/config/#mail'})
+                            i18n.t('warnings.index.unableToSendEmail'),
+                            i18n.t('common.seeLinkForInstructions', {link: 'https://ghost.org/docs/concepts/config/#mail'})
                         ].join(' ')
                     }]
                 },
@@ -47,7 +47,7 @@ module.exports = {
                     mail: [{
                         message: {
                             to: frame.user.get('email'),
-                            subject: common.i18n.t('common.api.mail.testGhostEmail'),
+                            subject: i18n.t('common.api.mail.testGhostEmail'),
                             html: content.html,
                             text: content.text
                         }

--- a/core/server/api/v2/notifications.js
+++ b/core/server/api/v2/notifications.js
@@ -4,7 +4,8 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 const settingsCache = require('../../services/settings/cache');
 const ghostVersion = require('../../lib/ghost-version');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const ObjectId = require('bson-objectid');
 const api = require('./index');
 const internalContext = {context: {internal: true}};
@@ -170,14 +171,14 @@ module.exports = {
             });
 
             if (notificationToMarkAsSeenIndex > -1 && !notificationToMarkAsSeen.dismissible) {
-                return Promise.reject(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.api.notifications.noPermissionToDismissNotif')
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.api.notifications.noPermissionToDismissNotif')
                 }));
             }
 
             if (notificationToMarkAsSeenIndex < 0) {
-                return Promise.reject(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.notifications.notificationDoesNotExist')
+                return Promise.reject(new errors.NotFoundError({
+                    message: i18n.t('errors.api.notifications.notificationDoesNotExist')
                 }));
             }
 

--- a/core/server/api/v2/oembed.js
+++ b/core/server/api/v2/oembed.js
@@ -1,4 +1,5 @@
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const {extract, hasProvider} = require('oembed-parser');
 const Promise = require('bluebird');
 const request = require('../../lib/request');
@@ -30,15 +31,15 @@ const findUrlWithProvider = (url) => {
 };
 
 function unknownProvider(url) {
-    return Promise.reject(new common.errors.ValidationError({
-        message: common.i18n.t('errors.api.oembed.unknownProvider'),
+    return Promise.reject(new errors.ValidationError({
+        message: i18n.t('errors.api.oembed.unknownProvider'),
         context: url
     }));
 }
 
 function knownProvider(url) {
     return extract(url, {maxwith: 1280}).catch((err) => {
-        return Promise.reject(new common.errors.InternalServerError({
+        return Promise.reject(new errors.InternalServerError({
             message: err.message
         }));
     });

--- a/core/server/api/v2/pages-public.js
+++ b/core/server/api/v2/pages-public.js
@@ -1,4 +1,5 @@
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 const ALLOWED_INCLUDES = ['tags', 'authors'];
 
@@ -61,8 +62,8 @@ module.exports = {
             return models.Post.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.pages.pageNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.pages.pageNotFound')
                         });
                     }
 

--- a/core/server/api/v2/pages.js
+++ b/core/server/api/v2/pages.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const urlUtils = require('../../lib/url-utils');
 const ALLOWED_INCLUDES = ['tags', 'authors', 'authors.roles'];
 const UNSAFE_ATTRS = ['status', 'authors', 'visibility'];
@@ -71,8 +72,8 @@ module.exports = {
             return models.Post.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.pages.pageNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.pages.pageNotFound')
                         });
                     }
 
@@ -198,8 +199,8 @@ module.exports = {
             return models.Post.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Post.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.pages.pageNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.pages.pageNotFound')
                     }));
                 });
         }

--- a/core/server/api/v2/posts-public.js
+++ b/core/server/api/v2/posts-public.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const allowedIncludes = ['tags', 'authors'];
 
 module.exports = {
@@ -61,8 +62,8 @@ module.exports = {
             return models.Post.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.posts.postNotFound')
                         });
                     }
 

--- a/core/server/api/v2/posts.js
+++ b/core/server/api/v2/posts.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const urlUtils = require('../../lib/url-utils');
 const allowedIncludes = ['tags', 'authors', 'authors.roles'];
 const unsafeAttrs = ['status', 'authors', 'visibility'];
@@ -69,8 +70,8 @@ module.exports = {
             return models.Post.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.posts.postNotFound')
                         });
                     }
 
@@ -193,8 +194,8 @@ module.exports = {
             return models.Post.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Post.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.posts.postNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.posts.postNotFound')
                     }));
                 });
         }

--- a/core/server/api/v2/preview.js
+++ b/core/server/api/v2/preview.js
@@ -1,4 +1,5 @@
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 const ALLOWED_INCLUDES = ['authors', 'tags'];
 
@@ -29,8 +30,8 @@ module.exports = {
             return models.Post.findOne(Object.assign({status: 'all'}, frame.data), frame.options)
                 .then((model) => {
                     if (!model) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.posts.postNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.api.posts.postNotFound')
                         });
                     }
 

--- a/core/server/api/v2/schedules.js
+++ b/core/server/api/v2/schedules.js
@@ -3,7 +3,8 @@ const moment = require('moment');
 const config = require('../../config');
 const models = require('../../models');
 const urlUtils = require('../../lib/url-utils');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const api = require('./index');
 
 module.exports = {
@@ -53,11 +54,11 @@ module.exports = {
                         const publishedAtMoment = moment(resource.published_at);
 
                         if (publishedAtMoment.diff(moment(), 'minutes') > publishAPostBySchedulerToleranceInMinutes) {
-                            return Promise.reject(new common.errors.NotFoundError({message: common.i18n.t('errors.api.job.notFound')}));
+                            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.job.notFound')}));
                         }
 
                         if (publishedAtMoment.diff(moment(), 'minutes') < publishAPostBySchedulerToleranceInMinutes * -1 && frame.data.force !== true) {
-                            return Promise.reject(new common.errors.NotFoundError({message: common.i18n.t('errors.api.job.publishInThePast')}));
+                            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.job.publishInThePast')}));
                         }
 
                         const editedResource = {};

--- a/core/server/api/v2/session.js
+++ b/core/server/api/v2/session.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 const auth = require('../../services/auth');
 const api = require('./index');
@@ -18,8 +19,8 @@ const session = {
         const object = frame.data;
 
         if (!object || !object.username || !object.password) {
-            return Promise.reject(new common.errors.UnauthorizedError({
-                message: common.i18n.t('errors.middleware.auth.accessDenied')
+            return Promise.reject(new errors.UnauthorizedError({
+                message: i18n.t('errors.middleware.auth.accessDenied')
             }));
         }
 
@@ -37,9 +38,9 @@ const session = {
                 });
             });
         }).catch(async (err) => {
-            if (!common.errors.utils.isIgnitionError(err)) {
-                throw new common.errors.UnauthorizedError({
-                    message: common.i18n.t('errors.middleware.auth.accessDenied'),
+            if (!errors.utils.isIgnitionError(err)) {
+                throw new errors.UnauthorizedError({
+                    message: i18n.t('errors.middleware.auth.accessDenied'),
                     err
                 });
             }

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -2,7 +2,8 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 const models = require('../../models');
 const routing = require('../../../frontend/services/routing');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const settingsCache = require('../../services/settings/cache');
 
 const SETTINGS_BLACKLIST = [
@@ -58,8 +59,8 @@ module.exports = {
             let setting = settingsCache.get(frame.options.key, {resolve: false});
 
             if (!setting) {
-                return Promise.reject(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+                return Promise.reject(new errors.NotFoundError({
+                    message: i18n.t('errors.api.settings.problemFindingSetting', {
                         key: frame.options.key
                     })
                 }));
@@ -67,8 +68,8 @@ module.exports = {
 
             // @TODO: handle in settings model permissible fn
             if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
-                return Promise.reject(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                 }));
             }
 
@@ -91,8 +92,8 @@ module.exports = {
 
                 frame.data.settings.map((setting) => {
                     if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
-                        errors.push(new common.errors.NoPermissionError({
-                            message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                        errors.push(new errors.NoPermissionError({
+                            message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                         }));
                     }
                 });
@@ -121,15 +122,15 @@ module.exports = {
                 const settingFromCache = settingsCache.get(setting.key, {resolve: false});
 
                 if (!settingFromCache) {
-                    errors.push(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.settings.problemFindingSetting', {
+                    errors.push(new errors.NotFoundError({
+                        message: i18n.t('errors.api.settings.problemFindingSetting', {
                             key: setting.key
                         })
                     }));
                 } else if (settingFromCache.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
                     // @TODO: handle in settings model permissible fn
-                    errors.push(new common.errors.NoPermissionError({
-                        message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                    errors.push(new errors.NoPermissionError({
+                        message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                     }));
                 }
             });

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const models = require('../../models');
 const routing = require('../../../frontend/services/routing');
 const {i18n} = require('../../lib/common');
-const errors = require('@tryghost/errors');
+const {NoPermissionError, NotFoundError} = require('@tryghost/errors');
 const settingsCache = require('../../services/settings/cache');
 
 const SETTINGS_BLACKLIST = [
@@ -59,7 +59,7 @@ module.exports = {
             let setting = settingsCache.get(frame.options.key, {resolve: false});
 
             if (!setting) {
-                return Promise.reject(new errors.NotFoundError({
+                return Promise.reject(new NotFoundError({
                     message: i18n.t('errors.api.settings.problemFindingSetting', {
                         key: frame.options.key
                     })
@@ -68,7 +68,7 @@ module.exports = {
 
             // @TODO: handle in settings model permissible fn
             if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
-                return Promise.reject(new errors.NoPermissionError({
+                return Promise.reject(new NoPermissionError({
                     message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                 }));
             }
@@ -92,7 +92,7 @@ module.exports = {
 
                 frame.data.settings.map((setting) => {
                     if (setting.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
-                        errors.push(new errors.NoPermissionError({
+                        errors.push(new NoPermissionError({
                             message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                         }));
                     }
@@ -122,14 +122,14 @@ module.exports = {
                 const settingFromCache = settingsCache.get(setting.key, {resolve: false});
 
                 if (!settingFromCache) {
-                    errors.push(new errors.NotFoundError({
+                    errors.push(new NotFoundError({
                         message: i18n.t('errors.api.settings.problemFindingSetting', {
                             key: setting.key
                         })
                     }));
                 } else if (settingFromCache.type === 'core' && !(frame.options.context && frame.options.context.internal)) {
                     // @TODO: handle in settings model permissible fn
-                    errors.push(new errors.NoPermissionError({
+                    errors.push(new NoPermissionError({
                         message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
                     }));
                 }

--- a/core/server/api/v2/slack.js
+++ b/core/server/api/v2/slack.js
@@ -1,11 +1,11 @@
-const common = require('../../lib/common');
+const {events} = require('../../lib/common');
 
 module.exports = {
     docName: 'slack',
     sendTest: {
         permissions: false,
         query() {
-            common.events.emit('slack.test');
+            events.emit('slack.test');
         }
     }
 };

--- a/core/server/api/v2/slugs.js
+++ b/core/server/api/v2/slugs.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 
 const allowedTypes = {
     post: models.Post,
@@ -35,8 +36,8 @@ module.exports = {
             return models.Base.Model.generateSlug(allowedTypes[frame.options.type], frame.data.name, {status: 'all'})
                 .then((slug) => {
                     if (!slug) {
-                        return Promise.reject(new common.errors.GhostError({
-                            message: common.i18n.t('errors.api.slugs.couldNotGenerateSlug')
+                        return Promise.reject(new errors.GhostError({
+                            message: i18n.t('errors.api.slugs.couldNotGenerateSlug')
                         }));
                     }
                     return slug;

--- a/core/server/api/v2/tags-public.js
+++ b/core/server/api/v2/tags-public.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.posts'];
@@ -54,8 +55,8 @@ module.exports = {
             return models.TagPublic.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.tags.tagNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.tags.tagNotFound')
                         }));
                     }
 

--- a/core/server/api/v2/tags.js
+++ b/core/server/api/v2/tags.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.posts'];
@@ -54,8 +55,8 @@ module.exports = {
             return models.Tag.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.tags.tagNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.tags.tagNotFound')
                         }));
                     }
 
@@ -106,8 +107,8 @@ module.exports = {
             return models.Tag.edit(frame.data.tags[0], frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.tags.tagNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.tags.tagNotFound')
                         }));
                     }
 
@@ -145,8 +146,8 @@ module.exports = {
             return models.Tag.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Tag.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.tags.tagNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.tags.tagNotFound')
                     }));
                 });
         }

--- a/core/server/api/v2/themes.js
+++ b/core/server/api/v2/themes.js
@@ -1,4 +1,4 @@
-const common = require('../../lib/common');
+const {events} = require('../../lib/common');
 const themeService = require('../../../frontend/services/themes');
 const models = require('../../models');
 
@@ -66,7 +66,7 @@ module.exports = {
                         // CASE: clear cache
                         this.headers.cacheInvalidate = true;
                     }
-                    common.events.emit('theme.uploaded');
+                    events.emit('theme.uploaded');
                     return theme;
                 });
         }

--- a/core/server/api/v2/users.js
+++ b/core/server/api/v2/users.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../models');
 const permissionsService = require('../../services/permissions');
 const ALLOWED_INCLUDES = ['count.posts', 'permissions', 'roles', 'roles.permissions'];
@@ -56,8 +57,8 @@ module.exports = {
             return models.User.findOne(frame.data, frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.users.userNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.users.userNotFound')
                         }));
                     }
 
@@ -89,8 +90,8 @@ module.exports = {
             return models.User.edit(frame.data.users[0], frame.options)
                 .then((model) => {
                     if (!model) {
-                        return Promise.reject(new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.api.users.userNotFound')
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.users.userNotFound')
                         }));
                     }
 
@@ -131,7 +132,7 @@ module.exports = {
                     return models.User.destroy(Object.assign({status: 'all'}, frame.options));
                 }).then(() => null);
             }).catch((err) => {
-                return Promise.reject(new common.errors.NoPermissionError({
+                return Promise.reject(new errors.NoPermissionError({
                     err: err
                 }));
             });

--- a/core/server/api/v2/utils/permissions.js
+++ b/core/server/api/v2/utils/permissions.js
@@ -2,7 +2,8 @@ const debug = require('ghost-ignition').debug('api:v2:utils:permissions');
 const Promise = require('bluebird');
 const _ = require('lodash');
 const permissions = require('../../../services/permissions');
-const common = require('../../../lib/common');
+const {i18n} = require('../../../lib/common');
+const errors = require('@tryghost/errors');
 
 /**
  * @description Handle requests, which need authentication.
@@ -49,19 +50,19 @@ const nonePublicAuth = (apiConfig, frame) => {
             frame.data[apiConfig.docName][0] = _.omit(frame.data[apiConfig.docName][0], result.excludedAttrs);
         }
     }).catch((err) => {
-        if (err instanceof common.errors.NoPermissionError) {
-            err.message = common.i18n.t('errors.api.utils.noPermissionToCall', {
+        if (err instanceof errors.NoPermissionError) {
+            err.message = i18n.t('errors.api.utils.noPermissionToCall', {
                 method: apiConfig.method,
                 docName: apiConfig.docName
             });
             return Promise.reject(err);
         }
 
-        if (common.errors.utils.isIgnitionError(err)) {
+        if (errors.utils.isIgnitionError(err)) {
             return Promise.reject(err);
         }
 
-        return Promise.reject(new common.errors.GhostError({
+        return Promise.reject(new errors.GhostError({
             err: err
         }));
     });

--- a/core/server/api/v2/utils/serializers/output/authentication.js
+++ b/core/server/api/v2/utils/serializers/output/authentication.js
@@ -1,4 +1,4 @@
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
 const mapper = require('./utils/mapper');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:output:authentication');
 
@@ -28,7 +28,7 @@ module.exports = {
     generateResetToken(data, apiConfig, frame) {
         frame.response = {
             passwordreset: [{
-                message: common.i18n.t('common.api.authentication.mail.checkEmailForInstructions')
+                message: i18n.t('common.api.authentication.mail.checkEmailForInstructions')
             }]
         };
     },
@@ -36,7 +36,7 @@ module.exports = {
     resetPassword(data, apiConfig, frame) {
         frame.response = {
             passwordreset: [{
-                message: common.i18n.t('common.api.authentication.mail.passwordChanged')
+                message: i18n.t('common.api.authentication.mail.passwordChanged')
             }]
         };
     },
@@ -46,7 +46,7 @@ module.exports = {
 
         frame.response = {
             invitation: [
-                {message: common.i18n.t('common.api.authentication.mail.invitationAccepted')}
+                {message: i18n.t('common.api.authentication.mail.invitationAccepted')}
             ]
         };
     },

--- a/core/server/api/v2/utils/serializers/output/users.js
+++ b/core/server/api/v2/utils/serializers/output/users.js
@@ -1,5 +1,5 @@
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:output:users');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
 const mapper = require('./utils/mapper');
 
 module.exports = {
@@ -29,7 +29,7 @@ module.exports = {
         debug('changePassword');
 
         frame.response = {
-            password: [{message: common.i18n.t('notices.api.users.pwdChangedSuccessfully')}]
+            password: [{message: i18n.t('notices.api.users.pwdChangedSuccessfully')}]
         };
     },
 

--- a/core/server/api/v2/utils/validators/input/images.js
+++ b/core/server/api/v2/utils/validators/input/images.js
@@ -1,6 +1,7 @@
 const jsonSchema = require('../utils/json-schema');
 const config = require('../../../../../config');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 const imageLib = require('../../../../../lib/image');
 
 const profileImage = (frame) => {
@@ -10,8 +11,8 @@ const profileImage = (frame) => {
 
         // CASE: file needs to be a square
         if (frame.file.dimensions.width !== frame.file.dimensions.height) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.images.isNotSquare')
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.api.images.isNotSquare')
             }));
         }
     });
@@ -26,8 +27,8 @@ const icon = (frame) => {
 
     // CASE: file should not be larger than 100kb
     if (!validIconFileSize(frame.file.size)) {
-        return Promise.reject(new common.errors.ValidationError({
-            message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+        return Promise.reject(new errors.ValidationError({
+            message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
         }));
     }
 
@@ -37,23 +38,23 @@ const icon = (frame) => {
 
         // CASE: file needs to be a square
         if (frame.file.dimensions.width !== frame.file.dimensions.height) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
             }));
         }
 
         // CASE: icon needs to be bigger than or equal to 60px
         // .ico files can contain multiple sizes, we need at least a minimum of 60px (16px is ok, as long as 60px are present as well)
         if (frame.file.dimensions.width < 60) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
             }));
         }
 
         // CASE: icon needs to be smaller than or equal to 1000px
         if (frame.file.dimensions.width > 1000) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
             }));
         }
     });

--- a/core/server/api/v2/utils/validators/input/invitations.js
+++ b/core/server/api/v2/utils/validators/input/invitations.js
@@ -1,7 +1,8 @@
 const Promise = require('bluebird');
 const validator = require('validator');
 const debug = require('ghost-ignition').debug('api:v2:utils:validators:input:invitation');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     acceptInvitation(apiConfig, frame) {
@@ -10,19 +11,19 @@ module.exports = {
         const data = frame.data.invitation[0];
 
         if (!data.token) {
-            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noTokenProvided')}));
+            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noTokenProvided')}));
         }
 
         if (!data.email) {
-            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noEmailProvided')}));
+            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noEmailProvided')}));
         }
 
         if (!data.password) {
-            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noPasswordProvided')}));
+            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noPasswordProvided')}));
         }
 
         if (!data.name) {
-            return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.authentication.noNameProvided')}));
+            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noNameProvided')}));
         }
     },
 
@@ -32,8 +33,8 @@ module.exports = {
         const email = frame.data.email;
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
-            throw new common.errors.BadRequestError({
-                message: common.i18n.t('errors.api.authentication.invalidEmailReceived')
+            throw new errors.BadRequestError({
+                message: i18n.t('errors.api.authentication.invalidEmailReceived')
             });
         }
     }

--- a/core/server/api/v2/utils/validators/input/invites.js
+++ b/core/server/api/v2/utils/validators/input/invites.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 const models = require('../../../../../models');
 
 module.exports = {
@@ -7,8 +8,8 @@ module.exports = {
         return models.User.findOne({email: frame.data.invites[0].email}, frame.options)
             .then((user) => {
                 if (user) {
-                    return Promise.reject(new common.errors.ValidationError({
-                        message: common.i18n.t('errors.api.users.userAlreadyRegistered')
+                    return Promise.reject(new errors.ValidationError({
+                        message: i18n.t('errors.api.users.userAlreadyRegistered')
                     }));
                 }
             });

--- a/core/server/api/v2/utils/validators/input/oembed.js
+++ b/core/server/api/v2/utils/validators/input/oembed.js
@@ -1,11 +1,12 @@
 const Promise = require('bluebird');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     read(apiConfig, frame) {
         if (!frame.data.url || !frame.data.url.trim()) {
-            return Promise.reject(new common.errors.BadRequestError({
-                message: common.i18n.t('errors.api.oembed.noUrlProvided')
+            return Promise.reject(new errors.BadRequestError({
+                message: i18n.t('errors.api.oembed.noUrlProvided')
             }));
         }
     }

--- a/core/server/api/v2/utils/validators/input/passwordreset.js
+++ b/core/server/api/v2/utils/validators/input/passwordreset.js
@@ -1,7 +1,8 @@
 const Promise = require('bluebird');
 const validator = require('validator');
 const debug = require('ghost-ignition').debug('api:v2:utils:validators:input:passwordreset');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     resetPassword(apiConfig, frame) {
@@ -10,8 +11,8 @@ module.exports = {
         const data = frame.data.passwordreset[0];
 
         if (data.newPassword !== data.ne2Password) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.models.user.newPasswordsDoNotMatch')
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.models.user.newPasswordsDoNotMatch')
             }));
         }
     },
@@ -22,8 +23,8 @@ module.exports = {
         const email = frame.data.passwordreset[0].email;
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
-            throw new common.errors.BadRequestError({
-                message: common.i18n.t('errors.api.authentication.invalidEmailReceived')
+            throw new errors.BadRequestError({
+                message: i18n.t('errors.api.authentication.invalidEmailReceived')
             });
         }
     }

--- a/core/server/api/v2/utils/validators/input/settings.js
+++ b/core/server/api/v2/utils/validators/input/settings.js
@@ -1,13 +1,13 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 const {i18n} = require('../../../../../lib/common');
-const errors = require('@tryghost/errors');
+const {NotFoundError, BadRequestError} = require('@tryghost/errors');
 
 module.exports = {
     read(apiConfig, frame) {
         // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
         if (frame.options.key === 'permalinks') {
-            return Promise.reject(new errors.NotFoundError({
+            return Promise.reject(new NotFoundError({
                 message: i18n.t('errors.errors.resourceNotFound')
             }));
         }
@@ -20,14 +20,14 @@ module.exports = {
             if (setting.key === 'active_theme') {
                 // @NOTE: active theme has to be changed via theme endpoints
                 errors.push(
-                    new errors.BadRequestError({
+                    new BadRequestError({
                         message: i18n.t('errors.api.settings.activeThemeSetViaAPI.error'),
                         help: i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
                     })
                 );
             } else if (setting.key === 'permalinks') {
                 // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
-                errors.push(new errors.NotFoundError({
+                errors.push(new NotFoundError({
                     message: i18n.t('errors.api.settings.problemFindingSetting', {key: setting.key})
                 }));
             }

--- a/core/server/api/v2/utils/validators/input/settings.js
+++ b/core/server/api/v2/utils/validators/input/settings.js
@@ -1,13 +1,14 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     read(apiConfig, frame) {
         // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
         if (frame.options.key === 'permalinks') {
-            return Promise.reject(new common.errors.NotFoundError({
-                message: common.i18n.t('errors.errors.resourceNotFound')
+            return Promise.reject(new errors.NotFoundError({
+                message: i18n.t('errors.errors.resourceNotFound')
             }));
         }
     },
@@ -19,15 +20,15 @@ module.exports = {
             if (setting.key === 'active_theme') {
                 // @NOTE: active theme has to be changed via theme endpoints
                 errors.push(
-                    new common.errors.BadRequestError({
-                        message: common.i18n.t('errors.api.settings.activeThemeSetViaAPI.error'),
-                        help: common.i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
+                    new errors.BadRequestError({
+                        message: i18n.t('errors.api.settings.activeThemeSetViaAPI.error'),
+                        help: i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
                     })
                 );
             } else if (setting.key === 'permalinks') {
                 // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
-                errors.push(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.settings.problemFindingSetting', {key: setting.key})
+                errors.push(new errors.NotFoundError({
+                    message: i18n.t('errors.api.settings.problemFindingSetting', {key: setting.key})
                 }));
             }
         });

--- a/core/server/api/v2/utils/validators/input/setup.js
+++ b/core/server/api/v2/utils/validators/input/setup.js
@@ -1,12 +1,13 @@
 const debug = require('ghost-ignition').debug('api:v2:utils:validators:input:updateSetup');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     updateSetup(apiConfig, frame) {
         debug('resetPassword');
 
         if (!frame.options.context || !frame.options.context.user) {
-            throw new common.errors.NoPermissionError({message: common.i18n.t('errors.api.authentication.notTheBlogOwner')});
+            throw new errors.NoPermissionError({message: i18n.t('errors.api.authentication.notTheBlogOwner')});
         }
     }
 };

--- a/core/server/api/v2/utils/validators/input/users.js
+++ b/core/server/api/v2/utils/validators/input/users.js
@@ -1,6 +1,7 @@
 const Promise = require('bluebird');
 const debug = require('ghost-ignition').debug('api:v2:utils:validators:input:users');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     changePassword(apiConfig, frame) {
@@ -9,8 +10,8 @@ module.exports = {
         const data = frame.data.password[0];
 
         if (data.newPassword !== data.ne2Password) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.models.user.newPasswordsDoNotMatch')
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.models.user.newPasswordsDoNotMatch')
             }));
         }
     }

--- a/core/server/api/v2/utils/validators/utils/json-schema.js
+++ b/core/server/api/v2/utils/validators/utils/json-schema.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
 const Ajv = require('ajv');
 const stripKeyword = require('./strip-keyword');
-const common = require('../../../../../lib/common');
+const {i18n} = require('../../../../../lib/common');
+const errors = require('@tryghost/errors');
 
 const ajv = new Ajv({
     allErrors: true,
@@ -42,8 +43,8 @@ const validate = (schema, definition, data) => {
             key = schema.$id.split('.')[0];
         }
 
-        return Promise.reject(new common.errors.ValidationError({
-            message: common.i18n.t('notices.data.validation.index.schemaValidationFailed', {
+        return Promise.reject(new errors.ValidationError({
+            message: i18n.t('notices.data.validation.index.schemaValidationFailed', {
                 key: key
             }),
             property: key,

--- a/core/server/api/v2/webhooks.js
+++ b/core/server/api/v2/webhooks.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = {
     docName: 'webhooks',
@@ -28,7 +29,7 @@ module.exports = {
             ).then((webhook) => {
                 if (webhook) {
                     return Promise.reject(
-                        new common.errors.ValidationError({message: common.i18n.t('errors.api.webhooks.webhookAlreadyExists')})
+                        new errors.ValidationError({message: i18n.t('errors.api.webhooks.webhookAlreadyExists')})
                     );
                 }
 
@@ -59,8 +60,8 @@ module.exports = {
         query({data, options}) {
             return models.Webhook.edit(data.webhooks[0], Object.assign(options, {require: true}))
                 .catch(models.Webhook.NotFoundError, () => {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Webhook'
                         })
                     });
@@ -87,8 +88,8 @@ module.exports = {
             return models.Webhook.destroy(frame.options)
                 .then(() => null)
                 .catch(models.Webhook.NotFoundError, () => {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.resource.resourceNotFound', {
                             resource: 'Webhook'
                         })
                     }));

--- a/core/server/data/db/backup.js
+++ b/core/server/data/db/backup.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const Promise = require('bluebird');
 const config = require('../../config');
-const common = require('../../lib/common');
+const {logging} = require('../../lib/common');
 const urlUtils = require('../../lib/url-utils');
 const exporter = require('../exporter');
 let writeExportFile;
@@ -38,7 +38,7 @@ const readBackup = async (filename) => {
  * @returns {Promise<*>}
  */
 backup = function backup(options) {
-    common.logging.info('Creating database backup');
+    logging.info('Creating database backup');
     options = options || {};
 
     const props = {
@@ -49,7 +49,7 @@ backup = function backup(options) {
     return Promise.props(props)
         .then(writeExportFile)
         .then(function successMessage(filename) {
-            common.logging.info('Database backup written to: ' + filename);
+            logging.info('Database backup written to: ' + filename);
             return filename;
         });
 };

--- a/core/server/data/db/connection.js
+++ b/core/server/data/db/connection.js
@@ -1,6 +1,7 @@
 const knex = require('knex');
 const config = require('../../config');
-const common = require('../../lib/common');
+const {logging} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 let knexInstance;
 
 // @TODO:
@@ -19,7 +20,7 @@ function configure(dbConfig) {
         dbConfig.connection.charset = 'utf8mb4';
 
         dbConfig.connection.loggingHook = function loggingHook(err) {
-            common.logging.error(new common.errors.InternalServerError({
+            logging.error(new errors.InternalServerError({
                 code: 'MYSQL_LOGGING_HOOK',
                 err: err
             }));

--- a/core/server/data/db/migrator.js
+++ b/core/server/data/db/migrator.js
@@ -1,6 +1,6 @@
 const KnexMigrator = require('knex-migrator');
 const config = require('../../config');
-const common = require('../../lib/common');
+const errors = require('@tryghost/errors');
 
 const knexMigrator = new KnexMigrator({
     knexMigratorFilePath: config.get('paths:appRoot')
@@ -56,7 +56,7 @@ module.exports.isDbCompatible = (connection) => {
                 return;
             }
 
-            throw new common.errors.DatabaseVersionError({
+            throw new errors.DatabaseVersionError({
                 message: 'Your database version is not compatible with Ghost 2.0.',
                 help: 'Want to keep your DB? Use Ghost < 1.0.0 or the "0.11" branch.' +
                       '\n\n\n' +

--- a/core/server/data/exporter/index.js
+++ b/core/server/data/exporter/index.js
@@ -3,7 +3,8 @@ const Promise = require('bluebird');
 const db = require('../../data/db');
 const commands = require('../schema').commands;
 const ghostVersion = require('../../lib/ghost-version');
-const common = require('../../lib/common');
+const {logging, i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const security = require('../../lib/security');
 const models = require('../../models');
 const EXCLUDED_TABLES = ['sessions', 'mobiledoc_revisions'];
@@ -46,7 +47,7 @@ exportFileName = function exportFileName(options) {
 
         return title + 'ghost.' + datetime + '.json';
     }).catch(function (err) {
-        common.logging.error(new common.errors.GhostError({err: err}));
+        logging.error(new errors.GhostError({err: err}));
         return 'ghost.' + datetime + '.json';
     });
 };
@@ -105,9 +106,9 @@ doExport = function doExport(options) {
 
         return exportData;
     }).catch(function (err) {
-        return Promise.reject(new common.errors.DataExportError({
+        return Promise.reject(new errors.DataExportError({
             err: err,
-            context: common.i18n.t('errors.data.export.errorExportingData')
+            context: i18n.t('errors.data.export.errorExportingData')
         }));
     });
 };

--- a/core/server/data/importer/handlers/json.js
+++ b/core/server/data/importer/handlers/json.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const fs = require('fs-extra');
-const common = require('../../../lib/common');
+const {i18n} = require('../../../lib/common');
+const errors = require('@tryghost/errors');
 let JSONHandler;
 
 JSONHandler = {
@@ -23,8 +24,8 @@ JSONHandler = {
                 // if importData follows JSON-API format `{ db: [exportedData] }`
                 if (_.keys(importData).length === 1) {
                     if (!importData.db || !Array.isArray(importData.db)) {
-                        throw new common.errors.GhostError({
-                            message: common.i18n.t('errors.data.importer.handlers.json.invalidJsonFormat')
+                        throw new errors.GhostError({
+                            message: i18n.t('errors.data.importer.handlers.json.invalidJsonFormat')
                         });
                     }
 
@@ -33,10 +34,10 @@ JSONHandler = {
 
                 return importData;
             } catch (err) {
-                return Promise.reject(new common.errors.BadRequestError({
+                return Promise.reject(new errors.BadRequestError({
                     err: err,
                     message: err.message,
-                    help: common.i18n.t('errors.data.importer.handlers.json.checkImportJsonIsValid')
+                    help: i18n.t('errors.data.importer.handlers.json.checkImportJsonIsValid')
                 }));
             }
         });

--- a/core/server/data/importer/importers/data/base.js
+++ b/core/server/data/importer/importers/data/base.js
@@ -2,7 +2,7 @@ const debug = require('ghost-ignition').debug('importer:base');
 const _ = require('lodash');
 const Promise = require('bluebird');
 const ObjectId = require('bson-objectid');
-const common = require('../../../../lib/common');
+const errors = require('@tryghost/errors');
 const sequence = require('../../../../lib/promise/sequence');
 const models = require('../../../../models');
 
@@ -128,14 +128,14 @@ class Base {
                         });
                     }
                 } else {
-                    errorsToReject.push(new common.errors.DataImportError({
+                    errorsToReject.push(new errors.DataImportError({
                         message: 'Detected duplicated entry.',
                         help: this.modelName,
                         context: JSON.stringify(obj),
                         err: err
                     }));
                 }
-            } else if (err instanceof common.errors.NotFoundError) {
+            } else if (err instanceof errors.NotFoundError) {
                 if (this.errorConfig.showNotFoundWarning) {
                     problems.push({
                         message: 'Entry was not imported and ignored. Could not find entry.',
@@ -145,8 +145,8 @@ class Base {
                     });
                 }
             } else {
-                if (!common.errors.utils.isIgnitionError(err)) {
-                    err = new common.errors.DataImportError({
+                if (!errors.utils.isIgnitionError(err)) {
+                    err = new errors.DataImportError({
                         message: err.message,
                         context: JSON.stringify(obj),
                         help: this.modelName,

--- a/core/server/data/importer/importers/data/index.js
+++ b/core/server/data/importer/importers/data/index.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const semver = require('semver');
-const common = require('../../../../lib/common');
+const {IncorrectUsageError} = require('@tryghost/errors');
 const debug = require('ghost-ignition').debug('importer:data');
 const sequence = require('../../../../lib/promise/sequence');
 const models = require('../../../../models');
@@ -55,14 +55,14 @@ DataImporter = {
         }
 
         if (!importData.meta) {
-            return Promise.reject(new common.errors.IncorrectUsageError({
+            return Promise.reject(new IncorrectUsageError({
                 message: 'Wrong importer structure. `meta` is missing.',
                 help: 'https://ghost.org/docs/api/migration/#json-file-structure'
             }));
         }
 
         if (!importData.meta.version) {
-            return Promise.reject(new common.errors.IncorrectUsageError({
+            return Promise.reject(new IncorrectUsageError({
                 message: 'Wrong importer structure. `meta.version` is missing.',
                 help: 'https://ghost.org/docs/api/migration/#json-file-structure'
             }));
@@ -71,7 +71,7 @@ DataImporter = {
         // CASE: We deny LTS imports, because these are major version jumps. Only imports from v1 until the latest are supported.
         //       We can detect a wrong structure by checking the meta version field. Ghost v0 doesn't use semver compliant versions.
         if (!semver.valid(importData.meta.version)) {
-            return Promise.reject(new common.errors.IncorrectUsageError({
+            return Promise.reject(new IncorrectUsageError({
                 message: 'Detected unsupported file structure.',
                 help: 'Please install Ghost 1.0, import the file and then update your blog to the latest Ghost version.\nVisit https://ghost.org/update/?v=0.1 or ask for help in our https://forum.ghost.org.'
             }));

--- a/core/server/data/importer/index.js
+++ b/core/server/data/importer/index.js
@@ -8,7 +8,8 @@ const uuid = require('uuid');
 const {extract} = require('@tryghost/zip');
 const sequence = require('../../lib/promise/sequence');
 const pipeline = require('../../lib/promise/pipeline');
-const common = require('../../lib/common');
+const {logging, i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const ImageHandler = require('./handlers/image');
 const JSONHandler = require('./handlers/json');
 const MarkdownHandler = require('./handlers/markdown');
@@ -110,10 +111,10 @@ _.extend(ImportManager.prototype, {
 
         fs.remove(self.fileToDelete, function (err) {
             if (err) {
-                common.logging.error(new common.errors.GhostError({
+                logging.error(new errors.GhostError({
                     err: err,
-                    context: common.i18n.t('errors.data.importer.index.couldNotCleanUpFile.error'),
-                    help: common.i18n.t('errors.data.importer.index.couldNotCleanUpFile.context')
+                    context: i18n.t('errors.data.importer.index.couldNotCleanUpFile.error'),
+                    help: i18n.t('errors.data.importer.index.couldNotCleanUpFile.context')
                 }));
             }
 
@@ -152,7 +153,7 @@ _.extend(ImportManager.prototype, {
 
         // This is a temporary extra message for the old format roon export which doesn't work with Ghost
         if (oldRoonMatches.length > 0) {
-            throw new common.errors.UnsupportedMediaTypeError({message: common.i18n.t('errors.data.importer.index.unsupportedRoonExport')});
+            throw new errors.UnsupportedMediaTypeError({message: i18n.t('errors.data.importer.index.unsupportedRoonExport')});
         }
 
         // If this folder contains importable files or a content or images directory
@@ -161,10 +162,10 @@ _.extend(ImportManager.prototype, {
         }
 
         if (extMatchesAll.length < 1) {
-            throw new common.errors.UnsupportedMediaTypeError({message: common.i18n.t('errors.data.importer.index.noContentToImport')});
+            throw new errors.UnsupportedMediaTypeError({message: i18n.t('errors.data.importer.index.noContentToImport')});
         }
 
-        throw new common.errors.UnsupportedMediaTypeError({message: common.i18n.t('errors.data.importer.index.invalidZipStructure')});
+        throw new errors.UnsupportedMediaTypeError({message: i18n.t('errors.data.importer.index.invalidZipStructure')});
     },
     /**
      * Use the extract module to extract the given zip file to a temp directory & return the temp directory path
@@ -213,7 +214,7 @@ _.extend(ImportManager.prototype, {
             this.getExtensionGlob(this.getExtensions(), ALL_DIRS), {cwd: directory}
         );
         if (extMatchesAll.length < 1 || extMatchesAll[0].split('/') < 1) {
-            throw new common.errors.ValidationError({message: common.i18n.t('errors.data.importer.index.invalidZipFileBaseDirectory')});
+            throw new errors.ValidationError({message: i18n.t('errors.data.importer.index.invalidZipFileBaseDirectory')});
         }
 
         return extMatchesAll[0].split('/')[0];
@@ -241,8 +242,8 @@ _.extend(ImportManager.prototype, {
             _.each(self.handlers, function (handler) {
                 if (Object.prototype.hasOwnProperty.call(importData, handler.type)) {
                     // This limitation is here to reduce the complexity of the importer for now
-                    return Promise.reject(new common.errors.UnsupportedMediaTypeError({
-                        message: common.i18n.t('errors.data.importer.index.zipContainsMultipleDataFormats')
+                    return Promise.reject(new errors.UnsupportedMediaTypeError({
+                        message: i18n.t('errors.data.importer.index.zipContainsMultipleDataFormats')
                     }));
                 }
 
@@ -258,8 +259,8 @@ _.extend(ImportManager.prototype, {
             });
 
             if (ops.length === 0) {
-                return Promise.reject(new common.errors.UnsupportedMediaTypeError({
-                    message: common.i18n.t('errors.data.importer.index.noContentToImport')
+                return Promise.reject(new errors.UnsupportedMediaTypeError({
+                    message: i18n.t('errors.data.importer.index.noContentToImport')
                 }));
             }
 

--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n, logging} = require('../../lib/common');
 const db = require('../db');
 const schema = require('./schema');
 const clients = require('./clients');
@@ -102,7 +102,7 @@ function getTables(transaction) {
         return clients[client].getTables(transaction);
     }
 
-    return Promise.reject(common.i18n.t('notices.data.utils.index.noSupportForDatabase', {client: client}));
+    return Promise.reject(i18n.t('notices.data.utils.index.noSupportForDatabase', {client: client}));
 }
 
 function getIndexes(table, transaction) {
@@ -112,7 +112,7 @@ function getIndexes(table, transaction) {
         return clients[client].getIndexes(table, transaction);
     }
 
-    return Promise.reject(common.i18n.t('notices.data.utils.index.noSupportForDatabase', {client: client}));
+    return Promise.reject(i18n.t('notices.data.utils.index.noSupportForDatabase', {client: client}));
 }
 
 function getColumns(table, transaction) {
@@ -122,7 +122,7 @@ function getColumns(table, transaction) {
         return clients[client].getColumns(table);
     }
 
-    return Promise.reject(common.i18n.t('notices.data.utils.index.noSupportForDatabase', {client: client}));
+    return Promise.reject(i18n.t('notices.data.utils.index.noSupportForDatabase', {client: client}));
 }
 
 function checkTables(transaction) {
@@ -133,7 +133,7 @@ function checkTables(transaction) {
     }
 }
 
-const createLog = type => msg => common.logging[type](msg);
+const createLog = type => msg => logging[type](msg);
 
 function createColumnMigration(...migrations) {
     async function runColumnMigration(conn, migration) {

--- a/core/server/data/schema/fixtures/utils.js
+++ b/core/server/data/schema/fixtures/utils.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 
 const Promise = require('bluebird');
-const common = require('../../../lib/common');
+const {logging} = require('../../../lib/common');
 const models = require('../../../models');
 const baseUtils = require('../../../models/base/utils');
 const sequence = require('../../../lib/promise/sequence');
@@ -161,7 +161,7 @@ addFixturesForRelation = function addFixturesForRelation(relationFixture, option
             // As soon as an **older** migration script wants to add permissions for any resource, it iterates over the
             // permissions for each role. But if the role does not exist yet, it won't find the matching db entry and breaks.
             if (!fromItem) {
-                common.logging.warn('Skip: Target database entry not found for key: ' + key);
+                logging.warn('Skip: Target database entry not found for key: ' + key);
                 return Promise.resolve();
             }
 

--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -4,7 +4,8 @@ const validator = require('validator');
 const moment = require('moment-timezone');
 const assert = require('assert');
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const settingsCache = require('../../services/settings/cache');
 const urlUtils = require('../../lib/url-utils');
 let validatePassword;
@@ -113,7 +114,7 @@ validatePassword = function validatePassword(password, email, blogTitle) {
     // password must be longer than 10 characters
     if (!validator.isLength(password, 10)) {
         validationResult.isValid = false;
-        validationResult.message = common.i18n.t('errors.models.user.passwordDoesNotComplyLength', {minLength: 10});
+        validationResult.message = i18n.t('errors.models.user.passwordDoesNotComplyLength', {minLength: 10});
 
         return validationResult;
     }
@@ -154,7 +155,7 @@ validatePassword = function validatePassword(password, email, blogTitle) {
 
     // Generic error message for the rules where no dedicated error massage is set
     if (!validationResult.isValid && !validationResult.message) {
-        validationResult.message = common.i18n.t('errors.models.user.passwordDoesNotComplySecurity');
+        validationResult.message = i18n.t('errors.models.user.passwordDoesNotComplySecurity');
     }
 
     return validationResult;
@@ -195,11 +196,11 @@ validateSchema = function validateSchema(tableName, model, options) {
             !Object.prototype.hasOwnProperty.call(schema[tableName][columnKey], 'defaultTo')
         ) {
             if (validator.empty(strVal)) {
-                message = common.i18n.t('notices.data.validation.index.valueCannotBeBlank', {
+                message = i18n.t('notices.data.validation.index.valueCannotBeBlank', {
                     tableName: tableName,
                     columnKey: columnKey
                 });
-                validationErrors.push(new common.errors.ValidationError({
+                validationErrors.push(new errors.ValidationError({
                     message: message,
                     context: tableName + '.' + columnKey
                 }));
@@ -210,11 +211,11 @@ validateSchema = function validateSchema(tableName, model, options) {
         if (Object.prototype.hasOwnProperty.call(schema[tableName][columnKey], 'type')
             && schema[tableName][columnKey].type === 'bool') {
             if (!(validator.isBoolean(strVal) || validator.empty(strVal))) {
-                message = common.i18n.t('notices.data.validation.index.valueMustBeBoolean', {
+                message = i18n.t('notices.data.validation.index.valueMustBeBoolean', {
                     tableName: tableName,
                     columnKey: columnKey
                 });
-                validationErrors.push(new common.errors.ValidationError({
+                validationErrors.push(new errors.ValidationError({
                     message: message,
                     context: tableName + '.' + columnKey
                 }));
@@ -231,13 +232,13 @@ validateSchema = function validateSchema(tableName, model, options) {
             // check length
             if (Object.prototype.hasOwnProperty.call(schema[tableName][columnKey], 'maxlength')) {
                 if (!validator.isLength(strVal, 0, schema[tableName][columnKey].maxlength)) {
-                    message = common.i18n.t('notices.data.validation.index.valueExceedsMaxLength',
+                    message = i18n.t('notices.data.validation.index.valueExceedsMaxLength',
                         {
                             tableName: tableName,
                             columnKey: columnKey,
                             maxlength: schema[tableName][columnKey].maxlength
                         });
-                    validationErrors.push(new common.errors.ValidationError({
+                    validationErrors.push(new errors.ValidationError({
                         message: message,
                         context: tableName + '.' + columnKey
                     }));
@@ -252,11 +253,11 @@ validateSchema = function validateSchema(tableName, model, options) {
             // check type
             if (Object.prototype.hasOwnProperty.call(schema[tableName][columnKey], 'type')) {
                 if (schema[tableName][columnKey].type === 'integer' && !validator.isInt(strVal)) {
-                    message = common.i18n.t('notices.data.validation.index.valueIsNotInteger', {
+                    message = i18n.t('notices.data.validation.index.valueIsNotInteger', {
                         tableName: tableName,
                         columnKey: columnKey
                     });
-                    validationErrors.push(new common.errors.ValidationError({
+                    validationErrors.push(new errors.ValidationError({
                         message: message,
                         context: tableName + '.' + columnKey
                     }));
@@ -332,20 +333,20 @@ validate = function validate(value, key, validations, tableName) {
         // equivalent of validator.isSomething(option1, option2)
         if (validator[validationName].apply(validator, validationOptions) !== goodResult) {
             // CASE: You can define specific translations for validators e.g. isLength
-            if (common.i18n.doesTranslationKeyExist('notices.data.validation.index.validationFailedTypes.' + validationName)) {
-                translation = common.i18n.t('notices.data.validation.index.validationFailedTypes.' + validationName, _.merge({
+            if (i18n.doesTranslationKeyExist('notices.data.validation.index.validationFailedTypes.' + validationName)) {
+                translation = i18n.t('notices.data.validation.index.validationFailedTypes.' + validationName, _.merge({
                     validationName: validationName,
                     key: key,
                     tableName: tableName
                 }, validationOptions[1]));
             } else {
-                translation = common.i18n.t('notices.data.validation.index.validationFailed', {
+                translation = i18n.t('notices.data.validation.index.validationFailed', {
                     validationName: validationName,
                     key: key
                 });
             }
 
-            validationErrors.push(new common.errors.ValidationError({
+            validationErrors.push(new errors.ValidationError({
                 message: translation,
                 context: `${tableName}.${key}`
             }));

--- a/core/server/models/api-key.js
+++ b/core/server/models/api-key.js
@@ -1,5 +1,6 @@
 const omit = require('lodash/omit');
-const common = require('../lib/common');
+const {logging} = require('../lib/common');
+const errors = require('@tryghost/errors');
 const _ = require('lodash');
 const crypto = require('crypto');
 const ghostBookshelf = require('./base');
@@ -53,7 +54,7 @@ const addAction = (model, event, options) => {
                     err = err[0];
                 }
 
-                common.logging.error(new common.errors.InternalServerError({
+                logging.error(new errors.InternalServerError({
                     err
                 }));
             });

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -15,7 +15,8 @@ const ObjectId = require('bson-objectid');
 const debug = require('ghost-ignition').debug('models:base');
 const config = require('../../config');
 const db = require('../../data/db');
-const common = require('../../lib/common');
+const {logging, events, i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const security = require('../../lib/security');
 const schema = require('../../data/schema');
 const urlUtils = require('../../lib/url-utils');
@@ -125,7 +126,7 @@ const addAction = (model, event, options) => {
                     err = err[0];
                 }
 
-                common.logging.error(new common.errors.InternalServerError({
+                logging.error(new errors.InternalServerError({
                     err
                 }));
             });
@@ -181,7 +182,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             debug(model.tableName, ghostEvent);
 
             // @NOTE: Internal Ghost events. These are very granular e.g. post.published
-            common.events.emit(ghostEvent, model, opts);
+            events.emit(ghostEvent, model, opts);
         };
 
         if (!options.transacting) {
@@ -557,8 +558,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         } else if (options.context.external) {
             return ghostBookshelf.Model.externalUser;
         } else {
-            throw new common.errors.NotFoundError({
-                message: common.i18n.t('errors.models.base.index.missingContext'),
+            throw new errors.NotFoundError({
+                message: i18n.t('errors.models.base.index.missingContext'),
                 level: 'critical'
             });
         }
@@ -744,8 +745,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
                 // CASE: client sends `0000-00-00 00:00:00`
                 if (isNaN(date)) {
-                    throw new common.errors.ValidationError({
-                        message: common.i18n.t('errors.models.base.invalidDate', {key: property}),
+                    throw new errors.ValidationError({
+                        message: i18n.t('errors.models.base.invalidDate', {key: property}),
                         code: 'DATE_INVALID'
                     });
                 }
@@ -771,8 +772,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
                             // CASE: client sends `0000-00-00 00:00:00`
                             if (isNaN(date)) {
-                                throw new common.errors.ValidationError({
-                                    message: common.i18n.t('errors.models.base.invalidDate', {key: relationProperty}),
+                                throw new errors.ValidationError({
+                                    message: i18n.t('errors.models.base.invalidDate', {key: relationProperty}),
                                     code: 'DATE_INVALID'
                                 });
                             }
@@ -798,7 +799,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         filterConfig = filterConfig || {};
 
         if (Object.prototype.hasOwnProperty.call(unfilteredOptions, 'include')) {
-            throw new common.errors.IncorrectUsageError({
+            throw new errors.IncorrectUsageError({
                 message: 'The model layer expects using `withRelated`.'
             });
         }
@@ -982,7 +983,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
                     return object.save(data, options);
                 }
 
-                throw new common.errors.NotFoundError();
+                throw new errors.NotFoundError();
             });
     },
 

--- a/core/server/models/base/listeners.js
+++ b/core/server/models/base/listeners.js
@@ -1,7 +1,8 @@
 const moment = require('moment-timezone');
 const _ = require('lodash');
 const models = require('../../models');
-const common = require('../../lib/common');
+const {events, logging} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const sequence = require('../../lib/promise/sequence');
 
 /**
@@ -9,7 +10,7 @@ const sequence = require('../../lib/promise/sequence');
  * - reschedule all scheduled posts
  * - draft scheduled posts, when the published_at would be in the past
  */
-common.events.on('settings.active_timezone.edited', function (settingModel, options) {
+events.on('settings.active_timezone.edited', function (settingModel, options) {
     options = options || {};
     options = _.merge({}, options, {context: {internal: true}});
 
@@ -67,14 +68,14 @@ common.events.on('settings.active_timezone.edited', function (settingModel, opti
                     };
                 })).each(function (result) {
                     if (!result.isFulfilled()) {
-                        common.logging.error(new common.errors.GhostError({
+                        logging.error(new errors.GhostError({
                             err: result.reason()
                         }));
                     }
                 });
             })
             .catch(function (err) {
-                common.logging.error(new common.errors.GhostError({
+                logging.error(new errors.GhostError({
                     err: err,
                     level: 'critical'
                 }));
@@ -87,7 +88,7 @@ common.events.on('settings.active_timezone.edited', function (settingModel, opti
  * No transaction, because notifications are not sensitive and we would have to add `forUpdate`
  * to the settings model to create real lock.
  */
-common.events.on('settings.notifications.edited', function (settingModel) {
+events.on('settings.notifications.edited', function (settingModel) {
     let allNotifications = JSON.parse(settingModel.attributes.value || []);
     const options = {context: {internal: true}};
     let skip = true;
@@ -114,6 +115,6 @@ common.events.on('settings.notifications.edited', function (settingModel) {
         key: 'notifications',
         value: JSON.stringify(allNotifications)
     }, options).catch(function (err) {
-        common.errors.logError(err);
+        errors.logError(err);
     });
 });

--- a/core/server/models/base/utils.js
+++ b/core/server/models/base/utils.js
@@ -6,7 +6,7 @@ const _ = require('lodash');
 
 const Promise = require('bluebird');
 const ObjectId = require('bson-objectid');
-const common = require('../../lib/common');
+const errors = require('@tryghost/errors');
 let attach;
 let detach;
 
@@ -34,7 +34,7 @@ attach = function attach(Model, effectedModelId, relation, modelsToAttach, optio
             fetchedModel = _fetchedModel;
 
             if (!fetchedModel) {
-                throw new common.errors.NotFoundError({level: 'critical', help: effectedModelId});
+                throw new errors.NotFoundError({level: 'critical', help: effectedModelId});
             }
 
             fetchedModel.related(relation).on('creating', function (collection, data) {
@@ -76,7 +76,7 @@ detach = function detach(Model, effectedModelId, relation, modelsToAttach, optio
             fetchedModel = _fetchedModel;
 
             if (!fetchedModel) {
-                throw new common.errors.NotFoundError({level: 'critical', help: effectedModelId});
+                throw new errors.NotFoundError({level: 'critical', help: effectedModelId});
             }
 
             return Promise.resolve(modelsToAttach)

--- a/core/server/models/invite.js
+++ b/core/server/models/invite.js
@@ -1,6 +1,7 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
-const common = require('../lib/common');
+const {i18n} = require('../lib/common');
+const errors = require('@tryghost/errors');
 const constants = require('../lib/constants');
 const security = require('../lib/security');
 const settingsCache = require('../services/settings/cache');
@@ -50,8 +51,8 @@ Invite = ghostBookshelf.Model.extend({
                 return Promise.resolve();
             }
 
-            return Promise.reject(new common.errors.NoPermissionError({
-                message: common.i18n.t('errors.models.invite.notEnoughPermission')
+            return Promise.reject(new errors.NoPermissionError({
+                message: i18n.t('errors.models.invite.notEnoughPermission')
             }));
         }
 
@@ -60,14 +61,14 @@ Invite = ghostBookshelf.Model.extend({
             .findOne({id: unsafeAttrs.role_id})
             .then((roleToInvite) => {
                 if (!roleToInvite) {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.invites.roleNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.invites.roleNotFound')
                     }));
                 }
 
                 if (roleToInvite.get('name') === 'Owner') {
-                    return Promise.reject(new common.errors.NoPermissionError({
-                        message: common.i18n.t('errors.api.invites.notAllowedToInviteOwner')
+                    return Promise.reject(new errors.NoPermissionError({
+                        message: i18n.t('errors.api.invites.notAllowedToInviteOwner')
                     }));
                 }
 
@@ -81,8 +82,8 @@ Invite = ghostBookshelf.Model.extend({
                 }
 
                 if (allowed.indexOf(roleToInvite.get('name')) === -1) {
-                    throw new common.errors.NoPermissionError({
-                        message: common.i18n.t('errors.api.invites.notAllowedToInvite')
+                    throw new errors.NoPermissionError({
+                        message: i18n.t('errors.api.invites.notAllowedToInvite')
                     });
                 }
 
@@ -90,8 +91,8 @@ Invite = ghostBookshelf.Model.extend({
                     return Promise.resolve();
                 }
 
-                return Promise.reject(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.models.invite.notEnoughPermission')
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.models.invite.notEnoughPermission')
                 }));
             });
     }

--- a/core/server/models/label.js
+++ b/core/server/models/label.js
@@ -1,5 +1,6 @@
 const ghostBookshelf = require('./base');
-const common = require('../lib/common');
+const {i18n} = require('../lib/common');
+const errors = require('@tryghost/errors');
 
 let Label;
 let Labels;
@@ -110,8 +111,8 @@ Label = ghostBookshelf.Model.extend({
             .fetch(options)
             .then(function destroyLabelsAndMember(label) {
                 if (!label) {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.labels.labelNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.labels.labelNotFound')
                     }));
                 }
 

--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -1,7 +1,7 @@
 const moment = require('moment-timezone');
 const Promise = require('bluebird');
 const _ = require('lodash');
-const common = require('../../lib/common');
+const errors = require('@tryghost/errors');
 
 module.exports = function (Bookshelf) {
     const ParentModel = Bookshelf.Model;
@@ -58,7 +58,7 @@ module.exports = function (Bookshelf) {
                         if (Object.keys(changed).length) {
                             if (clientUpdatedAt.diff(serverUpdatedAt) !== 0) {
                                 // @NOTE: This will rollback the update. We cannot know if relations were updated before doing the update.
-                                return Promise.reject(new common.errors.UpdateCollisionError({
+                                return Promise.reject(new errors.UpdateCollisionError({
                                     message: 'Saving failed! Someone else is editing this post.',
                                     code: 'UPDATE_COLLISION',
                                     level: 'critical',

--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -1,5 +1,6 @@
 const debug = require('ghost-ignition').debug('models:plugins:filter');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 
 const RELATIONS = {
     tags: {
@@ -100,8 +101,8 @@ const filter = function filter(Bookshelf) {
                     }).querySQL(qb);
                 });
             } catch (err) {
-                throw new common.errors.BadRequestError({
-                    message: common.i18n.t('errors.models.plugins.filter.errorParsing'),
+                throw new errors.BadRequestError({
+                    message: i18n.t('errors.models.plugins.filter.errorParsing'),
                     err: err
                 });
             }

--- a/core/server/models/plugins/pagination.js
+++ b/core/server/models/plugins/pagination.js
@@ -3,7 +3,8 @@
 // Extends Bookshelf.Model with a `fetchPage` method. Handles everything to do with paginated requests.
 const _ = require('lodash');
 
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 let defaults;
 let paginationUtils;
 let pagination;
@@ -204,7 +205,7 @@ pagination = function pagination(bookshelf) {
                     .catch(function (err) {
                         // e.g. offset/limit reached max allowed integer value
                         if (err.errno === 20 || err.errno === 1064) {
-                            throw new common.errors.NotFoundError({message: common.i18n.t('errors.errors.pageNotFound')});
+                            throw new errors.NotFoundError({message: i18n.t('errors.errors.pageNotFound')});
                         }
 
                         throw err;
@@ -212,8 +213,8 @@ pagination = function pagination(bookshelf) {
             }).catch((err) => {
                 // CASE: SQL syntax is incorrect
                 if (err.errno === 1054 || err.errno === 1) {
-                    throw new common.errors.BadRequestError({
-                        message: common.i18n.t('errors.models.general.sql'),
+                    throw new errors.BadRequestError({
+                        message: i18n.t('errors.models.general.sql'),
                         err: err
                     });
                 }

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -4,7 +4,8 @@ const uuid = require('uuid');
 const moment = require('moment');
 const Promise = require('bluebird');
 const sequence = require('../lib/promise/sequence');
-const common = require('../lib/common');
+const {i18n} = require('../lib/common');
+const errors = require('@tryghost/errors');
 const htmlToText = require('html-to-text');
 const ghostBookshelf = require('./base');
 const config = require('../config');
@@ -283,8 +284,8 @@ Post = ghostBookshelf.Model.extend({
         // CASE: disallow published -> scheduled
         // @TODO: remove when we have versioning based on updated_at
         if (newStatus !== olderStatus && newStatus === 'scheduled' && olderStatus === 'published') {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.models.post.isAlreadyPublished', {key: 'status'})
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.models.post.isAlreadyPublished', {key: 'status'})
             }));
         }
 
@@ -297,12 +298,12 @@ Post = ghostBookshelf.Model.extend({
         // CASE: both page and post can get scheduled
         if (newStatus === 'scheduled') {
             if (!publishedAt) {
-                return Promise.reject(new common.errors.ValidationError({
-                    message: common.i18n.t('errors.models.post.valueCannotBeBlank', {key: 'published_at'})
+                return Promise.reject(new errors.ValidationError({
+                    message: i18n.t('errors.models.post.valueCannotBeBlank', {key: 'published_at'})
                 }));
             } else if (!moment(publishedAt).isValid()) {
-                return Promise.reject(new common.errors.ValidationError({
-                    message: common.i18n.t('errors.models.post.valueCannotBeBlank', {key: 'published_at'})
+                return Promise.reject(new errors.ValidationError({
+                    message: i18n.t('errors.models.post.valueCannotBeBlank', {key: 'published_at'})
                 }));
                 // CASE: to schedule/reschedule a post, a minimum diff of x minutes is needed (default configured is 2minutes)
             } else if (
@@ -311,8 +312,8 @@ Post = ghostBookshelf.Model.extend({
                 !options.importing &&
                 (!options.context || !options.context.internal)
             ) {
-                return Promise.reject(new common.errors.ValidationError({
-                    message: common.i18n.t('errors.models.post.expectedPublishedAtInFuture', {
+                return Promise.reject(new errors.ValidationError({
+                    message: i18n.t('errors.models.post.expectedPublishedAtInFuture', {
                         cannotScheduleAPostBeforeInMinutes: config.get('times').cannotScheduleAPostBeforeInMinutes
                     })
                 }));
@@ -409,7 +410,7 @@ Post = ghostBookshelf.Model.extend({
             try {
                 this.set('html', mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(this.get('mobiledoc'))));
             } catch (err) {
-                throw new common.errors.ValidationError({
+                throw new errors.ValidationError({
                     message: 'Invalid mobiledoc structure.',
                     help: 'https://ghost.org/docs/concepts/posts/'
                 });
@@ -436,7 +437,7 @@ Post = ghostBookshelf.Model.extend({
 
         // disabling sanitization until we can implement a better version
         if (!options.importing) {
-            title = this.get('title') || common.i18n.t('errors.models.post.untitled');
+            title = this.get('title') || i18n.t('errors.models.post.untitled');
             this.set('title', _.toString(title).trim());
         }
 
@@ -995,8 +996,8 @@ Post = ghostBookshelf.Model.extend({
             return Promise.resolve({excludedAttrs});
         }
 
-        return Promise.reject(new common.errors.NoPermissionError({
-            message: common.i18n.t('errors.models.post.notEnoughPermission')
+        return Promise.reject(new errors.NoPermissionError({
+            message: i18n.t('errors.models.post.notEnoughPermission')
         }));
     }
 });

--- a/core/server/models/relations/authors.js
+++ b/core/server/models/relations/authors.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../lib/common');
+const {i18n} = require('../../lib/common');
+const errors = require('@tryghost/errors');
 const sequence = require('../../lib/promise/sequence');
 
 /**
@@ -113,7 +114,7 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
 
             // CASE: you can't delete all authors
             if (model.get('authors') && !model.get('authors').length) {
-                throw new common.errors.ValidationError({
+                throw new errors.ValidationError({
                     message: 'At least one author is required.'
                 });
             }
@@ -194,7 +195,7 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
              */
             if (this._originalOptions.withRelated && this._originalOptions.withRelated && this._originalOptions.withRelated.indexOf('author') !== -1) {
                 if (!authors.models.length) {
-                    throw new common.errors.ValidationError({
+                    throw new errors.ValidationError({
                         message: 'The target post has no primary author.'
                     });
                 }
@@ -296,8 +297,8 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
             let authorId = options.id;
 
             if (!authorId) {
-                return Promise.reject(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.models.post.noUserFound')
+                return Promise.reject(new errors.NotFoundError({
+                    message: i18n.t('errors.models.post.noUserFound')
                 }));
             }
 
@@ -317,7 +318,7 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                             .then(() => response);
                     })
                     .catch((err) => {
-                        throw new common.errors.GhostError({err: err});
+                        throw new errors.GhostError({err: err});
                     });
             });
 
@@ -351,9 +352,9 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                 return this.findOne({id: postModelOrId, status: 'all'}, {withRelated: ['authors']})
                     .then(function then(foundPostModel) {
                         if (!foundPostModel) {
-                            throw new common.errors.NotFoundError({
+                            throw new errors.NotFoundError({
                                 level: 'critical',
-                                message: common.i18n.t('errors.models.post.postNotFound')
+                                message: i18n.t('errors.models.post.postNotFound')
                             });
                         }
 
@@ -448,8 +449,8 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                 });
             }
 
-            return Promise.reject(new common.errors.NoPermissionError({
-                message: common.i18n.t('errors.models.post.notEnoughPermission')
+            return Promise.reject(new errors.NoPermissionError({
+                message: i18n.t('errors.models.post.notEnoughPermission')
             }));
         }
     });

--- a/core/server/models/role.js
+++ b/core/server/models/role.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
 const ghostBookshelf = require('./base');
 const Promise = require('bluebird');
-const common = require('../lib/common');
+const {i18n} = require('../lib/common');
+const errors = require('@tryghost/errors');
 let Role;
 let Roles;
 
@@ -57,8 +58,8 @@ Role = ghostBookshelf.Model.extend({
             return this.findOne({id: roleModelOrId, status: 'all'})
                 .then((foundRoleModel) => {
                     if (!foundRoleModel) {
-                        throw new common.errors.NotFoundError({
-                            message: common.i18n.t('errors.models.role.roleNotFound')
+                        throw new errors.NotFoundError({
+                            message: i18n.t('errors.models.role.roleNotFound')
                         });
                     }
 
@@ -88,8 +89,8 @@ Role = ghostBookshelf.Model.extend({
         if (action === 'assign' && loadedPermissions.apiKey) {
             // apiKey cannot 'assign' the 'Owner' role
             if (roleModel.get('name') === 'Owner') {
-                return Promise.reject(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.models.role.notEnoughPermission')
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.models.role.notEnoughPermission')
                 }));
             }
         }
@@ -98,7 +99,7 @@ Role = ghostBookshelf.Model.extend({
             return Promise.resolve();
         }
 
-        return Promise.reject(new common.errors.NoPermissionError({message: common.i18n.t('errors.models.role.notEnoughPermission')}));
+        return Promise.reject(new errors.NoPermissionError({message: i18n.t('errors.models.role.notEnoughPermission')}));
     }
 });
 

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -4,7 +4,8 @@ const uuid = require('uuid');
 const crypto = require('crypto');
 const keypair = require('keypair');
 const ghostBookshelf = require('./base');
-const common = require('../lib/common');
+const {i18n} = require('../lib/common');
+const errors = require('@tryghost/errors');
 const validation = require('../data/validation');
 const settingsCache = require('../services/settings/cache');
 const internalContext = {context: {internal: true}};
@@ -184,7 +185,7 @@ Settings = ghostBookshelf.Model.extend({
                 item = item.toJSON();
             }
             if (!(_.isString(item.key) && item.key.length > 0)) {
-                return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.models.settings.valueCannotBeBlank')}));
+                return Promise.reject(new errors.ValidationError({message: i18n.t('errors.models.settings.valueCannotBeBlank')}));
             }
 
             item = self.filterData(item);
@@ -213,7 +214,7 @@ Settings = ghostBookshelf.Model.extend({
                     }
                 }
 
-                return Promise.reject(new common.errors.NotFoundError({message: common.i18n.t('errors.models.settings.unableToFindSetting', {key: item.key})}));
+                return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.models.settings.unableToFindSetting', {key: item.key})}));
             });
         });
     },
@@ -277,8 +278,8 @@ Settings = ghostBookshelf.Model.extend({
             return Promise.resolve();
         }
 
-        return Promise.reject(new common.errors.NoPermissionError({
-            message: common.i18n.t('errors.models.post.notEnoughPermission')
+        return Promise.reject(new errors.NoPermissionError({
+            message: i18n.t('errors.models.post.notEnoughPermission')
         }));
     }
 });

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -1,5 +1,6 @@
 const ghostBookshelf = require('./base');
-const common = require('../lib/common');
+const {i18n} = require('../lib/common');
+const errors = require('@tryghost/errors');
 
 let Tag;
 let Tags;
@@ -120,8 +121,8 @@ Tag = ghostBookshelf.Model.extend({
             .fetch(options)
             .then(function destroyTagsAndPost(tag) {
                 if (!tag) {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.api.tags.tagNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.api.tags.tagNotFound')
                     }));
                 }
 

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -4,7 +4,8 @@ const validator = require('validator');
 const ObjectId = require('bson-objectid');
 const ghostBookshelf = require('./base');
 const baseUtils = require('./base/utils');
-const common = require('../lib/common');
+const {i18n, errors: {PasswordResetRequiredError}} = require('../lib/common');
+const errors = require('@tryghost/errors');
 const security = require('../lib/security');
 const imageLib = require('../lib/image');
 const pipeline = require('../lib/promise/pipeline');
@@ -122,8 +123,8 @@ User = ghostBookshelf.Model.extend({
          * Before we can generate a slug, we have to ensure that the name is not blank.
          */
         if (!this.get('name')) {
-            throw new common.errors.ValidationError({
-                message: common.i18n.t('notices.data.validation.index.valueCannotBeBlank', {
+            throw new errors.ValidationError({
+                message: i18n.t('notices.data.validation.index.valueCannotBeBlank', {
                     tableName: this.tableName,
                     columnKey: 'name'
                 })
@@ -194,7 +195,7 @@ User = ghostBookshelf.Model.extend({
                 passwordValidation = validation.validatePassword(this.get('password'), this.get('email'));
 
                 if (!passwordValidation.isValid) {
-                    return Promise.reject(new common.errors.ValidationError({
+                    return Promise.reject(new errors.ValidationError({
                         message: passwordValidation.message
                     }));
                 }
@@ -436,8 +437,8 @@ User = ghostBookshelf.Model.extend({
 
         if (data.roles && data.roles.length > 1) {
             return Promise.reject(
-                new common.errors.ValidationError({
-                    message: common.i18n.t('errors.models.user.onlyOneRolePerUserSupported')
+                new errors.ValidationError({
+                    message: i18n.t('errors.models.user.onlyOneRolePerUserSupported')
                 })
             );
         }
@@ -446,8 +447,8 @@ User = ghostBookshelf.Model.extend({
             ops.push(function checkForDuplicateEmail() {
                 return self.getByEmail(data.email, options).then(function then(user) {
                     if (user && user.id !== options.id) {
-                        return Promise.reject(new common.errors.ValidationError({
-                            message: common.i18n.t('errors.models.user.userUpdateError.emailIsAlreadyInUse')
+                        return Promise.reject(new errors.ValidationError({
+                            message: i18n.t('errors.models.user.userUpdateError.emailIsAlreadyInUse')
                         }));
                     }
                 });
@@ -473,8 +474,8 @@ User = ghostBookshelf.Model.extend({
                 }).then((roleToAssign) => {
                     if (roleToAssign && roleToAssign.get('name') === 'Owner') {
                         return Promise.reject(
-                            new common.errors.ValidationError({
-                                message: common.i18n.t('errors.models.user.methodDoesNotSupportOwnerRole')
+                            new errors.ValidationError({
+                                message: i18n.t('errors.models.user.methodDoesNotSupportOwnerRole')
                             })
                         );
                     } else {
@@ -516,8 +517,8 @@ User = ghostBookshelf.Model.extend({
 
         // check for too many roles
         if (data.roles && data.roles.length > 1) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.models.user.onlyOneRolePerUserSupported')
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.models.user.onlyOneRolePerUserSupported')
             }));
         }
 
@@ -609,7 +610,7 @@ User = ghostBookshelf.Model.extend({
         passwordValidation = validation.validatePassword(userData.password, userData.email, data.blogTitle);
 
         if (!passwordValidation.isValid) {
-            return Promise.reject(new common.errors.ValidationError({
+            return Promise.reject(new errors.ValidationError({
                 message: passwordValidation.message
             }));
         }
@@ -641,8 +642,8 @@ User = ghostBookshelf.Model.extend({
             status: 'all'
         }, options).then(function (owner) {
             if (!owner) {
-                return Promise.reject(new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.models.user.ownerNotFound')
+                return Promise.reject(new errors.NotFoundError({
+                    message: i18n.t('errors.models.user.ownerNotFound')
                 }));
             }
 
@@ -670,8 +671,8 @@ User = ghostBookshelf.Model.extend({
                 status: 'all'
             }, {withRelated: ['roles']}).then(function then(foundUserModel) {
                 if (!foundUserModel) {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.models.user.userNotFound')
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.models.user.userNotFound')
                     });
                 }
 
@@ -701,8 +702,8 @@ User = ghostBookshelf.Model.extend({
         if (action === 'destroy') {
             // Owner cannot be deleted EVER
             if (userModel.hasRole('Owner')) {
-                return Promise.reject(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.models.user.notEnoughPermission')
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.models.user.notEnoughPermission')
                 }));
             }
 
@@ -716,8 +717,8 @@ User = ghostBookshelf.Model.extend({
         // CASE: can't edit my own status to inactive or locked
         if (action === 'edit' && userModel.id === context.user) {
             if (User.inactiveStates.indexOf(unsafeAttrs.status) !== -1) {
-                return Promise.reject(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.api.users.cannotChangeStatus')
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.api.users.cannotChangeStatus')
                 }));
             }
         }
@@ -731,8 +732,8 @@ User = ghostBookshelf.Model.extend({
             let contextRoleId = loadedPermissions.user.roles[0].id;
 
             if (roleId !== contextRoleId && editedUserId === context.user) {
-                return Promise.reject(new common.errors.NoPermissionError({
-                    message: common.i18n.t('errors.api.users.cannotChangeOwnRole')
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.api.users.cannotChangeOwnRole')
                 }));
             }
 
@@ -744,16 +745,16 @@ User = ghostBookshelf.Model.extend({
                             return Promise.resolve();
                         }
 
-                        return Promise.reject(new common.errors.NoPermissionError({
-                            message: common.i18n.t('errors.models.user.notEnoughPermission')
+                        return Promise.reject(new errors.NoPermissionError({
+                            message: i18n.t('errors.models.user.notEnoughPermission')
                         }));
                     }
 
                     // CASE: You try to change the role of the owner user
                     if (editedUserId === owner.id) {
                         if (owner.related('roles').at(0).id !== roleId) {
-                            return Promise.reject(new common.errors.NoPermissionError({
-                                message: common.i18n.t('errors.api.users.cannotChangeOwnersRole')
+                            return Promise.reject(new errors.NoPermissionError({
+                                message: i18n.t('errors.api.users.cannotChangeOwnersRole')
                             }));
                         }
                     } else if (roleId !== contextRoleId) {
@@ -766,8 +767,8 @@ User = ghostBookshelf.Model.extend({
                                     return Promise.resolve();
                                 }
 
-                                return Promise.reject(new common.errors.NoPermissionError({
-                                    message: common.i18n.t('errors.models.user.notEnoughPermission')
+                                return Promise.reject(new errors.NoPermissionError({
+                                    message: i18n.t('errors.models.user.notEnoughPermission')
                                 }));
                             });
                     }
@@ -776,8 +777,8 @@ User = ghostBookshelf.Model.extend({
                         return Promise.resolve();
                     }
 
-                    return Promise.reject(new common.errors.NoPermissionError({
-                        message: common.i18n.t('errors.models.user.notEnoughPermission')
+                    return Promise.reject(new errors.NoPermissionError({
+                        message: i18n.t('errors.models.user.notEnoughPermission')
                     }));
                 });
         }
@@ -786,8 +787,8 @@ User = ghostBookshelf.Model.extend({
             return Promise.resolve();
         }
 
-        return Promise.reject(new common.errors.NoPermissionError({
-            message: common.i18n.t('errors.models.user.notEnoughPermission')
+        return Promise.reject(new errors.NoPermissionError({
+            message: i18n.t('errors.models.user.notEnoughPermission')
         }));
     },
 
@@ -799,18 +800,18 @@ User = ghostBookshelf.Model.extend({
         return this.getByEmail(object.email)
             .then((user) => {
                 if (!user) {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.models.user.noUserWithEnteredEmailAddr')
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.models.user.noUserWithEnteredEmailAddr')
                     });
                 }
 
                 if (user.isLocked()) {
-                    throw new common.errors.PasswordResetRequiredError();
+                    throw new PasswordResetRequiredError();
                 }
 
                 if (user.isInactive()) {
-                    throw new common.errors.NoPermissionError({
-                        message: common.i18n.t('errors.models.user.accountSuspended')
+                    throw new errors.NoPermissionError({
+                        message: i18n.t('errors.models.user.accountSuspended')
                     });
                 }
 
@@ -825,8 +826,8 @@ User = ghostBookshelf.Model.extend({
             })
             .catch((err) => {
                 if (err.message === 'NotFound' || err.message === 'EmptyResponse') {
-                    throw new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.models.user.noUserWithEnteredEmailAddr')
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.models.user.noUserWithEnteredEmailAddr')
                     });
                 }
 
@@ -839,8 +840,8 @@ User = ghostBookshelf.Model.extend({
         const hashedPassword = object.hashedPassword;
 
         if (!plainPassword || !hashedPassword) {
-            return Promise.reject(new common.errors.ValidationError({
-                message: common.i18n.t('errors.models.user.passwordRequiredForOperation')
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('errors.models.user.passwordRequiredForOperation')
             }));
         }
 
@@ -850,10 +851,10 @@ User = ghostBookshelf.Model.extend({
                     return;
                 }
 
-                return Promise.reject(new common.errors.ValidationError({
-                    context: common.i18n.t('errors.models.user.incorrectPassword'),
-                    message: common.i18n.t('errors.models.user.incorrectPassword'),
-                    help: common.i18n.t('errors.models.user.userUpdateError.help'),
+                return Promise.reject(new errors.ValidationError({
+                    context: i18n.t('errors.models.user.incorrectPassword'),
+                    message: i18n.t('errors.models.user.incorrectPassword'),
+                    help: i18n.t('errors.models.user.userUpdateError.help'),
                     code: 'PASSWORD_INCORRECT'
                 }));
             });
@@ -912,8 +913,8 @@ User = ghostBookshelf.Model.extend({
                 // check if user has the owner role
                 const currentRoles = contextUser.toJSON(options).roles;
                 if (!_.some(currentRoles, {id: ownerRole.id})) {
-                    return Promise.reject(new common.errors.NoPermissionError({
-                        message: common.i18n.t('errors.models.user.onlyOwnerCanTransferOwnerRole')
+                    return Promise.reject(new errors.NoPermissionError({
+                        message: i18n.t('errors.models.user.onlyOwnerCanTransferOwnerRole')
                     }));
                 }
 
@@ -925,22 +926,22 @@ User = ghostBookshelf.Model.extend({
                 const user = results[1];
 
                 if (!user) {
-                    return Promise.reject(new common.errors.NotFoundError({
-                        message: common.i18n.t('errors.models.user.userNotFound')
+                    return Promise.reject(new errors.NotFoundError({
+                        message: i18n.t('errors.models.user.userNotFound')
                     }));
                 }
 
                 const {roles: currentRoles, status} = user.toJSON(options);
 
                 if (!_.some(currentRoles, {id: adminRole.id})) {
-                    return Promise.reject(new common.errors.ValidationError({
-                        message: common.i18n.t('errors.models.user.onlyAdmCanBeAssignedOwnerRole')
+                    return Promise.reject(new errors.ValidationError({
+                        message: i18n.t('errors.models.user.onlyAdmCanBeAssignedOwnerRole')
                     }));
                 }
 
                 if (status !== 'active') {
-                    return Promise.reject(new common.errors.ValidationError({
-                        message: common.i18n.t('errors.models.user.onlyActiveAdmCanBeAssignedOwnerRole')
+                    return Promise.reject(new errors.ValidationError({
+                        message: i18n.t('errors.models.user.onlyActiveAdmCanBeAssignedOwnerRole')
                     }));
                 }
 

--- a/test/unit/data/exporter/index_spec.js
+++ b/test/unit/data/exporter/index_spec.js
@@ -2,8 +2,8 @@ const should = require('should');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const Promise = require('bluebird');
+const errors = require('@tryghost/errors');
 const db = require('../../../../core/server/data/db');
-const common = require('../../../../core/server/lib/common');
 const exporter = rewire('../../../../core/server/data/exporter');
 const schema = require('../../../../core/server/data/schema');
 const models = require('../../../../core/server/models');
@@ -139,7 +139,7 @@ describe('Exporter', function () {
                     done(new Error('expected error for export'));
                 })
                 .catch(function (err) {
-                    (err instanceof common.errors.DataExportError).should.eql(true);
+                    (err instanceof errors.DataExportError).should.eql(true);
                     done();
                 });
         });

--- a/test/unit/models/user_spec.js
+++ b/test/unit/models/user_spec.js
@@ -1,14 +1,12 @@
 const should = require('should');
-const url = require('url');
 const sinon = require('sinon');
 const Promise = require('bluebird');
-const _ = require('lodash');
-const schema = require('../../../core/server/data/schema');
+const errors = require('@tryghost/errors');
 const models = require('../../../core/server/models');
 const permissions = require('../../../core/server/services/permissions');
 const validation = require('../../../core/server/data/validation');
-const common = require('../../../core/server/lib/common');
 const security = require('../../../core/server/lib/security');
+const common = require('../../../core/server/lib/common');
 const testUtils = require('../../utils');
 
 describe('Unit: models/user', function () {
@@ -58,7 +56,7 @@ describe('Unit: models/user', function () {
                         throw new Error('expected ValidationError');
                     })
                     .catch(function (err) {
-                        (err instanceof common.errors.ValidationError).should.eql(true);
+                        (err instanceof errors.ValidationError).should.eql(true);
                         err.message.should.match(/users\.name/);
                     });
             });
@@ -73,7 +71,7 @@ describe('Unit: models/user', function () {
                     })
                     .catch(function (err) {
                         err.should.be.an.Array();
-                        (err[0] instanceof common.errors.ValidationError).should.eql(true);
+                        (err[0] instanceof errors.ValidationError).should.eql(true);
                         err[0].message.should.match(/users\.email/);
                     });
             });
@@ -128,11 +126,11 @@ describe('Unit: models/user', function () {
             }));
 
             sinon.stub(models.User, 'getByEmail').resolves(user);
-            sinon.stub(models.User, 'isPasswordCorrect').rejects(new common.errors.ValidationError());
+            sinon.stub(models.User, 'isPasswordCorrect').rejects(new errors.ValidationError());
 
             return models.User.check({email: user.get('email'), password: 'test'})
                 .catch(function (err) {
-                    (err instanceof common.errors.ValidationError).should.eql(true);
+                    (err instanceof errors.ValidationError).should.eql(true);
                 });
         });
 
@@ -172,7 +170,7 @@ describe('Unit: models/user', function () {
             models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.owner, true, true, true).then(() => {
                 done(new Error('Permissible function should have errored'));
             }).catch((error) => {
-                error.should.be.an.instanceof(common.errors.NoPermissionError);
+                error.should.be.an.instanceof(errors.NoPermissionError);
                 should(mockUser.hasRole.calledOnce).be.true();
                 done();
             });
@@ -194,7 +192,7 @@ describe('Unit: models/user', function () {
             return models.User.permissible(mockUser, 'edit', context, {status: 'inactive'}, testUtils.permissions.editor, false, true, true)
                 .then(Promise.reject)
                 .catch((err) => {
-                    err.should.be.an.instanceof(common.errors.NoPermissionError);
+                    err.should.be.an.instanceof(errors.NoPermissionError);
                 });
         });
 
@@ -251,7 +249,7 @@ describe('Unit: models/user', function () {
                 return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, false, true, true)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.should.be.an.instanceof(common.errors.NoPermissionError);
+                        err.should.be.an.instanceof(errors.NoPermissionError);
                     });
             });
 
@@ -274,7 +272,7 @@ describe('Unit: models/user', function () {
                 return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, false, true, true)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.should.be.an.instanceof(common.errors.NoPermissionError);
+                        err.should.be.an.instanceof(errors.NoPermissionError);
                     });
             });
 
@@ -310,7 +308,7 @@ describe('Unit: models/user', function () {
                 return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.author, false, true, true)
                     .then(Promise.reject)
                     .catch((err) => {
-                        err.should.be.an.instanceof(common.errors.NoPermissionError);
+                        err.should.be.an.instanceof(errors.NoPermissionError);
                     });
             });
         });
@@ -323,7 +321,7 @@ describe('Unit: models/user', function () {
                 models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
-                    error.should.be.an.instanceof(common.errors.NoPermissionError);
+                    error.should.be.an.instanceof(errors.NoPermissionError);
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                     done();
@@ -337,7 +335,7 @@ describe('Unit: models/user', function () {
                 models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
-                    error.should.be.an.instanceof(common.errors.NoPermissionError);
+                    error.should.be.an.instanceof(errors.NoPermissionError);
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                     done();
@@ -351,7 +349,7 @@ describe('Unit: models/user', function () {
                 models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
-                    error.should.be.an.instanceof(common.errors.NoPermissionError);
+                    error.should.be.an.instanceof(errors.NoPermissionError);
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                     done();
@@ -395,7 +393,7 @@ describe('Unit: models/user', function () {
                 models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
-                    error.should.be.an.instanceof(common.errors.NoPermissionError);
+                    error.should.be.an.instanceof(errors.NoPermissionError);
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                     done();
@@ -409,7 +407,7 @@ describe('Unit: models/user', function () {
                 models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
-                    error.should.be.an.instanceof(common.errors.NoPermissionError);
+                    error.should.be.an.instanceof(errors.NoPermissionError);
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                     done();
@@ -468,7 +466,7 @@ describe('Unit: models/user', function () {
             return models.User.transferOwnership({id: loggedInUser.context.user}, loggedInUser)
                 .then(Promise.reject)
                 .catch((err) => {
-                    err.should.be.an.instanceof(common.errors.NoPermissionError);
+                    err.should.be.an.instanceof(errors.NoPermissionError);
                 });
         });
 
@@ -499,7 +497,7 @@ describe('Unit: models/user', function () {
             return models.User.transferOwnership({id: userToChange.context.user}, loggedInUser)
                 .then(Promise.reject)
                 .catch((err) => {
-                    err.should.be.an.instanceof(common.errors.ValidationError);
+                    err.should.be.an.instanceof(errors.ValidationError);
                     err.message.indexOf('Only administrators can')
                         .should.be.aboveOrEqual(0, 'contains correct error message');
                 });
@@ -530,7 +528,7 @@ describe('Unit: models/user', function () {
             return models.User.transferOwnership({id: userToChange.context.user}, loggedInUser)
                 .then(Promise.reject)
                 .catch((err) => {
-                    err.should.be.an.instanceof(common.errors.ValidationError);
+                    err.should.be.an.instanceof(errors.ValidationError);
                     err.message.indexOf('Only active administrators can')
                         .should.be.aboveOrEqual(0, 'contains correct error message');
                 });


### PR DESCRIPTION
no issue

- prefer `const {i18n} = require('../common')` over `const common = require('../common')`
- prefer `@tryghost/errors` rather than `common.errors`