### PR TITLE
Fixed sqlite3 errors when email analytics jobs run

### DIFF
--- a/core/server/overrides.js
+++ b/core/server/overrides.js
@@ -5,6 +5,12 @@
  */
 process.env.BLUEBIRD_DEBUG = 0;
 
+/**
+ * Force bthreads to use child_process backend until a worker_thread-compatible version of sqlite3 is published
+ * https://github.com/mapbox/node-sqlite3/issues/1386
+ */
+process.env.BTHREADS_BACKEND = 'child_process';
+
 const moment = require('moment-timezone');
 
 /**

--- a/core/server/services/email-analytics/jobs/fetch-all.js
+++ b/core/server/services/email-analytics/jobs/fetch-all.js
@@ -1,5 +1,5 @@
 const logging = require('../../../../shared/logging');
-const {parentPort} = require('worker_threads');
+const {parentPort} = require('bthreads');
 const debug = require('ghost-ignition').debug('jobs:email-analytics:fetch-all');
 
 // one-off job to fetch all available events and re-process them idempotently

--- a/core/server/services/email-analytics/jobs/fetch-latest.js
+++ b/core/server/services/email-analytics/jobs/fetch-latest.js
@@ -1,5 +1,5 @@
 const logging = require('../../../../shared/logging');
-const {parentPort} = require('worker_threads');
+const {parentPort} = require('bthreads');
 const debug = require('ghost-ignition').debug('jobs:email-analytics:fetch-latest');
 
 // recurring job to fetch analytics since the most recently seen event timestamp


### PR DESCRIPTION
no issue

- the 4.2.0 version of `sqlite3` that we're using is not compatible with `worker_threads`
- 5.0.0 should add support this but there are other errors
- 5.0.1 is released but not published (https://github.com/mapbox/node-sqlite3/issues/1386)