### PR TITLE
Added missing PUBLIC flag for logo setting in migration

### DIFF
--- a/core/server/data/migrations/versions/3.22/04-populate-settings-groups-and-flags.js
+++ b/core/server/data/migrations/versions/3.22/04-populate-settings-groups-and-flags.js
@@ -109,6 +109,9 @@ const flagMapping = [{
     key: 'description',
     flags: 'PUBLIC'
 }, {
+    key: 'logo',
+    flags: 'PUBLIC'
+}, {
     key: 'accent_color',
     flags: 'PUBLIC'
 }, {


### PR DESCRIPTION
refs #10318

- `logo` setting should have had the `PUBLIC` flag but it was missed