### PR TITLE
Added migrations for support and reply email address setting

### DIFF
--- a/core/server/data/migrations/versions/3.32/01-add-member-support-address-setting.js
+++ b/core/server/data/migrations/versions/3.32/01-add-member-support-address-setting.js
@@ -1,0 +1,27 @@
+const logging = require('../../../../../shared/logging');
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up({transacting: knex}) {
+        const fromAddressSetting = await knex('settings')
+            .select('value')
+            .where('key', 'members_from_address')
+            .first();
+        const fromAddressValue = fromAddressSetting ? fromAddressSetting.value : 'noreply';
+        logging.info(`Updating members_support_address setting to members group with value ${fromAddressValue}`);
+        await knex('settings')
+            .update({
+                group: 'members',
+                flags: 'RO',
+                value: fromAddressValue
+            })
+            .where({
+                key: 'members_support_address'
+            });
+    },
+
+    async down() {}
+};

--- a/core/server/data/migrations/versions/3.32/02-add-member-reply-address-setting.js
+++ b/core/server/data/migrations/versions/3.32/02-add-member-reply-address-setting.js
@@ -1,0 +1,20 @@
+const logging = require('../../../../../shared/logging');
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    async up({transacting: knex}) {
+        logging.info('Updating members_reply_address setting to members group');
+        await knex('settings')
+            .update({
+                group: 'members'
+            })
+            .where({
+                key: 'members_reply_address'
+            });
+    },
+
+    async down() {}
+};

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -241,6 +241,19 @@
             "flags": "RO",
             "type": "string"
         },
+        "members_support_address": {
+            "defaultValue": "noreply",
+            "flags": "RO",
+            "type": "string"
+        },
+        "members_reply_address": {
+            "defaultValue": "newsletter",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["newsletter", "support"]]
+            },
+            "type": "string"
+        },
         "stripe_product_name": {
             "defaultValue": "Ghost Subscription",
             "type": "string"

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -37,6 +37,8 @@ const defaultSettingsKeyTypes = [
     {key: 'default_content_visibility', type: 'members'},
     {key: 'members_allow_free_signup', type: 'members'},
     {key: 'members_from_address', type: 'members'},
+    {key: 'members_support_address', type: 'members'},
+    {key: 'members_reply_address', type: 'members'},
     {key: 'stripe_product_name', type: 'members'},
     {key: 'stripe_plans', type: 'members'},
     {key: 'stripe_secret_key', type: 'members'},

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -34,6 +34,8 @@ const defaultSettingsKeyTypes = [
     {key: 'default_content_visibility', type: 'members'},
     {key: 'members_allow_free_signup', type: 'members'},
     {key: 'members_from_address', type: 'members'},
+    {key: 'members_support_address', type: 'members'},
+    {key: 'members_reply_address', type: 'members'},
     {key: 'stripe_product_name', type: 'members'},
     {key: 'stripe_plans', type: 'members'},
     {key: 'stripe_secret_key', type: 'members'},

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -37,6 +37,8 @@ const defaultSettingsKeys = [
     'default_content_visibility',
     'members_allow_free_signup',
     'members_from_address',
+    'members_support_address',
+    'members_reply_address',
     'stripe_product_name',
     'stripe_plans',
     'stripe_secret_key',

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -23,7 +23,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '42a966364eb4b5851e807133374821da';
     const currentFixturesHash = '29148c40dfaf4f828c5fca95666f6545';
-    const currentSettingsHash = 'a4ac78d3810175428b4833645231d6d5';
+    const currentSettingsHash = '869f7b14a3cc67c2e422b75c31b98dc4';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
no issue

- Added default settings for the two new member email settings - `members_support_address` and `members_reply_address`
- Added migrations for group/flags for new email settings
- Updated integrity test for new settings

The new settings are -

- `members_support_address` - How members can reach for help with their account
- `members_reply_address` - Where you receive responses to newsletters, is one of newsletter or support email address
