### PR TITLE
Removed import of common sub-modules

### DIFF
--- a/core/server/data/migrations/versions/1.19/1-webhook-permissions.js
+++ b/core/server/data/migrations/versions/1.19/1-webhook-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const resource = 'webhook';
 const _private = {};
 

--- a/core/server/data/migrations/versions/1.21/1-add-contributor-role.js
+++ b/core/server/data/migrations/versions/1.21/1-add-contributor-role.js
@@ -2,7 +2,7 @@ const merge = require('lodash/merge');
 const utils = require('../../../schema/fixtures/utils');
 const models = require('../../../../models');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const _private = {};
 
 _private.addRole = function addRole(options) {

--- a/core/server/data/migrations/versions/2.15/2-insert-zapier-integration.js
+++ b/core/server/data/migrations/versions/2.15/2-insert-zapier-integration.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const merge = require('lodash/merge');
 const models = require('../../../../models');
 const utils = require('../../../schema/fixtures/utils');

--- a/core/server/data/migrations/versions/2.2/2-add-integrations-and-api-key-tables.js
+++ b/core/server/data/migrations/versions/2.2/2-add-integrations-and-api-key-tables.js
@@ -1,5 +1,5 @@
 const commands = require('../../../schema').commands;
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const tables = ['integrations', 'api_keys'];
 const _private = {};

--- a/core/server/data/migrations/versions/2.2/3-insert-admin-integration-role.js
+++ b/core/server/data/migrations/versions/2.2/3-insert-admin-integration-role.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const merge = require('lodash/merge');
 const models = require('../../../../models');
 const utils = require('../../../schema/fixtures/utils');

--- a/core/server/data/migrations/versions/2.2/4-insert-integration-and-api-key-permissions.js
+++ b/core/server/data/migrations/versions/2.2/4-insert-integration-and-api-key-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const resources = ['integration', 'api_key'];
 const _private = {};

--- a/core/server/data/migrations/versions/2.21/1-update-editor-permissions.js
+++ b/core/server/data/migrations/versions/2.21/1-update-editor-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const resources = ['notification'];
 

--- a/core/server/data/migrations/versions/2.27/1-insert-ghost-db-backup-role.js
+++ b/core/server/data/migrations/versions/2.27/1-insert-ghost-db-backup-role.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const merge = require('lodash/merge');
 const models = require('../../../../models');
 const utils = require('../../../schema/fixtures/utils');

--- a/core/server/data/migrations/versions/2.27/2-insert-db-backup-integration.js
+++ b/core/server/data/migrations/versions/2.27/2-insert-db-backup-integration.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const merge = require('lodash/merge');
 const models = require('../../../../models');
 const utils = require('../../../schema/fixtures/utils');

--- a/core/server/data/migrations/versions/2.28/1-add-db-backup-content-permission.js
+++ b/core/server/data/migrations/versions/2.28/1-add-db-backup-content-permission.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const models = require('../../../../models');
 const utils = require('../../../schema/fixtures/utils');
 

--- a/core/server/data/migrations/versions/2.28/2-add-db-backup-content-permission-to-roles.js
+++ b/core/server/data/migrations/versions/2.28/2-add-db-backup-content-permission-to-roles.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const utils = require('../../../schema/fixtures/utils');
 
 const relationFixtures = {

--- a/core/server/data/migrations/versions/2.28/3-insert-ghost-scheduler-role.js
+++ b/core/server/data/migrations/versions/2.28/3-insert-ghost-scheduler-role.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const merge = require('lodash/merge');
 const models = require('../../../../models');
 const utils = require('../../../schema/fixtures/utils');

--- a/core/server/data/migrations/versions/2.28/4-insert-scheduler-integration.js
+++ b/core/server/data/migrations/versions/2.28/4-insert-scheduler-integration.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const merge = require('lodash/merge');
 const models = require('../../../../models');
 const utils = require('../../../schema/fixtures/utils');

--- a/core/server/data/migrations/versions/2.28/5-add-scheduler-permission-to-roles.js
+++ b/core/server/data/migrations/versions/2.28/5-add-scheduler-permission-to-roles.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const utils = require('../../../schema/fixtures/utils');
 
 const relationFixtures = {

--- a/core/server/data/migrations/versions/2.3/2-add-webhook-edit-permission.js
+++ b/core/server/data/migrations/versions/2.3/2-add-webhook-edit-permission.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const resources = ['webhook'];
 const _private = {};

--- a/core/server/data/migrations/versions/2.6/1-add-webhook-permission-roles.js
+++ b/core/server/data/migrations/versions/2.6/1-add-webhook-permission-roles.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const resources = ['webhook'];
 const _private = {};

--- a/core/server/data/migrations/versions/3.1/03-add-email-preview-permissions.js
+++ b/core/server/data/migrations/versions/3.1/03-add-email-preview-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const resources = ['email_preview'];
 const _private = {};

--- a/core/server/data/migrations/versions/3.1/06-add-email-permissions.js
+++ b/core/server/data/migrations/versions/3.1/06-add-email-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const resources = ['email'];
 const _private = {};

--- a/core/server/data/migrations/versions/3.1/09-add-further-email-permissions.js
+++ b/core/server/data/migrations/versions/3.1/09-add-further-email-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const resources = ['email'];
 const _private = {};

--- a/core/server/data/migrations/versions/3.6/3-add-labels-permissions.js
+++ b/core/server/data/migrations/versions/3.6/3-add-labels-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const resources = ['label'];
 const _private = {};

--- a/core/server/data/migrations/versions/3.7/01-fix-incorrect-member-labels-foreign-keys.js
+++ b/core/server/data/migrations/versions/3.7/01-fix-incorrect-member-labels-foreign-keys.js
@@ -1,4 +1,4 @@
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 const commands = require('../../../schema').commands;
 
 const table = 'members_labels';

--- a/core/server/data/migrations/versions/3.9/01-add-member-sigin-url-permissions.js
+++ b/core/server/data/migrations/versions/3.9/01-add-member-sigin-url-permissions.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const utils = require('../../../schema/fixtures/utils');
 const permissions = require('../../../../services/permissions');
-const logging = require('../../../../lib/common/logging');
+const {logging} = require('../../../../lib/common');
 
 const resources = ['member_signin_url'];
 const _private = {};

--- a/test/regression/api/admin_spec.js
+++ b/test/regression/api/admin_spec.js
@@ -6,12 +6,12 @@
 const should = require('should');
 
 const supertest = require('supertest');
-const testUtils = require('../../utils/index');
+const testUtils = require('../../utils');
 const configUtils = require('../../utils/configUtils');
 const urlUtils = require('../../utils/urlUtils');
 const ghost = testUtils.startGhost;
-const {i18n} = require('../../../core/server/lib/common/index');
-const config = require('../../../core/server/config/index');
+const {i18n} = require('../../../core/server/lib/common');
+const config = require('../../../core/server/config');
 let request;
 
 i18n.init();


### PR DESCRIPTION
- removed reference to `index` in admin regression test
- replaced import of `common/logging` with destructuring the "module" in migrations

lib/common is the "root" module, and all dependencies should come from this. This was missed in the first pass because the first pass was just searching for imports of `lib/common` while this is searching for `common/`