### PR TITLE
Updated support/reply email address flow

### DIFF
--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -143,7 +143,7 @@ class SettingsImporter extends BaseImporter {
             }
 
             // CASE: we do not import "from address" for members settings as that needs to go via validation with magic link
-            if (obj.key === 'members_from_address') {
+            if ((obj.key === 'members_from_address') || (obj.key === 'members_support_address')) {
                 obj.value = null;
             }
 

--- a/core/server/services/bulk-email/index.js
+++ b/core/server/services/bulk-email/index.js
@@ -81,6 +81,8 @@ module.exports = {
         }
 
         const blogTitle = settingsCache.get('title') ? settingsCache.get('title').replace(/"/g, '\\"') : '';
+        const supportAddress = settingsCache.get('members_support_address');
+        const replyToAddress = (settingsCache.get('members_reply_address') === 'support') ? supportAddress : fromAddress;
         fromAddress = blogTitle ? `"${blogTitle}"<${fromAddress}>` : fromAddress;
 
         const chunkedRecipients = _.chunk(recipients, BATCH_SIZE);
@@ -94,6 +96,7 @@ module.exports = {
             const batchData = {
                 to: toAddresses,
                 from: fromAddress,
+                'h:Reply-To': replyToAddress || fromAddress,
                 'recipient-variables': recipientVariables
             };
 

--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -26,7 +26,7 @@ function createApiInstance(config) {
                         logging.warn(message.text);
                     }
                     let msg = Object.assign({
-                        from: config.getEmailFromAddress(),
+                        from: config.getAuthEmailFromAddress(),
                         subject: 'Signin',
                         forceTextContent: true
                     }, message);

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -44,6 +44,11 @@ class MembersConfigProvider {
         return fromAddress;
     }
 
+    getAuthEmailFromAddress() {
+        const supportAddress = this._settingsCache.get('members_support_address');
+        return supportAddress || this.getEmailFromAddress();
+    }
+
     getPublicPlans() {
         const CURRENCY_SYMBOLS = {
             USD: '$',

--- a/core/server/services/members/index.js
+++ b/core/server/services/members/index.js
@@ -39,6 +39,8 @@ events.on('settings.edited', function updateSettingFromModel(settingModel) {
     if (![
         'members_allow_free_signup',
         'members_from_address',
+        'members_support_address',
+        'members_reply_address',
         'stripe_publishable_key',
         'stripe_secret_key',
         'stripe_product_name',

--- a/core/server/services/members/settings.js
+++ b/core/server/services/members/settings.js
@@ -17,7 +17,7 @@ function createSettingsInstance(config) {
                     logging.warn(message.text);
                 }
                 let msg = Object.assign({
-                    from: config.getEmailFromAddress(),
+                    from: config.getAuthEmailFromAddress(),
                     subject: 'Update email address',
                     forceTextContent: true
                 }, message);

--- a/core/server/services/members/settings.js
+++ b/core/server/services/members/settings.js
@@ -71,6 +71,20 @@ function createSettingsInstance(config) {
     });
 
     const sendEmailAddressUpdateMagicLink = ({email, payload = {}, type = 'fromAddressUpdate'}) => {
+        magicLinkService.transporter = {
+            sendMail(message) {
+                if (process.env.NODE_ENV !== 'production') {
+                    logging.warn(message.text);
+                }
+                let msg = Object.assign({
+                    from: email,
+                    subject: 'Update email address',
+                    forceTextContent: true
+                }, message);
+
+                return ghostMailer.send(msg);
+            }
+        };
         return magicLinkService.sendMagicLink({email, payload, subject: email, type});
     };
 

--- a/core/server/services/members/settings.js
+++ b/core/server/services/members/settings.js
@@ -70,21 +70,21 @@ function createSettingsInstance(config) {
         getSubject
     });
 
-    const sendFromAddressUpdateMagicLink = ({email, payload = {}}) => {
-        return magicLinkService.sendMagicLink({email, payload, subject: email, type: 'updateFromAddress'});
+    const sendEmailAddressUpdateMagicLink = ({email, payload = {}, type = 'fromAddressUpdate'}) => {
+        return magicLinkService.sendMagicLink({email, payload, subject: email, type});
     };
 
     const getEmailFromToken = ({token}) => {
         return magicLinkService.getUserFromToken(token);
     };
 
-    const getAdminRedirectLink = () => {
+    const getAdminRedirectLink = ({type}) => {
         const adminUrl = urlUtils.urlFor('admin', true);
-        return urlUtils.urlJoin(adminUrl, '#/settings/labs/?fromAddressUpdate=success');
+        return urlUtils.urlJoin(adminUrl, `#/settings/labs/?${type}=success`);
     };
 
     return {
-        sendFromAddressUpdateMagicLink,
+        sendEmailAddressUpdateMagicLink,
         getEmailFromToken,
         getAdminRedirectLink
     };

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -61,8 +61,8 @@ module.exports = function apiRoutes() {
     router.get('/settings', mw.authAdminApi, http(apiCanary.settings.browse));
     router.get('/settings/:key', mw.authAdminApi, http(apiCanary.settings.read));
     router.put('/settings', mw.authAdminApi, http(apiCanary.settings.edit));
-    router.get('/settings/members/email', http(apiCanary.settings.validateMembersFromEmail));
-    router.post('/settings/members/email', mw.authAdminApi, http(apiCanary.settings.updateMembersFromEmail));
+    router.get('/settings/members/email', http(apiCanary.settings.validateMembersEmailUpdate));
+    router.post('/settings/members/email', mw.authAdminApi, http(apiCanary.settings.updateMembersEmail));
     router.del('/settings/stripe/connect', mw.authAdminApi, http(apiCanary.settings.disconnectStripeConnectIntegration));
 
     // ## Users


### PR DESCRIPTION
Adds 2 new settings for member emails and the updated flows -

- `members_support_address` - How members can reach for help with their account
- `members_reply_address` - Where you receive responses to newsletters, is one of newsletter or support email address
- Added default settings for the two new member email settings - `members_support_address` and `members_reply_address`
- Added migrations for setting group for new email settings
- Updated tests for new settings
- Added handling for new members support/reply email addresses
- Updated member auth emails to use support address as sender when available, fallbacks to newsletter address
- Updated newsletter emails to include reply-to address based on `members_reply_address`
- Updated ownership verification emails to use same address for sender