### PR TITLE
Stripe connect test mode

### DIFF
--- a/core/server/api/canary/membersStripeConnect.js
+++ b/core/server/api/canary/membersStripeConnect.js
@@ -4,13 +4,24 @@ module.exports = {
     docName: 'members_stripe_connect',
     auth: {
         permissions: true,
+        options: [
+            'mode'
+        ],
+        validation: {
+            options: {
+                mode: {
+                    values: ['live', 'test']
+                }
+            }
+        },
         query(frame) {
             // This is something you have to do if you want to use the "framework" with access to the raw req/res
             frame.response = async function (req, res) {
                 function setSessionProp(prop, val) {
                     req.session[prop] = val;
                 }
-                const stripeConnectAuthURL = await membersService.stripeConnect.getStripeConnectOAuthUrl(setSessionProp);
+                const mode = frame.options.mode || 'live';
+                const stripeConnectAuthURL = await membersService.stripeConnect.getStripeConnectOAuthUrl(setSessionProp, mode);
                 return res.redirect(stripeConnectAuthURL);
             };
         }

--- a/core/server/services/members/stripe-connect.js
+++ b/core/server/services/members/stripe-connect.js
@@ -4,7 +4,8 @@ const {URL} = require('url');
 
 const STATE_PROP = 'stripe-connect-state';
 
-const clientID = 'ca_8LBuZWhYshxF0A55KgCXu8PRTquCKC5x';
+const liveClientID = 'ca_8LBuZWhYshxF0A55KgCXu8PRTquCKC5x';
+const testClientID = 'ca_8LBum4Ctv3mmJ1oD0ZRmxjdAhNrrBUy3';
 const redirectURI = 'https://stripe.ghost.org';
 
 /**
@@ -12,13 +13,16 @@ const redirectURI = 'https://stripe.ghost.org';
  * @desc Returns a url for the auth endpoint for Stripe Connect, generates state and stores it on the session.
  *
  * @param {(prop: string, val: any) => Promise<void>} setSessionProp - A function to set data on the current session
+ * @param {'live' | 'test'} mode - Which stripe mode to set up
  *
  * @returns {Promise<URL>}
  */
-async function getStripeConnectOAuthUrl(setSessionProp) {
+async function getStripeConnectOAuthUrl(setSessionProp, mode = 'live') {
     const state = randomBytes(16).toString('hex');
 
     await setSessionProp(STATE_PROP, state);
+
+    const clientID = mode === 'live' ? liveClientID : testClientID;
 
     const authUrl = new URL('https://connect.stripe.com/oauth/authorize');
     authUrl.searchParams.set('response_type', 'code');

--- a/core/server/services/members/stripe-connect.js
+++ b/core/server/services/members/stripe-connect.js
@@ -18,7 +18,11 @@ const redirectURI = 'https://stripe.ghost.org';
  * @returns {Promise<URL>}
  */
 async function getStripeConnectOAuthUrl(setSessionProp, mode = 'live') {
-    const state = randomBytes(16).toString('hex');
+    const randomState = randomBytes(16).toString('hex');
+    const state = Buffer.from(JSON.stringify({
+        mode,
+        randomState
+    })).toString('base64');
 
     await setSessionProp(STATE_PROP, state);
 


### PR DESCRIPTION
no-issu

This adds the ability to pass a `mode` param of 'test' to the members stripe
connect service, which will ensure we use a testmode client_id for the
Stripe Connect OAuth flow.

This will allow users to connect their account in testmode.