### PR TITLE
Removed invalid require in v2 input validator

### DIFF
--- a/core/server/api/v2/utils/validators/input/index.js
+++ b/core/server/api/v2/utils/validators/input/index.js
@@ -23,10 +23,6 @@ module.exports = {
         return require('./invitations');
     },
 
-    get members() {
-        return require('./members');
-    },
-
     get settings() {
         return require('./settings');
     },


### PR DESCRIPTION
no issue

Discovered in #11850 - the file `members.js` does not exist in `core/server/api/v2/utils/validators/input`