### PR TITLE
Members stripe enabled cleanup

### DIFF
--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -2,7 +2,7 @@
 // Usage: `{{ghost_head}}`
 //
 // Outputs scripts and other assets at the top of a Ghost theme
-const {metaData, escapeExpression, SafeString, logging, settingsCache, config, blogIcon, labs} = require('../services/proxy');
+const {metaData, escapeExpression, SafeString, logging, settingsCache, members, config, blogIcon, labs} = require('../services/proxy');
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('ghost_head');
 
@@ -37,17 +37,11 @@ function finaliseStructuredData(metaData) {
 }
 
 function getMembersHelper() {
-    const stripePaymentProcessor = settingsCache.get('members_subscription_settings').paymentProcessors.find(
-        paymentProcessor => paymentProcessor.adapter === 'stripe'
-    );
-    const stripeSecretToken = stripePaymentProcessor.config.secret_token;
-    const stripePublicToken = stripePaymentProcessor.config.public_token;
-
     let membersHelper = `<script defer src="${getAssetUrl('public/members.js', true)}"></script>`;
     if (config.get('enableDeveloperExperiments')) {
         membersHelper = `<script defer src="https://unpkg.com/@tryghost/members-js@latest/umd/members.min.js"></script>`;
     }
-    if (!!stripeSecretToken && stripeSecretToken !== '' && !!stripePublicToken && stripePublicToken !== '') {
+    if (members.config.isStripeConnected()) {
         membersHelper += '<script src="https://js.stripe.com/v3/"></script>';
     }
     return membersHelper;

--- a/core/frontend/services/proxy.js
+++ b/core/frontend/services/proxy.js
@@ -27,6 +27,9 @@ module.exports = {
     // TODO: Only expose "get"
     settingsCache: settingsCache,
 
+    // TODO: Rethink how we get config in
+    members: require('../../server/services/members'),
+
     // These 3 are kind of core and required all the time
     errors,
     i18n,


### PR DESCRIPTION
no-issue

This cleans up any remaining places where references are made directly to the `secret_token` stored in `members_subscription_settings`. 
