### PR TITLE
Updated newsletter functionality to use `email_recipient_filter`

### DIFF
--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -124,7 +124,7 @@ module.exports = {
             'id',
             'formats',
             'source',
-            'send_email_when_published',
+            'email_recipient_filter',
             'force_rerender',
             // NOTE: only for internal context
             'forUpdate',
@@ -141,8 +141,8 @@ module.exports = {
                 source: {
                     values: ['html']
                 },
-                send_email_when_published: {
-                    values: [true, false, 'none', 'free', 'paid', 'all']
+                email_recipient_filter: {
+                    values: ['none', 'free', 'paid', 'all']
                 }
             }
         },
@@ -151,7 +151,7 @@ module.exports = {
         },
         async query(frame) {
             /**Check host limits for members when send email is true**/
-            if (frame.options.send_email_when_published) {
+            if (frame.options.email_recipient_filter && frame.options.email_recipient_filter !== 'none') {
                 await membersService.checkHostLimit();
             }
 

--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -88,8 +88,7 @@ module.exports = {
         options: [
             'include',
             'formats',
-            'source',
-            'send_email_when_published'
+            'source'
         ],
         validation: {
             options: {
@@ -98,9 +97,6 @@ module.exports = {
                 },
                 source: {
                     values: ['html']
-                },
-                send_email_when_published: {
-                    values: [true, false, 'none', 'free', 'paid', 'all']
                 }
             }
         },

--- a/core/server/api/canary/posts.js
+++ b/core/server/api/canary/posts.js
@@ -98,6 +98,9 @@ module.exports = {
                 },
                 source: {
                     values: ['html']
+                },
+                send_email_when_published: {
+                    values: [true, false, 'none', 'free', 'paid', 'all']
                 }
             }
         },
@@ -141,6 +144,9 @@ module.exports = {
                 },
                 source: {
                     values: ['html']
+                },
+                send_email_when_published: {
+                    values: [true, false, 'none', 'free', 'paid', 'all']
                 }
             }
         },
@@ -156,7 +162,7 @@ module.exports = {
             let model = await models.Post.edit(frame.data.posts[0], frame.options);
 
             /**Handle newsletter email */
-            if (model.get('send_email_when_published')) {
+            if (model.get('email_recipient_filter') !== 'none') {
                 const postPublished = model.wasChanged() && (model.get('status') === 'published') && (model.previous('status') !== 'published');
                 if (postPublished) {
                     let postEmail = model.relations.email;

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -89,6 +89,7 @@ const mapPage = (model, frame) => {
 
     delete jsonModel.email_subject;
     delete jsonModel.send_email_when_published;
+    delete jsonModel.email_recipient_filter;
 
     return jsonModel;
 };

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -76,6 +76,7 @@ const mapPost = (model, frame) => {
 
     delete jsonModel.posts_meta;
     delete jsonModel.send_email_when_published;
+    delete jsonModel.email_recipient_filter;
     delete jsonModel.email_subject;
 
     return jsonModel;

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -505,32 +505,21 @@ Post = ghostBookshelf.Model.extend({
             }
         }
 
-        // send_email_when_published is read-only and should only be set using a query param when publishing/scheduling
+        // email_recipient_filter is read-only and should only be set using a query param when publishing/scheduling
         if (this.hasChanged('status') && (newStatus === 'published' || newStatus === 'scheduled')) {
             if (typeof options.email_recipient_filter === 'undefined') {
-                this.set('send_email_when_published', false);
                 this.set('email_recipient_filter', 'none');
-            } else if (typeof options.send_email_when_published === 'boolean') {
-                this.set('send_email_when_published', options.send_email_when_published);
-                const emailRecipientFilter = this.get('visibility') === 'paid' ? 'paid' : 'all';
-                this.set('email_recipient_filter', emailRecipientFilter);
             } else {
-                this.set('email_recipient_filter', options.send_email_when_published);
-                if (options.send_email_when_published === 'none') {
-                    this.set('send_email_when_published', false);
-                } else {
-                    this.set('send_email_when_published', true);
-                }
+                this.set('email_recipient_filter', options.email_recipient_filter);
             }
         }
 
-        // ensure draft posts have the send_email_when_published reset unless an email has already been sent
+        // ensure draft posts have the email_recipient_filter reset unless an email has already been sent
         if (newStatus === 'draft' && this.hasChanged('status')) {
             ops.push(function ensureSendEmailWhenPublishedIsUnchanged() {
                 return self.related('email').fetch({transacting: options.transacting}).then((email) => {
                     if (!email) {
                         self.set('email_recipient_filter', 'none');
-                        self.set('send_email_when_published', false);
                     }
                 });
             });
@@ -856,7 +845,7 @@ Post = ghostBookshelf.Model.extend({
             findPage: ['status'],
             findAll: ['columns', 'filter'],
             destroy: ['destroyAll', 'destroyBy'],
-            edit: ['filter', 'send_email_when_published', 'force_rerender']
+            edit: ['filter', 'email_recipient_filter', 'force_rerender']
         };
 
         // The post model additionally supports having a formats option

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -525,13 +525,11 @@ Post = ghostBookshelf.Model.extend({
         }
 
         // ensure draft posts have the send_email_when_published reset unless an email has already been sent
-        // @TODO - not sure how to handle this with non-boolean values
         if (newStatus === 'draft' && this.hasChanged('status')) {
             ops.push(function ensureSendEmailWhenPublishedIsUnchanged() {
                 return self.related('email').fetch({transacting: options.transacting}).then((email) => {
-                    if (email) {
-                        self.set('send_email_when_published', true);
-                    } else {
+                    if (!email) {
+                        self.set('email_recipient_filter', 'none');
                         self.set('send_email_when_published', false);
                     }
                 });

--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -95,8 +95,21 @@ const addEmail = async (postModel, options) => {
     const knexOptions = _.pick(options, ['transacting', 'forUpdate']);
     const filterOptions = Object.assign({}, knexOptions, {filter: 'subscribed:true', limit: 1});
 
-    if (postModel.get('visibility') === 'paid') {
+    const emailRecipientFilter = postModel.get('email_recipient_filter');
+
+    switch (emailRecipientFilter) {
+    case 'paid':
         filterOptions.paid = true;
+        break;
+    case 'free':
+        filterOptions.paid = false;
+        break;
+    case 'all':
+        break;
+    case 'none':
+        throw new Error('Cannot sent email to "none" email_recipient_filter');
+    default:
+        throw new Error(`Unknown email_recipient_filter ${emailRecipientFilter}`);
     }
 
     const startRetrieve = Date.now();
@@ -127,7 +140,8 @@ const addEmail = async (postModel, options) => {
             html: emailData.html,
             plaintext: emailData.plaintext,
             submitted_at: moment().toDate(),
-            track_opens: config.get('enableDeveloperExperiments')
+            track_opens: config.get('enableDeveloperExperiments'),
+            recipient_filter: emailRecipientFilter
         }, knexOptions);
     } else {
         return existing;
@@ -264,13 +278,23 @@ async function sendEmailJob({emailModel, options}) {
 // instantiations and associated processing and event loop blocking
 async function getEmailMemberRows({emailModel, options}) {
     const knexOptions = _.pick(options, ['transacting', 'forUpdate']);
-    const postModel = await models.Post.findOne({id: emailModel.get('post_id')}, knexOptions);
 
     // TODO: this will clobber a user-assigned filter if/when we allow emails to be sent to filtered member lists
     const filterOptions = Object.assign({}, knexOptions, {filter: 'subscribed:true'});
 
-    if (postModel.get('visibility') === 'paid') {
+    const recipientFilter = emailModel.get('recipient_filter');
+
+    switch (recipientFilter) {
+    case 'paid':
         filterOptions.paid = true;
+        break;
+    case 'free':
+        filterOptions.paid = false;
+        break;
+    case 'all':
+        break;
+    default:
+        throw new Error(`Unknown recipient_filter ${recipientFilter}`);
     }
 
     const startRetrieve = Date.now();

--- a/test/api-acceptance/admin/utils.js
+++ b/test/api-acceptance/admin/utils.js
@@ -58,6 +58,7 @@ const expectedProperties = {
         .without('author_id', 'author')
         // pages are not sent as emails
         .without('send_email_when_published')
+        .without('email_recipient_filter')
         // always returns computed properties
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         // returned by default

--- a/test/regression/api/v2/admin/utils.js
+++ b/test/regression/api/v2/admin/utils.js
@@ -28,6 +28,7 @@ const expectedProperties = {
         .without('author_id', 'author')
         // emails are not supported in API v2
         .without('send_email_when_published')
+        .without('email_recipient_filter')
         // always returns computed properties
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         .concat('authors', 'tags')

--- a/test/regression/api/v2/content/utils.js
+++ b/test/regression/api/v2/content/utils.js
@@ -23,6 +23,7 @@ const expectedProperties = {
         .without('locale', 'visibility')
         // emails are not supported in API v2
         .without('send_email_when_published')
+        .without('email_recipient_filter')
         // These fields aren't useful as they always have known values
         .without('status')
         .concat('page')


### PR DESCRIPTION
no-issue

This updates the logic around sending emails to
- Use `email_recipient_filter` to determine which members to email
- Use `email_recipient_filter` to determine if we should send an email
- Effectively deprecate `send_email_when_published` - allowing us to replace it 