### PR TITLE
Database seeding tool.

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,9 +144,11 @@
   "devDependencies": {
     "@lodder/grunt-postcss": "2.0.4",
     "coffeescript": "2.5.1",
+    "commander": "6.1.0",
     "cssnano": "4.1.10",
     "eslint": "7.11.0",
     "eslint-plugin-ghost": "1.5.0",
+    "faker": "5.1.0",
     "grunt": "1.3.0",
     "grunt-bg-shell": "2.3.3",
     "grunt-contrib-clean": "2.0.0",

--- a/test/tools/seeder/generator.js
+++ b/test/tools/seeder/generator.js
@@ -1,0 +1,61 @@
+const faker = require('faker');
+const ObjectId = require('bson-objectid');
+
+function html() {
+    const numParagraphs = Math.round(Math.random() * 10);
+    const paragraphs = [];
+
+    for (let i = 0; i < numParagraphs; i++) {
+        paragraphs.push(faker.lorem.sentences());
+    }
+
+    return paragraphs.map((p) => {
+        return `<p>${p}</p>`;
+    }).join('\n');
+}
+
+function visibility() {
+    const types = ['public', 'draft', 'member', 'paid'];
+    const num = Math.floor(Math.random() * (types.length + 1));
+
+    return types[num];
+}
+
+function post() {
+    return {
+        id: ObjectId.generate(),
+        title: faker.lorem.words(),
+        slug: faker.lorem.slug(),
+        html: html(),
+        published_at: faker.date.past(),
+        feature_image: faker.image.imageUrl(),
+        visibility: visibility()
+    };
+}
+
+function email(index) {
+    const fakeEmail = faker.internet.email();
+
+    if (index === -1) {
+        return fakeEmail;
+    } else {
+        const parts = fakeEmail.split('@');
+        parts[0] = `${parts[0]}.${index}`;
+
+        return parts.join('@');
+    }
+}
+
+function member(index = -1) {
+    return {
+        id: ObjectId.generate(),
+        email: email(index),
+        name: `${faker.name.firstName()} ${faker.name.lastName()}`,
+        subscribed: Math.round(Math.random()) // 0 or 1
+    };
+}
+
+module.exports = {
+    post,
+    member
+};

--- a/test/tools/seeder/index.js
+++ b/test/tools/seeder/index.js
@@ -1,0 +1,113 @@
+const {program} = require('commander');
+const fs = require('fs-extra');
+const path = require('path');
+const moment = require('moment');
+const migrator = require('../../../core/server/data/db/migrator');
+const models = require('../../../core/server/models');
+const testUtils = require('../../utils');
+const generator = require('./generator');
+
+const DB_PATH = path.join(__dirname, '../../../content/data/ghost-dev.db');
+
+async function setupDatabase() {
+    if (fs.existsSync(DB_PATH)) {
+        // eslint-disable-next-line no-console
+        console.log('sqlite database file exists. Rerun this command after backing up your file with backup command.');
+    } else {
+        return migrator.dbInit().then(() => {
+            // eslint-disable-next-line no-console
+            console.log('Database has been set up.');
+        });
+    }
+}
+
+program.version('0.0.1');
+program
+    .command('backup')
+    .description('Back up current SQLite database')
+    .action(async () => {
+        if (fs.existsSync(DB_PATH)) {
+            const filename = `ghost-dev-${moment().format('YYYY-MM-DD-HH-mm-ss')}.db`;
+            const backupPath = path.join(__dirname, `../../../content/data/${filename}`);
+
+            await fs.move(DB_PATH, backupPath);
+
+            // eslint-disable-next-line no-console
+            console.log(`database file has been backed up to ${filename}`);
+        } else {
+            // eslint-disable-next-line no-console
+            console.log(`sqlite database file does't exist`);
+        }
+    });
+
+program
+    .command('setup')
+    .description('Create SQLite database and tables')
+    .action(async () => {
+        await setupDatabase();
+    });
+
+program
+    .command('populate <type>')
+    .option('-c --count <number>', 'The number of records to create')
+    .description('Populate database with data.')
+    .action(async (type, options) => {
+        models.init();
+
+        const count = options && options.count ? parseInt(options.count) : 1;
+
+        if (type.toLowerCase() === 'post') {
+            for (let i = 0; i < count; i++) {
+                await models.Post.add(generator.post(), {
+                    withRelated: ['author'],
+                    context: testUtils.context.owner.context
+                });
+
+                if (i > 0 && i % 100 === 0) {
+                    // eslint-disable-next-line no-console
+                    console.log(`${i} posts are generated.`);
+                }
+            }
+
+            // eslint-disable-next-line no-console
+            console.log('post generation finished.');
+            process.exit();
+        }
+
+        if (type.toLowerCase() === 'member') {
+            for (let i = 0; i < count; i++) {
+                await models.Member.add(generator.member(i));
+
+                if (i > 0 && i % 100 === 0) {
+                    // eslint-disable-next-line no-console
+                    console.log(`${i} members are generated.`);
+                }
+            }
+
+            // eslint-disable-next-line no-console
+            console.log('member generation finished.');
+            process.exit();
+        }
+    });
+
+program
+    .command('reset')
+    .description('Delete everything')
+    .action(async () => {
+        if (fs.existsSync(DB_PATH)) {
+            await fs.remove(DB_PATH);
+
+            // eslint-disable-next-line no-console
+            console.log(`database file has been removed.`);
+        } else {
+            // eslint-disable-next-line no-console
+            console.log(`sqlite database file does't exist.`);
+        }
+
+        // eslint-disable-next-line no-console
+        console.log('Start the setup process.');
+
+        await setupDatabase();
+    });
+
+program.parseAsync(process.argv);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,6 +1968,11 @@ commander@5.1.0, commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+commander@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
+  integrity sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==
+
 commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -3417,6 +3422,11 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+faker@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.1.0.tgz#e10fa1dec4502551aee0eb771617a7e7b94692e8"
+  integrity sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw==
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"


### PR DESCRIPTION
ref no-issue

I created this tool for the database performance test in #12180. 

Sometimes, we need to generate a lot of random contents for some tests. This tool generates them with simple commands like:

```
node ./test/tools/seeder populate post --count=10000
```

It also supports backup and reset. 

Currently, it's in the basic stage. 

* It only supports SQLite
* It only generates post and member types.
* The author of the post is always the author.
* It doesn't take stripe data of the member into account. 

But I'm publishing this PR because it can be a good starting point for other developers. If you don't want this, just close this. 

----

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
