### PR TITLE
Renamed settings table keys

### DIFF
--- a/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
+++ b/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
@@ -1,0 +1,81 @@
+const logging = require('../../../../../shared/logging');
+
+const renameMapping = [{
+    down: 'default_locale',
+    up: 'lang'
+}, {
+    down: 'active_timezone',
+    up: 'timezone'
+}, {
+    down: 'ghost_head',
+    up: 'codeinjection_head'
+}, {
+    down: 'ghost_foot',
+    up: 'codeinjection_foot'
+}];
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up(options) {
+        await Promise.map(renameMapping, async (renameMap) => {
+            logging.info(`Renaming ${renameMap.down} to ${renameMap.up}`);
+
+            return await options
+                .transacting('settings')
+                .where('key', renameMap.down)
+                .update({
+                    key: renameMap.up
+                });
+        });
+
+        const brandResult = await options
+            .transacting('settings')
+            .where('key', 'brand')
+            .select('value');
+
+        const brand = JSON.parse(brandResult[0].value);
+
+        logging.info(`Updating brand.publicationColor in settings to accent_color with value ${brand.primaryColor}`);
+
+        return await options
+            .transacting('settings')
+            .where('key', 'brand')
+            .update('key', 'accent_color')
+            .update('value', brand.primaryColor);
+    },
+
+    async down(options) {
+        await Promise.map(renameMapping, async (renameMap) => {
+            logging.info(`Renaming ${renameMap.up} to ${renameMap.down}`);
+
+            return await options
+                .transacting('settings')
+                .where('key', renameMap.up)
+                .update({
+                    key: renameMap.down
+                });
+        });
+
+        let accentColor = await options
+            .transacting('settings')
+            .where('key', 'accent_color')
+            .select('value');
+
+        const brand = accentColor[0].value;
+
+        logging.info(`Updating accent_color in settings to brand.publicationColor with value ${brand.primaryColor}`);
+
+        return await options
+            .transacting('settings')
+            .where('key', 'accent_color')
+            .update('key', 'brand')
+            .update('value', JSON.stringify({
+                brand: {
+                    primaryColor: ''
+                }
+            }));
+    }
+};

--- a/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
+++ b/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
@@ -1,17 +1,17 @@
 const logging = require('../../../../../shared/logging');
 
 const renameMapping = [{
-    down: 'default_locale',
-    up: 'lang'
+    from: 'default_locale',
+    to: 'lang'
 }, {
-    down: 'active_timezone',
-    up: 'timezone'
+    from: 'active_timezone',
+    to: 'timezone'
 }, {
-    down: 'ghost_head',
-    up: 'codeinjection_head'
+    from: 'ghost_head',
+    to: 'codeinjection_head'
 }, {
-    down: 'ghost_foot',
-    up: 'codeinjection_foot'
+    from: 'ghost_foot',
+    to: 'codeinjection_foot'
 }];
 
 module.exports = {
@@ -21,13 +21,13 @@ module.exports = {
 
     async up(options) {
         await Promise.map(renameMapping, async (renameMap) => {
-            logging.info(`Renaming ${renameMap.down} to ${renameMap.up}`);
+            logging.info(`Renaming ${renameMap.from} to ${renameMap.to}`);
 
             return await options
                 .transacting('settings')
-                .where('key', renameMap.down)
+                .where('key', renameMap.from)
                 .update({
-                    key: renameMap.up
+                    key: renameMap.to
                 });
         });
 
@@ -49,13 +49,13 @@ module.exports = {
 
     async down(options) {
         await Promise.map(renameMapping, async (renameMap) => {
-            logging.info(`Renaming ${renameMap.up} to ${renameMap.down}`);
+            logging.info(`Renaming ${renameMap.to} to ${renameMap.from}`);
 
             return await options
                 .transacting('settings')
-                .where('key', renameMap.up)
+                .where('key', renameMap.to)
                 .update({
-                    key: renameMap.down
+                    key: renameMap.from
                 });
         });
 

--- a/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
+++ b/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
@@ -38,7 +38,7 @@ module.exports = {
 
         const brand = JSON.parse(brandResult[0].value);
 
-        logging.info(`Updating brand.publicationColor in settings to accent_color with value ${brand.primaryColor}`);
+        logging.info(`Updating brand.primaryColor in settings to accent_color with value ${brand.primaryColor}`);
 
         return await options
             .transacting('settings')
@@ -66,7 +66,7 @@ module.exports = {
 
         const brand = accentColor[0].value;
 
-        logging.info(`Updating accent_color in settings to brand.publicationColor with value ${brand.primaryColor}`);
+        logging.info(`Updating accent_color in settings to brand.primaryColor with value ${brand.primaryColor}`);
 
         return await options
             .transacting('settings')


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/10318

Adds following renames to settings table keys:
  'default_locale' -> 'lang'
  'active_timezone' -> 'timezone'
  'ghost_head' -> 'codeinjection_head'
  'ghost_foot' -> 'codeinjection_foot'
  'brand.publicationColor' -> 'accent_color'

@kevinansfield @rishabhgrg migration review please. Thanksyou :pray: 
