### PR TITLE
Use raw from e-mail address if config is set

### DIFF
--- a/core/server/services/mail/GhostMailer.js
+++ b/core/server/services/mail/GhostMailer.js
@@ -27,8 +27,10 @@ function getFromAddress(requestedFromAddress) {
         return getFromAddress(`noreply@${getDomain()}`);
     }
 
+    const useRawFrom = config.get('mail') && config.get('mail').useRawFrom;
+
     // If we do have a from address, and it's just an email
-    if (validator.isEmail(address, {require_tld: false})) {
+    if (validator.isEmail(address, {require_tld: false}) && !useRawFrom) {
         const defaultBlogTitle = settingsCache.get('title') ? settingsCache.get('title').replace(/"/g, '\\"') : i18n.t('common.mail.title', {domain: getDomain()});
         return `"${defaultBlogTitle}" <${address}>`;
     }


### PR DESCRIPTION
When sending e-mail GhostMailer changes the from e-mail address to add the sender name but on some e-mail providers sender validation fails if the sender e-mail address is not raw. Having the ability to send raw from e-mail address by a config value solves this.
