### PR TITLE
✨ Switched on Stripe Connect by default

### DIFF
--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -109,5 +109,5 @@
     "preloadHeaders": false,
     "adminFrameProtection": true,
     "sendWelcomeEmail": true,
-    "stripeDirect": true
+    "stripeDirect": false
 }


### PR DESCRIPTION
no-issue

This flags switches off the old API Key UI and replaces it with the new
Stripe Connect flow!