### PR TITLE
Support redirects.yaml.

### DIFF
--- a/core/frontend/services/redirects/settings.js
+++ b/core/frontend/services/redirects/settings.js
@@ -142,8 +142,14 @@ const setFromFilePath = (filePath, ext) => {
         });
 };
 
+const defaultJsonFileContent = '[]';
+
 const get = () => {
     return getCurrentRedirectsFilePath().then((filePath) => {
+        if (filePath === null) {
+            return defaultJsonFileContent;
+        }
+
         return readRedirectsFile(filePath);
     });
 };

--- a/core/frontend/services/redirects/settings.js
+++ b/core/frontend/services/redirects/settings.js
@@ -96,6 +96,21 @@ const getCurrentRedirectsFilePath = async () => {
     return null;
 };
 
+const getCurrentRedirectsFilePathSync = () => {
+    const yamlPath = createRedirectsFilePath('.yaml');
+    const jsonPath = createRedirectsFilePath('.json');
+
+    if (fs.existsSync(yamlPath)) {
+        return yamlPath;
+    }
+
+    if (fs.existsSync(jsonPath)) {
+        return jsonPath;
+    }
+
+    return null;
+};
+
 const getBackupRedirectsFilePath = (filePath) => {
     const {dir, name, ext} = path.parse(filePath);
 
@@ -142,7 +157,7 @@ const setFromFilePath = (filePath, ext) => {
         });
 };
 
-const defaultJsonFileContent = '[]';
+const defaultJsonFileContent = [];
 
 const get = () => {
     return getCurrentRedirectsFilePath().then((filePath) => {
@@ -150,11 +165,16 @@ const get = () => {
             return defaultJsonFileContent;
         }
 
-        return readRedirectsFile(filePath);
+        return readRedirectsFile(filePath).then((content) => {
+            return path.extname(filePath) === '.json'
+                ? parseRedirectsFile(content, '.json')
+                : content;
+        });
     });
 };
 
 module.exports.get = get;
 module.exports.setFromFilePath = setFromFilePath;
 module.exports.getCurrentRedirectsFilePath = getCurrentRedirectsFilePath;
+module.exports.getCurrentRedirectsFilePathSync = getCurrentRedirectsFilePathSync;
 module.exports.parseRedirectsFile = parseRedirectsFile;

--- a/core/frontend/services/redirects/settings.js
+++ b/core/frontend/services/redirects/settings.js
@@ -45,6 +45,17 @@ const parseRedirectsFile = (content, ext) => {
         let redirects = [];
         let configYaml = yaml.safeLoad(content);
 
+        // yaml.safeLoad passes almost every yaml code.
+        // Because of that, it's hard to detect if there's an error in the file.
+        // But one of the obvious errors is the plain string output.
+        // Here we check if the user made this mistake.
+        if (typeof configYaml === 'string') {
+            throw new errors.BadRequestError({
+                message: i18n.t('errors.api.redirects.yamlParse'),
+                help: 'https://ghost.org/docs/api/handlebars-themes/routing/redirects/'
+            });
+        }
+
         /**
          * 302: Temporary redirects
          */

--- a/core/frontend/services/redirects/settings.js
+++ b/core/frontend/services/redirects/settings.js
@@ -117,7 +117,7 @@ const getBackupRedirectsFilePath = (filePath) => {
     return path.join(dir, `${name}-${moment().format('YYYY-MM-DD-HH-mm-ss')}${ext}`);
 };
 
-const setFromFilePath = (filePath, ext) => {
+const setFromFilePath = (filePath, ext = '.json') => {
     return getCurrentRedirectsFilePath()
         .then((redirectsFilePath) => {
             if (!redirectsFilePath) {

--- a/core/frontend/services/redirects/settings.js
+++ b/core/frontend/services/redirects/settings.js
@@ -143,9 +143,12 @@ const setFromFilePath = (filePath, ext) => {
 };
 
 const get = () => {
-    return readRedirectsFile(path.join(config.getContentPath('data'), 'redirects.json'));
+    return getCurrentRedirectsFilePath().then((filePath) => {
+        return readRedirectsFile(filePath);
+    });
 };
 
 module.exports.get = get;
 module.exports.setFromFilePath = setFromFilePath;
+module.exports.getCurrentRedirectsFilePath = getCurrentRedirectsFilePath;
 module.exports.parseRedirectsFile = parseRedirectsFile;

--- a/core/server/api/canary/redirects.js
+++ b/core/server/api/canary/redirects.js
@@ -11,7 +11,7 @@ module.exports = {
             disposition: {
                 type: 'file',
                 value() {
-                    return redirects.settings.getCurrentRedirectsFilePath()
+                    return redirects.settings.getRedirectsFilePath()
                         .then((filePath) => {
                             // TODO: Default file type is .json for backward compatibility.
                             // When .yaml becomes default or .json is removed at v4,
@@ -25,8 +25,8 @@ module.exports = {
         },
         permissions: true,
         response: {
-            format() {
-                const filePath = redirects.settings.getCurrentRedirectsFilePathSync();
+            async format() {
+                const filePath = await redirects.settings.getRedirectsFilePath();
 
                 return filePath === null || path.extname(filePath) === '.json' ? 'json' : 'plain';
             }

--- a/core/server/api/canary/redirects.js
+++ b/core/server/api/canary/redirects.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const web = require('../../web');
 const redirects = require('../../../frontend/services/redirects');
 
@@ -8,10 +10,20 @@ module.exports = {
         headers: {
             disposition: {
                 type: 'file',
-                value: 'redirects.json'
+                value() {
+                    return redirects.settings.getCurrentRedirectsFilePath()
+                        .then((filePath) => {
+                            return path.extname(filePath) === '.yaml'
+                                ? 'redirects.yaml'
+                                : 'redirects.json';
+                        });
+                }
             }
         },
         permissions: true,
+        response: {
+            format: 'plain'
+        },
         query() {
             return redirects.settings.get();
         }

--- a/core/server/api/canary/redirects.js
+++ b/core/server/api/canary/redirects.js
@@ -13,9 +13,12 @@ module.exports = {
                 value() {
                     return redirects.settings.getCurrentRedirectsFilePath()
                         .then((filePath) => {
-                            return path.extname(filePath) === '.yaml'
-                                ? 'redirects.yaml'
-                                : 'redirects.json';
+                            // TODO: Default file type is .json for backward compatibility.
+                            // When .yaml becomes default or .json is removed at v4,
+                            // This part should be changed.
+                            return filePath === null || path.extname(filePath) === '.json'
+                                ? 'redirects.json'
+                                : 'redirects.yaml';
                         });
                 }
             }

--- a/core/server/api/canary/redirects.js
+++ b/core/server/api/canary/redirects.js
@@ -25,7 +25,11 @@ module.exports = {
         },
         permissions: true,
         response: {
-            format: 'plain'
+            format() {
+                const filePath = redirects.settings.getCurrentRedirectsFilePathSync();
+
+                return filePath === null || path.extname(filePath) === '.json' ? 'json' : 'plain';
+            }
         },
         query() {
             return redirects.settings.get();

--- a/core/server/api/canary/redirects.js
+++ b/core/server/api/canary/redirects.js
@@ -23,7 +23,7 @@ module.exports = {
             cacheInvalidate: true
         },
         query(frame) {
-            return redirects.settings.setFromFilePath(frame.file.path)
+            return redirects.settings.setFromFilePath(frame.file.path, frame.file.ext)
                 .then(() => {
                     // CASE: trigger that redirects are getting re-registered
                     web.shared.middlewares.customRedirects.reload();

--- a/core/server/api/shared/http.js
+++ b/core/server/api/shared/http.js
@@ -85,7 +85,17 @@ const http = (apiImpl) => {
                 // CASE: generate headers based on the api ctrl configuration
                 res.set(headers);
 
-                if (apiImpl.response && apiImpl.response.format === 'plain') {
+                let format;
+
+                if (apiImpl.response){
+                    if (typeof apiImpl.response.format === 'function') {
+                        format = apiImpl.response.format();
+                    } else {
+                        format = apiImpl.response.format;
+                    }
+                }
+
+                if (format === 'plain') {
                     debug('plain text response');
                     return res.send(result);
                 }

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -370,7 +370,7 @@
             "redirects": {
                 "missingFile": "Please select a JSON file.",
                 "invalidFile": "Please select a valid JSON file to import.",
-                "yamlParse": "The parsed result of the YAML file is a plain string. Please check the format of your redirects file."
+                "yamlParse": "YAML output cannot be a plain string. Check the format of your YAML file."
             },
             "resource": {
                 "resourceNotFound": "{resource} not found."

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -369,7 +369,8 @@
             },
             "redirects": {
                 "missingFile": "Please select a JSON file.",
-                "invalidFile": "Please select a valid JSON file to import."
+                "invalidFile": "Please select a valid JSON file to import.",
+                "yamlParse": "The parsed result of the YAML file is a plain string. Please check the format of your redirects file."
             },
             "resource": {
                 "resourceNotFound": "{resource} not found."

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -220,6 +220,9 @@ module.exports = function apiRoutes() {
     router.del('/invites/:id', mw.authAdminApi, http(apiCanary.invites.destroy));
 
     // ## Redirects (JSON based)
+    // TODO: yaml support has been added to https://github.com/TryGhost/Ghost/issues/11085
+    // The endpoints below are left for backward compatibility.
+    // Maybe their names should be changed to /redirects/file in the next version(v4).
     router.get('/redirects/json', mw.authAdminApi, http(apiCanary.redirects.download));
     router.post('/redirects/json',
         mw.authAdminApi,

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -219,12 +219,18 @@ module.exports = function apiRoutes() {
     router.post('/invites', mw.authAdminApi, http(apiCanary.invites.add));
     router.del('/invites/:id', mw.authAdminApi, http(apiCanary.invites.destroy));
 
-    // ## Redirects (JSON based)
+    // ## Redirects
     // TODO: yaml support has been added to https://github.com/TryGhost/Ghost/issues/11085
-    // The endpoints below are left for backward compatibility.
-    // Maybe their names should be changed to /redirects/file in the next version(v4).
+    // The `/json` endpoints below are left for backward compatibility. They'll be removed in v4.
     router.get('/redirects/json', mw.authAdminApi, http(apiCanary.redirects.download));
     router.post('/redirects/json',
+        mw.authAdminApi,
+        apiMw.upload.single('redirects'),
+        apiMw.upload.validation({type: 'redirects'}),
+        http(apiCanary.redirects.upload)
+    );
+    router.get('/redirects/download', mw.authAdminApi, http(apiCanary.redirects.download));
+    router.post('/redirects/upload',
         mw.authAdminApi,
         apiMw.upload.single('redirects'),
         apiMw.upload.validation({type: 'redirects'}),

--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -1,7 +1,5 @@
-const fs = require('fs-extra');
 const express = require('../../../../shared/express');
 const url = require('url');
-const path = require('path');
 const debug = require('ghost-ignition').debug('web:shared:mw:custom-redirects');
 const config = require('../../../../shared/config');
 const urlUtils = require('../../../../shared/url-utils');
@@ -14,22 +12,13 @@ const _private = {};
 
 let customRedirectsRouter;
 
-const getRedirectsFilePath = () => {
-    const yamlPath = path.join(config.getContentPath('data'), `redirects.yaml`);
-    const jsonPath = path.join(config.getContentPath('data'), `redirects.json`);
-
-    return fs.existsSync(yamlPath) ? yamlPath : jsonPath;
-};
-
 _private.registerRoutes = () => {
     debug('redirects loading');
 
     customRedirectsRouter = express.Router('redirects');
 
     try {
-        const filePath = getRedirectsFilePath();
-        const content = fs.readFileSync(filePath);
-        const redirects = redirectsService.settings.parseRedirectsFile(content, path.extname(filePath));
+        const redirects = redirectsService.settings.loadRedirectsFile();
 
         redirectsService.validation.validate(redirects);
 

--- a/core/shared/config/overrides.json
+++ b/core/shared/config/overrides.json
@@ -43,8 +43,8 @@
             "contentTypes": ["application/zip", "application/x-zip-compressed", "application/octet-stream"]
         },
         "redirects": {
-            "extensions": [".json"],
-            "contentTypes": ["text/plain", "application/octet-stream", "application/json"]
+            "extensions": [".json", ".yaml"],
+            "contentTypes": ["text/plain", "text/yaml", "application/octet-stream", "application/json", "application/yaml", "application/x-yaml"]
         },
         "routes": {
             "extensions": [".yaml"],

--- a/test/regression/api/canary/admin/redirects_spec.js
+++ b/test/regression/api/canary/admin/redirects_spec.js
@@ -255,7 +255,18 @@ describe('Redirects API', function () {
     });
 
     describe('Upload yaml', function () {
-        // No error cases here because there are no easy syntax pitfalls in the yaml format.
+        describe('Error cases', function () {
+            it('syntax error', function () {
+                fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects.yaml'), 'x');
+
+                return request
+                    .post(localUtils.API.getApiQuery('redirects/json/'))
+                    .set('Origin', config.get('url'))
+                    .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects.yaml'))
+                    .expect('Content-Type', /application\/json/)
+                    .expect(400);
+            });
+        });
 
         describe('Ensure re-registering redirects works', function () {
             const startGhost = (options) => {

--- a/test/regression/api/canary/admin/redirects_spec.js
+++ b/test/regression/api/canary/admin/redirects_spec.js
@@ -65,6 +65,33 @@ describe('Redirects API', function () {
         });
     });
 
+    describe('Download yaml', function () {
+        beforeEach(function () {
+            testUtils.setupRedirectsFile(config.get('paths:contentPath'), '.yaml');
+        });
+
+        afterEach(function () {
+            testUtils.setupRedirectsFile(config.get('paths:contentPath'), '.json');
+        });
+
+        // 'file does not exist' doesn't have to be tested because it always returns .json file.
+
+        it('file exists', function () {
+            return request
+                .get(localUtils.API.getApiQuery('redirects/json/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /text\/html/)
+                .expect('Content-Disposition', 'Attachment; filename="redirects.yaml"')
+                .expect(200)
+                .then((res) => {
+                    res.headers['content-disposition'].should.eql('Attachment; filename="redirects.yaml"');
+                    res.headers['content-type'].should.eql('text/html; charset=utf-8');
+
+                    should.deepEqual(res.text, fs.readFileSync(path.join(__dirname, '../../../../utils/fixtures/data/redirects.yaml')).toString());
+                });
+        });
+    });
+
     describe('Upload', function () {
         describe('Error cases', function () {
             it('syntax error', function () {
@@ -219,6 +246,134 @@ describe('Redirects API', function () {
                             .expect(200);
                     })
                     .then(() => {
+                        const dataFiles = fs.readdirSync(config.getContentPath('data'));
+                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(3);
+                    });
+            });
+        });
+    });
+
+    describe('Upload yaml', function () {
+        // No error cases here because there are no easy syntax pitfalls in the yaml format.
+
+        describe('Ensure re-registering redirects works', function () {
+            const startGhost = (options) => {
+                return ghost(options)
+                    .then(() => {
+                        request = supertest.agent(config.get('url'));
+                    })
+                    .then(() => {
+                        return localUtils.doAuth(request);
+                    });
+            };
+
+            it('no redirects file exists', function () {
+                return startGhost({redirectsFile: false, forceStart: true})
+                    .then(() => {
+                        return request
+                            .get('/my-old-blog-post/')
+                            .expect(404);
+                    })
+                    .then(() => {
+                        // Provide a redirects file in the root directory of the content test folder
+                        fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects-init.yaml'), '302:\n  k: l');
+                    })
+                    .then(() => {
+                        return request
+                            .post(localUtils.API.getApiQuery('redirects/json/'))
+                            .set('Origin', config.get('url'))
+                            .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects-init.yaml'))
+                            .expect('Content-Type', /application\/json/)
+                            .expect(200);
+                    })
+                    .then((res) => {
+                        res.headers['x-cache-invalidate'].should.eql('/*');
+
+                        return request
+                            .get('/k/')
+                            .expect(302);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/l');
+
+                        const dataFiles = fs.readdirSync(config.getContentPath('data'));
+                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(1);
+                    });
+            });
+
+            it('override', function () {
+                // We want to test if we can override old redirects.json with new redirects.yaml
+                // That's why we start with .json.
+                return startGhost({forceStart: true, redirectsFileExt: '.json'})
+                    .then(() => {
+                        return request
+                            .get('/my-old-blog-post/')
+                            .expect(301);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/revamped-url/');
+                    })
+                    .then(() => {
+                        // Provide a second redirects file in the root directory of the content test folder
+                        fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects.yaml'), '302:\n  c: d');
+                    })
+                    .then(() => {
+                        // Override redirects file
+                        return request
+                            .post(localUtils.API.getApiQuery('redirects/json/'))
+                            .set('Origin', config.get('url'))
+                            .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects.yaml'))
+                            .expect('Content-Type', /application\/json/)
+                            .expect(200);
+                    })
+                    .then((res) => {
+                        res.headers['x-cache-invalidate'].should.eql('/*');
+
+                        return request
+                            .get('/my-old-blog-post/')
+                            .expect(404);
+                    })
+                    .then(() => {
+                        return request
+                            .get('/c/')
+                            .expect(302);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/d');
+
+                        // check backup of redirects files
+                        const dataFiles = fs.readdirSync(config.getContentPath('data'));
+                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(2);
+
+                        // Provide another redirects file in the root directory of the content test folder
+                        fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects-something.json'), JSON.stringify([{
+                            from: 'e',
+                            to: 'b'
+                        }]));
+                    })
+                    .then(() => {
+                        // the backup is in the format HH:mm:ss, we have to wait minimum a second
+                        return new Promise((resolve) => {
+                            setTimeout(resolve, 1100);
+                        });
+                    })
+                    .then(() => {
+                        // Override redirects file again and ensure the backup file works twice
+                        return request
+                            .post(localUtils.API.getApiQuery('redirects/json/'))
+                            .set('Origin', config.get('url'))
+                            .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects-something.json'))
+                            .expect('Content-Type', /application\/json/)
+                            .expect(200);
+                    })
+                    .then(() => {
+                        return request
+                            .get('/e/')
+                            .expect(302);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/b');
+
                         const dataFiles = fs.readdirSync(config.getContentPath('data'));
                         dataFiles.join(',').match(/(redirects)/g).length.should.eql(3);
                     });

--- a/test/regression/api/canary/admin/redirects_spec.js
+++ b/test/regression/api/canary/admin/redirects_spec.js
@@ -392,4 +392,33 @@ describe('Redirects API', function () {
             });
         });
     });
+
+    // TODO: For backward compatibility, we only check if download, upload endpoints work here.
+    // when updating to v4, the old endpoints should be updated to the new ones.
+    // And the tests below should be removed.
+    describe('New endpoints work', function () {
+        it('download', function () {
+            return request
+                .get(localUtils.API.getApiQuery('redirects/download/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /application\/json/)
+                .expect('Content-Disposition', 'Attachment; filename="redirects.json"')
+                .expect(200);
+        });
+
+        it('upload', function () {
+            // Provide a redirects file in the root directory of the content test folder
+            fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects-init.json'), JSON.stringify([{
+                from: 'k',
+                to: 'l'
+            }]));
+
+            return request
+                .post(localUtils.API.getApiQuery('redirects/upload/'))
+                .set('Origin', config.get('url'))
+                .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects-init.json'))
+                .expect('Content-Type', /application\/json/)
+                .expect(200);
+        });
+    });
 });

--- a/test/regression/api/canary/admin/redirects_spec.js
+++ b/test/regression/api/canary/admin/redirects_spec.js
@@ -75,6 +75,7 @@ describe('Redirects API', function () {
         });
 
         // 'file does not exist' doesn't have to be tested because it always returns .json file.
+        // TODO: But it should be written when the default redirects file type is changed to yaml.
 
         it('file exists', function () {
             return request

--- a/test/regression/api/v3/admin/redirects_spec.js
+++ b/test/regression/api/v3/admin/redirects_spec.js
@@ -65,6 +65,33 @@ describe('Redirects API', function () {
         });
     });
 
+    describe('Download yaml', function () {
+        beforeEach(function () {
+            testUtils.setupRedirectsFile(config.get('paths:contentPath'), '.yaml');
+        });
+
+        afterEach(function () {
+            testUtils.setupRedirectsFile(config.get('paths:contentPath'), '.json');
+        });
+
+        // 'file does not exist' doesn't have to be tested because it always returns .json file.
+
+        it('file exists', function () {
+            return request
+                .get(localUtils.API.getApiQuery('redirects/json/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /text\/html/)
+                .expect('Content-Disposition', 'Attachment; filename="redirects.yaml"')
+                .expect(200)
+                .then((res) => {
+                    res.headers['content-disposition'].should.eql('Attachment; filename="redirects.yaml"');
+                    res.headers['content-type'].should.eql('text/html; charset=utf-8');
+
+                    should.deepEqual(res.text, fs.readFileSync(path.join(__dirname, '../../../../utils/fixtures/data/redirects.yaml')).toString());
+                });
+        });
+    });
+
     describe('Upload', function () {
         describe('Error cases', function () {
             it('syntax error', function () {
@@ -219,6 +246,134 @@ describe('Redirects API', function () {
                             .expect(200);
                     })
                     .then(() => {
+                        const dataFiles = fs.readdirSync(config.getContentPath('data'));
+                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(3);
+                    });
+            });
+        });
+    });
+
+    describe('Upload yaml', function () {
+        // No error cases here because there are no easy syntax pitfalls in the yaml format.
+
+        describe('Ensure re-registering redirects works', function () {
+            const startGhost = (options) => {
+                return ghost(options)
+                    .then(() => {
+                        request = supertest.agent(config.get('url'));
+                    })
+                    .then(() => {
+                        return localUtils.doAuth(request);
+                    });
+            };
+
+            it('no redirects file exists', function () {
+                return startGhost({redirectsFile: false, forceStart: true})
+                    .then(() => {
+                        return request
+                            .get('/my-old-blog-post/')
+                            .expect(404);
+                    })
+                    .then(() => {
+                        // Provide a redirects file in the root directory of the content test folder
+                        fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects-init.yaml'), '302:\n  k: l');
+                    })
+                    .then(() => {
+                        return request
+                            .post(localUtils.API.getApiQuery('redirects/json/'))
+                            .set('Origin', config.get('url'))
+                            .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects-init.yaml'))
+                            .expect('Content-Type', /application\/json/)
+                            .expect(200);
+                    })
+                    .then((res) => {
+                        res.headers['x-cache-invalidate'].should.eql('/*');
+
+                        return request
+                            .get('/k/')
+                            .expect(302);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/l');
+
+                        const dataFiles = fs.readdirSync(config.getContentPath('data'));
+                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(1);
+                    });
+            });
+
+            it('override', function () {
+                // We want to test if we can override old redirects.json with new redirects.yaml
+                // That's why we start with .json.
+                return startGhost({forceStart: true, redirectsFileExt: '.json'})
+                    .then(() => {
+                        return request
+                            .get('/my-old-blog-post/')
+                            .expect(301);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/revamped-url/');
+                    })
+                    .then(() => {
+                        // Provide a second redirects file in the root directory of the content test folder
+                        fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects.yaml'), '302:\n  c: d');
+                    })
+                    .then(() => {
+                        // Override redirects file
+                        return request
+                            .post(localUtils.API.getApiQuery('redirects/json/'))
+                            .set('Origin', config.get('url'))
+                            .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects.yaml'))
+                            .expect('Content-Type', /application\/json/)
+                            .expect(200);
+                    })
+                    .then((res) => {
+                        res.headers['x-cache-invalidate'].should.eql('/*');
+
+                        return request
+                            .get('/my-old-blog-post/')
+                            .expect(404);
+                    })
+                    .then(() => {
+                        return request
+                            .get('/c/')
+                            .expect(302);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/d');
+
+                        // check backup of redirects files
+                        const dataFiles = fs.readdirSync(config.getContentPath('data'));
+                        dataFiles.join(',').match(/(redirects)/g).length.should.eql(2);
+
+                        // Provide another redirects file in the root directory of the content test folder
+                        fs.writeFileSync(path.join(config.get('paths:contentPath'), 'redirects-something.json'), JSON.stringify([{
+                            from: 'e',
+                            to: 'b'
+                        }]));
+                    })
+                    .then(() => {
+                        // the backup is in the format HH:mm:ss, we have to wait minimum a second
+                        return new Promise((resolve) => {
+                            setTimeout(resolve, 1100);
+                        });
+                    })
+                    .then(() => {
+                        // Override redirects file again and ensure the backup file works twice
+                        return request
+                            .post(localUtils.API.getApiQuery('redirects/json/'))
+                            .set('Origin', config.get('url'))
+                            .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects-something.json'))
+                            .expect('Content-Type', /application\/json/)
+                            .expect(200);
+                    })
+                    .then(() => {
+                        return request
+                            .get('/e/')
+                            .expect(302);
+                    })
+                    .then((response) => {
+                        response.headers.location.should.eql('/b');
+
                         const dataFiles = fs.readdirSync(config.getContentPath('data'));
                         dataFiles.join(',').match(/(redirects)/g).length.should.eql(3);
                     });

--- a/test/utils/fixtures/data/redirects.yaml
+++ b/test/utils/fixtures/data/redirects.yaml
@@ -1,0 +1,17 @@
+301:
+  /my-old-blog-post/: /revamped-url/
+
+302:
+  ^/post/[0-9]+/([a-z0-9\-]+): /$1
+  ^/what(/?)$: /what-does-god-say
+  ^/search/label/([^\%20]+)$: /tag/$1
+  ^/topic/: /
+  ^/resources/download(/?)$: /shubal-stearns
+  ^\/(?:capture1|capture2)\/([A-Za-z0-9\-]+): /$1
+  ^/[0-9]{4}/[0-9]{2}/([a-z0-9\-]+)(\.html)?(/)?$: /$1
+  ^/prefix/([a-z0-9\-]+)?: /blog/$1
+  /^/case-insensitive/i: /redirected-insensitive
+  ^/Case-Sensitive: /redirected-sensitive
+  ^/Default-Sensitive: /redirected-default
+  /external-url: https://ghost.org
+  /external-url/(.*): https://ghost.org/$1

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -799,7 +799,7 @@ const teardownDb = function teardownDb() {
 /**
  * Set up the redirects file with the extension you want.
  */
-setupRedirectsFile = (contentFolderForTests, ext) => {
+const setupRedirectsFile = (contentFolderForTests, ext) => {
     const yamlPath = path.join(contentFolderForTests, 'data', 'redirects.yaml');
     const jsonPath = path.join(contentFolderForTests, 'data', 'redirects.json');
 

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -796,6 +796,37 @@ const teardownDb = function teardownDb() {
     });
 };
 
+/**
+ * Set up the redirects file with the extension you want.
+ */
+setupRedirectsFile = (contentFolderForTests, ext) => {
+    const yamlPath = path.join(contentFolderForTests, 'data', 'redirects.yaml');
+    const jsonPath = path.join(contentFolderForTests, 'data', 'redirects.json');
+
+    if (ext === '.json') {
+        if (fs.existsSync(yamlPath)) {
+            fs.removeSync(yamlPath);
+        }
+        fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.json'), jsonPath);
+    }
+
+    if (ext === '.yaml') {
+        if (fs.existsSync(jsonPath)) {
+            fs.removeSync(jsonPath);
+        }
+        fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.yaml'), yamlPath);
+    }
+
+    if (ext === null) {
+        if (fs.existsSync(yamlPath)) {
+            fs.removeSync(yamlPath);
+        }
+        if (fs.existsSync(jsonPath)) {
+            fs.removeSync(jsonPath);
+        }
+    }
+};
+
 let ghostServer;
 
 /**
@@ -839,23 +870,7 @@ const startGhost = function startGhost(options) {
     }
 
     if (options.redirectsFile) {
-        if (options.redirectsFileExt === '.json') {
-            const yamlPath = path.join(contentFolderForTests, 'data', 'redirects.yaml');
-
-            if (fs.existsSync(yamlPath)) {
-                fs.removeSync(yamlPath);
-            }
-            fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.json'), path.join(contentFolderForTests, 'data', 'redirects.json'));
-        }
-
-        if (options.redirectsFileExt === '.yaml') {
-            const jsonPath = path.join(contentFolderForTests, 'data', 'redirects.json');
-
-            if (fs.existsSync(jsonPath)) {
-                fs.removeSync(jsonPath);
-            }
-            fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.yaml'), path.join(contentFolderForTests, 'data', 'redirects.yaml'));
-        }
+        setupRedirectsFile(contentFolderForTests, options.redirectsFileExt);
     }
 
     if (options.copySettings) {
@@ -1149,6 +1164,7 @@ module.exports = {
     initData: initData,
     clearData: clearData,
     clearBruteData: clearBruteData,
+    setupRedirectsFile,
 
     fixtures: fixtures,
 

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -808,6 +808,7 @@ const startGhost = function startGhost(options) {
     console.time('Start Ghost'); // eslint-disable-line no-console
     options = _.merge({
         redirectsFile: true,
+        redirectsFileExt: '.json',
         forceStart: false,
         copyThemes: true,
         copySettings: true,
@@ -838,7 +839,23 @@ const startGhost = function startGhost(options) {
     }
 
     if (options.redirectsFile) {
-        fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.json'), path.join(contentFolderForTests, 'data', 'redirects.json'));
+        if (options.redirectsFileExt === '.json') {
+            const yamlPath = path.join(contentFolderForTests, 'data', 'redirects.yaml');
+
+            if (fs.existsSync(yamlPath)) {
+                fs.removeSync(yamlPath);
+            }
+            fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.json'), path.join(contentFolderForTests, 'data', 'redirects.json'));
+        }
+
+        if (options.redirectsFileExt === '.yaml') {
+            const jsonPath = path.join(contentFolderForTests, 'data', 'redirects.json');
+
+            if (fs.existsSync(jsonPath)) {
+                fs.removeSync(jsonPath);
+            }
+            fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.yaml'), path.join(contentFolderForTests, 'data', 'redirects.yaml'));
+        }
     }
 
     if (options.copySettings) {


### PR DESCRIPTION
Closes #11085 

Thanks @assisting!

## Todos

- [x] Allow current Admin UI to accept both JSON and YAML file. => TryGhost/Ghost-Admin#1703
- [x] Make server save the redirects file in yaml format. 
- [x] Let users download the current redirects file. (Extension doesn't matter.)
- [x] Add related tests.
- [x] Add a test about invalid yaml file.

----

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)
