### PR TITLE
Added migration for members.email_open_rate column

### DIFF
--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -100,7 +100,8 @@ function serializeMember(member, options) {
         labels: json.labels,
         stripe: json.stripe,
         avatar_image: json.avatar_image,
-        comped: comped
+        comped: comped,
+        email_open_rate: json.email_open_rate
     };
 }
 
@@ -144,6 +145,7 @@ function createSerializer(debugString, serialize) {
  * @prop {null|SerializedMemberStripeData} stripe
  * @prop {string} avatar_image
  * @prop {boolean} comped
+ * @prop {number} email_open_rate
  */
 
 /**

--- a/core/server/data/migrations/versions/3.40/01-add-members-email-open-rate-column.js
+++ b/core/server/data/migrations/versions/3.40/01-add-members-email-open-rate-column.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members', 'email_open_rate', {
+    type: 'integer',
+    unsigned: true,
+    nullable: true,
+    index: true
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -378,6 +378,7 @@ module.exports = {
         note: {type: 'string', maxlength: 2000, nullable: true},
         geolocation: {type: 'string', maxlength: 2000, nullable: true},
         subscribed: {type: 'bool', nullable: true, defaultTo: true},
+        email_open_rate: {type: 'integer', unsigned: true, nullable: true, index: true},
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'bd3ddfbe8e2ec223d8a57c9ebbe7b2ba';
+    const currentSchemaHash = '4e31c2f48018f5a95244a78064ddf4ff';
     const currentFixturesHash = 'd46d696c94d03e41a5903500547fea77';
     const currentSettingsHash = 'd3821715e4b34d92d6ba6ed0d4918f5c';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12421

- nullable so we can distinguish between members that have and haven't received any trackable emails
- indexed because we'll be using this column for sorting