### PR TITLE
Fixed Members Stripe config for Stripe Connect

### DIFF
--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -131,10 +131,6 @@ class MembersConfigProvider {
             return null;
         }
 
-        if (!stripePaymentProcessor.config.public_token || !stripePaymentProcessor.config.secret_token) {
-            return null;
-        }
-
         // NOTE: "Complimentary" plan has to be first in the queue so it is created even if regular plans are not configured
         stripePaymentProcessor.config.plans.unshift(COMPLIMENTARY_PLAN);
 
@@ -156,6 +152,10 @@ class MembersConfigProvider {
             stripePaymentProcessor.config.public_token,
             stripePaymentProcessor.config.secret_token
         );
+
+        if (!stripeApiKeys.publicKey || !stripeApiKeys.secretKey) {
+            return null;
+        }
 
         return {
             publicKey: stripeApiKeys.publicKey,

--- a/core/server/services/members/index.js
+++ b/core/server/services/members/index.js
@@ -23,7 +23,7 @@ let membersSettings;
 
 // Bind to events to automatically keep subscription info up-to-date from settings
 events.on('settings.edited', function updateSettingFromModel(settingModel) {
-    if (!['members_subscription_settings'].includes(settingModel.get('key'))) {
+    if (!['members_subscription_settings', 'stripe_connect_integration'].includes(settingModel.get('key'))) {
         return;
     }
 


### PR DESCRIPTION
no-issue

This was initially missed as local settings always had the original
stripeDirect keys, this ensures that regardless of Connect vs Direct vs
Both vs Neither that the config is correct.

Also ensures that the Members API instance is reloaded when the Stripe
Connect settings are changed.
