### PR TITLE
Added migration to store from/reply-to values in email table

### DIFF
--- a/core/server/data/migrations/versions/3.35/01-add-address-columns-to-emails-table.js
+++ b/core/server/data/migrations/versions/3.35/01-add-address-columns-to-emails-table.js
@@ -1,0 +1,41 @@
+const commands = require('../../../schema').commands;
+
+const newColumns = [{
+    column: 'from',
+    columnDefinition: {
+        type: 'string',
+        maxlength: 191,
+        nullable: true
+    }
+}, {
+    column: 'reply_to',
+    columnDefinition: {
+        type: 'string',
+        maxlength: 191,
+        nullable: true
+    }
+}];
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+
+    up: commands.createColumnMigration(...newColumns.map((column) => {
+        return Object.assign({}, column, {
+            table: 'emails',
+            dbIsInCorrectState: hasColumn => hasColumn === true,
+            operation: commands.addColumn,
+            operationVerb: 'Adding'
+        });
+    })),
+
+    down: commands.createColumnMigration(...newColumns.map((column) => {
+        return Object.assign({}, column, {
+            table: 'emails',
+            dbIsInCorrectState: hasColumn => hasColumn === false,
+            operation: commands.dropColumn,
+            operationVerb: 'Removing'
+        });
+    }))
+};

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -452,6 +452,8 @@ module.exports = {
         stats: {type: 'text', maxlength: 65535, nullable: true},
         email_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         subject: {type: 'string', maxlength: 300, nullable: true},
+        from: {type: 'string', maxlength: 2000, nullable: true},
+        reply_to: {type: 'string', maxlength: 2000, nullable: true},
         html: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         plaintext: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         submitted_at: {type: 'dateTime', nullable: false},

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '6fb451dbbe6ae6105e92b39c715e9afd';
+    const currentSchemaHash = 'edd2611c5a774ac64035b71ea966ade4';
     const currentFixturesHash = '29148c40dfaf4f828c5fca95666f6545';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
no issue

The email table should be a reference for all data that was used when sending an email. From and Reply-to addresses can change over time and we don't have any other reference for their value at the time of sending an email so we should store them alongside the email content.

- schema updated with `from` and `reply_to` columns and migration added to add/remove those columns
- both are set to `nullable` because we don't have historic data (can be populated and changed in later migrations if needed)
- neither have `isEmail` validations because from/reply-to values can have name+email in an email-specific format
- will help keep concerns separated in the future. `mega` service can deal with all of the email contents/properties, and the `bulk-email` service's concerns are then only email sending and any provider-specific needs