### PR TITLE
Added new settings for members modal settings

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -220,24 +220,22 @@
         },
         "stripe_connect_integration": {
             "defaultValue": "{}"
-        }
-    },
-    "membersjs": {
-        "show_signup_name": {
+        },
+        "membersjs_show_signup_name": {
             "defaultValue": "true",
             "validations": {
                 "isEmpty": false,
                 "isIn": [["true", "false"]]
             }
         },
-        "show_beacon": {
+        "membersjs_show_beacon": {
             "defaultValue": "true",
             "validations": {
                 "isEmpty": false,
                 "isIn": [["true", "false"]]
             }
         },
-        "allowed_plans": {
+        "membersjs_allowed_plans": {
             "defaultValue": "[\"free\", \"monthly\", \"yearly\"]"
         }
     },

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -222,6 +222,25 @@
             "defaultValue": "{}"
         }
     },
+    "membersjs": {
+        "show_signup_name": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            }
+        },
+        "show_beacon": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            }
+        },
+        "allowed_plans": {
+            "defaultValue": "[\"free\", \"monthly\", \"yearly\"]"
+        }
+    },
     "bulk_email": {
         "bulk_email_settings": {
             "defaultValue": "{\"provider\":\"mailgun\", \"apiKey\": \"\", \"domain\": \"\", \"baseUrl\": \"\"}"

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -152,7 +152,7 @@ module.exports = {
             maxlength: 50,
             nullable: false,
             defaultTo: 'core',
-            validations: {isIn: [['core', 'blog', 'theme', 'private', 'members', 'bulk_email', 'membersjs']]}
+            validations: {isIn: [['core', 'blog', 'theme', 'private', 'members', 'bulk_email']]}
         },
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -152,7 +152,7 @@ module.exports = {
             maxlength: 50,
             nullable: false,
             defaultTo: 'core',
-            validations: {isIn: [['core', 'blog', 'theme', 'private', 'members', 'bulk_email']]}
+            validations: {isIn: [['core', 'blog', 'theme', 'private', 'members', 'bulk_email', 'membersjs']]}
         },
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -89,7 +89,9 @@ const getMemberSiteData = async function (req, res) {
     );
     const stripeSecretToken = stripePaymentProcessor && stripePaymentProcessor.config.secret_token;
     const stripePublicToken = stripePaymentProcessor && stripePaymentProcessor.config.public_token;
-    const isStripeConfigured = (!!stripeSecretToken && stripeSecretToken !== '' && !!stripePublicToken && stripePublicToken !== '');
+    const stripeConnectIntegration = settingsCache.get('stripe_connect_integration');
+
+    const isStripeConfigured = (!!stripeSecretToken && !!stripePublicToken) || !!(stripeConnectIntegration && stripeConnectIntegration.account_id);
     const response = {
         title: settingsCache.get('title'),
         description: settingsCache.get('description'),

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -102,9 +102,9 @@ const getMemberSiteData = async function (req, res) {
         plans: membersService.config.getPublicPlans(),
         allowSelfSignup: membersService.config.getAllowSelfSignup(),
         isStripeConfigured,
-        show_beacon: settingsCache.get('show_beacon'),
-        show_signup_name: settingsCache.get('show_signup_name'),
-        allowed_plans: settingsCache.get('allowed_plans')
+        show_beacon: settingsCache.get('membersjs_show_beacon'),
+        show_signup_name: settingsCache.get('membersjs_show_signup_name'),
+        allowed_plans: settingsCache.get('membersjs_allowed_plans')
     };
 
     // Brand is currently an experimental feature

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -101,7 +101,10 @@ const getMemberSiteData = async function (req, res) {
         version: ghostVersion.safe,
         plans: membersService.config.getPublicPlans(),
         allowSelfSignup: membersService.config.getAllowSelfSignup(),
-        isStripeConfigured
+        isStripeConfigured,
+        show_beacon: settingsCache.get('show_beacon'),
+        show_signup_name: settingsCache.get('show_signup_name'),
+        allowed_plans: settingsCache.get('allowed_plans')
     };
 
     // Brand is currently an experimental feature


### PR DESCRIPTION
- Adds new settings for members modal customization to default settings
- `membersjs_show_beacon` controls the visibility of beacon in members modal
- `membersjs_show_signup_name` controls the visibility of name field in signup
- `membersjs_allowed_plans` controls the visibility of plans allowed for member to signup with