### PR TITLE
Added migration to populate settings.{group,flags} columns

### DIFF
--- a/core/server/data/migrations/versions/3.22/04-populate-settings-groups-and-flags.js
+++ b/core/server/data/migrations/versions/3.22/04-populate-settings-groups-and-flags.js
@@ -1,0 +1,190 @@
+const logging = require('../../../../../shared/logging');
+
+// settings with new groups
+const typeGroupMapping = [{
+    keys: [
+        'members_public_key',
+        'members_private_key',
+        'members_email_auth_secret'
+    ],
+    from: 'members',
+    to: 'core'
+}, {
+    keys: [
+        'title',
+        'description',
+        'logo',
+        'cover_image',
+        'icon',
+        'accent_color',
+        'lang',
+        'timezone',
+        'codeinjection_head',
+        'codeinjection_foot',
+        'facebook',
+        'twitter',
+        'navigation',
+        'secondary_navigation',
+        'meta_title',
+        'meta_description',
+        'og_image',
+        'og_title',
+        'og_description',
+        'twitter_image',
+        'twitter_title',
+        'twitter_description'
+
+    ],
+    from: 'blog',
+    to: 'site'
+}, {
+    keys: ['amp'],
+    from: 'blog',
+    to: 'amp'
+}, {
+    keys: ['labs'],
+    from: 'blog',
+    to: 'labs'
+}, {
+    keys: ['slack'],
+    from: 'blog',
+    to: 'slack'
+}, {
+    keys: ['unsplash'],
+    from: 'blog',
+    to: 'unsplash'
+}, {
+    keys: ['shared_views'],
+    from: 'blog',
+    to: 'views'
+}, {
+    keys: ['bulk_email_settings'],
+    from: 'bulk_email',
+    to: 'email'
+}];
+
+// settings with the same groups
+const groupMapping = [{
+    group: 'core',
+    keys: [
+        'db_hash',
+        'next_update_check',
+        'notifications',
+        'session_secret',
+        'theme_session_secret',
+        'ghost_public_key',
+        'ghost_private_key'
+    ]
+}, {
+    group: 'theme',
+    keys: ['active_theme']
+}, {
+    group: 'private',
+    keys: [
+        'is_private',
+        'password',
+        'public_hash'
+    ]
+}, {
+    group: 'members',
+    keys: [
+        'default_content_visibility',
+        'members_subscription_settings',
+        'stripe_connect_integration'
+    ]
+}, {
+    group: 'portal',
+    keys: [
+        'portal_name',
+        'portal_button',
+        'portal_plans'
+    ]
+}];
+
+// flags to be added to settings
+const flagMapping = [{
+    key: 'title',
+    flags: 'PUBLIC'
+}, {
+    key: 'description',
+    flags: 'PUBLIC'
+}, {
+    key: 'accent_color',
+    flags: 'PUBLIC'
+}, {
+    key: 'active_theme',
+    flags: 'RO'
+}];
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up(options) {
+        // set the new group for each changed setting and rename type
+        await Promise.map(typeGroupMapping, async (typeGroupMap) => {
+            return await Promise.map(typeGroupMap.keys, async (key) => {
+                logging.info(`Moving setting ${key} from ${typeGroupMap.from} to ${typeGroupMap.to}`);
+
+                return await options
+                    .transacting('settings')
+                    .where('key', key)
+                    .update({
+                        group: typeGroupMap.to,
+                        type: typeGroupMap.to
+                    });
+            });
+        });
+
+        // set the correct group value settings which aren't changing type
+        await Promise.map(groupMapping, async (groupMap) => {
+            return await Promise.map(groupMap.keys, async (key) => {
+                logging.info(`Adding setting ${key} to ${groupMap.group}`);
+
+                return await options
+                    .transacting('settings')
+                    .where('key', key)
+                    .update({
+                        group: groupMap.group
+                    });
+            });
+        });
+
+        return await Promise.map(flagMapping, async (flagMap) => {
+            logging.info(`Adding ${flagMap.flags} flag to ${flagMap.key} setting`);
+
+            return await options
+                .transacting('settings')
+                .where('key', flagMap.key)
+                .update({
+                    flags: flagMap.flags
+                });
+        });
+    },
+
+    async down(options) {
+        // clear all flags values
+        logging.info('Clearing all settings flags values');
+        await options
+            .transacting('settings')
+            .update({
+                flags: null
+            });
+
+        // put type values back but leave all group values as-is because we
+        // didn't change them from anything specific in `up`
+        return await Promise.map(typeGroupMapping, async (typeGroupMap) => {
+            return await Promise.map(typeGroupMap.keys, async (key) => {
+                logging.info(`Moving setting ${key} from ${typeGroupMap.from} to ${typeGroupMap.to}`);
+
+                return await options
+                    .transacting('settings')
+                    .where('key', key)
+                    .update({
+                        type: typeGroupMap.from
+                    });
+            });
+        });
+    }
+};

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -38,7 +38,8 @@
                 "isLength": {
                     "max": 150
                 }
-            }
+            },
+            "flags": "PUBLIC"
         },
         "description": {
             "defaultValue": "The professional publishing platform",
@@ -46,7 +47,8 @@
                 "isLength": {
                     "max": 200
                 }
-            }
+            },
+            "flags": "PUBLIC"
         },
         "logo": {
             "defaultValue": "https://static.ghost.org/v1.0.0/images/ghost-logo.svg"
@@ -58,7 +60,8 @@
             "defaultValue": ""
         },
         "accent_color": {
-            "defaultValue": ""
+            "defaultValue": "",
+            "flags": "PUBLIC"
         },
         "lang": {
             "defaultValue": "en",
@@ -158,7 +161,8 @@
     },
     "theme": {
         "active_theme": {
-            "defaultValue": "casper"
+            "defaultValue": "casper",
+            "flags": "RO"
         }
     },
     "private": {

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -174,20 +174,22 @@ module.exports = {
             maxlength: 50,
             nullable: false,
             defaultTo: 'core',
-            validations: {isIn: [[
-                'core',
-                'site',
-                'theme',
-                'private',
-                'members',
-                'portal',
-                'email',
-                'amp',
-                'labs',
-                'slack',
-                'unsplash',
-                'views'
-            ]]}
+            validations: {
+                isIn: [[
+                    'amp',
+                    'core',
+                    'email',
+                    'labs',
+                    'members',
+                    'portal',
+                    'private',
+                    'site',
+                    'slack',
+                    'theme',
+                    'unsplash',
+                    'views'
+                ]]
+            }
         },
         flags: {type: 'string', maxlength: 50, nullable: true},
         created_at: {type: 'dateTime', nullable: false},


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/10318

- maps old` settings.type` values to new `settings.type/group` values
  - uses an explicit map so that we don't lose information and can safely roll back even though we're modifying `settings.type` too
  - updates `settings.type` values too to keep code working while we switch to using `settings.group`
- sets the `settings.group` value for all settings which are keeping the same group as their current type
- adapts `settings.type` validations to match new groups
- adds flags to specific settings, both in the migration for existing settings records and in default-settings.json for new settings records