### PR TITLE
Granted Admin users ability to impersonate member

### DIFF
--- a/core/server/data/migrations/versions/3.30/01-add-member-signin-url-permission-roles.js
+++ b/core/server/data/migrations/versions/3.30/01-add-member-signin-url-permission-roles.js
@@ -1,11 +1,8 @@
 const {
-    addPermissionToRole,
-    combineTransactionalMigrations
+    addPermissionToRole
 } = require('../../utils');
 
-module.exports = combineTransactionalMigrations(
-    addPermissionToRole({
-        permission: 'Read member signin urls',
-        role: 'Administrator'
-    })
-);
+module.exports = addPermissionToRole({
+    permission: 'Read member signin urls',
+    role: 'Administrator'
+});

--- a/core/server/data/migrations/versions/3.30/01-add-member-signin-url-permission-roles.js
+++ b/core/server/data/migrations/versions/3.30/01-add-member-signin-url-permission-roles.js
@@ -1,0 +1,11 @@
+const {
+    addPermissionToRole,
+    combineTransactionalMigrations
+} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionToRole({
+        permission: 'Read member signin urls',
+        role: 'Administrator'
+    })
+);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -624,7 +624,8 @@
                     "member": "all",
                     "label": "all",
                     "email_preview": "all",
-                    "email": "all"
+                    "email": "all",
+                    "member_signin_url": "read"
                 },
                 "DB Backup Integration": {
                     "db": "all"

--- a/test/regression/api/canary/admin/members_signin_url_spec.js
+++ b/test/regression/api/canary/admin/members_signin_url_spec.js
@@ -49,10 +49,10 @@ describe('Members Sigin URL API', function () {
         });
     });
 
-    describe('As non-Owner', function () {
+    describe('As Admin', function () {
         before(function () {
             return ghost()
-                .then(function (_ghostServer) {
+                .then(function () {
                     request = supertest.agent(config.get('url'));
                 })
                 .then(function () {
@@ -63,6 +63,45 @@ describe('Members Sigin URL API', function () {
                 })
                 .then(function (admin) {
                     request.user = admin;
+
+                    return localUtils.doAuth(request, 'member');
+                });
+        });
+
+        it('Can read', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`members/${testUtils.DataGenerator.Content.members[0].id}/signin_urls/`))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .then((res) => {
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.member_signin_urls);
+                    jsonResponse.member_signin_urls.should.have.length(1);
+                    localUtils.API.checkResponse(jsonResponse.member_signin_urls[0], 'member_signin_url');
+                });
+        });
+    });
+
+    describe('As non-Owner and non-Admin', function () {
+        before(function () {
+            return ghost()
+                .then(function (_ghostServer) {
+                    request = supertest.agent(config.get('url'));
+                })
+                .then(function () {
+                    return testUtils.createUser({
+                        user: testUtils.DataGenerator.forKnex.createUser({
+                            email: 'test+editor@ghost.org'
+                        }),
+                        role: testUtils.DataGenerator.Content.roles[1].name
+                    });
+                })
+                .then((user) => {
+                    request.user = user;
 
                     return localUtils.doAuth(request, 'member');
                 });

--- a/test/unit/data/schema/fixtures/utils_spec.js
+++ b/test/unit/data/schema/fixtures/utils_spec.js
@@ -152,19 +152,19 @@ describe('Migration Fixture Utils', function () {
             fixtureUtils.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
-                result.should.have.property('expected', 68);
-                result.should.have.property('done', 68);
+                result.should.have.property('expected', 69);
+                result.should.have.property('done', 69);
 
                 // Permissions & Roles
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(68);
+                dataMethodStub.filter.callCount.should.eql(69);
                 dataMethodStub.find.callCount.should.eql(7);
-                baseUtilAttachStub.callCount.should.eql(68);
+                baseUtilAttachStub.callCount.should.eql(69);
 
-                fromItem.related.callCount.should.eql(68);
-                fromItem.findWhere.callCount.should.eql(68);
-                toItem[0].get.callCount.should.eql(136);
+                fromItem.related.callCount.should.eql(69);
+                fromItem.findWhere.callCount.should.eql(69);
+                toItem[0].get.callCount.should.eql(138);
 
                 done();
             }).catch(done);

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -22,7 +22,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '42a966364eb4b5851e807133374821da';
-    const currentFixturesHash = '3d942c46e8487c4aee1e9ac898ed29ca';
+    const currentFixturesHash = '29148c40dfaf4f828c5fca95666f6545';
     const currentSettingsHash = 'a4ac78d3810175428b4833645231d6d5';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12126

- Adds migration to add impersonation permission to administrators
- Adds default permission fixture for administrators to read member impersonation urls
- Allows administrators to create member impersonation magic links
