### PR TITLE
Updated migration to assume new settings exist

### DIFF
--- a/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
+++ b/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
@@ -15,12 +15,12 @@ const renameMappings = [{
 }, {
     from: 'brand',
     to: 'accent_color',
-    getValue: (oldValue) => {
-        return JSON.parse(oldValue).primaryColor || '';
+    getToValue: (fromValue) => {
+        return JSON.parse(fromValue).primaryColor || '';
     },
-    getOldValue: (newValue) => {
+    getFromValue: (toValue) => {
         return JSON.stringify({
-            primaryColor: newValue || ''
+            primaryColor: toValue || ''
         });
     }
 }];
@@ -37,7 +37,7 @@ module.exports = {
                 .select('value')
                 .first();
 
-            const updatedValue = renameMapping.getValue ? renameMapping.getValue(oldSetting.value) : oldSetting.value;
+            const updatedValue = renameMapping.getToValue ? renameMapping.getToValue(oldSetting.value) : oldSetting.value;
 
             logging.info(`Updating ${renameMapping.to} with value from ${renameMapping.from}`);
             await options.transacting('settings')
@@ -58,7 +58,7 @@ module.exports = {
                 .select('value')
                 .first();
 
-            const updatedValue = renameMapping.getOldValue ? renameMapping.getOldValue(newSetting.value) : newSetting.value;
+            const updatedValue = renameMapping.getFromValue ? renameMapping.getFromValue(newSetting.value) : newSetting.value;
 
             logging.info(`Updating ${renameMapping.from} with value from ${renameMapping.to}`);
             await options.transacting('settings')

--- a/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
+++ b/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
@@ -1,6 +1,6 @@
 const logging = require('../../../../../shared/logging');
 
-const renameMapping = [{
+const renameMappings = [{
     from: 'default_locale',
     to: 'lang'
 }, {
@@ -12,6 +12,17 @@ const renameMapping = [{
 }, {
     from: 'ghost_foot',
     to: 'codeinjection_foot'
+}, {
+    from: 'brand',
+    to: 'accent_color',
+    getValue: (oldValue) => {
+        return JSON.parse(oldValue).primaryColor || '';
+    },
+    getOldValue: (newValue) => {
+        return JSON.stringify({
+            primaryColor: newValue || ''
+        });
+    }
 }];
 
 module.exports = {
@@ -20,61 +31,44 @@ module.exports = {
     },
 
     async up(options) {
-        await Promise.map(renameMapping, async (renameMap) => {
-            logging.info(`Renaming ${renameMap.from} to ${renameMap.to}`);
+        for (const renameMapping of renameMappings) {
+            const oldSetting = await options.transacting('settings')
+                .where('key', renameMapping.from)
+                .select('value')
+                .first();
 
-            return await options
-                .transacting('settings')
-                .where('key', renameMap.from)
-                .update({
-                    key: renameMap.to
-                });
-        });
+            const updatedValue = renameMapping.getValue ? renameMapping.getValue(oldSetting.value) : oldSetting.value;
 
-        const brandResult = await options
-            .transacting('settings')
-            .where('key', 'brand')
-            .select('value');
+            logging.info(`Updating ${renameMapping.to} with value from ${renameMapping.from}`);
+            await options.transacting('settings')
+                .where('key', renameMapping.to)
+                .update('value', updatedValue);
 
-        const value = JSON.parse(brandResult[0].value);
-        const accentColor = value.primaryColor || '';
-
-        logging.info(`Updating brand.primaryColor in settings to accent_color with value '${accentColor}'`);
-
-        return await options
-            .transacting('settings')
-            .where('key', 'brand')
-            .update('key', 'accent_color')
-            .update('value', accentColor);
+            logging.info(`Deleting ${renameMapping.from}`);
+            await options.transacting('settings')
+                .where('key', renameMapping.from)
+                .del();
+        }
     },
 
     async down(options) {
-        await Promise.map(renameMapping, async (renameMap) => {
-            logging.info(`Renaming ${renameMap.to} to ${renameMap.from}`);
+        for (const renameMapping of renameMappings) {
+            const newSetting = await options.transacting('settings')
+                .where('key', renameMapping.to)
+                .select('value')
+                .first();
 
-            return await options
-                .transacting('settings')
-                .where('key', renameMap.to)
-                .update({
-                    key: renameMap.from
-                });
-        });
+            const updatedValue = renameMapping.getOldValue ? renameMapping.getOldValue(newSetting.value) : newSetting.value;
 
-        let accentColor = await options
-            .transacting('settings')
-            .where('key', 'accent_color')
-            .select('value');
+            logging.info(`Updating ${renameMapping.from} with value from ${renameMapping.to}`);
+            await options.transacting('settings')
+                .where('key', renameMapping.from)
+                .update('value', updatedValue);
 
-        const primaryColor = accentColor[0].value || '';
-
-        logging.info(`Updating accent_color in settings to brand.primaryColor with value '${primaryColor}'`);
-
-        return await options
-            .transacting('settings')
-            .where('key', 'accent_color')
-            .update('key', 'brand')
-            .update('value', JSON.stringify({
-                primaryColor
-            }));
+            logging.info(`Deleting ${renameMapping.from}`);
+            await options.transacting('settings')
+                .where('key', renameMapping.from)
+                .del();
+        }
     }
 };


### PR DESCRIPTION
refs #10318

As populateDefaults is run _before_ migrations, the new settings will
already be inserted in the database, so we just need to update their
values and then delete the old settings.

Depends on https://github.com/TryGhost/Ghost/pull/11962

