### PR TITLE
🐛 Fixed special chars in single use token

### DIFF
--- a/core/server/models/single-use-token.js
+++ b/core/server/models/single-use-token.js
@@ -10,8 +10,8 @@ const SingleUseToken = ghostBookshelf.Model.extend({
                 .randomBytes(192 / 8)
                 .toString('base64')
                 // base64url encoding means the tokens are URL safe
-                .replace('+', '-')
-                .replace('/', '_')
+                .replace(/\+/g, '-')
+                .replace(/\//g, '_')
         };
     }
 }, {


### PR DESCRIPTION
no refs

- The token generation logic for single use token was replacing only the first instance of `+` or `/` to make the token URL safe, instead of replacing all instances which caused a bug where token was not validated properly in case it included multiple `+` or `/` in it.
- The fix ensures replacing all the `+` or `/` in the token with URL safe `_` or `-` so it can be properly validated via magic link