### PR TITLE
Increase the user bio field length to 800 characters.

### DIFF
--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -73,7 +73,7 @@ module.exports = {
         email: {type: 'string', maxlength: 191, nullable: false, unique: true, validations: {isEmail: true}},
         profile_image: {type: 'string', maxlength: 2000, nullable: true},
         cover_image: {type: 'string', maxlength: 2000, nullable: true},
-        bio: {type: 'text', maxlength: 65535, nullable: true, validations: {isLength: {max: 200}}},
+        bio: {type: 'text', maxlength: 65535, nullable: true, validations: {isLength: {max: 800}}},
         website: {type: 'string', maxlength: 2000, nullable: true, validations: {isEmptyOrURL: true}},
         location: {type: 'text', maxlength: 65535, nullable: true, validations: {isLength: {max: 150}}},
         facebook: {type: 'string', maxlength: 2000, nullable: true},


### PR DESCRIPTION
There have been a [few posts about this in the forum][1]. The primary
use case here is to have a longer bio for an author. This is an
arbitrary number that I chose - if it should be longer am absolutely
open to suggests!

[1]: https://forum.ghost.org/t/bio-length-for-users/1084