### PR TITLE
Fixed EmailBatch and EmailRecipient collections

### DIFF
--- a/core/server/models/email-batch.js
+++ b/core/server/models/email-batch.js
@@ -26,5 +26,5 @@ const EmailBatches = ghostBookshelf.Collection.extend({
 
 module.exports = {
     EmailBatch: ghostBookshelf.model('EmailBatch', EmailBatch),
-    EmailBatches: ghostBookshelf.model('EmailBatches', EmailBatches)
+    EmailBatches: ghostBookshelf.collection('EmailBatches', EmailBatches)
 };

--- a/core/server/models/email-recipient.js
+++ b/core/server/models/email-recipient.js
@@ -21,5 +21,5 @@ const EmailRecipients = ghostBookshelf.Collection.extend({
 
 module.exports = {
     EmailRecipient: ghostBookshelf.model('EmailRecipient', EmailRecipient),
-    EmailRecipients: ghostBookshelf.model('EmailRecipients', EmailRecipients)
+    EmailRecipients: ghostBookshelf.collection('EmailRecipients', EmailRecipients)
 };

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -28,7 +28,6 @@ const models = [
     'api-key',
     'mobiledoc-revision',
     'member',
-    'action',
     'posts-meta',
     'member-stripe-customer',
     'stripe-customer-subscription',
@@ -36,7 +35,10 @@ const models = [
     'email-batch',
     'email-recipient',
     'label',
-    'single-use-token'
+    'single-use-token',
+    // Action model MUST be loaded last as it loops through all of the registered models
+    // Please do not append items to this array.
+    'action'
 ];
 
 function init() {


### PR DESCRIPTION
no-issue

This also ensures that the Action model is loaded last as per the conversation in slack.

> Hey gang - I ran into a weird issue/bug today with models.I think it's two-fold, first the Action model, when it's first loaded will generate a list of candidates here: https://github.com/TryGhost/Ghost/blob/master/core/server/models/action.js#L6-L8. When this was first added to the codebase, the action model was the last model loaded https://github.com/TryGhost/Ghost/commit/8bb2c7d3d5c6f2b7e76f8c0462256c25a6e88e39#diff-3601f8c226e16bd8cc12e5c3ce4ef9cd27538a81f197be220f26f50c679696ef - this meant that it was able to pick up all models apart from itself.This IMO is quite brittle, because since then we now have 8 models which are not handled by the Action model https://github.com/TryGhost/Ghost/blob/master/core/server/models/index.js#L32-L39 - TBH I'm not 100% sure what this code does, or what the effect of not being handled is, but I don't think it's intentional, nor correct!This problem was discovered when I was adding some new models, and I copied the EmailRecipient model as a base, I started getting errors in the Action model about the tableName being undefined - I eventually found that this was due to use adding a model instead of a collection here: https://github.com/TryGhost/Ghost/blob/master/core/server/models/email-recipient.js#L24