### PR TITLE
🐛 Fixed private blogging exposing 404 and robots

### DIFF
--- a/core/frontend/apps/private-blogging/index.js
+++ b/core/frontend/apps/private-blogging/index.js
@@ -42,5 +42,9 @@ module.exports = {
     setupMiddleware: function setupMiddleware(siteApp) {
         siteApp.use(middleware.checkIsPrivate);
         siteApp.use(middleware.filterPrivateRoutes);
+    },
+
+    setupErrorHandling: function setupErrorHandling(siteApp) {
+        siteApp.use(middleware.handle404);
     }
 };

--- a/core/frontend/apps/private-blogging/lib/middleware.js
+++ b/core/frontend/apps/private-blogging/lib/middleware.js
@@ -172,7 +172,10 @@ const privateBlogging = {
         }
 
         // CASE: 404 - redirect this page back to /private/ if the user isn't verified
-        return privateBlogging.authenticatePrivateSession(req, res, next);
+        return privateBlogging.authenticatePrivateSession(req, res, function onSessionVerified() {
+            // CASE: RSS is disabled for private blogging e.g. they create overhead
+            return next(err);
+        });
     }
 };
 

--- a/core/frontend/apps/private-blogging/lib/middleware.js
+++ b/core/frontend/apps/private-blogging/lib/middleware.js
@@ -173,7 +173,7 @@ const privateBlogging = {
 
         // CASE: 404 - redirect this page back to /private/ if the user isn't verified
         return privateBlogging.authenticatePrivateSession(req, res, function onSessionVerified() {
-            // CASE: RSS is disabled for private blogging e.g. they create overhead
+            // CASE: User is logged in, render an error
             return next(err);
         });
     }

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -135,13 +135,6 @@ module.exports = function setupSiteApp(options = {}) {
     siteApp.use(themeMiddleware);
     debug('Themes done');
 
-    // Theme static assets/files
-    siteApp.use(mw.staticTheme());
-    debug('Static content done');
-
-    // Serve robots.txt if not found in theme
-    siteApp.use(mw.servePublicFile('robots.txt', 'text/plain', constants.ONE_HOUR_S));
-
     // setup middleware for internal apps
     // @TODO: refactor this to be a proper app middleware hook for internal apps
     config.get('apps:internal').forEach((appName) => {
@@ -151,6 +144,13 @@ module.exports = function setupSiteApp(options = {}) {
             app.setupMiddleware(siteApp);
         }
     });
+
+    // Theme static assets/files
+    siteApp.use(mw.staticTheme());
+    debug('Static content done');
+
+    // Serve robots.txt if not found in theme
+    siteApp.use(mw.servePublicFile('robots.txt', 'text/plain', constants.ONE_HOUR_S));
 
     // site map - this should probably be refactored to be an internal app
     sitemapHandler(siteApp);
@@ -183,6 +183,13 @@ module.exports = function setupSiteApp(options = {}) {
 
     // ### Error handlers
     siteApp.use(shared.middlewares.errorHandler.pageNotFound);
+    config.get('apps:internal').forEach((appName) => {
+        const app = require(path.join(config.get('paths').internalAppPath, appName));
+
+        if (Object.prototype.hasOwnProperty.call(app, 'setupErrorHandling')) {
+            app.setupErrorHandling(siteApp);
+        }
+    });
     siteApp.use(shared.middlewares.errorHandler.handleThemeResponse);
 
     debug('Site setup end');

--- a/test/unit/apps/private-blogging/middleware_spec.js
+++ b/test/unit/apps/private-blogging/middleware_spec.js
@@ -69,6 +69,12 @@ describe('Private Blogging', function () {
             res.redirect.called.should.be.true();
             res.redirect.calledWith('http://127.0.0.1:2369/').should.be.true();
         });
+
+        it('handle404 should still 404', function () {
+            privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
+            next.called.should.be.true();
+            (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
+        });
     });
 
     describe('Private Mode Enabled', function () {
@@ -95,6 +101,22 @@ describe('Private Blogging', function () {
         });
 
         describe('Logged Out Behaviour', function () {
+            it('authenticatePrivateSession should redirect', function () {
+                req.path = req.url = '/welcome/';
+                privateBlogging.authenticatePrivateSession(req, res, next);
+                next.called.should.be.false();
+                res.redirect.called.should.be.true();
+                res.redirect.calledWith('/private/?r=%2Fwelcome%2F').should.be.true();
+            });
+
+            it('handle404 should redirect', function () {
+                req.path = req.url = '/welcome/';
+                privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
+                next.called.should.be.false();
+                res.redirect.called.should.be.true();
+                res.redirect.calledWith('/private/?r=%2Fwelcome%2F').should.be.true();
+            });
+
             describe('Site privacy managed by filterPrivateRoutes', function () {
                 it('should call next for the /private/ route', function () {
                     req.path = req.url = '/private/';
@@ -280,6 +302,12 @@ describe('Private Blogging', function () {
             it('authenticatePrivateSession should return next', function () {
                 privateBlogging.authenticatePrivateSession(req, res, next);
                 next.called.should.be.true();
+            });
+
+            it('handle404 should still 404', function () {
+                privateBlogging.handle404(new errors.NotFoundError(), req, res, next);
+                next.called.should.be.true();
+                (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
             });
 
             describe('Site privacy managed by filterPrivateRoutes', function () {

--- a/test/unit/apps/private-blogging/middleware_spec.js
+++ b/test/unit/apps/private-blogging/middleware_spec.js
@@ -102,6 +102,14 @@ describe('Private Blogging', function () {
                     next.called.should.be.true();
                 });
 
+                it('should redirect to /private/ for private route with extra path', function () {
+                    req.path = req.url = '/private/welcome/';
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    res.redirect.calledOnce.should.be.true();
+                    res.redirect.calledWith('/private/?r=%2Fprivate%2Fwelcome%2F').should.be.true();
+                });
+
                 it('should redirect to /private/ for sitemap', function () {
                     req.path = req.url = '/sitemap.xml';
 
@@ -152,6 +160,8 @@ describe('Private Blogging', function () {
                 });
 
                 it('should render custom robots.txt', function () {
+                    // Note this test doesn't cover the full site behaviour,
+                    // another robots.txt can be incorrectly served if middleware is out of order
                     req.url = req.path = '/robots.txt';
                     res.writeHead = sinon.spy();
                     res.end = sinon.spy();
@@ -179,6 +189,14 @@ describe('Private Blogging', function () {
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     next.called.should.be.true();
                     req.url.should.eql('/tag/getting-started/rss/');
+                });
+
+                it('should redirect to /private/ for private rss with extra path', function () {
+                    req.url = req.originalUrl = req.path = '/777aaa/rss/hackme/';
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    res.redirect.calledOnce.should.be.true();
+                    res.redirect.calledWith('/private/?r=%2F777aaa%2Frss%2Fhackme%2F').should.be.true();
                 });
             });
 


### PR DESCRIPTION
Cases:

1. `/private/anything-here` served a 404 instead of redirecting
2. `/anything-there/${publicHash}/rss/` served a 404 instead of redirecting
3. `/robots.txt` incorrectly served theme robots if one was present, not private one
4.  `/robots.txtanthinghere` incorrectly served private robots.txt.


----

- There were various cases where it was possible to trigger a private site to display a 404 instead of redirecting to /private/
- Private mode was also not always displaying the correct robots.txt
- This PR includes tests for all cases in test/frontend-acceptance/default_routes_spec.js & where possible the unit tests have also been updated for completeness
- Fixing the 404 issues required
    - Better handling of paths using req.path instead of req.url in filterPrivateRoutes
    - Additional error handling, to cover the case that a tag/author RSS feed does not exist
 - Fixing the robots.txt required the order of middleware to be changed, so that private blogging gets a chance to render first
    - NOTE private blogging is the only app with a setupMiddleware function so nothing else is affected

----

Reviewers are requested to try to break this, either by finding new holes or ways old functionality is broken.
