### PR TITLE
Updated Stripe JS to load async in head

### DIFF
--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -46,7 +46,7 @@ function getMembersHelper() {
         membersHelper = `<script defer src="https://unpkg.com/@tryghost/members-js@latest/umd/members.min.js" data-ghost="${urlUtils.getSiteUrl()}"></script>`;
     }
     if ((!!stripeDirectSecretKey && !!stripeDirectPublishableKey) || !!stripeConnectAccountId) {
-        membersHelper += '<script src="https://js.stripe.com/v3/"></script>';
+        membersHelper += '<script async src="https://js.stripe.com/v3/"></script>';
     }
     return membersHelper;
 }


### PR DESCRIPTION
no issue

- Stripe JS is added to a theme via ghost_head if a Stripe account is connected to members enabled site
- Previously, the script was not loading async which blocked the main thread, changes the script load to async to avoid rendering block
- Members script is already being loaded with `defer` so does not block the main thread