### PR TITLE
Only include search params for non-custom redirect

### DIFF
--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -154,9 +154,12 @@ const createSessionFromMagicLink = async function (req, res, next) {
             }
         }
 
-        // Do a standard 302 redirect, with success=true
-        searchParams.set('success', true);
-        res.redirect(`${urlUtils.getSubdir()}${redirectPath}?${searchParams.toString()}`);
+        if (redirectPath === '/') {
+            searchParams.set('success', true);
+            redirectPath = redirectPath + '?' + searchParams.toString();
+        }
+
+        res.redirect(`${urlUtils.getSubdir()}${redirectPath}`);
     } catch (err) {
         logging.warn(err.message);
 


### PR DESCRIPTION
no-issue

This means that custom redirects will not have members/portal behaviour with regards to displaying notifications