### PR TITLE
Updated sender email to existing "from-address"

### DIFF
--- a/core/server/services/members/settings.js
+++ b/core/server/services/members/settings.js
@@ -17,6 +17,7 @@ function createSettingsInstance(config) {
                     logging.warn(message.text);
                 }
                 let msg = Object.assign({
+                    from: config.getEmailFromAddress(),
                     subject: 'Update email address',
                     forceTextContent: true
                 }, message);


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12043

- On updating From-address from Members settings in Labs, we send a confirmation email to the updated address with magic link for verification
- Previously, the sender address being used falling back to default
- This updates the sender address to use the current from address as default
