### PR TITLE
Add Polish Złoty currency support

### DIFF
--- a/core/frontend/services/themes/middleware.js
+++ b/core/frontend/services/themes/middleware.js
@@ -53,7 +53,8 @@ function haxGetMembersPriceData() {
         CAD: '$',
         GBP: '£',
         EUR: '€',
-        INR: '₹'
+        INR: '₹',
+        PLN: 'PLN'
     };
     const defaultPriceData = {
         monthly: 0,

--- a/core/server/models/stripe-customer-subscription.js
+++ b/core/server/models/stripe-customer-subscription.js
@@ -6,7 +6,8 @@ const CURRENCY_SYMBOLS = {
     cad: '$',
     gbp: '£',
     eur: '€',
-    inr: '₹'
+    inr: '₹',
+    pln: 'PLN'
 };
 
 const StripeCustomerSubscription = ghostBookshelf.Model.extend({

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -65,7 +65,8 @@ class MembersConfigProvider {
             CAD: '$',
             GBP: '£',
             EUR: '€',
-            INR: '₹'
+            INR: '₹',
+            PLN: 'PLN'
         };
 
         const defaultPriceData = {


### PR DESCRIPTION
Added Polish Złoty currency support. Stripe supports it since couple of months now and it would be very useful to get it in default Ghost installation (as opposed to manually patching the codebase).