### PR TITLE
Added new meta tag for site url behind dev flag

### DIFF
--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -2,7 +2,7 @@
 // Usage: `{{ghost_head}}`
 //
 // Outputs scripts and other assets at the top of a Ghost theme
-const {metaData, escapeExpression, SafeString, logging, settingsCache, config, blogIcon, labs} = require('../services/proxy');
+const {metaData, escapeExpression, SafeString, logging, settingsCache, config, blogIcon, labs, urlUtils} = require('../services/proxy');
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('ghost_head');
 
@@ -47,7 +47,9 @@ function getMembersHelper() {
 
     let membersHelper = `<script defer src="${getAssetUrl('public/members.js', true)}"></script>`;
     if (config.get('enableDeveloperExperiments')) {
-        membersHelper = `<script defer src="https://unpkg.com/@tryghost/members-js@latest/umd/members.min.js"></script>`;
+        const siteUrl = urlUtils.getSiteUrl().replace(/\/$/, '');
+        membersHelper = `<meta name="ghost:site" content='${siteUrl}' />`;
+        membersHelper += `<script defer src="https://unpkg.com/@tryghost/members-js@latest/umd/members.min.js"></script>`;
     }
     if ((!!stripeSecretToken && !!stripePublicToken) || !!stripeConnectIntegration.account_id) {
         membersHelper += '<script src="https://js.stripe.com/v3/"></script>';


### PR DESCRIPTION
refs https://github.com/TryGhost/members.js/issues/39

Currently, there is no way to determine exact Ghost site url from a theme, which is used by new members.js to initialize the script and use members/admin API. This change

- adds a new meta tag - `ghost:site` with value as ghost site url, when members is enabled
- new meta tag is behind dev flag along with new members.js script
