### PR TITLE
Added migration for emails.track_opens column

### DIFF
--- a/core/server/data/migrations/versions/3.38/05-add-emails-track-opens-column.js
+++ b/core/server/data/migrations/versions/3.38/05-add-emails-track-opens-column.js
@@ -1,0 +1,24 @@
+const {createColumnMigration, addColumn, dropColumn} = require('../../../schema').commands;
+
+module.exports = {
+    up: createColumnMigration({
+        table: 'emails',
+        column: 'track_opens',
+        dbIsInCorrectState: hasColumn => hasColumn === true,
+        operation: addColumn,
+        operationVerb: 'Adding',
+        columnDefinition: {
+            type: 'bool',
+            nullable: false,
+            defaultTo: false
+        }
+    }),
+
+    down: createColumnMigration({
+        table: 'emails',
+        column: 'track_opens',
+        dbIsInCorrectState: hasColumn => hasColumn === false,
+        operation: dropColumn,
+        operationVerb: 'Removing'
+    })
+};

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -470,6 +470,7 @@ module.exports = {
         reply_to: {type: 'string', maxlength: 2000, nullable: true},
         html: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         plaintext: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+        track_opens: {type: 'bool', nullable: false, defaultTo: false},
         submitted_at: {type: 'dateTime', nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},

--- a/core/server/models/email.js
+++ b/core/server/models/email.js
@@ -16,7 +16,8 @@ const Email = ghostBookshelf.Model.extend({
                 clicked: 0,
                 unsubscribed: 0,
                 complaints: 0
-            })
+            }),
+            track_opens: false
         };
     },
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '875ecd7995d0dccdbc0ae64be8dfbca0';
+    const currentSchemaHash = '97705c7f5ae33414fcdb009c143480a8';
     const currentFixturesHash = 'd46d696c94d03e41a5903500547fea77';
     const currentSettingsHash = 'c8daa2c9632bb75f9d60655de09ae3bd';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
no issue

- tracking of bulk email opens can be enabled/disabled over time, if we're calculating analytics for emails we don't want emails which didn't have tracking enabled skewing the results so we need a record of whether tracking was enabled for each email