### PR TITLE
🐛  Fixed page preview

### DIFF
--- a/core/frontend/services/routing/helpers/context.js
+++ b/core/frontend/services/routing/helpers/context.js
@@ -59,6 +59,7 @@ function setResponseContext(req, res, data) {
 
     // @TODO: remove first if condition when only page key is returned
     //        ref.: https://github.com/TryGhost/Ghost/issues/10042
+    // The first if is now used by the preview route
     if (data && data.post && data.post.page) {
         if (!res.locals.context.includes('page')) {
             res.locals.context.push('page');

--- a/core/server/api/canary/utils/serializers/output/preview.js
+++ b/core/server/api/canary/utils/serializers/output/preview.js
@@ -5,5 +5,6 @@ module.exports = {
         frame.response = {
             preview: [mapper.mapPost(model, frame)]
         };
+        frame.response.preview[0].page = model.get('type') === 'page';
     }
 };

--- a/test/unit/api/canary/utils/serializers/output/preview_spec.js
+++ b/test/unit/api/canary/utils/serializers/output/preview_spec.js
@@ -1,0 +1,45 @@
+const should = require('should');
+const sinon = require('sinon');
+const testUtils = require('../../../../../../utils');
+const mapper = require('../../../../../../../core/server/api/canary/utils/serializers/output/utils/mapper');
+const serializers = require('../../../../../../../core/server/api/canary/utils/serializers');
+
+describe('Unit: canary/utils/serializers/output/preview', function () {
+    let pageModel;
+
+    beforeEach(function () {
+        pageModel = (data) => {
+            return Object.assign(data, {toJSON: sinon.stub().returns(data), get: key => (key === 'type' ? 'page' : '')});
+        };
+
+        sinon.stub(mapper, 'mapPost').returns({});
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('calls the mapper', function () {
+        const apiConfig = {};
+        const frame = {
+            options: {
+                withRelated: ['tags', 'authors'],
+                context: {
+                    private: false
+                }
+            }
+        };
+
+        const ctrlResponse = pageModel(testUtils.DataGenerator.forKnex.createPost({
+            id: 'id1',
+            type: 'page'
+        }));
+
+        serializers.output.preview.all(ctrlResponse, apiConfig, frame);
+
+        mapper.mapPost.callCount.should.equal(1);
+        mapper.mapPost.getCall(0).args.should.eql([ctrlResponse, frame]);
+
+        frame.response.preview[0].page.should.equal(true);
+    });
+});


### PR DESCRIPTION
issue #12444

We're adding the `page` property set to true in the serializer so that the context is correctly set to `page` in the context helper.

https://github.com/TryGhost/Ghost/blob/4ef019d88d1c65d15d79b9c720f45218ea34e143/core/frontend/services/routing/helpers/context.js#L62-L65