### PR TITLE
Updated migrations to always set group,types,flags

### DIFF
--- a/core/server/data/migrations/versions/3.22/06-migrate-stripe-connect-settings.js
+++ b/core/server/data/migrations/versions/3.22/06-migrate-stripe-connect-settings.js
@@ -8,6 +8,31 @@ module.exports = {
 
     async up(config) {
         const knex = config.transacting;
+        const defaultOperations = [{
+            key: 'stripe_connect_publishable_key'
+        }, {
+            key: 'stripe_connect_secret_key'
+        }, {
+            key: 'stripe_connect_livemode'
+        }, {
+            key: 'stripe_connect_display_name'
+        }, {
+            key: 'stripe_connect_account_id'
+        }];
+
+        for (const operation of defaultOperations) {
+            logging.info(`Updating ${operation.key} setting group,type,flags`);
+            await knex('settings')
+                .where({
+                    key: operation.key
+                })
+                .update({
+                    group: 'members',
+                    flags: '',
+                    type: 'members'
+                });
+        }
+
         const stripeConnectIntegrationJSON = await knex('settings')
             .select('value')
             .where('key', 'stripe_connect_integration')
@@ -20,7 +45,7 @@ module.exports = {
 
         const stripeConnectIntegration = JSON.parse(stripeConnectIntegrationJSON.value);
 
-        const operations = [{
+        const valueOperations = [{
             key: 'stripe_connect_publishable_key',
             value: stripeConnectIntegration.public_key || ''
         }, {
@@ -37,17 +62,14 @@ module.exports = {
             value: stripeConnectIntegration.account_id || ''
         }];
 
-        for (const operation of operations) {
-            logging.info(`Updating ${operation.key} setting`);
+        for (const operation of valueOperations) {
+            logging.info(`Updating ${operation.key} setting value`);
             await knex('settings')
                 .where({
                     key: operation.key
                 })
                 .update({
-                    value: operation.value,
-                    group: 'members',
-                    flags: '',
-                    type: 'members'
+                    value: operation.value
                 });
         }
 

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -187,7 +187,8 @@
             "defaultValue": "true"
         },
         "members_from_address": {
-            "defaultValue": "noreply"
+            "defaultValue": "noreply",
+            "flags": "RO"
         },
         "stripe_product_name": {
             "defaultValue": "Ghost Subscription"


### PR DESCRIPTION
refs #10318

Because settings are not populated with the correct group and flags, we
must _always_ set these. Then we can check to see if there are values
which need migrating, and if not, can safely exit and leave the values
as default.

Without this PR, when migration from 2.38.2 to 3.22 - the stripe settings would have a group of `core` rather than `members`.