### PR TITLE
🐛 Fixed newsletter and preview to support inlining pseudo css classes

### DIFF
--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -132,7 +132,9 @@ const serialize = async (postModel, options = {isBrowserPreview: false}) => {
         htmlTemplate = htmlTemplate.replace('%recipient.unsubscribe_url%', previewUnsubscribeUrl);
     }
 
-    let juicedHtml = juice(htmlTemplate);
+    // Inline css to style attributes, turn on support for pseudo classes.
+    const juiceOptions = {inlinePseudoElements: true};
+    let juicedHtml = juice(htmlTemplate, juiceOptions);
 
     // Force all links to open in new tab
     let _cheerio = cheerio.load(juicedHtml);


### PR DESCRIPTION
🐛 Fixed newsletter and preview to support inlining pseudo css classes

closes #12078
- Root cause was that pseudo class .kg-bookmark-author:after was not getting inlined to email newsletter or its preview.
  - That is where the margin and bullet-point content are added between author and publisher.
- Dependency juice supports an option inlinePseudoElements which is false by default.
- Fix was to set inlinePseudoElements to true when serializing post email.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
