### PR TITLE
  Added support for filtering Members CSV exports

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -399,7 +399,10 @@ module.exports = {
 
     exportCSV: {
         options: [
-            'limit'
+            'limit',
+            'filter',
+            'search',
+            'paid'
         ],
         headers: {
             disposition: {

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "mocha": "8.1.3",
     "mock-knex": "0.4.9",
     "nock": "13.0.4",
+    "papaparse": "^5.3.0",
     "proxyquire": "2.1.3",
     "rewire": "5.0.0",
     "should": "13.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,7 +388,7 @@
   resolved "https://registry.yarnpkg.com/@tryghost/constants/-/constants-0.1.1.tgz#f92f9e5938c3bc1839fbc16353009a106bbd19ee"
   integrity sha512-CTLFnSz0XREKZqDUn7yoBWnsVoUa4dWOJrz/3Dk55IVSIaPAG/qcgKCOmroZ9f1IyJZFIrqCRfPOO9k0mUaWoA==
 
-"@tryghost/errors@0.2.4", "@tryghost/errors@^0.2.4":
+"@tryghost/errors@0.2.4", "@tryghost/errors@^0.2.3", "@tryghost/errors@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-0.2.4.tgz#873107f0915667852f86e616a8698eddf7b1f59e"
   integrity sha512-U0S/oeRCvYDe2Uuzx+D7dKQDW91D24wGm0cP90wf3EOzJH82imYFYgRXT4FZ6ypnraSSC74IFPT/+2Kyp9CnFQ==
@@ -6888,7 +6888,7 @@ pako@^1.0.11, pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-papaparse@5.3.0:
+papaparse@5.3.0, papaparse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.0.tgz#ab1702feb96e79ab4309652f36db9536563ad05a"
   integrity sha512-Lb7jN/4bTpiuGPrYy4tkKoUS8sTki8zacB5ke1p5zolhcSE4TlWgrlsxjrDTbG/dFVh07ck7X36hUf/b5V68pg==


### PR DESCRIPTION
no-issue

This adds support for filtering to the Admin API's Members CSV export endpoint, which will be used by Ghost-Admin to give custom exports

