### PR TITLE
🐛 Fixed test email permissions for non-owner roles

### DIFF
--- a/core/server/data/migrations/versions/3.18/01-add-email-preview-permissions-to-roles.js
+++ b/core/server/data/migrations/versions/3.18/01-add-email-preview-permissions-to-roles.js
@@ -1,0 +1,36 @@
+const utils = require('../../../schema/fixtures/utils');
+const logging = require('../../../../../shared/logging');
+
+const resource = 'email_preview';
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up(options) {
+        const relationFixtures = utils.findPermissionRelationsForObject(resource);
+        try {
+            const result = await utils.addFixturesForRelation(relationFixtures, options);
+            const success = result.done === result.expected;
+            if (!success) {
+                return logging.warn('Adding email_preview permissions to roles (did not insert)');
+            }
+            return logging.info('Adding email_preview permissions to roles');
+        } catch (err) {
+            logging.error('Issue adding email_preview permissions to roles');
+            throw err;
+        }
+    },
+
+    async down(options) {
+        const relationFixtures = utils.findPermissionRelationsForObject(resource);
+        try {
+            await utils.removeFixturesForRelation(relationFixtures, options);
+            return logging.info('Removing email_preview permissions from roles');
+        } catch (err) {
+            logging.error('Issue removing email_preview permissions from roles');
+            throw err;
+        }
+    }
+};

--- a/test/api-acceptance/admin/email_preview_spec.js
+++ b/test/api-acceptance/admin/email_preview_spec.js
@@ -109,4 +109,99 @@ describe('Email Preview API', function () {
             });
         });
     });
+
+    describe('As Owner', function () {
+        it('can send test email', function () {
+            const url = localUtils.API.getApiQuery(`email_preview/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
+            return request
+                .post(url)
+                .set('Origin', config.get('url'))
+                .send({
+                    emails: ['test@ghost.org']
+                })
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+        });
+    });
+    describe('As Admin', function () {
+        before(function () {
+            testUtils.createUser({
+                user: testUtils.DataGenerator.forKnex.createUser({email: 'admin+1@ghost.org'}),
+                role: testUtils.DataGenerator.Content.roles[0].name
+            }).then((user) => {
+                request.user = user;
+                return localUtils.doAuth(request);
+            });
+        });
+
+        it('can send test email', function () {
+            const url = localUtils.API.getApiQuery(`email_preview/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
+            return request
+                .post(url)
+                .set('Origin', config.get('url'))
+                .send({
+                    emails: ['test@ghost.org']
+                })
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+        });
+    });
+    describe('As Editor', function () {
+        before(function () {
+            return testUtils.createUser({
+                user: testUtils.DataGenerator.forKnex.createUser({
+                    email: 'test+editor@ghost.org'
+                }),
+                role: testUtils.DataGenerator.Content.roles[1].name
+            }).then((user) => {
+                request.user = user;
+                return localUtils.doAuth(request);
+            });
+        });
+
+        it('can send test email', function () {
+            const url = localUtils.API.getApiQuery(`email_preview/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
+            return request
+                .post(url)
+                .set('Origin', config.get('url'))
+                .send({
+                    emails: ['test@ghost.org']
+                })
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+        });
+    });
+    describe('As Author', function () {
+        before(function () {
+            return testUtils.createUser({
+                user: testUtils.DataGenerator.forKnex.createUser({
+                    email: 'test+author@ghost.org'
+                }),
+                role: testUtils.DataGenerator.Content.roles[2].name
+            }).then((user) => {
+                request.user = user;
+                return localUtils.doAuth(request);
+            });
+        });
+
+        it('cannot send test email', function () {
+            const url = localUtils.API.getApiQuery(`email_preview/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
+            return request
+                .post(url)
+                .set('Origin', config.get('url'))
+                .send({
+                    emails: ['test@ghost.org']
+                })
+                .set('Accept', 'application/json')
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(403);
+        });
+    });
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/11841

- Adds migration mapping permissions and roles for email_preview `sendTestMail`
- Only owner previously had correct permission to send test emails
- Fixture existed to allow Admin/Editor/Integrations to send test mails but had missing migration
- Adds tests to check different roles for sending test emails 