### PR TITLE
Fix some embedded elements being too big on public posts. 

### DIFF
--- a/core/server/api/canary/oembed.js
+++ b/core/server/api/canary/oembed.js
@@ -85,7 +85,7 @@ function unknownProvider(url) {
 }
 
 function knownProvider(url) {
-    return extract(url, {maxwidth: 1280}).catch((err) => {
+    return extract(url).catch((err) => {
         return Promise.reject(new errors.InternalServerError({
             message: err.message
         }));


### PR DESCRIPTION
refs #12018

maxWidth:1280 sets the width attribute of iframe to 1280. It causes the oversize of embedded items in the public posts. Removing the option makes the width to 100%.

----

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
