### PR TITLE
🐛 Fixed settings cache being out of sync after migrations

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -130,8 +130,8 @@ const minimalRequiredSetupToStartGhost = (dbState) => {
 
                 migrator.migrate()
                     .then(() => {
-                        events.emit('db.ready');
                         return settings.reinit().then(() => {
+                            events.emit('db.ready');
                             return initialiseServices();
                         });
                     })

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -131,7 +131,9 @@ const minimalRequiredSetupToStartGhost = (dbState) => {
                 migrator.migrate()
                     .then(() => {
                         events.emit('db.ready');
-                        return initialiseServices();
+                        return settings.reinit().then(() => {
+                            return initialiseServices();
+                        });
                     })
                     .then(() => {
                         config.set('maintenance:enabled', false);

--- a/core/server/services/settings/index.js
+++ b/core/server/services/settings/index.js
@@ -14,5 +14,10 @@ module.exports = {
                 // This will bind to events for further updates
                 SettingsCache.init(settingsCollection);
             });
+    },
+
+    reinit: function reinit() {
+        SettingsCache.shutdown();
+        return this.init();
     }
 };


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/10318

- re-initialize settings cache after migrations by shutting down to clean up event listeners then and calling `init` again