### PR TITLE
Updated getMagicLink call to handle Promise return

### DIFF
--- a/core/server/api/canary/memberSigninUrls.js
+++ b/core/server/api/canary/memberSigninUrls.js
@@ -19,7 +19,7 @@ module.exports = {
                 });
             }
 
-            const magicLink = membersService.api.getMagicLink(model.get('email'));
+            const magicLink = await membersService.api.getMagicLink(model.get('email'));
 
             return {
                 member_id: model.get('id'),


### PR DESCRIPTION
no-issue

refs: https://github.com/TryGhost/Members/commit/63942f03

The above commit updated all magic-link methods to be async, this change
ensures that we will handle a Promise return when it's updated in Ghost.
`await` has no effect on non Promise return values so it's safe to add
this now.
