### PR TITLE
Updated all Origin header checks to handle 'null'

### DIFF
--- a/core/server/services/auth/session/index.js
+++ b/core/server/services/auth/session/index.js
@@ -13,7 +13,7 @@ function getOriginOfRequest(req) {
     const origin = req.get('origin');
     const referrer = req.get('referrer') || urlUtils.getAdminUrl() || urlUtils.getSiteUrl();
 
-    if (!origin && !referrer) {
+    if (!origin && !referrer || origin === 'null') {
         return null;
     }
 

--- a/core/server/web/api/middleware/cors.js
+++ b/core/server/web/api/middleware/cors.js
@@ -68,7 +68,7 @@ function handleCORS(req, cb) {
     const origin = req.get('origin');
 
     // Request must have an Origin header
-    if (!origin) {
+    if (!origin || origin === 'null') {
         return cb(null, DISABLE_CORS);
     }
 

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -31,7 +31,7 @@ const corsOptionsDelegate = function corsOptionsDelegate(req, callback) {
         credentials: true // required to allow admin-client to login to private sites
     };
 
-    if (!origin) {
+    if (!origin || origin === 'null') {
         return callback(null, corsOptions);
     }
 


### PR DESCRIPTION
closes #12244

As per RFC 6454 the Origin header MUST be set to the string 'null' when
in a "privacy-sensitive" context. We were not handling this string and
this was causing errors. This commit updates all checks of the 'Origin'
header to treat the value 'null' as if the header was not present.

ref: https://tools.ietf.org/html/rfc6454#section-7.3