### PR TITLE
Remove global promise override

### DIFF
--- a/core/frontend/services/routing/settings.js
+++ b/core/frontend/services/routing/settings.js
@@ -1,3 +1,4 @@
+const Promise = require('bluebird');
 const moment = require('moment-timezone');
 const fs = require('fs-extra');
 const path = require('path');

--- a/core/frontend/services/settings/ensure-settings.js
+++ b/core/frontend/services/settings/ensure-settings.js
@@ -25,7 +25,7 @@ module.exports = function ensureSettingsFiles(knownSettings) {
         const defaultFileName = `default-${fileName}`;
         const filePath = path.join(contentPath, fileName);
 
-        return fs.readFile(filePath, 'utf8')
+        return Promise.resolve(fs.readFile(filePath, 'utf8'))
             .catch({code: 'ENOENT'}, () => {
                 const defaultFilePath = path.join(defaultSettingsPath, defaultFileName);
                 // CASE: file doesn't exist, copy it from our defaults

--- a/core/server/api/canary/images.js
+++ b/core/server/api/canary/images.js
@@ -1,3 +1,4 @@
+const Promise = require('bluebird');
 const storage = require('../../adapters/storage');
 
 module.exports = {

--- a/core/server/api/canary/utils/serializers/output/roles.js
+++ b/core/server/api/canary/utils/serializers/output/roles.js
@@ -1,3 +1,4 @@
+const Promise = require('bluebird');
 const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:roles');
 const canThis = require('../../../../../services/permissions').canThis;
 

--- a/core/server/data/db/backup.js
+++ b/core/server/data/db/backup.js
@@ -12,7 +12,7 @@ const exporter = require('../exporter');
 const writeExportFile = function writeExportFile(exportResult) {
     const filename = path.resolve(urlUtils.urlJoin(config.get('paths').contentPath, 'data', exportResult.filename));
 
-    return fs.writeFile(filename, JSON.stringify(exportResult.data)).return(filename);
+    return Promise.resolve(fs.writeFile(filename, JSON.stringify(exportResult.data))).return(filename);
 };
 
 const readBackup = async (filename) => {

--- a/core/server/lib/fs/package-json/read.js
+++ b/core/server/lib/fs/package-json/read.js
@@ -60,7 +60,7 @@ const readPackage = function readPackage(packagePath, packageName) {
 };
 
 const readPackages = function readPackages(packagePath) {
-    return fs.readdir(packagePath)
+    return Promise.resolve(fs.readdir(packagePath))
         .filter(function (packageName) {
             // Filter out things which are not packages by regex
             if (packageName.match(notAPackageRegex)) {

--- a/core/server/lib/image/gravatar.js
+++ b/core/server/lib/image/gravatar.js
@@ -12,7 +12,7 @@ module.exports.lookup = function lookup(userData, timeout) {
         return Promise.resolve();
     }
 
-    return request('https:' + gravatarUrl + '&d=404&r=x', {timeout: timeout || 2 * 1000})
+    return Promise.resolve(request('https:' + gravatarUrl + '&d=404&r=x', {timeout: timeout || 2 * 1000}))
         .then(function () {
             gravatarUrl += '&d=mm&r=x';
 

--- a/core/server/overrides.js
+++ b/core/server/overrides.js
@@ -23,8 +23,3 @@ const {extract, hasProvider} = require('oembed-parser'); // eslint-disable-line
  *   - be careful when you work with date operations, therefor always wrap a date into moment
  */
 moment.tz.setDefault('UTC');
-
-/**
- * https://github.com/TryGhost/Ghost/issues/9064
- */
-global.Promise = require('bluebird');

--- a/test/unit/data/migrations/utils.test.js
+++ b/test/unit/data/migrations/utils.test.js
@@ -3,11 +3,6 @@ const sinon = require('sinon');
 
 const utils = require('../../../../core/server/data/migrations/utils');
 
-// Get access to the core Promise constructor
-// as global.Promise is overidden by Ghost
-// https://github.com/TryGhost/Ghost/issues/9064
-const Promise = (async () => {})().constructor;
-
 class Deferred {
     constructor() {
         this.promise = new Promise((resolve, reject) => {

--- a/test/unit/services/auth/api-key/content_spec.js
+++ b/test/unit/services/auth/api-key/content_spec.js
@@ -20,8 +20,8 @@ describe('Content API Key Auth', function () {
         this.fakeApiKey = fakeApiKey;
 
         this.apiKeyStub = sinon.stub(models.ApiKey, 'findOne');
-        this.apiKeyStub.returns(new Promise.resolve());
-        this.apiKeyStub.withArgs({secret: fakeApiKey.secret}).returns(new Promise.resolve(fakeApiKey));
+        this.apiKeyStub.returns(Promise.resolve());
+        this.apiKeyStub.withArgs({secret: fakeApiKey.secret}).returns(Promise.resolve(fakeApiKey));
     });
 
     afterEach(function () {


### PR DESCRIPTION
Closes #11943 

Currently, there's a bug in `brute-knex` when we don't set global `Promise` to `bluebird`(llambda/brute-knex#11). Because of that, I had to use the fixed version of mine. 

I'm waiting for the PR(llambda/brute-knex#13) to be merged and released a new version.

----

- [x] There's a clear use-case for this code change -> We can use more `await` syntax.
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

----

Debt paid in full.
