### PR TITLE
🐛 Fixed /edit redirect to work on unpublished pages

### DIFF
--- a/core/server/api/canary/utils/index.js
+++ b/core/server/api/canary/utils/index.js
@@ -26,6 +26,10 @@ module.exports = {
         return frame.apiType === 'content';
     },
 
+    isPreviewFrame: (frame) => {
+        return frame.docName === 'preview';
+    },
+
     // @TODO: Remove, not used.
     isAdminAPIKey: (frame) => {
         return frame.options.context && Object.keys(frame.options.context).length !== 0 && frame.options.context.api_key &&

--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -101,7 +101,11 @@ const post = (attrs, frame) => {
             delete attrs.visibility;
         }
     } else {
-        delete attrs.page;
+        // Generic preview handler needs to distinguish between
+        // page or post for /edit redirect
+        if (!localUtils.isPreviewFrame(frame)) {
+            delete attrs.page;
+        }
     }
 
     if (columns && columns.includes('email_recipient_filter') && fields && !fields.includes('email_recipient_filter')) {

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -38,8 +38,10 @@ const mapPost = (model, frame) => {
 
     extraAttrs.forPost(frame, model, jsonModel);
 
-    if (utils.isContentAPI(frame)) {
-        // Content api v2 still expects page prop
+    if (utils.isContentAPI(frame) || utils.isPreviewFrame(frame)) {
+        // Content api v2 still expects page prop,
+        // Generic preview handler needs to distinguish between
+        // page or post for /edit redirect
         if (jsonModel.type === 'page') {
             jsonModel.page = true;
         }

--- a/core/server/api/v2/utils/index.js
+++ b/core/server/api/v2/utils/index.js
@@ -26,6 +26,10 @@ module.exports = {
         return frame.apiType === 'content';
     },
 
+    isPreviewFrame: (frame) => {
+        return frame.docName === 'preview';
+    },
+
     // @TODO: Remove, not used.
     isAdminAPIKey: (frame) => {
         return frame.options.context && Object.keys(frame.options.context).length !== 0 && frame.options.context.api_key &&

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -35,8 +35,10 @@ const mapPost = (model, frame) => {
 
     url.forPost(model.id, jsonModel, frame);
 
-    if (utils.isContentAPI(frame)) {
-        // Content api v2 still expects page prop
+    if (utils.isContentAPI(frame) || utils.isPreviewFrame(frame)) {
+        // Content api v2 still expects page prop,
+        // Generic preview handler needs to distinguish between
+        // page or post for /edit redirect
         if (!frame.options.columns || frame.options.columns.includes('page')) {
             if (jsonModel.type === 'page') {
                 jsonModel.page = true;


### PR DESCRIPTION
[refs/closes #12258](https://github.com/TryGhost/Ghost/issues/12258)
Previously, appending /edit to an unpublished page URL incorrectly
redirects to a post editor url, resulting in a 404.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
