### PR TITLE
Add tokens table

### DIFF
--- a/core/server/data/migrations/versions/3.34/01-add-tokens-table.js
+++ b/core/server/data/migrations/versions/3.34/01-add-tokens-table.js
@@ -1,0 +1,2 @@
+const {addTable} = require('../../utils');
+module.exports = addTable('tokens');

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -483,5 +483,12 @@ module.exports = {
         member_uuid: {type: 'string', maxlength: 36, nullable: false},
         member_email: {type: 'string', maxlength: 191, nullable: false},
         member_name: {type: 'string', maxlength: 191, nullable: true}
+    },
+    tokens: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        token: {type: 'string', maxlength: 24, nullable: false, index: true},
+        data: {type: 'string', maxlength: 2000, nullable: true},
+        created_at: {type: 'dateTime', nullable: false},
+        created_by: {type: 'string', maxlength: 24, nullable: false}
     }
 };

--- a/test/api-acceptance/admin/db_spec.js
+++ b/test/api-acceptance/admin/db_spec.js
@@ -55,7 +55,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(32);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(33);
             });
     });
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c2b2de0157edddb68791dde49391d4e5';
+    const currentSchemaHash = 'e90889dff39d27934ad7550dcb0e641c';
     const currentFixturesHash = '29148c40dfaf4f828c5fca95666f6545';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
This is a table to store single use tokens for use in magic links, the
columns are as simple as possible at the moment and are designed as:

`id` - standard ObjectID like all of our tables
`token` - 128bit base64 encoded string
`data` - arbitrary data to store against the token
`created_at` - timestamp to allow for expiry to be implemented for tokens