### PR TITLE
Removed "from address" overwrite in importer

### DIFF
--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -122,6 +122,13 @@ class SettingsImporter extends BaseImporter {
                 obj.value = JSON.stringify([{url: ''}]);
             }
 
+            // CASE: we do not import "from address" for members settings as that needs to go via validation with magic link
+            if (obj.key === 'members_subscription_settings' && obj.value) {
+                const oldMemberSettings = _.find(this.existingData, {key: 'members_subscription_settings'}) || {};
+                const oldMemberSettingsVal = oldMemberSettings.value ? JSON.parse(oldMemberSettings.value) : {};
+                obj.value = JSON.stringify(_.assign({}, JSON.parse(obj.value), {fromAddress: oldMemberSettingsVal.fromAddress}));
+            }
+
             // CASE: export files might contain "0" or "1" for booleans. Model layer needs real booleans.
             // transform "0" to false
             if (obj.value === '0' || obj.value === '1') {

--- a/test/unit/data/importer/importers/data/settings_spec.js
+++ b/test/unit/data/importer/importers/data/settings_spec.js
@@ -40,6 +40,23 @@ describe('SettingsImporter', function () {
             should.equal(passwordSetting, undefined);
         });
 
+        it('Does not overwrite members from address', function () {
+            const fakeSettings = [{
+                key: 'members_subscription_settings',
+                value: '{"fromAddress":"newemail@example.com"}'
+            }];
+
+            const importer = new SettingsImporter({settings: fakeSettings}, {dataKeyToImport: 'settings'});
+
+            importer.beforeImport();
+
+            const membersetting = find(importer.dataToImport, {key: 'members_subscription_settings'});
+            const membersSettingsVal = JSON.parse(membersetting.value);
+            const membersFromAddress = membersSettingsVal.fromAddress;
+
+            should.not.exist(membersFromAddress);
+        });
+
         it('Adds a problem if the existing data is_private is false, and new data is_private is true', function () {
             const fakeSettings = [{
                 key: 'password',


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/11414

- Importing data currently overwrites the existing "from address" with new value
- "from address" needs to go through email validation flow before update which was bypassed
- Updates importer to not allow overwrite for "from address" and use existing instead