### PR TITLE
Prevented scheduling of recurring analytics jobs when not using emails

### DIFF
--- a/core/server/services/email-analytics/jobs/index.js
+++ b/core/server/services/email-analytics/jobs/index.js
@@ -1,0 +1,38 @@
+const path = require('path');
+const config = require('../../../../shared/config');
+const models = require('../../../models');
+const jobsService = require('../../jobs');
+
+let hasScheduled = false;
+
+module.exports = {
+    async scheduleRecurringJobs() {
+        if (
+            !hasScheduled &&
+            config.get('backgroundJobs:emailAnalytics') &&
+            !process.env.NODE_ENV.match(/^testing/)
+        ) {
+            // don't register email analytics job if we have no emails,
+            // processer usage from many sites spinning up threads can be high
+            const emailCount = await models.Email.count();
+
+            if (emailCount > 0) {
+                // use a random seconds value to avoid spikes to external APIs on the minute
+                const s = Math.floor(Math.random() * 60); // 0-59
+                // run every 5 minutes, on 1,6,11..., 2,7,12..., 3,8,13..., etc
+                const m = Math.floor(Math.random() * 5); // 0-4
+
+                jobsService.scheduleJob(
+                    `${s} ${m}/5 * * * *`,
+                    path.resolve(__dirname, 'fetch-latest.js'),
+                    undefined,
+                    'email-analytics-fetch-latest'
+                );
+
+                hasScheduled = true;
+            }
+        }
+
+        return hasScheduled;
+    }
+};

--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -220,6 +220,10 @@ async function pendingEmailHandler(emailModel, options) {
         return;
     }
 
+    // make sure recurring background analytics jobs are running once we have emails
+    const emailAnalyticsJobs = require('../email-analytics/jobs');
+    emailAnalyticsJobs.scheduleRecurringJobs();
+
     return jobService.addJob(sendEmailJob, {emailModel});
 }
 


### PR DESCRIPTION
no issue

- recurring jobs spin up worker threads which can be quite CPU intensive even when not performing much processing, this can be problematic in environments where there are many Ghost instances running
- updated the email job scheduling to be skipped on bootup when there are no emails in the database and to be started when the first email is created as long as we're not in testing env
- increase analytics job schedule from every 2 minutes to every 5 minutes to help spread the load further across instances