### PR TITLE
Removed unneeded type='text/css'

### DIFF
--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -42,7 +42,7 @@ function getMembersHelper() {
     const stripeConnectAccountId = settingsCache.get('stripe_connect_account_id');
 
     let membersHelper = `<script defer src="https://unpkg.com/@tryghost/portal@latest/umd/portal.min.js" data-ghost="${urlUtils.getSiteUrl()}"></script>`;
-    membersHelper += (`<style type='text/css'> ${templateStyles}</style>`);
+    membersHelper += (`<style> ${templateStyles}</style>`);
     if ((!!stripeDirectSecretKey && !!stripeDirectPublishableKey) || !!stripeConnectAccountId) {
         membersHelper += '<script async src="https://js.stripe.com/v3/"></script>';
     }


### PR DESCRIPTION
I removed unneeded `type='text/css'` attribute from style tag. 

Having these attribute makes W3C validation fail.

![Zrzut ekranu 2020-11-4 o 11 22 03](https://user-images.githubusercontent.com/23366922/98101536-a8253000-1e92-11eb-9868-68566226d6a1.png)

