### PR TITLE
Moved definition of default max image width to config

### DIFF
--- a/core/server/web/api/middleware/normalize-image.js
+++ b/core/server/web/api/middleware/normalize-image.js
@@ -18,7 +18,7 @@ module.exports = function normalize(req, res, next) {
         in: originalPath,
         out,
         ext: req.file.ext,
-        width: 2000
+        width: config.get('imageOptimization:defaultMaxWidth')
     }, imageOptimizationOptions);
 
     imageTransform.resizeFromPath(options)

--- a/core/shared/config/overrides.json
+++ b/core/shared/config/overrides.json
@@ -77,6 +77,7 @@
         }
     },
     "imageOptimization": {
+        "defaultMaxWidth": 2000,
         "contentImageSizes": {
             "w600": {"width": 600},
             "w1000": {"width": 1000},


### PR DESCRIPTION
no issue

- centralises definition of max width and allows customisation if needed
- allows for passing of the config value through to rendering libraries