### PR TITLE
Provide a method to lazy loaded content images

### DIFF
--- a/core/frontend/helpers/content.js
+++ b/core/frontend/helpers/content.js
@@ -27,9 +27,9 @@ module.exports = function content(options = {}) {
 
     if (hash.lazy && (hash.lazy === 'true')) {
         this.html = this.html
-        .replace(/<img(.*?) srcset="/gi, '<img$1 data-srcset="')
-        .replace(/<img(.*?) src="/gi, '<img$1 data-src="')
-        .replace(/<img(.*?) class="/gi, '<img$1 loading="lazy" class="lazyload ')
+            .replace(/<img(.*?) srcset="/gi, '<img$1 data-srcset="')
+            .replace(/<img(.*?) src="/gi, '<img$1 data-src="')
+            .replace(/<img(.*?) class="/gi, '<img$1 loading="lazy" class="lazyload ');
     }
 
     if (runTruncate) {

--- a/core/frontend/helpers/content.js
+++ b/core/frontend/helpers/content.js
@@ -25,6 +25,13 @@ module.exports = function content(options = {}) {
         this.html = '';
     }
 
+    if (hash.lazy && (hash.lazy === 'true')) {
+        this.html = this.html
+        .replace(/<img(.*?) srcset="/gi, '<img$1 data-srcset="')
+        .replace(/<img(.*?) src="/gi, '<img$1 data-src="')
+        .replace(/<img(.*?) class="/gi, '<img$1 loading="lazy" class="lazyload ')
+    }
+
     if (runTruncate) {
         return new SafeString(
             downsize(this.html, truncateOptions)


### PR DESCRIPTION
## Objective
Provide theme authors with the option to optionally place image src in data attributes to allow for lazy load image integration. This would provide substantial performance value options in themes.

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
