### PR TITLE
Updated Member and StripeCustomerSubscription relations

### DIFF
--- a/core/server/api/canary/memberSigninUrls.js
+++ b/core/server/api/canary/memberSigninUrls.js
@@ -1,4 +1,3 @@
-const models = require('../../models');
 const {i18n} = require('../../lib/common');
 const errors = require('@tryghost/errors');
 const membersService = require('../../services/members');
@@ -12,7 +11,7 @@ module.exports = {
         ],
         permissions: true,
         async query(frame) {
-            let model = await models.Member.findOne(frame.data, frame.options);
+            let model = await membersService.api.members.get(frame.data, frame.options);
 
             if (!model) {
                 throw new errors.NotFoundError({

--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -148,7 +148,7 @@ module.exports = {
         permissions: true,
         validation: {},
         async query(frame) {
-            frame.options.withRelated = ['stripeSubscriptions', 'stripeSubscriptions.customer'];
+            frame.options.withRelated = ['labels', 'stripeSubscriptions', 'stripeSubscriptions.customer'];
             const page = await models.Member.findPage(frame.options);
             const members = page.data.map(model => model.toJSON(frame.options));
 
@@ -168,7 +168,7 @@ module.exports = {
         validation: {},
         permissions: true,
         async query(frame) {
-            frame.options.withRelated = ['stripeSubscriptions', 'stripeSubscriptions.customer'];
+            frame.options.withRelated = ['labels', 'stripeSubscriptions', 'stripeSubscriptions.customer'];
             let model = await models.Member.findOne(frame.data, frame.options);
 
             if (!model) {

--- a/core/server/models/member.js
+++ b/core/server/models/member.js
@@ -49,6 +49,19 @@ const Member = ghostBookshelf.Model.extend({
         );
     },
 
+    serialize(options) {
+        const defaultSerializedObject = ghostBookshelf.Model.prototype.serialize.call(this, options);
+
+        if (defaultSerializedObject.stripeSubscriptions) {
+            defaultSerializedObject.stripe = {
+                subscriptions: defaultSerializedObject.stripeSubscriptions
+            };
+            delete defaultSerializedObject.stripeSubscriptions;
+        }
+
+        return defaultSerializedObject;
+    },
+
     emitChange: function emitChange(event, options) {
         const eventToTrigger = 'member' + '.' + event;
         ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);

--- a/core/server/models/member.js
+++ b/core/server/models/member.js
@@ -37,6 +37,18 @@ const Member = ghostBookshelf.Model.extend({
         return this.hasMany('MemberStripeCustomer', 'member_id', 'id');
     },
 
+    stripeSubscriptions() {
+        // TODO need to filter for active/trialing
+        return this.belongsToMany(
+            'StripeCustomerSubscription',
+            'members_stripe_customers',
+            'member_id',
+            'customer_id',
+            'id',
+            'customer_id'
+        );
+    },
+
     emitChange: function emitChange(event, options) {
         const eventToTrigger = 'member' + '.' + event;
         ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);

--- a/core/server/models/member.js
+++ b/core/server/models/member.js
@@ -38,7 +38,6 @@ const Member = ghostBookshelf.Model.extend({
     },
 
     stripeSubscriptions() {
-        // TODO need to filter for active/trialing
         return this.belongsToMany(
             'StripeCustomerSubscription',
             'members_stripe_customers',
@@ -46,7 +45,7 @@ const Member = ghostBookshelf.Model.extend({
             'customer_id',
             'id',
             'customer_id'
-        );
+        ).query('whereIn', 'status', ['active', 'trialing']);
     },
 
     serialize(options) {

--- a/core/server/models/stripe-customer-subscription.js
+++ b/core/server/models/stripe-customer-subscription.js
@@ -1,11 +1,48 @@
 const ghostBookshelf = require('./base');
 
+const CURRENCY_SYMBOLS = {
+    usd: '$',
+    aud: '$',
+    cad: '$',
+    gbp: '£',
+    eur: '€',
+    inr: '₹'
+};
+
 const StripeCustomerSubscription = ghostBookshelf.Model.extend({
     tableName: 'members_stripe_customers_subscriptions',
 
     customer() {
         return this.belongsTo('MemberStripeCustomer', 'customer_id', 'customer_id');
+    },
+
+    serialize(options) {
+        const defaultSerializedObject = ghostBookshelf.Model.prototype.serialize.call(this, options);
+
+        return {
+            id: defaultSerializedObject.subscription_id,
+            customer: {
+                id: defaultSerializedObject.customer_id,
+                // TODO? The customer is not fetched by default so these sometimes won't exist
+                name: defaultSerializedObject.customer ? defaultSerializedObject.customer.name : null,
+                email: defaultSerializedObject.customer ? defaultSerializedObject.customer.email : null
+            },
+            plan: {
+                id: defaultSerializedObject.plan_id,
+                nickname: defaultSerializedObject.plan_nickname,
+                amount: defaultSerializedObject.plan_amount,
+                interval: defaultSerializedObject.plan_interval,
+                currency: String.prototype.toUpperCase.call(defaultSerializedObject.plan_currency),
+                currency_symbol: CURRENCY_SYMBOLS[String.prototype.toLowerCase.call(defaultSerializedObject.plan_currency)]
+            },
+            status: defaultSerializedObject.status,
+            start_date: defaultSerializedObject.start_date,
+            default_payment_card_last4: defaultSerializedObject.default_payment_card_last4,
+            cancel_at_period_end: defaultSerializedObject.cancel_at_period_end,
+            current_period_end: defaultSerializedObject.current_period_end
+        };
     }
+
 }, {
     async upsert(data, unfilteredOptions) {
         const subscriptionId = unfilteredOptions.subscription_id;

--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -60,7 +60,7 @@ const sendEmail = async (postModel, memberModels) => {
 
 const sendTestEmail = async (postModel, toEmails) => {
     const recipients = await Promise.all(toEmails.map(async (email) => {
-        const member = await models.Member.findOne({email});
+        const member = await membersService.api.members.get({email});
         return member || new models.Member({email});
     }));
     const {emailTmpl, emails, emailData} = await getEmailData(postModel, recipients);
@@ -87,7 +87,7 @@ const addEmail = async (postModel, options) => {
 
     const startRetrieve = Date.now();
     debug('addEmail: retrieving members count');
-    const {meta: {pagination: {total: membersCount}}} = await models.Member.findPage(Object.assign({}, knexOptions, filterOptions));
+    const {meta: {pagination: {total: membersCount}}} = await membersService.api.members.list(Object.assign({}, knexOptions, filterOptions));
     debug(`addEmail: retrieved members count - ${membersCount} members (${Date.now() - startRetrieve}ms)`);
 
     // NOTE: don't create email object when there's nobody to send the email to
@@ -214,7 +214,7 @@ async function pendingEmailHandler(emailModel, options) {
 
         const startRetrieve = Date.now();
         debug('pendingEmailHandler: retrieving members list');
-        const {data: members} = await models.Member.findPage(Object.assign({}, knexOptions, filterOptions));
+        const {data: members} = await membersService.api.members.list(Object.assign({}, knexOptions, filterOptions));
         debug(`pendingEmailHandler: retrieved members list - ${members.length} members (${Date.now() - startRetrieve}ms)`);
 
         if (!members.length) {

--- a/core/server/services/members/importer/index.js
+++ b/core/server/services/members/importer/index.js
@@ -184,7 +184,7 @@ const doImport = async ({membersBatch: members, allLabelModels, importSetLabels,
             if (membersWithStripeCustomers.length) {
                 await Promise.map(membersWithStripeCustomers, async (stripeMember) => {
                     try {
-                        await membersService.api.members.linkStripeCustomer(stripeMember.stripe_customer_id, stripeMember);
+                        await membersService.api.members.linkStripeCustomerById(stripeMember.stripe_customer_id, stripeMember.id);
                     } catch (error) {
                         if (error.message.indexOf('customer') && error.code === 'resource_missing') {
                             error.message = `Member not imported. ${error.message}`;
@@ -204,7 +204,7 @@ const doImport = async ({membersBatch: members, allLabelModels, importSetLabels,
             if (membersWithComplimentaryPlans.length) {
                 await Promise.map(membersWithComplimentaryPlans, async (complimentaryMember) => {
                     try {
-                        await membersService.api.members.setComplimentarySubscription(complimentaryMember);
+                        await membersService.api.members.setComplimentarySubscriptionById(complimentaryMember.id);
                     } catch (error) {
                         logging.error(error);
                         invalid.errors.push(error);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@tryghost/kg-markdown-html-renderer": "2.0.1",
     "@tryghost/kg-mobiledoc-html-renderer": "3.0.1",
     "@tryghost/magic-link": "0.4.13",
-    "@tryghost/members-api": "0.25.2",
+    "@tryghost/members-api": "0.26.0",
     "@tryghost/members-csv": "0.2.1",
     "@tryghost/members-ssr": "0.8.5",
     "@tryghost/mw-session-from-token": "0.1.7",

--- a/test/regression/models/model_members_spec.js
+++ b/test/regression/models/model_members_spec.js
@@ -74,7 +74,6 @@ describe('Member Model', function run() {
 
             const subscriptions = memberWithRelations.related('stripeSubscriptions').toJSON();
 
-
             const subscription1 = subscriptions.find(({id}) => id === 'fake_subscription_id1');
             const subscription2 = subscriptions.find(({id}) => id === 'fake_subscription_id2');
 

--- a/test/regression/models/model_members_spec.js
+++ b/test/regression/models/model_members_spec.js
@@ -12,6 +12,77 @@ describe('Member Model', function run() {
     beforeEach(testUtils.setup('roles'));
     afterEach(testUtils.teardownDb);
 
+    describe('stripeSubscriptions', function () {
+        it('It is correctly mapped to all a members subscriptions, regardless of customer', async function () {
+            const context = testUtils.context.admin;
+            await Member.add({
+                email: 'test@test.member',
+                labels: []
+            }, context);
+            const member = await Member.findOne({
+                email: 'test@test.member'
+            }, context);
+
+            should.exist(member, 'Member should have been created');
+
+            await MemberStripeCustomer.add({
+                member_id: member.get('id'),
+                customer_id: 'fake_customer_id1'
+            }, context);
+
+            await MemberStripeCustomer.add({
+                member_id: member.get('id'),
+                customer_id: 'fake_customer_id2'
+            }, context);
+
+            await StripeCustomerSubscription.add({
+                customer_id: 'fake_customer_id1',
+                subscription_id: 'fake_subscription_id1',
+                plan_id: 'fake_plan_id',
+                plan_amount: 1337,
+                plan_nickname: 'e-LEET',
+                plan_interval: 'year',
+                plan_currency: 'btc',
+                status: 'active',
+                start_date: new Date(),
+                current_period_end: new Date(),
+                cancel_at_period_end: false
+            }, context);
+
+            await StripeCustomerSubscription.add({
+                customer_id: 'fake_customer_id2',
+                subscription_id: 'fake_subscription_id2',
+                plan_id: 'fake_plan_id',
+                plan_amount: 1337,
+                plan_nickname: 'e-LEET',
+                plan_interval: 'year',
+                plan_currency: 'btc',
+                status: 'active',
+                start_date: new Date(),
+                current_period_end: new Date(),
+                cancel_at_period_end: false
+            }, context);
+
+            const memberWithRelations = await Member.findOne({
+                email: 'test@test.member'
+            }, Object.assign({
+                withRelated: [
+                    'stripeSubscriptions',
+                    'stripeSubscriptions.customer'
+                ]
+            }, context));
+
+            const subscriptions = memberWithRelations.related('stripeSubscriptions').toJSON();
+
+
+            const subscription1 = subscriptions.find(({id}) => id === 'fake_subscription_id1');
+            const subscription2 = subscriptions.find(({id}) => id === 'fake_subscription_id2');
+
+            should.exist(subscription1);
+            should.exist(subscription2);
+        });
+    });
+
     describe('stripeCustomers', function () {
         it('Is correctly mapped to the stripe customers', async function () {
             const context = testUtils.context.admin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,10 +408,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.25.2.tgz#64fd5270f44620761e9f01d4f96925a0bdceb09d"
-  integrity sha512-oNfFZTSO2TA0BEuEk0mbGSZmSZCUq2wvdD63z2AGup+hiDTQHOVlXJGVwKPRqDP5+DJW2wIISh8UxMriXn+8Ow==
+"@tryghost/members-api@0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-0.26.0.tgz#6a6fbb58a485da04217c9df0d6cf335003b3188f"
+  integrity sha512-jZ5Rxt3m7sMonIVbvxJnpElTTq+QPmBGS2bsOFp3cOVjIazD31fCKTWBaV3waGYQ9W5Lx4CrIJ0A4taJKKbKbA==
   dependencies:
     "@tryghost/magic-link" "^0.4.13"
     bluebird "^3.5.4"


### PR DESCRIPTION
no-issue

This includes changes to move toward using proper relations rather than the custom decoration and listing methods that we currently use for members.

I've updated the serialize method on the models, so that we can deal with models in application code, and when converting to JSON for transport, we retain the same structure that we currently have. This greatly simplifies the changes as there are a lot of places that rely on this structure (specifically the `member.stripe.subscriptions` array and the form of the `subscription` objects in the array)