### PR TITLE
Remove references to bulk email settings

### DIFF
--- a/core/server/api/canary/utils/serializers/input/settings.js
+++ b/core/server/api/canary/utils/serializers/input/settings.js
@@ -90,12 +90,6 @@ module.exports = {
             if (['cover_image', 'icon', 'logo'].includes(setting.key)) {
                 setting = url.forSetting(setting);
             }
-
-            //CASE: Ensure we don't store calculated fields `isEnabled/Config` in bulk email settings
-            if (setting.key === 'bulk_email_settings') {
-                const {apiKey = '', domain = '', baseUrl = '', provider = 'mailgun'} = setting.value ? JSON.parse(setting.value) : {};
-                setting.value = JSON.stringify({apiKey, domain, baseUrl, provider});
-            }
         });
     }
 };

--- a/core/server/api/canary/utils/serializers/input/settings.js
+++ b/core/server/api/canary/utils/serializers/input/settings.js
@@ -48,6 +48,10 @@ module.exports = {
             return !settingFlagsArr.includes('RO');
         });
 
+        frame.data.settings = frame.data.settings.filter((setting) => {
+            return setting.key !== 'bulk_email_settings';
+        });
+
         frame.data.settings.forEach((setting) => {
             // CASE: transform objects/arrays into string (we store stringified objects in the db)
             // @TODO: This belongs into the model layer. We should stringify before saving and parse when fetching from db.

--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const localUtils = require('../../../index');
-const config = require('../../../../../../../shared/config');
 
 const tag = (attrs, frame) => {
     if (localUtils.isContentAPI(frame)) {
@@ -143,28 +142,7 @@ const action = (attrs) => {
     }
 };
 
-const settings = (attrs) => {
-    if (_.isArray(attrs)) {
-        attrs.forEach((attr) => {
-            if (attr.key === 'bulk_email_settings') {
-                const {provider, apiKey, domain, baseUrl} = attr.value ? JSON.parse(attr.value) : {};
-
-                const bulkEmailConfig = config.get('bulkEmail');
-                const hasMailgunConfig = !!(bulkEmailConfig && bulkEmailConfig.mailgun);
-                const hasMailgunSetting = !!(apiKey && baseUrl && domain);
-
-                attr.value = JSON.stringify({
-                    provider, apiKey, domain, baseUrl,
-                    isEnabled: (hasMailgunConfig || hasMailgunSetting),
-                    isConfig: hasMailgunConfig
-                });
-            }
-        });
-    }
-};
-
 module.exports.post = post;
 module.exports.tag = tag;
 module.exports.author = author;
 module.exports.action = action;
-module.exports.settings = settings;

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -92,7 +92,6 @@ const mapPage = (model, frame) => {
 const mapSettings = (attrs, frame) => {
     url.forSettings(attrs);
     extraAttrs.forSettings(attrs, frame);
-    clean.settings(attrs, frame);
 
     // NOTE: The cleanup of deprecated ghost_head/ghost_foot has to happen here
     //       because codeinjection_head/codeinjection_foot are assigned on a previous

--- a/core/server/api/v2/utils/serializers/input/settings.js
+++ b/core/server/api/v2/utils/serializers/input/settings.js
@@ -45,6 +45,10 @@ module.exports = {
             return !settingFlagsArr.includes('RO');
         });
 
+        frame.data.settings = frame.data.settings.filter((setting) => {
+            return setting.key !== 'bulk_email_settings';
+        });
+
         frame.data.settings.forEach((setting) => {
             const settingType = settings[setting.key] ? settings[setting.key].type : '';
 

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -118,7 +118,7 @@ class SettingsImporter extends BaseImporter {
         });
 
         this.dataToImport = _.filter(this.dataToImport, (data) => {
-            return !(['members_subscription_settings', 'stripe_connect_integration'].includes(data.key));
+            return !(['members_subscription_settings', 'stripe_connect_integration', 'bulk_email_settings'].includes(data.key));
         });
 
         // Only show warning if we are importing a private site into a non-private site.

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -293,10 +293,6 @@
         }
     },
     "email": {
-        "bulk_email_settings": {
-            "defaultValue": "{\"provider\":\"mailgun\", \"apiKey\": \"\", \"domain\": \"\", \"baseUrl\": \"\"}",
-            "type": "object"
-        },
         "mailgun_domain": {
             "defaultValue": null,
             "type": "string"

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -49,7 +49,6 @@ const defaultSettingsKeyTypes = [
     {key: 'portal_name', type: 'portal'},
     {key: 'portal_button', type: 'portal'},
     {key: 'portal_plans', type: 'portal'},
-    {key: 'bulk_email_settings', type: 'bulk_email'},
     {key: 'mailgun_api_key', type: 'bulk_email'},
     {key: 'mailgun_domain', type: 'bulk_email'},
     {key: 'mailgun_base_url', type: 'bulk_email'},

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -46,7 +46,6 @@ const defaultSettingsKeyTypes = [
     {key: 'portal_name', type: 'portal'},
     {key: 'portal_button', type: 'portal'},
     {key: 'portal_plans', type: 'portal'},
-    {key: 'bulk_email_settings', type: 'bulk_email'},
     {key: 'mailgun_api_key', type: 'bulk_email'},
     {key: 'mailgun_domain', type: 'bulk_email'},
     {key: 'mailgun_base_url', type: 'bulk_email'},

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -49,7 +49,6 @@ const defaultSettingsKeys = [
     'portal_name',
     'portal_button',
     'portal_plans',
-    'bulk_email_settings',
     'mailgun_api_key',
     'mailgun_domain',
     'mailgun_base_url',


### PR DESCRIPTION
refs #10318 

This removes all the left over references to the `bulk_email_settings` - it will be followed by a migration to clean up the db