### PR TITLE
Added Location header to API's POST request responses

### DIFF
--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -84,9 +84,7 @@ module.exports = {
 
     add: {
         statusCode: 201,
-        headers: {
-            location: true
-        },
+        headers: {},
         options: [
             'include',
             'formats',

--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -84,7 +84,9 @@ module.exports = {
 
     add: {
         statusCode: 201,
-        headers: {},
+        headers: {
+            location: true
+        },
         options: [
             'include',
             'formats',

--- a/core/server/api/canary/webhooks.js
+++ b/core/server/api/canary/webhooks.js
@@ -7,7 +7,10 @@ module.exports = {
 
     add: {
         statusCode: 201,
-        headers: {},
+        headers: {
+            // NOTE: remove if there is ever a 'read' method
+            location: false
+        },
         options: [],
         data: [],
         permissions: true,

--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -123,7 +123,8 @@ module.exports = {
         }
 
         const locationHeaderDisabled = apiConfigHeaders && apiConfigHeaders.location === false;
-        const hasFrameData = (frame.method === 'add')
+        const hasFrameData = frame
+            && (frame.method === 'add')
             && result[frame.docName]
             && result[frame.docName][0]
             && result[frame.docName][0].id;

--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -1,3 +1,4 @@
+const url = require('url');
 const debug = require('ghost-ignition').debug('api:shared:headers');
 const Promise = require('bluebird');
 const INVALIDATE_ALL = '/*';
@@ -130,9 +131,15 @@ module.exports = {
         if (!locationHeaderDisabled && hasFrameData) {
             const protocol = (frame.original.url.secure === false) ? 'http://' : 'https://';
             const resourceId = result[frame.docName][0].id;
-            const location = `${protocol}${frame.original.url.host}${frame.original.url.pathname}${resourceId}/`;
+
+            let locationURL = url.resolve(`${protocol}${frame.original.url.host}`,frame.original.url.pathname);
+            if (!locationURL.endsWith('/')) {
+                locationURL += '/';
+            }
+            locationURL += `${resourceId}/`;
+
             const locationHeader = {
-                location: location
+                location: locationURL
             };
 
             Object.assign(headers, locationHeader);

--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -140,7 +140,7 @@ module.exports = {
             locationURL += `${resourceId}/`;
 
             const locationHeader = {
-                location: locationURL
+                Location: locationURL
             };
 
             Object.assign(headers, locationHeader);

--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -121,15 +121,18 @@ module.exports = {
             }
         }
 
-        if (apiConfigHeaders.location
+        const locationHeaderDisabled = apiConfigHeaders && apiConfigHeaders.location === false;
+        const hasFrameData = (frame.method === 'add')
             && result[frame.docName]
             && result[frame.docName][0]
-            && result[frame.docName][0].id) {
+            && result[frame.docName][0].id;
+
+        if (!locationHeaderDisabled && hasFrameData) {
             const protocol = (frame.original.url.secure === false) ? 'http://' : 'https://';
             const resourceId = result[frame.docName][0].id;
             const location = `${protocol}${frame.original.url.host}${frame.original.url.pathname}${resourceId}/`;
             const locationHeader = {
-                Location: location
+                location: location
             };
 
             Object.assign(headers, locationHeader);

--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -99,9 +99,10 @@ module.exports = {
      *
      * @param {Object} result - API response
      * @param {Object} apiConfigHeaders
+     * @param {Object} frame
      * @return {Promise}
      */
-    async get(result, apiConfigHeaders = {}) {
+    async get(result, apiConfigHeaders = {}, frame) {
         let headers = {};
 
         if (apiConfigHeaders.disposition) {
@@ -118,6 +119,20 @@ module.exports = {
             if (cacheInvalidationHeader) {
                 Object.assign(headers, cacheInvalidationHeader);
             }
+        }
+
+        if (apiConfigHeaders.location
+            && result[frame.docName]
+            && result[frame.docName][0]
+            && result[frame.docName][0].id) {
+            const protocol = (frame.original.url.secure === false) ? 'http://' : 'https://';
+            const resourceId = result[frame.docName][0].id;
+            const location = `${protocol}${frame.original.url.host}${frame.original.url.pathname}${resourceId}`;
+            const locationHeader = {
+                Location: location
+            };
+
+            Object.assign(headers, locationHeader);
         }
 
         debug(headers);

--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -98,22 +98,22 @@ module.exports = {
      * @description Get header based on ctrl configuration.
      *
      * @param {Object} result - API response
-     * @param {Object} apiConfig
+     * @param {Object} apiConfigHeaders
      * @return {Promise}
      */
-    async get(result, apiConfig = {}) {
+    async get(result, apiConfigHeaders = {}) {
         let headers = {};
 
-        if (apiConfig.disposition) {
-            const dispositionHeader = await disposition[apiConfig.disposition.type](result, apiConfig.disposition);
+        if (apiConfigHeaders.disposition) {
+            const dispositionHeader = await disposition[apiConfigHeaders.disposition.type](result, apiConfigHeaders.disposition);
 
             if (dispositionHeader) {
                 Object.assign(headers, dispositionHeader);
             }
         }
 
-        if (apiConfig.cacheInvalidate) {
-            const cacheInvalidationHeader = cacheInvalidate(result, apiConfig.cacheInvalidate);
+        if (apiConfigHeaders.cacheInvalidate) {
+            const cacheInvalidationHeader = cacheInvalidate(result, apiConfigHeaders.cacheInvalidate);
 
             if (cacheInvalidationHeader) {
                 Object.assign(headers, cacheInvalidationHeader);

--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -127,7 +127,7 @@ module.exports = {
             && result[frame.docName][0].id) {
             const protocol = (frame.original.url.secure === false) ? 'http://' : 'https://';
             const resourceId = result[frame.docName][0].id;
-            const location = `${protocol}${frame.original.url.host}${frame.original.url.pathname}${resourceId}`;
+            const location = `${protocol}${frame.original.url.host}${frame.original.url.pathname}${resourceId}/`;
             const locationHeader = {
                 Location: location
             };

--- a/core/server/api/shared/http.js
+++ b/core/server/api/shared/http.js
@@ -1,3 +1,4 @@
+const url = require('url');
 const debug = require('ghost-ignition').debug('api:shared:http');
 const shared = require('../shared');
 const models = require('../../models');
@@ -41,6 +42,11 @@ const http = (apiImpl) => {
             params: req.params,
             user: req.user,
             session: req.session,
+            url: {
+                host: req.vhost ? req.vhost.host : req.get('host'),
+                pathname: url.parse(req.originalUrl || req.url).pathname,
+                secure: req.secure
+            },
             context: {
                 api_key: apiKey,
                 user: user,

--- a/core/server/api/v2/webhooks.js
+++ b/core/server/api/v2/webhooks.js
@@ -7,7 +7,10 @@ module.exports = {
 
     add: {
         statusCode: 201,
-        headers: {},
+        headers: {
+            // NOTE: remove if there is ever a 'read' method
+            location: false
+        },
         options: [],
         data: [],
         validation: {

--- a/test/api-acceptance/admin/integrations_spec.js
+++ b/test/api-acceptance/admin/integrations_spec.js
@@ -65,14 +65,14 @@ describe('Integrations API', function () {
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201)
-            .end(function (err, {body}) {
+            .end(function (err, res) {
                 if (err) {
                     return done(err);
                 }
 
-                should.equal(body.integrations.length, 1);
+                should.equal(res.body.integrations.length, 1);
 
-                const [integration] = body.integrations;
+                const [integration] = res.body.integrations;
                 should.equal(integration.name, 'Dis-Integrate!!');
 
                 should.equal(integration.api_keys.length, 2);
@@ -90,6 +90,9 @@ describe('Integrations API', function () {
                 should.equal(id, adminApiKey.id);
                 should.exist(secret);
                 secret.length.should.equal(64);
+
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
 
                 done();
             });
@@ -110,20 +113,23 @@ describe('Integrations API', function () {
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(201)
-            .end(function (err, {body}) {
+            .end(function (err, res) {
                 if (err) {
                     return done(err);
                 }
 
-                should.equal(body.integrations.length, 1);
+                should.equal(res.body.integrations.length, 1);
 
-                const [integration] = body.integrations;
+                const [integration] = res.body.integrations;
                 should.equal(integration.name, 'Integratatron4000');
 
                 should.equal(integration.webhooks.length, 1);
 
                 const webhook = integration.webhooks[0];
                 should.equal(webhook.integration_id, integration.id);
+
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('integrations/')}${res.body.integrations[0].id}/`);
 
                 done();
             });

--- a/test/api-acceptance/admin/invites_spec.js
+++ b/test/api-acceptance/admin/invites_spec.js
@@ -116,6 +116,9 @@ describe('Invites API', function () {
 
                 mailService.GhostMailer.prototype.send.called.should.be.true();
 
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('invites/')}${res.body.invites[0].id}/`);
+
                 done();
             });
     });

--- a/test/api-acceptance/admin/labels_spec.js
+++ b/test/api-acceptance/admin/labels_spec.js
@@ -46,6 +46,9 @@ describe('Labels API', function () {
                 jsonResponse.labels.should.have.length(1);
                 jsonResponse.labels[0].name.should.equal(label.name);
                 jsonResponse.labels[0].slug.should.equal(label.name);
+
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('labels/')}${res.body.labels[0].id}/`);
             });
     });
 });

--- a/test/api-acceptance/admin/members_spec.js
+++ b/test/api-acceptance/admin/members_spec.js
@@ -165,6 +165,9 @@ describe('Members API', function () {
 
                 jsonResponse.members[0].labels.length.should.equal(1);
                 jsonResponse.members[0].labels[0].name.should.equal('test-label');
+
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('members/')}${res.body.members[0].id}/`);
             })
             .then(() => {
                 return request
@@ -205,6 +208,9 @@ describe('Members API', function () {
                 should.exist(jsonResponse);
                 should.exist(jsonResponse.members);
                 jsonResponse.members.should.have.length(1);
+
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('members/')}${res.body.members[0].id}/`);
 
                 return jsonResponse.members[0];
             })

--- a/test/api-acceptance/admin/notifications_spec.js
+++ b/test/api-acceptance/admin/notifications_spec.js
@@ -49,6 +49,9 @@ describe('Notifications API', function () {
                 should.exist(jsonResponse.notifications[0].location);
                 jsonResponse.notifications[0].location.should.equal('bottom');
                 jsonResponse.notifications[0].id.should.be.a.String();
+
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('notifications/')}${res.body.notifications[0].id}/`);
             });
     });
 

--- a/test/api-acceptance/admin/pages_spec.js
+++ b/test/api-acceptance/admin/pages_spec.js
@@ -75,6 +75,9 @@ describe('Pages API', function () {
                 localUtils.API.checkResponse(res.body.pages[0], 'page');
                 should.exist(res.headers['x-cache-invalidate']);
 
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('pages/')}${res.body.pages[0].id}/`);
+
                 return models.Post.findOne({
                     id: res.body.pages[0].id
                 }, testUtils.context.internal);

--- a/test/api-acceptance/admin/posts_spec.js
+++ b/test/api-acceptance/admin/posts_spec.js
@@ -291,6 +291,9 @@ describe('Posts API', function () {
                 res.body.posts[0].url.should.match(new RegExp(`${config.get('url')}/p/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`));
                 should.not.exist(res.headers['x-cache-invalidate']);
 
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
+
                 return models.Post.findOne({
                     id: res.body.posts[0].id,
                     status: 'draft'

--- a/test/api-acceptance/admin/tags_spec.js
+++ b/test/api-acceptance/admin/tags_spec.js
@@ -107,6 +107,9 @@ describe('Tag API', function () {
 
                 localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
                 testUtils.API.isISO8601(jsonResponse.tags[0].created_at).should.be.true();
+
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
             });
     });
 
@@ -132,6 +135,9 @@ describe('Tag API', function () {
                 jsonResponse.tags[0].visibility.should.eql('internal');
                 jsonResponse.tags[0].name.should.eql('#test');
                 jsonResponse.tags[0].slug.should.eql('hash-test');
+
+                should.exist(res.headers.location);
+                res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('tags/')}${res.body.tags[0].id}/`);
             });
     });
 

--- a/test/api-acceptance/admin/webhooks_spec.js
+++ b/test/api-acceptance/admin/webhooks_spec.js
@@ -50,6 +50,8 @@ describe('Webhooks API', function () {
                 jsonResponse.webhooks[0].name.should.equal(webhookData.name);
                 jsonResponse.webhooks[0].api_version.should.equal(webhookData.api_version);
                 jsonResponse.webhooks[0].integration_id.should.equal(webhookData.integration_id);
+
+                should.not.exist(res.headers.location);
             });
     });
 

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -135,6 +135,7 @@ describe('Posts API', function () {
                 })
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Location', /^http:\/\/127.0.0.1:2369\/ghost\/api\/canary\/admin\/posts\/\w*/g)
                 .expect(201)
                 .then((res) => {
                     should.exist(res.body.posts);

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -135,15 +135,14 @@ describe('Posts API', function () {
                 })
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect('Location', /^http:\/\/127.0.0.1:2369\/ghost\/api\/canary\/admin\/posts\/\w*/g)
                 .expect(201)
                 .then((res) => {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].title);
                     res.body.posts[0].title.should.equal('(Untitled)');
 
-                    should.exist(res.headers.Location);
-                    res.headers.Location.should.equal(`${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}`);
+                    should.exist(res.headers.location);
+                    res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
                 });
         });
     });

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -141,6 +141,9 @@ describe('Posts API', function () {
                     should.exist(res.body.posts);
                     should.exist(res.body.posts[0].title);
                     res.body.posts[0].title.should.equal('(Untitled)');
+
+                    should.exist(res.headers.Location);
+                    res.headers.Location.should.equal(`${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}`);
                 });
         });
     });

--- a/test/unit/api/shared/headers_spec.js
+++ b/test/unit/api/shared/headers_spec.js
@@ -86,7 +86,7 @@ describe('Unit: api/shared/headers', function () {
                 .then((result) => {
                     result.should.eql({
                         // NOTE: the backslash in the end is important to avoid unecessary 301s using the header
-                        location: 'https://example.com/api/canary/posts/id_value/'
+                        Location: 'https://example.com/api/canary/posts/id_value/'
                     });
                 });
         });
@@ -114,7 +114,7 @@ describe('Unit: api/shared/headers', function () {
                 .then((result) => {
                     result.should.eql({
                         // NOTE: the backslash in the end is important to avoid unecessary 301s using the header
-                        location: 'https://example.com/api/canary/posts/id_value/'
+                        Location: 'https://example.com/api/canary/posts/id_value/'
                     });
                 });
         });

--- a/test/unit/api/shared/headers_spec.js
+++ b/test/unit/api/shared/headers_spec.js
@@ -61,4 +61,56 @@ describe('Unit: api/shared/headers', function () {
                 });
         });
     });
+
+    describe('config.location', function () {
+        it('adds header when all needed data is present', function () {
+            const apiResult = {
+                posts: [{
+                    id: 'id_value'
+                }]
+            };
+
+            const apiConfigHeaders = {
+                location: true
+            };
+            const frame = {
+                docName: 'posts',
+                original: {
+                    url: {
+                        host: 'example.com',
+                        pathname: `/api/canary/posts/`
+                    }
+                }
+            };
+
+            return shared.headers.get(apiResult, apiConfigHeaders, frame)
+                .then((result) => {
+                    result.should.eql({
+                        Location: 'https://example.com/api/canary/posts/id_value'
+                    });
+                });
+        });
+
+        it('does not add header when missing result values', function () {
+            const apiResult = {};
+
+            const apiConfigHeaders = {
+                location: true
+            };
+            const frame = {
+                docName: 'posts',
+                original: {
+                    url: {
+                        host: 'example.com',
+                        pathname: `/api/canary/posts/`
+                    }
+                }
+            };
+
+            return shared.headers.get(apiResult, apiConfigHeaders, frame)
+                .then((result) => {
+                    result.should.eql({});
+                });
+        });
+    });
 });

--- a/test/unit/api/shared/headers_spec.js
+++ b/test/unit/api/shared/headers_spec.js
@@ -62,7 +62,7 @@ describe('Unit: api/shared/headers', function () {
         });
     });
 
-    describe('config.location', function () {
+    describe('location header', function () {
         it('adds header when all needed data is present', function () {
             const apiResult = {
                 posts: [{
@@ -70,11 +70,10 @@ describe('Unit: api/shared/headers', function () {
                 }]
             };
 
-            const apiConfigHeaders = {
-                location: true
-            };
+            const apiConfigHeaders = {};
             const frame = {
                 docName: 'posts',
+                method: 'add',
                 original: {
                     url: {
                         host: 'example.com',
@@ -87,7 +86,35 @@ describe('Unit: api/shared/headers', function () {
                 .then((result) => {
                     result.should.eql({
                         // NOTE: the backslash in the end is important to avoid unecessary 301s using the header
-                        Location: 'https://example.com/api/canary/posts/id_value/'
+                        location: 'https://example.com/api/canary/posts/id_value/'
+                    });
+                });
+        });
+
+        it('adds and resolves header to correct url when pathname does not contain backslash in the end', function () {
+            const apiResult = {
+                posts: [{
+                    id: 'id_value'
+                }]
+            };
+
+            const apiConfigHeaders = {};
+            const frame = {
+                docName: 'posts',
+                method: 'add',
+                original: {
+                    url: {
+                        host: 'example.com',
+                        pathname: `/api/canary/posts`
+                    }
+                }
+            };
+
+            return shared.headers.get(apiResult, apiConfigHeaders, frame)
+                .then((result) => {
+                    result.should.eql({
+                        // NOTE: the backslash in the end is important to avoid unecessary 301s using the header
+                        location: 'https://example.com/api/canary/posts/id_value/'
                     });
                 });
         });
@@ -95,11 +122,10 @@ describe('Unit: api/shared/headers', function () {
         it('does not add header when missing result values', function () {
             const apiResult = {};
 
-            const apiConfigHeaders = {
-                location: true
-            };
+            const apiConfigHeaders = {};
             const frame = {
                 docName: 'posts',
+                method: 'add',
                 original: {
                     url: {
                         host: 'example.com',

--- a/test/unit/api/shared/headers_spec.js
+++ b/test/unit/api/shared/headers_spec.js
@@ -86,7 +86,8 @@ describe('Unit: api/shared/headers', function () {
             return shared.headers.get(apiResult, apiConfigHeaders, frame)
                 .then((result) => {
                     result.should.eql({
-                        Location: 'https://example.com/api/canary/posts/id_value'
+                        // NOTE: the backslash in the end is important to avoid unecessary 301s using the header
+                        Location: 'https://example.com/api/canary/posts/id_value/'
                     });
                 });
         });

--- a/test/unit/api/shared/http_spec.js
+++ b/test/unit/api/shared/http_spec.js
@@ -15,6 +15,10 @@ describe('Unit: api/shared/http', function () {
         req.body = {
             a: 'a'
         };
+        req.vhost = {
+            host: 'example.com'
+        };
+        req.url = 'https://example.com/ghost/api/canary/',
 
         res.status = sinon.stub();
         res.json = sinon.stub();


### PR DESCRIPTION
refs #2635

@daniellockyer not much to review on the code side here. Wanted to have a place where we could colab on needed changes if the Location header doesn't show up or need some modifications when doing logging.

NOTE, this is a WIP and needs:
- [x] fix and add a test for URL correctness in Location header (e.g. should not cause a 301) 
- [x] location attribute added to **some** endpoints that create new resources along with test updates:
1. `/posts/`
2. `/pages/`
3. `/integrations/`
4. `/tags/`
5. `/members/`
6. `/labels/`
7. `/notifications/`
8. `/invites/`
- [x] check if header is correctly handled for subdirectory setup