### PR TITLE
Added migration to ensure stripe_plans in correct state

### DIFF
--- a/core/server/data/migrations/versions/3.23/04-handle-empty-stripe-plans.js
+++ b/core/server/data/migrations/versions/3.23/04-handle-empty-stripe-plans.js
@@ -1,0 +1,71 @@
+const logging = require('../../../../../shared/logging');
+
+function isValidValue(value) {
+    if (!value) {
+        return false;
+    }
+    try {
+        const parsed = JSON.parse(value);
+        if (!parsed || !Array.isArray(parsed)) {
+            return false;
+        }
+
+        const monthly = parsed.find(x => x.interval === 'month' && x.name !== 'Complimentary');
+        const yearly = parsed.find(x => x.interval === 'year' && x.name !== 'Complimentary');
+        if (!monthly || !yearly) {
+            return false;
+        }
+
+        return true;
+    } catch (err) {
+        return false;
+    }
+}
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up({transacting: knex}) {
+        const stripePlans = await knex('settings')
+            .select('value')
+            .where({
+                key: 'stripe_plans'
+            })
+            .first();
+
+        if (!stripePlans) {
+            logging.warn('No stripe_plans setting found');
+            // If for some reason the setting is not found we defer to default handling in core.
+            return;
+        }
+
+        if (isValidValue(stripePlans.value)) {
+            logging.info(`The stripe_plans setting contained valid data - skipping migration.`);
+            return;
+        }
+
+        logging.info(`The stripe_plans setting contained invalid data: ${stripePlans.value} - updating to use defaults`);
+        await knex('settings')
+            .update({
+                value: JSON.stringify([{
+                    name: 'Monthly',
+                    currency: 'usd',
+                    interval: 'month',
+                    amount: 500
+                }, {
+                    name: 'Yearly',
+                    currency: 'usd',
+                    interval: 'year',
+                    amount: 5000
+                }])
+            })
+            .where({
+                key: 'stripe_plans'
+            });
+    },
+
+    // This migration fixes data, we don't want to undo it.
+    async down() {}
+};


### PR DESCRIPTION
closes #12020 

This fixes an issue which occurs if you upgrade to 3.22.0, attempt to save settings and then upgrade to 3.22.2 where the stripe_plans settings are lost.

There should only be two cases when encountering this migration

1. The installation was not affected by the bug, `stripe_plans` setting is valid & this migration will exit early, doing nothing.
2. The installation was affected by the bug, `stripe_plans` setting is empty & this migration will update it with the default settings.

The migration also tries to cater for undefined cases by validating the existence of the monthly & yearly plans in the `stripe_plans` setting - if these are not present it will update the value with the default settings