### PR TITLE
Added `npm version minor` to Ghost-CLI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,13 @@ jobs:
           ghost install local -d $DIR
           ghost update -d $DIR --zip $GITHUB_WORKSPACE/ghost.zip
 
-      - name: Previous Major
+      - name: Upgrade from v1
+        run: |
+          DIR=$(mktemp -d)
+          ghost install v1 --local -d $DIR
+          ghost update -f -d $DIR --zip $GITHUB_WORKSPACE/ghost.zip
+
+      - name: Upgrade from v2
         run: |
           DIR=$(mktemp -d)
           ghost install v2 --local -d $DIR

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           node-version: '10.13.0'
       - run: npm install -g ghost-cli@latest
+      - run: npm --no-git-tag-version version minor # We need to artificially bump the minor version to get migrations to run
       - run: zip -r ghost.zip .
 
       - name: Clean Install


### PR DESCRIPTION
no issue

- migrations in master aren't run in Ghost-CLI tests because the
  package.json version is less than the migration versions
- we should be able to artificially bump the package.json so they get
  run

Also adds `upgrade from v1` to tests.