### PR TITLE
✨ Add Swiss Franc currency

### DIFF
--- a/core/frontend/services/themes/middleware.js
+++ b/core/frontend/services/themes/middleware.js
@@ -53,7 +53,8 @@ function haxGetMembersPriceData() {
         CAD: '$',
         GBP: '£',
         EUR: '€',
-        INR: '₹'
+        INR: '₹',
+        CHF: 'CHF'
     };
     const defaultPriceData = {
         monthly: 0,

--- a/core/server/models/stripe-customer-subscription.js
+++ b/core/server/models/stripe-customer-subscription.js
@@ -6,7 +6,8 @@ const CURRENCY_SYMBOLS = {
     cad: '$',
     gbp: '£',
     eur: '€',
-    inr: '₹'
+    inr: '₹',
+    chf: 'CHF'
 };
 
 const StripeCustomerSubscription = ghostBookshelf.Model.extend({

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -65,7 +65,8 @@ class MembersConfigProvider {
             CAD: '$',
             GBP: '£',
             EUR: '€',
-            INR: '₹'
+            INR: '₹',
+            CHF: 'CHF'
         };
 
         const defaultPriceData = {


### PR DESCRIPTION
Add Swiss Franc currency symbol and official abbreviation to relevant strings to enable currency in Stripe.
I would love to see this as I'd like to use Ghost for the magazine I'm currently starting ❤️ 