### PR TITLE
Added amp_gtag_id setting migration & default

### DIFF
--- a/core/frontend/apps/amp/lib/helpers/amp_analytics.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_analytics.js
@@ -1,0 +1,35 @@
+// # Amp Components Helper
+// Usage: `{{amp_analytics}}`
+//
+// Outputs inline scripts used for analytics
+
+const proxy = require('../../../../services/proxy');
+
+const SafeString = proxy.SafeString;
+const settingsCache = proxy.settingsCache;
+
+function ampComponents() {
+    let components = [];
+
+    const ampGtagId = settingsCache.get('amp_gtag_id');
+    if (ampGtagId) {
+        components.push(`
+            <amp-analytics type="gtag" data-credentials="include">
+                <script type="application/json">
+                    {
+                        "vars" : {
+                            "gtag_id": "${ampGtagId}",
+                            "config" : {
+                                "${ampGtagId}": { "groups": "default" }
+                            }
+                        }
+                    }
+                </script>
+            </amp-analytics>
+        `);
+    }
+
+    return new SafeString(components.join('\n'));
+}
+
+module.exports = ampComponents;

--- a/core/frontend/apps/amp/lib/helpers/amp_components.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_components.js
@@ -39,6 +39,10 @@ function ampComponents() {
         components.push('<script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>');
     }
 
+    if (proxy.settingsCache.get('amp_gtag_id')) {
+        components.push('<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>');
+    }
+
     return new SafeString(components.join('\n'));
 }
 

--- a/core/frontend/apps/amp/lib/helpers/index.js
+++ b/core/frontend/apps/amp/lib/helpers/index.js
@@ -6,6 +6,8 @@ function registerAmpHelpers(ghost) {
 
     ghost.helpers.register('amp_components', require('./amp_components'));
 
+    ghost.helpers.register('amp_analytics', require('./amp_analytics'));
+
     // we use the {{ghost_head}} helper, but call it {{amp_ghost_head}}, so it's consistent
     ghost.helpers.registerAsync('amp_ghost_head', ghostHead);
 }

--- a/core/frontend/apps/amp/lib/views/amp.hbs
+++ b/core/frontend/apps/amp/lib/views/amp.hbs
@@ -622,5 +622,6 @@
         <p><a href="{{@site.url}}">Read more posts →</a></p>
         <a class="powered" href="https://ghost.org" target="_blank" rel="noopener"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 156 156"><g fill="none" fill-rule="evenodd"><rect fill="#15212B" width="156" height="156" rx="27"/><g transform="translate(36 36)" fill="#F6F8FA"><path d="M0 71.007A4.004 4.004 0 014 67h26a4 4 0 014 4.007v8.986A4.004 4.004 0 0130 84H4a4 4 0 01-4-4.007v-8.986zM50 71.007A4.004 4.004 0 0154 67h26a4 4 0 014 4.007v8.986A4.004 4.004 0 0180 84H54a4 4 0 01-4-4.007v-8.986z"/><rect y="34" width="84" height="17" rx="4"/><path d="M0 4.007A4.007 4.007 0 014.007 0h41.986A4.003 4.003 0 0150 4.007v8.986A4.007 4.007 0 0145.993 17H4.007A4.003 4.003 0 010 12.993V4.007z"/><rect x="67" width="17" height="17" rx="4"/></g></g></svg> Published with Ghost</a></span>
     </footer>
+    {{amp_analytics}}
 </body>
 </html>

--- a/core/server/data/migrations/versions/3.25/02-add-amp-gtag-id-setting.js
+++ b/core/server/data/migrations/versions/3.25/02-add-amp-gtag-id-setting.js
@@ -1,0 +1,20 @@
+const logging = require('../../../../../shared/logging');
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up({transacting: knex}) {
+        logging.info('Updating amp_gtag_id setting to amp group');
+        await knex('settings')
+            .update({
+                group: 'amp'
+            })
+            .where({
+                key: 'amp_gtag_id'
+            });
+    },
+
+    async down() {}
+};

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -337,6 +337,10 @@
                 "isIn": [["true", "false"]]
             },
             "type": "boolean"
+        },
+        "amp_gtag_id": {
+            "defaultValue": null,
+            "type": "string"
         }
     },
     "labs": {

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -56,6 +56,7 @@ const defaultSettingsKeyTypes = [
     {key: 'mailgun_domain', type: 'bulk_email'},
     {key: 'mailgun_base_url', type: 'bulk_email'},
     {key: 'amp', type: 'blog'},
+    {key: 'amp_gtag_id', type: 'blog'},
     {key: 'labs', type: 'blog'},
     {key: 'slack', type: 'blog'},
     {key: 'unsplash', type: 'blog'},

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -53,6 +53,7 @@ const defaultSettingsKeyTypes = [
     {key: 'mailgun_domain', type: 'bulk_email'},
     {key: 'mailgun_base_url', type: 'bulk_email'},
     {key: 'amp', type: 'blog'},
+    {key: 'amp_gtag_id', type: 'blog'},
     {key: 'labs', type: 'blog'},
     {key: 'slack', type: 'blog'},
     {key: 'unsplash', type: 'blog'},

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -56,6 +56,7 @@ const defaultSettingsKeys = [
     'mailgun_domain',
     'mailgun_base_url',
     'amp',
+    'amp_gtag_id',
     'labs',
     'slack',
     'unsplash',

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -23,7 +23,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '134c9de4e59b31ec6b73f03638a01396';
     const currentFixturesHash = '3d942c46e8487c4aee1e9ac898ed29ca';
-    const currentSettingsHash = 'b0291920e168e74cf63a1919cd594fd6';
+    const currentSettingsHash = 'a4ac78d3810175428b4833645231d6d5';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
refs #11980

This lays the ground for the rest of the work surrounding Google
Analytics in AMP.