### PR TITLE
Fixed migrations for missing settings

### DIFF
--- a/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
+++ b/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
@@ -37,6 +37,11 @@ module.exports = {
                 .select('value')
                 .first();
 
+            if (!oldSetting) {
+                logging.warn(`Could not find setting ${renameMapping.from}, not updating ${renameMapping.to} value`);
+                return;
+            }
+
             const updatedValue = renameMapping.getToValue ? renameMapping.getToValue(oldSetting.value) : oldSetting.value;
 
             logging.info(`Updating ${renameMapping.to} with value from ${renameMapping.from}`);
@@ -57,6 +62,11 @@ module.exports = {
                 .where('key', renameMapping.to)
                 .select('value')
                 .first();
+
+            if (!newSetting) {
+                logging.warn(`Could not find setting ${renameMapping.to}, not updating ${renameMapping.from} value`);
+                return;
+            }
 
             const updatedValue = renameMapping.getFromValue ? renameMapping.getFromValue(newSetting.value) : newSetting.value;
 

--- a/core/server/data/migrations/versions/3.22/06-migrate-stripe-connect-settings.js
+++ b/core/server/data/migrations/versions/3.22/06-migrate-stripe-connect-settings.js
@@ -13,6 +13,11 @@ module.exports = {
             .where('key', 'stripe_connect_integration')
             .first();
 
+        if (!stripeConnectIntegrationJSON) {
+            logging.warn(`Could not find stripe_connect_integration - using default values`);
+            return;
+        }
+
         const stripeConnectIntegration = JSON.parse(stripeConnectIntegrationJSON.value);
 
         const operations = [{
@@ -64,11 +69,11 @@ module.exports = {
         const secretKey = await getSetting('stripe_connect_secret_key');
 
         const stripeConnectIntegration = {
-            account_id: accountId.value,
-            display_name: displayName.value,
-            livemode: livemode.value,
-            public_key: publishableKey.value,
-            secret_key: secretKey.value
+            account_id: accountId ? accountId.value : null,
+            display_name: displayName ? displayName.value : null,
+            livemode: livemode ? livemode.value : null,
+            public_key: publishableKey ? publishableKey.value : null,
+            secret_key: secretKey ? secretKey.value : null
         };
 
         const now = knex.raw('CURRENT_TIMESTAMP');


### PR DESCRIPTION
refs #10318

If migrating from a previous version that does not include the setting
being migrated from we can safely not update the new setting, and just
rely on its default value being present. When rolling back we can use
defaults if the new setting does not exist.