### PR TITLE
Enabled filtering by posts_meta table fields

### DIFF
--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -24,6 +24,11 @@ const RELATIONS = {
         joinTable: 'members_labels',
         joinFrom: 'member_id',
         joinTo: 'label_id'
+    },
+    posts_meta: {
+        tableName: 'posts_meta',
+        type: 'oneToOne',
+        joinFrom: 'post_id'
     }
 };
 
@@ -66,7 +71,7 @@ const filter = function filter(Bookshelf) {
         enforcedFilters() {},
         defaultFilters() {},
         extraFilters() {},
-
+        filterExpansions() {},
         /**
          * Method which makes the necessary query builder calls (through knex) for the filters set on this model
          * instance.
@@ -74,7 +79,15 @@ const filter = function filter(Bookshelf) {
         applyDefaultAndCustomFilters: function applyDefaultAndCustomFilters(options) {
             const nql = require('@nexes/nql');
 
-            const expansions = EXPANSIONS[this.tableName];
+            const expansions = [];
+
+            if (EXPANSIONS[this.tableName]) {
+                expansions.push(...EXPANSIONS[this.tableName]);
+            }
+
+            if (this.filterExpansions()) {
+                expansions.push(...this.filterExpansions());
+            }
 
             let custom = options.filter;
             let extra = this.extraFilters(options);

--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -27,33 +27,36 @@ const RELATIONS = {
     }
 };
 
-const EXPANSIONS = [{
-    key: 'primary_tag',
-    replacement: 'tags.slug',
-    expansion: 'posts_tags.sort_order:0+tags.visibility:public'
-}, {
-    key: 'primary_author',
-    replacement: 'authors.slug',
-    expansion: 'posts_authors.sort_order:0+authors.visibility:public'
-}, {
-    key: 'authors',
-    replacement: 'authors.slug'
-}, {
-    key: 'author',
-    replacement: 'authors.slug'
-}, {
-    key: 'tag',
-    replacement: 'tags.slug'
-}, {
-    key: 'tags',
-    replacement: 'tags.slug'
-}, {
-    key: 'label',
-    replacement: 'labels.slug'
-}, {
-    key: 'labels',
-    replacement: 'labels.slug'
-}];
+const EXPANSIONS = {
+    posts: [{
+        key: 'primary_tag',
+        replacement: 'tags.slug',
+        expansion: 'posts_tags.sort_order:0+tags.visibility:public'
+    }, {
+        key: 'primary_author',
+        replacement: 'authors.slug',
+        expansion: 'posts_authors.sort_order:0+authors.visibility:public'
+    }, {
+        key: 'authors',
+        replacement: 'authors.slug'
+    }, {
+        key: 'author',
+        replacement: 'authors.slug'
+    }, {
+        key: 'tag',
+        replacement: 'tags.slug'
+    }, {
+        key: 'tags',
+        replacement: 'tags.slug'
+    }],
+    members: [{
+        key: 'label',
+        replacement: 'labels.slug'
+    }, {
+        key: 'labels',
+        replacement: 'labels.slug'
+    }]
+};
 
 const filter = function filter(Bookshelf) {
     const Model = Bookshelf.Model.extend({
@@ -70,6 +73,8 @@ const filter = function filter(Bookshelf) {
          */
         applyDefaultAndCustomFilters: function applyDefaultAndCustomFilters(options) {
             const nql = require('@nexes/nql');
+
+            const expansions = EXPANSIONS[this.tableName];
 
             let custom = options.filter;
             let extra = this.extraFilters(options);
@@ -94,7 +99,7 @@ const filter = function filter(Bookshelf) {
                 this.query((qb) => {
                     nql(custom, {
                         relations: RELATIONS,
-                        expansions: EXPANSIONS,
+                        expansions: expansions,
                         overrides: overrides,
                         defaults: defaults,
                         transformer: transformer

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -99,6 +99,17 @@ Post = ghostBookshelf.Model.extend({
         return [...keys, ...postsMetaKeys];
     },
 
+    filterExpansions: function filterExpansions() {
+        const postsMetaKeys = _.without(ghostBookshelf.model('PostsMeta').prototype.orderAttributes(), 'posts_meta.id', 'posts_meta.post_id');
+
+        return postsMetaKeys.map((pmk) => {
+            return {
+                key: pmk.split('.')[1],
+                replacement: pmk
+            };
+        });
+    },
+
     emitChange: function emitChange(event, options = {}) {
         let eventToTrigger;
         let resourceType = this.get('type');

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cli": "^1.12.0"
   },
   "dependencies": {
-    "@nexes/nql": "0.4.0",
+    "@nexes/nql": "0.5.0",
     "@sentry/node": "5.27.2",
     "@tryghost/adapter-manager": "0.1.11",
     "@tryghost/admin-api-schema": "1.2.0",

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -90,6 +90,35 @@ describe('Posts API', function () {
                 });
         });
 
+        it('can filter by fields coming from posts_meta table', function (done) {
+            request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:-null`))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    localUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(1);
+                    jsonResponse.posts[0].id.should.equal('CHECK IF ID IS CORRECT');
+
+                    localUtils.API.checkResponse(
+                        jsonResponse.posts[0],
+                        'post'
+                    );
+
+                    localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+
+                    done();
+                });
+        });
+
         it('can order by fields coming from posts_meta table', function (done) {
             request.get(localUtils.API.getApiQuery('posts/?order=meta_description%20ASC'))
                 .set('Origin', config.get('url'))

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -90,7 +90,7 @@ describe('Posts API', function () {
                 });
         });
 
-        it('can filter by fields coming from posts_meta table', function (done) {
+        it('can filter by fields coming from posts_meta table non null meta_description', function (done) {
             request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:-null`))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
@@ -106,7 +106,9 @@ describe('Posts API', function () {
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(2);
-                    jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[2].id);
+                    jsonResponse.posts.forEach((post) => {
+                        should.notEqual(post.meta_description, null);
+                    });
 
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],
@@ -120,7 +122,7 @@ describe('Posts API', function () {
         });
 
         it('can filter by fields coming from posts_meta table by value', function (done) {
-            request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:'test description'`))
+            request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:'meta description for short and sweet'`))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
@@ -136,6 +138,7 @@ describe('Posts API', function () {
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(1);
                     jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[2].id);
+                    jsonResponse.posts[0].meta_description.should.equal('meta description for short and sweet');
 
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],
@@ -167,7 +170,7 @@ describe('Posts API', function () {
 
                     should.equal(jsonResponse.posts[0].meta_description, null);
                     jsonResponse.posts[12].slug.should.equal('short-and-sweet');
-                    jsonResponse.posts[12].meta_description.should.equal('test stuff');
+                    jsonResponse.posts[12].meta_description.should.equal('meta description for short and sweet');
 
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -119,6 +119,35 @@ describe('Posts API', function () {
                 });
         });
 
+        it('can filter by fields coming from posts_meta table by value', function (done) {
+            request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:'test description'`))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    const jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    localUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(1);
+                    jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[2].id);
+
+                    localUtils.API.checkResponse(
+                        jsonResponse.posts[0],
+                        'post'
+                    );
+
+                    localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+
+                    done();
+                });
+        });
+
         it('can order by fields coming from posts_meta table', function (done) {
             request.get(localUtils.API.getApiQuery('posts/?order=meta_description%20ASC'))
                 .set('Origin', config.get('url'))

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -105,7 +105,7 @@ describe('Posts API', function () {
                     const jsonResponse = res.body;
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
-                    jsonResponse.posts.should.have.length(1);
+                    jsonResponse.posts.should.have.length(2);
                     jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[2].id);
 
                     localUtils.API.checkResponse(

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -106,7 +106,7 @@ describe('Posts API', function () {
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(1);
-                    jsonResponse.posts[0].id.should.equal('CHECK IF ID IS CORRECT');
+                    jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[2].id);
 
                     localUtils.API.checkResponse(
                         jsonResponse.posts[0],

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -816,7 +816,7 @@ DataGenerator.forKnex = (function () {
         {
             id: ObjectId.generate(),
             post_id: DataGenerator.Content.posts[2].id,
-            meta_description: 'test stuff'
+            meta_description: 'meta description for short and sweet'
         },
         {
             id: ObjectId.generate(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,10 +94,10 @@
     url-regex "~5.0.0"
     video-extensions "~1.1.0"
 
-"@nexes/mongo-knex@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@nexes/mongo-knex/-/mongo-knex-0.3.0.tgz#e0078f8ddf7fcd4d907fe5cf2390644218753cf0"
-  integrity sha512-LgPWH4mR+IWYh1/Y/ob22kVMYVBY2k/evE/QdXYifQcEOd2G0NRggRB7SQX8kLQ024FcjtIMfRXC3UjzFamUcw==
+"@nexes/mongo-knex@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@nexes/mongo-knex/-/mongo-knex-0.4.0.tgz#bdaef8d8cefeb9935ab7e3a1f5d0bbcfb764722e"
+  integrity sha512-RyfcK1+WJQ0SM7r0D5fMhKwjggxyrDb8hMaQ1vqfcMe/SE2J/qoSra9+fAdwN8zYRdz6Lovd6fqCaRQ5zFv5ZA==
   dependencies:
     debug "^4.1.0"
     lodash "^4.17.10"
@@ -116,12 +116,12 @@
   resolved "https://registry.yarnpkg.com/@nexes/nql-lang/-/nql-lang-0.0.1.tgz#a13c023873f9bc11b9e4e284449c6cfbeccc8011"
   integrity sha1-oTwCOHP5vBG55OKERJxs++zMgBE=
 
-"@nexes/nql@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@nexes/nql/-/nql-0.4.0.tgz#5ae28f8d339d56812eb8452ead9a5e5996087efd"
-  integrity sha512-fEsV2aMiPpqBneZosamFLypLAQAp8M5SA5MgeeJKMpHF0dQiHn9ifD556RgaSSY5RgO0gbRGoKypgy0YmyE1KQ==
+"@nexes/nql@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@nexes/nql/-/nql-0.5.0.tgz#bff22dbd4e2aa697d5c33031675cb100b013a0a4"
+  integrity sha512-skn8cfr0OJFu6HdcLRgBL19bJ2S7pATrgR/RnZR3v4T4iHfAkZ8zzLDMGib+721eFaAURnpGfPittO+RyPAhiQ==
   dependencies:
-    "@nexes/mongo-knex" "0.3.0"
+    "@nexes/mongo-knex" "0.4.0"
     "@nexes/mongo-utils" "0.3.0"
     "@nexes/nql-lang" "0.0.1"
     mingo "2.2.2"


### PR DESCRIPTION
refs #11572

@kevinansfield @allouis @rishabhgrg raising this PR mostly to raise awareness in the team about change in filtering plugin. There are few things to note:
1. The `EXPANSIONS` lookup is now keyed by table name - this allows to avoid conflicts in the future when same key expansion has to be declared with different expansion. For example, right now `meta_description` would expand to `posts_meta.meta_description`. If we were to add `tags_meta` in the future with same key names it would be impossible to distinguish expansion into `posts_meta` or `tags_meta` table.
2.  New model method `filterExpansions` - main usecase for this method is to be able to declare expansions directly on the model. In future iterations might be a good idea to get rid of whole `EXPANSIONS` lookup in favor of using model specific properties.
3. We now support filtering in 1:1 relations :tada: 

I'll keep this PR open till Monday to allow for any comments if there are any. Let me know if you have questions or feedback about the approach taken :wink: 
