### PR TITLE
Hardened members subscription migration against missing data

### DIFF
--- a/core/server/data/migrations/versions/3.22/05-migrate-members-subscription-settings.js
+++ b/core/server/data/migrations/versions/3.22/05-migrate-members-subscription-settings.js
@@ -42,7 +42,7 @@ module.exports = {
             .where('key', 'members_subscription_settings')
             .first();
 
-        if (!membersSubscriptionSettingsJSON) {
+        if (!membersSubscriptionSettingsJSON || !membersSubscriptionSettingsJSON.value) {
             logging.warn(`Could not find members_subscription_settings - using default values`);
             return;
         }

--- a/core/server/data/migrations/versions/3.22/05-migrate-members-subscription-settings.js
+++ b/core/server/data/migrations/versions/3.22/05-migrate-members-subscription-settings.js
@@ -49,16 +49,18 @@ module.exports = {
 
         const membersSubscriptionSettings = JSON.parse(membersSubscriptionSettingsJSON.value);
 
-        const membersFromAddress = membersSubscriptionSettings.fromAddress;
-        const membersAllowSelfSignup = membersSubscriptionSettings.allowSelfSignup;
+        const membersFromAddress = typeof membersSubscriptionSettings.fromAddress === 'string' ? membersSubscriptionSettings.fromAddress : 'noreply';
+        const membersAllowSelfSignup = typeof membersSubscriptionSettings.allowSelfSignup === 'boolean' ? membersSubscriptionSettings.allowSelfSignup : true;
 
-        const stripe = membersSubscriptionSettings.paymentProcessors[0];
+        const stripe = membersSubscriptionSettings && membersSubscriptionSettings.paymentProcessors && membersSubscriptionSettings.paymentProcessors[0];
 
-        const stripeDirectSecretKey = stripe.config.secret_token;
-        const stripeDirectPublishableKey = stripe.config.public_token;
-        const stripeProductName = stripe.config.product.name;
+        const stripeConfig = stripe && stripe.config || {};
 
-        const stripePlans = stripe.config.plans.map((plan) => {
+        const stripeDirectSecretKey = stripeConfig.secret_token || '';
+        const stripeDirectPublishableKey = stripeConfig.public_token || '';
+        const stripeProductName = stripeConfig.product && stripeConfig.product.name || 'Ghost Members';
+
+        const stripePlans = (stripeConfig.plans || []).map((plan) => {
             return Object.assign(plan, {
                 amount: plan.amount || 0
             });


### PR DESCRIPTION
closes #11993

We had some issues with some databases being in an unexpected state this
check for each property before using it add uses defaults when it is
missing.