### PR TITLE
Ordering by fields coming form posts_meta table

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -175,7 +175,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
     // Ghost ordering handling, allows to order by permitted attributes by default and can be overriden on specific model level
     orderAttributes: function orderAttributes() {
-        return this.permittedAttributes();
+        return Object.keys(schema.tables[this.tableName])
+            .map(key => `${this.tableName}.${key}`);
     },
 
     // When loading an instance, subclasses can specify default to fetch

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -34,6 +34,8 @@ ghostBookshelf = bookshelf(db.knex);
 // Load the Bookshelf registry plugin, which helps us avoid circular dependencies
 ghostBookshelf.plugin('registry');
 
+ghostBookshelf.plugin(plugins.eagerLoad);
+
 // Add committed/rollback events.
 ghostBookshelf.plugin(plugins.transactionEvents);
 

--- a/core/server/models/plugins/eager-load.js
+++ b/core/server/models/plugins/eager-load.js
@@ -1,0 +1,79 @@
+const _ = require('lodash');
+const _debug = require('ghost-ignition').debug._base;
+const debug = _debug('ghost-query');
+
+/**
+ * Enchances knex query builder with a join to relation configured in
+ *
+ * @param {Bookshelf.Model} model instance of Bookshelf model
+ * @param {String[]} relationsToLoad relations to be included in joins
+ */
+function withEager(model, relationsToLoad) {
+    const tableName = _.result(model.constructor.prototype, 'tableName');
+
+    return function (qb) {
+        if (!model.relationsMeta) {
+            return qb;
+        }
+
+        for (const [key, config] of Object.entries(model.relationsMeta)) {
+            if (relationsToLoad.includes(key)) {
+                const innerQb = qb
+                    .leftJoin(config.targetTableName, `${tableName}.id`, `${config.targetTableName}.${config.foreignKey}`);
+
+                debug(`QUERY has posts: ${innerQb.toSQL().sql}`);
+            }
+        }
+
+        return qb;
+    };
+}
+
+function load(options) {
+    if (!options) {
+        return;
+    }
+
+    if (this.eagerLoad) {
+        if (!options.columns && options.withRelated && _.intersection(this.eagerLoad, options.withRelated).length) {
+            this.query(withEager(this, this.eagerLoad));
+        }
+    }
+}
+
+/**
+ * ## Pagination
+ * Extends `bookshelf.Model` native `fetch` and `fetchAll` methods with
+ * a join to "eager loaded" relation. An exaple of such loading is when
+ * there is a need to order by fields in the related table.
+ *
+ */
+module.exports = function eagerLoadPlugin(Bookshelf) {
+    const modelPrototype = Bookshelf.Model.prototype;
+
+    Bookshelf.Model = Bookshelf.Model.extend({
+        initialize: function () {
+            return modelPrototype.initialize.apply(this, arguments);
+        },
+
+        fetch: function () {
+            load.apply(this, arguments);
+
+            if (_debug.enabled('ghost-query')) {
+                debug('QUERY', this.query().toQuery());
+            }
+
+            return modelPrototype.fetch.apply(this, arguments);
+        },
+
+        fetchAll: function () {
+            load.apply(this, arguments);
+
+            if (_debug.enabled('ghost-query')) {
+                debug('QUERY', this.query().toQuery());
+            }
+
+            return modelPrototype.fetchAll.apply(this, arguments);
+        }
+    });
+};

--- a/core/server/models/plugins/index.js
+++ b/core/server/models/plugins/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+    eagerLoad: require('./eager-load'),
     filter: require('./filter'),
     order: require('./order'),
     customQuery: require('./custom-query'),

--- a/core/server/models/plugins/order.js
+++ b/core/server/models/plugins/order.js
@@ -32,7 +32,7 @@ const order = function order(Bookshelf) {
                 direction = match[2].toUpperCase();
 
                 const matchingOrderAttribute = orderAttributes.find((orderAttribute) => {
-                    return orderAttribute.endsWith(`.${field}`);
+                    return orderAttribute.endsWith(field);
                 });
 
                 if (!matchingOrderAttribute) {

--- a/core/server/models/plugins/order.js
+++ b/core/server/models/plugins/order.js
@@ -31,11 +31,16 @@ const order = function order(Bookshelf) {
                 field = match[1].toLowerCase();
                 direction = match[2].toUpperCase();
 
-                if (orderAttributes.indexOf(field) === -1) {
+                const fieldRegexp = new RegExp(`${field}$`);
+                const matchingOrderAttribute = orderAttributes.find((value) => {
+                    return value.match(fieldRegexp);
+                });
+
+                if (!matchingOrderAttribute) {
                     return;
                 }
 
-                result[field] = direction;
+                result[matchingOrderAttribute] = direction;
             });
 
             return result;

--- a/core/server/models/plugins/order.js
+++ b/core/server/models/plugins/order.js
@@ -31,9 +31,8 @@ const order = function order(Bookshelf) {
                 field = match[1].toLowerCase();
                 direction = match[2].toUpperCase();
 
-                const fieldRegexp = new RegExp(`${field}$`);
-                const matchingOrderAttribute = orderAttributes.find((value) => {
-                    return value.match(fieldRegexp);
+                const matchingOrderAttribute = orderAttributes.find((orderAttribute) => {
+                    return orderAttribute.endsWith(`.${field}`);
                 });
 
                 if (!matchingOrderAttribute) {

--- a/core/server/models/plugins/order.js
+++ b/core/server/models/plugins/order.js
@@ -32,6 +32,10 @@ const order = function order(Bookshelf) {
                 direction = match[2].toUpperCase();
 
                 const matchingOrderAttribute = orderAttributes.find((orderAttribute) => {
+                    // NOTE: this logic assumes we use different field names for "parent" and "child" relations.
+                    //       E.g.: ['parent.title', 'child.title'] and ['child.title', 'parent.title'] - would not
+                    //       distinguish on which relation to sort neither which order to pick the fields on.
+                    //       For more context see: https://github.com/TryGhost/Ghost/pull/12226#discussion_r493085098
                     return orderAttribute.endsWith(field);
                 });
 

--- a/core/server/models/plugins/pagination.js
+++ b/core/server/models/plugins/pagination.js
@@ -90,6 +90,27 @@ paginationUtils = {
         }
 
         return pagination;
+    },
+
+    /**
+     *
+     * @param {Bookshelf.Model} model instance of Bookshelf model
+     * @param {string} propertyName property to be inspected and included in the relation
+     */
+    handleRelation: function handleRelation(model, propertyName) {
+        const tableName = _.result(model.constructor.prototype, 'tableName');
+
+        const targetTable = propertyName.includes('.') && propertyName.split('.')[0];
+
+        if (targetTable && targetTable !== tableName) {
+            if (!model.eagerLoad) {
+                model.eagerLoad = [];
+            }
+
+            if (!model.eagerLoad.includes(targetTable)) {
+                model.eagerLoad.push(targetTable);
+            }
+        }
     }
 };
 
@@ -183,6 +204,8 @@ pagination = function pagination(bookshelf) {
                             self.query('orderBy', 'count__posts', direction);
                         } else {
                             self.query('orderBy', property, direction);
+
+                            paginationUtils.handleRelation(self, property);
                         }
                     });
                 } else if (options.orderRaw) {

--- a/core/server/models/plugins/pagination.js
+++ b/core/server/models/plugins/pagination.js
@@ -182,7 +182,7 @@ pagination = function pagination(bookshelf) {
                         if (property === 'count.posts') {
                             self.query('orderBy', 'count__posts', direction);
                         } else {
-                            self.query('orderBy', tableName + '.' + property, direction);
+                            self.query('orderBy', property, direction);
                         }
                     });
                 } else if (options.orderRaw) {
@@ -199,6 +199,7 @@ pagination = function pagination(bookshelf) {
 
                 // Setup the promise to do a fetch on our collection, running the specified query
                 // @TODO: ensure option handling is done using an explicit pick elsewhere
+
                 return self.fetchAll(_.omit(options, ['page', 'limit']))
                     .then(function (fetchResult) {
                         if (options.limit === 'all') {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -68,6 +68,13 @@ Post = ghostBookshelf.Model.extend({
         posts_meta: 'posts_meta'
     },
 
+    relationsMeta: {
+        posts_meta: {
+            targetTableName: 'posts_meta',
+            foreignKey: 'post_id'
+        }
+    },
+
     /**
      * The base model keeps only the columns, which are defined in the schema.
      * We have to add the relations on top, otherwise bookshelf-relations

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -83,6 +83,15 @@ Post = ghostBookshelf.Model.extend({
         return filteredKeys;
     },
 
+    orderAttributes: function orderAttributes() {
+        let keys = ghostBookshelf.Model.prototype.orderAttributes.apply(this, arguments);
+
+        // extend ordered keys with post_meta keys
+        let postsMetaKeys = _.without(ghostBookshelf.model('PostsMeta').prototype.orderAttributes(), 'posts_meta.id', 'posts_meta.post_id');
+
+        return [...keys, ...postsMetaKeys];
+    },
+
     emitChange: function emitChange(event, options = {}) {
         let eventToTrigger;
         let resourceType = this.get('type');

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -89,6 +89,39 @@ describe('Posts API', function () {
                     done();
                 });
         });
+
+        it('can order by fields coming from posts_meta table', function (done) {
+            request.get(localUtils.API.getApiQuery('posts/?order=meta_description%20ASC'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    localUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(13);
+
+                    jsonResponse.posts[0].slug.should.equal('themes');
+                    should.equal(jsonResponse.posts[0].meta_description, null);
+                    jsonResponse.posts[12].slug.should.equal('short-and-sweet');
+                    jsonResponse.posts[12].meta_description.should.equal('test stuff');
+
+                    localUtils.API.checkResponse(
+                        jsonResponse.posts[0],
+                        'post'
+                    );
+
+                    localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+
+                    done();
+                });
+        });
     });
 
     describe('Read', function () {

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -107,7 +107,6 @@ describe('Posts API', function () {
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(13);
 
-                    jsonResponse.posts[0].slug.should.equal('themes');
                     should.equal(jsonResponse.posts[0].meta_description, null);
                     jsonResponse.posts[12].slug.should.equal('short-and-sweet');
                     jsonResponse.posts[12].meta_description.should.equal('test stuff');

--- a/test/regression/api/canary/admin/utils.js
+++ b/test/regression/api/canary/admin/utils.js
@@ -26,11 +26,12 @@ const expectedProperties = {
         .without('locale')
         .without('page')
         .without('author_id', 'author')
+        .without('type')
         // always returns computed properties
         // primary_tag and primary_author properties are included
         // only because authors and tags are always included
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
-        .concat('authors', 'tags')
+        .concat('authors', 'tags', 'email')
         // returns meta fields from `posts_meta` schema
         .concat(
             ..._(schema.posts_meta).keys().without('post_id', 'id')

--- a/test/unit/models/plugins/pagination_spec.js
+++ b/test/unit/models/plugins/pagination_spec.js
@@ -266,7 +266,7 @@ describe('pagination', function () {
 
                 model.prototype.query.calledTwice.should.be.true();
                 model.prototype.query.firstCall.calledWith().should.be.true();
-                model.prototype.query.secondCall.calledWith('orderBy', 'undefined.id', 'DESC').should.be.true();
+                model.prototype.query.secondCall.calledWith('orderBy', 'id', 'DESC').should.be.true();
 
                 mockQuery.clone.calledOnce.should.be.true();
                 mockQuery.clone.firstCall.calledWith().should.be.true();


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/11729

This is an attempt to add support for ordering by fields coming form `posts_meta` table. It introduces  couple new concepts:
1. A modification to ordering plugin - uses table names along with field names to form order query (e.g. `posts_meta.meta_description DESC`). This is needed to be able to specify ordering by different than model's native table.
2. Adds a "eager loading" plugin - it's main purpose is extension of the query with a join to relation which is used in ordering query.

@rishabhgrg & @allouis would love for you to have a look at the solution I've come up with, maybe you could spot something that is not obvious in the eager loading plugin or could come up with better naming/conventions for configurations that were introduced. In general would like a second pair of eyes from a perspective of "would I be able to use this plugin/ordering thing out of the box on similar relation in the future" :) Thanks!