### PR TITLE
Added validation layer to members import endpoint

### DIFF
--- a/core/server/api/canary/utils/validators/input/schemas/members-upload.json
+++ b/core/server/api/canary/utils/validators/input/schemas/members-upload.json
@@ -1,0 +1,49 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "members.upload",
+    "title": "members.upload",
+    "description": "Schema for members.upload",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["email"],
+        "properties": {
+            "name": {
+                "type": "string",
+                "maxLength": 191,
+                "pattern": "^([^,]|$)"
+            },
+            "email": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 191,
+                "format": "email"
+            },
+            "note": {
+                "type": "string",
+                "minLength": 0,
+                "maxLength": 2000
+            },
+            "subscribed": {
+                "type": ["string"],
+                "enum": ["true", "false", "TRUE", "FALSE", ""]
+            },
+            "labels": {
+                "type": "string"
+            },
+            "created_at": {
+                "type": ["string", "null"],
+                "format": "date-time"
+            },
+            "stripe_customer_id": {
+                "type": ["string", "null"]
+            },
+            "complimentary_plan": {
+                "type": ["string"],
+                "enum": ["true", "false", "TRUE", "FALSE", ""]
+            }
+        }
+    }
+  }

--- a/core/server/api/canary/utils/validators/input/schemas/members-upload.json
+++ b/core/server/api/canary/utils/validators/input/schemas/members-upload.json
@@ -11,7 +11,7 @@
         "required": ["email"],
         "properties": {
             "name": {
-                "type": "string",
+                "type": ["null", "string"],
                 "maxLength": 191,
                 "pattern": "^([^,]|$)"
             },
@@ -22,7 +22,7 @@
                 "format": "email"
             },
             "note": {
-                "type": "string",
+                "type": ["null", "string"],
                 "minLength": 0,
                 "maxLength": 2000
             },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@tryghost/kg-mobiledoc-html-renderer": "3.0.1",
     "@tryghost/magic-link": "0.4.13",
     "@tryghost/members-api": "0.26.0",
-    "@tryghost/members-csv": "0.2.1",
+    "@tryghost/members-csv": "0.3.0",
     "@tryghost/members-ssr": "0.8.5",
     "@tryghost/mw-session-from-token": "0.1.7",
     "@tryghost/promise": "0.1.0",

--- a/test/regression/api/canary/admin/members_spec.js
+++ b/test/regression/api/canary/admin/members_spec.js
@@ -456,7 +456,7 @@ describe('Members API', function () {
     it('Fails to import memmber with invalid values', function () {
         return request
             .post(localUtils.API.getApiQuery(`members/upload/`))
-            .attach('membersfile', path.join(__dirname, '/../../../../utils/fixtures/csv/member-invalid-email.csv'))
+            .attach('membersfile', path.join(__dirname, '/../../../../utils/fixtures/csv/members-invalid-values.csv'))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
@@ -470,10 +470,20 @@ describe('Members API', function () {
                 should.exist(jsonResponse.meta.stats);
 
                 jsonResponse.meta.stats.imported.count.should.equal(0);
-                jsonResponse.meta.stats.invalid.count.should.equal(1);
+                jsonResponse.meta.stats.invalid.count.should.equal(2);
 
-                should.equal(jsonResponse.meta.stats.invalid.errors.length, 1);
-                jsonResponse.meta.stats.invalid.errors[0].message.should.equal('Validation (isEmail) failed for email');
+                should.equal(jsonResponse.meta.stats.invalid.errors.length, 4);
+                jsonResponse.meta.stats.invalid.errors[0].message.should.equal('Validation failed for \'name\'');
+                jsonResponse.meta.stats.invalid.errors[0].count.should.equal(1);
+
+                jsonResponse.meta.stats.invalid.errors[1].message.should.equal('Validation failed for \'email\'');
+                jsonResponse.meta.stats.invalid.errors[1].count.should.equal(2);
+
+                jsonResponse.meta.stats.invalid.errors[2].message.should.equal('Validation failed for \'created_at\'');
+                jsonResponse.meta.stats.invalid.errors[2].count.should.equal(1);
+
+                jsonResponse.meta.stats.invalid.errors[3].message.should.equal('Validation failed for \'complimentary_plan\'');
+                jsonResponse.meta.stats.invalid.errors[3].count.should.equal(1);
             });
     });
 

--- a/test/utils/fixtures/csv/member-invalid-email.csv
+++ b/test/utils/fixtures/csv/member-invalid-email.csv
@@ -1,2 +1,0 @@
-email
-invalid_email_value

--- a/test/utils/fixtures/csv/members-invalid-values.csv
+++ b/test/utils/fixtures/csv/members-invalid-values.csv
@@ -1,0 +1,3 @@
+email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,labels
+invalid_email_value1,",name starting with coma",,not_boolean,false,,not_a_date,labels
+invalid_email_value2,"good name",,true,not_boolean,,2019-10-30T14:52:08.000Z,more-labels

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,10 +504,10 @@
     node-jose "^1.1.3"
     stripe "^7.4.0"
 
-"@tryghost/members-csv@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-csv/-/members-csv-0.2.1.tgz#7c7c5d8722567d433fe5825bb7df72d2ee1ae390"
-  integrity sha512-1uCariL7wdSYwje/kszU9y4VNid0ozqBqMGVOZdI8RJ5kjqMhHq461q7E54qlG2cHq+nJlWwsUbBpiEhx0x9vA==
+"@tryghost/members-csv@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-csv/-/members-csv-0.3.0.tgz#96d7daa33476ea3f528981f9cf99f346354604a1"
+  integrity sha512-phZBbw6Nbs7GjAfItbLoekUW4Qj2q2BwmDchEh414pyVq2zfvKykZujpbzovzPSRYcpjxAu64w+1t3jCQ5mqdg==
   dependencies:
     papaparse "5.2.0"
 


### PR DESCRIPTION
#### Why?

- Additional validation is needed for imported data because in case of bulk insertions (through knex) we bypass model layer validation - this could lead to invalid data in the database, which would be hard to get rid of
- Chose validation method we use for other endpoints - through JSON Schema. It proved to be very performant (200ms overhead for 50k records). When comparing it with iterative method (validating each record separately) this was adding about 17s of overhead.
- Refactored returned values from "sanitizeInput" method to encapsulate more logic so that the caller doesn't have to calculate amount of invalid records and deal with error types
- Whole sanitizeInput method could now be easily extracted into separate module (somewhere close to members importer)

@allouis just wanted for you to see this change as you are closely working with this part as well. Also have some comments around where you could take this code next if you are to touch it today :) Will leave them in the PR
