### PR TITLE
Fix settings cache

### DIFF
--- a/core/server/services/settings/index.js
+++ b/core/server/services/settings/index.js
@@ -15,5 +15,8 @@ module.exports = {
         SettingsCache.shutdown();
         const settingsCollection = await models.Settings.populateDefaults();
         SettingsCache.init(settingsCollection);
+        for (const model of settingsCollection.models) {
+            model.emitChange(model.attributes.key + '.' + 'edited', {});
+        }
     }
 };

--- a/core/server/services/settings/index.js
+++ b/core/server/services/settings/index.js
@@ -6,18 +6,14 @@ const models = require('../../models');
 const SettingsCache = require('./cache');
 
 module.exports = {
-    init: function init() {
-        // Update the defaults
-        return models.Settings.populateDefaults()
-            .then((settingsCollection) => {
-                // Initialise the cache with the result
-                // This will bind to events for further updates
-                SettingsCache.init(settingsCollection);
-            });
+    async init() {
+        const settingsCollection = await models.Settings.populateDefaults();
+        SettingsCache.init(settingsCollection);
     },
 
-    reinit: function reinit() {
+    async reinit() {
         SettingsCache.shutdown();
-        return this.init();
+        const settingsCollection = await models.Settings.populateDefaults();
+        SettingsCache.init(settingsCollection);
     }
 };


### PR DESCRIPTION
closes #12003

There are a few parts of Ghost that rely on the settings events being
emitted anytime a setting is changed, so that the data is kept in sync.

When a setting is renamed in a migration essentially what happens is
that the settings value is changed from a default value to its actual
value, but this does not emit an event.

Anything that is 1. initialised before migrations have run and 2. relies on
the events to keep it up to date will have stale data - e.g. the themes
i18n service.

This change ensures that when we `reinit` after migrations have been
run, we emit events for every setting to tell the rest of Ghost that it
has changed.