### PR TITLE
🐛 Moved access to an API property

### DIFF
--- a/core/frontend/services/routing/controllers/entry.js
+++ b/core/frontend/services/routing/controllers/entry.js
@@ -83,12 +83,6 @@ module.exports = function entryController(req, res, next) {
                 }));
             }
 
-            // CASE: Add access property to entry for v3+ api
-            // @TODO: reconsider the location of this - it's part of members
-            if (res.locals.apiVersion !== 'v0.1' && res.locals.apiVersion !== 'v2') {
-                entry.access = !!entry.html;
-            }
-
             helpers.secure(req, entry);
 
             const renderer = helpers.renderEntry(req, res);

--- a/core/server/api/canary/utils/serializers/output/utils/post-gating.js
+++ b/core/server/api/canary/utils/serializers/output/utils/post-gating.js
@@ -1,6 +1,7 @@
 const membersService = require('../../../../../../services/members');
 const labs = require('../../../../../../services/labs');
 
+// @TODO: reconsider the location of this - it's part of members and adds a property to the API
 const forPost = (attrs, frame) => {
     if (labs.isSet('members')) {
         const memberHasAccess = membersService.contentGating.checkPostAccess(attrs, frame.original.context.member);
@@ -12,8 +13,11 @@ const forPost = (attrs, frame) => {
                 }
             });
         }
-    }
 
+        if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') || (frame.options.columns.includes('access'))) {
+            attrs.access = memberHasAccess;
+        }
+    }
     return attrs;
 };
 

--- a/test/regression/api/canary/content/posts_spec.js
+++ b/test/regression/api/canary/content/posts_spec.js
@@ -227,6 +227,7 @@ describe('api/canary/content/posts', function () {
         let publicPost;
         let membersPost;
         let paidPost;
+        let contentGatingFields = ['access'];
 
         before(function () {
             // NOTE: ideally this would be set through Admin API request not a stub
@@ -290,7 +291,7 @@ describe('api/canary/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', null, null);
+                    localUtils.API.checkResponse(post, 'post', contentGatingFields, null);
                     post.slug.should.eql('thou-shalt-not-be-seen');
                     post.html.should.eql('');
                 });
@@ -308,7 +309,7 @@ describe('api/canary/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', null, null);
+                    localUtils.API.checkResponse(post, 'post', contentGatingFields, null);
                     post.slug.should.eql('thou-shalt-be-paid-for');
                     post.html.should.eql('');
                 });
@@ -347,7 +348,7 @@ describe('api/canary/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(14);
-                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', contentGatingFields, null);
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 

--- a/test/regression/api/v3/content/posts_spec.js
+++ b/test/regression/api/v3/content/posts_spec.js
@@ -227,6 +227,7 @@ describe('api/v3/content/posts', function () {
         let publicPost;
         let membersPost;
         let paidPost;
+        let contentGatingFields = ['access'];
 
         before(function () {
             // NOTE: ideally this would be set through Admin API request not a stub
@@ -290,7 +291,7 @@ describe('api/v3/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', null, null);
+                    localUtils.API.checkResponse(post, 'post', contentGatingFields, null);
                     post.slug.should.eql('thou-shalt-not-be-seen');
                     post.html.should.eql('');
                 });
@@ -308,7 +309,7 @@ describe('api/v3/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', null, null);
+                    localUtils.API.checkResponse(post, 'post', contentGatingFields, null);
                     post.slug.should.eql('thou-shalt-be-paid-for');
                     post.html.should.eql('');
                 });
@@ -347,7 +348,7 @@ describe('api/v3/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(14);
-                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', contentGatingFields, null);
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 

--- a/test/unit/api/canary/utils/serializers/output/utils/post-gating_spec.js
+++ b/test/unit/api/canary/utils/serializers/output/utils/post-gating_spec.js
@@ -32,6 +32,7 @@ describe('Unit: canary/utils/serializers/output/utils/post-gating', function () 
                 };
 
                 const frame = {
+                    options: {},
                     original: {
                         context: {}
                     }
@@ -50,6 +51,7 @@ describe('Unit: canary/utils/serializers/output/utils/post-gating', function () 
                 };
 
                 const frame = {
+                    options: {},
                     original: {
                         context: {}
                     }
@@ -69,6 +71,7 @@ describe('Unit: canary/utils/serializers/output/utils/post-gating', function () 
                 };
 
                 const frame = {
+                    options: {},
                     original: {
                         context: {
                             member: {}
@@ -90,6 +93,7 @@ describe('Unit: canary/utils/serializers/output/utils/post-gating', function () 
                 };
 
                 const frame = {
+                    options: {},
                     original: {
                         context: {
                             member: {
@@ -115,6 +119,7 @@ describe('Unit: canary/utils/serializers/output/utils/post-gating', function () 
                 };
 
                 const frame = {
+                    options: {},
                     original: {
                         context: {
                             member: {


### PR DESCRIPTION
This fix has a fairly small surface area 

closes #11574

- the current implementation of the access property has it frontend only, and wired up only in one place
- this leaves it only available in a handful of places, e.g. can't use it in a post loop or get helper
- the current implementation also fails logically if the html content of the post is blank

This fix moves the behaviour to the API

- this ensures the field is always available no matter what context you are in
- it also updates the logic to use the same membersHasAccess logic as is used to gate the post, so it's always correct

TODO: should reconsider the location of this code

@naz @allouis tagging you on this mostly so that you see it go by, but I have one small question - do you thing it makes sense to keep the addition of the `access` property here in content-gating, or move it to the extra-attrs util? I can see it both ways, here at least all members behaviour is together, but I am adding a prop. If I moved it to the extra-attrs util, I'd have to call checkPostAccess a second time, which seems unnecessary. 