### PR TITLE
Added API endpoints for disconnecting Stripe

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -123,6 +123,19 @@ const createLabels = async (labels, options) => {
 
 const members = {
     docName: 'members',
+
+    hasActiveStripeSubscriptions: {
+        permissions: {
+            method: 'browse'
+        },
+        async query() {
+            const hasActiveStripeSubscriptions = await membersService.api.hasActiveStripeSubscriptions();
+            return {
+                hasActiveStripeSubscriptions
+            };
+        }
+    },
+
     browse: {
         options: [
             'limit',

--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -150,6 +150,25 @@ module.exports = {
         }
     },
 
+    disconnectStripeConnectIntegration: {
+        permissions: {
+            method: 'edit'
+        },
+        async query(frame) {
+            const hasActiveStripeSubscriptions = await membersService.api.hasActiveStripeSubscriptions();
+            if (hasActiveStripeSubscriptions) {
+                throw new BadRequestError({
+                    message: 'Cannot disconnect Stripe whilst you have active subscriptions.'
+                });
+            }
+
+            return models.Settings.edit({
+                key: 'stripe_connect_integration',
+                value: '{}'
+            }, frame.options);
+        }
+    },
+
     edit: {
         headers: {
             cacheInvalidate: true

--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -6,6 +6,9 @@ const mapper = require('./utils/mapper');
 const papaparse = require('papaparse');
 
 module.exports = {
+    hasActiveStripeSubscriptions(data, apiConfig, frame) {
+        frame.response = data;
+    },
     browse(data, apiConfig, frame) {
         debug('browse');
 

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -100,6 +100,8 @@ module.exports = function apiRoutes() {
         http(apiCanary.members.importCSV)
     );
 
+    router.get('/members/hasActiveStripeSubscriptions', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.hasActiveStripeSubscriptions));
+
     router.get('/members/stripe_connect', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.membersStripeConnect.auth));
 
     router.get('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.read));

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -63,6 +63,7 @@ module.exports = function apiRoutes() {
     router.put('/settings', mw.authAdminApi, http(apiCanary.settings.edit));
     router.get('/settings/members/email', http(apiCanary.settings.validateMembersFromEmail));
     router.post('/settings/members/email', mw.authAdminApi, http(apiCanary.settings.updateMembersFromEmail));
+    router.del('/settings/stripe/connect', mw.authAdminApi, http(apiCanary.settings.disconnectStripeConnectIntegration));
 
     // ## Users
     router.get('/users', mw.authAdminApi, http(apiCanary.users.browse));

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@tryghost/kg-markdown-html-renderer": "2.0.1",
     "@tryghost/kg-mobiledoc-html-renderer": "3.0.1",
     "@tryghost/magic-link": "^0.4.8",
-    "@tryghost/members-api": "0.22.0",
+    "@tryghost/members-api": "0.23.0",
     "@tryghost/members-ssr": "0.8.1",
     "@tryghost/mw-session-from-token": "0.1.4",
     "@tryghost/session-service": "0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -496,10 +496,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.22.0.tgz#70f6c06731b82b12aa117912ca9277b987ed2886"
-  integrity sha512-ABHSXOv/DdxlVaAwySqZeATByBdylyST/Tq19GAcGiK3ejDSPv7YW3+yL6a7ebM5RgbTchAULRNHyJKPAy63eg==
+"@tryghost/members-api@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.23.0.tgz#227a957b4d80fee928c4d91577b871c6b7d26b50"
+  integrity sha512-ttDS9ZV6Z0iT7Zlig87pXUVI7PvCkVIiEZOQKUW7wA9isGNL800SJuXwTcBTW/KWfmY/AmqtKBXVMl8Ko4+Abw==
   dependencies:
     "@tryghost/magic-link" "^0.4.9"
     bluebird "^3.5.4"


### PR DESCRIPTION
no-issue

This adds two new endpoints

### `DELETE /ghost/api/v3/admin/settings/stripe/connect`

This will delete the stripe connect integration, but fail if there are any active subscriptions

### `GET /ghost/api/v3/admin/members/hasActiveStripeSubscriptions/`

This returns an object with a `hasActiveStripeSubscriptions` boolean