### PR TITLE
Refactored migrations to destructure `common` lib import

### DIFF
--- a/core/server/data/migrations/init/1-create-tables.js
+++ b/core/server/data/migrations/init/1-create-tables.js
@@ -1,14 +1,14 @@
 const Promise = require('bluebird');
 const commands = require('../../schema').commands;
 const schema = require('../../schema').tables;
-const common = require('../../../lib/common');
+const {logging} = require('../../../lib/common');
 const schemaTables = Object.keys(schema);
 
 module.exports.up = function createTables(options) {
     const connection = options.connection;
 
     return Promise.mapSeries(schemaTables, function createTable(table) {
-        common.logging.info('Creating table: ' + table);
+        logging.info('Creating table: ' + table);
         return commands.createTable(table, connection);
     });
 };
@@ -23,7 +23,7 @@ module.exports.up = function createTables(options) {
         // Reference between tables!
         schemaTables.reverse();
         return Promise.mapSeries(schemaTables, function dropTable(table) {
-            common.logging.info('Drop table: ' + table);
+            logging.info('Drop table: ' + table);
             return commands.deleteTable(table, connection);
         });
     };

--- a/core/server/data/migrations/init/2-create-fixtures.js
+++ b/core/server/data/migrations/init/2-create-fixtures.js
@@ -1,7 +1,7 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 const fixtures = require('../../schema/fixtures');
-const common = require('../../../lib/common');
+const {logging} = require('../../../lib/common');
 
 module.exports.config = {
     transaction: true
@@ -14,12 +14,12 @@ module.exports.up = function insertFixtures(options) {
     }, options);
 
     return Promise.mapSeries(fixtures.models, function (model) {
-        common.logging.info('Model: ' + model.name);
+        logging.info('Model: ' + model.name);
 
         return fixtures.utils.addFixturesForModel(model, localOptions);
     }).then(function () {
         return Promise.mapSeries(fixtures.relations, function (relation) {
-            common.logging.info('Relation: ' + relation.from.model + ' to ' + relation.to.model);
+            logging.info('Relation: ' + relation.from.model + ' to ' + relation.to.model);
             return fixtures.utils.addFixturesForRelation(relation, localOptions);
         });
     });

--- a/core/server/data/migrations/versions/1.13/1-custom-template-post.js
+++ b/core/server/data/migrations/versions/1.13/1-custom-template-post.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'posts';
 const columns = ['custom_template'];
@@ -23,11 +23,11 @@ _private.handle = function handle(options) {
                     return connection.schema.hasColumn(table, column)
                         .then(function (exists) {
                             if (exists && isAdding || !exists && !isAdding) {
-                                common.logging.warn(`${type} column ${table}.${column}`);
+                                logging.warn(`${type} column ${table}.${column}`);
                                 return Promise.resolve();
                             }
 
-                            common.logging.info(`${type} column ${table}.${column}`);
+                            logging.info(`${type} column ${table}.${column}`);
                             return operation(table, column, connection);
                         });
                 });

--- a/core/server/data/migrations/versions/1.13/2-theme-permissions.js
+++ b/core/server/data/migrations/versions/1.13/2-theme-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const resource = 'theme';
 const _private = {};
 
@@ -15,9 +15,9 @@ _private.getRelations = function getRelations() {
 
 _private.printResult = function printResult(result, message) {
     if (result.done === result.expected) {
-        common.logging.info(message);
+        logging.info(message);
     } else {
-        common.logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
+        logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
     }
 };
 

--- a/core/server/data/migrations/versions/1.18/1-add-webhooks-table.js
+++ b/core/server/data/migrations/versions/1.18/1-add-webhooks-table.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'webhooks';
 const message1 = 'Adding table: ' + table;
@@ -11,11 +11,11 @@ module.exports.up = function addWebhooksTable(options) {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return Promise.resolve();
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -26,11 +26,11 @@ module.exports.down = function removeWebhooksTable(options) {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return Promise.resolve();
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };

--- a/core/server/data/migrations/versions/1.20/1-remove-settings-keys.js
+++ b/core/server/data/migrations/versions/1.20/1-remove-settings-keys.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const models = require('../../../../models');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 
 module.exports.config = {
     transaction: true
@@ -14,11 +14,11 @@ module.exports.up = function removeSettingKeys(options) {
     return models.Settings.findOne({key: 'display_update_notification'}, localOptions)
         .then(function (settingsModel) {
             if (!settingsModel) {
-                common.logging.warn('Deleted Settings Key `display_update_notification`.');
+                logging.warn('Deleted Settings Key `display_update_notification`.');
                 return;
             }
 
-            common.logging.info('Deleted Settings Key `display_update_notification`.');
+            logging.info('Deleted Settings Key `display_update_notification`.');
             return models.Settings.destroy(_.merge({id: settingsModel.id}, localOptions));
         })
         .then(function () {
@@ -26,11 +26,11 @@ module.exports.up = function removeSettingKeys(options) {
         })
         .then(function (settingsModel) {
             if (!settingsModel) {
-                common.logging.warn('Deleted Settings Key `seen_notifications`.');
+                logging.warn('Deleted Settings Key `seen_notifications`.');
                 return;
             }
 
-            common.logging.info('Deleted Settings Key `seen_notifications`.');
+            logging.info('Deleted Settings Key `seen_notifications`.');
             return models.Settings.destroy(_.merge({id: settingsModel.id}, localOptions));
         });
 };
@@ -43,11 +43,11 @@ module.exports.down = function addSettingsKeys(options) {
     return models.Settings.findOne({key: 'display_update_notification'}, localOptions)
         .then(function (settingsModel) {
             if (settingsModel) {
-                common.logging.warn('Added Settings Key `display_update_notification`.');
+                logging.warn('Added Settings Key `display_update_notification`.');
                 return;
             }
 
-            common.logging.info('Added Settings Key `display_update_notification`.');
+            logging.info('Added Settings Key `display_update_notification`.');
             return models.Settings.forge({key: 'display_update_notification'}).save(null, localOptions);
         })
         .then(function () {
@@ -55,11 +55,11 @@ module.exports.down = function addSettingsKeys(options) {
         })
         .then(function (settingsModel) {
             if (settingsModel) {
-                common.logging.warn('Added Settings Key `seen_notifications`.');
+                logging.warn('Added Settings Key `seen_notifications`.');
                 return;
             }
 
-            common.logging.info('Added Settings Key `seen_notifications`.');
+            logging.info('Added Settings Key `seen_notifications`.');
             return models.Settings.forge({key: 'seen_notifications', value: '[]'}).save([], localOptions);
         });
 };

--- a/core/server/data/migrations/versions/1.22/1-multiple-authors-DDL.js
+++ b/core/server/data/migrations/versions/1.22/1-multiple-authors-DDL.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'posts_authors';
 const message1 = 'Adding table: ' + table;
@@ -11,11 +11,11 @@ module.exports.up = function addMultipleAuthorsTable(options) {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return Promise.resolve();
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -26,11 +26,11 @@ module.exports.down = function removeMultipleAuthorsTable(options) {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return Promise.resolve();
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };

--- a/core/server/data/migrations/versions/1.22/1-multiple-authors-DML.js
+++ b/core/server/data/migrations/versions/1.22/1-multiple-authors-DML.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const ObjectId = require('bson-objectid');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const models = require('../../../../models');
 
 module.exports.config = {
@@ -20,7 +20,7 @@ module.exports.up = function handleMultipleAuthors(options) {
         .then(function (ownerUser) {
             return models.Post.findAll(_.merge({columns: postAllColumns}, localOptions))
                 .then(function (posts) {
-                    common.logging.info('Adding `posts_authors` relations');
+                    logging.info('Adding `posts_authors` relations');
 
                     return Promise.map(posts.models, function (post) {
                         let invalidAuthorId = false;
@@ -58,6 +58,6 @@ module.exports.up = function handleMultipleAuthors(options) {
 };
 
 module.exports.down = function handleMultipleAuthors(options) {
-    common.logging.info('Removing `posts_authors` relations');
+    logging.info('Removing `posts_authors` relations');
     return options.connection('posts_authors').truncate();
 };

--- a/core/server/data/migrations/versions/1.25/1-update-koenig-beta-html.js
+++ b/core/server/data/migrations/versions/1.25/1-update-koenig-beta-html.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const mobiledocLib = require('../../../../lib/mobiledoc');
 const models = require('../../../../models');
 const message1 = 'Migrating Koenig beta post\'s mobiledoc/HTML to 2.0 format';
@@ -33,7 +33,7 @@ module.exports.up = function regenerateKoenigBetaHTML(options) {
         context: {internal: true}
     }, options);
 
-    common.logging.info(message1);
+    logging.info(message1);
 
     return models.Post.findAll(_.merge({columns: postAllColumns}, localOptions))
         .then(function (posts) {
@@ -64,6 +64,6 @@ module.exports.up = function regenerateKoenigBetaHTML(options) {
             }, {concurrency: 100});
         })
         .then(() => {
-            common.logging.info(message2);
+            logging.info(message2);
         });
 };

--- a/core/server/data/migrations/versions/1.25/2-demo-post.js
+++ b/core/server/data/migrations/versions/1.25/2-demo-post.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const models = require('../../../../models');
 const fixtures = require('../../../../data/schema/fixtures');
 const message1 = 'Adding demo post.';
@@ -18,14 +18,14 @@ module.exports.up = (options) => {
 
     let userId;
 
-    common.logging.info(message1);
+    logging.info(message1);
 
     const demoPost = _.cloneDeep(fixtures.models[5].entries[0]);
 
     return models.Post.findOne({slug: demoPost.slug, status: 'all'}, localOptions)
         .then((model) => {
             if (model) {
-                common.logging.warn(message3);
+                logging.warn(message3);
                 return;
             }
 
@@ -49,7 +49,7 @@ module.exports.up = (options) => {
                     return models.Post.add(demoPost, localOptions);
                 })
                 .then(() => {
-                    common.logging.info(message2);
+                    logging.info(message2);
                 });
         });
 };

--- a/core/server/data/migrations/versions/1.3/1-post-excerpt.js
+++ b/core/server/data/migrations/versions/1.3/1-post-excerpt.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'posts';
 const columns = ['custom_excerpt'];
@@ -23,11 +23,11 @@ _private.handle = function handle(options) {
                     return connection.schema.hasColumn(table, column)
                         .then(function (exists) {
                             if (exists && isAdding || !exists && !isAdding) {
-                                common.logging.warn(`${type} column ${table}.${column}`);
+                                logging.warn(`${type} column ${table}.${column}`);
                                 return Promise.resolve();
                             }
 
-                            common.logging.info(`${type} column ${table}.${column}`);
+                            logging.info(`${type} column ${table}.${column}`);
                             return operation(table, column, connection);
                         });
                 });

--- a/core/server/data/migrations/versions/1.4/1-codeinjection-post.js
+++ b/core/server/data/migrations/versions/1.4/1-codeinjection-post.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'posts';
 const columns = ['codeinjection_head', 'codeinjection_foot'];
@@ -23,11 +23,11 @@ _private.handle = function handle(options) {
                     return connection.schema.hasColumn(table, column)
                         .then(function (exists) {
                             if (exists && isAdding || !exists && !isAdding) {
-                                common.logging.warn(`${type} column ${table}.${column}`);
+                                logging.warn(`${type} column ${table}.${column}`);
                                 return Promise.resolve();
                             }
 
-                            common.logging.info(`${type} column ${table}.${column}`);
+                            logging.info(`${type} column ${table}.${column}`);
                             return operation(table, column, connection);
                         });
                 });

--- a/core/server/data/migrations/versions/1.5/1-og-twitter-post.js
+++ b/core/server/data/migrations/versions/1.5/1-og-twitter-post.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'posts';
 const columns = ['og_image', 'og_title', 'og_description', 'twitter_image', 'twitter_title', 'twitter_description'];
@@ -23,11 +23,11 @@ _private.handle = function handle(options) {
                     return connection.schema.hasColumn(table, column)
                         .then(function (exists) {
                             if (exists && isAdding || !exists && !isAdding) {
-                                common.logging.warn(`${type} column ${table}.${column}`);
+                                logging.warn(`${type} column ${table}.${column}`);
                                 return Promise.resolve();
                             }
 
-                            common.logging.info(`${type} column ${table}.${column}`);
+                            logging.info(`${type} column ${table}.${column}`);
                             return operation(table, column, connection);
                         });
                 });

--- a/core/server/data/migrations/versions/1.9/1-add-permissions-redirect.js
+++ b/core/server/data/migrations/versions/1.9/1-add-permissions-redirect.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const resource = 'redirect';
 const _private = {};
 
@@ -15,9 +15,9 @@ _private.getRelations = function getRelations() {
 
 _private.printResult = function printResult(result, message) {
     if (result.done === result.expected) {
-        common.logging.info(message);
+        logging.info(message);
     } else {
-        common.logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
+        logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
     }
 };
 

--- a/core/server/data/migrations/versions/2.0/1-rename-amp-column.js
+++ b/core/server/data/migrations/versions/2.0/1-rename-amp-column.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const table = 'posts';
 const columnNameOld = 'amp';
 const columnNameNew = 'comment_id';
@@ -10,7 +10,7 @@ const message4 = `Rollback: Renamed column ${columnNameNew} to ${columnNameOld}`
 module.exports.up = (options) => {
     const connection = options.connection;
 
-    common.logging.info(message1);
+    logging.info(message1);
 
     return connection.schema.hasColumn(table, columnNameOld)
         .then((exists) => {
@@ -21,14 +21,14 @@ module.exports.up = (options) => {
             }
         })
         .then(() => {
-            common.logging.info(message3);
+            logging.info(message3);
         });
 };
 
 module.exports.down = (options) => {
     let connection = options.connection;
 
-    common.logging.warn(message2);
+    logging.warn(message2);
 
     return connection.schema.hasColumn(table, columnNameNew)
         .then((exists) => {
@@ -39,6 +39,6 @@ module.exports.down = (options) => {
             }
         })
         .then(() => {
-            common.logging.warn(message4);
+            logging.warn(message4);
         });
 };

--- a/core/server/data/migrations/versions/2.0/2-update-posts.js
+++ b/core/server/data/migrations/versions/2.0/2-update-posts.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const mobiledocLib = require('../../../../lib/mobiledoc');
 const message1 = 'Updating posts: apply new editor format and set comment_id field.';
 const message2 = 'Updated posts: apply new editor format and set comment_id field.';
@@ -35,7 +35,7 @@ module.exports.up = (options) => {
         migrating: true
     }, options);
 
-    common.logging.info(message1);
+    logging.info(message1);
 
     // @NOTE: raw knex query, because of https://github.com/TryGhost/Ghost/issues/9983
     return localOptions
@@ -53,7 +53,7 @@ module.exports.up = (options) => {
                         mobiledoc = mobiledocLib.blankDocument;
                     }
                 } catch (err) {
-                    common.logging.warn(`Invalid mobiledoc structure for ${post.id}. Falling back to blank structure.`);
+                    logging.warn(`Invalid mobiledoc structure for ${post.id}. Falling back to blank structure.`);
                     mobiledoc = mobiledocLib.blankDocument;
                 }
 
@@ -73,7 +73,7 @@ module.exports.up = (options) => {
                     });
             }, {concurrency: 100});
         }).then(() => {
-            common.logging.info(message2);
+            logging.info(message2);
         });
 };
 
@@ -85,7 +85,7 @@ module.exports.down = (options) => {
         migrating: true
     }, options);
 
-    common.logging.info(message3);
+    logging.info(message3);
     return localOptions
         .transacting('posts')
         .select(postAllColumns)
@@ -113,6 +113,6 @@ module.exports.down = (options) => {
             }, {concurrency: 100});
         })
         .then(() => {
-            common.logging.info(message4);
+            logging.info(message4);
         });
 };

--- a/core/server/data/migrations/versions/2.0/3-remove-koenig-labs.js
+++ b/core/server/data/migrations/versions/2.0/3-remove-koenig-labs.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const models = require('../../../../models');
 const message1 = 'Removing `koenigEditor` from labs.';
 const message2 = 'Removed `koenigEditor` from labs.';
@@ -18,25 +18,25 @@ module.exports.up = (options) => {
     return models.Settings.findOne({key: 'labs'}, localOptions)
         .then(function (settingsModel) {
             if (!settingsModel) {
-                common.logging.warn('Labs field does not exist.');
+                logging.warn('Labs field does not exist.');
                 return;
             }
 
             const labsValue = JSON.parse(settingsModel.get('value'));
             delete labsValue.koenigEditor;
 
-            common.logging.info(message1);
+            logging.info(message1);
             return models.Settings.edit({
                 key: 'labs',
                 value: JSON.stringify(labsValue)
             }, localOptions);
         })
         .then(() => {
-            common.logging.info(message2);
+            logging.info(message2);
         });
 };
 
 module.exports.down = () => {
-    common.logging.warn(message3);
+    logging.warn(message3);
     return Promise.resolve();
 };

--- a/core/server/data/migrations/versions/2.0/4-permalink-setting.js
+++ b/core/server/data/migrations/versions/2.0/4-permalink-setting.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs-extra');
 const config = require('../../../../config');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const models = require('../../../../models');
 const message1 = 'Removing `globals.permalinks` from routes.yaml.';
 const message2 = 'Removed `globals.permalinks` from routes.yaml.';
@@ -19,7 +19,7 @@ module.exports.up = () => {
     const filePath = path.join(contentPath, fileName);
     let settingsModel;
 
-    common.logging.info(message1);
+    logging.info(message1);
 
     return fs.readFile(filePath, 'utf8')
         .then((content) => {
@@ -54,10 +54,10 @@ module.exports.up = () => {
                         return fs.writeFile(filePath, modifiedContent, 'utf8');
                     })
                     .then(() => {
-                        common.logging.info(message2);
+                        logging.info(message2);
                     });
             } else {
-                common.logging.warn(message3);
+                logging.warn(message3);
             }
         });
 };
@@ -67,7 +67,7 @@ module.exports.down = () => {
     const contentPath = config.getContentPath('settings');
     const filePath = path.join(contentPath, fileName);
 
-    common.logging.info(message4);
+    logging.info(message4);
 
     return fs.readFile(filePath, 'utf8')
         .then(() => {
@@ -80,6 +80,6 @@ module.exports.down = () => {
             return fs.remove(filePath);
         })
         .catch(() => {
-            common.logging.warn(message5);
+            logging.warn(message5);
         });
 };

--- a/core/server/data/migrations/versions/2.0/5-remove-demo-post.js
+++ b/core/server/data/migrations/versions/2.0/5-remove-demo-post.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const message1 = 'Removing demo post.';
 const message2 = 'Removed demo post.';
 const message3 = 'Rollback: Bring back demo post.';
@@ -39,10 +39,10 @@ module.exports.up = (options) => {
         .where('status', 'all')
         .select().then((posts) => {
             if (!posts || posts.length === 0) {
-                common.logging.warn(message4);
+                logging.warn(message4);
                 return;
             }
-            common.logging.info(message1);
+            logging.info(message1);
             let post = posts[0];
 
             // @NOTE: raw knex query, because of https://github.com/TryGhost/Ghost/issues/9983
@@ -58,7 +58,7 @@ module.exports.up = (options) => {
                 });
         })
         .then(() => {
-            common.logging.info(message2);
+            logging.info(message2);
         });
 };
 
@@ -75,11 +75,11 @@ module.exports.down = (options) => {
         .where('status', 'all')
         .select().then((posts) => {
             if (posts && posts.length > 0) {
-                common.logging.warn(message5);
+                logging.warn(message5);
                 return;
             }
 
-            common.logging.info(message3);
+            logging.info(message3);
             return localOptions.transacting('posts').insert(demoPost);
         });
 };

--- a/core/server/data/migrations/versions/2.14/1-add-actions-table.js
+++ b/core/server/data/migrations/versions/2.14/1-add-actions-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'actions';
 const message1 = `Adding table: ${table}`;
@@ -10,11 +10,11 @@ module.exports.up = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return;
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -25,11 +25,11 @@ module.exports.down = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return;
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };

--- a/core/server/data/migrations/versions/2.14/2-add-actions-permissions.js
+++ b/core/server/data/migrations/versions/2.14/2-add-actions-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const resource = 'action';
 const _private = {};
 
@@ -15,9 +15,9 @@ _private.getRelations = function getRelations() {
 
 _private.printResult = function printResult(result, message) {
     if (result.done === result.expected) {
-        common.logging.info(message);
+        logging.info(message);
     } else {
-        common.logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
+        logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
     }
 };
 

--- a/core/server/data/migrations/versions/2.15/1-add-type-column-to-integrations.js
+++ b/core/server/data/migrations/versions/2.15/1-add-type-column-to-integrations.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'integrations';
 const newColumnNames = [
@@ -15,10 +15,10 @@ module.exports.up = (options) => {
         return connection.schema.hasColumn(table, newColumnName)
             .then((exists) => {
                 if (exists) {
-                    common.logging.warn(printResult('Adding', newColumnName));
+                    logging.warn(printResult('Adding', newColumnName));
                     return;
                 }
-                common.logging.info(printResult('Adding', newColumnName));
+                logging.info(printResult('Adding', newColumnName));
                 return commands.addColumn(table, newColumnName, connection);
             });
     });
@@ -30,10 +30,10 @@ module.exports.down = (options) => {
         return connection.schema.hasColumn(table, newColumnName)
             .then((exists) => {
                 if (!exists) {
-                    common.logging.warn(printResult('Dropping', newColumnName));
+                    logging.warn(printResult('Dropping', newColumnName));
                     return;
                 }
-                common.logging.info(printResult('Dropping', newColumnName));
+                logging.info(printResult('Dropping', newColumnName));
                 return commands.dropColumn(table, newColumnName, connection);
             });
     });

--- a/core/server/data/migrations/versions/2.17/1-normalize-settings.js
+++ b/core/server/data/migrations/versions/2.17/1-normalize-settings.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 
 module.exports.config = {
     transaction: true
@@ -15,7 +15,7 @@ module.exports.up = (options) => {
         .transacting('settings')
         .then((response) => {
             if (!response) {
-                common.logging.warn('Cannot find settings.');
+                logging.warn('Cannot find settings.');
                 return;
             }
 
@@ -26,7 +26,7 @@ module.exports.up = (options) => {
                     if ((entry.value === '0' || entry.value === '1')) {
                         const value = (!!+entry.value).toString();
 
-                        common.logging.info(`Setting ${entry.key} to ${value} because it was ${entry.value}`);
+                        logging.info(`Setting ${entry.key} to ${value} because it was ${entry.value}`);
 
                         /**
                          * @NOTE: we have update raw data, because otherwise the `Settings.edit` fn will re-fetch the data
@@ -43,7 +43,7 @@ module.exports.up = (options) => {
                     // @NOTE: null or undefined were obviously intended to be false
                     if (entry.value === null || entry.value === undefined || entry.value === 'null' || entry.value === 'undefined') {
                         const value = 'false';
-                        common.logging.info(`Setting ${entry.key} to ${value} because it was ${entry.value}`);
+                        logging.info(`Setting ${entry.key} to ${value} because it was ${entry.value}`);
 
                         return localOptions
                             .transacting('settings')
@@ -56,7 +56,7 @@ module.exports.up = (options) => {
                     // @NOTE: Something other than true/false is stored, set to true, because that's how it would have behaved
                     if (entry.value !== 'false' && entry.value !== 'true') {
                         const value = 'true';
-                        common.logging.info(`Setting ${entry.key} to ${value} because it was ${entry.value}`);
+                        logging.info(`Setting ${entry.key} to ${value} because it was ${entry.value}`);
 
                         return localOptions
                             .transacting('settings')
@@ -67,7 +67,7 @@ module.exports.up = (options) => {
                     }
                 }
 
-                common.logging.info(`Skip setting ${entry.key}`);
+                logging.info(`Skip setting ${entry.key}`);
                 return Promise.resolve();
             });
         });

--- a/core/server/data/migrations/versions/2.17/2-posts-add-canonical-url.js
+++ b/core/server/data/migrations/versions/2.17/2-posts-add-canonical-url.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'posts';
 const columns = ['canonical_url'];
@@ -23,11 +23,11 @@ _private.handle = function handle(options) {
                     return connection.schema.hasColumn(table, column)
                         .then(function (exists) {
                             if (exists && isAdding || !exists && !isAdding) {
-                                common.logging.warn(`${type} column ${table}.${column}`);
+                                logging.warn(`${type} column ${table}.${column}`);
                                 return Promise.resolve();
                             }
 
-                            common.logging.info(`${type} column ${table}.${column}`);
+                            logging.info(`${type} column ${table}.${column}`);
                             return operation(table, column, connection);
                         });
                 });

--- a/core/server/data/migrations/versions/2.18/1-restore-settings-from-backup.js
+++ b/core/server/data/migrations/versions/2.18/1-restore-settings-from-backup.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const settingsCache = require('../../../../services/settings/cache');
 const config = require('../../../../config');
 const moment = require('moment');
@@ -25,7 +25,7 @@ module.exports.up = (options) => {
     return fs.readdir(dataPath).then(function (files) {
         return files;
     }).catch(function () {
-        common.logging.warn(`Error reading ${dataPath} whilst trying to ensure boolean settings are correct. Please double check your settings after this upgrade`);
+        logging.warn(`Error reading ${dataPath} whilst trying to ensure boolean settings are correct. Please double check your settings after this upgrade`);
         return [];
     }).then(function (files) {
         const backups = files.filter(function (filename) {
@@ -38,25 +38,25 @@ module.exports.up = (options) => {
         });
 
         if (backups.length === 0) {
-            common.logging.warn('No backup files found, skipping...');
+            logging.warn('No backup files found, skipping...');
             return;
         }
 
         const mostRecentBackup = backups[0];
 
-        common.logging.info(`Using backupfile ${path.join(dataPath, mostRecentBackup)}`);
+        logging.info(`Using backupfile ${path.join(dataPath, mostRecentBackup)}`);
 
         let backup;
         try {
             backup = require(path.join(dataPath, mostRecentBackup));
         } catch (e) {
-            common.logging.warn(`Could not read ${path.join(dataPath, mostRecentBackup)} whilst trying to ensure boolean settings are correct. Please double check your settings after this upgrade`);
+            logging.warn(`Could not read ${path.join(dataPath, mostRecentBackup)} whilst trying to ensure boolean settings are correct. Please double check your settings after this upgrade`);
             return;
         }
         const settings = backup && backup.data && backup.data.settings;
 
         if (!settings) {
-            common.logging.warn('Could not read settings from backup file, skipping...');
+            logging.warn('Could not read settings from backup file, skipping...');
             return;
         }
 
@@ -64,7 +64,7 @@ module.exports.up = (options) => {
             .transacting('migrations')
             .then((response) => {
                 if (!response) {
-                    common.logging.warn('Cannot find migrations.');
+                    logging.warn('Cannot find migrations.');
                     return;
                 }
 
@@ -73,11 +73,11 @@ module.exports.up = (options) => {
                 const isAffected = _.find(response, {currentVersion: '2.17', version: '2.17'});
 
                 if (!isAffected) {
-                    common.logging.warn('Skipping migration. Not affected.');
+                    logging.warn('Skipping migration. Not affected.');
                     return;
                 }
 
-                common.logging.warn('...is affected.');
+                logging.warn('...is affected.');
 
                 const relevantBackupSettings = settings.filter(function (entry) {
                     return ['is_private', 'force_i18n', 'amp'].includes(entry.key);
@@ -91,7 +91,7 @@ module.exports.up = (options) => {
                     .transacting('settings')
                     .then((response) => {
                         if (!response) {
-                            common.logging.warn('Cannot find settings.');
+                            logging.warn('Cannot find settings.');
                             return;
                         }
 
@@ -103,7 +103,7 @@ module.exports.up = (options) => {
                             const backupSetting = relevantBackupSettings[liveSetting.key];
 
                             if (liveSetting.value === 'false' && backupSetting.value === 'true') {
-                                common.logging.info(`Reverting setting ${liveSetting.key}`);
+                                logging.info(`Reverting setting ${liveSetting.key}`);
 
                                 return localOptions
                                     .transacting('settings')

--- a/core/server/data/migrations/versions/2.2/1-add-sessions-table.js
+++ b/core/server/data/migrations/versions/2.2/1-add-sessions-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'sessions';
 const message1 = 'Adding table: ' + table;
@@ -10,11 +10,11 @@ module.exports.up = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return;
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -25,11 +25,11 @@ module.exports.down = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return;
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };

--- a/core/server/data/migrations/versions/2.2/5-add-mobiledoc-revisions-table.js
+++ b/core/server/data/migrations/versions/2.2/5-add-mobiledoc-revisions-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'mobiledoc_revisions';
 const message1 = 'Adding table: ' + table;
@@ -10,11 +10,11 @@ module.exports.up = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return;
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -25,11 +25,11 @@ module.exports.down = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return;
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };

--- a/core/server/data/migrations/versions/2.22/1-add-member-permissions-to-roles.js
+++ b/core/server/data/migrations/versions/2.22/1-add-member-permissions-to-roles.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const resource = 'member';
 const _private = {};
 
@@ -15,9 +15,9 @@ _private.getRelations = function getRelations() {
 
 _private.printResult = function printResult(result, message) {
     if (result.done === result.expected) {
-        common.logging.info(message);
+        logging.info(message);
     } else {
-        common.logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
+        logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
     }
 };
 

--- a/core/server/data/migrations/versions/2.27/3-add-subdirectory-to-relative-canonical-urls.js
+++ b/core/server/data/migrations/versions/2.27/3-add-subdirectory-to-relative-canonical-urls.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const config = require('../../../../config');
 const {URL} = require('url');
 
@@ -25,7 +25,7 @@ module.exports.up = (options) => {
     }, options);
 
     if (url.pathname === '/') {
-        common.logging.info('Skipping posts.canonical_url subdirectory fix: no subdirectory configured');
+        logging.info('Skipping posts.canonical_url subdirectory fix: no subdirectory configured');
         return Promise.resolve();
     }
 
@@ -46,11 +46,11 @@ module.exports.up = (options) => {
                             canonical_url: canonicalUrl
                         });
                 }).then(() => {
-                    common.logging.info(`Added subdirectory prefix to canonical_url in ${posts.length} posts`);
+                    logging.info(`Added subdirectory prefix to canonical_url in ${posts.length} posts`);
                 });
             }
 
-            common.logging.info('Skipping posts.canonical_url subdirectory fix: no canonical_urls to fix');
+            logging.info('Skipping posts.canonical_url subdirectory fix: no canonical_urls to fix');
             return Promise.resolve();
         });
 };
@@ -71,7 +71,7 @@ module.exports.down = (options) => {
     }, options);
 
     if (url.pathname === '/') {
-        common.logging.info('Skipping posts.canonical_url subdirectory fix: no subdirectory configured');
+        logging.info('Skipping posts.canonical_url subdirectory fix: no subdirectory configured');
         return Promise.resolve();
     }
 
@@ -89,11 +89,11 @@ module.exports.down = (options) => {
                             canonical_url: canonicalUrl
                         });
                 }).then(() => {
-                    common.logging.info(`Removed subdirectory prefix from canonical_url in ${posts.length} posts`);
+                    logging.info(`Removed subdirectory prefix from canonical_url in ${posts.length} posts`);
                 });
             }
 
-            common.logging.info('Skipping posts.canonical_url subdirectory fix: no canonical_urls to fix');
+            logging.info('Skipping posts.canonical_url subdirectory fix: no canonical_urls to fix');
             return Promise.resolve();
         });
 };

--- a/core/server/data/migrations/versions/2.29/1-add-post-page-column.js
+++ b/core/server/data/migrations/versions/2.29/1-add-post-page-column.js
@@ -1,7 +1,7 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
-const createLog = type => msg => common.logging[type](msg);
+const createLog = type => msg => logging[type](msg);
 
 function createColumnMigration({table, column, dbIsInCorrectState, operation, operationVerb}) {
     return function columnMigrations({transacting}) {

--- a/core/server/data/migrations/versions/2.29/2-populate-post-page-column.js
+++ b/core/server/data/migrations/versions/2.29/2-populate-post-page-column.js
@@ -1,5 +1,5 @@
 const toPairs = require('lodash/toPairs');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 
 /*
  * @param from: object with a SINGLE entry { 'fromColumn': 'fromValue' }
@@ -9,7 +9,7 @@ const createColumnToColumnMap = ({from, to, tableName}) => (connection) => {
     return connection.schema.hasTable(tableName)
         .then((tableExists) => {
             if (!tableExists) {
-                common.logging.warn(
+                logging.warn(
                     `Table ${tableName} does not exist`
                 );
                 return;
@@ -23,12 +23,12 @@ const createColumnToColumnMap = ({from, to, tableName}) => (connection) => {
                 connection.schema.hasColumn(tableName, toColumn)
             ]).then(([fromColumnExists, toColumnExists]) => {
                 if (!fromColumnExists) {
-                    common.logging.warn(
+                    logging.warn(
                         `Table '${tableName}' does not have column '${fromColumn}'`
                     );
                 }
                 if (!toColumnExists) {
-                    common.logging.warn(
+                    logging.warn(
                         `Table '${tableName}' does not have column '${toColumn}'`
                     );
                 }
@@ -36,7 +36,7 @@ const createColumnToColumnMap = ({from, to, tableName}) => (connection) => {
                     return;
                 }
 
-                common.logging.info(
+                logging.info(
                     `Updating ${tableName}, setting "${toColumn}" column to "${toValue}" where "${fromColumn}" column is "${fromValue}"`
                 );
 

--- a/core/server/data/migrations/versions/2.29/3-remove-page-type-column.js
+++ b/core/server/data/migrations/versions/2.29/3-remove-page-type-column.js
@@ -1,7 +1,7 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
-const createLog = type => msg => common.logging[type](msg);
+const createLog = type => msg => logging[type](msg);
 
 function createColumnMigration({table, column, dbIsInCorrectState, operation, operationVerb, columnDefinition}) {
     return function columnMigrations({transacting}) {

--- a/core/server/data/migrations/versions/2.3/1-add-webhook-columns.js
+++ b/core/server/data/migrations/versions/2.3/1-add-webhook-columns.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'webhooks';
 const newColumnNames = [
@@ -22,10 +22,10 @@ module.exports.up = (options) => {
         return connection.schema.hasColumn(table, newColumnName)
             .then((exists) => {
                 if (exists) {
-                    common.logging.warn(printResult('Adding', newColumnName));
+                    logging.warn(printResult('Adding', newColumnName));
                     return;
                 }
-                common.logging.info(printResult('Adding', newColumnName));
+                logging.info(printResult('Adding', newColumnName));
                 return commands.addColumn(table, newColumnName, connection);
             });
     });
@@ -37,10 +37,10 @@ module.exports.down = (options) => {
         return connection.schema.hasColumn(table, newColumnName)
             .then((exists) => {
                 if (!exists) {
-                    common.logging.warn(printResult('Dropping', newColumnName));
+                    logging.warn(printResult('Dropping', newColumnName));
                     return;
                 }
-                common.logging.info(printResult('Dropping', newColumnName));
+                logging.info(printResult('Dropping', newColumnName));
                 return commands.dropColumn(table, newColumnName, connection);
             });
     });

--- a/core/server/data/migrations/versions/2.33/01-correct-members-stripe-customers-table.js
+++ b/core/server/data/migrations/versions/2.33/01-correct-members-stripe-customers-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema/commands');
 
 module.exports = {
@@ -11,13 +11,13 @@ module.exports = {
         const hasTable = await conn.schema.hasTable('members_stripe_customers');
 
         if (hasTable) {
-            common.logging.info('Dropping table: members_stripe_customers');
+            logging.info('Dropping table: members_stripe_customers');
             await commands.deleteTable('members_stripe_customers', conn);
         } else {
-            common.logging.warn('Dropping table: members_stripe_customers');
+            logging.warn('Dropping table: members_stripe_customers');
         }
 
-        common.logging.info('Adding table: members_stripe_customers');
+        logging.info('Adding table: members_stripe_customers');
         return commands.createTable('members_stripe_customers', conn);
     },
 
@@ -26,11 +26,11 @@ module.exports = {
         const hasTable = await conn.schema.hasTable('members_stripe_customers');
 
         if (!hasTable) {
-            common.logging.warn('Dropping table: members_stripe_customers');
+            logging.warn('Dropping table: members_stripe_customers');
             return;
         }
 
-        common.logging.info('Dropping table: members_stripe_customers');
+        logging.info('Dropping table: members_stripe_customers');
         return commands.deleteTable('members_stripe_customers', conn);
     }
 };

--- a/core/server/data/migrations/versions/2.34/01-add-stripe-customers-subscriptions-table.js
+++ b/core/server/data/migrations/versions/2.34/01-add-stripe-customers-subscriptions-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema/commands');
 
 module.exports = {
@@ -11,11 +11,11 @@ module.exports = {
         const hasTable = await conn.schema.hasTable('members_stripe_customers_subscriptions');
 
         if (hasTable) {
-            common.logging.warn('Adding table: members_stripe_customers_subscriptions');
+            logging.warn('Adding table: members_stripe_customers_subscriptions');
             return;
         }
 
-        common.logging.info('Adding table: members_stripe_customers_subscriptions');
+        logging.info('Adding table: members_stripe_customers_subscriptions');
         return commands.createTable('members_stripe_customers_subscriptions', conn);
     },
 
@@ -24,11 +24,11 @@ module.exports = {
         const hasTable = await conn.schema.hasTable('members_stripe_customers_subscriptions');
 
         if (!hasTable) {
-            common.logging.warn('Dropping table: members_stripe_customers_subscriptions');
+            logging.warn('Dropping table: members_stripe_customers_subscriptions');
             return;
         }
 
-        common.logging.info('Dropping table: members_stripe_customers_subscriptions');
+        logging.info('Dropping table: members_stripe_customers_subscriptions');
         return commands.deleteTable('members_stripe_customers_subscriptions', conn);
     }
 };

--- a/core/server/data/migrations/versions/2.37/01-add-self-signup-and-from address-to-members-settings.js
+++ b/core/server/data/migrations/versions/2.37/01-add-self-signup-and-from address-to-members-settings.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 
 module.exports.config = {
     transaction: true
@@ -15,7 +15,7 @@ module.exports.up = (options) => {
         .transacting('settings')
         .then((response) => {
             if (!response) {
-                common.logging.warn('Cannot find settings.');
+                logging.warn('Cannot find settings.');
                 return;
             }
             let subscriptionSettingsEntry = response.find((entry) => {
@@ -23,7 +23,7 @@ module.exports.up = (options) => {
             });
 
             if (!subscriptionSettingsEntry) {
-                common.logging.warn('Cannot find members subscription settings.');
+                logging.warn('Cannot find members subscription settings.');
                 return;
             }
             let subscriptionSettings = JSON.parse(subscriptionSettingsEntry.value);
@@ -42,10 +42,10 @@ module.exports.up = (options) => {
             
             if (hasRequirePaymentProperty) {
                 if (!hasSelfSignupProperty) {
-                    common.logging.info(`Adding allowSelfSignup property from requirePaymentForSignup in member settings`);
+                    logging.info(`Adding allowSelfSignup property from requirePaymentForSignup in member settings`);
                     subscriptionSettings.allowSelfSignup = !subscriptionSettings.requirePaymentForSignup;
                 }
-                common.logging.info(`Removing requirePaymentForSignup property in member settings`);
+                logging.info(`Removing requirePaymentForSignup property in member settings`);
                 delete subscriptionSettings.requirePaymentForSignup;
             }
 

--- a/core/server/data/migrations/versions/2.8/1-add-members-table.js
+++ b/core/server/data/migrations/versions/2.8/1-add-members-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'members';
 const message1 = 'Adding table: ' + table;
@@ -10,11 +10,11 @@ module.exports.up = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return;
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -25,11 +25,11 @@ module.exports.down = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return;
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };

--- a/core/server/data/migrations/versions/3.0/01-remove-user-ghost-auth-columns.js
+++ b/core/server/data/migrations/versions/3.0/01-remove-user-ghost-auth-columns.js
@@ -1,7 +1,7 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
-const createLog = type => msg => common.logging[type](msg);
+const createLog = type => msg => logging[type](msg);
 
 function createColumnMigrations(migrations) {
     return function columnMigrations({transacting}) {

--- a/core/server/data/migrations/versions/3.0/02-drop-token-auth-tables.js
+++ b/core/server/data/migrations/versions/3.0/02-drop-token-auth-tables.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
 const tables = [
@@ -13,11 +13,11 @@ module.exports.up = (options) => {
         return connection.schema.hasTable(table)
             .then(function (exists) {
                 if (!exists) {
-                    common.logging.warn(`Dropping table: ${table}`);
+                    logging.warn(`Dropping table: ${table}`);
                     return;
                 }
 
-                common.logging.info(`Dropping table: ${table}`);
+                logging.info(`Dropping table: ${table}`);
                 return commands.deleteTable(table, connection);
             });
     });

--- a/core/server/data/migrations/versions/3.0/03-drop-client-auth-tables.js
+++ b/core/server/data/migrations/versions/3.0/03-drop-client-auth-tables.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
 const tables = [
@@ -17,11 +17,11 @@ module.exports.up = (options) => {
         return connection.schema.hasTable(table)
             .then(function (exists) {
                 if (!exists) {
-                    common.logging.warn(`Dropping table: ${table}`);
+                    logging.warn(`Dropping table: ${table}`);
                     return;
                 }
 
-                common.logging.info(`Dropping table: ${table}`);
+                logging.info(`Dropping table: ${table}`);
                 return commands.deleteTable(table, connection);
             });
     });

--- a/core/server/data/migrations/versions/3.0/04-add-posts-meta-table.js
+++ b/core/server/data/migrations/versions/3.0/04-add-posts-meta-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'posts_meta';
 const message1 = `Adding table: ${table}`;
@@ -10,11 +10,11 @@ module.exports.up = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return;
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -25,11 +25,11 @@ module.exports.down = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return;
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };

--- a/core/server/data/migrations/versions/3.0/05-populate-posts-meta-table.js
+++ b/core/server/data/migrations/versions/3.0/05-populate-posts-meta-table.js
@@ -2,7 +2,7 @@ const postsMetaSchema = require('../../../schema').tables.posts_meta;
 const ObjectId = require('bson-objectid');
 const _ = require('lodash');
 const models = require('../../../../models');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 
 module.exports.config = {
     transaction: true
@@ -31,7 +31,7 @@ module.exports.up = (options) => {
         .fetch(localOptions)
         .then(({models: posts}) => {
             if (posts.length > 0) {
-                common.logging.info(`Adding ${posts.length} entries to posts_meta`);
+                logging.info(`Adding ${posts.length} entries to posts_meta`);
                 let postsMetaEntries = _.map(posts, (post) => {
                     let postsMetaEntry = metaAttrs.reduce(function (obj, entry) {
                         return Object.assign(obj, {
@@ -48,7 +48,7 @@ module.exports.up = (options) => {
                     return localOptions.transacting('posts_meta').insert(postsMeta);
                 });
             } else {
-                common.logging.info('Skipping populating posts_meta table: found 0 posts with metadata');
+                logging.info('Skipping populating posts_meta table: found 0 posts with metadata');
                 return Promise.resolve();
             }
         });
@@ -65,7 +65,7 @@ module.exports.down = function (options) {
         .findAll(localOptions)
         .then(({models: postsMeta}) => {
             if (postsMeta.length > 0) {
-                common.logging.info(`Adding metadata for ${postsMeta.length} posts from posts_meta table`);
+                logging.info(`Adding metadata for ${postsMeta.length} posts from posts_meta table`);
                 return Promise.map(postsMeta, (postsMeta) => {
                     let data = metaAttrs.reduce(function (obj, entry) {
                         return Object.assign(obj, {
@@ -75,7 +75,7 @@ module.exports.down = function (options) {
                     return localOptions.transacting('posts').where({id: postsMeta.get('post_id')}).update(data);
                 });
             } else {
-                common.logging.info('Skipping populating meta fields from posts_meta: found 0 entries');
+                logging.info('Skipping populating meta fields from posts_meta: found 0 entries');
                 return Promise.resolve();
             }
         });

--- a/core/server/data/migrations/versions/3.0/07-add-posts-type-column.js
+++ b/core/server/data/migrations/versions/3.0/07-add-posts-type-column.js
@@ -1,7 +1,7 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
-const createLog = type => msg => common.logging[type](msg);
+const createLog = type => msg => logging[type](msg);
 
 function createColumnMigration({table, column, dbIsInCorrectState, operation, operationVerb}) {
     return function columnMigrations({transacting}) {

--- a/core/server/data/migrations/versions/3.0/08-populate-posts-type-column.js
+++ b/core/server/data/migrations/versions/3.0/08-populate-posts-type-column.js
@@ -1,6 +1,6 @@
 const Promise = require('bluebird');
 const toPairs = require('lodash/toPairs');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 
 /*
 * @param from: object with a SINGLE entry { 'fromColumn': 'fromValue' }
@@ -10,7 +10,7 @@ const createColumnToColumnMap = ({from, to, tableName}) => (connection) => {
     return connection.schema.hasTable(tableName)
         .then((tableExists) => {
             if (!tableExists) {
-                common.logging.warn(
+                logging.warn(
                     `Table ${tableName} does not exist`
                 );
                 return;
@@ -24,12 +24,12 @@ const createColumnToColumnMap = ({from, to, tableName}) => (connection) => {
                 connection.schema.hasColumn(tableName, toColumn)
             ]).then(([fromColumnExists, toColumnExists]) => {
                 if (!fromColumnExists) {
-                    common.logging.warn(
+                    logging.warn(
                         `Table '${tableName}' does not have column '${fromColumn}'`
                     );
                 }
                 if (!toColumnExists) {
-                    common.logging.warn(
+                    logging.warn(
                         `Table '${tableName}' does not have column '${toColumn}'`
                     );
                 }
@@ -37,7 +37,7 @@ const createColumnToColumnMap = ({from, to, tableName}) => (connection) => {
                     return;
                 }
 
-                common.logging.info(
+                logging.info(
                     `Updating ${tableName}, setting "${toColumn}" column to "${toValue}" where "${fromColumn}" column is "${fromValue}"`
                 );
 

--- a/core/server/data/migrations/versions/3.0/09-remove-posts-page-column.js
+++ b/core/server/data/migrations/versions/3.0/09-remove-posts-page-column.js
@@ -1,7 +1,7 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
-const createLog = type => msg => common.logging[type](msg);
+const createLog = type => msg => logging[type](msg);
 
 function createColumnMigration({table, column, dbIsInCorrectState, operation, operationVerb, columnDefinition}) {
     return function columnMigrations({transacting}) {

--- a/core/server/data/migrations/versions/3.0/10-remove-empty-strings.js
+++ b/core/server/data/migrations/versions/3.0/10-remove-empty-strings.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const schema = require('../../../schema');
 
 /*
@@ -27,7 +27,7 @@ const createReplace = (connection, from, to) => (tableName, columnName) => {
     return connection.schema.hasTable(tableName)
         .then((tableExists) => {
             if (!tableExists) {
-                common.logging.warn(
+                logging.warn(
                     `Table ${tableName} does not exist`
                 );
                 return;
@@ -35,13 +35,13 @@ const createReplace = (connection, from, to) => (tableName, columnName) => {
             return connection.schema.hasColumn(tableName, columnName)
                 .then((columnExists) => {
                     if (!columnExists) {
-                        common.logging.warn(
+                        logging.warn(
                             `Table '${tableName}' does not have column '${columnName}'`
                         );
                         return;
                     }
 
-                    common.logging.info(
+                    logging.info(
                         `Updating ${tableName}, setting '${from}' in ${columnName} to '${to}'`
                     );
 

--- a/core/server/data/migrations/versions/3.0/11-update-posts-html.js
+++ b/core/server/data/migrations/versions/3.0/11-update-posts-html.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const htmlToText = require('html-to-text');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const mobiledocLib = require('../../../../lib/mobiledoc');
 
 module.exports.config = {
@@ -16,7 +16,7 @@ module.exports.up = (options) => {
         migrating: true
     }, options);
 
-    common.logging.info('Starting re-generation of posts html.');
+    logging.info('Starting re-generation of posts html.');
     return localOptions
         .transacting('posts')
         .select(columns)
@@ -28,11 +28,11 @@ module.exports.up = (options) => {
                     mobiledoc = JSON.parse(post.mobiledoc || null);
 
                     if (!mobiledoc) {
-                        common.logging.warn(`No mobiledoc for ${post.id}. Skipping.`);
+                        logging.warn(`No mobiledoc for ${post.id}. Skipping.`);
                         return Promise.resolve();
                     }
                 } catch (err) {
-                    common.logging.warn(`Invalid JSON structure for ${post.id}. Skipping.`);
+                    logging.warn(`Invalid JSON structure for ${post.id}. Skipping.`);
                     return Promise.resolve();
                 }
 
@@ -68,7 +68,7 @@ module.exports.up = (options) => {
             }, {concurrency: 100});
         })
         .then(() => {
-            common.logging.info('Finished re-generation of posts html.');
+            logging.info('Finished re-generation of posts html.');
         });
 };
 

--- a/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
+++ b/core/server/data/migrations/versions/3.0/12-populate-members-table-from-subscribers.js
@@ -1,6 +1,6 @@
 const ObjectId = require('bson-objectid');
 const _ = require('lodash');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 
 module.exports.config = {
     transaction: true,
@@ -25,7 +25,7 @@ module.exports.up = (options) => {
     return localOptions.transacting('subscribers').select()
         .then((subscribers) => {
             if (subscribers && subscribers.length > 0) {
-                common.logging.info(`Adding ${subscribers.length} entries to members`);
+                logging.info(`Adding ${subscribers.length} entries to members`);
 
                 let members = _.map(subscribers, (subscriber) => {
                     let member = memberAttrs.reduce(function (obj, prop) {
@@ -42,7 +42,7 @@ module.exports.up = (options) => {
                     return localOptions.transacting('members').insert(member);
                 });
             } else {
-                common.logging.info('Skipping populating members table: found 0 subscribers');
+                logging.info('Skipping populating members table: found 0 subscribers');
                 return Promise.resolve();
             }
         });

--- a/core/server/data/migrations/versions/3.0/13-drop-subscribers-table.js
+++ b/core/server/data/migrations/versions/3.0/13-drop-subscribers-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
 const tables = [
@@ -16,11 +16,11 @@ module.exports.up = (options) => {
         return connection.schema.hasTable(table)
             .then(function (exists) {
                 if (!exists) {
-                    common.logging.warn(`Dropping table: ${table}`);
+                    logging.warn(`Dropping table: ${table}`);
                     return;
                 }
 
-                common.logging.info(`Dropping table: ${table}`);
+                logging.info(`Dropping table: ${table}`);
                 return commands.deleteTable(table, connection);
             });
     });

--- a/core/server/data/migrations/versions/3.0/14-remove-subscribers-flag.js
+++ b/core/server/data/migrations/versions/3.0/14-remove-subscribers-flag.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 
 module.exports = {
     async up({connection}) {
@@ -7,7 +7,7 @@ module.exports = {
             .select('value');
 
         if (!result || !result[0]) {
-            common.logging.warn(`Could not find labs setting`);
+            logging.warn(`Could not find labs setting`);
             result = [{}];
         }
 
@@ -15,7 +15,7 @@ module.exports = {
 
         labs.members = !!labs.members || !!labs.subscribers;
 
-        common.logging.info(`Updating labs setting removing subscribers (was ${labs.subscribers}) settings members to ${labs.members}`);
+        logging.info(`Updating labs setting removing subscribers (was ${labs.subscribers}) settings members to ${labs.members}`);
         labs.subscribers = undefined;
 
         await connection('settings')

--- a/core/server/data/migrations/versions/3.1/04-add-subscribed-flag-to-members.js
+++ b/core/server/data/migrations/versions/3.1/04-add-subscribed-flag-to-members.js
@@ -1,7 +1,7 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
-const createLog = type => msg => common.logging[type](msg);
+const createLog = type => msg => logging[type](msg);
 
 function createColumnMigration({table, column, dbIsInCorrectState, operation, operationVerb}) {
     return function columnMigrations({transacting}) {

--- a/core/server/data/migrations/versions/3.1/05-add-emails-table.js
+++ b/core/server/data/migrations/versions/3.1/05-add-emails-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'emails';
 const message1 = 'Adding table: ' + table;
@@ -10,11 +10,11 @@ module.exports.up = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return;
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -25,11 +25,11 @@ module.exports.down = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return;
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };

--- a/core/server/data/migrations/versions/3.1/07-add-uuid-field-to-members.js
+++ b/core/server/data/migrations/versions/3.1/07-add-uuid-field-to-members.js
@@ -1,7 +1,7 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
-const createLog = type => msg => common.logging[type](msg);
+const createLog = type => msg => logging[type](msg);
 
 function createColumnMigration({table, column, dbIsInCorrectState, operation, operationVerb}) {
     return function columnMigrations({transacting}) {

--- a/core/server/data/migrations/versions/3.1/08-add-uuid-values-to-members.js
+++ b/core/server/data/migrations/versions/3.1/08-add-uuid-values-to-members.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const uuid = require('uuid');
 
 module.exports = {
@@ -10,7 +10,7 @@ module.exports = {
 
         const membersWithoutUUID = await conn.select('id').from('members').whereNull('uuid');
 
-        common.logging.info(`Adding uuid field value to ${membersWithoutUUID.length} members.`);
+        logging.info(`Adding uuid field value to ${membersWithoutUUID.length} members.`);
 
         for (const member of membersWithoutUUID) {
             await conn('members').update('uuid', uuid.v4()).where('id', member.id);

--- a/core/server/data/migrations/versions/3.11/01-remove-broken-complimentary-plan-from-members-settings.js
+++ b/core/server/data/migrations/versions/3.11/01-remove-broken-complimentary-plan-from-members-settings.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const debug = require('ghost-ignition').debug('migrations');
 
 module.exports.config = {
@@ -17,7 +17,7 @@ module.exports.up = (options) => {
         .transacting('settings')
         .then((response) => {
             if (!response) {
-                common.logging.warn('Cannot find settings.');
+                logging.warn('Cannot find settings.');
                 return;
             }
 
@@ -26,7 +26,7 @@ module.exports.up = (options) => {
             });
 
             if (!subscriptionSettingsEntry) {
-                common.logging.warn('Cannot find members subscription settings.');
+                logging.warn('Cannot find members subscription settings.');
                 return;
             }
 

--- a/core/server/data/migrations/versions/3.12/01-add-identity-permission.js
+++ b/core/server/data/migrations/versions/3.12/01-add-identity-permission.js
@@ -1,5 +1,5 @@
 const ObjectId = require('bson-objectid');
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 
 module.exports.config = {
     transaction: true
@@ -14,11 +14,11 @@ module.exports.up = async (options) => {
     }).first();
 
     if (existingIdentityPermission) {
-        common.logging.warn('Permission for read:identity already added');
+        logging.warn('Permission for read:identity already added');
         return;
     }
 
-    common.logging.info('Adding permission for read:identity');
+    logging.info('Adding permission for read:identity');
 
     const date = connection.raw('CURRENT_TIMESTAMP');
 
@@ -43,11 +43,11 @@ module.exports.down = async (options) => {
     }).first();
 
     if (!existingIdentityPermission) {
-        common.logging.warn('Permission for read:identity already removed');
+        logging.warn('Permission for read:identity already removed');
         return;
     }
 
-    common.logging.info('Removing permission for read:identity');
+    logging.info('Removing permission for read:identity');
 
     await connection('permissions').where({
         action_type: 'read',

--- a/core/server/data/migrations/versions/3.12/02-remove-legacy-is-paid-flag-from-settings.js
+++ b/core/server/data/migrations/versions/3.12/02-remove-legacy-is-paid-flag-from-settings.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const debug = require('ghost-ignition').debug('migrations');
 
 module.exports.config = {
@@ -16,7 +16,7 @@ module.exports.up = (options) => {
         .then((subscriptionSettingsEntry) => {
             debug(subscriptionSettingsEntry);
             if (!subscriptionSettingsEntry) {
-                common.logging.warn(`Cannot find ${settingsKey} settings.`);
+                logging.warn(`Cannot find ${settingsKey} settings.`);
                 return;
             }
 
@@ -55,7 +55,7 @@ module.exports.down = (options) => {
         .then((subscriptionSettingsEntry) => {
             debug(subscriptionSettingsEntry);
             if (!subscriptionSettingsEntry) {
-                common.logging.warn(`Cannot find ${settingsKey} settings.`);
+                logging.warn(`Cannot find ${settingsKey} settings.`);
                 return;
             }
 

--- a/core/server/data/migrations/versions/3.6/1-add-labels-table.js
+++ b/core/server/data/migrations/versions/3.6/1-add-labels-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'labels';
 const message1 = 'Adding table: ' + table;
@@ -10,11 +10,11 @@ module.exports.up = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return;
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -25,11 +25,11 @@ module.exports.down = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return;
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };

--- a/core/server/data/migrations/versions/3.6/2-add-members-labels-table.js
+++ b/core/server/data/migrations/versions/3.6/2-add-members-labels-table.js
@@ -1,4 +1,4 @@
-const common = require('../../../../lib/common');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 const table = 'members_labels';
 const message1 = 'Adding table: ' + table;
@@ -10,11 +10,11 @@ module.exports.up = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (exists) {
-                common.logging.warn(message1);
+                logging.warn(message1);
                 return;
             }
 
-            common.logging.info(message1);
+            logging.info(message1);
             return commands.createTable(table, connection);
         });
 };
@@ -25,11 +25,11 @@ module.exports.down = (options) => {
     return connection.schema.hasTable(table)
         .then(function (exists) {
             if (!exists) {
-                common.logging.warn(message2);
+                logging.warn(message2);
                 return;
             }
 
-            common.logging.info(message2);
+            logging.info(message2);
             return commands.deleteTable(table, connection);
         });
 };


### PR DESCRIPTION
Refs #11835 

Since this modifies the migration, I'm opening this separate PR for @daniellockyer to review. All of the changes are pretty much changing `common.logging...` to `logging...`
