### PR TITLE
Forward query params when redirect.

### DIFF
--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -1,5 +1,6 @@
 const express = require('../../../../shared/express');
 const url = require('url');
+const querystring = require('querystring');
 const debug = require('ghost-ignition').debug('web:shared:mw:custom-redirects');
 const config = require('../../../../shared/config');
 const urlUtils = require('../../../../shared/url-utils');
@@ -52,10 +53,14 @@ _private.registerRoutes = () => {
             customRedirectsRouter.get(new RegExp(redirect.from, options), function (req, res) {
                 const maxAge = redirect.permanent ? config.get('caching:customRedirects:maxAge') : 0;
                 const toURL = url.parse(redirect.to);
+                const toURLParams = querystring.parse(toURL.query);
                 const currentURL = url.parse(req.url);
+                const currentURLParams = querystring.parse(currentURL.query);
+                const params = Object.assign({}, currentURLParams, toURLParams);
+                const search = querystring.stringify(params);
 
                 toURL.pathname = currentURL.pathname.replace(new RegExp(redirect.from, options), toURL.pathname);
-                toURL.search = currentURL.search;
+                toURL.search = search !== '' ? `?${search}` : null;
 
                 /**
                  * Only if the URL is internal should we prepend the Ghost subdirectory

--- a/test/utils/fixtures/data/redirects.json
+++ b/test/utils/fixtures/data/redirects.json
@@ -9,6 +9,11 @@
         "to": "/revamped-url/"
     },
     {
+        "permanent": true,
+        "from": "/test-params",
+        "to": "/result?q=abc"
+    },
+    {
         "from": "^\\/what(\\/?)$",
         "to": "/what-does-god-say"
     },

--- a/test/utils/fixtures/data/redirects.yaml
+++ b/test/utils/fixtures/data/redirects.yaml
@@ -1,5 +1,6 @@
 301:
   /my-old-blog-post/: /revamped-url/
+  /test-params/: /result?q=abc
 
 302:
   ^/post/[0-9]+/([a-z0-9\-]+): /$1


### PR DESCRIPTION
ref #10898

* It parses query params and merge them and stringify it.
* This PR ignores 2 cases: querystring in redirects definition and not passing through URL query params.

----

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
