### PR TITLE
✨ Added `email.open_rate` order option to posts api

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -937,7 +937,10 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         }
 
         if (options.order) {
-            options.order = itemCollection.parseOrderOption(options.order, options.withRelated);
+            const {order, orderRaw, eagerLoad} = itemCollection.parseOrderOption(options.order, options.withRelated);
+            options.orderRaw = orderRaw;
+            options.order = order;
+            options.eagerLoad = eagerLoad;
         } else if (options.autoOrder) {
             options.orderRaw = options.autoOrder;
         } else if (this.orderDefaultRaw) {

--- a/core/server/models/plugins/pagination.js
+++ b/core/server/models/plugins/pagination.js
@@ -207,10 +207,16 @@ const pagination = function pagination(bookshelf) {
                             paginationUtils.handleRelation(self, property);
                         }
                     });
-                } else if (options.orderRaw) {
-                    self.query(function (qb) {
+                }
+
+                if (options.orderRaw) {
+                    self.query((qb) => {
                         qb.orderByRaw(options.orderRaw);
                     });
+                }
+
+                if (!_.isEmpty(options.eagerLoad)) {
+                    options.eagerLoad.forEach(property => paginationUtils.handleRelation(self, property));
                 }
 
                 if (options.groups && !_.isEmpty(options.groups)) {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -72,6 +72,10 @@ Post = ghostBookshelf.Model.extend({
         posts_meta: {
             targetTableName: 'posts_meta',
             foreignKey: 'post_id'
+        },
+        email: {
+            targetTableName: 'emails',
+            foreignKey: 'post_id'
         }
     },
 
@@ -97,6 +101,19 @@ Post = ghostBookshelf.Model.extend({
         let postsMetaKeys = _.without(ghostBookshelf.model('PostsMeta').prototype.orderAttributes(), 'posts_meta.id', 'posts_meta.post_id');
 
         return [...keys, ...postsMetaKeys];
+    },
+
+    orderRawQuery: function orderRawQuery(field, direction, withRelated) {
+        if (field === 'email.open_rate' && withRelated && withRelated.indexOf('email') > -1) {
+            return {
+                // *1.0 is needed on one of the columns to prevent sqlite from
+                // performing integer division rounding and always giving 0.
+                // Order by emails.track_opens desc first so we always tracked emails
+                // before untracked emails in the posts list
+                orderByRaw: `emails.track_opens desc, emails.opened_count * 1.0 / emails.email_count * 100 ${direction}`,
+                eagerLoad: 'email.open_rate'
+            };
+        }
     },
 
     filterExpansions: function filterExpansions() {

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -748,6 +748,14 @@ DataGenerator.forKnex = (function () {
         });
     }
 
+    function createEmail(overrides) {
+        const newObj = _.cloneDeep(overrides);
+
+        return _.defaults(createBasic(newObj), {
+            submitted_at: new Date()
+        });
+    }
+
     const posts = [
         createPost(DataGenerator.Content.posts[0]),
         createPost(DataGenerator.Content.posts[1]),
@@ -951,8 +959,8 @@ DataGenerator.forKnex = (function () {
     ];
 
     const emails = [
-        createBasic(DataGenerator.Content.emails[0]),
-        createBasic(DataGenerator.Content.emails[1])
+        createEmail(DataGenerator.Content.emails[0]),
+        createEmail(DataGenerator.Content.emails[1])
     ];
 
     const members = [
@@ -1010,6 +1018,7 @@ DataGenerator.forKnex = (function () {
         createInvite,
         createWebhook,
         createIntegration,
+        createEmail,
 
         invites,
         posts,

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -122,6 +122,14 @@ fixtures = {
         });
     },
 
+    insertEmailedPosts: function insertEmailedPosts({postCount = 2} = {}) {
+        const posts = [];
+
+        for (let i = 0; i < postCount; i++) {
+            posts.push(DataGenerator.forKnex.createGenericPost);
+        }
+    },
+
     insertExtraPosts: function insertExtraPosts(max) {
         let lang;
         let status;
@@ -749,6 +757,19 @@ const createPost = function createPost(options) {
     return models.Post.add(post, module.exports.context.internal);
 };
 
+const createEmail = function createEmail(options) {
+    const email = DataGenerator.forKnex.createEmail(options.email);
+    return models.Email.add(email, module.exports.context.internal);
+};
+
+const createEmailedPost = async function createEmailedPost({postOptions, emailOptions}) {
+    const post = await createPost(postOptions);
+    emailOptions.email.post_id = post.id;
+    const email = await createEmail(emailOptions);
+
+    return {post, email};
+};
+
 /**
  * Has to run in a transaction for MySQL, otherwise the foreign key check does not work.
  * Sqlite3 has no truncate command.
@@ -1131,6 +1152,7 @@ module.exports = {
     setup: setup,
     createUser: createUser,
     createPost: createPost,
+    createEmailedPost,
 
     /**
      * renderObject:    res.render(view, dbResponse)


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12420

- updated `order` bookshelf plugin's `parseOrderOption()` method to return multiple order-related properties
  - `order` same as before, a key-value object of property-direction
  - `orderRaw` new property that is a raw SQL order string generated from `orderRawAttributes()` method in models
  - `eagerLoad` new property that is an array of properties the `eagerLoad` plugin should use to join across
- updated `pagination.fetchAll()` to apply normal order + raw order if both are available and to handle eager loading / joins when `options.eagerLoad` is populated
- updated post model to include details for email relationship and to add `orderRawAttributes()` that allows `email.open_rate` to be used as an order option