### PR TITLE
Updated frontend meta helpers to support tag metadata

### DIFF
--- a/core/frontend/meta/canonical_url.js
+++ b/core/frontend/meta/canonical_url.js
@@ -8,6 +8,10 @@ function getCanonicalUrl(data) {
         return data.post.canonical_url;
     }
 
+    if (_.includes(data.context, 'tag') && data.tag && data.tag.canonical_url) {
+        return data.tag.canonical_url;
+    }
+
     let url = urlUtils.urlJoin(urlUtils.urlFor('home', true), getUrl(data, false));
 
     if (url.indexOf('/amp/')) {

--- a/core/frontend/meta/description.js
+++ b/core/frontend/meta/description.js
@@ -36,7 +36,8 @@ function getDescription(data, root, options = {}) {
         if (!options.property && _.includes(context, 'paged')) {
             description = '';
         } else {
-            description = data.tag.meta_description
+            description = data.tag[`${options.property}_description`]
+                || data.tag.meta_description
                 || data.tag.description
                 || (options.property ? settingsCache.get('meta_description') : '')
                 || '';

--- a/core/frontend/meta/og_image.js
+++ b/core/frontend/meta/og_image.js
@@ -25,7 +25,9 @@ function getOgImage(data) {
     }
 
     if (_.includes(context, 'tag')) {
-        if (contextObject.feature_image) {
+        if (contextObject.og_image) {
+            return urlUtils.relativeToAbsolute(contextObject.og_image);
+        } else if (contextObject.feature_image) {
             return urlUtils.relativeToAbsolute(contextObject.feature_image);
         } else if (settingsCache.get('cover_image')) {
             return urlUtils.relativeToAbsolute(settingsCache.get('cover_image'));

--- a/core/frontend/meta/title.js
+++ b/core/frontend/meta/title.js
@@ -37,7 +37,7 @@ function getTitle(data, root, options = {}) {
         title = data.tag.meta_title || data.tag.name + ' - ' + siteTitle + pageString;
     // Tag title, index
     } else if (_.includes(context, 'tag') && data.tag) {
-        title = data.tag.meta_title || data.tag.name + ' - ' + siteTitle;
+        title = data.tag[optionsPropertyName] || data.tag.meta_title || data.tag.name + ' - ' + siteTitle;
     // Post title
     } else if (_.includes(context, 'post') && data.post) {
         title = data.post[optionsPropertyName] || data.post.meta_title || data.post.title;

--- a/core/frontend/meta/twitter_image.js
+++ b/core/frontend/meta/twitter_image.js
@@ -25,7 +25,9 @@ function getTwitterImage(data) {
     }
 
     if (_.includes(context, 'tag')) {
-        if (contextObject.feature_image) {
+        if (contextObject.twitter_image) {
+            return urlUtils.relativeToAbsolute(contextObject.twitter_image);
+        } else if (contextObject.feature_image) {
             return urlUtils.relativeToAbsolute(contextObject.feature_image);
         } else if (settingsCache.get('cover_image')) {
             return urlUtils.relativeToAbsolute(settingsCache.get('cover_image'));


### PR DESCRIPTION
no-issue

- `url`
  - Currently determined from site url
- `canonicalUrl`
  - Currently same as `url`
  - Updated to use `canonical_url` & fall back to previous functionality
- `metaTitle`
  - Currently uses `meta_title` & falls back to `"${name} - ${site.title}"`
- `metaDescription`
  - Currently uses `meta_description` & falls back to `description`
- `ogType`
  - Currently set to "website"
- `ogTitle`
  - Currently same as `metaTitle`
  - Updated to use `og_title` and fall back to previous functionality
- `ogImage`
  - Currently uses `feature_image` & falls back to `site.cover_image`
  - Updated to use `og_image` and fall back to previous functionality
- `ogDescription`
  - Currently uses `meta_description` & falls back to `description`, & then to `site.meta_description`
  - Updated to use `og_description` and fall back to previous functionality
- `twitterTitle`
  - Currently same as `metaTitle`
  - Updated to use `twitter_title` and fall back to previous functionality
- `twitterImage`
  - Currently uses `feature_image` & falls back to `site.cover_image`
  - Upated to use `twitter_image` and fall back to previous functionality
- `twitterDescription`
  - Currently uses `meta_description` & falls back to `description`, & then to `site.meta_description`
  - Updated to use `twitter_description` and fall back to previous functionality