### PR TITLE
Updated Members DELETE endpoint to accept `cancel` query param 

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -303,7 +303,8 @@ const members = {
         statusCode: 204,
         headers: {},
         options: [
-            'id'
+            'id',
+            'cancel'
         ],
         validation: {
             options: {
@@ -326,10 +327,12 @@ const members = {
                 });
             }
 
-            // NOTE: move to a model layer once Members/MemberStripeCustomer relations are in place
-            await membersService.api.members.destroyStripeSubscriptions(member);
+            if (frame.options.cancel === true) {
+                await membersService.api.members.cancelStripeSubscriptions(member);
+            }
 
-            await models.Member.destroy(frame.options)
+            // Wrapped in bluebird promise to allow "filtered catch"
+            await Promise.resolve(models.Member.destroy(frame.options))
                 .catch(models.Member.NotFoundError, () => {
                     throw new errors.NotFoundError({
                         message: i18n.t('errors.api.resource.resourceNotFound', {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@tryghost/kg-markdown-html-renderer": "2.0.1",
     "@tryghost/kg-mobiledoc-html-renderer": "3.0.1",
     "@tryghost/magic-link": "0.4.12",
-    "@tryghost/members-api": "0.24.5",
+    "@tryghost/members-api": "0.25.0",
     "@tryghost/members-csv": "0.2.1",
     "@tryghost/members-ssr": "0.8.3",
     "@tryghost/mw-session-from-token": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@tryghost/kg-markdown-html-renderer": "2.0.1",
     "@tryghost/kg-mobiledoc-html-renderer": "3.0.1",
     "@tryghost/magic-link": "0.4.12",
-    "@tryghost/members-api": "0.25.0",
+    "@tryghost/members-api": "0.25.1",
     "@tryghost/members-csv": "0.2.1",
     "@tryghost/members-ssr": "0.8.3",
     "@tryghost/mw-session-from-token": "0.1.5",

--- a/test/regression/api/canary/admin/members_spec.js
+++ b/test/regression/api/canary/admin/members_spec.js
@@ -156,6 +156,115 @@ describe('Members API', function () {
             });
     });
 
+    it('Can delete a member without cancelling Stripe Subscription', async function () {
+        const member = {
+            name: 'Member 2 Delete',
+            email: 'Member2Delete@test.com'
+        };
+
+        const createdMember = await request.post(localUtils.API.getApiQuery(`members/`))
+            .send({members: [member]})
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.members);
+                jsonResponse.members.should.have.length(1);
+
+                return jsonResponse.members[0];
+            });
+
+        await request.delete(localUtils.API.getApiQuery(`members/${createdMember.id}/`))
+            .set('Origin', config.get('url'))
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(204)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+
+                const jsonResponse = res.body;
+
+                should.exist(jsonResponse);
+            });
+    });
+
+    // NOTE: this test should be enabled and expanded once test suite fully supports Stripe mocking
+    it.skip('Can delete a member and cancel Stripe Subscription', async function () {
+        const member = {
+            name: 'Member 2 Delete',
+            email: 'Member2Delete@test.com',
+            comped: true
+        };
+
+        const createdMember = await request.post(localUtils.API.getApiQuery(`members/`))
+            .send({members: [member]})
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.members);
+                jsonResponse.members.should.have.length(1);
+
+                return jsonResponse.members[0];
+            });
+
+        await request.delete(localUtils.API.getApiQuery(`members/${createdMember.id}/?cancel=true`))
+            .set('Origin', config.get('url'))
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(204)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+
+                const jsonResponse = res.body;
+
+                should.exist(jsonResponse);
+            });
+    });
+
+    // NOTE: this test should be enabled and expanded once test suite fully supports Stripe mocking
+    it.skip('Does not cancel Stripe Subscription if cancel_subscriptions is not set to "true"', async function () {
+        const member = {
+            name: 'Member 2 Delete',
+            email: 'Member2Delete@test.com',
+            comped: true
+        };
+
+        const createdMember = await request.post(localUtils.API.getApiQuery(`members/`))
+            .send({members: [member]})
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+                const jsonResponse = res.body;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.members);
+                jsonResponse.members.should.have.length(1);
+
+                return jsonResponse.members[0];
+            });
+
+        await request.delete(localUtils.API.getApiQuery(`members/${createdMember.id}/?cancel=false`))
+            .set('Origin', config.get('url'))
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(204)
+            .then((res) => {
+                should.not.exist(res.headers['x-cache-invalidate']);
+
+                const jsonResponse = res.body;
+
+                should.exist(jsonResponse);
+            });
+    });
+
     it('Can import CSV with minimum one field and labels', function () {
         return request
             .post(localUtils.API.getApiQuery(`members/upload/`))

--- a/yarn.lock
+++ b/yarn.lock
@@ -397,7 +397,7 @@
   dependencies:
     "@tryghost/kg-clean-basic-html" "^0.1.8"
 
-"@tryghost/magic-link@0.4.12":
+"@tryghost/magic-link@0.4.12", "@tryghost/magic-link@^0.4.12":
   version "0.4.12"
   resolved "https://registry.yarnpkg.com/@tryghost/magic-link/-/magic-link-0.4.12.tgz#3a4c6eeb5bf5c8420e006928ccc02da716ea4662"
   integrity sha512-sFwGd0x5FjBXfFBRLqLJSQCzluDf+dMsA2j2LUZV+iesPvT/P+fAcb3pwXQ6nohjl/aGYpR3N9/yj0AL3m2qrw==
@@ -407,22 +407,12 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/magic-link@^0.4.11":
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/@tryghost/magic-link/-/magic-link-0.4.11.tgz#25746a435456939c22026188b37e27b177289e85"
-  integrity sha512-+Iqe0uQL9TqL6AbuWbUO8OznMe5Mdgo4YXoxW9FjCYrbwLYCGq9Y9B21DjMR/hiQA4B40Zvk8Kdui8Iyu+LLrA==
+"@tryghost/members-api@0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.25.0.tgz#34d00cc334c20700f563326db86521b3a6867414"
+  integrity sha512-kM8I9ET3pPnt0VHMmeqvU6BSJwO+LQmAo6+pCzP5EnqkNLGRL3x9h1UigCL1dlnIor1Fb6hGgdxJS5yP9E4KHw==
   dependencies:
-    bluebird "^3.5.5"
-    ghost-ignition "^4.0.0"
-    jsonwebtoken "^8.5.1"
-    lodash "^4.17.15"
-
-"@tryghost/members-api@0.24.5":
-  version "0.24.5"
-  resolved "https://registry.npmjs.org/@tryghost/members-api/-/members-api-0.24.5.tgz#54f67f433211625e28e55cbd60b0bcc2518644e8"
-  integrity sha512-Trx7dfaDrp2d5ATi95/uiefCtvKgWHOkrm4ISBC/6/f2TZomVj+2/OR4wef68mTosgKXsHRx8DHzGbwYM32uvg==
-  dependencies:
-    "@tryghost/magic-link" "^0.4.11"
+    "@tryghost/magic-link" "^0.4.12"
     bluebird "^3.5.4"
     body-parser "^1.19.0"
     cookies "^0.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,10 +407,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.25.0.tgz#34d00cc334c20700f563326db86521b3a6867414"
-  integrity sha512-kM8I9ET3pPnt0VHMmeqvU6BSJwO+LQmAo6+pCzP5EnqkNLGRL3x9h1UigCL1dlnIor1Fb6hGgdxJS5yP9E4KHw==
+"@tryghost/members-api@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.25.1.tgz#b921f2b87e46f9a23811ab6bc7cf32042d82c722"
+  integrity sha512-+Hu5ebp7JuLT+sNQ7mmajv1wpsseaw0kj38VABncAgChCrDl11tjs99FcV1IGZ1RCNaTS8OF8lOciEXB/MlKyw==
   dependencies:
     "@tryghost/magic-link" "^0.4.12"
     bluebird "^3.5.4"


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/11557

- [x] Fixed deleting members with missing stripe data
- [x] Updated DELETE endpoint
  - [x] Does not cancel subscriptions by default
  - [x] Accepts a `?cancel=true` query parameter to cancel subscriptions.
  - [x] Added tests _n.b. until we have Stripe mocking, the Stripe specific ones must be skipped :disappointed:_
