### PR TITLE
✨ Add New Zealand Dollar currency

### DIFF
--- a/core/frontend/services/themes/middleware.js
+++ b/core/frontend/services/themes/middleware.js
@@ -50,6 +50,7 @@ function haxGetMembersPriceData() {
     const CURRENCY_SYMBOLS = {
         USD: '$',
         AUD: '$',
+        NZD: '$',
         CAD: '$',
         GBP: '£',
         EUR: '€',

--- a/core/server/models/stripe-customer-subscription.js
+++ b/core/server/models/stripe-customer-subscription.js
@@ -3,6 +3,7 @@ const ghostBookshelf = require('./base');
 const CURRENCY_SYMBOLS = {
     usd: '$',
     aud: '$',
+    nzd: '$',
     cad: '$',
     gbp: '£',
     eur: '€',

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -62,6 +62,7 @@ class MembersConfigProvider {
         const CURRENCY_SYMBOLS = {
             USD: '$',
             AUD: '$',
+            NZD: '$',
             CAD: '$',
             GBP: '£',
             EUR: '€',


### PR DESCRIPTION
Added New Zealand Dollar currency symbol and abbreviations to bottom of relevant strings to enable currency in Stripe.

NZD is used across many island nations in the South Pacific area.

Notably:
- Niue
- Cook Islands
- Pitcairn Island
- Tokelau