### PR TITLE
Removed DISTINCT from member labels association query

### DIFF
--- a/core/server/models/member.js
+++ b/core/server/models/member.js
@@ -25,7 +25,12 @@ const Member = ghostBookshelf.Model.extend({
     labels: function labels() {
         return this.belongsToMany('Label', 'members_labels', 'member_id', 'label_id')
             .withPivot('sort_order')
-            .query('orderBy', 'sort_order', 'ASC');
+            .query('orderBy', 'sort_order', 'ASC')
+            .query((qb) => {
+                // avoids bookshelf adding a `DISTINCT` to the query
+                // we know the result set will already be unique and DISTINCT hurts query performance
+                qb.columns('labels.*');
+            });
     },
 
     stripeCustomers() {


### PR DESCRIPTION
no issue

- bookshelf adds `DISTINCT` to any relation query that does not have an explicit `columns` statement
- in this case the returned result set will always be unique so `DISTINCT` is not required
- when measuring the impact of `DISTINCT` on the eager-loading association query when listing members using `{withRelated: 'labels'}`, it can be 2x slower with no index on the sort_order column or 4x slower with an index on sort_order