### PR TITLE
Added migration for snippets table creation

### DIFF
--- a/core/server/data/migrations/versions/3.36/01-add-snippets-table.js
+++ b/core/server/data/migrations/versions/3.36/01-add-snippets-table.js
@@ -1,0 +1,2 @@
+const {addTable} = require('../../utils');
+module.exports = addTable('snippets');

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -492,5 +492,14 @@ module.exports = {
         data: {type: 'string', maxlength: 2000, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false}
+    },
+    snippets: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        name: {type: 'string', maxlength: 191, nullable: false, unique: true},
+        mobiledoc: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: false},
+        created_at: {type: 'dateTime', nullable: false},
+        created_by: {type: 'string', maxlength: 24, nullable: false},
+        updated_at: {type: 'dateTime', nullable: true},
+        updated_by: {type: 'string', maxlength: 24, nullable: true}
     }
 };

--- a/test/api-acceptance/admin/db_spec.js
+++ b/test/api-acceptance/admin/db_spec.js
@@ -55,7 +55,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(33);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(34);
             });
     });
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'edd2611c5a774ac64035b71ea966ade4';
+    const currentSchemaHash = 'c4de64f1c1114eb8b05c7473e3adc29e';
     const currentFixturesHash = '29148c40dfaf4f828c5fca95666f6545';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
no issue

- minimal table structure required for the first iteration of content snippets
- snippets are stored pieces of re-usable content that could effectively be entire posts so the `mobiledoc` field length matches the `posts.mobiledoc` field length