### PR TITLE
🐛 Fixed error caused by accepting invitation with existing email

### DIFF
--- a/core/server/services/invitations/accept.js
+++ b/core/server/services/invitations/accept.js
@@ -23,7 +23,7 @@ async function accept(invitation) {
         throw new errors.ValidationError({
             message: i18n.t('errors.api.invites.inviteEmailAlreadyExist.message'),
             context: i18n.t('errors.api.invites.inviteEmailAlreadyExist.context'),
-            errorDetails: i18n.t('errors.api.invites.inviteEmailAlreadyExist.help')
+            help: i18n.t('errors.api.invites.inviteEmailAlreadyExist.help')
         });
     }
 

--- a/core/server/services/invitations/accept.js
+++ b/core/server/services/invitations/accept.js
@@ -18,6 +18,15 @@ async function accept(invitation) {
         throw new errors.NotFoundError({message: i18n.t('errors.api.invites.inviteExpired')});
     }
 
+    let user = await models.User.findOne({email: data.email});
+    if (user) {
+        throw new errors.ValidationError({
+            message: i18n.t('errors.api.invites.inviteEmailAlreadyExist.message'),
+            context: i18n.t('errors.api.invites.inviteEmailAlreadyExist.context'),
+            errorDetails: i18n.t('errors.api.invites.inviteEmailAlreadyExist.help')
+        });
+    }
+
     await models.User.add({
         email: data.email,
         name: data.name,

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -449,6 +449,11 @@
                 "invalidIdProvided": "Invalid id provided."
             },
             "invites": {
+                "inviteEmailAlreadyExist": {
+                    "message": "Could not create an account, email is already in use.",
+                    "context": "Attempting to create an account with existing email address.",
+                    "help": "Use different email address to register your account."
+                },
                 "inviteNotFound": "Invite not found.",
                 "inviteExpired": "Invite is expired.",
                 "emailIsRequired": "E-Mail is required.",

--- a/test/regression/api/canary/admin/authentication_spec.js
+++ b/test/regression/api/canary/admin/authentication_spec.js
@@ -193,6 +193,22 @@ describe('Authentication API v3', function () {
                 .expect(404);
         });
 
+        it('try to accept with invite and existing email address', function () {
+            return request
+                .post(localUtils.API.getApiQuery('authentication/invitation'))
+                .set('Origin', config.get('url'))
+                .send({
+                    invitation: [{
+                        token: testUtils.DataGenerator.forKnex.invites[0].token,
+                        password: '12345678910',
+                        email: testUtils.DataGenerator.forKnex.users[0].email,
+                        name: 'invited'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect(422);
+        });
+
         it('try to accept with invite', function () {
             return request
                 .post(localUtils.API.getApiQuery('authentication/invitation'))


### PR DESCRIPTION
closes #12060
- on invitation, if user uses an email which is already an existing user
  - it causes the DB to throw an error because the email would no longer
    be unique. This was not handled
  - Added an extra check to query user model
    - If user exists, raise a Validation Error
    - else create user

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)
