### PR TITLE
Fix image size in fastmail

### DIFF
--- a/core/server/services/mega/template.js
+++ b/core/server/services/mega/template.js
@@ -421,6 +421,7 @@ figure blockquote p {
     border-radius: 0 3px 3px 0;
 
     object-fit: cover;
+    max-height: 100%;
 }
 
 .kg-bookmark-metadata {


### PR DESCRIPTION
Closes #11907
The image in the bookmark card was being shown out of the bounds of
the card because of a general style `height: auto !important`.

I added a new `max-height` property to the image to avoid exceeding
parent height.

<img width="1260" alt="example" src="https://user-images.githubusercontent.com/6099223/86066094-d1dad000-ba36-11ea-8bf3-1cd9991133c9.png">
