### PR TITLE
Permission migration utils

### DIFF
--- a/core/server/data/migrations/utils.js
+++ b/core/server/data/migrations/utils.js
@@ -1,0 +1,249 @@
+const ObjectId = require('bson-objectid').default;
+const logging = require('../../../shared/logging');
+
+const MIGRATION_USER = 1;
+
+/**
+ * Creates a migration which will add a permission to the database
+ *
+ * @param {Object} config
+ * @param {string} config.name - The name of the permission
+ * @param {string} config.action - The action_type of the permission
+ * @param {string} config.object - The object_type of the permission
+ *
+ * @returns {Migration}
+ */
+function addPermission(config) {
+    return createTransactionalMigration(
+        async function up(connection) {
+            const existingPermission = await connection('permissions').where({
+                name: config.name,
+                action_type: config.action,
+                object_type: config.object
+            }).first();
+
+            if (existingPermission) {
+                logging.warn(`Permission for ${config.action}:${config.object} already added`);
+                return;
+            }
+
+            logging.info(`Adding permission for ${config.action}:${config.object}`);
+
+            const date = connection.raw('CURRENT_TIMESTAMP');
+
+            await connection('permissions').insert({
+                id: ObjectId.generate(),
+                name: config.name,
+                action_type: config.action,
+                object_type: config.object,
+                created_at: date,
+                created_by: MIGRATION_USER,
+                updated_at: date,
+                updated_by: MIGRATION_USER
+            });
+        },
+        async function down(connection) {
+            const existingPermission = await connection('permissions').where({
+                name: config.name,
+                action_type: config.action,
+                object_type: config.object
+            }).first();
+
+            if (!existingPermission) {
+                logging.warn(`Permission for ${config.action}:${config.object} already removed`);
+                return;
+            }
+
+            logging.info(`Removing permission for ${config.action}:${config.object}`);
+
+            await connection('permissions').where({
+                action_type: config.action,
+                object_type: config.object
+            }).del();
+        }
+    );
+}
+
+/**
+ * Creates a migration which will link a permission to a role in the database
+ *
+ * @param {Object} config
+ * @param {string} config.permission - The name of the permission
+ * @param {string} config.role - The name of the role
+ *
+ * @returns {Migration}
+ */
+function addPermissionToRole(config) {
+    return createTransactionalMigration(
+        async function up(connection) {
+            const permission = await connection('permissions').where({
+                name: config.permission
+            }).first();
+
+            if (!permission) {
+                throw new Error(
+                    `Cannot add permission(${config.permission}) to role(${config.role}) - permission does not exist`
+                );
+            }
+
+            const role = await connection('roles').where({
+                name: config.role
+            }).first();
+
+            if (!role) {
+                throw new Error(
+                    `Cannot add permission(${config.permission}) to role(${config.role}) - role does not exist`
+                );
+            }
+
+            const existingRelation = await connection('permissions_roles').where({
+                permission_id: permission.id,
+                role_id: role.id
+            }).first();
+
+            if (existingRelation) {
+                logging.warn(`Adding permission(${config.permission}) to role(${config.role}) - already exists`);
+                return;
+            }
+
+            logging.warn(`Adding permission(${config.permission}) to role(${config.role})`);
+            await connection('permissions_roles').insert({
+                id: ObjectId.generate(),
+                permission_id: permission.id,
+                role_id: role.id
+            });
+        },
+        async function down(connection) {
+            const permission = await connection('permissions').where({
+                name: config.permission
+            }).first();
+
+            if (!permission) {
+                throw new Error(
+                    `Cannot remove permission(${config.permission}) from role(${config.role}) - permission does not exist`
+                );
+            }
+
+            const role = await connection('roles').where({
+                name: config.role
+            }).first();
+
+            if (!role) {
+                throw new Error(
+                    `Cannot remove permission(${config.permission}) from role(${config.role}) - role does not exist`
+                );
+            }
+
+            const existingRelation = await connection('permissions_roles').where({
+                permission_id: permission.id,
+                role_id: role.id
+            }).first();
+
+            if (!existingRelation) {
+                logging.warn(`Removing permission(${config.permission}) from role(${config.role}) - already removed`);
+                return;
+            }
+
+            logging.info(`Removing permission(${config.permission}) from role(${config.role})`);
+            await connection('permissions_roles').where({
+                permission_id: permission.id,
+                role_id: role.id
+            }).del();
+        }
+    );
+}
+
+/**
+ * Creates a migration which will add a permission to the database, and then link it to roles
+ *
+ * @param {Object} config
+ * @param {string} config.name - The name of the permission
+ * @param {string} config.action - The action_type of the permission
+ * @param {string} config.object - The object_type of the permission
+ *
+ * @param {string[]} roles - A list of role names
+ *
+ * @returns {Migration}
+ */
+function addPermissionWithRoles(config, roles) {
+    return combineTransactionalMigrations(
+        addPermission(config),
+        ...roles.map((role => addPermissionToRole({permission: config.name, role})))
+    );
+}
+
+/**
+ * @param {(connection: import('knex')) => Promise<void>} up
+ * @param {(connection: import('knex')) => Promise<void>} down
+ *
+ * @returns {Migration}
+ */
+function createTransactionalMigration(up, down) {
+    return {
+        config: {
+            transaction: true
+        },
+        async up(config) {
+            await up(config.transacting);
+        },
+        async down(config) {
+            await down(config.transacting);
+        }
+    };
+}
+
+/**
+ * @param {Migration[]} migrations
+ *
+ * @returns {Migration}
+ */
+function combineTransactionalMigrations(...migrations) {
+    return {
+        config: {
+            transaction: true
+        },
+        async up(config) {
+            for (const migration of migrations) {
+                await migration.up(config);
+            }
+        },
+        async down(config) {
+            // Down migrations must be run backwards!!
+            const reverseMigrations = migrations.slice().reverse();
+            for (const migration of reverseMigrations) {
+                await migration.down(config);
+            }
+        }
+    };
+}
+
+module.exports = {
+    addPermission,
+    addPermissionToRole,
+    addPermissionWithRoles,
+    createTransactionalMigration,
+    combineTransactionalMigrations,
+    meta: {
+        MIGRATION_USER
+    }
+};
+
+/**
+ * @typedef {Object} TransactionalMigrationFunctionOptions
+ *
+ * @prop {import('knex')} transacting
+ */
+
+/**
+ * @typedef {(options: TransactionalMigrationFunctionOptions) => Promise<void>} TransactionalMigrationFunction
+ */
+
+/**
+ * @typedef {Object} Migration
+ *
+ * @prop {Object} config
+ * @prop {boolean} config.transaction
+ *
+ * @prop {TransactionalMigrationFunction} up
+ * @prop {TransactionalMigrationFunction} down
+ */

--- a/core/server/data/migrations/versions/1.13/2-theme-permissions.js
+++ b/core/server/data/migrations/versions/1.13/2-theme-permissions.js
@@ -1,51 +1,58 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
-const resource = 'theme';
-const _private = {};
+const {
+    addPermissionWithRoles,
+    combineTransactionalMigrations
+} = require('../../utils');
 
-_private.getPermissions = function getPermissions() {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.getRelations = function getRelations() {
-    return utils.findPermissionRelationsForObject(resource);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = function addRedirectsPermissions(options) {
-    const modelToAdd = _private.getPermissions();
-    const relationToAdd = _private.getRelations();
-
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return utils.addFixturesForModel(modelToAdd, localOptions)
-        .then(function (result) {
-            _private.printResult(result, 'Adding permissions fixtures for ' + resource + 's');
-            return utils.addFixturesForRelation(relationToAdd, localOptions);
-        })
-        .then(function (result) {
-            _private.printResult(result, 'Adding permissions_roles fixtures for ' + resource + 's');
-            return permissions.init(localOptions);
-        });
-};
-
-/**
- * @TODO:
- * The down function is quite tricky, because the fixture utility adds **all** missing fixtures for a target resource.
- * So if we are writing a down function, we are only allowed to remove the fixtures which were added between two Ghost versions.
- */
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse themes',
+        action: 'browse',
+        object: 'theme'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor',
+        'Author',
+        'Contributor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit themes',
+        action: 'edit',
+        object: 'theme'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Activate themes',
+        action: 'activate',
+        object: 'theme'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Upload themes',
+        action: 'add',
+        object: 'theme'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Download themes',
+        action: 'read',
+        object: 'theme'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete themes',
+        action: 'destroy',
+        object: 'theme'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ])
+);

--- a/core/server/data/migrations/versions/1.19/1-webhook-permissions.js
+++ b/core/server/data/migrations/versions/1.19/1-webhook-permissions.js
@@ -1,45 +1,31 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
-const resource = 'webhook';
-const _private = {};
+const {
+    addPermissionWithRoles,
+    combineTransactionalMigrations
+} = require('../../utils');
 
-_private.getPermissions = function getPermissions() {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.getRelations = function getRelations() {
-    return utils.findPermissionRelationsForObject(resource);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = function addRedirectsPermissions(options) {
-    const modelToAdd = _private.getPermissions();
-    const relationToAdd = _private.getRelations();
-
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return utils.addFixturesForModel(modelToAdd, localOptions)
-        .then(function (result) {
-            _private.printResult(result, 'Adding permissions fixtures for ' + resource + 's');
-            return utils.addFixturesForRelation(relationToAdd, localOptions);
-        })
-        .then(function (result) {
-            _private.printResult(result, 'Adding permissions_roles fixtures for ' + resource + 's');
-            return permissions.init(localOptions);
-        });
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Add webhooks',
+        action: 'add',
+        object: 'webhook'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit webhooks',
+        action: 'edit',
+        object: 'webhook'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete webhooks',
+        action: 'destroy',
+        object: 'webhook'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ])
+);

--- a/core/server/data/migrations/versions/1.9/1-add-permissions-redirect.js
+++ b/core/server/data/migrations/versions/1.9/1-add-permissions-redirect.js
@@ -1,50 +1,23 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
-const resource = 'redirect';
-const _private = {};
+const {
+    addPermissionWithRoles,
+    combineTransactionalMigrations
+} = require('../../utils');
 
-_private.getPermissions = function getPermissions() {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.getRelations = function getRelations() {
-    return utils.findPermissionRelationsForObject(resource);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = function addRedirectsPermissions(options) {
-    const modelToAdd = _private.getPermissions();
-    const relationToAdd = _private.getRelations();
-
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return utils.addFixturesForModel(modelToAdd, localOptions).then(function (result) {
-        _private.printResult(result, 'Adding permissions fixtures for ' + resource + 's');
-        return utils.addFixturesForRelation(relationToAdd, localOptions);
-    }).then(function (result) {
-        _private.printResult(result, 'Adding permissions_roles fixtures for ' + resource + 's');
-    }).then(function () {
-        return permissions.init(localOptions);
-    });
-};
-
-/**
- * @TODO:
- * The down function is quite tricky, because the fixture utility adds **all** missing fixtures for a target resource.
- * So if we are writing a down function, we are only allowed to remove the fixtures which were added between two Ghost versions.
- */
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Download redirects',
+        action: 'download',
+        object: 'redirect'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Upload redirects',
+        action: 'download',
+        object: 'redirect'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ])
+);

--- a/core/server/data/migrations/versions/2.14/2-add-actions-permissions.js
+++ b/core/server/data/migrations/versions/2.14/2-add-actions-permissions.js
@@ -1,47 +1,12 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
-const resource = 'action';
-const _private = {};
+const {
+    addPermissionWithRoles
+} = require('../../utils');
 
-_private.getPermissions = function getPermissions() {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.getRelations = function getRelations() {
-    return utils.findPermissionRelationsForObject(resource);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = function addRedirectsPermissions(options) {
-    const modelToAdd = _private.getPermissions();
-    const relationToAdd = _private.getRelations();
-    const localOptions = _.merge({
-        context: {
-            internal: true,
-            migrating: true
-        }
-    }, options);
-
-    return utils.addFixturesForModel(modelToAdd, localOptions)
-        .then(function (result) {
-            _private.printResult(result, 'Adding permissions fixtures for ' + resource + 's');
-            return utils.addFixturesForRelation(relationToAdd, localOptions);
-        })
-        .then(function (result) {
-            _private.printResult(result, 'Adding permissions_roles fixtures for ' + resource + 's');
-            return permissions.init(localOptions);
-        });
-};
+module.exports = addPermissionWithRoles({
+    name: 'Browse Actions',
+    action: 'browse',
+    object: 'action'
+}, [
+    'Administrator',
+    'Admin Integration'
+]);

--- a/core/server/data/migrations/versions/2.2/4-insert-integration-and-api-key-permissions.js
+++ b/core/server/data/migrations/versions/2.2/4-insert-integration-and-api-key-permissions.js
@@ -1,58 +1,77 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
+const {
+    addPermissionWithRoles,
+    combineTransactionalMigrations
+} = require('../../utils');
 
-const resources = ['integration', 'api_key'];
-const _private = {};
-
-_private.getPermissions = function getPermissions(resource) {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.getRelations = function getRelations(resource) {
-    return utils.findPermissionRelationsForObject(resource);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn(`(${result.done}/${result.expected}) ${message}`);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToAdd = _private.getPermissions(resource);
-        const relationToAdd = _private.getRelations(resource);
-
-        return utils.addFixturesForModel(modelToAdd, localOptions)
-            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}s`))
-            .then(() => utils.addFixturesForRelation(relationToAdd, localOptions))
-            .then(result => _private.printResult(result, `Adding permissions_roles fixtures for ${resource}s`))
-            .then(() => permissions.init(localOptions));
-    });
-};
-
-module.exports.down = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToRemove = _private.getPermissions(resource);
-
-        // permission model automatically cleans up permissions_roles on .destroy()
-        return utils.removeFixturesForModel(modelToRemove, localOptions)
-            .then(result => _private.printResult(result, `Removing permissions fixtures for ${resource}s`));
-    });
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse integrations',
+        action: 'browse',
+        object: 'integration'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Read integrations',
+        action: 'read',
+        object: 'integration'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit integrations',
+        action: 'edit',
+        object: 'integration'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add integrations',
+        action: 'add',
+        object: 'integration'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete integrations',
+        action: 'destroy',
+        object: 'integration'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Browse API keys',
+        action: 'browse',
+        object: 'api_key'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Read API keys',
+        action: 'read',
+        object: 'api_key'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit API keys',
+        action: 'edit',
+        object: 'api_key'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add API keys',
+        action: 'add',
+        object: 'api_key'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete API keys',
+        action: 'destroy',
+        object: 'api_key'
+    }, [
+        'Administrator'
+    ])
+);

--- a/core/server/data/migrations/versions/2.21/1-update-editor-permissions.js
+++ b/core/server/data/migrations/versions/2.21/1-update-editor-permissions.js
@@ -1,51 +1,28 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
+const {
+    combineTransactionalMigrations,
+    addPermissionWithRoles
+} = require('../../utils');
 
-const resources = ['notification'];
-
-const _private = {};
-
-_private.getRelations = function getRelations(resource, role) {
-    return utils.findPermissionRelationsForObject(resource, role);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn(`(${result.done}/${result.expected}) ${message}`);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const relations = _private.getRelations(resource, 'Editor');
-
-        return Promise.resolve()
-            .then(() => utils.addFixturesForRelation(relations, localOptions))
-            .then(result => _private.printResult(result, `Adding permissions_roles fixtures for ${resource}s`))
-            .then(() => permissions.init(localOptions));
-    });
-};
-
-module.exports.down = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const relations = _private.getRelations(resource, 'Editor');
-
-        return utils.removeFixturesForRelation(relations, localOptions);
-    });
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse notifications',
+        action: 'browse',
+        object: 'notification'
+    }, [
+        'Editor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add notifications',
+        action: 'add',
+        object: 'notification'
+    }, [
+        'Editor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete notifications',
+        action: 'destroy',
+        object: 'notification'
+    }, [
+        'Editor'
+    ])
+);

--- a/core/server/data/migrations/versions/2.22/1-add-member-permissions-to-roles.js
+++ b/core/server/data/migrations/versions/2.22/1-add-member-permissions-to-roles.js
@@ -1,49 +1,47 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
-const resource = 'member';
-const _private = {};
+const {
+    addPermissionWithRoles,
+    combineTransactionalMigrations
+} = require('../../utils');
 
-_private.getPermissions = function getPermissions() {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.getRelations = function getRelations() {
-    return utils.findPermissionRelationsForObject(resource);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn('(' + result.done + '/' + result.expected + ') ' + message);
-    }
-};
-
-module.exports.up = function addMembersPermissions(options) {
-    const modelToAdd = _private.getPermissions();
-    const relationToAdd = _private.getRelations();
-    const localOptions = _.merge({
-        context: {
-            internal: true,
-            migrating: true
-        }
-    }, options);
-
-    return utils.addFixturesForModel(modelToAdd, localOptions)
-        .then(function (result) {
-            _private.printResult(
-                result,
-                `Adding permissions fixtures for ${resource}s`
-            );
-            return utils.addFixturesForRelation(relationToAdd, localOptions);
-        })
-        .then(function (result) {
-            _private.printResult(
-                result,
-                `Adding permissions_roles fixtures for ${resource}s`
-            );
-            return permissions.init(localOptions);
-        });
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse Members',
+        action: 'browse',
+        object: 'member'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Read Members',
+        action: 'read',
+        object: 'member'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit Members',
+        action: 'edit',
+        object: 'member'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add Members',
+        action: 'add',
+        object: 'member'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete Members',
+        action: 'destroy',
+        object: 'member'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ])
+);

--- a/core/server/data/migrations/versions/2.28/1-add-db-backup-content-permission.js
+++ b/core/server/data/migrations/versions/2.28/1-add-db-backup-content-permission.js
@@ -1,61 +1,9 @@
-const logging = require('../../../../../shared/logging');
-const models = require('../../../../models');
-const utils = require('../../../schema/fixtures/utils');
+const {
+    addPermission
+} = require('../../utils');
 
-const fixtureBackupContentPerm = utils.findModelFixtureEntry('Permission', {
-    object_type: 'db',
-    action_type: 'backupContent'
+module.exports = addPermission({
+    name: 'Backup database',
+    action: 'backupContect',
+    object: 'db'
 });
-
-module.exports = {
-    config: {
-        transaction: true
-    },
-
-    async up(options) {
-        try {
-            const existingBackupContentPerm = await models.Permission.findOne(
-                fixtureBackupContentPerm,
-                options
-            );
-
-            if (existingBackupContentPerm) {
-                return logging.warn('Issue adding db.backupContent (already exists)');
-            }
-
-            const result = await utils.addFixturesForModel({
-                name: 'Permission',
-                entries: [fixtureBackupContentPerm]
-            }, options);
-
-            const success = result.done === result.expected;
-
-            if (!success) {
-                return logging.warn('Issue adding db.backupContent permission (did not insert)');
-            }
-
-            return logging.info('Completed adding db.backupContent permission');
-        } catch (err) {
-            return logging.error('Errored when adding db.backupContent permission');
-        }
-    },
-
-    async down(options) {
-        try {
-            const existingBackupContentPerm = await models.Permission.findOne(
-                fixtureBackupContentPerm,
-                options
-            );
-
-            if (!existingBackupContentPerm) {
-                return logging.warn('Issue removing db.backupContent (already removed)');
-            }
-
-            await existingBackupContentPerm.destroy(options);
-
-            return logging.info('Completed removing db.backupContent permission');
-        } catch (err) {
-            return logging.error('Errored when removing db.backupContent permission');
-        }
-    }
-};

--- a/core/server/data/migrations/versions/2.28/2-add-db-backup-content-permission-to-roles.js
+++ b/core/server/data/migrations/versions/2.28/2-add-db-backup-content-permission-to-roles.js
@@ -1,46 +1,15 @@
-const logging = require('../../../../../shared/logging');
-const utils = require('../../../schema/fixtures/utils');
+const {
+    addPermissionToRole,
+    combineTransactionalMigrations
+} = require('../../utils');
 
-const relationFixtures = {
-    from: {
-        model: 'Role',
-        match: 'name',
-        relation: 'permissions'
-    },
-    to: {
-        model: 'Permission',
-        match: ['object_type', 'action_type']
-    },
-    entries: {
-        Administrator: {
-            db: 'backupContent'
-        },
-        'DB Backup Integration': {
-            db: 'backupContent'
-        }
-    }
-};
-
-module.exports = {
-    config: {
-        transaction: true
-    },
-
-    async up(options) {
-        try {
-            await utils.addFixturesForRelation(relationFixtures, options);
-            return logging.info('Completed adding db.backupContent permission to roles');
-        } catch (err) {
-            return logging.warn('Issue adding db.backupContent permission to roles');
-        }
-    },
-
-    async down(options) {
-        try {
-            await utils.removeFixturesForRelation(relationFixtures, options);
-            return logging.info('Completed removing db.backupContent permission from roles');
-        } catch (err) {
-            return logging.warn('Issue removing db.backupContent permission from roles');
-        }
-    }
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionToRole({
+        permission: 'Backup database',
+        role: 'Administrator'
+    }),
+    addPermissionToRole({
+        permission: 'Backup database',
+        role: 'DB Backup Integration'
+    })
+);

--- a/core/server/data/migrations/versions/2.28/5-add-scheduler-permission-to-roles.js
+++ b/core/server/data/migrations/versions/2.28/5-add-scheduler-permission-to-roles.js
@@ -1,52 +1,23 @@
-const logging = require('../../../../../shared/logging');
-const utils = require('../../../schema/fixtures/utils');
+const {
+    addPermissionToRole,
+    combineTransactionalMigrations
+} = require('../../utils');
 
-const relationFixtures = {
-    from: {
-        model: 'Role',
-        match: 'name',
-        relation: 'permissions'
-    },
-    to: {
-        model: 'Permission',
-        match: ['object_type', 'action_type']
-    },
-    entries: {
-        Administrator: {
-            post: 'publish'
-        },
-        'Admin Integration': {
-            post: 'publish'
-        },
-        Editor: {
-            post: 'publish'
-        },
-        'Scheduler Integration': {
-            post: 'publish'
-        }
-    }
-};
-
-module.exports = {
-    config: {
-        transaction: true
-    },
-
-    async up(options) {
-        try {
-            await utils.addFixturesForRelation(relationFixtures, options);
-            return logging.info('Completed adding post.publish permission to roles');
-        } catch (err) {
-            return logging.warn('Issue adding post.publish permission to roles');
-        }
-    },
-
-    async down(options) {
-        try {
-            await utils.removeFixturesForRelation(relationFixtures, options);
-            return logging.info('Completed removing post.publish permission from roles');
-        } catch (err) {
-            return logging.warn('Issue removing post.publish permission from roles');
-        }
-    }
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionToRole({
+        permission: 'Publish posts',
+        role: 'Administrator'
+    }),
+    addPermissionToRole({
+        permission: 'Publish posts',
+        role: 'Admin Integration'
+    }),
+    addPermissionToRole({
+        permission: 'Publish posts',
+        role: 'Editor'
+    }),
+    addPermissionToRole({
+        permission: 'Publish posts',
+        role: 'Scheduler Integration'
+    })
+);

--- a/core/server/data/migrations/versions/2.3/2-add-webhook-edit-permission.js
+++ b/core/server/data/migrations/versions/2.3/2-add-webhook-edit-permission.js
@@ -1,51 +1,9 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
+const {
+    addPermission
+} = require('../../utils');
 
-const resources = ['webhook'];
-const _private = {};
-
-_private.getPermissions = function getPermissions(resource) {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn(`(${result.done}/${result.expected}) ${message}`);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToAdd = _private.getPermissions(resource);
-
-        return utils.addFixturesForModel(modelToAdd, localOptions)
-            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}s`))
-            .then(() => permissions.init(localOptions));
-    });
-};
-
-module.exports.down = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToRemove = _private.getPermissions(resource);
-
-        // permission model automatically cleans up permissions_roles on .destroy()
-        return utils.removeFixturesForModel(modelToRemove, localOptions)
-            .then(result => _private.printResult(result, `Removing permissions fixtures for ${resource}s`));
-    });
-};
+module.exports = addPermission({
+    name: 'Edit webhooks',
+    action: 'edit',
+    object: 'webhook'
+});

--- a/core/server/data/migrations/versions/2.6/1-add-webhook-permission-roles.js
+++ b/core/server/data/migrations/versions/2.6/1-add-webhook-permission-roles.js
@@ -1,37 +1,31 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
+const {
+    addPermissionWithRoles,
+    combineTransactionalMigrations
+} = require('../../utils');
 
-const resources = ['webhook'];
-const _private = {};
-
-_private.getRelations = function getRelations(resource) {
-    return utils.findPermissionRelationsForObject(resource);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn(`(${result.done}/${result.expected}) ${message}`);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const relationToAdd = _private.getRelations(resource);
-
-        return utils.addFixturesForRelation(relationToAdd, localOptions)
-            .then(result => _private.printResult(result, `Adding permissions_roles fixtures for ${resource}s`))
-            .then(() => permissions.init(localOptions));
-    });
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Add webhooks',
+        action: 'add',
+        object: 'webhook'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit webhooks',
+        action: 'edit',
+        object: 'webhook'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete webhooks',
+        action: 'destroy',
+        object: 'webhook'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ])
+);

--- a/core/server/data/migrations/versions/3.1/03-add-email-preview-permissions.js
+++ b/core/server/data/migrations/versions/3.1/03-add-email-preview-permissions.js
@@ -1,51 +1,18 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
+const {
+    combineTransactionalMigrations,
+    addPermission
+} = require('../../utils');
 
-const resources = ['email_preview'];
-const _private = {};
+module.exports = combineTransactionalMigrations(
+    addPermission({
+        name: 'Email preview',
+        object: 'email_preview',
+        action: 'read'
+    }),
 
-_private.getPermissions = function getPermissions(resource) {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn(`(${result.done}/${result.expected}) ${message}`);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToAdd = _private.getPermissions(resource);
-
-        return utils.addFixturesForModel(modelToAdd, localOptions)
-            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}s`))
-            .then(() => permissions.init(localOptions));
-    });
-};
-
-module.exports.down = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToRemove = _private.getPermissions(resource);
-
-        // permission model automatically cleans up permissions_roles on .destroy()
-        return utils.removeFixturesForModel(modelToRemove, localOptions)
-            .then(result => _private.printResult(result, `Removing permissions fixtures for ${resource}s`));
-    });
-};
+    addPermission({
+        name: 'Send test email',
+        object: 'email_preview',
+        action: 'sendTestEmail'
+    })
+);

--- a/core/server/data/migrations/versions/3.1/06-add-email-permissions.js
+++ b/core/server/data/migrations/versions/3.1/06-add-email-permissions.js
@@ -1,51 +1,15 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
+const {
+    addPermissionWithRoles
+} = require('../../utils');
 
-const resources = ['email'];
-const _private = {};
-
-_private.getPermissions = function getPermissions(resource) {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn(`(${result.done}/${result.expected}) ${message}`);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToAdd = _private.getPermissions(resource);
-
-        return utils.addFixturesForModel(modelToAdd, localOptions)
-            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}`))
-            .then(() => permissions.init(localOptions));
-    });
-};
-
-module.exports.down = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToRemove = _private.getPermissions(resource);
-
-        // permission model automatically cleans up permissions_roles on .destroy()
-        return utils.removeFixturesForModel(modelToRemove, localOptions)
-            .then(result => _private.printResult(result, `Removing permissions fixtures for ${resource}s`));
-    });
-};
+module.exports = addPermissionWithRoles({
+    name: 'Read emails',
+    action: 'read',
+    object: 'email'
+}, [
+    'Administrator',
+    'Admin Integration',
+    'Editor',
+    'Author',
+    'Contributor'
+]);

--- a/core/server/data/migrations/versions/3.1/09-add-further-email-permissions.js
+++ b/core/server/data/migrations/versions/3.1/09-add-further-email-permissions.js
@@ -1,51 +1,25 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
+const {
+    combineTransactionalMigrations,
+    addPermissionWithRoles
+} = require('../../utils');
 
-const resources = ['email'];
-const _private = {};
-
-_private.getPermissions = function getPermissions(resource) {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn(`(${result.done}/${result.expected}) ${message}`);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToAdd = _private.getPermissions(resource);
-
-        return utils.addFixturesForModel(modelToAdd, localOptions)
-            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}`))
-            .then(() => permissions.init(localOptions));
-    });
-};
-
-module.exports.down = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToRemove = _private.getPermissions(resource);
-
-        // permission model automatically cleans up permissions_roles on .destroy()
-        return utils.removeFixturesForModel(modelToRemove, localOptions)
-            .then(result => _private.printResult(result, `Removing permissions fixtures for ${resource}s`));
-    });
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse emails',
+        action: 'browse',
+        object: 'email'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Retry emails',
+        action: 'retry',
+        object: 'email'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor'
+    ])
+);

--- a/core/server/data/migrations/versions/3.12/01-add-identity-permission.js
+++ b/core/server/data/migrations/versions/3.12/01-add-identity-permission.js
@@ -1,56 +1,7 @@
-const ObjectId = require('bson-objectid');
-const logging = require('../../../../../shared/logging');
+const {addPermission} = require('../../utils');
 
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = async (options) => {
-    const connection = options.transacting;
-
-    const existingIdentityPermission = await connection('permissions').where({
-        action_type: 'read',
-        object_type: 'identity'
-    }).first();
-
-    if (existingIdentityPermission) {
-        logging.warn('Permission for read:identity already added');
-        return;
-    }
-
-    logging.info('Adding permission for read:identity');
-
-    const date = connection.raw('CURRENT_TIMESTAMP');
-
-    await connection('permissions').insert({
-        id: ObjectId.generate(),
-        name: 'Read identities',
-        action_type: 'read',
-        object_type: 'identity',
-        created_at: date,
-        created_by: 1,
-        updated_at: date,
-        updated_by: 1
-    });
-};
-
-module.exports.down = async (options) => {
-    const connection = options.transacting;
-
-    const existingIdentityPermission = await connection('permissions').where({
-        action_type: 'read',
-        object_type: 'identity'
-    }).first();
-
-    if (!existingIdentityPermission) {
-        logging.warn('Permission for read:identity already removed');
-        return;
-    }
-
-    logging.info('Removing permission for read:identity');
-
-    await connection('permissions').where({
-        action_type: 'read',
-        object_type: 'identity'
-    }).del();
-};
+module.exports = addPermission({
+    name: 'Read identities',
+    action: 'read',
+    object: 'identity'
+});

--- a/core/server/data/migrations/versions/3.18/01-add-email-preview-permissions-to-roles.js
+++ b/core/server/data/migrations/versions/3.18/01-add-email-preview-permissions-to-roles.js
@@ -1,36 +1,39 @@
-const utils = require('../../../schema/fixtures/utils');
-const logging = require('../../../../../shared/logging');
+const {
+    combineTransactionalMigrations,
+    addPermissionToRole
+} = require('../../utils');
 
-const resource = 'email_preview';
-
-module.exports = {
-    config: {
-        transaction: true
-    },
-
-    async up(options) {
-        const relationFixtures = utils.findPermissionRelationsForObject(resource);
-        try {
-            const result = await utils.addFixturesForRelation(relationFixtures, options);
-            const success = result.done === result.expected;
-            if (!success) {
-                return logging.warn('Adding email_preview permissions to roles (did not insert)');
-            }
-            return logging.info('Adding email_preview permissions to roles');
-        } catch (err) {
-            logging.error('Issue adding email_preview permissions to roles');
-            throw err;
-        }
-    },
-
-    async down(options) {
-        const relationFixtures = utils.findPermissionRelationsForObject(resource);
-        try {
-            await utils.removeFixturesForRelation(relationFixtures, options);
-            return logging.info('Removing email_preview permissions from roles');
-        } catch (err) {
-            logging.error('Issue removing email_preview permissions from roles');
-            throw err;
-        }
-    }
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionToRole({
+        permission: 'Email preview',
+        role: 'Administrator'
+    }),
+    addPermissionToRole({
+        permission: 'Email preview',
+        role: 'Admin Integration'
+    }),
+    addPermissionToRole({
+        permission: 'Email preview',
+        role: 'Editor'
+    }),
+    addPermissionToRole({
+        permission: 'Email preview',
+        role: 'Author'
+    }),
+    addPermissionToRole({
+        permission: 'Email preview',
+        role: 'Contributor'
+    }),
+    addPermissionToRole({
+        permission: 'Send test email',
+        role: 'Administrator'
+    }),
+    addPermissionToRole({
+        permission: 'Send test email',
+        role: 'Admin Integration'
+    }),
+    addPermissionToRole({
+        permission: 'Send test email',
+        role: 'Editor'
+    })
+);

--- a/core/server/data/migrations/versions/3.18/02-add-members_stripe_connect-auth-permissions.js
+++ b/core/server/data/migrations/versions/3.18/02-add-members_stripe_connect-auth-permissions.js
@@ -1,56 +1,7 @@
-const ObjectId = require('bson-objectid');
-const logging = require('../../../../../shared/logging');
+const {addPermission} = require('../../utils');
 
-module.exports = {
-    config: {
-        transaction: true
-    },
-    async up(options) {
-        const connection = options.transacting;
-
-        const existingIdentityPermission = await connection('permissions').where({
-            action_type: 'auth',
-            object_type: 'members_stripe_connect'
-        }).first();
-
-        if (existingIdentityPermission) {
-            logging.warn('Permission for auth:members_stripe_connect already added');
-            return;
-        }
-
-        logging.info('Adding permission for auth:members_stripe_connect');
-
-        const date = connection.raw('CURRENT_TIMESTAMP');
-
-        await connection('permissions').insert({
-            id: ObjectId.generate(),
-            name: 'Auth Stripe Connect for Members',
-            action_type: 'auth',
-            object_type: 'members_stripe_connect',
-            created_at: date,
-            created_by: 1,
-            updated_at: date,
-            updated_by: 1
-        });
-    },
-    async down(options) {
-        const connection = options.transacting;
-
-        const existingIdentityPermission = await connection('permissions').where({
-            action_type: 'auth',
-            object_type: 'members_stripe_connect'
-        }).first();
-
-        if (!existingIdentityPermission) {
-            logging.warn('Permission for auth:members_stripe_connect already removed');
-            return;
-        }
-
-        logging.info('Removing permission for auth:members_stripe_connect');
-
-        await connection('permissions').where({
-            action_type: 'auth',
-            object_type: 'members_stripe_connect'
-        }).del();
-    }
-};
+module.exports = addPermission({
+    name: 'Auth Stripe Connect for Members',
+    action: 'auth',
+    object: 'members_stripe_connect'
+});

--- a/core/server/data/migrations/versions/3.6/3-add-labels-permissions.js
+++ b/core/server/data/migrations/versions/3.6/3-add-labels-permissions.js
@@ -1,58 +1,47 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
+const {
+    combineTransactionalMigrations,
+    addPermissionWithRoles
+} = require('../../utils');
 
-const resources = ['label'];
-const _private = {};
-
-_private.getPermissions = function getPermissions(resource) {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.getRelations = function getRelations(resource) {
-    return utils.findPermissionRelationsForObject(resource);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn(`(${result.done}/${result.expected}) ${message}`);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToAdd = _private.getPermissions(resource);
-        const relationToAdd = _private.getRelations(resource);
-
-        return utils.addFixturesForModel(modelToAdd, localOptions)
-            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}s`))
-            .then(() => utils.addFixturesForRelation(relationToAdd, localOptions))
-            .then(result => _private.printResult(result, `Adding permissions_roles fixtures for ${resource}s`))
-            .then(() => permissions.init(localOptions));
-    });
-};
-
-module.exports.down = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToRemove = _private.getPermissions(resource);
-
-        // permission model automatically cleans up permissions_roles on .destroy()
-        return utils.removeFixturesForModel(modelToRemove, localOptions)
-            .then(result => _private.printResult(result, `Removing permissions fixtures for ${resource}s`));
-    });
-};
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse labels',
+        action: 'browse',
+        object: 'label'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Read labels',
+        action: 'read',
+        object: 'label'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit labels',
+        action: 'edit',
+        object: 'label'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add labels',
+        action: 'add',
+        object: 'label'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete labels',
+        action: 'destroy',
+        object: 'label'
+    }, [
+        'Administrator',
+        'Admin Integration'
+    ])
+);

--- a/core/server/data/migrations/versions/3.9/01-add-member-sigin-url-permissions.js
+++ b/core/server/data/migrations/versions/3.9/01-add-member-sigin-url-permissions.js
@@ -1,58 +1,7 @@
-const _ = require('lodash');
-const utils = require('../../../schema/fixtures/utils');
-const permissions = require('../../../../services/permissions');
-const logging = require('../../../../../shared/logging');
+const {addPermission} = require('../../utils');
 
-const resources = ['member_signin_url'];
-const _private = {};
-
-_private.getPermissions = function getPermissions(resource) {
-    return utils.findModelFixtures('Permission', {object_type: resource});
-};
-
-_private.getRelations = function getRelations(resource) {
-    return utils.findPermissionRelationsForObject(resource);
-};
-
-_private.printResult = function printResult(result, message) {
-    if (result.done === result.expected) {
-        logging.info(message);
-    } else {
-        logging.warn(`(${result.done}/${result.expected}) ${message}`);
-    }
-};
-
-module.exports.config = {
-    transaction: true
-};
-
-module.exports.up = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToAdd = _private.getPermissions(resource);
-        const relationToAdd = _private.getRelations(resource);
-
-        return utils.addFixturesForModel(modelToAdd, localOptions)
-            .then(result => _private.printResult(result, `Adding permissions fixtures for ${resource}s`))
-            .then(() => utils.addFixturesForRelation(relationToAdd, localOptions))
-            .then(result => _private.printResult(result, `Adding permissions_roles fixtures for ${resource}s`))
-            .then(() => permissions.init(localOptions));
-    });
-};
-
-module.exports.down = (options) => {
-    const localOptions = _.merge({
-        context: {internal: true}
-    }, options);
-
-    return Promise.map(resources, (resource) => {
-        const modelToRemove = _private.getPermissions(resource);
-
-        // permission model automatically cleans up permissions_roles on .destroy()
-        return utils.removeFixturesForModel(modelToRemove, localOptions)
-            .then(result => _private.printResult(result, `Removing permissions fixtures for ${resource}s`));
-    });
-};
+module.exports = addPermission({
+    name: 'Read member signin urls',
+    action: 'read',
+    object: 'member_signin_url'
+});

--- a/test/unit/data/migrations/utils.test.js
+++ b/test/unit/data/migrations/utils.test.js
@@ -1,0 +1,493 @@
+const should = require('should');
+const sinon = require('sinon');
+
+const utils = require('../../../../core/server/data/migrations/utils');
+
+// Get access to the core Promise constructor
+// as global.Promise is overidden by Ghost
+// https://github.com/TryGhost/Ghost/issues/9064
+const Promise = (async () => {})().constructor;
+
+class Deferred {
+    constructor() {
+        this.promise = new Promise((resolve, reject) => {
+            this.resolve = async (val) => {
+                resolve(val);
+                return this.promise;
+            };
+            this.reject = async (val) => {
+                reject(val);
+                return this.promise;
+            };
+        });
+    }
+}
+
+describe('migrations/utils', function () {
+    describe('createTransactionalMigration', function () {
+        it('Accepts two functions and creates a transactional migration from them', function () {
+            const config = {
+                transacting: {}
+            };
+            const up = sinon.spy();
+            const down = sinon.spy();
+
+            const migration = utils.createTransactionalMigration(up, down);
+            const upResult = migration.up(config);
+            const downResult = migration.down(config);
+
+            should.ok(migration.config.transaction, 'Migration config should set transaction to true');
+
+            should.ok(upResult instanceof Promise, 'Migration up method should return a Promise');
+            should.ok(downResult instanceof Promise, 'Migration down method should return a Promise');
+
+            should.ok(up.calledOnceWith(config.transacting), 'up function should be called with transacting');
+            should.ok(down.calledOnceWith(config.transacting), 'down function should be called with transacting');
+        });
+    });
+
+    describe('combineTransactionalMigrations', function () {
+        it('Accepts a number of migrations and returns a single migration', async function () {
+            const config = {
+                transacting: {}
+            };
+            const upA = sinon.stub().resolves();
+            const downA = sinon.stub().resolves();
+            const upB = sinon.stub().resolves();
+            const downB = sinon.stub().resolves();
+
+            const migrationA = utils.createTransactionalMigration(upA, downA);
+            const migrationB = utils.createTransactionalMigration(upB, downB);
+            const combinedMigration = utils.combineTransactionalMigrations(migrationA, migrationB);
+
+            should.ok(combinedMigration.config.transaction, 'Migration config should set transaction to true');
+
+            const upResult = combinedMigration.up(config);
+            should.ok(upResult instanceof Promise, 'Migration up method should return a Promise');
+
+            await upResult;
+            should.ok(upA.calledOnceWith(config.transacting), 'first up fn should be called with transacting');
+            should.ok(upB.calledOnceWith(config.transacting), 'second up fn should be called with transacting');
+            should.ok(upA.calledBefore(upB), 'Migration up method should call child up methods in order');
+
+            const downResult = combinedMigration.down(config);
+            should.ok(downResult instanceof Promise, 'Migration down method should return a Promise');
+
+            await downResult;
+            should.ok(downA.calledOnceWith(config.transacting), 'first down fn should be called with transacting');
+            should.ok(downB.calledOnceWith(config.transacting), 'second down fn should be called with transacting');
+            should.ok(downB.calledBefore(downA), 'Migration down method should call child down methods in reverse order');
+        });
+
+        it('Waits for each migration to finish before executing the next', async function () {
+            const config = {
+                transacting: {}
+            };
+            const upDeferredA = new Deferred();
+            const upDeferredB = new Deferred();
+            const downDeferredA = new Deferred();
+            const downDeferredB = new Deferred();
+
+            const upA = sinon.stub().returns(upDeferredA.promise);
+            const downA = sinon.stub().returns(downDeferredA.promise);
+            const upB = sinon.stub().returns(upDeferredB.promise);
+            const downB = sinon.stub().returns(downDeferredB.promise);
+
+            const migrationA = utils.createTransactionalMigration(upA, downA);
+            const migrationB = utils.createTransactionalMigration(upB, downB);
+            const combinedMigration = utils.combineTransactionalMigrations(migrationA, migrationB);
+
+            combinedMigration.up(config);
+
+            should.ok(!upB.called, 'second up fn should not be called until first up fn has resolved');
+            await upDeferredA.resolve();
+            should.ok(upB.calledOnce, 'second up fn should be called once first up fn has resolved');
+
+            combinedMigration.down(config);
+
+            should.ok(!downA.called, 'penultimate down fn should not be called until last down fn has resolved');
+            await downDeferredB.resolve();
+            should.ok(downA.calledOnce, 'penultimate down fn should be called once last down fn has resolved');
+        });
+
+        it('Stops execution if a migration errors, and propagates error', async function () {
+            const config = {
+                transacting: {}
+            };
+            const upDeferredA = new Deferred();
+            const upDeferredB = new Deferred();
+            const downDeferredA = new Deferred();
+            const downDeferredB = new Deferred();
+
+            const upA = sinon.stub().returns(upDeferredA.promise);
+            const downA = sinon.stub().returns(downDeferredA.promise);
+            const upB = sinon.stub().returns(upDeferredB.promise);
+            const downB = sinon.stub().returns(downDeferredB.promise);
+
+            const migrationA = utils.createTransactionalMigration(upA, downA);
+            const migrationB = utils.createTransactionalMigration(upB, downB);
+            const combinedMigration = utils.combineTransactionalMigrations(migrationA, migrationB);
+
+            const upResult = combinedMigration.up(config);
+
+            should.ok(!upB.called, 'second up fn should not be called until first up fn has resolved');
+            try {
+                await upDeferredA.reject(new Error('some reason'));
+            } catch (err) {
+                //
+            } finally {
+                should.ok(!upB.called, 'second up fn should not be called if first up fn has rejected');
+            }
+
+            let upError = null;
+            try {
+                await upResult;
+            } catch (err) {
+                upError = true;
+            } finally {
+                should.ok(upError, 'Migration up should error if child errors');
+            }
+
+            const downResult = combinedMigration.down(config);
+
+            should.ok(!downA.called, 'penultimate down fn should not be called until last down fn has resolved');
+            try {
+                await downDeferredB.reject(new Error('some reason'));
+            } catch (err) {
+                //
+            } finally {
+                should.ok(!downA.called, 'penultimate down fn should not be called if last down fn has rejected');
+            }
+
+            let downErr = null;
+            try {
+                await downResult;
+            } catch (err) {
+                downErr = err;
+            } finally {
+                should.ok(downErr, 'Migration down should error if child errors');
+            }
+        });
+    });
+});
+
+const Knex = require('knex');
+const ObjectId = require('bson-objectid').default;
+
+async function setupDb() {
+    const knex = Knex({
+        client: 'sqlite',
+        connection: {
+            filename: ':memory:'
+        },
+        // Suppress warnings from knex
+        useNullAsDefault: true
+    });
+
+    await knex.raw(`
+        CREATE TABLE \`permissions\` (
+            \`id\` varchar(24) not null,
+            \`name\` varchar(50) not null,
+            \`object_type\` varchar(50) not null,
+            \`action_type\` varchar(50) not null,
+            \`object_id\` varchar(24) null,
+            \`created_at\` datetime not null,
+            \`created_by\` varchar(24) not null,
+            \`updated_at\` datetime null,
+            \`updated_by\` varchar(24) null,
+            primary key (\`id\`)
+        );
+        CREATE UNIQUE INDEX \`permissions_name_unique\` on \`permissions\` (\`name\`);\`);
+    `);
+
+    await knex.raw(`
+        CREATE TABLE \`permissions_roles\` (
+            \`id\` varchar(24) not null,
+            \`role_id\` varchar(24) not null,
+            \`permission_id\` varchar(24) not null,
+            primary key (\`id\`)
+        );
+    `);
+
+    await knex.raw(`
+        CREATE TABLE \`roles\` (
+            \`id\` varchar(24) not null,
+            \`name\` varchar(50) not null,
+            \`description\` varchar(2000) null,
+            \`created_at\` datetime not null,
+            \`created_by\` varchar(24) not null,
+            \`updated_at\` datetime null,
+            \`updated_by\` varchar(24) null,
+            primary key (\`id\`)
+        );
+        CREATE UNIQUE INDEX \`roles_name_unique\` on \`roles\` (\`name\`);
+    `);
+
+    const date = knex.raw('CURRENT_TIMESTAMP');
+    await knex('roles').insert({
+        id: ObjectId.generate(),
+        name: 'Role Name',
+        description: 'Role description',
+        created_at: date,
+        created_by: utils.meta.MIGRATION_USER,
+        updated_at: date,
+        updated_by: utils.meta.MIGRATION_USER
+    });
+
+    await knex('roles').insert({
+        id: ObjectId.generate(),
+        name: 'Other Role Name',
+        description: 'Other Role description',
+        created_at: date,
+        created_by: utils.meta.MIGRATION_USER,
+        updated_at: date,
+        updated_by: utils.meta.MIGRATION_USER
+    });
+
+    await knex('permissions').insert({
+        id: ObjectId.generate(),
+        name: 'Permission Name',
+        action_type: 'action',
+        object_type: 'object',
+        created_at: date,
+        created_by: utils.meta.MIGRATION_USER,
+        updated_at: date,
+        updated_by: utils.meta.MIGRATION_USER
+    });
+
+    return knex;
+}
+
+async function runUpMigration(knex, migration) {
+    {
+        const transacting = await knex.transaction();
+        await migration.up({transacting});
+        transacting.commit();
+    }
+
+    return async function runDownMigration() {
+        const transacting = await knex.transaction();
+        await migration.down({transacting});
+        transacting.commit();
+    };
+}
+
+describe('migrations/utils/permissions', function () {
+    describe('addPermission', function () {
+        it('Accepts a name, action and object and returns a migration which adds a permission to the database', async function () {
+            const knex = await setupDb();
+
+            const migration = utils.addPermission({
+                name: 'scarface',
+                object: 'my little friend',
+                action: 'say hello'
+            });
+
+            should.ok(migration.config.transaction, 'addPermission creates a transactional migration');
+
+            const runDownMigration = await runUpMigration(knex, migration);
+
+            const allPermissionsAfterUp = await knex('permissions').select();
+            const insertedPermissionsAfterUp = allPermissionsAfterUp.filter((row) => {
+                return row.name === 'scarface';
+            });
+
+            should.ok(insertedPermissionsAfterUp.length === 1, 'The permission was inserted into the database');
+
+            await runDownMigration();
+
+            const allPermissionsAfterDown = await knex('permissions').select();
+            const insertedPermissionsAfterDown = allPermissionsAfterDown.filter((row) => {
+                return row.name === 'scarface';
+            });
+
+            should.ok(insertedPermissionsAfterDown.length === 0, 'The permission was removed');
+        });
+    });
+
+    describe('addPermissionToRole', function () {
+        it('Accepts a permisson name and role name and returns a migration which adds a permission to the database', async function () {
+            const knex = await setupDb();
+
+            const migration = utils.addPermissionToRole({
+                permission: 'Permission Name',
+                role: 'Role Name'
+            });
+
+            const runDownMigration = await runUpMigration(knex, migration);
+
+            const allPermissionsForRoleAfterUp = await knex.raw(`
+                SELECT
+                    p.name
+                FROM
+                    permissions p
+                INNER JOIN
+                    permissions_roles pr
+                ON
+                    pr.permission_id = p.id
+                INNER JOIN
+                    roles r
+                ON
+                    pr.role_id = r.id
+                WHERE
+                    r.name = 'Role Name';
+            `);
+
+            const attachedPermissionAfterUp = allPermissionsForRoleAfterUp.find((row) => {
+                return row.name === 'Permission Name';
+            });
+
+            should.ok(attachedPermissionAfterUp, 'The permission was attached to the role.');
+
+            await runDownMigration();
+
+            const allPermissionsForRoleAfterDown = await knex.raw(`
+                SELECT
+                    p.name
+                FROM
+                    permissions p
+                INNER JOIN
+                    permissions_roles pr
+                ON
+                    pr.permission_id = p.id
+                INNER JOIN
+                    roles r
+                ON
+                    pr.role_id = r.id
+                WHERE
+                    r.name = 'Role Name';
+            `);
+
+            const attachedPermissionAfterDown = allPermissionsForRoleAfterDown.find((row) => {
+                return row.name === 'Permission Name';
+            });
+
+            should.ok(!attachedPermissionAfterDown, 'The permission was removed from the role.');
+        });
+    });
+
+    describe('addPermissionWithRoles', function () {
+        it('Accepts addPermission config and a list of roles, and creates the permission, linking it to roles', async function () {
+            const knex = await setupDb();
+
+            const migration = utils.addPermissionWithRoles({
+                name: 'scarface',
+                object: 'my little friend',
+                action: 'say hello'
+            }, [
+                'Role Name',
+                'Other Role Name'
+            ]);
+
+            const runDownMigration = await runUpMigration(knex, migration);
+
+            const allPermissionsAfterUp = await knex('permissions').select();
+            const insertedPermissionsAfterUp = allPermissionsAfterUp.filter((row) => {
+                return row.name === 'scarface';
+            });
+
+            should.ok(insertedPermissionsAfterUp.length === 1, 'The permission was inserted into the database');
+
+            const allPermissionsForRoleAfterUp = await knex.raw(`
+                SELECT
+                    p.name
+                FROM
+                    permissions p
+                INNER JOIN
+                    permissions_roles pr
+                ON
+                    pr.permission_id = p.id
+                INNER JOIN
+                    roles r
+                ON
+                    pr.role_id = r.id
+                WHERE
+                    r.name = 'Role Name';
+            `);
+
+            const permissionAttachedToRoleAfterUp = allPermissionsForRoleAfterUp.find((row) => {
+                return row.name === 'scarface';
+            });
+
+            should.ok(permissionAttachedToRoleAfterUp, 'The permission was attached to the role.');
+
+            const allPermissionsForOtherRoleAfterUp = await knex.raw(`
+                SELECT
+                    p.name
+                FROM
+                    permissions p
+                INNER JOIN
+                    permissions_roles pr
+                ON
+                    pr.permission_id = p.id
+                INNER JOIN
+                    roles r
+                ON
+                    pr.role_id = r.id
+                WHERE
+                    r.name = 'Other Role Name';
+            `);
+
+            const permissionAttachedToOtherRoleAfterUp = allPermissionsForRoleAfterUp.find((row) => {
+                return row.name === 'scarface';
+            });
+
+            should.ok(permissionAttachedToOtherRoleAfterUp, 'The permission was attached to the other role.');
+
+            await runDownMigration();
+
+            const allPermissionsAfterDown = await knex('permissions').select();
+            const insertedPermissionsAfterDown = allPermissionsAfterDown.filter((row) => {
+                return row.name === 'scarface';
+            });
+
+            should.ok(insertedPermissionsAfterDown.length === 0, 'The permission was removed from the database');
+
+            const allPermissionsForRoleAfterDown = await knex.raw(`
+                SELECT
+                    p.name
+                FROM
+                    permissions p
+                INNER JOIN
+                    permissions_roles pr
+                ON
+                    pr.permission_id = p.id
+                INNER JOIN
+                    roles r
+                ON
+                    pr.role_id = r.id
+                WHERE
+                    r.name = 'Role Name';
+            `);
+
+            const permissionAttachedToRoleAfterDown = allPermissionsForRoleAfterDown.find((row) => {
+                return row.name === 'scarface';
+            });
+
+            should.ok(!permissionAttachedToRoleAfterDown, 'The permission was removed from the role.');
+
+            const allPermissionsForOtherRoleAfterDown = await knex.raw(`
+                SELECT
+                    p.name
+                FROM
+                    permissions p
+                INNER JOIN
+                    permissions_roles pr
+                ON
+                    pr.permission_id = p.id
+                INNER JOIN
+                    roles r
+                ON
+                    pr.role_id = r.id
+                WHERE
+                    r.name = 'Other Role Name';
+            `);
+
+            const permissionAttachedToOtherRoleAfterDown = allPermissionsForOtherRoleAfterDown.find((row) => {
+                return row.name === 'scarface';
+            });
+
+            should.ok(!permissionAttachedToOtherRoleAfterDown, 'The permission was removed from the other role.');
+        });
+    });
+});


### PR DESCRIPTION
no-issue

This PR adds a new `utils` module/file to the migrations directory, with some permission migration util functions, as well as a generic "combinator" function that can merge migrations together.

We've also updated every permission migration in Ghost (I _think_ at least, I looked pretty hard!) to use the utils.

I've tested migrating from 1.26.2, 2.0.0, 2.38.2 & 3.0.0 to latest, as well as rolling back.

Testing is a bit of a pain in the arse, but I did for each of the versions I wanted to test:

```
git checkout 1.26.2
nvm use <valid-version>
yarn
npm install -g knex-migrator
rm content/data/ghost-dev.db
knex-migrator init
yarn start # exit after boot, this is to ensure the settings are populated
mv content/data/ghost-dev.db content/data/ghost-1.26.2.db
```

Followed by coming back to this branch and testing each version like so:

```
cp content/data/ghost-<vers>.db content/data/ghost-dev.db
knex-migrator migrate
knex-migrator rollback
```

Remaining:

- [x] Tests
- [ ] Better naming
- [x] Better logging