### PR TITLE
Updated members-api & webhook handling

### DIFF
--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -144,9 +144,26 @@ function createApiInstance(config) {
         paymentConfig: {
             stripe: config.getStripePaymentConfig()
         },
-        memberStripeCustomerModel: models.MemberStripeCustomer,
-        stripeCustomerSubscriptionModel: models.StripeCustomerSubscription,
-        memberModel: models.Member,
+        models: {
+            /**
+             * Settings do not have their own models, so we wrap the webhook in a "fake" model
+             */
+            StripeWebhook: {
+                async upsert(data, options) {
+                    const settings = [{
+                        key: 'members_stripe_webhook_id',
+                        value: data.webhook_id
+                    }, {
+                        key: 'members_stripe_webhook_secret',
+                        value: data.secret
+                    }];
+                    await models.Settings.edit(settings, options);
+                }
+            },
+            StripeCustomer: models.MemberStripeCustomer,
+            StripeCustomerSubscription: models.StripeCustomerSubscription,
+            Member: models.Member
+        },
         logger: logging
     });
 

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -133,7 +133,7 @@ class MembersConfigProvider {
     getStripeUrlConfig() {
         const siteUrl = this._urlUtils.getSiteUrl();
 
-        const webhookHandlerUrl = new URL('/members/webhooks/stripe', siteUrl);
+        const webhookHandlerUrl = new URL('members/webhooks/stripe/', siteUrl);
 
         const checkoutSuccessUrl = new URL(siteUrl);
         checkoutSuccessUrl.searchParams.set('stripe', 'success');

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -174,6 +174,10 @@ class MembersConfigProvider {
             billingSuccessUrl: urls.billingSuccess,
             billingCancelUrl: urls.billingCancel,
             webhookHandlerUrl: urls.webhookHandler,
+            webhook: {
+                id: this._settingsCache.get('members_stripe_webhook_id'),
+                secret: this._settingsCache.get('members_stripe_webhook_secret')
+            },
             product: {
                 name: this._settingsCache.get('stripe_product_name')
             },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@tryghost/kg-markdown-html-renderer": "2.0.1",
     "@tryghost/kg-mobiledoc-html-renderer": "3.0.1",
     "@tryghost/magic-link": "0.4.10",
-    "@tryghost/members-api": "0.23.2",
+    "@tryghost/members-api": "0.24.0",
     "@tryghost/members-csv": "0.2.1",
     "@tryghost/members-ssr": "0.8.2",
     "@tryghost/mw-session-from-token": "0.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,10 +486,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.23.2":
-  version "0.23.2"
-  resolved "https://registry.npmjs.org/@tryghost/members-api/-/members-api-0.23.2.tgz#a4c644e175d4ede7cec2797c75f822b1f801f8bc"
-  integrity sha512-/1r7/gg7xPHeEikt5FwXx1zmwK3pdqBsCk55Nc0W+TRZznAvKSGuUMNx3mpdQpSf6ry7/0E8RyEaC5p521W6iQ==
+"@tryghost/members-api@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.24.0.tgz#d4f07ec52e6a93f5563e26e1c2d083fb69fb2da1"
+  integrity sha512-2jIl02vDdT9iphsTiQB2mmLANZ7UVmZB50xPuGIL9b8YEE4vddHHR8yPoW97TdSqHOMFIQ7CZPyOJjxQ5gFqUA==
   dependencies:
     "@tryghost/magic-link" "^0.4.10"
     bluebird "^3.5.4"


### PR DESCRIPTION
This updates the members-api version to 0.24.0 which includes a new way of handling the webhook creation.

It expects all models passed to it under the `model` property, and a new "model" `StripeWebhook` which it uses to persist the id and the secret of the webhook to.

We also fix a bug for sites running on a subdirectory and add a unit test to make sure we don't experience it again.