### PR TITLE
Allowed for `comped` field when creating a member through Members API

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -399,8 +399,8 @@
             "members": {
                 "memberNotFound": "Member not found.",
                 "stripeNotConnected": {
-                    "message": "Missing Stripe connection",
-                    "context": "Attempting to import members with Stripe data when there is no Stripe account connected",
+                    "message": "Missing Stripe connection.",
+                    "context": "Attempting to import members with Stripe data when there is no Stripe account connected.",
                     "help": "You need to connect to Stripe to import Stripe customers. "
                 },
                 "stripeCustomerNotFound": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nexes/nql": "0.4.0",
     "@sentry/node": "5.26.0",
     "@tryghost/adapter-manager": "0.1.11",
-    "@tryghost/admin-api-schema": "1.0.1",
+    "@tryghost/admin-api-schema": "1.1.0",
     "@tryghost/bootstrap-socket": "0.2.2",
     "@tryghost/constants": "0.1.1",
     "@tryghost/errors": "0.2.4",

--- a/test/regression/api/canary/admin/members_spec.js
+++ b/test/regression/api/canary/admin/members_spec.js
@@ -105,6 +105,30 @@ describe('Members API', function () {
             .expect(422);
     });
 
+    it('Add should fail when comped flag is passed in but Stripe is not enabled', function () {
+        const member = {
+            email: 'memberTestAdd@test.com',
+            comped: true
+        };
+
+        return request
+            .post(localUtils.API.getApiQuery(`members/`))
+            .send({members: [member]})
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(422)
+            .then((res) => {
+                const jsonResponse = res.body;
+
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.errors);
+
+                jsonResponse.errors[0].message.should.eql('Validation error, cannot save member.');
+                jsonResponse.errors[0].context.should.match(/Missing Stripe connection./);
+            });
+    });
+
     // NOTE: this test should be enabled and expanded once test suite fully supports Stripe mocking
     it.skip('Can set a "Complimentary" subscription', function () {
         const memberToChange = {

--- a/test/regression/api/canary/admin/members_spec.js
+++ b/test/regression/api/canary/admin/members_spec.js
@@ -474,7 +474,7 @@ describe('Members API', function () {
                 jsonResponse.meta.stats.invalid.count.should.equal(2);
 
                 should.equal(jsonResponse.meta.stats.invalid.errors.length, 1);
-                jsonResponse.meta.stats.invalid.errors[0].message.should.equal('Missing Stripe connection');
+                jsonResponse.meta.stats.invalid.errors[0].message.should.match(/Missing Stripe connection/);
 
                 should.not.exist(jsonResponse.meta.import_label);
             });

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,10 +383,10 @@
   dependencies:
     "@tryghost/errors" "^0.2.4"
 
-"@tryghost/admin-api-schema@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-1.0.1.tgz#df5b736e7f217e070d643b4a5e46eba9e95be66f"
-  integrity sha512-AsaBPN3mdgu2dicFS82rdBhV8idz+nxy9Z7FNKaiv0jNRvHHSu9lQyAReio/JevBxnGsywp90CH3sJFUvgOSbw==
+"@tryghost/admin-api-schema@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-1.1.0.tgz#97224a9f5b74d08bdd93c1f89a85dfb2bfff9379"
+  integrity sha512-VSn4LMtVmIAHJxXPeW380s3TKy2UbXaWwVsPaUmtYKCAtyO1DelVB20Lnh/UMuWpKOBLVdzMwI66E7V5xxj/ww==
   dependencies:
     "@tryghost/errors" "0.2.4"
     bluebird "^3.5.3"


### PR DESCRIPTION
closes #12273

This PR is here for any possible discussion around copy/behavior change.

@peterzimon this is a change that allows for `comped` field to be passed in when creating a member. There were couple assumptions I've made around copy and behavior change, which wanted to confirm with you:
1. Previously the logic for `comped` field was to skip and continue member record creation if Stripe was not connected. Now we throw an error - same as the one we have been throwing before when `stripe_customer_id` field was passed in. The implication of this change is that we won't be creating any record now if `comped === true` and Stripe is disabled. I think this behavior makes the most sense, and would allow the client to re-run same 'POST /members/` call after failure if they have to configure Stripe on their instance.
2. I reused error message copy from `stripe_customer_id` error, which is:
```json
"stripeNotConnected": {
    "message": "Missing Stripe connection.",
    "context": "Attempting to import members with Stripe data when there is no Stripe account connected.",
    "help": "You need to connect to Stripe to import Stripe customers. "
},
```

I'm merging these changes as is for now, but let me know if you have any feedback on the above. Thx :) 