### PR TITLE
Updated default config for newsletter badge

### DIFF
--- a/core/server/data/migrations/versions/3.38/07-migrate-newsletter-settings-from-config.js
+++ b/core/server/data/migrations/versions/3.38/07-migrate-newsletter-settings-from-config.js
@@ -38,7 +38,7 @@ module.exports = createTransactionalMigration(
         logging.info('Updating newsletter_show_badge setting to default "false"');
         await connection('settings')
             .update({
-                value: 'false'
+                value: 'true'
             })
             .where({
                 key: 'newsletter_show_badge'

--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -33,7 +33,7 @@
         "paymentProcessors": [],
         "emailTemplate": {
             "showSiteHeader": true,
-            "showPoweredBy": false
+            "showPoweredBy": true
         }
     },
     "logging": {


### PR DESCRIPTION
no refs

The expected default for badge is to show by default, i.e. `true`
- Migrations were using previous default for badge which was set to `false`
- Default config for badge was `false` which caused migration to switch off the badge, updated to `true`
