### PR TITLE
Published Time and Modified Time was not populating for pages structured data

### DIFF
--- a/core/frontend/meta/modified_date.js
+++ b/core/frontend/meta/modified_date.js
@@ -4,7 +4,8 @@ function getModifiedDate(data) {
     let context = data.context ? data.context : null;
     let modDate;
 
-    context = _.includes(context, 'amp') ? 'post' : context;
+    //Since page is an extension of post
+    context = _.includes(context, 'amp') || _.includes(context, 'page') ? 'post' : context;
 
     if (data[context]) {
         modDate = data[context].updated_at || null;

--- a/core/frontend/meta/published_date.js
+++ b/core/frontend/meta/published_date.js
@@ -1,7 +1,8 @@
 function getPublishedDate(data) {
     let context = data.context ? data.context[0] : null;
 
-    context = context === 'amp' ? 'post' : context;
+    //Since page is an extension of post
+    context = context === 'amp' || context === 'page' ? 'post' : context;
 
     if (data[context] && data[context].published_at) {
         return new Date(data[context].published_at).toISOString();


### PR DESCRIPTION

closes TryGhost#12059
Published Time and Modified Time were not populating for 'page' context because it is an extension of 'post' and hence there was no context 'page'. Fixed it by handling this scenario for published time and modified time