### PR TITLE
Update password reset error messages

### DIFF
--- a/core/server/lib/security/tokens.js
+++ b/core/server/lib/security/tokens.js
@@ -87,12 +87,12 @@ module.exports.resetToken = {
         let i;
 
         if (isNaN(parts.expires)) {
-            return false;
+            return {isCorrect: false, isExpired: false};
         }
 
         // Check if token is expired to prevent replay attacks
         if (parts.expires < Date.now()) {
-            return false;
+            return {isCorrect: false, isExpired: true};
         }
 
         generatedToken = exports.resetToken.generateHash({
@@ -110,6 +110,6 @@ module.exports.resetToken = {
             diff |= tokenToCompare.charCodeAt(i) ^ generatedToken.charCodeAt(i);
         }
 
-        return diff === 0;
+        return {isCorrect: diff === 0, isExpired: false};
     }
 };

--- a/core/server/services/auth/passwordreset.js
+++ b/core/server/services/auth/passwordreset.js
@@ -86,15 +86,21 @@ function doReset(options, tokenParts, settingsAPI) {
                 throw new errors.NotFoundError({message: i18n.t('errors.api.users.userNotFound')});
             }
 
-            let tokenIsCorrect = security.tokens.resetToken.compare({
+            let tokenStatus = security.tokens.resetToken.compare({
                 token: resetToken,
                 dbHash: dbHash,
                 password: user.get('password')
             });
 
-            if (!tokenIsCorrect) {
+            if (tokenStatus.isExpired) {
+                return Promise.reject(new errors.UnauthorizedError({
+                    message: i18n.t('errors.api.common.expiredToken')
+                }));
+            }
+
+            if (!tokenStatus.isCorrect) {
                 return Promise.reject(new errors.BadRequestError({
-                    message: i18n.t('errors.api.common.invalidTokenStructure')
+                    message: i18n.t('errors.api.common.invalidTokenOrPasswordReset')
                 }));
             }
 

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -285,6 +285,8 @@
         "api": {
             "common": {
                 "invalidTokenStructure": "Invalid token structure",
+                "invalidTokenOrPasswordReset": "The token is invalid or the password has already been reset",
+                "expiredToken": "The token has expired",
                 "notImplemented": "The server does not support the functionality required to fulfill the request."
             },
             "authentication": {

--- a/test/unit/lib/security/tokens_spec.js
+++ b/test/unit/lib/security/tokens_spec.js
@@ -23,7 +23,7 @@ describe('Utils: tokens', function () {
         const expires = Date.now() + 60 * 1000;
         const dbHash = uuid.v4();
         let token;
-        let tokenIsCorrect;
+        let tokenStatus;
 
         token = security.tokens.resetToken.generateHash({
             email: 'test1@ghost.org',
@@ -32,20 +32,20 @@ describe('Utils: tokens', function () {
             dbHash: dbHash
         });
 
-        tokenIsCorrect = security.tokens.resetToken.compare({
+        tokenStatus = security.tokens.resetToken.compare({
             token: token,
             dbHash: dbHash,
             password: '12345678'
         });
 
-        tokenIsCorrect.should.eql(true);
+        tokenStatus.isCorrect.should.eql(true);
     });
 
     it('compare: error', function () {
         const expires = Date.now() + 60 * 1000;
         const dbHash = uuid.v4();
         let token;
-        let tokenIsCorrect;
+        let tokenStatus;
 
         token = security.tokens.resetToken.generateHash({
             email: 'test1@ghost.org',
@@ -54,13 +54,57 @@ describe('Utils: tokens', function () {
             dbHash: dbHash
         });
 
-        tokenIsCorrect = security.tokens.resetToken.compare({
+        tokenStatus = security.tokens.resetToken.compare({
             token: token,
             dbHash: dbHash,
             password: '123456'
         });
 
-        tokenIsCorrect.should.eql(false);
+        tokenStatus.isCorrect.should.eql(false);
+    });
+
+    it('compare: expired', function () {
+        const expires = Date.now() - 60 * 1000;
+        const dbHash = uuid.v4();
+        let token;
+        let tokenStatus;
+
+        token = security.tokens.resetToken.generateHash({
+            email: 'test1@ghost.org',
+            expires: expires,
+            password: '12345678',
+            dbHash: dbHash
+        });
+
+        tokenStatus = security.tokens.resetToken.compare({
+            token: token,
+            dbHash: dbHash,
+            password: '123456'
+        });
+
+        tokenStatus.isExpired.should.eql(true);
+    });
+
+    it('compare: not expired', function () {
+        const expires = Date.now() + 60 * 1000;
+        const dbHash = uuid.v4();
+        let token;
+        let tokenStatus;
+
+        token = security.tokens.resetToken.generateHash({
+            email: 'test1@ghost.org',
+            expires: expires,
+            password: '12345678',
+            dbHash: dbHash
+        });
+
+        tokenStatus = security.tokens.resetToken.compare({
+            token: token,
+            dbHash: dbHash,
+            password: '123456'
+        });
+
+        tokenStatus.isExpired.should.eql(false);
     });
 
     it('extract', function () {
@@ -116,7 +160,7 @@ describe('Utils: tokens', function () {
         const email = 'test1@ghost.org';
         const dbHash = uuid.v4();
         let token;
-        let tokenIsCorrect;
+        let tokenStatus;
         let parts;
 
         token = security.tokens.resetToken.generateHash({
@@ -138,13 +182,13 @@ describe('Utils: tokens', function () {
         parts.email.should.eql(email);
         parts.expires.should.eql(expires);
 
-        tokenIsCorrect = security.tokens.resetToken.compare({
+        tokenStatus = security.tokens.resetToken.compare({
             token: token,
             dbHash: dbHash,
             password: '12345678'
         });
 
-        tokenIsCorrect.should.eql(true);
+        tokenStatus.isCorrect.should.eql(true);
     });
 });
 


### PR DESCRIPTION
Closes #11878
Two new error messages were added to make the password reset errors more
specific, from now there are three messages:

1. Token has expired - The token has expired
2. Password has been already reset/Invalid token - The token is invalid or the password has already been reset
3. Token has missing parts - Invalid Token Structure

In passwordreset.js return type in compare method was changed from a
boolean to an object because the method already verify if the token has
expired which allows verifying both cases if the token is valid and if
it has not expired.