### PR TITLE
Removed force_i18n and other deprecated settings fields from the codebase

### DIFF
--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -10,8 +10,7 @@ const membersService = require('../../services/members');
 
 const SETTINGS_BLACKLIST = [
     'members_public_key',
-    'members_private_key',
-    'members_session_secret'
+    'members_private_key'
 ];
 
 module.exports = {

--- a/core/server/api/canary/utils/serializers/input/settings.js
+++ b/core/server/api/canary/utils/serializers/input/settings.js
@@ -68,12 +68,5 @@ module.exports = {
                 setting.value = JSON.stringify(memberSubscriptionSettings);
             }
         });
-
-        // CASE: deprecated, won't accept
-        const index = _.findIndex(frame.data.settings, {key: 'force_i18n'});
-
-        if (index !== -1) {
-            frame.data.settings.splice(index, 1);
-        }
     }
 };

--- a/core/server/api/canary/utils/serializers/output/settings.js
+++ b/core/server/api/canary/utils/serializers/output/settings.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const utils = require('../../index');
 const mapper = require('./utils/mapper');
 const _private = {};
-const deprecatedSettings = ['permalinks'];
 
 /**
  * ### Settings Filter
@@ -16,10 +15,10 @@ _private.settingsFilter = (settings, filter) => {
     let filteredTypes = filter ? filter.split(',') : false;
     return _.filter(settings, (setting) => {
         if (filteredTypes) {
-            return _.includes(filteredTypes, setting.type) && !_.includes(deprecatedSettings, setting.key);
+            return _.includes(filteredTypes, setting.type);
         }
 
-        return !_.includes(deprecatedSettings, setting.key);
+        return true;
     });
 };
 

--- a/core/server/api/canary/utils/serializers/output/settings.js
+++ b/core/server/api/canary/utils/serializers/output/settings.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const utils = require('../../index');
 const mapper = require('./utils/mapper');
 const _private = {};
-const deprecatedSettings = ['force_i18n', 'permalinks'];
+const deprecatedSettings = ['permalinks'];
 
 /**
  * ### Settings Filter

--- a/core/server/api/canary/utils/validators/input/settings.js
+++ b/core/server/api/canary/utils/validators/input/settings.js
@@ -5,15 +5,6 @@ const {BadRequestError, NotFoundError} = require('@tryghost/errors');
 
 module.exports = {
     read(apiConfig, frame) {
-        // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
-        if (frame.options.key === 'permalinks') {
-            return Promise.reject(new NotFoundError({
-                message: i18n.t('errors.api.settings.problemFindingSetting', {
-                    key: frame.options.key
-                })
-            }));
-        }
-
         // @NOTE: was removed https://github.com/TryGhost/Ghost/issues/10373
         if (frame.options.key === 'ghost_head' || frame.options.key === 'ghost_foot') {
             return Promise.reject(new NotFoundError({
@@ -36,13 +27,6 @@ module.exports = {
                         help: i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
                     })
                 );
-            } else if (setting.key === 'permalinks') {
-                // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
-                errors.push(new NotFoundError({
-                    message: i18n.t('errors.api.settings.problemFindingSetting', {
-                        key: setting.key
-                    })
-                }));
             } else if (setting.key === 'ghost_head' || setting.key === 'ghost_foot') {
                 // @NOTE: was removed https://github.com/TryGhost/Ghost/issues/10373
                 errors.push(new NotFoundError({

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -8,8 +8,7 @@ const settingsCache = require('../../services/settings/cache');
 
 const SETTINGS_BLACKLIST = [
     'members_public_key',
-    'members_private_key',
-    'members_session_secret'
+    'members_private_key'
 ];
 
 module.exports = {

--- a/core/server/api/v2/utils/serializers/input/settings.js
+++ b/core/server/api/v2/utils/serializers/input/settings.js
@@ -50,12 +50,5 @@ module.exports = {
                 setting = url.forSetting(setting);
             }
         });
-
-        // CASE: deprecated, won't accept
-        const index = _.findIndex(frame.data.settings, {key: 'force_i18n'});
-
-        if (index !== -1) {
-            frame.data.settings.splice(index, 1);
-        }
     }
 };

--- a/core/server/api/v2/utils/serializers/output/settings.js
+++ b/core/server/api/v2/utils/serializers/output/settings.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const utils = require('../../index');
 const mapper = require('./utils/mapper');
 const _private = {};
-const deprecatedSettings = ['force_i18n', 'permalinks', 'secondary_nav'];
+const deprecatedSettings = ['permalinks', 'secondary_nav'];
 
 /**
  * ### Settings Filter

--- a/core/server/api/v2/utils/serializers/output/settings.js
+++ b/core/server/api/v2/utils/serializers/output/settings.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const utils = require('../../index');
 const mapper = require('./utils/mapper');
 const _private = {};
-const deprecatedSettings = ['permalinks', 'secondary_nav'];
+const deprecatedSettings = ['secondary_nav'];
 
 /**
  * ### Settings Filter

--- a/core/server/api/v2/utils/validators/input/settings.js
+++ b/core/server/api/v2/utils/validators/input/settings.js
@@ -1,18 +1,9 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 const {i18n} = require('../../../../../lib/common');
-const {NotFoundError, BadRequestError} = require('@tryghost/errors');
+const {BadRequestError} = require('@tryghost/errors');
 
 module.exports = {
-    read(apiConfig, frame) {
-        // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
-        if (frame.options.key === 'permalinks') {
-            return Promise.reject(new NotFoundError({
-                message: i18n.t('errors.errors.resourceNotFound')
-            }));
-        }
-    },
-
     edit(apiConfig, frame) {
         const errors = [];
 
@@ -25,11 +16,6 @@ module.exports = {
                         help: i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
                     })
                 );
-            } else if (setting.key === 'permalinks') {
-                // @NOTE: was removed (https://github.com/TryGhost/Ghost/commit/8bb7088ba026efd4a1c9cf7d6f1a5e9b4fa82575)
-                errors.push(new NotFoundError({
-                    message: i18n.t('errors.api.settings.problemFindingSetting', {key: setting.key})
-                }));
             }
         });
 

--- a/core/server/data/exporter/index.js
+++ b/core/server/data/exporter/index.js
@@ -10,14 +10,6 @@ const security = require('../../lib/security');
 const models = require('../../models');
 const EXCLUDED_TABLES = ['sessions', 'mobiledoc_revisions'];
 
-const EXCLUDED_FIELDS_CONDITIONS = {
-    settings: [{
-        operator: 'whereNot',
-        key: 'key',
-        value: 'permalinks'
-    }]
-};
-
 const modelOptions = {context: {internal: true}};
 
 // private
@@ -66,12 +58,6 @@ exportTable = function exportTable(tableName, options) {
     if (EXCLUDED_TABLES.indexOf(tableName) < 0 ||
         (options.include && _.isArray(options.include) && options.include.indexOf(tableName) !== -1)) {
         const query = (options.transacting || db.knex)(tableName);
-
-        if (EXCLUDED_FIELDS_CONDITIONS[tableName]) {
-            EXCLUDED_FIELDS_CONDITIONS[tableName].forEach((condition) => {
-                query[condition.operator](condition.key, condition.value);
-            });
-        }
 
         return query.select();
     }

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -71,20 +71,6 @@ class SettingsImporter extends BaseImporter {
             return !_.includes(deprecatedSettings, data.key);
         });
 
-        const permalinks = _.find(this.dataToImport, {key: 'permalinks'});
-
-        if (permalinks) {
-            this.problems.push({
-                message: 'Permalink Setting was removed. Please configure permalinks in your routes.yaml.',
-                help: this.modelName,
-                context: JSON.stringify(permalinks)
-            });
-
-            this.dataToImport = _.filter(this.dataToImport, (data) => {
-                return data.key !== 'permalinks';
-            });
-        }
-
         // Remove core and theme data types
         this.dataToImport = _.filter(this.dataToImport, (data) => {
             return ['core', 'theme'].indexOf(data.type) === -1;

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -64,14 +64,6 @@
                 "isEmpty": false
             }
         },
-        "permalinks": {
-            "defaultValue": "/:slug/",
-            "validations": {
-                "matches": "^(\/:?[a-z0-9_-]+){1,5}\/$",
-                "matches": "(:id|:slug|:year|:month|:day|:author|:primary_tag|:primary_author)",
-                "notContains": "/ghost/"
-            }
-        },
         "amp": {
             "defaultValue" : "true",
             "validations": {

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -64,13 +64,6 @@
                 "isEmpty": false
             }
         },
-        "force_i18n": {
-            "defaultValue": "true",
-            "validations": {
-                "isEmpty": false,
-                "isIn": [["true", "false"]]
-            }
-        },
         "permalinks": {
             "defaultValue": "/:slug/",
             "validations": {

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -191,9 +191,6 @@
         "members_private_key": {
             "defaultValue": null
         },
-        "members_session_secret": {
-            "defaultValue": null
-        },
         "members_email_auth_secret": {
             "defaultValue": null
         },

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -46,7 +46,6 @@ function parseDefaultSettings() {
         public_hash: () => crypto.randomBytes(15).toString('hex'),
         // @TODO: session_secret would ideally be named "admin_session_secret"
         session_secret: () => crypto.randomBytes(32).toString('hex'),
-        members_session_secret: () => crypto.randomBytes(32).toString('hex'),
         theme_session_secret: () => crypto.randomBytes(32).toString('hex'),
         members_public_key: () => getMembersKey('public'),
         members_private_key: () => getMembersKey('private'),

--- a/test/regression/importer/importer_spec.js
+++ b/test/regression/importer/importer_spec.js
@@ -920,22 +920,13 @@ describe('Integration: Importer', function () {
                 value: '[{\\"url\\":\\"https://hook.slack.com\\"}]'
             });
 
-            exportData.data.settings[1] = testUtils.DataGenerator.forKnex.createSetting({
-                key: 'permalinks',
-                value: '/:primary_author/:slug/'
-            });
-
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
-                    imported.problems.length.should.eql(1);
+                    imported.problems.length.should.eql(0);
                     return models.Settings.findOne(_.merge({key: 'slack'}, testUtils.context.internal));
                 })
                 .then(function (result) {
                     result.attributes.value.should.eql('[{"url":""}]');
-                    return models.Settings.findOne(_.merge({key: 'permalinks'}, testUtils.context.internal));
-                })
-                .then((result) => {
-                    result.attributes.value.should.eql('/:slug/');
                 });
         });
 

--- a/test/regression/importer/importer_spec.js
+++ b/test/regression/importer/importer_spec.js
@@ -952,11 +952,6 @@ describe('Integration: Importer', function () {
                 value: '0'
             });
 
-            exportData.data.settings[2] = testUtils.DataGenerator.forKnex.createSetting({
-                key: 'force_i18n',
-                value: false
-            });
-
             return dataImporter.doImport(exportData, importOptions)
                 .then(function (imported) {
                     imported.problems.length.should.eql(0);
@@ -965,10 +960,6 @@ describe('Integration: Importer', function () {
                 .then(function (result) {
                     result.attributes.value.should.eql(true);
                     return models.Settings.findOne(_.merge({key: 'is_private'}, testUtils.context.internal));
-                })
-                .then((result) => {
-                    result.attributes.value.should.eql(false);
-                    return models.Settings.findOne(_.merge({key: 'force_i18n'}, testUtils.context.internal));
                 })
                 .then((result) => {
                     result.attributes.value.should.eql(false);
@@ -983,13 +974,6 @@ describe('Integration: Importer', function () {
                     return db
                         .knex('settings')
                         .where('key', 'is_private');
-                })
-                .then((result) => {
-                    result[0].value.should.eql('false');
-
-                    return db
-                        .knex('settings')
-                        .where('key', 'force_i18n');
                 })
                 .then((result) => {
                     result[0].value.should.eql('false');

--- a/test/unit/data/exporter/index_spec.js
+++ b/test/unit/data/exporter/index_spec.js
@@ -43,9 +43,6 @@ describe('Exporter', function () {
         });
 
         it('should try to export all the correct tables (without excluded)', function (done) {
-            // Setup for success
-            queryMock.select.returns(new Promise.resolve({}));
-
             // Execute
             exporter.doExport().then(function (exportData) {
                 // No tables, less the number of excluded tables
@@ -58,8 +55,6 @@ describe('Exporter', function () {
 
                 tablesStub.calledOnce.should.be.true();
                 db.knex.called.should.be.true();
-                queryMock.select.called.should.be.true();
-                queryMock.whereNot.calledOnce.should.be.true();
 
                 knexMock.callCount.should.eql(expectedCallCount);
                 queryMock.select.callCount.should.have.eql(expectedCallCount);

--- a/test/utils/fixtures/export/default_export.json
+++ b/test/utils/fixtures/export/default_export.json
@@ -2483,16 +2483,6 @@
                         "created_by": "1",
                         "updated_at": "2019-01-02T11:56:16.000Z",
                         "updated_by": "1"
-                    },
-                    {
-                        "id": "5c2ca6e0e015a6761618242b",
-                        "key": "members_session_secret",
-                        "value": "77ec615343ad860d9320a65719182e046b7d925f01139dae68386009d98c9498",
-                        "type": "members",
-                        "created_at": "2019-01-02T11:56:16.000Z",
-                        "created_by": "1",
-                        "updated_at": "2019-01-02T11:56:16.000Z",
-                        "updated_by": "1"
                     }
                 ],
                 "subscribers": [],

--- a/test/utils/fixtures/export/default_export.json
+++ b/test/utils/fixtures/export/default_export.json
@@ -2315,16 +2315,6 @@
                         "updated_by": "1"
                     },
                     {
-                        "id": "5c2ca6e0e015a67616182418",
-                        "key": "force_i18n",
-                        "value": "true",
-                        "type": "blog",
-                        "created_at": "2019-01-02T11:56:16.000Z",
-                        "created_by": "1",
-                        "updated_at": "2019-01-02T11:56:16.000Z",
-                        "updated_by": "1"
-                    },
-                    {
                         "id": "5c2ca6e0e015a6761618241a",
                         "key": "amp",
                         "value": "true",

--- a/test/utils/fixtures/export/valid.json
+++ b/test/utils/fixtures/export/valid.json
@@ -1273,16 +1273,6 @@
                         "updated_by": "1"
                     },
                     {
-                        "id": "59a952c2ebbf7206b369cdce",
-                        "key": "permalinks",
-                        "value": "/:slug/",
-                        "type": "blog",
-                        "created_at": "2017-09-01T12:18:30.000Z",
-                        "created_by": "1",
-                        "updated_at": "2017-09-01T12:30:47.000Z",
-                        "updated_by": "1"
-                    },
-                    {
                         "id": "59a952c2ebbf7206b369cdcf",
                         "key": "amp",
                         "value": "true",

--- a/test/utils/fixtures/export/valid.json
+++ b/test/utils/fixtures/export/valid.json
@@ -1273,16 +1273,6 @@
                         "updated_by": "1"
                     },
                     {
-                        "id": "59a952c2ebbf7206b369cdcd",
-                        "key": "force_i18n",
-                        "value": "true",
-                        "type": "blog",
-                        "created_at": "2017-09-01T12:29:54.000Z",
-                        "created_by": "1",
-                        "updated_at": "2017-09-01T12:29:54.000Z",
-                        "updated_by": "1"
-                    },
-                    {
                         "id": "59a952c2ebbf7206b369cdce",
                         "key": "permalinks",
                         "value": "/:slug/",


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/10318

Have moved migrations into a separate PR. This set of changes only removes `force_i18n`, `permalinks`, and `members_session_secret` usage from the codebase.