### PR TITLE
🐛 Fixed missing text version in bulk email

### DIFF
--- a/core/server/services/bulk-email/index.js
+++ b/core/server/services/bulk-email/index.js
@@ -98,6 +98,10 @@ module.exports = {
 
             const messageData = Object.assign({}, message, batchData);
 
+            // Rename plaintext field to text for Mailgun
+            messageData.text = messageData.plaintext;
+            delete messageData.plaintext;
+
             return new Promise((resolve) => {
                 mailgunInstance.messages().send(messageData, (error, body) => {
                     if (error) {


### PR DESCRIPTION
closes #11917

- Pass text-only version to mailgun as `text` not `plaintext`
- This ensures we send a text-only version of the email, and this in turn should help to improve spam scores