### PR TITLE
🐛 Fixed unable to delete member when stripe is connected

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -385,14 +385,15 @@ module.exports = {
             frame.options.require = true;
             frame.options.cancelStripeSubscriptions = frame.options.cancel;
 
-            await Promise.resolve(membersService.api.members.destroy(frame.options))
-                .catch(models.Member.NotFoundError, () => {
-                    throw new errors.NotFoundError({
-                        message: i18n.t('errors.api.resource.resourceNotFound', {
-                            resource: 'Member'
-                        })
-                    });
+            await Promise.resolve(membersService.api.members.destroy({
+                id: frame.options.id
+            }, frame.options)).catch(models.Member.NotFoundError, () => {
+                throw new errors.NotFoundError({
+                    message: i18n.t('errors.api.resource.resourceNotFound', {
+                        resource: 'Member'
+                    })
                 });
+            });
 
             return null;
         }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12150

- The `destroy` method on members-api method was called incorrectly with not enough params, as it expects both `data` and `options` passed down [here](https://github.com/TryGhost/Members/blob/master/packages/members-api/lib/users.js#L14)
- Missing `options` in method call throws error as we read `cancelStripeSubscriptions` property on options if stripe is connected
- Fix updates the `destroy` method call with both data and options value