### PR TITLE
Fixed migration for SQLite3

### DIFF
--- a/core/server/data/migrations/versions/3.38/04-populate-recipient-filter-column.js
+++ b/core/server/data/migrations/versions/3.38/04-populate-recipient-filter-column.js
@@ -18,8 +18,12 @@ module.exports = createTransactionalMigration(
             .select('id')
             .where('visibility', 'public')).map(row => row.id);
 
-        const paidPostIdChunks = chunk(paidPostIds, 999);
-        const membersAndPublicPostIdChunks = chunk(membersPostIds.concat(publicPostIds), 999);
+        // Umm? Well... The current version of SQLite3 bundled with Ghost supports
+        // a maximum of 999 variables, we use one variable for the UPDATE value
+        // and so we're left with 998 for our WHERE IN clause values
+        const chunkSize = 998;
+        const paidPostIdChunks = chunk(paidPostIds, chunkSize);
+        const membersAndPublicPostIdChunks = chunk(membersPostIds.concat(publicPostIds), chunkSize);
 
         for (const paidPostIdsChunk of paidPostIdChunks) {
             await connection('emails')

--- a/core/server/data/migrations/versions/3.38/04-populate-recipient-filter-column.js
+++ b/core/server/data/migrations/versions/3.38/04-populate-recipient-filter-column.js
@@ -19,7 +19,7 @@ module.exports = createTransactionalMigration(
             .where('visibility', 'public')).map(row => row.id);
 
         // Umm? Well... The current version of SQLite3 bundled with Ghost supports
-        // a maximum of 999 variables, we use one variable for the UPDATE value
+        // a maximum of 999 variables, we use one variable for the SET value
         // and so we're left with 998 for our WHERE IN clause values
         const chunkSize = 998;
         const paidPostIdChunks = chunk(paidPostIds, chunkSize);


### PR DESCRIPTION
no-issue

SQLite3 bundled with node-sqlite3 has a maximum number of variables
capped at 999. Which will cause this migration to error in the case of
a `posts` table with more than 999 rows.