### PR TITLE
Updated portal button setting to false

### DIFF
--- a/core/server/data/migrations/versions/3.23/03-update-portal-button-setting.js
+++ b/core/server/data/migrations/versions/3.23/03-update-portal-button-setting.js
@@ -1,0 +1,24 @@
+const logging = require('../../../../../shared/logging');
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up(options) {
+        // update portal button setting to false
+        logging.info(`Updating portal button setting to false`);
+        return await options
+            .transacting('settings')
+            .where('key', 'portal_button')
+            .update({
+                value: 'false'
+            });
+    },
+
+    // `up` is only run to fix previously set default value for portal button,
+    // it doesn't make sense to be revert it back as `true` as feature is still behind dev flag
+    async down() {
+        return Promise.resolve();
+    }
+};


### PR DESCRIPTION
no issue

- Existing sites should have portal button hidden by default and need explicit switch on from Admin.
- Migration here resets portal button setting to false for all existing site