### PR TITLE
Ensured Admin API members resource only returns known fields

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -165,12 +165,8 @@ module.exports = {
         async query(frame) {
             frame.options.withRelated = ['labels', 'stripeSubscriptions', 'stripeSubscriptions.customer'];
             const page = await membersService.api.members.list(frame.options);
-            const members = page.data.map(model => model.toJSON(frame.options));
 
-            return {
-                members: members,
-                meta: page.meta
-            };
+            return page;
         }
     },
 
@@ -192,7 +188,7 @@ module.exports = {
                 });
             }
 
-            return model.toJSON(frame.options);
+            return model;
         }
     },
 
@@ -240,7 +236,7 @@ module.exports = {
                     await membersService.api.sendEmailWithMagicLink({email: member.get('email'), requestedType: frame.options.email_type});
                 }
 
-                return member.toJSON(frame.options);
+                return member;
             } catch (error) {
                 if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
                     throw new errors.ValidationError({
@@ -305,7 +301,7 @@ module.exports = {
 
                 await member.load(['stripeSubscriptions.customer']);
 
-                return member.toJSON(frame.options);
+                return member;
             } catch (error) {
                 if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
                     throw new errors.ValidationError({
@@ -363,7 +359,7 @@ module.exports = {
                 });
             }
 
-            return model.toJSON(frame.options);
+            return model;
         }
     },
 
@@ -426,12 +422,8 @@ module.exports = {
         async query(frame) {
             frame.options.withRelated = ['labels', 'stripeSubscriptions', 'stripeSubscriptions.customer'];
             const page = await membersService.api.members.list(frame.options);
-            const members = page.data.map(model => model.toJSON(frame.options));
 
-            return {
-                members: members,
-                meta: page.meta
-            };
+            return page;
         }
     },
 

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -142,23 +142,6 @@ const mapAction = (model, frame) => {
     return attrs;
 };
 
-const mapMember = (model, frame) => {
-    const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
-
-    if (_.get(jsonModel, 'stripe.subscriptions')) {
-        let compedSubscriptions = _.get(jsonModel, 'stripe.subscriptions').filter(sub => (sub.plan.nickname === 'Complimentary'));
-        const hasCompedSubscription = !!(compedSubscriptions.length);
-
-        // NOTE: `frame.options.fields` has to be taken into account in the same way as for `stripe.subscriptions`
-        //       at the moment of implementation fields were not fully supported by members endpoints
-        Object.assign(jsonModel, {
-            comped: hasCompedSubscription
-        });
-    }
-
-    return jsonModel;
-};
-
 const mapLabel = (model, frame) => {
     const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
     return jsonModel;
@@ -189,5 +172,4 @@ module.exports.mapIntegration = mapIntegration;
 module.exports.mapSettings = mapSettings;
 module.exports.mapImage = mapImage;
 module.exports.mapAction = mapAction;
-module.exports.mapMember = mapMember;
 module.exports.mapEmail = mapEmail;


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12055

As part of the work in https://github.com/TryGhost/Members/pull/206 we load the `stripeCustomers` relation on the member model, and we do not want this to be part of the API response. The changes here include a refactor but the main thing is that the serialized object is explicit and does not include unexpected or unknown fields.