### PR TITLE
Updated twitter social profile default value

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -107,7 +107,7 @@
             "type": "string"
         },
         "twitter": {
-            "defaultValue": "tryghost",
+            "defaultValue": "ghost",
             "type": "string"
         },
         "navigation": {


### PR DESCRIPTION
Updates Twitter profile fixture from `tryghost` to the correct `ghost`
