### PR TITLE
Added custom action param for portal magic links

### DIFF
--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -237,12 +237,13 @@ class MembersConfigProvider {
         };
     }
 
-    getSigninURL(token, type) {
+    getSigninURL(token, type, requestSrc) {
         const siteUrl = this._urlUtils.getSiteUrl();
         const signinURL = new URL(siteUrl);
         signinURL.pathname = path.join(signinURL.pathname, '/members/');
+        const actionParam = requestSrc === 'portal' ? 'portal-action' : 'action';
         signinURL.searchParams.set('token', token);
-        signinURL.searchParams.set('action', type);
+        signinURL.searchParams.set(actionParam, type);
         return signinURL.href;
     }
 }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12253

- Allows using custom action param for requests from Portal by using a new `requestSrc` option that is passed down when a request for magic link is made via Portal
