### PR TITLE
Added emailAnalytics config feature flag

### DIFF
--- a/core/server/api/canary/config.js
+++ b/core/server/api/canary/config.js
@@ -20,7 +20,8 @@ module.exports = {
                 clientExtensions: config.get('clientExtensions') || {},
                 enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
                 stripeDirect: config.get('stripeDirect'),
-                mailgunIsConfigured: config.get('bulkEmail') && config.get('bulkEmail').mailgun
+                mailgunIsConfigured: config.get('bulkEmail') && config.get('bulkEmail').mailgun,
+                emailAnalytics: config.get('emailAnalytics')
             };
             if (billingUrl) {
                 response.billingUrl = billingUrl;

--- a/core/server/services/email-analytics/jobs/index.js
+++ b/core/server/services/email-analytics/jobs/index.js
@@ -10,6 +10,7 @@ module.exports = {
     async scheduleRecurringJobs() {
         if (
             !hasScheduled &&
+            config.get('emailAnalytics') &&
             config.get('backgroundJobs:emailAnalytics') &&
             !process.env.NODE_ENV.match(/^testing/)
         ) {

--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -116,6 +116,7 @@
     "sendWelcomeEmail": true,
     "stripeDirect": false,
     "enableStripePromoCodes": false,
+    "emailAnalytics": true,
     "backgroundJobs": {
         "emailAnalytics": true
     }

--- a/test/api-acceptance/admin/utils.js
+++ b/test/api-acceptance/admin/utils.js
@@ -24,7 +24,7 @@ const expectedProperties = {
 
     action: ['id', 'resource_type', 'actor_type', 'event', 'created_at', 'actor'],
 
-    config: ['version', 'environment', 'database', 'mail', 'labs', 'clientExtensions', 'enableDeveloperExperiments', 'useGravatar', 'stripeDirect'],
+    config: ['version', 'environment', 'database', 'mail', 'labs', 'clientExtensions', 'enableDeveloperExperiments', 'useGravatar', 'stripeDirect', 'emailAnalytics'],
 
     post: _(schema.posts)
         .keys()


### PR DESCRIPTION
no issue

- email analytics may be desirable to fully switch off in certain circumstances, when that happens we want to prevent related background jobs from running and expose the feature flag via the config endpoint in the Admin API so that clients can adjust accordingly