### PR TITLE
Added type of data to CollectionRouter context

### DIFF
--- a/core/frontend/services/routing/CollectionRouter.js
+++ b/core/frontend/services/routing/CollectionRouter.js
@@ -52,7 +52,7 @@ class CollectionRouter extends ParentRouter {
             return this.permalinks.value;
         };
 
-        this.context = [this.routerName];
+        this.context = [this.routerName].concat(Object.keys(this.data.query));
 
         debug(this.name, this.route, this.permalinks);
 


### PR DESCRIPTION
closes #12130

When defining a custom collection with a `data` property the context is
not updated to reflect it, this results in metadata not being applied to
the collection index page.