### PR TITLE
✨ Add Japanese Yen currency

### DIFF
--- a/core/frontend/services/themes/middleware.js
+++ b/core/frontend/services/themes/middleware.js
@@ -53,7 +53,8 @@ function haxGetMembersPriceData() {
         CAD: '$',
         GBP: '£',
         EUR: '€',
-        INR: '₹'
+        INR: '₹',
+        JPY: '¥'
     };
     const defaultPriceData = {
         monthly: 0,

--- a/core/server/models/stripe-customer-subscription.js
+++ b/core/server/models/stripe-customer-subscription.js
@@ -6,7 +6,8 @@ const CURRENCY_SYMBOLS = {
     cad: '$',
     gbp: '£',
     eur: '€',
-    inr: '₹'
+    inr: '₹',
+    jpy: '¥'
 };
 
 const StripeCustomerSubscription = ghostBookshelf.Model.extend({

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -65,7 +65,8 @@ class MembersConfigProvider {
             CAD: '$',
             GBP: '£',
             EUR: '€',
-            INR: '₹'
+            INR: '₹',
+            JPY: '¥'
         };
 
         const defaultPriceData = {


### PR DESCRIPTION
Added Japanese Yen currency symbol and abbreviations to bottom of relevant strings to enable currency in Stripe.