### PR TITLE
Added workflow to build the latest code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+jobs:
+  zip:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Set up Git
+        run: |
+          git config --global pull.rebase true
+          git config --global user.name "Ghost CI"
+          git config --global user.email "ghost@example.com"
+
+      - run: yarn
+      - run: grunt master --upstream=origin
+
+      - run: echo "ghost_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - run: echo "ghost_admin_hash=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        working-directory: core/client
+
+      - run: git add core/client content/themes/casper && git commit -m "Updated Ghost-Admin and Casper"
+
+      - run: npm version minor
+      - run: npm version minor
+        working-directory: core/client
+
+      - run: grunt release --skip-update
+
+      - run: |
+          for file in *; do
+            basename="${file%.*}"
+            extension="${file##*.}"
+            mv "$file" "$basename-$ghost_hash-$ghost_admin_hash.$extension"
+          done
+        working-directory: .dist/release
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ghost-latest
+          path: .dist/release/*
+          retention-days: 7

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -614,9 +614,13 @@ const configureGrunt = function (grunt) {
                 }]
             });
 
+            if (!grunt.option('skip-update')) {
+                grunt.task
+                    .run('update_submodules:pinned')
+                    .run('subgrunt:init');
+            }
+
             grunt.task
-                .run('update_submodules:pinned')
-                .run('subgrunt:init')
                 .run('clean:built')
                 .run('clean:tmp')
                 .run('prod')


### PR DESCRIPTION
- we want to allow people to download and run the latest code in Ghost
  and Ghost-Admin from Ghost-CLI without going through the process of
  cloning the repos
- this GitHub Actions will generate a release zip and upload it as an
  artifact
- we then have a tool to download the latest artifact, which can be used
  in Ghost-CLI