### PR TITLE
Added schema+migration for email_{batches,recipients} tables

### DIFF
--- a/core/server/data/migrations/versions/3.33/01-add-email-recipients-tables.js
+++ b/core/server/data/migrations/versions/3.33/01-add-email-recipients-tables.js
@@ -9,7 +9,7 @@ module.exports = {
             const tableExists = await connection.schema.hasTable(table);
 
             if (tableExists) {
-                return logging.warn(`Adding table: ${table}`);
+                return logging.warn(`Skipping add table "${table}" - already exists`);
             }
 
             logging.info(`Adding table: ${table}`);
@@ -24,7 +24,7 @@ module.exports = {
             const tableExists = await connection.schema.hasTable(table);
 
             if (!tableExists) {
-                return logging.warn(`Dropping table: ${table}`);
+                return logging.warn(`Skipping drop table "${table}" - does not exist`);
             }
 
             logging.info(`Dropping table: ${table}`);

--- a/core/server/data/migrations/versions/3.33/01-add-email-recipients-tables.js
+++ b/core/server/data/migrations/versions/3.33/01-add-email-recipients-tables.js
@@ -1,11 +1,11 @@
 const logging = require('../../../../../shared/logging');
 const commands = require('../../../schema').commands;
 
-const TABLES = ['email_batches', 'email_recipients'];
-
 module.exports = {
     async up({connection}) {
-        return Promise.each(TABLES, async (table) => {
+        // table creation order is important because of foreign key constraints,
+        // email_recipients references email_batches so email_batches has to exist when creating
+        return Promise.each(['email_batches', 'email_recipients'], async (table) => {
             const tableExists = await connection.schema.hasTable(table);
 
             if (tableExists) {
@@ -18,7 +18,9 @@ module.exports = {
     },
 
     async down({connection}) {
-        return Promise.each(TABLES.reverse(), async (table) => {
+        // table deletion order is important because of foreign key constraints,
+        // email_recipients references email_batches so it has to be deleted first to not break constraints
+        return Promise.each(['email_recipients', 'email_batches'], async (table) => {
             const tableExists = await connection.schema.hasTable(table);
 
             if (!tableExists) {

--- a/core/server/data/migrations/versions/3.33/01-add-email-recipients-tables.js
+++ b/core/server/data/migrations/versions/3.33/01-add-email-recipients-tables.js
@@ -1,0 +1,32 @@
+const logging = require('../../../../../shared/logging');
+const commands = require('../../../schema').commands;
+
+const TABLES = ['email_batches', 'email_recipients'];
+
+module.exports = {
+    async up({connection}) {
+        return Promise.each(TABLES, async (table) => {
+            const tableExists = await connection.schema.hasTable(table);
+
+            if (tableExists) {
+                return logging.warn(`Adding table: ${table}`);
+            }
+
+            logging.info(`Adding table: ${table}`);
+            return commands.createTable(table, connection);
+        });
+    },
+
+    async down({connection}) {
+        return Promise.each(TABLES.reverse(), async (table) => {
+            const tableExists = await connection.schema.hasTable(table);
+
+            if (!tableExists) {
+                return logging.warn(`Dropping table: ${table}`);
+            }
+
+            logging.info(`Dropping table: ${table}`);
+            return commands.deleteTable(table, connection);
+        });
+    }
+};

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -471,7 +471,7 @@ module.exports = {
             defaultTo: 'pending',
             validations: {isIn: [['pending', 'submitting', 'submitted', 'failed']]}
         },
-        error_data: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true}
+        updated_at: {type: 'dateTime', nullable: false}
     },
     email_recipients: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
@@ -479,9 +479,6 @@ module.exports = {
         member_id: {type: 'string', maxlength: 24, nullable: false, index: true},
         batch_id: {type: 'string', maxlength: 24, nullable: false, references: 'email_batches.id'},
         processed_at: {type: 'dateTime', nullable: true},
-        delivered_at: {type: 'dateTime', nullable: true},
-        failed_at: {type: 'dateTime', nullable: true},
-        opened_at: {type: 'dateTime', nullable: true},
         member_uuid: {type: 'string', maxlength: 36, nullable: false},
         member_email: {type: 'string', maxlength: 191, nullable: false},
         member_name: {type: 'string', maxlength: 191, nullable: true}

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -459,5 +459,31 @@ module.exports = {
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true}
+    },
+    email_batches: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        email_id: {type: 'string', maxlength: 24, nullable: false, references: 'emails.id'},
+        provider_id: {type: 'string', maxlength: 255, nullable: true},
+        status: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'pending',
+            validations: {isIn: [['pending', 'submitting', 'submitted', 'failed']]}
+        },
+        error_data: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true}
+    },
+    email_recipients: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        email_id: {type: 'string', maxlength: 24, nullable: false, references: 'emails.id'},
+        member_id: {type: 'string', maxlength: 24, nullable: false, index: true},
+        batch_id: {type: 'string', maxlength: 24, nullable: false, references: 'email_batches.id'},
+        processed_at: {type: 'dateTime', nullable: true},
+        delivered_at: {type: 'dateTime', nullable: true},
+        failed_at: {type: 'dateTime', nullable: true},
+        opened_at: {type: 'dateTime', nullable: true},
+        member_uuid: {type: 'string', maxlength: 36, nullable: false},
+        member_email: {type: 'string', maxlength: 191, nullable: false},
+        member_name: {type: 'string', maxlength: 191, nullable: true}
     }
 };

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -471,6 +471,7 @@ module.exports = {
             defaultTo: 'pending',
             validations: {isIn: [['pending', 'submitting', 'submitted', 'failed']]}
         },
+        created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false}
     },
     email_recipients: {

--- a/test/api-acceptance/admin/db_spec.js
+++ b/test/api-acceptance/admin/db_spec.js
@@ -55,7 +55,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(30);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(32);
             });
     });
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -21,7 +21,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '0b03c464882cbe5c0aef7514e944fa29';
+    const currentSchemaHash = 'cc25e59b162fb26393a5b77cd0721445';
     const currentFixturesHash = '29148c40dfaf4f828c5fca95666f6545';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -21,7 +21,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'cc25e59b162fb26393a5b77cd0721445';
+    const currentSchemaHash = 'c2b2de0157edddb68791dde49391d4e5';
     const currentFixturesHash = '29148c40dfaf4f828c5fca95666f6545';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -21,7 +21,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '42a966364eb4b5851e807133374821da';
+    const currentSchemaHash = '0b03c464882cbe5c0aef7514e944fa29';
     const currentFixturesHash = '29148c40dfaf4f828c5fca95666f6545';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
 


### PR DESCRIPTION
no issue

We want to store a list of recipients for each bulk email so that we have a consistent set of data that background processing/sending jobs can work from without worrying about moving large data sets around or member data changing mid-send.

- `email_batches` table acts as a join table with status for email<->email_recipient
  - stores a provider-specific ID that we get back when submitting a batch for sending to the bulk email provider
  - `status` allows for batch-specific status updates and picking up where we left off when submitting batches if needed
  - explicitly tieing a list of email recipients to a batch allows for partial retries
- `email_recipients` table acts as a join table for email<->member
  - `member_id` does not have a foreign key constraint because members can be deleted but does have an index so that we can efficiently query which emails a member has received
  - stores static copies of the member info present at the time of sending an email for consistency in background jobs and auditing/historical data