### PR TITLE
Adds migration for new settings and settings integrity test

### DIFF
--- a/core/server/data/migrations/versions/3.24/01-populate-group-for-new-portal-settings.js
+++ b/core/server/data/migrations/versions/3.24/01-populate-group-for-new-portal-settings.js
@@ -1,0 +1,37 @@
+const logging = require('../../../../../shared/logging');
+
+// new setting keys and group mapping
+const groupMapping = [{
+    group: 'portal',
+    keys: [
+        'portal_button_style',
+        'portal_button_icon',
+        'portal_button_signup_text'
+    ]
+}];
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up(options) {
+        // set the correct group value for new settings
+        await Promise.map(groupMapping, async (groupMap) => {
+            return await Promise.map(groupMap.keys, async (key) => {
+                logging.info(`Updating setting ${key} to group ${groupMap.group}`);
+
+                return await options
+                    .transacting('settings')
+                    .where('key', key)
+                    .update({
+                        group: groupMap.group
+                    });
+            });
+        });
+    },
+
+    // `up` is only run to update correct group value for each setting instead of default.
+    // it doesn't make sense to be revert a setting's group to default `core` again
+    async down() {}
+};

--- a/test/regression/settings/settings_spec.js
+++ b/test/regression/settings/settings_spec.js
@@ -1,0 +1,50 @@
+const db = require('../../../core/server/data/db');
+const testUtils = require('../../utils');
+
+/**
+ * @NOTE
+ *
+ * If this test fails for you, you have modified the default settings.
+ * When you make a change or add new setting, please ensure that:
+ * - If a new `core` setting is added/removed/renamed, update the below whitelist
+ * - If a new non-`core` setting is added, it includes corresponding migration to populate its `group` and `flags`
+ */
+
+describe('Settings', function () {
+    before(function () {
+        return testUtils.startGhost();
+    });
+
+    // Whitelist: Only this list needs updating when a core setting is added/removed/renamed
+    const coreSettingKeys = [
+        'db_hash',
+        'next_update_check',
+        'notifications',
+        'session_secret',
+        'theme_session_secret',
+        'ghost_public_key',
+        'ghost_private_key',
+        'members_public_key',
+        'members_private_key',
+        'members_email_auth_secret'
+    ];
+    // If this test is failing, then it is likely a new setting has been added without group migration
+    // In case of `core` setting modifications, whitelist above needs to be updated
+    it('should not modify core keys without fixing this test', function () {
+        return db.knex('settings')
+            .where('group', 'core')
+            .whereNotIn('key', coreSettingKeys)
+            .count('*')
+            .then(function (data) {
+                const countResult = data[0]['count(*)'];
+                countResult.should.eql(0);
+            })
+            .catch(function (err) {
+            // CASE: table does not exist
+                if (err.errno === 1146) {
+                    return Promise.resolve();
+                }
+                throw err;
+            });
+    });
+});

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -3,11 +3,12 @@ const _ = require('lodash');
 const crypto = require('crypto');
 const schema = require('../../../../core/server/data/schema');
 const fixtures = require('../../../../core/server/data/schema/fixtures');
+const defaultSettings = require('../../../../core/server/data/schema/default-settings');
 
 /**
  * @NOTE
  *
- * If this test fails for you, you have modified the database schema or fixtures.
+ * If this test fails for you, you have modified the database schema or fixtures or default settings.
  * When you make a change, please test that:
  *
  * 1. A new blog get's installed and the database looks correct and complete.
@@ -16,11 +17,13 @@ const fixtures = require('../../../../core/server/data/schema/fixtures');
  * Typical cases:
  * You have to add a migration script if you've added/modified permissions.
  * You have to add a migration script if you've add a new table.
+ * You have to add a migration script if you've added new settings to populate group/flags column.
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '134c9de4e59b31ec6b73f03638a01396';
     const currentFixturesHash = '3d942c46e8487c4aee1e9ac898ed29ca';
+    const currentSettingsHash = '2dc22c4cf872edba848f059753049158';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation
@@ -28,6 +31,7 @@ describe('DB version integrity', function () {
         const tablesNoValidation = _.cloneDeep(schema.tables);
         let schemaHash;
         let fixturesHash;
+        let settingsHash;
 
         _.each(tablesNoValidation, function (table) {
             return _.each(table, function (column, name) {
@@ -37,8 +41,10 @@ describe('DB version integrity', function () {
 
         schemaHash = crypto.createHash('md5').update(JSON.stringify(tablesNoValidation), 'binary').digest('hex');
         fixturesHash = crypto.createHash('md5').update(JSON.stringify(fixtures), 'binary').digest('hex');
+        settingsHash = crypto.createHash('md5').update(JSON.stringify(defaultSettings), 'binary').digest('hex');
 
         schemaHash.should.eql(currentSchemaHash);
         fixturesHash.should.eql(currentFixturesHash);
+        settingsHash.should.eql(currentSettingsHash);
     });
 });


### PR DESCRIPTION
Added new settings integrity tests

- We made changes to settings table structure in 3.22 which added new columns for `group` and `flags`
- Any new setting needs explicit group and flag migrations since or they fallback to default group value of `core`
- PR adds 2 new tests to ensure
  - settings hash need to be updated in DB integrity test anytime default-settings are changed
  - a migration is present by maintaining a whitelist of allowed core settings and failing if new setting is added without correct group migration

Added migration to update group for new portal settings 

- 3 new portal settings were added in `3.23` in default settings - `portal_button_style`, `portal_button_icon`, `portal_button_signup_text`
- New settings default to group `core` on migrating from pre 3.22 versions due to missing columns in DB
- Migration here updates the new settings to correct group
