### PR TITLE
fix: content path issue resolution for custom adapter in ghost-v3

### DIFF
--- a/core/shared/config/utils.js
+++ b/core/shared/config/utils.js
@@ -50,17 +50,17 @@ exports.makePathsAbsolute = function makePathsAbsolute(obj, parent) {
 exports.getContentPath = function getContentPath(type) {
     switch (type) {
     case 'images':
-        return path.join(this.get('paths:contentPath'), 'images/');
+        return path.join(path.dirname(require.main.filename),this.get('paths:contentPath'), 'images/');
     case 'themes':
-        return path.join(this.get('paths:contentPath'), 'themes/');
+        return path.join(path.dirname(require.main.filename),this.get('paths:contentPath'), 'themes/');
     case 'adapters':
-        return path.join(this.get('paths:contentPath'), 'adapters/');
+        return path.join(path.dirname(require.main.filename),this.get('paths:contentPath'), 'adapters/');
     case 'logs':
-        return path.join(this.get('paths:contentPath'), 'logs/');
+        return path.join(path.dirname(require.main.filename),this.get('paths:contentPath'), 'logs/');
     case 'data':
-        return path.join(this.get('paths:contentPath'), 'data/');
+        return path.join(path.dirname(require.main.filename),this.get('paths:contentPath'), 'data/');
     case 'settings':
-        return path.join(this.get('paths:contentPath'), 'settings/');
+        return path.join(path.dirname(require.main.filename),this.get('paths:contentPath'), 'settings/');
     default:
         throw new Error('getContentPath was called with: ' + type);
     }


### PR DESCRIPTION
**Use Case**:
Wanted to use the `ghost-storage-adapter-s3` package in ghost v3.36

**What was the issue?**
In the config.production.json/config.development.json, added the paths
```
"paths": {
    "contentPath": "content"  
  }
```

But this path searches for module in `project-dir/node_modules/ghost/content` instead of `project-dir/content`

**How to reproduce this issue?**

1. Copy "ghost-storage-adapter-s3" package in `project-dir/content/adapters/storage` or use any custom adapter
2. Activate it from 'config' using
```
"storage": {
    "active": "ghost-storage-adapter-s3",
  },
```

3. Restart project, and now your `ghost` will search for this package in `project-dir/content` which its not able to find in current scenario.

**What i did to resolve this issue?**
The `utils` which is inside node_modules is constructing the path of inside "node_modules" instead of "project-directory"

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [X] There's a clear use-case for this code change
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
