### PR TITLE
Updated Settings.populateDefaults() to account for available columns

### DIFF
--- a/core/server/data/migrations/hooks/migrate/before.js
+++ b/core/server/data/migrations/hooks/migrate/before.js
@@ -3,5 +3,8 @@ const models = require('../../../../models');
 
 module.exports = function before() {
     models.init();
-    return dbBackup.backup();
+    return dbBackup.backup().then(() => {
+        // ensure that our default settings are created to limit possible db states in migrations
+        return models.Settings.populateDefaults();
+    });
 };

--- a/test/regression/models/base/listeners_spec.js
+++ b/test/regression/models/base/listeners_spec.js
@@ -23,7 +23,7 @@ describe('Models: listeners', function () {
 
     before(testUtils.teardownDb);
 
-    beforeEach(testUtils.setup('owner', 'settings'));
+    beforeEach(testUtils.setup('owner:pre', 'settings'));
 
     beforeEach(function () {
         sinon.stub(events, 'on').callsFake(function (eventName, callback) {

--- a/test/unit/models/settings_spec.js
+++ b/test/unit/models/settings_spec.js
@@ -108,7 +108,29 @@ describe('Unit: models/settings', function () {
         });
 
         it('populates unset defaults', function () {
+            let insertQueries = [];
+
             tracker.on('query', (query) => {
+                // skip group and flags columns so we can test the insertion column skip
+                if (query.method === 'columnInfo') {
+                    return query.response([
+                        {name: 'id', type: 'varchar'},
+                        // {name: 'group', type: 'varchar'},
+                        {name: 'key', type: 'varchar'},
+                        {name: 'value', type: 'varchar'},
+                        {name: 'type', type: 'varchar'},
+                        // {name: 'flags', type: 'varchar'},
+                        {name: 'created_at', type: 'datetime'},
+                        {name: 'created_by', type: 'varchar'},
+                        {name: 'updated_at', type: 'varchar'},
+                        {name: 'updated_by', type: 'datetime'}
+                    ]);
+                }
+
+                if (query.method === 'insert') {
+                    insertQueries.push(query);
+                }
+
                 return query.response([{}]);
             });
 
@@ -117,22 +139,34 @@ describe('Unit: models/settings', function () {
                     const numberOfSettings = Object.keys(defaultSettings).reduce((settings, settingGroup) => {
                         return settings.concat(Object.keys(defaultSettings[settingGroup]));
                     }, []).length;
-                    // 2 events per item - settings.added and settings.[name].added
-                    eventSpy.callCount.should.equal(numberOfSettings * 2);
 
-                    const eventsEmitted = eventSpy.args.map(args => args[0]);
-                    const checkEventEmitted = event => should.ok(eventsEmitted.includes(event), `${event} event should be emitted`);
+                    insertQueries.length.should.equal(numberOfSettings);
 
-                    checkEventEmitted('settings.db_hash.added');
-                    checkEventEmitted('settings.description.added');
+                    // non-existent columns should not be populated
+                    insertQueries[0].sql.should.not.match(/group/);
+                    insertQueries[0].sql.should.not.match(/flags/);
 
-                    checkEventEmitted('settings.default_content_visibility.added');
-                    checkEventEmitted('settings.members_subscription_settings.added');
+                    // no events are emitted because we're not using the model layer
+                    eventSpy.callCount.should.equal(0);
                 });
         });
 
         it('doesn\'t overwrite any existing settings', function () {
+            let insertQueries = [];
+
             tracker.on('query', (query) => {
+                if (query.method === 'columnInfo') {
+                    return query.response([
+                        {name: 'id', type: 'varchar'},
+                        {name: 'key', type: 'varchar'},
+                        {name: 'value', type: 'varchar'}
+                    ]);
+                }
+
+                if (query.method === 'insert') {
+                    insertQueries.push(query);
+                }
+
                 return query.response([{
                     key: 'description',
                     value: 'Adam\'s Blog'
@@ -141,9 +175,11 @@ describe('Unit: models/settings', function () {
 
             return models.Settings.populateDefaults()
                 .then(() => {
-                    const eventsEmitted = eventSpy.args.map(args => args[0]);
-                    const checkEventNotEmitted = event => should.ok(!eventsEmitted.includes(event), `${event} event should be emitted`);
-                    checkEventNotEmitted('settings.description.added');
+                    const numberOfSettings = Object.keys(defaultSettings).reduce((settings, settingGroup) => {
+                        return settings.concat(Object.keys(defaultSettings[settingGroup]));
+                    }, []).length;
+
+                    insertQueries.length.should.equal(numberOfSettings - 1);
                 });
         });
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/10318

`Settings.populateDefaults()` is run before migrations during Ghost's startup. This can cause problems when new settings table columns are added (and populated in `default-settings.json`) because `populateDefaults()` was using the model layer which assumes that those columns are available, resulting in `ER_BAD_FIELD_ERROR: Unknown column` type errors.

- query the database for the available `settings` table columns
- switch to using raw knex queries without Bookshelf for insertions so that we're in control of the columns that are added
- use `_.pick` to skip any properties in `default-settings.json` that do not match to an available column - those columns will be added and populated by later migrations
- moving away from using the model to insert settings has the side-effect of not emitting `settings.added/edited` and `settings.x.added/edited` events, this should be fine because `populateDefaults()` is called before anything else is set up and listening
- added a call to `populateDefaults()` in our knex-migrator "before migration" hook so that we have consistent db state across both startup initialised migrations and manually triggered knex migrations