### PR TITLE
Added acceptance test for absolute twitter/og fields in API output

### DIFF
--- a/test/api-acceptance/admin/posts_spec.js
+++ b/test/api-acceptance/admin/posts_spec.js
@@ -63,6 +63,8 @@ describe('Posts API', function () {
                 jsonResponse.posts[0].url.should.match(new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
                 jsonResponse.posts[2].url.should.eql(`${config.get('url')}/welcome/`);
                 jsonResponse.posts[11].feature_image.should.eql(`${config.get('url')}/content/images/2018/hey.jpg`);
+                jsonResponse.posts[11].twitter_image.should.eql(`${config.get('url')}/content/images/2020/hey-twitter.jpg`);
+                jsonResponse.posts[11].og_image.should.eql(`${config.get('url')}/content/images/2020/hey-facebook.jpg`);
 
                 jsonResponse.posts[0].tags.length.should.eql(0);
                 jsonResponse.posts[2].tags.length.should.eql(1);

--- a/test/regression/models/model_posts_spec.js
+++ b/test/regression/models/model_posts_spec.js
@@ -15,6 +15,19 @@ const configUtils = require('../../utils/configUtils');
 const context = testUtils.context.owner;
 const markdownToMobiledoc = testUtils.DataGenerator.markdownToMobiledoc;
 
+const cleanupTables = function cleanupTables() {
+    return testUtils.truncate('posts_meta')
+        .then(function () {
+            return testUtils.truncate('posts_tags');
+        })
+        .then(function () {
+            return testUtils.truncate('tags');
+        })
+        .then(function () {
+            return testUtils.truncate('posts');
+        });
+};
+
 /**
  * IMPORTANT:
  * - do not spy the events unit, because when we only spy, all listeners get the event
@@ -46,28 +59,12 @@ describe('Post Model', function () {
 
         describe('fetchOne/fetchAll/fetchPage', function () {
             before(testUtils.fixtures.insertPostsAndTags);
-            after(function () {
-                return testUtils.truncate('posts_tags')
-                    .then(function () {
-                        return testUtils.truncate('tags');
-                    })
-                    .then(function () {
-                        return testUtils.truncate('posts');
-                    });
-            });
+            after(cleanupTables);
 
             describe('findPage', function () {
                 // @TODO: this test case fails for mysql currently if you run all regression tests, the test does not fail if you run this as a single test
                 describe.skip('with more posts/tags', function () {
-                    beforeEach(function () {
-                        return testUtils.truncate('posts_tags')
-                            .then(function () {
-                                return testUtils.truncate('tags');
-                            })
-                            .then(function () {
-                                return testUtils.truncate('posts');
-                            });
-                    });
+                    beforeEach(cleanupTables);
 
                     beforeEach(function () {
                         return testUtils.fixtures.insertPostsAndTags()
@@ -172,15 +169,7 @@ describe('Post Model', function () {
         describe('edit', function () {
             beforeEach(testUtils.fixtures.insertPostsAndTags);
 
-            afterEach(function () {
-                return testUtils.truncate('posts_tags')
-                    .then(function () {
-                        return testUtils.truncate('tags');
-                    })
-                    .then(function () {
-                        return testUtils.truncate('posts');
-                    });
-            });
+            afterEach(cleanupTables);
 
             beforeEach(function () {
                 eventsTriggered = {};
@@ -689,16 +678,7 @@ describe('Post Model', function () {
 
         describe('add', function () {
             before(testUtils.fixtures.insertPostsAndTags);
-
-            after(function () {
-                return testUtils.truncate('posts_tags')
-                    .then(function () {
-                        return testUtils.truncate('tags');
-                    })
-                    .then(function () {
-                        return testUtils.truncate('posts');
-                    });
-            });
+            after(cleanupTables);
 
             beforeEach(function () {
                 eventsTriggered = {};
@@ -1164,16 +1144,7 @@ describe('Post Model', function () {
 
         describe('destroy', function () {
             beforeEach(testUtils.fixtures.insertPostsAndTags);
-
-            afterEach(function () {
-                return testUtils.truncate('posts_tags')
-                    .then(function () {
-                        return testUtils.truncate('tags');
-                    })
-                    .then(function () {
-                        return testUtils.truncate('posts');
-                    });
-            });
+            afterEach(cleanupTables);
 
             beforeEach(function () {
                 eventsTriggered = {};
@@ -1346,16 +1317,7 @@ describe('Post Model', function () {
 
         describe('Collision Protection', function () {
             before(testUtils.fixtures.insertPostsAndTags);
-
-            after(function () {
-                return testUtils.truncate('posts_tags')
-                    .then(function () {
-                        return testUtils.truncate('tags');
-                    })
-                    .then(function () {
-                        return testUtils.truncate('posts');
-                    });
-            });
+            after(cleanupTables);
 
             it('update post title, but updated_at is out of sync', function () {
                 const postToUpdate = {id: testUtils.DataGenerator.Content.posts[1].id};
@@ -1585,15 +1547,7 @@ describe('Post Model', function () {
         let editOptions;
         const createTag = testUtils.DataGenerator.forKnex.createTag;
 
-        beforeEach(function () {
-            return testUtils.truncate('posts_tags')
-                .then(function () {
-                    return testUtils.truncate('tags');
-                })
-                .then(function () {
-                    return testUtils.truncate('posts');
-                });
-        });
+        beforeEach(cleanupTables);
 
         beforeEach(function () {
             tagJSON = [];

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -39,7 +39,11 @@ DataGenerator.Content = {
             slug: 'ghostly-kitchen-sink',
             mobiledoc: DataGenerator.markdownToMobiledoc('<h1>HTML Ipsum Presents</h1><img src="/content/images/lol.jpg"><p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href=\\\"#\\\">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p><h2>Header Level 2</h2><ol><li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li><li>Aliquam tincidunt mauris eu risus.</li></ol><blockquote><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.</p></blockquote><h3>Header Level 3</h3><ul><li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li><li>Aliquam tincidunt mauris eu risus.</li></ul><pre><code>#header h1 a{display: block;width: 300px;height: 80px;}</code></pre>'),
             published_at: new Date('2015-01-02'),
-            feature_image: '/content/images/2018/hey.jpg'
+            feature_image: '/content/images/2018/hey.jpg',
+            posts_meta: {
+                twitter_image: '/content/images/2020/hey-twitter.jpg',
+                og_image: '/content/images/2020/hey-facebook.jpg'
+            }
         },
         {
             id: ObjectId.generate(),

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -56,6 +56,9 @@ require('./assertions');
 fixtures = {
     insertPosts: function insertPosts(posts) {
         return Promise.map(posts, function (post) {
+            if (post.posts_meta) {
+                post.posts_meta.post_id = post.id;
+            }
             return models.Post.add(post, module.exports.context.internal);
         });
     },
@@ -78,6 +81,10 @@ fixtures = {
 
                 post.tags = postTagRelations;
                 post.authors = postAuthorsRelations;
+
+                if (post.posts_meta) {
+                    post.posts_meta.post_id = post.id;
+                }
                 return models.Post.add(post, module.exports.context.internal);
             });
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/11975

- adds a `posts_meta` object with relative twitter and facebook image values to one of our post model test fixtures
- adds assertions to our Admin API posts acceptance test to show that relative URLs for twitter/facebook images are transformed to absolute
- updates the `insertPosts` and `insertPostsAndTags` test utils to add the necessary `post_id` relationship for `posts_meta`
- updates tests that are manually truncating the posts related tables to also truncate the `posts_meta` table

TODO:
- [ ] fix failing tests