### PR TITLE
🐛 Fixed facebook/twitter images having relative URLS in API output

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/url.js
+++ b/core/server/api/canary/utils/serializers/output/utils/url.js
@@ -46,9 +46,10 @@ const forPost = (id, attrs, frame) => {
         }
     });
 
-    ['feature_image', 'og_image', 'twitter_image', 'canonical_url'].forEach((attr) => {
-        if (attrs[attr]) {
-            attrs[attr] = urlUtils.relativeToAbsolute(attrs[attr]);
+    ['feature_image', 'canonical_url', 'posts_meta.og_image', 'posts_meta.twitter_image'].forEach((path) => {
+        const value = _.get(attrs, path);
+        if (value) {
+            _.set(attrs, path, urlUtils.relativeToAbsolute(value));
         }
     });
 

--- a/core/server/api/v2/utils/serializers/output/utils/url.js
+++ b/core/server/api/v2/utils/serializers/output/utils/url.js
@@ -56,9 +56,10 @@ const forPost = (id, attrs, frame) => {
         }
     });
 
-    ['feature_image', 'og_image', 'twitter_image', 'canonical_url'].forEach((attr) => {
-        if (attrs[attr]) {
-            attrs[attr] = urlUtils.relativeToAbsolute(attrs[attr], attrs.url, urlOptions);
+    ['feature_image', 'canonical_url', 'posts_meta.og_image', 'posts_meta.twitter_image'].forEach((path) => {
+        const value = _.get(attrs, path);
+        if (value) {
+            _.set(attrs, path, urlUtils.relativeToAbsolute(value));
         }
     });
 

--- a/test/unit/api/canary/utils/serializers/output/utils/url_spec.js
+++ b/test/unit/api/canary/utils/serializers/output/utils/url_spec.js
@@ -36,8 +36,10 @@ describe('Unit: canary/utils/serializers/output/utils/url', function () {
                 codeinjection_head: 'codeinjectionHead',
                 codeinjection_foot: 'codeinjectionFoot',
                 feature_image: 'featureImage',
-                og_image: 'ogImage',
-                twitter_image: 'twitterImage',
+                posts_meta: {
+                    og_image: 'ogImage',
+                    twitter_image: 'twitterImage'
+                },
                 canonical_url: 'canonicalUrl'
             }));
 

--- a/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
+++ b/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
@@ -36,8 +36,10 @@ describe('Unit: v2/utils/serializers/output/utils/url', function () {
                 codeinjection_head: 'codeinjectionHead',
                 codeinjection_foot: 'codeinjectionFoot',
                 feature_image: 'featureImage',
-                og_image: 'ogImage',
-                twitter_image: 'twitterImage',
+                posts_meta: {
+                    og_image: 'ogImage',
+                    twitter_image: 'twitterImage'
+                },
                 canonical_url: 'canonicalUrl'
             }));
 

--- a/test/unit/api/v3/utils/serializers/output/utils/url_spec.js
+++ b/test/unit/api/v3/utils/serializers/output/utils/url_spec.js
@@ -36,8 +36,10 @@ describe('Unit: v3/utils/serializers/output/utils/url', function () {
                 codeinjection_head: 'codeinjectionHead',
                 codeinjection_foot: 'codeinjectionFoot',
                 feature_image: 'featureImage',
-                og_image: 'ogImage',
-                twitter_image: 'twitterImage',
+                posts_meta: {
+                    og_image: 'ogImage',
+                    twitter_image: 'twitterImage'
+                },
                 canonical_url: 'canonicalUrl'
             }));
 


### PR DESCRIPTION
no issue

Output serializer's url util was expecting `og_image` and `twitter_image` to be top-level attributes in the `attrs` object but they are actually nested under `posts_meta`.

- updated the code to use lodash's `get/set()` so that we can work with paths for easier handling of nested objects
- fixed unit tests where the mocked data under test did not match real-world data
- added twitter/facebook images to one of the test fixtures so that we can test for relative->absolute in the API acceptance tests

TODO:
- [x] add tests