### PR TITLE
✨ Added `DELETE /members/` to the Admin API for bulk member deletion

### DIFF
--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -10,6 +10,7 @@ module.exports = {
     edit: createSerializer('edit', singleMember),
     add: createSerializer('add', singleMember),
     editSubscription: createSerializer('editSubscription', singleMember),
+    bulkDestroy: createSerializer('bulkDestroy', passthrough),
 
     exportCSV: createSerializer('exportCSV', exportCSV),
 

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -90,6 +90,7 @@ module.exports = function apiRoutes() {
     // ## Members
     router.get('/members', mw.authAdminApi, http(apiCanary.members.browse));
     router.post('/members', mw.authAdminApi, http(apiCanary.members.add));
+    router.del('/members', mw.authAdminApi, http(apiCanary.members.bulkDestroy));
 
     router.get('/members/stats/count', mw.authAdminApi, http(apiCanary.members.memberStats));
     router.get('/members/stats/mrr', mw.authAdminApi, http(apiCanary.members.mrrStats));

--- a/test/utils/fixtures/csv/valid-members-for-bulk-delete.csv
+++ b/test/utils/fixtures/csv/valid-members-for-bulk-delete.csv
@@ -1,0 +1,9 @@
+email,subscribed
+member+free_1@example.com,true
+member+free_2@example.com,true
+member+free_3@example.com,true
+member+free_4@example.com,true
+member+free_5@example.com,true
+member+free_6@example.com,true
+member+free_7@example.com,true
+member+free_8@example.com,true


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/585

- adds `DELETE /members/` route to the Admin API
- supports `?filter`, and `?search` query params to limit the members that are deleted
- `?all=true` is required if no other filter or query is provided
- uses `models.Member.bulkDestroy` which uses `knex` directly underneath and _will not_ cancel any Stripe subscriptions if members have them but _will_ clean up the Stripe relationship data in Ghost's database