### PR TITLE
Added new stripe webhook settings

### DIFF
--- a/core/server/data/migrations/versions/3.25/01-add-members-stripe-webhook-settings.js
+++ b/core/server/data/migrations/versions/3.25/01-add-members-stripe-webhook-settings.js
@@ -1,0 +1,22 @@
+const logging = require('../../../../../shared/logging');
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up({transacting: knex}) {
+        logging.info('Updating members_stripe_webhook_id & members_stripe_webhook_secret settings to group: core, type: string, flags: null');
+        await knex('settings')
+            .update({
+                group: 'core',
+                type: 'string',
+                flags: null
+            })
+            .whereIn('key', [
+                'members_stripe_webhook_id',
+                'members_stripe_webhook_secret'
+            ]);
+    },
+
+    async down() {}
+};

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -39,6 +39,14 @@
         "members_email_auth_secret": {
             "defaultValue": null,
             "type": "string"
+        },
+        "members_stripe_webhook_id": {
+            "defaultValue": null,
+            "type": "string"
+        },
+        "members_stripe_webhook_secret": {
+            "defaultValue": null,
+            "type": "string"
         }
     },
     "site": {

--- a/test/regression/settings/settings_spec.js
+++ b/test/regression/settings/settings_spec.js
@@ -26,7 +26,9 @@ describe('Settings', function () {
         'ghost_private_key',
         'members_public_key',
         'members_private_key',
-        'members_email_auth_secret'
+        'members_email_auth_secret',
+        'members_stripe_webhook_id',
+        'members_stripe_webhook_secret'
     ];
     // If this test is failing, then it is likely a new setting has been added without group migration
     // In case of `core` setting modifications, whitelist above needs to be updated

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -23,7 +23,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '134c9de4e59b31ec6b73f03638a01396';
     const currentFixturesHash = '3d942c46e8487c4aee1e9ac898ed29ca';
-    const currentSettingsHash = '2dc22c4cf872edba848f059753049158';
+    const currentSettingsHash = 'b0291920e168e74cf63a1919cd594fd6';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
This adds two new settings of `type` string to the `core` group.

They will be used to store webhook information so that we can persist it between boots and simplify the creation process of webhooks in members