### PR TITLE
Switched to running Ghost in CI migration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,9 @@ jobs:
           mysql root password: 'root'
 
       - run: yarn
-      - run: yarn knex-migrator init
+      - run: |
+          node index.js &
+          sleep 10 && { kill $! && wait $!; } 2>/dev/null
       - run: yarn knex-migrator rollback --v 3.0 --force
       - run: yarn knex-migrator migrate --force
 


### PR DESCRIPTION
- if we only run 'knex-migrator init', the settings don't get populated like
  they would when running Ghost
- switching to running Ghost for initialization is more realistic of
  what would happen IRL