### PR TITLE
Added new portal config flag

### DIFF
--- a/core/frontend/helpers/content.js
+++ b/core/frontend/helpers/content.js
@@ -42,7 +42,7 @@ module.exports = function content(options = {}) {
         this.html = '';
     }
 
-    if (!this.access && !!config.get('enableDeveloperExperiments')) {
+    if (!this.access && (!!config.get('enableDeveloperExperiments') || !!config.get('portal'))) {
         return restrictedCta.apply(self, args);
     }
 

--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -43,7 +43,7 @@ function getMembersHelper() {
     const stripeConnectAccountId = settingsCache.get('stripe_connect_account_id');
 
     let membersHelper = `<script defer src="${getAssetUrl('public/members.js', true)}"></script>`;
-    if (config.get('enableDeveloperExperiments')) {
+    if (config.get('enableDeveloperExperiments') || config.get('portal')) {
         membersHelper = `<script defer src="https://unpkg.com/@tryghost/members-js@latest/umd/members.min.js" data-ghost="${urlUtils.getSiteUrl()}"></script>`;
         membersHelper += (`<style type='text/css'> ${templateStyles}</style>`);
     }

--- a/core/server/api/canary/config.js
+++ b/core/server/api/canary/config.js
@@ -20,7 +20,8 @@ module.exports = {
                 clientExtensions: config.get('clientExtensions') || {},
                 enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
                 stripeDirect: config.get('stripeDirect'),
-                mailgunIsConfigured: config.get('bulkEmail') && config.get('bulkEmail').mailgun
+                mailgunIsConfigured: config.get('bulkEmail') && config.get('bulkEmail').mailgun,
+                portal: config.get('portal')
             };
             if (billingUrl) {
                 response.billingUrl = billingUrl;

--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -114,5 +114,6 @@
     "preloadHeaders": false,
     "adminFrameProtection": true,
     "sendWelcomeEmail": true,
-    "stripeDirect": false
+    "stripeDirect": false,
+    "portal": false
 }

--- a/test/api-acceptance/admin/utils.js
+++ b/test/api-acceptance/admin/utils.js
@@ -23,7 +23,7 @@ const expectedProperties = {
 
     action: ['id', 'resource_type', 'actor_type', 'event', 'created_at', 'actor'],
 
-    config: ['version', 'environment', 'database', 'mail', 'labs', 'clientExtensions', 'enableDeveloperExperiments', 'useGravatar', 'stripeDirect'],
+    config: ['version', 'environment', 'database', 'mail', 'labs', 'clientExtensions', 'enableDeveloperExperiments', 'useGravatar', 'stripeDirect', 'portal'],
 
     post: _(schema.posts)
         .keys()


### PR DESCRIPTION
no issue

- The new Portal config flag allows switching on Portal conditionally with config
- The dev experiment flag still works for enabling Portal
- The flag currently defaults to `false` as Portal is still a beta feature and switched off by default
- We expose it on the admin api config endpoint so that the Ghost-Admin client can use it to conditionally render Portal settings
