### PR TITLE
Stripe Connect integration

### DIFF
--- a/core/server/api/canary/index.js
+++ b/core/server/api/canary/index.js
@@ -71,6 +71,10 @@ module.exports = {
         return shared.pipeline(require('./settings'), localUtils);
     },
 
+    get membersStripeConnect() {
+        return shared.pipeline(require('./membersStripeConnect'), localUtils);
+    },
+
     get members() {
         return shared.pipeline(require('./members'), localUtils);
     },

--- a/core/server/api/canary/membersStripeConnect.js
+++ b/core/server/api/canary/membersStripeConnect.js
@@ -1,0 +1,18 @@
+const membersService = require('../../services/members');
+
+module.exports = {
+    docName: 'members_stripe_connect',
+    auth: {
+        permissions: true,
+        query(frame) {
+            // This is something you have to do if you want to use the "framework" with access to the raw req/res
+            frame.response = async function (req, res) {
+                function setSessionProp(prop, val) {
+                    req.session[prop] = val;
+                }
+                const stripeConnectAuthURL = await membersService.stripeConnect.getStripeConnectOAuthUrl(setSessionProp);
+                return res.redirect(stripeConnectAuthURL);
+            };
+        }
+    }
+};

--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -3,8 +3,9 @@ const _ = require('lodash');
 const models = require('../../models');
 const routing = require('../../../frontend/services/routing');
 const {i18n} = require('../../lib/common');
-const {NoPermissionError, NotFoundError} = require('@tryghost/errors');
+const {BadRequestError, NoPermissionError, NotFoundError} = require('@tryghost/errors');
 const settingsCache = require('../../services/settings/cache');
+const membersService = require('../../services/members');
 
 const SETTINGS_BLACKLIST = [
     'members_public_key',
@@ -101,7 +102,13 @@ module.exports = {
             }
         },
         async query(frame) {
-            const settings = frame.data.settings;
+            const stripeConnectIntegrationToken = frame.data.settings.find(setting => setting.key === 'stripe_connect_integration_token');
+
+            // The `stripe_connect_integration_token` "setting" is only used to set the `stripe_connect_integration` setting.
+            // The `stripe_connect_integration` setting is not allowed to be set directly.
+            const settings = frame.data.settings.filter((setting) => {
+                return !['stripe_connect_integration', 'stripe_connect_integration_token'].includes(setting.key);
+            });
 
             const getSetting = setting => settingsCache.get(setting.key, {resolve: false});
 
@@ -120,6 +127,21 @@ module.exports = {
                 if (firstCoreSetting) {
                     throw new NoPermissionError({
                         message: i18n.t('errors.api.settings.accessCoreSettingFromExtReq')
+                    });
+                }
+            }
+
+            if (stripeConnectIntegrationToken) {
+                const getSessionProp = prop => frame.original.session[prop];
+                try {
+                    const data = await membersService.stripeConnect.getStripeConnectTokenData(stripeConnectIntegrationToken.value, getSessionProp);
+                    settings.push({
+                        key: 'stripe_connect_integration',
+                        value: JSON.stringify(data)
+                    });
+                } catch (err) {
+                    throw new BadRequestError({
+                        message: 'The Stripe Connect token could not be parsed.'
                     });
                 }
             }

--- a/core/server/data/migrations/versions/3.18/02-add-members_stripe_connect-auth-permissions.js
+++ b/core/server/data/migrations/versions/3.18/02-add-members_stripe_connect-auth-permissions.js
@@ -1,0 +1,56 @@
+const ObjectId = require('bson-objectid');
+const logging = require('../../../../../shared/logging');
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+    async up(options) {
+        const connection = options.transacting;
+
+        const existingIdentityPermission = await connection('permissions').where({
+            action_type: 'auth',
+            object_type: 'members_stripe_connect'
+        }).first();
+
+        if (existingIdentityPermission) {
+            logging.warn('Permission for auth:members_stripe_connect already added');
+            return;
+        }
+
+        logging.info('Adding permission for auth:members_stripe_connect');
+
+        const date = connection.raw('CURRENT_TIMESTAMP');
+
+        await connection('permissions').insert({
+            id: ObjectId.generate(),
+            name: 'Auth Stripe Connect for Members',
+            action_type: 'auth',
+            object_type: 'members_stripe_connect',
+            created_at: date,
+            created_by: 1,
+            updated_at: date,
+            updated_by: 1
+        });
+    },
+    async down(options) {
+        const connection = options.transacting;
+
+        const existingIdentityPermission = await connection('permissions').where({
+            action_type: 'auth',
+            object_type: 'members_stripe_connect'
+        }).first();
+
+        if (!existingIdentityPermission) {
+            logging.warn('Permission for auth:members_stripe_connect already removed');
+            return;
+        }
+
+        logging.info('Removing permission for auth:members_stripe_connect');
+
+        await connection('permissions').where({
+            action_type: 'auth',
+            object_type: 'members_stripe_connect'
+        }).del();
+    }
+};

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -214,6 +214,9 @@
         },
         "members_subscription_settings": {
             "defaultValue": "{\"fromAddress\":\"noreply\",\"allowSelfSignup\":true,\"paymentProcessors\":[{\"adapter\":\"stripe\",\"config\":{\"secret_token\":\"\",\"public_token\":\"\",\"product\":{\"name\":\"Ghost Subscription\"},\"plans\":[{\"name\":\"Monthly\",\"currency\":\"usd\",\"interval\":\"month\",\"amount\":\"\"},{\"name\":\"Yearly\",\"currency\":\"usd\",\"interval\":\"year\",\"amount\":\"\"}]}}]}"
+        },
+        "stripe_connect_integration": {
+            "defaultValue": "{}"
         }
     },
     "bulk_email": {

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -422,6 +422,11 @@
                     "name": "Read identities",
                     "action_type": "read",
                     "object_type": "identity"
+                },
+                {
+                    "name": "Auth Stripe Connect for Members",
+                    "action_type": "auth",
+                    "object_type": "members_stripe_connect"
                 }
             ]
         },

--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -6,13 +6,12 @@ const models = require('../../models');
 const signinEmail = require('./emails/signin');
 const signupEmail = require('./emails/signup');
 const subscribeEmail = require('./emails/subscribe');
-const config = require('./config');
 
 const ghostMailer = new mail.GhostMailer();
 
 module.exports = createApiInstance;
 
-function createApiInstance() {
+function createApiInstance(config) {
     const membersApiInstance = MembersApi({
         tokenConfig: config.getTokenConfig(),
         auth: {

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -1,10 +1,6 @@
 const {URL} = require('url');
-const settingsCache = require('../settings/cache');
-const ghostVersion = require('../../lib/ghost-version');
 const crypto = require('crypto');
 const path = require('path');
-const logging = require('../../../shared/logging');
-const urlUtils = require('../../../shared/url-utils');
 
 const COMPLIMENTARY_PLAN = {
     name: 'Complimentary',
@@ -13,161 +9,170 @@ const COMPLIMENTARY_PLAN = {
     amount: '0'
 };
 
-// NOTE: the function is an exact duplicate of one in GhostMailer should be extracted
-//       into a common lib once it needs to be reused anywhere else again
-function getDomain() {
-    const domain = urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
-    return domain && domain[1];
-}
+class MembersConfigProvider {
+    /**
+     * @param {object} options
+     * @param {{get: (key: string) => any}} options.settingsCache
+     * @param {{get: (key: string) => any}} options.config
+     * @param {any} options.urlUtils
+     * @param {any} options.logging
+     * @param {{original: string}} options.ghostVersion
+     */
+    constructor(options) {
+        this._settingsCache = options.settingsCache;
+        this._config = options.config;
+        this._urlUtils = options.urlUtils;
+        this._logging = options.logging;
+        this._ghostVersion = options.ghostVersion;
+    }
 
-function getEmailFromAddress() {
-    const subscriptionSettings = settingsCache.get('members_subscription_settings') || {};
+    /**
+     * @private
+     */
+    _getDomain() {
+        const domain = this._urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
+        return domain && domain[1];
+    }
 
-    return `${subscriptionSettings.fromAddress || 'noreply'}@${getDomain()}`;
-}
+    /**
+     */
+    getEmailFromAddress() {
+        const subscriptionSettings = this._settingsCache.get('members_subscription_settings') || {};
 
-/** Copied from theme middleware, remove it there after cleanup to keep this in single place */
-function getPublicPlans() {
-    const CURRENCY_SYMBOLS = {
-        USD: '$',
-        AUD: '$',
-        CAD: '$',
-        GBP: '£',
-        EUR: '€'
-    };
-    const defaultPriceData = {
-        monthly: 0,
-        yearly: 0
-    };
+        return `${subscriptionSettings.fromAddress || 'noreply'}@${this._getDomain()}`;
+    }
 
-    try {
-        const membersSettings = settingsCache.get('members_subscription_settings');
-        const stripeProcessor = membersSettings.paymentProcessors.find(
-            processor => processor.adapter === 'stripe'
+    getPublicPlans() {
+        const CURRENCY_SYMBOLS = {
+            USD: '$',
+            AUD: '$',
+            CAD: '$',
+            GBP: '£',
+            EUR: '€'
+        };
+        const defaultPriceData = {
+            monthly: 0,
+            yearly: 0
+        };
+
+        try {
+            const membersSettings = this._settingsCache.get('members_subscription_settings');
+            const stripeProcessor = membersSettings.paymentProcessors.find(
+                processor => processor.adapter === 'stripe'
+            );
+
+            const priceData = stripeProcessor.config.plans.reduce((prices, plan) => {
+                const numberAmount = 0 + plan.amount;
+                const dollarAmount = numberAmount ? Math.round(numberAmount / 100) : 0;
+                return Object.assign(prices, {
+                    [plan.name.toLowerCase()]: dollarAmount
+                });
+            }, {});
+
+            priceData.currency = String.prototype.toUpperCase.call(stripeProcessor.config.currency || 'usd');
+            priceData.currency_symbol = CURRENCY_SYMBOLS[priceData.currency];
+
+            if (Number.isInteger(priceData.monthly) && Number.isInteger(priceData.yearly)) {
+                return priceData;
+            }
+
+            return defaultPriceData;
+        } catch (err) {
+            return defaultPriceData;
+        }
+    }
+
+    getStripePaymentConfig() {
+        const subscriptionSettings = this._settingsCache.get('members_subscription_settings');
+
+        const stripePaymentProcessor = subscriptionSettings.paymentProcessors.find(
+            paymentProcessor => paymentProcessor.adapter === 'stripe'
         );
 
-        const priceData = stripeProcessor.config.plans.reduce((prices, plan) => {
-            const numberAmount = 0 + plan.amount;
-            const dollarAmount = numberAmount ? Math.round(numberAmount / 100) : 0;
-            return Object.assign(prices, {
-                [plan.name.toLowerCase()]: dollarAmount
-            });
-        }, {});
-
-        priceData.currency = String.prototype.toUpperCase.call(stripeProcessor.config.currency || 'usd');
-        priceData.currency_symbol = CURRENCY_SYMBOLS[priceData.currency];
-
-        if (Number.isInteger(priceData.monthly) && Number.isInteger(priceData.yearly)) {
-            return priceData;
+        if (!stripePaymentProcessor || !stripePaymentProcessor.config) {
+            return null;
         }
 
-        return defaultPriceData;
-    } catch (err) {
-        return defaultPriceData;
-    }
-}
-
-const getApiUrl = ({version, type}) => {
-    const {href} = new URL(
-        urlUtils.getApiPath({version, type}),
-        urlUtils.urlFor('admin', true)
-    );
-    return href;
-};
-
-const siteUrl = urlUtils.getSiteUrl();
-const membersApiUrl = getApiUrl({version: 'v3', type: 'members'});
-
-function getStripePaymentConfig() {
-    const subscriptionSettings = settingsCache.get('members_subscription_settings');
-
-    const stripePaymentProcessor = subscriptionSettings.paymentProcessors.find(
-        paymentProcessor => paymentProcessor.adapter === 'stripe'
-    );
-
-    if (!stripePaymentProcessor || !stripePaymentProcessor.config) {
-        return null;
-    }
-
-    if (!stripePaymentProcessor.config.public_token || !stripePaymentProcessor.config.secret_token) {
-        return null;
-    }
-
-    // NOTE: "Complimentary" plan has to be first in the queue so it is created even if regular plans are not configured
-    stripePaymentProcessor.config.plans.unshift(COMPLIMENTARY_PLAN);
-
-    const webhookHandlerUrl = new URL('/members/webhooks/stripe', siteUrl);
-
-    const checkoutSuccessUrl = new URL(siteUrl);
-    checkoutSuccessUrl.searchParams.set('stripe', 'success');
-    const checkoutCancelUrl = new URL(siteUrl);
-    checkoutCancelUrl.searchParams.set('stripe', 'cancel');
-
-    const billingSuccessUrl = new URL(siteUrl);
-    billingSuccessUrl.searchParams.set('stripe', 'billing-update-success');
-    const billingCancelUrl = new URL(siteUrl);
-    billingCancelUrl.searchParams.set('stripe', 'billing-update-cancel');
-
-    return {
-        publicKey: stripePaymentProcessor.config.public_token,
-        secretKey: stripePaymentProcessor.config.secret_token,
-        checkoutSuccessUrl: checkoutSuccessUrl.href,
-        checkoutCancelUrl: checkoutCancelUrl.href,
-        billingSuccessUrl: billingSuccessUrl.href,
-        billingCancelUrl: billingCancelUrl.href,
-        webhookHandlerUrl: webhookHandlerUrl.href,
-        product: stripePaymentProcessor.config.product,
-        plans: stripePaymentProcessor.config.plans,
-        appInfo: {
-            name: 'Ghost',
-            partner_id: 'pp_partner_DKmRVtTs4j9pwZ',
-            version: ghostVersion.original,
-            url: 'https://ghost.org/'
+        if (!stripePaymentProcessor.config.public_token || !stripePaymentProcessor.config.secret_token) {
+            return null;
         }
-    };
-}
 
-function getAuthSecret() {
-    const hexSecret = settingsCache.get('members_email_auth_secret');
-    if (!hexSecret) {
-        logging.warn('Could not find members_email_auth_secret, using dynamically generated secret');
-        return crypto.randomBytes(64);
+        // NOTE: "Complimentary" plan has to be first in the queue so it is created even if regular plans are not configured
+        stripePaymentProcessor.config.plans.unshift(COMPLIMENTARY_PLAN);
+
+        const siteUrl = this._urlUtils.getSiteUrl();
+
+        const webhookHandlerUrl = new URL('/members/webhooks/stripe', siteUrl);
+
+        const checkoutSuccessUrl = new URL(siteUrl);
+        checkoutSuccessUrl.searchParams.set('stripe', 'success');
+        const checkoutCancelUrl = new URL(siteUrl);
+        checkoutCancelUrl.searchParams.set('stripe', 'cancel');
+
+        const billingSuccessUrl = new URL(siteUrl);
+        billingSuccessUrl.searchParams.set('stripe', 'billing-update-success');
+        const billingCancelUrl = new URL(siteUrl);
+        billingCancelUrl.searchParams.set('stripe', 'billing-update-cancel');
+
+        return {
+            publicKey: stripePaymentProcessor.config.public_token,
+            secretKey: stripePaymentProcessor.config.secret_token,
+            checkoutSuccessUrl: checkoutSuccessUrl.href,
+            checkoutCancelUrl: checkoutCancelUrl.href,
+            billingSuccessUrl: billingSuccessUrl.href,
+            billingCancelUrl: billingCancelUrl.href,
+            webhookHandlerUrl: webhookHandlerUrl.href,
+            product: stripePaymentProcessor.config.product,
+            plans: stripePaymentProcessor.config.plans,
+            appInfo: {
+                name: 'Ghost',
+                partner_id: 'pp_partner_DKmRVtTs4j9pwZ',
+                version: this._ghostVersion.original,
+                url: 'https://ghost.org/'
+            }
+        };
     }
-    const secret = Buffer.from(hexSecret, 'hex');
-    if (secret.length < 64) {
-        logging.warn('members_email_auth_secret not large enough (64 bytes), using dynamically generated secret');
-        return crypto.randomBytes(64);
+
+    getAuthSecret() {
+        const hexSecret = this._settingsCache.get('members_email_auth_secret');
+        if (!hexSecret) {
+            this._logging.warn('Could not find members_email_auth_secret, using dynamically generated secret');
+            return crypto.randomBytes(64);
+        }
+        const secret = Buffer.from(hexSecret, 'hex');
+        if (secret.length < 64) {
+            this._logging.warn('members_email_auth_secret not large enough (64 bytes), using dynamically generated secret');
+            return crypto.randomBytes(64);
+        }
+        return secret;
     }
-    return secret;
+
+    getAllowSelfSignup() {
+        const subscriptionSettings = this._settingsCache.get('members_subscription_settings');
+        return subscriptionSettings.allowSelfSignup;
+    }
+
+    getTokenConfig() {
+        const {href: membersApiUrl} = new URL(
+            this._urlUtils.getApiPath({version: 'v3', type: 'members'}),
+            this._urlUtils.urlFor('admin', true)
+        );
+
+        return {
+            issuer: membersApiUrl,
+            publicKey: this._settingsCache.get('members_public_key'),
+            privateKey: this._settingsCache.get('members_private_key')
+        };
+    }
+
+    getSigninURL(token, type) {
+        const siteUrl = this._urlUtils.getSiteUrl();
+        const signinURL = new URL(siteUrl);
+        signinURL.pathname = path.join(signinURL.pathname, '/members/');
+        signinURL.searchParams.set('token', token);
+        signinURL.searchParams.set('action', type);
+        return signinURL.href;
+    }
 }
 
-function getAllowSelfSignup() {
-    const subscriptionSettings = settingsCache.get('members_subscription_settings');
-    return subscriptionSettings.allowSelfSignup;
-}
-
-function getTokenConfig() {
-    return {
-        issuer: membersApiUrl,
-        publicKey: settingsCache.get('members_public_key'),
-        privateKey: settingsCache.get('members_private_key')
-    };
-}
-
-function getSigninURL(token, type) {
-    const signinURL = new URL(siteUrl);
-    signinURL.pathname = path.join(signinURL.pathname, '/members/');
-    signinURL.searchParams.set('token', token);
-    signinURL.searchParams.set('action', type);
-    return signinURL.href;
-}
-
-module.exports = {
-    getEmailFromAddress,
-    getPublicPlans,
-    getStripePaymentConfig,
-    getAllowSelfSignup,
-    getAuthSecret,
-    getTokenConfig,
-    getSigninURL
-};
+module.exports = MembersConfigProvider;

--- a/core/server/services/members/index.js
+++ b/core/server/services/members/index.js
@@ -45,7 +45,9 @@ const membersService = {
         cookieName: 'ghost-members-ssr',
         cookieCacheName: 'ghost-members-ssr-cache',
         getMembersApi: () => membersService.api
-    })
+    }),
+
+    stripeConnect: require('./stripe-connect')
 };
 
 module.exports = membersService;

--- a/core/server/services/members/index.js
+++ b/core/server/services/members/index.js
@@ -1,10 +1,21 @@
 const MembersSSR = require('@tryghost/members-ssr');
 
+const MembersConfigProvider = require('./config');
 const createMembersApiInstance = require('./api');
 const {events} = require('../../lib/common');
 const logging = require('../../../shared/logging');
 const urlUtils = require('../../../shared/url-utils');
 const settingsCache = require('../settings/cache');
+const config = require('../../../shared/config');
+const ghostVersion = require('../../lib/ghost-version');
+
+const membersConfig = new MembersConfigProvider({
+    config,
+    settingsCache,
+    urlUtils,
+    logging,
+    ghostVersion
+});
 
 let membersApi;
 
@@ -14,7 +25,7 @@ events.on('settings.edited', function updateSettingFromModel(settingModel) {
         return;
     }
 
-    const reconfiguredMembersAPI = createMembersApiInstance();
+    const reconfiguredMembersAPI = createMembersApiInstance(membersConfig);
     reconfiguredMembersAPI.bus.on('ready', function () {
         membersApi = reconfiguredMembersAPI;
     });
@@ -26,11 +37,11 @@ events.on('settings.edited', function updateSettingFromModel(settingModel) {
 const membersService = {
     contentGating: require('./content-gating'),
 
-    config: require('./config'),
+    config: membersConfig,
 
     get api() {
         if (!membersApi) {
-            membersApi = createMembersApiInstance();
+            membersApi = createMembersApiInstance(membersConfig);
 
             membersApi.bus.on('error', function (err) {
                 logging.error(err);

--- a/core/server/services/members/stripe-connect.js
+++ b/core/server/services/members/stripe-connect.js
@@ -1,0 +1,62 @@
+const {Buffer} = require('buffer');
+const {randomBytes} = require('crypto');
+const {URL} = require('url');
+
+const STATE_PROP = 'stripe-connect-state';
+
+const clientID = 'ca_8LBuZWhYshxF0A55KgCXu8PRTquCKC5x';
+const redirectURI = 'https://stripe.ghost.org';
+
+/**
+ * @function getStripeConnectOAuthUrl
+ * @desc Returns a url for the auth endpoint for Stripe Connect, generates state and stores it on the session.
+ *
+ * @param {(prop: string, val: any) => Promise<void>} setSessionProp - A function to set data on the current session
+ *
+ * @returns {Promise<URL>}
+ */
+async function getStripeConnectOAuthUrl(setSessionProp) {
+    const state = randomBytes(16).toString('hex');
+
+    await setSessionProp(STATE_PROP, state);
+
+    const authUrl = new URL('https://connect.stripe.com/oauth/authorize');
+    authUrl.searchParams.set('response_type', 'code');
+    authUrl.searchParams.set('scope', 'read_write');
+    authUrl.searchParams.set('client_id', clientID);
+    authUrl.searchParams.set('redirect_uri', redirectURI);
+    authUrl.searchParams.set('state', state);
+
+    return authUrl;
+}
+
+/**
+ * @function getStripeConnectTokenData
+ * @desc Returns the api keys and the livemode for a Stripe Connect integration after validating the state.
+ *
+ * @param {string} encodedData - A string encoding the response from Stripe Connect
+ * @param {(prop: string) => Promise<any>} getSessionProp - A function to retrieve data from the current session
+ *
+ * @returns {Promise<{secret_key: string, public_key: string, livemode: boolean}>}
+ */
+async function getStripeConnectTokenData(encodedData, getSessionProp) {
+    const data = JSON.parse(Buffer.from(encodedData, 'base64').toString());
+
+    const state = await getSessionProp(STATE_PROP);
+
+    if (state !== data.s) {
+        throw new Error('State did not match');
+    }
+
+    return {
+        public_key: data.p,
+        secret_key: data.a,
+        livemode: data.l
+    };
+}
+
+module.exports = {
+    getStripeConnectOAuthUrl,
+    getStripeConnectTokenData,
+    STATE_PROP
+};

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -97,6 +97,8 @@ module.exports = function apiRoutes() {
         http(apiCanary.members.importCSV)
     );
 
+    router.get('/members/stripe_connect', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.membersStripeConnect.auth));
+
     router.get('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.read));
     router.put('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.edit));
     router.del('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.destroy));

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -20,7 +20,7 @@ const fixtures = require('../../../../core/server/data/schema/fixtures');
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '7cd198f085844aa5725964069b051189';
-    const currentFixturesHash = '1e5856f5172a4389bd72a98b388792e6';
+    const currentFixturesHash = '94cf7dfe95e88022b3515c9664af2e66';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation

--- a/test/unit/models/settings_spec.js
+++ b/test/unit/models/settings_spec.js
@@ -4,6 +4,7 @@ const mockDb = require('mock-knex');
 const models = require('../../../core/server/models');
 const {knex} = require('../../../core/server/data/db');
 const {events} = require('../../../core/server/lib/common');
+const defaultSettings = require('../../../core/server/data/schema/default-settings');
 
 describe('Unit: models/settings', function () {
     before(function () {
@@ -113,8 +114,12 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
+                    const numberOfSettings = Object.keys(defaultSettings).reduce((settings, settingGroup) => {
+                        return settings.concat(Object.keys(defaultSettings[settingGroup]));
+                    }, []).length;
                     // 2 events per item - settings.added and settings.[name].added
-                    eventSpy.callCount.should.equal(92);
+                    eventSpy.callCount.should.equal(numberOfSettings * 2);
+
                     const eventsEmitted = eventSpy.args.map(args => args[0]);
                     const checkEventEmitted = event => should.ok(eventsEmitted.includes(event), `${event} event should be emitted`);
 

--- a/test/unit/services/members/config_spec.js
+++ b/test/unit/services/members/config_spec.js
@@ -1,0 +1,136 @@
+const should = require('should');
+const MembersConfigProvider = require('../../../../core/server/services/members/config');
+const urlUtils = require('../../../../core/shared/url-utils');
+const sinon = require('sinon');
+
+/**
+ * @param {object} options
+ * @param {boolean} options.stripeDirectValue - The value the stripeDirect config property should have
+ */
+function createConfigMock({stripeDirectValue}) {
+    return {
+        get: sinon.stub()
+            .withArgs('stripeDirect').returns(stripeDirectValue)
+    };
+}
+
+/**
+ * @param {object} options
+ * @param {boolean} options.setDirect - Whether the "direct" keys should be set
+ * @param {boolean} options.setConnect - Whether the connect_integration keys should be set
+ */
+
+function createSettingsMock({setDirect, setConnect}) {
+    const membersSubscriptionSettings = {
+        fromAddress: 'noreply',
+        allowSelfSignup: true,
+        paymentProcessors: [{
+            adapter: 'stripe',
+            config: {
+                secret_token: setDirect ? 'direct_secret' : null,
+                public_token: setDirect ? 'direct_public' : null,
+                product: {
+                    name: 'Test'
+                },
+                plans: [{
+                    name: 'Monthly',
+                    currency: 'usd',
+                    interval: 'month',
+                    amount: 1000
+                }, {
+                    name: 'Yearly',
+                    currency: 'usd',
+                    interval: 'year',
+                    amount: 10000
+                }]
+            }
+        }]
+    };
+
+    const stripeConnectIntegration = {
+        secret_key: setConnect ? 'connect_secret' : null,
+        public_key: setConnect ? 'connect_public' : null,
+        livemode: true
+    };
+
+    const getStub = sinon.stub();
+
+    getStub.withArgs('members_subscription_settings').returns(membersSubscriptionSettings);
+    getStub.withArgs('stripe_connect_integration').returns(stripeConnectIntegration);
+    return {
+        get: getStub
+    };
+}
+
+describe('Members - config', function () {
+    it('Uses direct keys when stripeDirect is true, regardles of which keys exist', function () {
+        const config = createConfigMock({stripeDirectValue: true});
+        const settingsCache = createSettingsMock({setDirect: true, setConnect: Math.random() < 0.5});
+
+        const membersConfig = new MembersConfigProvider({
+            config,
+            settingsCache,
+            urlUtils,
+            ghostVersion: {original: 'v7357'},
+            logging: console
+        });
+
+        const paymentConfig = membersConfig.getStripePaymentConfig();
+
+        should.equal(paymentConfig.publicKey, 'direct_public');
+        should.equal(paymentConfig.secretKey, 'direct_secret');
+    });
+
+    it('Does not use connect keys if stripeDirect is true, and the direct keys do not exist', function () {
+        const config = createConfigMock({stripeDirectValue: true});
+        const settingsCache = createSettingsMock({setDirect: false, setConnect: true});
+
+        const membersConfig = new MembersConfigProvider({
+            config,
+            settingsCache,
+            urlUtils,
+            ghostVersion: {original: 'v7357'},
+            logging: console
+        });
+
+        const paymentConfig = membersConfig.getStripePaymentConfig();
+
+        should.equal(paymentConfig, null);
+    });
+
+    it('Uses connect keys when stripeDirect is false, and the connect keys exist', function () {
+        const config = createConfigMock({stripeDirectValue: false});
+        const settingsCache = createSettingsMock({setDirect: true, setConnect: true});
+
+        const membersConfig = new MembersConfigProvider({
+            config,
+            settingsCache,
+            urlUtils,
+            ghostVersion: {original: 'v7357'},
+            logging: console
+        });
+
+        const paymentConfig = membersConfig.getStripePaymentConfig();
+
+        should.equal(paymentConfig.publicKey, 'connect_public');
+        should.equal(paymentConfig.secretKey, 'connect_secret');
+    });
+
+    it('Uses direct keys when stripeDirect is false, but the connect keys do not exist', function () {
+        const config = createConfigMock({stripeDirectValue: false});
+        const settingsCache = createSettingsMock({setDirect: true, setConnect: false});
+
+        const membersConfig = new MembersConfigProvider({
+            config,
+            settingsCache,
+            urlUtils,
+            ghostVersion: {original: 'v7357'},
+            logging: console
+        });
+
+        const paymentConfig = membersConfig.getStripePaymentConfig();
+
+        should.equal(paymentConfig.publicKey, 'direct_public');
+        should.equal(paymentConfig.secretKey, 'direct_secret');
+    });
+});

--- a/test/unit/services/members/stripe-connect_spec.js
+++ b/test/unit/services/members/stripe-connect_spec.js
@@ -1,0 +1,61 @@
+const should = require('should');
+const stripeConnect = require('../../../../core/server/services/members/stripe-connect');
+
+describe('Members - Stripe Connect', function () {
+    it('getStripeConnectOAuthUrl returns the correct url and sets the necessary state on session and url', async function () {
+        const session = new Map();
+        const setSessionProp = session.set.bind(session);
+
+        /** @type URL */
+        const url = await stripeConnect.getStripeConnectOAuthUrl(setSessionProp);
+
+        should.ok(url instanceof URL, 'getStripeConnectOAuthUrl should return an instance of URL');
+
+        should.exist(session.get(stripeConnect.STATE_PROP), 'The session should have a state set');
+
+        should.equal(url.origin, 'https://connect.stripe.com');
+        should.equal(url.pathname, '/oauth/authorize');
+
+        should.equal(url.searchParams.get('response_type'), 'code');
+        should.equal(url.searchParams.get('scope'), 'read_write');
+        should.equal(url.searchParams.get('state'), session.get(stripeConnect.STATE_PROP));
+    });
+
+    it('getStripeConnectTokenData returns token data when the state is correct', async function () {
+        const getSessionProp = prop => 'correct_state';
+
+        const data = {
+            p: 'publishable_stripe_key',
+            a: 'access_token',
+            l: 'livemode',
+            s: 'correct_state'
+        };
+
+        const encodedData = Buffer.from(JSON.stringify(data)).toString('base64');
+
+        const tokenData = await stripeConnect.getStripeConnectTokenData(encodedData, getSessionProp);
+
+        should.equal(tokenData.public_key, data.p);
+        should.equal(tokenData.secret_key, data.a);
+        should.equal(tokenData.livemode, data.l);
+    });
+
+    it('getStripeConnectTokenData throws when the state is incorrect', async function () {
+        const getSessionProp = prop => 'incorrect_state';
+
+        const data = {
+            p: 'publishable_stripe_key',
+            a: 'access_token',
+            l: 'livemode',
+            s: 'correct_state'
+        };
+
+        const encodedData = Buffer.from(JSON.stringify(data)).toString('base64');
+
+        await stripeConnect.getStripeConnectTokenData(encodedData, getSessionProp).then((success) => {
+            throw new Error('The token data should not be returned if the state is incorrect');
+        }, (error) => {
+            should.ok(error);
+        });
+    });
+});


### PR DESCRIPTION
no-issue

This is a WIP of wiring up Ghost to work with Stripe Connect and includes a few changes/additions

- `stripe-connect` module in the members service
	- This handles creating the stripe connect auth link & parsing the result
- `membersStripeConnect` controller
    - This is an API controller which issues a redirect to the stripe auth link
- `settings` controller
    - This has been updated to accept `stripe_connect_integration_tokens` in order to configure Stripe Connect
- `MembersConfigProvider` The existing members config has been wrapped in a class, so that we can pass settings/config to it, making it easier and quicker to test

@naz I would _love_ if you could look at the changes in the API, both the `membersStripeConnect` and `settings` controllers, check it makes sense to you, and that I'm not breaking any patterns!

@ErisDS It would be cool for you to look at the last commit, and check the `stripeDirect` config switch is working as you wanted it to (I've tried to give the tests decent names)