### PR TITLE
Added migration for updating members from address with domain

### DIFF
--- a/core/server/data/migrations/versions/3.19/01-update-member-from-email-address.js
+++ b/core/server/data/migrations/versions/3.19/01-update-member-from-email-address.js
@@ -1,0 +1,91 @@
+const logging = require('../../../../../shared/logging');
+const urlUtils = require('../../../../../shared/url-utils');
+const debug = require('ghost-ignition').debug('migrations');
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = (options) => {
+    const settingsKey = 'members_subscription_settings';
+
+    return options
+        .transacting('settings')
+        .where('key', settingsKey)
+        .select('value')
+        .first()
+        .then((subscriptionSettingsEntry) => {
+            debug(subscriptionSettingsEntry);
+            if (!subscriptionSettingsEntry) {
+                logging.warn(`Cannot find ${settingsKey} settings.`);
+                return;
+            }
+
+            let subscriptionSettings = JSON.parse(subscriptionSettingsEntry.value);
+
+            debug('before cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            const hasFromAddress = Object.prototype.hasOwnProperty.call(subscriptionSettings, 'fromAddress');
+            const domain = urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
+            const blogDomain = domain && domain[1];
+            if (hasFromAddress && blogDomain) {
+                logging.info(`Updating fromAddress in members settings with domain ${blogDomain}`);
+
+                subscriptionSettings.fromAddress = `${subscriptionSettings.fromAddress}@${blogDomain}`;
+
+                debug('after cleanup');
+                debug(JSON.stringify(subscriptionSettings, null, 2));
+
+                return options
+                    .transacting('settings')
+                    .where('key', settingsKey)
+                    .update({
+                        value: JSON.stringify(subscriptionSettings)
+                    });
+            }
+        });
+};
+
+module.exports.down = (options) => {
+    const settingsKey = 'members_subscription_settings';
+
+    return options
+        .transacting('settings')
+        .where('key', settingsKey)
+        .select('value')
+        .first()
+        .then((subscriptionSettingsEntry) => {
+            debug(subscriptionSettingsEntry);
+            if (!subscriptionSettingsEntry) {
+                logging.warn(`Cannot find ${settingsKey} settings.`);
+                return;
+            }
+
+            let subscriptionSettings = JSON.parse(subscriptionSettingsEntry.value);
+
+            debug('before cleanup');
+            debug(JSON.stringify(subscriptionSettings, null, 2));
+
+            const hasFromAddress = Object.prototype.hasOwnProperty.call(subscriptionSettings, 'fromAddress');
+
+            if (hasFromAddress) {
+                logging.info('Removing domain in fromAddress in members settings');
+                subscriptionSettings.fromAddress = subscriptionSettings.fromAddress.split('@')[0];
+
+                debug('after cleanup');
+                debug(JSON.stringify(subscriptionSettings, null, 2));
+
+                return options
+                    .transacting('settings')
+                    .where('key', settingsKey)
+                    .update({
+                        value: JSON.stringify(subscriptionSettings)
+                    });
+            }
+        });
+};
+
+module.exports.config = {
+    transaction: true
+};


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/11414

We want to allow adding custom domains to member's from address as long as the new email is verified using the magic link flow and not saved directly to DB. Since we currently don't store domain as part of fromAddress, this PR -

- adds migration to update all existing fromAddress by appending site domain