### PR TITLE
Refactored site url data attribute for new members script

### DIFF
--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -47,9 +47,7 @@ function getMembersHelper() {
 
     let membersHelper = `<script defer src="${getAssetUrl('public/members.js', true)}"></script>`;
     if (config.get('enableDeveloperExperiments')) {
-        const siteUrl = urlUtils.getSiteUrl().replace(/\/$/, '');
-        membersHelper = `<meta name="ghost:site" content='${siteUrl}' />`;
-        membersHelper += `<script defer src="https://unpkg.com/@tryghost/members-js@latest/umd/members.min.js"></script>`;
+        membersHelper += `<script defer src="https://unpkg.com/@tryghost/members-js@latest/umd/members.min.js" data-ghost="${urlUtils.getSiteUrl()}"></script>`;
     }
     if ((!!stripeSecretToken && !!stripePublicToken) || !!stripeConnectIntegration.account_id) {
         membersHelper += '<script src="https://js.stripe.com/v3/"></script>';


### PR DESCRIPTION
refs https://github.com/TryGhost/members.js/issues/54

- Previously new meta tag was added which defined the site url which was used by new script
- Removes meta tag and instead directly uses a data attribute defined on script tag which it can read on load, making it much simpler
