### PR TITLE
Included 'tag' context when data contains a tag

### DIFF
--- a/core/frontend/services/routing/helpers/context.js
+++ b/core/frontend/services/routing/helpers/context.js
@@ -71,6 +71,10 @@ function setResponseContext(req, res, data) {
         if (!res.locals.context.includes('page')) {
             res.locals.context.push('page');
         }
+    } else if (data && data.tag) {
+        if (!res.locals.context.includes('tag')) {
+            res.locals.context.push('tag');
+        }
     }
 }
 


### PR DESCRIPTION
closes #12130 

When defining a collection with a tag as the data source, the metadata
was not correctly applied due to the context array not including 'tag'.

This update keeps the context management all in the same context helper
file and follows the same pattern as for posts/pages as a data source.
