### PR TITLE
Fix image size bug in galleries.

### DIFF
--- a/core/server/lib/mobiledoc.js
+++ b/core/server/lib/mobiledoc.js
@@ -157,6 +157,38 @@ module.exports = {
         return JSON.stringify(mobiledoc);
     },
 
+    normalizeImageSizes(mobiledocJson) {
+        const mobiledoc = JSON.parse(mobiledocJson);
+
+        const resize = ({width, height}) => {
+            const isOverWidthLimit = width > 2000;
+
+            return {
+                height: isOverWidthLimit ? Math.round(height * 2000 / width) : height,
+                width: isOverWidthLimit ? 2000 : width
+            };
+        };
+
+        // The images are resized when its width is over 2000px.
+        mobiledoc.cards.forEach(([name, cardOptions]) => {
+            if (name === 'image') {
+                const {width, height} = resize(cardOptions);
+
+                cardOptions.height = height;
+                cardOptions.width = width;
+            } else if (name === 'gallery') {
+                cardOptions.images.forEach((image) => {
+                    const {width, height} = resize(image);
+
+                    image.height = height;
+                    image.width = width;
+                });
+            }
+        });
+
+        return JSON.stringify(mobiledoc);
+    },
+
     // allow config changes to be picked up - useful in tests
     reload() {
         cardFactory = null;

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -419,6 +419,7 @@ Post = ghostBookshelf.Model.extend({
             || (!this.get('html') && (options.migrating || options.importing))
         ) {
             try {
+                this.set('mobiledoc', mobiledocLib.normalizeImageSizes(this.get('mobiledoc')));
                 this.set('html', mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(this.get('mobiledoc'))));
             } catch (err) {
                 throw new errors.ValidationError({

--- a/test/unit/lib/mobiledoc_spec.js
+++ b/test/unit/lib/mobiledoc_spec.js
@@ -249,4 +249,32 @@ describe('lib/mobiledoc', function () {
             transformed.cards[1][1].height.should.equal(257);
         });
     });
+
+    describe('normalizeImageSizes', function () {
+        it('resizes the images whose width is over 2000px', async function () {
+            const mobiledoc = {
+                cards: [
+                    ['gallery', {
+                        images: [
+                            {src: 'a.jpg', width: 4500, height: 4500}
+                        ]
+                    }],
+                    ['image', {src: 'b.jpg', width: 3000, height: 31}],
+                    ['image', {src: 'c.jpg', width: 800, height: 3000}]
+                ]
+            };
+
+            const transformedMobiledoc = mobiledocLib.normalizeImageSizes(JSON.stringify(mobiledoc));
+            const transformed = JSON.parse(transformedMobiledoc);
+
+            transformed.cards[0][1].images[0].width.should.equal(2000);
+            transformed.cards[0][1].images[0].height.should.equal(2000);
+
+            transformed.cards[1][1].width.should.equal(2000);
+            transformed.cards[1][1].height.should.equal(21);
+
+            transformed.cards[2][1].width.should.equal(800);
+            transformed.cards[2][1].height.should.equal(3000);
+        });
+    });
 });


### PR DESCRIPTION
Closes #11548

The cause of the problem was the server resizing images whose width is over 2000px. (core/server/web/api/middleware/normalize-images.js)

To solve this problem, I introduced a new function `normalizeImageSizes` under `core/server/lib/mobiledoc.js`. It loops cards and checks if images and galleries have images whose width is over 2000px and normalize them.

----

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

----
