### PR TITLE
✨ Added admin endpoint for editing member subscription

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -366,7 +366,7 @@ module.exports = {
         }
     },
 
-    updateSubscription: {
+    editSubscription: {
         statusCode: 200,
         headers: {},
         options: [

--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -366,6 +366,52 @@ module.exports = {
         }
     },
 
+    updateSubscription: {
+        statusCode: 200,
+        headers: {},
+        options: [
+            'id',
+            'subscription_id'
+        ],
+        data: [
+            'cancel_at_period_end'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                },
+                subscription_id: {
+                    required: true
+                }
+            },
+            data: {
+                cancel_at_period_end: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            method: 'edit'
+        },
+        async query(frame) {
+            await membersService.api.members.updateSubscription(frame.options.id, {
+                subscriptionId: frame.options.subscription_id,
+                cancelAtPeriodEnd: frame.data.cancel_at_period_end
+            });
+            let model = await membersService.api.members.get({id: frame.options.id}, {
+                withRelated: ['labels', 'stripeSubscriptions', 'stripeSubscriptions.customer']
+            });
+            if (!model) {
+                throw new errors.NotFoundError({
+                    message: i18n.t('errors.api.members.memberNotFound')
+                });
+            }
+
+            return model.toJSON(frame.options);
+        }
+    },
+
     destroy: {
         statusCode: 204,
         headers: {},

--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -65,5 +65,12 @@ module.exports = {
     stats(data, apiConfig, frame) {
         debug('stats');
         frame.response = data;
+    },
+
+    editSubscription(data, apiConfig, frame) {
+        debug('editSubscription');
+        frame.response = {
+            members: [mapper.mapMember(data, frame)]
+        };
     }
 };

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -109,7 +109,7 @@ module.exports = function apiRoutes() {
     router.put('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.edit));
     router.del('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.destroy));
 
-    router.put('/members/:id/subscriptions/:subscription_id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.updateSubscription));
+    router.put('/members/:id/subscriptions/:subscription_id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.editSubscription));
 
     router.get('/members/:id/signin_urls', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.memberSigninUrls.read));
 

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -109,6 +109,8 @@ module.exports = function apiRoutes() {
     router.put('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.edit));
     router.del('/members/:id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.destroy));
 
+    router.put('/members/:id/subscriptions/:subscription_id', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.members.updateSubscription));
+
     router.get('/members/:id/signin_urls', shared.middlewares.labs.members, mw.authAdminApi, http(apiCanary.memberSigninUrls.read));
 
     // ## Labels


### PR DESCRIPTION
refs TryGhost/Ghost#12127

- Adds new `editSubscription` endpoint for members which allows updating individual subscription for a member - `PUT /members/:id/subscriptions/:subscription_id/`
- Currently allows toggling of cancellation at period end for an active subscription