### PR TITLE
🐛 Fixed email verification mails not sent

### DIFF
--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -97,7 +97,7 @@ module.exports = {
             frame.response = async function (req, res) {
                 try {
                     const {token, action} = frame.options;
-                    const updatedEmailAddress = membersService.settings.getEmailFromToken({token});
+                    const updatedEmailAddress = await membersService.settings.getEmailFromToken({token});
                     const actionToKeyMapping = {
                         fromAddressUpdate: 'members_from_address',
                         supportAddressUpdate: 'members_support_address'


### PR DESCRIPTION
no issue

- Email ownership verification emails for support/from address was not using the updated magic link service syntax