### PR TITLE
Added snippets permissions migration and fixtures

### DIFF
--- a/core/server/data/migrations/versions/3.36/02-add-snippets-permissions.js
+++ b/core/server/data/migrations/versions/3.36/02-add-snippets-permissions.js
@@ -1,0 +1,56 @@
+const {
+    combineTransactionalMigrations,
+    addPermissionWithRoles
+} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse snippets',
+        action: 'browse',
+        object: 'snippet'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor',
+        'Author',
+        'Contributor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Read snippets',
+        action: 'read',
+        object: 'snippet'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor',
+        'Author',
+        'Contributor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit snippets',
+        action: 'edit',
+        object: 'snippet'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add snippets',
+        action: 'add',
+        object: 'snippet'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete snippets',
+        action: 'destroy',
+        object: 'snippet'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor'
+    ])
+);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -427,6 +427,31 @@
                     "name": "Auth Stripe Connect for Members",
                     "action_type": "auth",
                     "object_type": "members_stripe_connect"
+                },
+                {
+                    "name": "Browse snippets",
+                    "action_type": "browse",
+                    "object_type": "snippet"
+                },
+                {
+                    "name": "Read snippets",
+                    "action_type": "read",
+                    "object_type": "snippet"
+                },
+                {
+                    "name": "Edit snippets",
+                    "action_type": "edit",
+                    "object_type": "snippet"
+                },
+                {
+                    "name": "Add snippets",
+                    "action_type": "add",
+                    "object_type": "snippet"
+                },
+                {
+                    "name": "Delete snippets",
+                    "action_type": "delete",
+                    "object_type": "snippet"
                 }
             ]
         },
@@ -625,7 +650,8 @@
                     "label": "all",
                     "email_preview": "all",
                     "email": "all",
-                    "member_signin_url": "read"
+                    "member_signin_url": "read",
+                    "snippet": "all"
                 },
                 "DB Backup Integration": {
                     "db": "all"
@@ -650,7 +676,8 @@
                     "member": "all",
                     "label": "all",
                     "email_preview": "all",
-                    "email": "all"
+                    "email": "all",
+                    "snippet": "all"
                 },
                 "Editor": {
                     "notification": "all",
@@ -663,7 +690,8 @@
                     "invite": "all",
                     "theme": ["browse"],
                     "email_preview": "all",
-                    "email": "all"
+                    "email": "all",
+                    "snippet": "all"
                 },
                 "Author": {
                     "post": ["browse", "read", "add"],
@@ -674,7 +702,8 @@
                     "role": ["browse"],
                     "theme": ["browse"],
                     "email_preview": "read",
-                    "email": "read"
+                    "email": "read",
+                    "snippet": ["browse", "read"]
                 },
                 "Contributor": {
                     "post": ["browse", "read", "add"],
@@ -685,7 +714,8 @@
                     "role": ["browse"],
                     "theme": ["browse"],
                     "email_preview": "read",
-                    "email": "read"
+                    "email": "read",
+                    "snippet": ["browse", "read"]
                 }
             }
         },

--- a/test/regression/migrations/migration_spec.js
+++ b/test/regression/migrations/migration_spec.js
@@ -201,12 +201,30 @@ describe('Database Migration (special functions)', function () {
             permissions[65].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
             permissions[66].name.should.eql('Retry emails');
             permissions[66].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
+
+            // Labels
             permissions[67].name.should.eql('Browse labels');
             permissions[68].name.should.eql('Read labels');
             permissions[69].name.should.eql('Edit labels');
             permissions[70].name.should.eql('Add labels');
             permissions[71].name.should.eql('Delete labels');
+
+            // Member auth
             permissions[72].name.should.eql('Read member signin urls');
+            permissions[73].name.should.eql('Read identities');
+            permissions[74].name.should.eql('Auth Stripe Connect for Members');
+
+            // Snippets
+            permissions[75].name.should.eql('Browse snippets');
+            permissions[75].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions[76].name.should.eql('Read snippets');
+            permissions[76].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions[77].name.should.eql('Edit snippets');
+            permissions[77].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
+            permissions[78].name.should.eql('Add snippets');
+            permissions[78].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
+            permissions[79].name.should.eql('Delete snippets');
+            permissions[79].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
         });
 
         describe('Populate', function () {
@@ -264,7 +282,7 @@ describe('Database Migration (special functions)', function () {
                     result.roles.at(7).get('name').should.eql('Scheduler Integration');
 
                     // Permissions
-                    result.permissions.length.should.eql(75);
+                    result.permissions.length.should.eql(80);
                     result.permissions.toJSON().should.be.CompletePermissions();
                 });
             });

--- a/test/unit/data/schema/fixtures/utils_spec.js
+++ b/test/unit/data/schema/fixtures/utils_spec.js
@@ -152,19 +152,19 @@ describe('Migration Fixture Utils', function () {
             fixtureUtils.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
-                result.should.have.property('expected', 69);
-                result.should.have.property('done', 69);
+                result.should.have.property('expected', 74);
+                result.should.have.property('done', 74);
 
                 // Permissions & Roles
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(69);
+                dataMethodStub.filter.callCount.should.eql(74);
                 dataMethodStub.find.callCount.should.eql(7);
-                baseUtilAttachStub.callCount.should.eql(69);
+                baseUtilAttachStub.callCount.should.eql(74);
 
-                fromItem.related.callCount.should.eql(69);
-                fromItem.findWhere.callCount.should.eql(69);
-                toItem[0].get.callCount.should.eql(138);
+                fromItem.related.callCount.should.eql(74);
+                fromItem.findWhere.callCount.should.eql(74);
+                toItem[0].get.callCount.should.eql(148);
 
                 done();
             }).catch(done);

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -33,7 +33,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'c4de64f1c1114eb8b05c7473e3adc29e';
-    const currentFixturesHash = '29148c40dfaf4f828c5fca95666f6545';
+    const currentFixturesHash = '3f99425b6349553ee246b14f3b24c9f8';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
no issue

- all staff users can browse/read snippets so they're usable in the editor for everyone
- only administrators, editors, and admin integrations are able to create/edit/delete snippets