### PR TITLE
Added email.open_rate column migration

### DIFF
--- a/core/server/data/migrations/versions/3.39/08-add-email-stats-columns.js
+++ b/core/server/data/migrations/versions/3.39/08-add-email-stats-columns.js
@@ -18,5 +18,11 @@ module.exports = combineNonTransactionalMigrations(
         unsigned: true,
         nullable: false,
         defaultTo: 0
+    }),
+    createAddColumnMigration('emails', 'open_rate', {
+        type: 'integer',
+        unsigned: true,
+        nullable: false,
+        defaultTo: 0
     })
 );

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -467,6 +467,7 @@ module.exports = {
         delivered_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         opened_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         failed_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
+        open_rate: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0, validations: {isLength: {min: 0, max: 100}}},
         subject: {type: 'string', maxlength: 300, nullable: true},
         from: {type: 'string', maxlength: 2000, nullable: true},
         reply_to: {type: 'string', maxlength: 2000, nullable: true},

--- a/core/server/models/email.js
+++ b/core/server/models/email.js
@@ -12,7 +12,8 @@ const Email = ghostBookshelf.Model.extend({
             track_opens: false,
             delivered_count: 0,
             opened_count: 0,
-            failed_count: 0
+            failed_count: 0,
+            open_rate: 0
         };
     },
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'bd3ddfbe8e2ec223d8a57c9ebbe7b2ba';
+    const currentSchemaHash = '8e82488bf92e77fdbe7764579838e851';
     const currentFixturesHash = 'd46d696c94d03e41a5903500547fea77';
     const currentSettingsHash = 'd3821715e4b34d92d6ba6ed0d4918f5c';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12420

- adds `open_rate` column to unreleased migration that adds other stats-related columns to the `emails` table