### PR TITLE
Fixed published time and modified time for Structured data

### DIFF
--- a/core/frontend/meta/author_url.js
+++ b/core/frontend/meta/author_url.js
@@ -1,16 +1,17 @@
 const urlService = require('../services/url');
+const getContextObject = require('./context_object.js');
 
 function getAuthorUrl(data, absolute) {
     let context = data.context ? data.context[0] : null;
 
-    context = context === 'amp' ? 'post' : context;
+    const contextObject = getContextObject(data, context);
 
     if (data.author) {
         return urlService.getUrlByResourceId(data.author.id, {absolute: absolute, secure: data.author.secure, withSubdirectory: true});
     }
 
-    if (data[context] && data[context].primary_author) {
-        return urlService.getUrlByResourceId(data[context].primary_author.id, {absolute: absolute, secure: data[context].secure, withSubdirectory: true});
+    if (contextObject && contextObject.primary_author) {
+        return urlService.getUrlByResourceId(contextObject.primary_author.id, {absolute: absolute, secure: contextObject.secure, withSubdirectory: true});
     }
 
     return null;

--- a/core/frontend/meta/context_object.js
+++ b/core/frontend/meta/context_object.js
@@ -26,13 +26,6 @@ function getContextObject(data, context) {
         chosenContext = data.tag;
     } else if (_.includes(context, 'author') && data.author) {
         chosenContext = data.author;
-    } else if (_.includes(context, 'page') && data.post) {
-        // The page context object does not have it's own field, it's just an extension of post,
-        // hence using the post field from data for page context.
-        // Not changing it in the above else if statement so that it doesn't break stuff,
-        // in case in future it gets its own field or if it was present in some legacy system
-        // Page dependent on legacy post https://github.com/TryGhost/Ghost/issues/10042
-        chosenContext = data.post;
     } else if (data[context]) {
         // @NOTE: This is confusing as hell. It tries to get data[['author']], which works, but coincidence?
         chosenContext = data[context];

--- a/core/frontend/meta/context_object.js
+++ b/core/frontend/meta/context_object.js
@@ -26,6 +26,13 @@ function getContextObject(data, context) {
         chosenContext = data.tag;
     } else if (_.includes(context, 'author') && data.author) {
         chosenContext = data.author;
+    } else if (_.includes(context, 'page') && data.post) {
+        // The page context object does not have it's own field, it's just an extension of post,
+        // hence using the post field from data for page context.
+        // Not changing it in the above else if statement so that it doesn't break stuff,
+        // in case in future it gets its own field or if it was present in some legacy system
+        // Page dependent on legacy post https://github.com/TryGhost/Ghost/issues/10042
+        chosenContext = data.post;
     } else if (data[context]) {
         // @NOTE: This is confusing as hell. It tries to get data[['author']], which works, but coincidence?
         chosenContext = data[context];

--- a/core/frontend/meta/modified_date.js
+++ b/core/frontend/meta/modified_date.js
@@ -1,14 +1,13 @@
-const _ = require('lodash');
+const getContextObject = require('./context_object.js');
 
 function getModifiedDate(data) {
     let context = data.context ? data.context : null;
     let modDate;
 
-    //Since page is an extension of post
-    context = _.includes(context, 'amp') || _.includes(context, 'page') ? 'post' : context;
+    const contextObject = getContextObject(data, context);
 
-    if (data[context]) {
-        modDate = data[context].updated_at || null;
+    if (contextObject) {
+        modDate = contextObject.updated_at || null;
         if (modDate) {
             return new Date(modDate).toISOString();
         }

--- a/core/frontend/meta/modified_date.js
+++ b/core/frontend/meta/modified_date.js
@@ -4,7 +4,8 @@ function getModifiedDate(data) {
     let context = data.context ? data.context : null;
     let modDate;
 
-    context = _.includes(context, 'amp') ? 'post' : context;
+    //Since page is an extension of post
+    context = _.includes(context, 'amp') || _.includes(context, 'page') ? 'post' : context;
 
     if (data[context]) {
         modDate = data[context].updated_at || null;

--- a/core/frontend/meta/published_date.js
+++ b/core/frontend/meta/published_date.js
@@ -1,7 +1,8 @@
 function getPublishedDate(data) {
     let context = data.context ? data.context[0] : null;
 
-    context = context === 'amp' ? 'post' : context;
+    //Since page is an extension of post
+    context = context === 'amp' || context === 'page' ? 'post' : context;
 
     if (data[context] && data[context].published_at) {
         return new Date(data[context].published_at).toISOString();

--- a/core/frontend/meta/published_date.js
+++ b/core/frontend/meta/published_date.js
@@ -1,11 +1,12 @@
+const getContextObject = require('./context_object.js');
+
 function getPublishedDate(data) {
     let context = data.context ? data.context[0] : null;
 
-    //Since page is an extension of post
-    context = context === 'amp' || context === 'page' ? 'post' : context;
+    const contextObject = getContextObject(data, context);
 
-    if (data[context] && data[context].published_at) {
-        return new Date(data[context].published_at).toISOString();
+    if (contextObject && contextObject.published_at) {
+        return new Date(contextObject.published_at).toISOString();
     }
     return null;
 }


### PR DESCRIPTION
closes #12059
Published Time and Modified Time were not populating for 'page' context because it is an extension of 'post' and hence there was no context 'page'. Fixed it by handling this scenario for published time and modified time