### PR TITLE
Removed extra redirect on Admin for from address update

### DIFF
--- a/core/server/services/members/settings.js
+++ b/core/server/services/members/settings.js
@@ -79,7 +79,7 @@ function createSettingsInstance(config) {
 
     const getAdminRedirectLink = () => {
         const adminUrl = urlUtils.urlFor('admin', true);
-        return urlUtils.urlJoin(adminUrl, 'settings/labs/?fromAddressUpdate=success');
+        return urlUtils.urlJoin(adminUrl, '#/settings/labs/?fromAddressUpdate=success');
     };
 
     return {


### PR DESCRIPTION
no issue

- Ghost-Admin redirects all paths to `/ghost/settings...` as `/ghost/#/settings/...`, this updates the admin redirect on successful magic link validation to directly use the latter to avoid extra redirect