### PR TITLE
Added default CTA to content helper

### DIFF
--- a/core/frontend/helpers/content.js
+++ b/core/frontend/helpers/content.js
@@ -5,11 +5,26 @@
 // escape it or tell handlebars to leave it alone with a triple-brace.
 //
 // Enables tag-safe truncation of content by characters or words.
+//
+// Dev flag feature: In case of restricted content access for member-only posts, shows CTA box
 
-const {SafeString} = require('../services/proxy');
+const {templates, hbs, config, SafeString} = require('../services/proxy');
 const downsize = require('downsize');
+const _ = require('lodash');
+const createFrame = hbs.handlebars.createFrame;
+
+function restrictedCta(options) {
+    options = options || {};
+    options.data = options.data || {};
+
+    const data = createFrame(options.data);
+    return templates.execute('content', this, {data});
+}
 
 module.exports = function content(options = {}) {
+    let self = this;
+    let args = arguments;
+
     const hash = options.hash || {};
     const truncateOptions = {};
     let runTruncate = false;
@@ -23,6 +38,10 @@ module.exports = function content(options = {}) {
 
     if (this.html === null) {
         this.html = '';
+    }
+
+    if (!this.access && !!config.get('enableDeveloperExperiments')) {
+        return restrictedCta.apply(self, args);
     }
 
     if (runTruncate) {

--- a/core/frontend/helpers/content.js
+++ b/core/frontend/helpers/content.js
@@ -16,7 +16,9 @@ const createFrame = hbs.handlebars.createFrame;
 function restrictedCta(options) {
     options = options || {};
     options.data = options.data || {};
-
+    _.merge(this, {
+        accentColor: (options.data.site && options.data.site.accent_color) || '#3db0ef'
+    });
     const data = createFrame(options.data);
     return templates.execute('content', this, {data});
 }

--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -5,6 +5,7 @@
 const {metaData, escapeExpression, SafeString, logging, settingsCache, config, blogIcon, labs, urlUtils} = require('../services/proxy');
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('ghost_head');
+const templateStyles = require('./tpl/styles');
 
 const getMetaData = metaData.get;
 const getAssetUrl = metaData.getAssetUrl;
@@ -47,6 +48,7 @@ function getMembersHelper() {
     }
     if ((!!stripeDirectSecretKey && !!stripeDirectPublishableKey) || !!stripeConnectAccountId) {
         membersHelper += '<script async src="https://js.stripe.com/v3/"></script>';
+        membersHelper += (`<style type='text/css'> ${templateStyles}</style>`);
     }
     return membersHelper;
 }

--- a/core/frontend/helpers/tpl/content.hbs
+++ b/core/frontend/helpers/tpl/content.hbs
@@ -1,5 +1,5 @@
-<aside class="post-upgrade-cta">
-    <div class="post-upgrade-cta-content" style="background-color: {{accentColor}}">
+<aside class="gh-post-upgrade-cta">
+    <div class="gh-post-upgrade-cta-content" style="background-color: {{accentColor}}">
         {{#has visibility="paid"}}
             <h2>This post is for paying subscribers only</h2>
         {{/has}}
@@ -7,9 +7,9 @@
             <h2>This post is for subscribers only</h2>
         {{/has}}
         {{#if @member}}
-            <a class="button large" data-portal="account/plans" style="color:{{accentColor}}"> Subscribe now</a>
+            <a class="gh-btn" data-portal="account/plans" style="color:{{accentColor}}">Subscribe now</a>
         {{else}}
-            <a class="button large" data-portal="signup" style="color:{{accentColor}}"> Signup now</a>
+            <a class="gh-btn" data-portal="signup" style="color:{{accentColor}}">Subscribe now</a>
             <p><small>Already have an account? <a data-portal="signin">Sign in</a></small></p>
         {{/if}}
     </div>

--- a/core/frontend/helpers/tpl/content.hbs
+++ b/core/frontend/helpers/tpl/content.hbs
@@ -1,5 +1,5 @@
 <aside class="post-upgrade-cta">
-    <div class="post-upgrade-cta-content" {{#if @site.accent_color}} style="background-color: {{@site.accent_color}}" {{/if}}>
+    <div class="post-upgrade-cta-content" style="background-color: {{accentColor}}">
         {{#has visibility="paid"}}
             <h2>This post is for paying subscribers only</h2>
         {{/has}}
@@ -7,9 +7,9 @@
             <h2>This post is for subscribers only</h2>
         {{/has}}
         {{#if @member}}
-            <a class="button large" data-portal="account/plans" {{#if @site.accent_color}} style="color:{{@site.accent_color}}" {{/if}}> Subscribe now</a>
+            <a class="button large" data-portal="account/plans" style="color:{{accentColor}}"> Subscribe now</a>
         {{else}}
-            <a class="button large" data-portal="signup" {{#if @site.accent_color}} style="color:{{@site.accent_color}}" {{/if}}> Signup now</a>
+            <a class="button large" data-portal="signup" style="color:{{accentColor}}"> Signup now</a>
             <p><small>Already have an account? <a data-portal="signin">Sign in</a></small></p>
         {{/if}}
     </div>

--- a/core/frontend/helpers/tpl/content.hbs
+++ b/core/frontend/helpers/tpl/content.hbs
@@ -1,0 +1,16 @@
+<aside class="post-upgrade-cta">
+    <div class="post-upgrade-cta-content" {{#if @site.accent_color}} style="background-color: {{@site.accent_color}}" {{/if}}>
+        {{#has visibility="paid"}}
+            <h2>This post is for paying subscribers only</h2>
+        {{/has}}
+        {{#has visibility="members"}}
+            <h2>This post is for subscribers only</h2>
+        {{/has}}
+        {{#if @member}}
+            <a class="button large" data-portal="account/plans" {{#if @site.accent_color}} style="color:{{@site.accent_color}}" {{/if}}> Subscribe now</a>
+        {{else}}
+            <a class="button large" data-portal="signup" {{#if @site.accent_color}} style="color:{{@site.accent_color}}" {{/if}}> Signup now</a>
+            <p><small>Already have an account? <a data-portal="signin">Sign in</a></small></p>
+        {{/if}}
+    </div>
+</aside>

--- a/core/frontend/helpers/tpl/styles.js
+++ b/core/frontend/helpers/tpl/styles.js
@@ -1,6 +1,6 @@
 /* Default CSS Styles for helpers which are appended in theme via ghost_head */
-const contentHelper = `.post-upgrade-cta-content,
-.post-upgrade-cta {
+const contentHelper = `.gh-post-upgrade-cta-content,
+.gh-post-upgrade-cta {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -11,12 +11,12 @@ const contentHelper = `.post-upgrade-cta-content,
     font-size: 16px;
 }
 
-.post-upgrade-cta-content {
+.gh-post-upgrade-cta-content {
     border-radius: 8px;
     padding: 40px 4vw;
 }
 
-.post-upgrade-cta h2 {
+.gh-post-upgrade-cta h2 {
     color: #ffffff;
     font-size: 28px;
     letter-spacing: -0.2px;
@@ -24,17 +24,17 @@ const contentHelper = `.post-upgrade-cta-content,
     padding: 0;
 }
 
-.post-upgrade-cta p {
+.gh-post-upgrade-cta p {
     margin: 20px 0 0;
     padding: 0;
 }
 
-.post-upgrade-cta small {
+.gh-post-upgrade-cta small {
     font-size: 16px;
     letter-spacing: -0.2px;
 }
 
-.post-upgrade-cta a {
+.gh-post-upgrade-cta a {
     color: #ffffff;
     cursor: pointer;
     font-weight: 500;
@@ -42,14 +42,14 @@ const contentHelper = `.post-upgrade-cta-content,
     text-decoration: underline;
 }
 
-.post-upgrade-cta a:hover {
+.gh-post-upgrade-cta a:hover {
     color: #ffffff;
     opacity: 0.8;
     box-shadow: none;
     text-decoration: underline;
 }
 
-.post-upgrade-cta a.button {
+.gh-post-upgrade-cta a.gh-btn {
     display: block;
     background: #ffffff;
     text-decoration: none;
@@ -60,7 +60,7 @@ const contentHelper = `.post-upgrade-cta-content,
     font-weight: 600;
 }
 
-.post-upgrade-cta a.button:hover {
+.gh-post-upgrade-cta a.gh-btn:hover {
     opacity: 0.92;
 }`;
 

--- a/core/frontend/helpers/tpl/styles.js
+++ b/core/frontend/helpers/tpl/styles.js
@@ -1,0 +1,69 @@
+/* Default CSS Styles for helpers which are appended in theme via ghost_head */
+const contentHelper = `.post-upgrade-cta-content,
+.post-upgrade-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    text-align: center;
+    width: 100%;
+    color: #ffffff;
+    font-size: 16px;
+}
+
+.post-upgrade-cta-content {
+    border-radius: 8px;
+    padding: 40px 4vw;
+}
+
+.post-upgrade-cta h2 {
+    color: #ffffff;
+    font-size: 28px;
+    letter-spacing: -0.2px;
+    margin: 0;
+    padding: 0;
+}
+
+.post-upgrade-cta p {
+    margin: 20px 0 0;
+    padding: 0;
+}
+
+.post-upgrade-cta small {
+    font-size: 16px;
+    letter-spacing: -0.2px;
+}
+
+.post-upgrade-cta a {
+    color: #ffffff;
+    cursor: pointer;
+    font-weight: 500;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.post-upgrade-cta a:hover {
+    color: #ffffff;
+    opacity: 0.8;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.post-upgrade-cta a.button {
+    display: block;
+    background: #ffffff;
+    text-decoration: none;
+    margin: 28px 0 0;
+    padding: 8px 18px;
+    border-radius: 4px;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.post-upgrade-cta a.button:hover {
+    opacity: 0.92;
+}`;
+
+const styles = contentHelper;
+
+module.exports = styles;


### PR DESCRIPTION
no issue

ATM users have to add logic to their themes in order to automatically hide restricted content. The {{content}} helper should return a default CTA box instead of the post content for restricted posts with default static text using site's accent color and open Portal for relevant action

-  Adds new default content helper template in case of restricted content
- Updates content helper to trigger new CTA template in case of restricted content
