### PR TITLE
🔥 Updated minimum Node versions to latest security releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.18.0'
       - run: yarn
 
       - run: grunt release --skip-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: [ '10.13.0', '12.10.0' ]
+        node: [ '10.21.0', '12.18.0' ]
         env:
           - DB: sqlite3
             NODE_ENV: testing
@@ -60,7 +60,7 @@ jobs:
           submodules: true
       - uses: actions/setup-node@v1
         with:
-          node-version: '10.13.0'
+          node-version: '10.21.0'
       - run: npm install -g ghost-cli@latest
       - run: zip -r ghost.zip .
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fixmodulenotdefined": "yarn cache clean && cd core/client && rm -rf node_modules tmp dist && yarn && cd ../../"
   },
   "engines": {
-    "node": "^10.13.0 || ^12.10.0",
+    "node": "^10.21.0 || ^12.18.0",
     "cli": "^1.12.0"
   },
   "dependencies": {


### PR DESCRIPTION
no issue

- Node 10.21.0 and 12.18.0 are the latest security releases

Not to be merged yet because there is another security release slated for today - https://nodejs.org/en/blog/vulnerability/june-2020-security-releases/

We also want to give some time for package managers to have this available.