### PR TITLE
🐛 Fixed key name for text-only email content

### DIFF
--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -63,7 +63,7 @@ const _parseReplacements = (emailTmpl) => {
     const ALLOWED_REPLACEMENTS = ['first_name'];
 
     const replacements = [];
-    ['html', 'plaintext'].forEach((format) => {
+    ['html', 'text'].forEach((format) => {
         emailTmpl[format] = emailTmpl[format].replace(EMAIL_REPLACEMENT_REGEX, (replacementMatch, replacementStr) => {
             const match = replacementStr.match(REPLACEMENT_STRING_REGEX);
 
@@ -134,7 +134,7 @@ const serialize = async (postModel, options = {isBrowserPreview: false}) => {
     const emailTmpl = {
         subject: post.email_subject || post.title,
         html: juicedHtml,
-        plaintext: post.plaintext
+        text: post.plaintext
     };
 
     // Extract known replacements and clean up unknown replacement strings

--- a/test/api-acceptance/admin/email_preview_spec.js
+++ b/test/api-acceptance/admin/email_preview_spec.js
@@ -101,10 +101,10 @@ describe('Email Preview API', function () {
                         jsonResponse.email_previews[0].html.should.match(/This is the actual post content\.\.\./);
                         jsonResponse.email_previews[0].html.should.match(/Another email card with a similar replacement, see\?/);
 
-                        jsonResponse.email_previews[0].plaintext.should.match(/Hey there {unknown}/);
-                        jsonResponse.email_previews[0].plaintext.should.match(/Welcome to your first Ghost email!/);
-                        jsonResponse.email_previews[0].plaintext.should.match(/This is the actual post content\.\.\./);
-                        jsonResponse.email_previews[0].plaintext.should.match(/Another email card with a similar replacement, see\?/);
+                        jsonResponse.email_previews[0].text.should.match(/Hey there {unknown}/);
+                        jsonResponse.email_previews[0].text.should.match(/Welcome to your first Ghost email!/);
+                        jsonResponse.email_previews[0].text.should.match(/This is the actual post content\.\.\./);
+                        jsonResponse.email_previews[0].text.should.match(/Another email card with a similar replacement, see\?/);
                     });
             });
         });

--- a/test/api-acceptance/admin/utils.js
+++ b/test/api-acceptance/admin/utils.js
@@ -112,7 +112,7 @@ const expectedProperties = {
     ,
     email: _(schema.emails)
         .keys(),
-    email_preview: ['html', 'subject', 'plaintext']
+    email_preview: ['html', 'subject', 'text']
 };
 
 _.each(expectedProperties, (value, key) => {


### PR DESCRIPTION
closes #11917

- Pass text-only version to mailgun as `text` not `plaintext`
- This not only ensures we send fallback text content, but also changes the Content-Type header from ASCII to utf-8
- Sending an ASCII header adds points to our spam score, and is really not desirable

---

The problem is that we send mailgun the `plaintext` post format as part of the email message with the key `plaintext`, where mailgun expects `text`. Changing that [on just this line](https://github.com/TryGhost/Ghost/compare/master...ErisDS:bulk-email-fix?expand=1#diff-c0f609c07ee42368d7e203056c7851ddR137) fixes the email, sends a text version with the right header.

However, this also means the email_preview API changes. So it requires changes in Ghost Admin too. Not a problem, but much bigger than a simple fix.

Alternatively I _could_ just add a [line here](https://github.com/TryGhost/Ghost/blob/6535f2ef75e3bf4c286f085b6a878b3ebd27e6b9/core/server/services/bulk-email/index.js#L99) mapping plaintext to text before sending to mailgun. 

## Comparing Solutions

**Change plaintext to text everywhere for email**

Pro:
- In email land, this field is always called text, not plaintext. It's therefore clearer & more correct.
- We don't have to remember we've got one single line mapping values specifically for mailgun

Cons:
- In post land, html and plaintext are our format names, them being different for email is maybe confusing
- It's a bigger change

**Map plaintext to text just prior to sending emails**

Pro:
- much smaller change for now
- our format names stay consistent

Con:
- have to remember that line of code is there 
- doesn't feel like the "right" fix atm

I'm leaning heavily towards fully changing plaintext to text everywhere for email, but wanted to check what you think first @kevinansfield & @naz.