### PR TITLE
Added support for ON DELETE CASCADE to the schema

### DIFF
--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -40,6 +40,9 @@ function addTableColumn(tableName, table, columnName, columnSpec = schema[tableN
         // check if table exists?
         column.references(columnSpec.references);
     }
+    if (Object.prototype.hasOwnProperty.call(columnSpec, 'cascadeDelete') && columnSpec.cascadeDelete === true) {
+        column.onDelete('CASCADE');
+    }
     if (Object.prototype.hasOwnProperty.call(columnSpec, 'defaultTo')) {
         column.defaultTo(columnSpec.defaultTo);
     }

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -393,7 +393,7 @@ module.exports = {
     },
     members_stripe_customers: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        member_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'members.id'},
+        member_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'members.id', cascadeDelete: true},
         customer_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
         name: {type: 'string', maxlength: 191, nullable: true},
         email: {type: 'string', maxlength: 191, nullable: true},
@@ -404,7 +404,7 @@ module.exports = {
     },
     members_stripe_customers_subscriptions: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'members_stripe_customers.customer_id'},
+        customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'members_stripe_customers.customer_id', cascadeDelete: true},
         subscription_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
         plan_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
         status: {type: 'string', maxlength: 50, nullable: false},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -393,9 +393,8 @@ module.exports = {
     },
     members_stripe_customers: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        member_id: {type: 'string', maxlength: 24, nullable: false, unique: false},
-        // customer_id is unique: false because mysql with innodb utf8mb4 cannot have unqiue columns larger than 191 chars
-        customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
+        member_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'members.id'},
+        customer_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
         name: {type: 'string', maxlength: 191, nullable: true},
         email: {type: 'string', maxlength: 191, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
@@ -405,7 +404,7 @@ module.exports = {
     },
     members_stripe_customers_subscriptions: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
+        customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'members_stripe_customers.customer_id'},
         subscription_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
         plan_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
         status: {type: 'string', maxlength: 50, nullable: false},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -387,8 +387,8 @@ module.exports = {
     },
     members_labels: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id'},
-        label_id: {type: 'string', maxlength: 24, nullable: false, references: 'labels.id'},
+        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+        label_id: {type: 'string', maxlength: 24, nullable: false, references: 'labels.id', cascadeDelete: true},
         sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
     },
     members_stripe_customers: {

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -405,7 +405,7 @@ module.exports = {
     members_stripe_customers_subscriptions: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'members_stripe_customers.customer_id', cascadeDelete: true},
-        subscription_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
+        subscription_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
         plan_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
         status: {type: 'string', maxlength: 50, nullable: false},
         cancel_at_period_end: {type: 'bool', nullable: false, defaultTo: false},

--- a/test/regression/models/model_stripe_customer_subscription_spec.js
+++ b/test/regression/models/model_stripe_customer_subscription_spec.js
@@ -1,4 +1,5 @@
 const should = require('should');
+const {Member} = require('../../../core/server/models/member');
 const {MemberStripeCustomer} = require('../../../core/server/models/member-stripe-customer');
 const {StripeCustomerSubscription} = require('../../../core/server/models/stripe-customer-subscription');
 
@@ -12,8 +13,11 @@ describe('StripeCustomerSubscription Model', function run() {
     describe('customer', function () {
         it('Is correctly mapped to the stripe customer', async function () {
             const context = testUtils.context.admin;
+            const member = await Member.add({
+                email: 'test@test.member'
+            }, context);
             await MemberStripeCustomer.add({
-                member_id: 'fake_member_id',
+                member_id: member.get('id'),
                 customer_id: 'fake_customer_id'
             }, context);
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -21,7 +21,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '1d0eaaccd1d2ac3142ea554459c7d1f3';
+    const currentSchemaHash = '42a966364eb4b5851e807133374821da';
     const currentFixturesHash = '3d942c46e8487c4aee1e9ac898ed29ca';
     const currentSettingsHash = 'a4ac78d3810175428b4833645231d6d5';
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -21,7 +21,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '134c9de4e59b31ec6b73f03638a01396';
+    const currentSchemaHash = 'eed6727eb51ab60823a86e4dee33747b';
     const currentFixturesHash = '3d942c46e8487c4aee1e9ac898ed29ca';
     const currentSettingsHash = 'a4ac78d3810175428b4833645231d6d5';
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -21,7 +21,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'eed6727eb51ab60823a86e4dee33747b';
+    const currentSchemaHash = '1d0eaaccd1d2ac3142ea554459c7d1f3';
     const currentFixturesHash = '3d942c46e8487c4aee1e9ac898ed29ca';
     const currentSettingsHash = 'a4ac78d3810175428b4833645231d6d5';
 


### PR DESCRIPTION
no-issue

We are in the process of creating migrations to add `ON DELETE CASCADE`
to the members_stripe_* tables to make bulk deletion faster. This change
allows us to support the constraint at db initialisation from the schema