### PR TITLE
Added text for invalid credentials on sign in form

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -801,6 +801,7 @@ User = ghostBookshelf.Model.extend({
             .then((user) => {
                 if (!user) {
                     throw new errors.NotFoundError({
+                        context: i18n.t('errors.models.user.invalidCredentials'),
                         message: i18n.t('errors.models.user.noUserWithEnteredEmailAddr')
                     });
                 }
@@ -827,6 +828,7 @@ User = ghostBookshelf.Model.extend({
             .catch((err) => {
                 if (err.message === 'NotFound' || err.message === 'EmptyResponse') {
                     throw new errors.NotFoundError({
+                        context: i18n.t('errors.models.user.invalidCredentials'),
                         message: i18n.t('errors.models.user.noUserWithEnteredEmailAddr')
                     });
                 }
@@ -852,7 +854,7 @@ User = ghostBookshelf.Model.extend({
                 }
 
                 return Promise.reject(new errors.ValidationError({
-                    context: i18n.t('errors.models.user.incorrectPassword'),
+                    context: i18n.t('errors.models.user.invalidCredentials'),
                     message: i18n.t('errors.models.user.incorrectPassword'),
                     help: i18n.t('errors.models.user.userUpdateError.help'),
                     code: 'PASSWORD_INCORRECT'

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -228,6 +228,7 @@
                     "help": "Visit and save your profile after logging in to check for problems."
                 },
                 "incorrectPassword": "Your password is incorrect.",
+                "invalidCredentials": "Your credentials are incorrect.",
                 "accountSuspended": "Your account was suspended.",
                 "newPasswordsDoNotMatch": "Your new passwords do not match",
                 "passwordRequiredForOperation": "Password is required for this operation",


### PR DESCRIPTION
As an extra layer of security, the sign in form does not tell which field is wrong but rather give a generic error message.
Without this, one could guess whether or not a certain mail address is registered as a user and can therefore go straight to guessing the user's password.
Refers to https://github.com/TryGhost/Ghost-Admin/pull/1645

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)