### PR TITLE
Fixed express-jwt config

### DIFF
--- a/core/server/services/auth/members/index.js
+++ b/core/server/services/auth/members/index.js
@@ -23,7 +23,7 @@ module.exports = {
                 requestProperty: 'member',
                 audience: siteOrigin,
                 issuer,
-                algorithm: 'RS512',
+                algorithms: ['RS512'],
                 secret(req, payload, done) {
                     membersService.api.getPublicConfig().then(({publicKey}) => {
                         done(null, publicKey);


### PR DESCRIPTION
no-issue

express-jwt expects an array of valid algorithms, not a single algorithm.