### PR TITLE
Add `email_recipient_filter` column to posts table

### DIFF
--- a/core/server/data/migrations/versions/3.38/01-add-email-recipient-filter-column.js
+++ b/core/server/data/migrations/versions/3.38/01-add-email-recipient-filter-column.js
@@ -1,0 +1,25 @@
+const {createColumnMigration, addColumn, dropColumn} = require('../../../schema/commands');
+
+module.exports = {
+    up: createColumnMigration({
+        table: 'posts',
+        column: 'email_recipient_filter',
+        dbIsInCorrectState: hasColumn => !!hasColumn,
+        operation: addColumn,
+        operationVerb: 'Adding',
+        columnDefinition: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'none',
+            validations: {isIn: [['none', 'all', 'free', 'paid']]}
+        }
+    }),
+    down: createColumnMigration({
+        table: 'posts',
+        column: 'email_recipient_filter',
+        dbIsInCorrectState: hasColumn => !hasColumn,
+        operation: dropColumn,
+        operationVerb: 'Removing'
+    })
+};

--- a/core/server/data/migrations/versions/3.38/02-populate-email-recipient-filter-column.js
+++ b/core/server/data/migrations/versions/3.38/02-populate-email-recipient-filter-column.js
@@ -1,0 +1,34 @@
+const {createTransactionalMigration} = require('../../utils');
+const logging = require('../../../../../shared/logging');
+
+module.exports = createTransactionalMigration(
+    async function up(connection) {
+        logging.info('Updating email_recipient_filter values based on visibility and send_email_when_published');
+        await connection('posts')
+            .update('email_recipient_filter', 'paid')
+            .where({
+                send_email_when_published: true,
+                visibility: 'paid'
+            });
+
+        await connection('posts')
+            .update('email_recipient_filter', 'all')
+            .where({
+                send_email_when_published: true,
+                visibility: 'members'
+            });
+
+        await connection('posts')
+            .update('email_recipient_filter', 'all')
+            .where({
+                send_email_when_published: true,
+                visibility: 'public'
+            });
+    },
+
+    async function down(connection) {
+        logging.info('Updating email_recipient_filter values to none');
+        await connection('posts')
+            .update('email_recipient_filter', 'none');
+    }
+);

--- a/core/server/data/migrations/versions/3.38/03-add-recipient-filter-column.js
+++ b/core/server/data/migrations/versions/3.38/03-add-recipient-filter-column.js
@@ -1,0 +1,25 @@
+const {createColumnMigration, addColumn, dropColumn} = require('../../../schema/commands');
+
+module.exports = {
+    up: createColumnMigration({
+        table: 'emails',
+        column: 'recipient_filter',
+        dbIsInCorrectState: hasColumn => !!hasColumn,
+        operation: addColumn,
+        operationVerb: 'Adding',
+        columnDefinition: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'paid',
+            validations: {isIn: [['all', 'free', 'paid']]}
+        }
+    }),
+    down: createColumnMigration({
+        table: 'emails',
+        column: 'recipient_filter',
+        dbIsInCorrectState: hasColumn => !hasColumn,
+        operation: dropColumn,
+        operationVerb: 'Removing'
+    })
+};

--- a/core/server/data/migrations/versions/3.38/04-populate-recipient-filter-column.js
+++ b/core/server/data/migrations/versions/3.38/04-populate-recipient-filter-column.js
@@ -1,0 +1,35 @@
+const {createTransactionalMigration} = require('../../utils');
+const logging = require('../../../../../shared/logging');
+
+module.exports = createTransactionalMigration(
+    async function up(connection) {
+        logging.info('Updating emails.recipient_filter values based on posts.visibility');
+
+        const paidPostIds = (await connection('posts')
+            .select('id')
+            .where('visibility', 'paid')).map(row => row.id);
+
+        const membersPostIds = (await connection('posts')
+            .select('id')
+            .where('visibility', 'members')).map(row => row.id);
+
+        const publicPostIds = (await connection('posts')
+            .select('id')
+            .where('visibility', 'public')).map(row => row.id);
+
+        await connection('emails')
+            .update('recipient_filter', 'paid')
+            .whereIn('post_id', paidPostIds);
+
+        await connection('emails')
+            .update('recipient_filter', 'all')
+            .whereIn('post_id', membersPostIds.concat(publicPostIds));
+    },
+
+    async function down(connection) {
+        logging.info('Updating emails.recipient_filter values to paid');
+        await connection('emails')
+            .update('recipient_filter', 'paid');
+    }
+);
+

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -453,6 +453,13 @@ module.exports = {
             defaultTo: 'pending',
             validations: {isIn: [['pending', 'submitting', 'submitted', 'failed']]}
         },
+        recipient_filter: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'paid',
+            validations: {isIn: [['all', 'free', 'paid']]}
+        },
         error: {type: 'string', maxlength: 2000, nullable: true},
         error_data: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         meta: {type: 'text', maxlength: 65535, nullable: true},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -30,6 +30,13 @@ module.exports = {
             validations: {isIn: [['public', 'members', 'paid']]}
         },
         send_email_when_published: {type: 'bool', nullable: true, defaultTo: false},
+        email_recipient_filter: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'none',
+            validations: {isIn: [['none', 'all', 'free', 'paid']]}
+        },
         /**
          * @deprecated: `author_id`, might be removed in Ghost 3.0
          * If we keep it, then only, because you can easier query post.author_id than posts_authors[*].sort_order.

--- a/core/server/models/email.js
+++ b/core/server/models/email.js
@@ -8,6 +8,7 @@ const Email = ghostBookshelf.Model.extend({
         return {
             uuid: uuid.v4(),
             status: 'pending',
+            recipient_filter: 'paid',
             stats: JSON.stringify({
                 delivered: 0,
                 failed: 0,

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -55,7 +55,8 @@ Post = ghostBookshelf.Model.extend({
             status: 'draft',
             featured: false,
             type: 'post',
-            visibility: visibility
+            visibility: visibility,
+            email_recipient_filter: 'none'
         };
     },
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c4de64f1c1114eb8b05c7473e3adc29e';
+    const currentSchemaHash = '7d841714b01e6d880d4d8a739ab62bff';
     const currentFixturesHash = 'd46d696c94d03e41a5903500547fea77';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '7d841714b01e6d880d4d8a739ab62bff';
+    const currentSchemaHash = '875ecd7995d0dccdbc0ae64be8dfbca0';
     const currentFixturesHash = 'd46d696c94d03e41a5903500547fea77';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
no-issue

This will be used to store the intended recipients for a newsletter email, and will allow us to decouple newsletter recipients from the visibility of a post.

There are two migrations here:
1. Add the new column
2. Populate the new column based on the existing visibility logic