### PR TITLE
✨ Added post.access with default true to v3 API

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/post-gating.js
+++ b/core/server/api/canary/utils/serializers/output/utils/post-gating.js
@@ -3,6 +3,12 @@ const labs = require('../../../../../../services/labs');
 
 // @TODO: reconsider the location of this - it's part of members and adds a property to the API
 const forPost = (attrs, frame) => {
+    // CASE: Access always defaults to true, unless members is enabled and the member does not have access
+    if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') || (frame.options.columns.includes('access'))) {
+        attrs.access = true;
+    }
+
+    // Handle members being enabled
     if (labs.isSet('members')) {
         const memberHasAccess = membersService.contentGating.checkPostAccess(attrs, frame.original.context.member);
 
@@ -18,6 +24,7 @@ const forPost = (attrs, frame) => {
             attrs.access = memberHasAccess;
         }
     }
+
     return attrs;
 };
 

--- a/test/api-acceptance/content/utils.js
+++ b/test/api-acceptance/content/utils.js
@@ -29,6 +29,8 @@ const expectedProperties = {
         // .without('page')
         // v2 returns a calculated excerpt field
         .concat('excerpt')
+        // Access is a calculated property in >= v3
+        .concat('access')
         // returns meta fields from `posts_meta` schema
         .concat(
             ..._(schema.posts_meta).keys().without('post_id', 'id')

--- a/test/regression/api/canary/content/posts_spec.js
+++ b/test/regression/api/canary/content/posts_spec.js
@@ -227,7 +227,6 @@ describe('api/canary/content/posts', function () {
         let publicPost;
         let membersPost;
         let paidPost;
-        let contentGatingFields = ['access'];
 
         before(function () {
             // NOTE: ideally this would be set through Admin API request not a stub
@@ -291,7 +290,7 @@ describe('api/canary/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', contentGatingFields, null);
+                    localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-not-be-seen');
                     post.html.should.eql('');
                 });
@@ -309,7 +308,7 @@ describe('api/canary/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', contentGatingFields, null);
+                    localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-be-paid-for');
                     post.html.should.eql('');
                 });
@@ -348,7 +347,7 @@ describe('api/canary/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(14);
-                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', contentGatingFields, null);
+                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, null);
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 

--- a/test/regression/api/canary/content/utils.js
+++ b/test/regression/api/canary/content/utils.js
@@ -28,6 +28,8 @@ const expectedProperties = {
         .without('type')
         // canary returns a calculated excerpt field
         .concat('excerpt')
+        // Access is a calculated property in >= v3
+        .concat('access')
         // returns meta fields from `posts_meta` schema
         .concat(
             ..._(schema.posts_meta).keys().without('post_id', 'id')

--- a/test/regression/api/v3/content/posts_spec.js
+++ b/test/regression/api/v3/content/posts_spec.js
@@ -227,7 +227,6 @@ describe('api/v3/content/posts', function () {
         let publicPost;
         let membersPost;
         let paidPost;
-        let contentGatingFields = ['access'];
 
         before(function () {
             // NOTE: ideally this would be set through Admin API request not a stub
@@ -291,7 +290,7 @@ describe('api/v3/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', contentGatingFields, null);
+                    localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-not-be-seen');
                     post.html.should.eql('');
                 });
@@ -309,7 +308,7 @@ describe('api/v3/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', contentGatingFields, null);
+                    localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-be-paid-for');
                     post.html.should.eql('');
                 });
@@ -348,7 +347,7 @@ describe('api/v3/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(14);
-                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', contentGatingFields, null);
+                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, null);
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 

--- a/test/regression/api/v3/content/utils.js
+++ b/test/regression/api/v3/content/utils.js
@@ -28,6 +28,8 @@ const expectedProperties = {
         .without('type')
         // v3 returns a calculated excerpt field
         .concat('excerpt')
+        // Access is a calculated property in >= v3
+        .concat('access')
         // returns meta fields from `posts_meta` schema
         .concat(
             ..._(schema.posts_meta).keys().without('post_id', 'id')


### PR DESCRIPTION
[Running regression tests]

closes #11990

- access should be a members feature, but it was already accidentally exposed to the theme layer
- it has now been added to the API even if members is disabled
- access defaults to true, unless members is enabled
- when members is enabled, access is set to the currently logged in members' access

