### PR TITLE
Added members.email_open_rate aggregation to email analytics

### DIFF
--- a/core/server/services/email-analytics/email-analytics.js
+++ b/core/server/services/email-analytics/email-analytics.js
@@ -81,7 +81,7 @@ class EmailAnalyticsService {
             await this.aggregateEmailStats(emailId);
         }
         for (const memberId of memberIds) {
-            await this.aggregateEmailStats(memberId);
+            await this.aggregateMemberStats(memberId);
         }
     }
 

--- a/core/server/services/email-analytics/jobs/fetch-all.js
+++ b/core/server/services/email-analytics/jobs/fetch-all.js
@@ -50,7 +50,7 @@ if (parentPort) {
         const aggregateEndDate = new Date();
         debug(`Finished aggregating email analytics in ${aggregateEndDate - aggregateStartDate}ms`);
 
-        logging.info(`Fetched ${eventStats.totalEvents} events and aggregated stats for ${eventStats.emailIds.length} emails in ${aggregateEndDate - fetchStartDate}ms`);
+        logging.info(`Fetched ${eventStats.totalEvents} events and aggregated stats for ${eventStats.emailIds.length} emails and ${eventStats.memberIds.length} members in ${aggregateEndDate - fetchStartDate}ms`);
 
         if (parentPort) {
             parentPort.postMessage('done');

--- a/core/server/services/email-analytics/jobs/fetch-latest.js
+++ b/core/server/services/email-analytics/jobs/fetch-latest.js
@@ -51,7 +51,7 @@ if (parentPort) {
         const aggregateEndDate = new Date();
         debug(`Finished aggregating email analytics in ${aggregateEndDate - aggregateStartDate}ms`);
 
-        logging.info(`Fetched ${eventStats.totalEvents} events and aggregated stats for ${eventStats.emailIds.length} emails in ${aggregateEndDate - fetchStartDate}ms`);
+        logging.info(`Fetched ${eventStats.totalEvents} events and aggregated stats for ${eventStats.emailIds.length} emails and ${eventStats.memberIds.length} members in ${aggregateEndDate - fetchStartDate}ms`);
 
         if (parentPort) {
             parentPort.postMessage('done');


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12421
requires https://github.com/TryGhost/Ghost/pull/12457

- updates stats aggregator to calculate and store an open rate for each member
  - uses two queries because I couldn't find a reasonable approach to perform the update in a single query as per the email aggregation
  - benchmarked locally at <1sec/1000members
  - will not store an open rate unless the number of tracked emails sent to a member is above a certain threshold (defaults to 5) to avoid new members being heavily weighted
- fixes typo in EmailAnalytics that was stopping member stats from being aggregated