### PR TITLE
🐛 Fixed sqlite constraint error caused by updating a member email with an already existing email

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -242,7 +242,9 @@ module.exports = {
                 if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
                     throw new errors.ValidationError({
                         message: i18n.t('errors.models.member.memberAlreadyExists.message'),
-                        context: i18n.t('errors.models.member.memberAlreadyExists.context')
+                        context: i18n.t('errors.models.member.memberAlreadyExists.context', {
+                            action: 'add'
+                        })
                     });
                 }
 
@@ -304,8 +306,10 @@ module.exports = {
             } catch (error) {
                 if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
                     throw new errors.ValidationError({
-                        message: i18n.t('errors.models.member.memberAlreadyExistsWithEmail.message'),
-                        context: i18n.t('errors.models.member.memberAlreadyExistsWithEmail.context')
+                        message: i18n.t('errors.models.member.memberAlreadyExists.message'),
+                        context: i18n.t('errors.models.member.memberAlreadyExists.context', {
+                            action: 'edit'
+                        })
                     });
                 }
 

--- a/core/server/services/members/importer/index.js
+++ b/core/server/services/members/importer/index.js
@@ -55,7 +55,9 @@ const doImport = async ({members, labels, importSetLabels, createdBy}) => {
                 if (error.code === 'ER_DUP_ENTRY') {
                     return new errors.ValidationError({
                         message: i18n.t('errors.models.member.memberAlreadyExists.message'),
-                        context: i18n.t('errors.models.member.memberAlreadyExists.context'),
+                        context: i18n.t('errors.models.member.memberAlreadyExists.context', {
+                            action: 'add'
+                        }),
                         err: error
                     });
                 } else {

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -251,6 +251,10 @@
                 "memberAlreadyExists": {
                     "message": "Member already exists",
                     "context": "Attempting to add member with existing email address."
+                },
+                "memberAlreadyExistsWithEmail": {
+                    "message": "Different member already exists with edited email",
+                    "context": "Attempting to edit member email to an existing email address."
                 }
             },
             "member_stripe_customer": {

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -250,11 +250,7 @@
             "member": {
                 "memberAlreadyExists": {
                     "message": "Member already exists",
-                    "context": "Attempting to add member with existing email address."
-                },
-                "memberAlreadyExistsWithEmail": {
-                    "message": "Different member already exists with edited email",
-                    "context": "Attempting to edit member email to an existing email address."
+                    "context": "Attempting to {action} member with existing email address."
                 }
             },
             "member_stripe_customer": {

--- a/test/regression/api/canary/admin/members_spec.js
+++ b/test/regression/api/canary/admin/members_spec.js
@@ -494,7 +494,7 @@ describe('Members API', function () {
             });
     });
 
-    it('Fails to import memmber duplicate emails', function () {
+    it('Fails to import member duplicate emails', function () {
         return request
             .post(localUtils.API.getApiQuery(`members/upload/`))
             .attach('membersfile', path.join(__dirname, '/../../../../utils/fixtures/csv/members-duplicate-emails.csv'))


### PR DESCRIPTION
🐛 Fixed sqlite constraint error caused by updating a member email with an already existing email of different member

closes #12045
- on editing a member, if email is updated to an already existing email of
different member
  - it causes sqlite to throw an error because the email would no longer
    be unique. This was not handled and error was sent to Frontend and
    shown to user
    - Added a try catch, and if it is duplicated email problem threw a
    Validation Error
    - else member is updated successfully

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

