### PR TITLE
Fixed handling of email_recipient_filter option

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -505,12 +505,8 @@ Post = ghostBookshelf.Model.extend({
         }
 
         // email_recipient_filter is read-only and should only be set using a query param when publishing/scheduling
-        if (this.hasChanged('status') && (newStatus === 'published' || newStatus === 'scheduled')) {
-            if (typeof options.email_recipient_filter === 'undefined') {
-                this.set('email_recipient_filter', 'none');
-            } else {
-                this.set('email_recipient_filter', options.email_recipient_filter);
-            }
+        if (options.email_recipient_filter && options.email_recipient_filter !== 'none' && this.hasChanged('status') && (newStatus === 'published' || newStatus === 'scheduled')) {
+            this.set('email_recipient_filter', options.email_recipient_filter);
         }
 
         // ensure draft posts have the email_recipient_filter reset unless an email has already been sent


### PR DESCRIPTION
no-issue

This logic would assume that the option was always passed at the point
of publishing the post, which is not the case for scheduled posts.

Instead of setting the property to 'none' when the option is not
present, we take the approach of ONLY setting the propery when
1. It is present and not 'none'
2. The post is being published or scheduled

This means that scheduled posts will have the property set correctly,
and any future publishing will leave the it in the original state