### PR TITLE
Added new settings for members modal

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -222,6 +222,25 @@
             "defaultValue": "{}"
         }
     },
+    "portal" : {
+        "portal_name": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            }
+        },
+        "portal_button": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            }
+        },
+        "portal_plans": {
+            "defaultValue": "[\"free\", \"monthly\", \"yearly\"]"
+        }
+    },
     "bulk_email": {
         "bulk_email_settings": {
             "defaultValue": "{\"provider\":\"mailgun\", \"apiKey\": \"\", \"domain\": \"\", \"baseUrl\": \"\"}"

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -152,7 +152,7 @@ module.exports = {
             maxlength: 50,
             nullable: false,
             defaultTo: 'core',
-            validations: {isIn: [['core', 'blog', 'theme', 'private', 'members', 'bulk_email']]}
+            validations: {isIn: [['core', 'blog', 'theme', 'private', 'members', 'bulk_email', 'portal']]}
         },
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -89,7 +89,9 @@ const getMemberSiteData = async function (req, res) {
     );
     const stripeSecretToken = stripePaymentProcessor && stripePaymentProcessor.config.secret_token;
     const stripePublicToken = stripePaymentProcessor && stripePaymentProcessor.config.public_token;
-    const isStripeConfigured = (!!stripeSecretToken && stripeSecretToken !== '' && !!stripePublicToken && stripePublicToken !== '');
+    const stripeConnectIntegration = settingsCache.get('stripe_connect_integration');
+
+    const isStripeConfigured = (!!stripeSecretToken && !!stripePublicToken) || !!(stripeConnectIntegration && stripeConnectIntegration.account_id);
     const response = {
         title: settingsCache.get('title'),
         description: settingsCache.get('description'),
@@ -98,8 +100,11 @@ const getMemberSiteData = async function (req, res) {
         url: urlUtils.urlFor('home', true),
         version: ghostVersion.safe,
         plans: membersService.config.getPublicPlans(),
-        allowSelfSignup: membersService.config.getAllowSelfSignup(),
-        isStripeConfigured
+        allow_self_signup: membersService.config.getAllowSelfSignup(),
+        is_stripe_configured: isStripeConfigured,
+        portal_button: settingsCache.get('portal_button'),
+        portal_name: settingsCache.get('portal_name'),
+        portal_plans: settingsCache.get('portal_plans')
     };
 
     // Brand is currently an experimental feature


### PR DESCRIPTION
no issue

-  reverts commit 87c31444fd41d182f3add55f72e0e0fb9cdcc1ff but with modifications to settings naming
-  Adds new settings for members modal customization to default settings
- `portal_button` controls the visibility of beacon in members modal
- `portal_name` controls the visibility of name field in signup
- `portal_plans` controls the visibility of plans allowed for member to signup with
-  Adds stripe connect check to determine if stripe is setup or not
-  Adds the 3 new settings to members site data
-  Updates to snake case naming for members site API data