### PR TITLE
Refactored core/server/lib/image for Dependency Injection

### DIFF
--- a/core/frontend/meta/image-dimensions.js
+++ b/core/frontend/meta/image-dimensions.js
@@ -1,6 +1,6 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
-const {imageSizeCache} = require('../../server/lib/image');
+const imageSizeCache = require('../../server/lib/image').cachedImageSizeFromUrl;
 
 /**
  * Get Image dimensions
@@ -11,10 +11,10 @@ const {imageSizeCache} = require('../../server/lib/image');
  */
 function getImageDimensions(metaData) {
     const fetch = {
-        coverImage: imageSizeCache(metaData.coverImage.url),
-        authorImage: imageSizeCache(metaData.authorImage.url),
-        ogImage: imageSizeCache(metaData.ogImage.url),
-        logo: imageSizeCache(metaData.site.logo.url)
+        coverImage: imageSizeCache.getCachedImageSizeFromUrl(metaData.coverImage.url),
+        authorImage: imageSizeCache.getCachedImageSizeFromUrl(metaData.authorImage.url),
+        ogImage: imageSizeCache.getCachedImageSizeFromUrl(metaData.ogImage.url),
+        logo: imageSizeCache.getCachedImageSizeFromUrl(metaData.site.logo.url)
     };
 
     return Promise

--- a/core/frontend/services/proxy.js
+++ b/core/frontend/services/proxy.js
@@ -65,7 +65,7 @@ module.exports = {
 
     // Various utils, needs cleaning up / simplifying
     socialUrls: require('@tryghost/social-urls'),
-    blogIcon: require('../../server/lib/image/blog-icon'),
+    blogIcon: require('../../server/lib/image').blogIcon,
     urlService: require('./url'),
     urlUtils: require('../../shared/url-utils'),
     localUtils: require('./themes/handlebars/utils')

--- a/core/server/lib/image/blog-icon.js
+++ b/core/server/lib/image/blog-icon.js
@@ -2,121 +2,122 @@ const sizeOf = require('image-size');
 const Promise = require('bluebird');
 const _ = require('lodash');
 const path = require('path');
-const config = require('../../../shared/config');
-const {i18n} = require('../common');
 const errors = require('@tryghost/errors');
-const urlUtils = require('../../../shared/url-utils');
-const settingsCache = require('../../services/settings/cache');
-const storageUtils = require('../../adapters/storage/utils');
 
-/**
- * Get dimensions for ico file from its real file storage path
- * Always returns {object} getIconDimensions
- * @param {string} path
- * @returns {Promise<Object>} getIconDimensions
- * @description Takes a file path and returns ico width and height.
- */
-const getIconDimensions = function getIconDimensions(storagePath) {
-    return new Promise(function getIconSize(resolve, reject) {
-        let dimensions;
+class BlogIcon {
+    constructor({config, i18n, urlUtils, settingsCache, storageUtils}) {
+        this.config = config;
+        this.i18n = i18n;
+        this.urlUtils = urlUtils;
+        this.settingsCache = settingsCache;
+        this.storageUtils = storageUtils;
+    }
 
-        try {
-            dimensions = sizeOf(storagePath);
-
-            if (dimensions.images) {
-                dimensions.width = _.maxBy(dimensions.images, function (w) {
-                    return w.width;
-                }).width;
-                dimensions.height = _.maxBy(dimensions.images, function (h) {
-                    return h.height;
-                }).height;
+    /**
+     * Get dimensions for ico file from its real file storage path
+     * Always returns {object} getIconDimensions
+     * @param {string} path
+     * @returns {Promise<Object>} getIconDimensions
+     * @description Takes a file path and returns ico width and height.
+     */
+    getIconDimensions(storagePath) {
+        return new Promise((resolve, reject) => {
+            let dimensions;
+    
+            try {
+                dimensions = sizeOf(storagePath);
+    
+                if (dimensions.images) {
+                    dimensions.width = _.maxBy(dimensions.images, function (w) {
+                        return w.width;
+                    }).width;
+                    dimensions.height = _.maxBy(dimensions.images, function (h) {
+                        return h.height;
+                    }).height;
+                }
+    
+                return resolve({
+                    width: dimensions.width,
+                    height: dimensions.height
+                });
+            } catch (err) {
+                return reject(new errors.ValidationError({
+                    message: this.i18n.t('errors.utils.blogIcon.error', {
+                        file: storagePath,
+                        error: err.message
+                    })
+                }));
             }
+        });
+    }
 
-            return resolve({
-                width: dimensions.width,
-                height: dimensions.height
-            });
-        } catch (err) {
-            return reject(new errors.ValidationError({
-                message: i18n.t('errors.utils.blogIcon.error', {
-                    file: storagePath,
-                    error: err.message
-                })
-            }));
-        }
-    });
-};
+    /**
+     * Check if file is `.ico` extension
+     * Always returns {object} isIcoImageType
+     * @param {string} icon
+     * @returns {boolean} true if submitted path is .ico file
+     * @description Takes a path and returns boolean value.
+     */
+    isIcoImageType(icon) {
+        const blogIcon = icon || this.settingsCache.get('icon');
+    
+        return blogIcon.match(/.ico$/i) ? true : false;
+    }
 
-/**
- * Check if file is `.ico` extension
- * Always returns {object} isIcoImageType
- * @param {string} icon
- * @returns {Boolean} true if submitted path is .ico file
- * @description Takes a path and returns boolean value.
- */
-const isIcoImageType = function isIcoImageType(icon) {
-    const blogIcon = icon || settingsCache.get('icon');
+    /**
+     * Check if file is `.ico` extension
+     * Always returns {object} isIcoImageType
+     * @param {string} icon
+     * @returns {boolean} true if submitted path is .ico file
+     * @description Takes a path and returns boolean value.
+     */
+    getIconType(icon) {
+        const blogIcon = icon || this.settingsCache.get('icon');
+    
+        return this.isIcoImageType(blogIcon) ? 'x-icon' : 'png';
+    }
 
-    return blogIcon.match(/.ico$/i) ? true : false;
-};
-
-/**
- * Check if file is `.ico` extension
- * Always returns {object} isIcoImageType
- * @param {string} icon
- * @returns {Boolean} true if submitted path is .ico file
- * @description Takes a path and returns boolean value.
- */
-const getIconType = function getIconType(icon) {
-    const blogIcon = icon || settingsCache.get('icon');
-
-    return isIcoImageType(blogIcon) ? 'x-icon' : 'png';
-};
-
-/**
- * Return URL for Blog icon: [subdirectory or not]favicon.[ico or png]
- * Always returns {string} getIconUrl
- * @returns {string} [subdirectory or not]favicon.[ico or png]
- * @description Checks if we have a custom uploaded icon and the extension of it. If no custom uploaded icon
- * exists, we're returning the default `favicon.ico`
- */
-const getIconUrl = function getIconUrl(absolut) {
-    const blogIcon = settingsCache.get('icon');
-
-    if (absolut) {
-        if (blogIcon) {
-            return isIcoImageType(blogIcon) ? urlUtils.urlFor({relativeUrl: '/favicon.ico'}, true) : urlUtils.urlFor({relativeUrl: '/favicon.png'}, true);
+    /**
+     * Return URL for Blog icon: [subdirectory or not]favicon.[ico or png]
+     * Always returns {string} getIconUrl
+     * @returns {string} [subdirectory or not]favicon.[ico or png]
+     * @description Checks if we have a custom uploaded icon and the extension of it. If no custom uploaded icon
+     * exists, we're returning the default `favicon.ico`
+     */
+    getIconUrl(absolut) {
+        const blogIcon = this.settingsCache.get('icon');
+    
+        if (absolut) {
+            if (blogIcon) {
+                return this.isIcoImageType(blogIcon) ? this.urlUtils.urlFor({relativeUrl: '/favicon.ico'}, true) : this.urlUtils.urlFor({relativeUrl: '/favicon.png'}, true);
+            } else {
+                return this.urlUtils.urlFor({relativeUrl: '/favicon.ico'}, true);
+            }
         } else {
-            return urlUtils.urlFor({relativeUrl: '/favicon.ico'}, true);
-        }
-    } else {
-        if (blogIcon) {
-            return isIcoImageType(blogIcon) ? urlUtils.urlFor({relativeUrl: '/favicon.ico'}) : urlUtils.urlFor({relativeUrl: '/favicon.png'});
-        } else {
-            return urlUtils.urlFor({relativeUrl: '/favicon.ico'});
+            if (blogIcon) {
+                return this.isIcoImageType(blogIcon) ? this.urlUtils.urlFor({relativeUrl: '/favicon.ico'}) : this.urlUtils.urlFor({relativeUrl: '/favicon.png'});
+            } else {
+                return this.urlUtils.urlFor({relativeUrl: '/favicon.ico'});
+            }
         }
     }
-};
 
-/**
- * Return path for Blog icon without [subdirectory]/content/image prefix
- * Always returns {string} getIconPath
- * @returns {string} physical storage path of icon
- * @description Checks if we have a custom uploaded icon. If no custom uploaded icon
- * exists, we're returning the default `favicon.ico`
- */
-const getIconPath = function getIconPath() {
-    const blogIcon = settingsCache.get('icon');
-
-    if (blogIcon) {
-        return storageUtils.getLocalFileStoragePath(blogIcon);
-    } else {
-        return path.join(config.get('paths:publicFilePath'), 'favicon.ico');
+    /**
+     * Return path for Blog icon without [subdirectory]/content/image prefix
+     * Always returns {string} getIconPath
+     * @returns {string} physical storage path of icon
+     * @description Checks if we have a custom uploaded icon. If no custom uploaded icon
+     * exists, we're returning the default `favicon.ico`
+     */
+    getIconPath() {
+        const blogIcon = this.settingsCache.get('icon');
+    
+        if (blogIcon) {
+            return this.storageUtils.getLocalFileStoragePath(blogIcon);
+        } else {
+            return path.join(this.config.get('paths:publicFilePath'), 'favicon.ico');
+        }
     }
-};
+}
 
-module.exports.getIconDimensions = getIconDimensions;
-module.exports.isIcoImageType = isIcoImageType;
-module.exports.getIconUrl = getIconUrl;
-module.exports.getIconPath = getIconPath;
-module.exports.getIconType = getIconType;
+module.exports = BlogIcon;

--- a/core/server/lib/image/cached-image-size-from-url.js
+++ b/core/server/lib/image/cached-image-size-from-url.js
@@ -1,49 +1,54 @@
 const debug = require('ghost-ignition').debug('utils:image-size-cache');
-const imageSize = require('./image-size');
 const errors = require('@tryghost/errors');
-const logging = require('../../../shared/logging');
-const cache = {};
 
-/**
- * Get cached image size from URL
- * Always returns {object} imageSizeCache
- * @param {string} url
- * @returns {Promise<Object>} imageSizeCache
- * @description Takes a url and returns image width and height from cache if available.
- * If not in cache, `getImageSizeFromUrl` is called and returns the dimensions in a Promise.
- */
-function getCachedImageSizeFromUrl(url) {
-    if (!url || url === undefined || url === null) {
-        return;
+class CachedImageSizeFromUrl {
+    constructor({logging, imageSize}) {
+        this.logging = logging;
+        this.imageSize = imageSize;
+        this.cache = new Map();
     }
 
-    // image size is not in cache
-    if (!cache[url]) {
-        return imageSize.getImageSizeFromUrl(url).then(function (res) {
-            cache[url] = res;
-
-            debug('Cached image:', url);
-
-            return cache[url];
-        }).catch(errors.NotFoundError, function () {
-            debug('Cached image (not found):', url);
-            // in case of error we just attach the url
-            cache[url] = url;
-
-            return cache[url];
-        }).catch(function (err) {
-            debug('Cached image (error):', url);
-            logging.error(err);
-
-            // in case of error we just attach the url
-            cache[url] = url;
-
-            return cache[url];
-        });
+    /**
+     * Get cached image size from URL
+     * Always returns {object} imageSizeCache
+     * @param {string} url
+     * @returns {Promise<Object>} imageSizeCache
+     * @description Takes a url and returns image width and height from cache if available.
+     * If not in cache, `getImageSizeFromUrl` is called and returns the dimensions in a Promise.
+     */
+    getCachedImageSizeFromUrl(url) {
+        if (!url || url === undefined || url === null) {
+            return;
+        }
+    
+        // image size is not in cache
+        if (!this.cache.has(url)) {
+            return this.imageSize.getImageSizeFromUrl(url).then((res) => {
+                this.cache.set(url, res);
+    
+                debug('Cached image:', url);
+    
+                return this.cache.get(url);
+            }).catch(errors.NotFoundError, () => {
+                debug('Cached image (not found):', url);
+                // in case of error we just attach the url
+                this.cache.set(url, url);
+    
+                return this.cache.get(url);
+            }).catch((err) => {
+                debug('Cached image (error):', url);
+                this.logging.error(err);
+    
+                // in case of error we just attach the url
+                this.cache.set(url, url);
+    
+                return this.cache.get(url);
+            });
+        }
+        debug('Read image from cache:', url);
+        // returns image size from cache
+        return this.cache.get(url);
     }
-    debug('Read image from cache:', url);
-    // returns image size from cache
-    return cache[url];
 }
 
-module.exports = getCachedImageSizeFromUrl;
+module.exports = CachedImageSizeFromUrl;

--- a/core/server/lib/image/gravatar.js
+++ b/core/server/lib/image/gravatar.js
@@ -1,31 +1,38 @@
 const Promise = require('bluebird');
 const crypto = require('crypto');
-const config = require('../../../shared/config');
-const request = require('../request');
 
-module.exports.lookup = function lookup(userData, timeout) {
-    let gravatarUrl = '//www.gravatar.com/avatar/' +
-        crypto.createHash('md5').update(userData.email.toLowerCase().trim()).digest('hex') +
-        '?s=250';
-
-    if (config.isPrivacyDisabled('useGravatar')) {
-        return Promise.resolve();
+class Gravatar {
+    constructor({config, request}) {
+        this.config = config;
+        this.request = request;
     }
 
-    return Promise.resolve(request('https:' + gravatarUrl + '&d=404&r=x', {timeout: timeout || 2 * 1000}))
-        .then(function () {
-            gravatarUrl += '&d=mm&r=x';
+    lookup(userData, timeout) {
+        let gravatarUrl = '//www.gravatar.com/avatar/' +
+            crypto.createHash('md5').update(userData.email.toLowerCase().trim()).digest('hex') +
+            '?s=250';
+    
+        if (this.config.isPrivacyDisabled('useGravatar')) {
+            return Promise.resolve();
+        }
+    
+        return Promise.resolve(this.request('https:' + gravatarUrl + '&d=404&r=x', {timeout: timeout || 2 * 1000}))
+            .then(function () {
+                gravatarUrl += '&d=mm&r=x';
+    
+                return {
+                    image: gravatarUrl
+                };
+            })
+            .catch({statusCode: 404}, function () {
+                return {
+                    image: undefined
+                };
+            })
+            .catch(function () {
+                // ignore error, just resolve with no image url
+            });
+    }
+}
 
-            return {
-                image: gravatarUrl
-            };
-        })
-        .catch({statusCode: 404}, function () {
-            return {
-                image: undefined
-            };
-        })
-        .catch(function () {
-            // ignore error, just resolve with no image url
-        });
-};
+module.exports = Gravatar;

--- a/core/server/lib/image/image-size.js
+++ b/core/server/lib/image/image-size.js
@@ -4,292 +4,294 @@ const probeSizeOf = require('probe-image-size');
 const url = require('url');
 const Promise = require('bluebird');
 const _ = require('lodash');
-const request = require('../request');
-const urlUtils = require('../../../shared/url-utils');
-const {i18n} = require('../common');
 const errors = require('@tryghost/errors');
-const config = require('../../../shared/config');
-const storage = require('../../adapters/storage');
-const storageUtils = require('../../adapters/storage/utils');
-const validator = require('../../data/validation').validator;
 
 // these are formats supported by image-size but not probe-image-size
 const FETCH_ONLY_FORMATS = [
     'cur', 'icns', 'ico', 'dds'
 ];
 
-const REQUEST_OPTIONS = {
-    // we need the user-agent, otherwise some https request may fail (e.g. cloudfare)
-    headers: {
-        'User-Agent': 'Mozilla/5.0 Safari/537.36'
-    },
-    timeout: config.get('times:getImageSizeTimeoutInMS') || 10000,
-    retry: 0, // for `got`, used with image-size
-    encoding: null
-};
+class ImageSize {
+    constructor({config, i18n, storage, storageUtils, validator, urlUtils, request}) {
+        this.config = config;
+        this.i18n = i18n;
+        this.storage = storage;
+        this.storageUtils = storageUtils;
+        this.validator = validator;
+        this.urlUtils = urlUtils;
+        this.request = request;
 
-// processes the Buffer result of an image file using image-size
-// returns promise which resolves dimensions
-function _imageSizeFromBuffer(buffer) {
-    return new Promise((resolve, reject) => {
-        try {
-            const dimensions = sizeOf(buffer);
-
-            // CASE: `.ico` files might have multiple images and therefore multiple sizes.
-            // We return the largest size found (image-size default is the first size found)
-            if (dimensions.images) {
-                dimensions.width = _.maxBy(dimensions.images, img => img.width).width;
-                dimensions.height = _.maxBy(dimensions.images, img => img.height).height;
-            }
-
-            return resolve(dimensions);
-        } catch (err) {
-            return reject(err);
-        }
-    });
-}
-
-// use probe-image-size to download enough of an image to get it's dimensions
-// returns promise which resolves dimensions
-function _probeImageSizeFromUrl(imageUrl) {
-    // probe-image-size uses `request` npm module which doesn't have our `got`
-    // override with custom URL validation so it needs duplicating here
-    if (_.isEmpty(imageUrl) || !validator.isURL(imageUrl)) {
-        return Promise.reject(new errors.InternalServerError({
-            message: 'URL empty or invalid.',
-            code: 'URL_MISSING_INVALID',
-            context: imageUrl
-        }));
-    }
-
-    return probeSizeOf(imageUrl, REQUEST_OPTIONS);
-}
-
-// download full image then use image-size to get it's dimensions
-// returns promise which resolves dimensions
-function _fetchImageSizeFromUrl(imageUrl) {
-    return request(imageUrl, REQUEST_OPTIONS).then((response) => {
-        return _imageSizeFromBuffer(response.body);
-    });
-}
-
-// wrapper for appropriate probe/fetch method for getting image dimensions from a URL
-// returns promise which resolves dimensions
-function _imageSizeFromUrl(imageUrl) {
-    return new Promise((resolve, reject) => {
-        let parsedUrl;
-
-        try {
-            parsedUrl = url.parse(imageUrl);
-        } catch (err) {
-            reject(err);
-        }
-
-        // check if we got an url without any protocol
-        if (!parsedUrl.protocol) {
-            // CASE: our gravatar URLs start with '//' and we need to add 'http:'
-            // to make the request work
-            imageUrl = 'http:' + imageUrl;
-        }
-
-        const extensionMatch = imageUrl.match(/(?:\.)([a-zA-Z]{3,4})(\?|$)/) || [];
-        const extension = (extensionMatch[1] || '').toLowerCase();
-
-        if (FETCH_ONLY_FORMATS.includes(extension)) {
-            return resolve(_fetchImageSizeFromUrl(imageUrl));
-        } else {
-            return resolve(_probeImageSizeFromUrl(imageUrl));
-        }
-    });
-}
-
-// Supported formats of https://github.com/image-size/image-size:
-// BMP, GIF, JPEG, PNG, PSD, TIFF, WebP, SVG, ICO
-// ***
-// Takes the url of the image and an optional timeout
-// getImageSizeFromUrl returns an Object like this
-// {
-//     height: 50,
-//     url: 'http://myblog.com/images/cat.jpg',
-//     width: 50
-// };
-// if the dimensions can be fetched, and rejects with error, if not.
-// ***
-// In case we get a locally stored image, which is checked withing the `isLocalImage`
-// function we switch to read the image from the local file storage with `getImageSizeFromStoragePath`.
-// In case the image is not stored locally and is missing the protocol (like //www.gravatar.com/andsoon),
-// we add the protocol and use urlFor() to get the absolute URL.
-// If the request fails or image-size is not able to read the file, we reject with error.
-
-/**
- * @description read image dimensions from URL
- * @param {String} imagePath as URL
- * @returns {Promise<Object>} imageObject or error
- */
-const getImageSizeFromUrl = (imagePath) => {
-    if (storageUtils.isLocalImage(imagePath)) {
-        // don't make a request for a locally stored image
-        return getImageSizeFromStoragePath(imagePath);
-    }
-
-    // CASE: pre 1.0 users were able to use an asset path for their blog logo
-    if (imagePath.match(/^\/assets/)) {
-        imagePath = urlUtils.urlJoin(urlUtils.urlFor('home', true), urlUtils.getSubdir(), '/', imagePath);
-    }
-
-    debug('requested imagePath:', imagePath);
-
-    return _imageSizeFromUrl(imagePath).then((dimensions) => {
-        debug('Image fetched (URL):', imagePath);
-
-        return {
-            url: imagePath,
-            width: dimensions.width,
-            height: dimensions.height
+        this.REQUEST_OPTIONS = {
+            // we need the user-agent, otherwise some https request may fail (e.g. cloudfare)
+            headers: {
+                'User-Agent': 'Mozilla/5.0 Safari/537.36'
+            },
+            timeout: this.config.get('times:getImageSizeTimeoutInMS') || 10000,
+            retry: 0, // for `got`, used with image-size
+            encoding: null
         };
-    }).catch({code: 'URL_MISSING_INVALID'}, (err) => {
-        return Promise.reject(new errors.InternalServerError({
-            message: err.message,
-            code: 'IMAGE_SIZE_URL',
-            statusCode: err.statusCode,
-            context: err.url || imagePath
-        }));
-    }).catch({code: 'ETIMEDOUT'}, {statusCode: 408}, (err) => {
-        return Promise.reject(new errors.InternalServerError({
-            message: 'Request timed out.',
-            code: 'IMAGE_SIZE_URL',
-            statusCode: err.statusCode,
-            context: err.url || imagePath
-        }));
-    }).catch({code: 'ENOENT'}, {statusCode: 404}, (err) => {
-        return Promise.reject(new errors.NotFoundError({
-            message: 'Image not found.',
-            code: 'IMAGE_SIZE_URL',
-            statusCode: err.statusCode,
-            context: err.url || imagePath
-        }));
-    }).catch(function (err) {
-        if (errors.utils.isIgnitionError(err)) {
-            return Promise.reject(err);
+    }
+
+    // processes the Buffer result of an image file using image-size
+    // returns promise which resolves dimensions
+    _imageSizeFromBuffer(buffer) {
+        return new Promise((resolve, reject) => {
+            try {
+                const dimensions = sizeOf(buffer);
+    
+                // CASE: `.ico` files might have multiple images and therefore multiple sizes.
+                // We return the largest size found (image-size default is the first size found)
+                if (dimensions.images) {
+                    dimensions.width = _.maxBy(dimensions.images, img => img.width).width;
+                    dimensions.height = _.maxBy(dimensions.images, img => img.height).height;
+                }
+    
+                return resolve(dimensions);
+            } catch (err) {
+                return reject(err);
+            }
+        });
+    }
+
+    // use probe-image-size to download enough of an image to get it's dimensions
+    // returns promise which resolves dimensions
+    _probeImageSizeFromUrl(imageUrl) {
+        // probe-image-size uses `request` npm module which doesn't have our `got`
+        // override with custom URL validation so it needs duplicating here
+        if (_.isEmpty(imageUrl) || !this.validator.isURL(imageUrl)) {
+            return Promise.reject(new errors.InternalServerError({
+                message: 'URL empty or invalid.',
+                code: 'URL_MISSING_INVALID',
+                context: imageUrl
+            }));
         }
+    
+        return probeSizeOf(imageUrl, this.REQUEST_OPTIONS);
+    }
 
-        return Promise.reject(new errors.InternalServerError({
-            message: 'Unknown Request error.',
-            code: 'IMAGE_SIZE_URL',
-            statusCode: err.statusCode,
-            context: err.url || imagePath,
-            err: err
-        }));
-    });
-};
+    // download full image then use image-size to get it's dimensions
+    // returns promise which resolves dimensions
+    _fetchImageSizeFromUrl(imageUrl) {
+        return this.request(imageUrl, this.REQUEST_OPTIONS).then((response) => {
+            return this._imageSizeFromBuffer(response.body);
+        });
+    }
 
-// Supported formats of https://github.com/image-size/image-size:
-// BMP, GIF, JPEG, PNG, PSD, TIFF, WebP, SVG, ICO
-// ***
-// Takes the url or filepath of the image and reads it form the local
-// file storage.
-// getImageSizeFromStoragePath returns an Object like this
-// {
-//     height: 50,
-//     url: 'http://myblog.com/images/cat.jpg',
-//     width: 50
-// };
-// if the image is found and dimensions can be fetched, and rejects with error, if not.
-/**
- * @description read image dimensions from local file storage
- * @param {String} imagePath
- * @returns {object} imageObject or error
- */
-const getImageSizeFromStoragePath = (imagePath) => {
-    let filePath;
-
-    imagePath = urlUtils.urlFor('image', {image: imagePath}, true);
-
-    // get the storage readable filePath
-    filePath = storageUtils.getLocalFileStoragePath(imagePath);
-
-    return storage.getStorage()
-        .read({path: filePath})
-        .then((buf) => {
-            debug('Image fetched (storage):', filePath);
-            return _imageSizeFromBuffer(buf);
-        })
-        .then((dimensions) => {
+    // wrapper for appropriate probe/fetch method for getting image dimensions from a URL
+    // returns promise which resolves dimensions
+    _imageSizeFromUrl(imageUrl) {
+        return new Promise((resolve, reject) => {
+            let parsedUrl;
+    
+            try {
+                parsedUrl = url.parse(imageUrl);
+            } catch (err) {
+                reject(err);
+            }
+    
+            // check if we got an url without any protocol
+            if (!parsedUrl.protocol) {
+                // CASE: our gravatar URLs start with '//' and we need to add 'http:'
+                // to make the request work
+                imageUrl = 'http:' + imageUrl;
+            }
+    
+            const extensionMatch = imageUrl.match(/(?:\.)([a-zA-Z]{3,4})(\?|$)/) || [];
+            const extension = (extensionMatch[1] || '').toLowerCase();
+    
+            if (FETCH_ONLY_FORMATS.includes(extension)) {
+                return resolve(this._fetchImageSizeFromUrl(imageUrl));
+            } else {
+                return resolve(this._probeImageSizeFromUrl(imageUrl));
+            }
+        });
+    }
+    // Supported formats of https://github.com/image-size/image-size:
+    // BMP, GIF, JPEG, PNG, PSD, TIFF, WebP, SVG, ICO
+    // ***
+    // Takes the url of the image and an optional timeout
+    // getImageSizeFromUrl returns an Object like this
+    // {
+    //     height: 50,
+    //     url: 'http://myblog.com/images/cat.jpg',
+    //     width: 50
+    // };
+    // if the dimensions can be fetched, and rejects with error, if not.
+    // ***
+    // In case we get a locally stored image, which is checked withing the `isLocalImage`
+    // function we switch to read the image from the local file storage with `getImageSizeFromStoragePath`.
+    // In case the image is not stored locally and is missing the protocol (like //www.gravatar.com/andsoon),
+    // we add the protocol and use urlFor() to get the absolute URL.
+    // If the request fails or image-size is not able to read the file, we reject with error.
+    
+    /**
+     * @description read image dimensions from URL
+     * @param {string} imagePath as URL
+     * @returns {Promise<Object>} imageObject or error
+     */
+    getImageSizeFromUrl(imagePath) {
+        if (this.storageUtils.isLocalImage(imagePath)) {
+            // don't make a request for a locally stored image
+            return this.getImageSizeFromStoragePath(imagePath);
+        }
+    
+        // CASE: pre 1.0 users were able to use an asset path for their blog logo
+        if (imagePath.match(/^\/assets/)) {
+            imagePath = this.urlUtils.urlJoin(this.urlUtils.urlFor('home', true), this.urlUtils.getSubdir(), '/', imagePath);
+        }
+    
+        debug('requested imagePath:', imagePath);
+    
+        return this._imageSizeFromUrl(imagePath).then((dimensions) => {
+            debug('Image fetched (URL):', imagePath);
+    
             return {
                 url: imagePath,
                 width: dimensions.width,
                 height: dimensions.height
             };
-        })
-        .catch({code: 'ENOENT'}, (err) => {
-            return Promise.reject(new errors.NotFoundError({
+        }).catch({code: 'URL_MISSING_INVALID'}, (err) => {
+            return Promise.reject(new errors.InternalServerError({
                 message: err.message,
-                code: 'IMAGE_SIZE_STORAGE',
-                err: err,
-                context: filePath,
-                errorDetails: {
-                    originalPath: imagePath,
-                    reqFilePath: filePath
-                }
+                code: 'IMAGE_SIZE_URL',
+                statusCode: err.statusCode,
+                context: err.url || imagePath
             }));
-        }).catch((err) => {
+        }).catch({code: 'ETIMEDOUT'}, {code: 'ESOCKETTIMEDOUT'}, {statusCode: 408}, (err) => {
+            return Promise.reject(new errors.InternalServerError({
+                message: 'Request timed out.',
+                code: 'IMAGE_SIZE_URL',
+                statusCode: err.statusCode,
+                context: err.url || imagePath
+            }));
+        }).catch({code: 'ENOENT'}, {statusCode: 404}, (err) => {
+            return Promise.reject(new errors.NotFoundError({
+                message: 'Image not found.',
+                code: 'IMAGE_SIZE_URL',
+                statusCode: err.statusCode,
+                context: err.url || imagePath
+            }));
+        }).catch(function (err) {
             if (errors.utils.isIgnitionError(err)) {
                 return Promise.reject(err);
             }
-
+    
             return Promise.reject(new errors.InternalServerError({
-                message: err.message,
-                code: 'IMAGE_SIZE_STORAGE',
-                err: err,
-                context: filePath,
-                errorDetails: {
-                    originalPath: imagePath,
-                    reqFilePath: filePath
-                }
+                message: 'Unknown Request error.',
+                code: 'IMAGE_SIZE_URL',
+                statusCode: err.statusCode,
+                context: err.url || imagePath,
+                err: err
             }));
         });
-};
+    }
 
-/**
- * Supported formats of https://github.com/image-size/image-size:
- * BMP, GIF, JPEG, PNG, PSD, TIFF, WebP, SVG, ICO
- * Get dimensions for a file from its real file storage path
- * Always returns {object} getImageDimensions
- * @param {string} path
- * @returns {Promise<Object>} getImageDimensions
- * @description Takes a file path and returns width and height.
- */
-const getImageSizeFromPath = (path) => {
-    return new Promise(function getSize(resolve, reject) {
-        let dimensions;
-
-        try {
-            dimensions = sizeOf(path);
-
-            if (dimensions.images) {
-                dimensions.width = _.maxBy(dimensions.images, (w) => {
-                    return w.width;
-                }).width;
-                dimensions.height = _.maxBy(dimensions.images, (h) => {
-                    return h.height;
-                }).height;
-            }
-
-            return resolve({
-                width: dimensions.width,
-                height: dimensions.height
+    // Supported formats of https://github.com/image-size/image-size:
+    // BMP, GIF, JPEG, PNG, PSD, TIFF, WebP, SVG, ICO
+    // ***
+    // Takes the url or filepath of the image and reads it form the local
+    // file storage.
+    // getImageSizeFromStoragePath returns an Object like this
+    // {
+    //     height: 50,
+    //     url: 'http://myblog.com/images/cat.jpg',
+    //     width: 50
+    // };
+    // if the image is found and dimensions can be fetched, and rejects with error, if not.
+    /**
+     * @description read image dimensions from local file storage
+     * @param {string} imagePath
+     * @returns {object} imageObject or error
+     */
+    getImageSizeFromStoragePath(imagePath) {
+        let filePath;
+    
+        imagePath = this.urlUtils.urlFor('image', {image: imagePath}, true);
+    
+        // get the storage readable filePath
+        filePath = this.storageUtils.getLocalFileStoragePath(imagePath);
+    
+        return this.storage.getStorage()
+            .read({path: filePath})
+            .then((buf) => {
+                debug('Image fetched (storage):', filePath);
+                return this._imageSizeFromBuffer(buf);
+            })
+            .then((dimensions) => {
+                return {
+                    url: imagePath,
+                    width: dimensions.width,
+                    height: dimensions.height
+                };
+            })
+            .catch({code: 'ENOENT'}, (err) => {
+                return Promise.reject(new errors.NotFoundError({
+                    message: err.message,
+                    code: 'IMAGE_SIZE_STORAGE',
+                    err: err,
+                    context: filePath,
+                    errorDetails: {
+                        originalPath: imagePath,
+                        reqFilePath: filePath
+                    }
+                }));
+            }).catch((err) => {
+                if (errors.utils.isIgnitionError(err)) {
+                    return Promise.reject(err);
+                }
+    
+                return Promise.reject(new errors.InternalServerError({
+                    message: err.message,
+                    code: 'IMAGE_SIZE_STORAGE',
+                    err: err,
+                    context: filePath,
+                    errorDetails: {
+                        originalPath: imagePath,
+                        reqFilePath: filePath
+                    }
+                }));
             });
-        } catch (err) {
-            return reject(new errors.ValidationError({
-                message: i18n.t('errors.utils.images.invalidDimensions', {
-                    file: path,
-                    error: err.message
-                })
-            }));
-        }
-    });
-};
+    }
 
-module.exports.getImageSizeFromUrl = getImageSizeFromUrl;
-module.exports.getImageSizeFromStoragePath = getImageSizeFromStoragePath;
-module.exports.getImageSizeFromPath = getImageSizeFromPath;
+    /**
+     * Supported formats of https://github.com/image-size/image-size:
+     * BMP, GIF, JPEG, PNG, PSD, TIFF, WebP, SVG, ICO
+     * Get dimensions for a file from its real file storage path
+     * Always returns {object} getImageDimensions
+     * @param {string} path
+     * @returns {Promise<Object>} getImageDimensions
+     * @description Takes a file path and returns width and height.
+     */
+    getImageSizeFromPath(path) {
+        return new Promise(function getSize(resolve, reject) {
+            let dimensions;
+    
+            try {
+                dimensions = sizeOf(path);
+    
+                if (dimensions.images) {
+                    dimensions.width = _.maxBy(dimensions.images, (w) => {
+                        return w.width;
+                    }).width;
+                    dimensions.height = _.maxBy(dimensions.images, (h) => {
+                        return h.height;
+                    }).height;
+                }
+    
+                return resolve({
+                    width: dimensions.width,
+                    height: dimensions.height
+                });
+            } catch (err) {
+                return reject(new errors.ValidationError({
+                    message: this.i18n.t('errors.utils.images.invalidDimensions', {
+                        file: path,
+                        error: err.message
+                    })
+                }));
+            }
+        });
+    }
+}
+
+module.exports = ImageSize;

--- a/core/server/lib/image/image-utils.js
+++ b/core/server/lib/image/image-utils.js
@@ -1,0 +1,15 @@
+const BlogIcon = require('./blog-icon');
+const CachedImageSizeFromUrl = require('./cached-image-size-from-url');
+const Gravatar = require('./gravatar');
+const ImageSize = require('./image-size');
+
+class ImageUtils {
+    constructor({config, logging, i18n, urlUtils, settingsCache, storageUtils, storage, validator, request}) {
+        this.blogIcon = new BlogIcon({config, i18n, urlUtils, settingsCache, storageUtils});
+        this.imageSize = new ImageSize({config, i18n, storage, storageUtils, validator, urlUtils, request});
+        this.cachedImageSizeFromUrl = new CachedImageSizeFromUrl({logging, imageSize: this.imageSize});
+        this.gravatar = new Gravatar({config, request});
+    }
+}
+
+module.exports = ImageUtils;

--- a/core/server/lib/image/index.js
+++ b/core/server/lib/image/index.js
@@ -1,17 +1,12 @@
-module.exports = {
-    get blogIcon() {
-        return require('./blog-icon');
-    },
+const request = require('../request');
+const urlUtils = require('../../../shared/url-utils');
+const storage = require('../../adapters/storage');
+const storageUtils = require('../../adapters/storage/utils');
+const validator = require('../../data/validation').validator;
+const config = require('../../../shared/config');
+const logging = require('../../../shared/logging');
+const {i18n} = require('../common');
+const settingsCache = require('../../services/settings/cache');
+const ImageUtils = require('./image-utils');
 
-    get imageSize() {
-        return require('./image-size');
-    },
-
-    get gravatar() {
-        return require('./gravatar');
-    },
-
-    get imageSizeCache() {
-        return require('./cached-image-size-from-url');
-    }
-};
+module.exports = new ImageUtils({config, logging, i18n, urlUtils, settingsCache, storageUtils, storage, validator, request});

--- a/core/server/lib/mobiledoc.js
+++ b/core/server/lib/mobiledoc.js
@@ -92,7 +92,7 @@ module.exports = {
     populateImageSizes: async function (mobiledocJson) {
         // do not require image-size until it's requested to avoid circular dependencies
         // shared/url-utils > server/lib/mobiledoc > server/lib/image/image-size > server/adapters/storage/utils
-        const imageSize = require('./image/image-size');
+        const {imageSize} = require('./image');
         const urlUtils = require('../../shared/url-utils');
         const storageInstance = storage.getStorage();
 

--- a/test/unit/data/meta/image-dimensions_spec.js
+++ b/test/unit/data/meta/image-dimensions_spec.js
@@ -38,7 +38,9 @@ describe('getImageDimensions', function () {
             type: 'jpg'
         });
 
-        getImageDimensions.__set__('imageSizeCache', sizeOfStub);
+        getImageDimensions.__set__('imageSizeCache', {
+            getCachedImageSizeFromUrl: sizeOfStub
+        });
 
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);
@@ -89,7 +91,9 @@ describe('getImageDimensions', function () {
 
         sizeOfStub.returns({});
 
-        getImageDimensions.__set__('imageSizeCache', sizeOfStub);
+        getImageDimensions.__set__('imageSizeCache', {
+            getCachedImageSizeFromUrl: sizeOfStub
+        });
 
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);
@@ -133,7 +137,9 @@ describe('getImageDimensions', function () {
             type: 'jpg'
         });
 
-        getImageDimensions.__set__('imageSizeCache', sizeOfStub);
+        getImageDimensions.__set__('imageSizeCache', {
+            getCachedImageSizeFromUrl: sizeOfStub
+        });
 
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);
@@ -185,7 +191,9 @@ describe('getImageDimensions', function () {
             type: 'jpg'
         });
 
-        getImageDimensions.__set__('imageSizeCache', sizeOfStub);
+        getImageDimensions.__set__('imageSizeCache', {
+            getCachedImageSizeFromUrl: sizeOfStub
+        });
 
         getImageDimensions(metaData).then(function (result) {
             should.exist(result);

--- a/test/unit/lib/image/blog-icon_spec.js
+++ b/test/unit/lib/image/blog-icon_spec.js
@@ -2,120 +2,202 @@ const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
 const path = require('path');
-const rewire = require('rewire');
-const settingsCache = require('../../../../core/server/services/settings/cache');
-const storageUtils = require('../../../../core/server/adapters/storage/utils');
-const urlUtils = require('../../../utils/urlUtils');
-
-// stuff we are testing
-const blogIcon = rewire('../../../../core/server/lib/image/blog-icon');
+const BlogIcon = require('../../../../core/server/lib/image/blog-icon');
 
 describe('lib/image: blog icon', function () {
-    afterEach(function () {
-        sinon.restore();
-        rewire('../../../../core/server/lib/image/blog-icon');
-    });
-
     describe('getIconUrl', function () {
         it('custom uploaded ico blog icon', function () {
-            sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
-            blogIcon.getIconUrl().should.eql('/favicon.ico');
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {
+                urlFor: (key, boolean) => [key, boolean]
+            }, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return '/content/images/2017/04/my-icon.ico';
+                    }
+                }
+            }});
+            blogIcon.getIconUrl().should.deepEqual([{relativeUrl: '/favicon.ico'}, undefined]);
         });
 
         it('custom uploaded png blog icon', function () {
-            sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
-            blogIcon.getIconUrl().should.eql('/favicon.png');
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {
+                urlFor: (key, boolean) => [key, boolean]
+            }, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return '/content/images/2017/04/my-icon.png';
+                    }
+                }
+            }});
+            blogIcon.getIconUrl().should.deepEqual([{relativeUrl: '/favicon.png'}, undefined]);
         });
 
         it('default ico blog icon', function () {
-            blogIcon.getIconUrl().should.eql('/favicon.ico');
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {
+                urlFor: key => key
+            }, settingsCache: {
+                get: () => {}
+            }});
+            blogIcon.getIconUrl().should.deepEqual({relativeUrl: '/favicon.ico'});
         });
 
         describe('absolute URL', function () {
             it('custom uploaded ico blog icon', function () {
-                blogIcon.__set__('urlUtils', urlUtils.getInstance({url: 'http://my-ghost-blog.com/'}));
-                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
-                blogIcon.getIconUrl(true).should.eql('http://my-ghost-blog.com/favicon.ico');
+                const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {
+                    urlFor: (key, boolean) => [key, boolean]
+                }, settingsCache: {
+                    get: (key) => {
+                        if (key === 'icon') {
+                            return '/content/images/2017/04/my-icon.ico';
+                        }
+                    }
+                }});
+                blogIcon.getIconUrl(true).should.deepEqual([{relativeUrl: '/favicon.ico'}, true]);
             });
 
             it('custom uploaded png blog icon', function () {
-                blogIcon.__set__('urlUtils', urlUtils.getInstance({url: 'http://my-ghost-blog.com/'}));
-                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
-                blogIcon.getIconUrl(true).should.eql('http://my-ghost-blog.com/favicon.png');
+                const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {
+                    urlFor: (key, boolean) => [key, boolean]
+                }, settingsCache: {
+                    get: (key) => {
+                        if (key === 'icon') {
+                            return '/content/images/2017/04/my-icon.png';
+                        }
+                    }
+                }});
+                blogIcon.getIconUrl(true).should.deepEqual([{relativeUrl: '/favicon.png'}, true]);
             });
 
             it('default ico blog icon', function () {
-                blogIcon.__set__('urlUtils', urlUtils.getInstance({url: 'http://my-ghost-blog.com/'}));
-                blogIcon.getIconUrl(true).should.eql('http://my-ghost-blog.com/favicon.ico');
-            });
-        });
-
-        describe('with subdirectory', function () {
-            it('custom uploaded ico blog icon', function () {
-                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
-                blogIcon.__set__('urlUtils', urlUtils.getInstance({url: 'http://my-ghost-blog.com/blog'}));
-
-                blogIcon.getIconUrl().should.eql('/blog/favicon.ico');
-            });
-
-            it('custom uploaded png blog icon', function () {
-                sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
-                blogIcon.__set__('urlUtils', urlUtils.getInstance({url: 'http://my-ghost-blog.com/blog'}));
-
-                blogIcon.getIconUrl().should.eql('/blog/favicon.png');
-            });
-
-            it('default ico blog icon', function () {
-                blogIcon.__set__('urlUtils', urlUtils.getInstance({url: 'http://my-ghost-blog.com/blog'}));
-                blogIcon.getIconUrl().should.eql('/blog/favicon.ico');
+                const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {
+                    urlFor: (key, boolean) => [key, boolean]
+                }, settingsCache: {
+                    get: () => {}
+                }});
+                blogIcon.getIconUrl(true).should.deepEqual([{relativeUrl: '/favicon.ico'}, true]);
             });
         });
     });
 
     describe('getIconPath', function () {
         it('custom uploaded ico blog icon', function () {
-            sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.ico');
-            sinon.stub(storageUtils, 'getLocalFileStoragePath');
-            blogIcon.getIconPath();
+            const stub = sinon.stub();
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {
+                getLocalFileStoragePath: stub
+            }, urlUtils: {}, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return '/content/images/2017/04/my-icon.ico';
+                    }
+                }
+            }});
 
-            storageUtils.getLocalFileStoragePath.calledOnce.should.be.true();
+            blogIcon.getIconPath();
+            stub.calledOnce.should.be.true();
         });
 
         it('custom uploaded png blog icon', function () {
-            sinon.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
-            sinon.stub(storageUtils, 'getLocalFileStoragePath');
-            blogIcon.getIconPath();
+            const stub = sinon.stub();
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {
+                getLocalFileStoragePath: stub
+            }, urlUtils: {}, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return '/content/images/2017/04/my-icon.png';
+                    }
+                }
+            }});
 
-            storageUtils.getLocalFileStoragePath.calledOnce.should.be.true();
+            blogIcon.getIconPath();
+            stub.calledOnce.should.be.true();
         });
 
         it('default ico blog icon', function () {
-            blogIcon.getIconPath().should.eql(path.join(__dirname, '../../../../core/server/public/favicon.ico'));
+            const root = '/home/test';
+            const blogIcon = new BlogIcon({config: {
+                get: (key) => {
+                    if (key === 'paths:publicFilePath') {
+                        return root;
+                    }
+                }
+            }, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {
+                get: () => {}
+            }});
+            blogIcon.getIconPath().should.eql(path.join(root, 'favicon.ico'));
         });
     });
 
     describe('isIcoImageType', function () {
         it('returns true, if icon is .ico filetype', function () {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.isIcoImageType('icon.ico').should.be.true();
         });
 
         it('returns false, if icon is not .ico filetype', function () {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.isIcoImageType('icon.png').should.be.false();
+        });
+
+        it('returns true, if icon is .ico filetype when using settingsCache', function () {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return 'icon.ico';
+                    }
+                }
+            }});
+            blogIcon.isIcoImageType().should.be.true();
+        });
+
+        it('returns false, if icon is not .ico filetype when using settingsCache', function () {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return 'icon.png';
+                    }
+                }
+            }});
+            blogIcon.isIcoImageType().should.be.false();
         });
     });
 
     describe('getIconType', function () {
         it('returns x-icon for ico icons', function () {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.getIconType('favicon.ico').should.eql('x-icon');
         });
 
         it('returns png for png icon', function () {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.getIconType('favicon.png').should.eql('png');
+        });
+
+        it('returns x-icon for ico icons when the icon is cached', function () {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return 'favicon.ico';
+                    }
+                }
+            }});
+            blogIcon.getIconType().should.eql('x-icon');
+        });
+
+        it('returns png for png icon when the icon is cached', function () {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {
+                get: (key) => {
+                    if (key === 'icon') {
+                        return 'favicon.png';
+                    }
+                }
+            }});
+            blogIcon.getIconType().should.eql('png');
         });
     });
 
     describe('getIconDimensions', function () {
         it('[success] returns .ico dimensions', function (done) {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.getIconDimensions(path.join(__dirname, '../../../utils/fixtures/images/favicon.ico'))
                 .then(function (result) {
                     should.exist(result);
@@ -128,6 +210,7 @@ describe('lib/image: blog icon', function () {
         });
 
         it('[success] returns .png dimensions', function (done) {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.getIconDimensions(path.join(__dirname, '../../../utils/fixtures/images/favicon.png'))
                 .then(function (result) {
                     should.exist(result);
@@ -140,6 +223,7 @@ describe('lib/image: blog icon', function () {
         });
 
         it('[success] returns .ico dimensions for icon with multiple sizes', function (done) {
+            const blogIcon = new BlogIcon({config: {}, i18n: {}, storageUtils: {}, urlUtils: {}, settingsCache: {}});
             blogIcon.getIconDimensions(path.join(__dirname, '../../../utils/fixtures/images/favicon_multi_sizes.ico'))
                 .then(function (result) {
                     should.exist(result);
@@ -152,16 +236,14 @@ describe('lib/image: blog icon', function () {
         });
 
         it('[failure] return error message', function (done) {
-            const sizeOfStub = sinon.stub();
+            const blogIcon = new BlogIcon({config: {}, i18n: {
+                t: key => key
+            }, storageUtils: {}, urlUtils: {}, settingsCache: {}});
 
-            sizeOfStub.throws({error: 'image-size could not find dimensions'});
-
-            blogIcon.__set__('sizeOf', sizeOfStub);
-
-            blogIcon.getIconDimensions(path.join(__dirname, '../../../utils/fixtures/images/favicon_multi_sizes.ico'))
+            blogIcon.getIconDimensions(path.join(__dirname, '../../../utils/fixtures/images/favicon_multi_sizes_FILE_DOES_NOT_EXIST.ico'))
                 .catch(function (error) {
                     should.exist(error);
-                    error.message.should.eql('Could not fetch icon dimensions.');
+                    error.message.should.eql('errors.utils.blogIcon.error');
                     done();
                 });
         });

--- a/test/unit/lib/image/cached-image-size-from-url_spec.js
+++ b/test/unit/lib/image/cached-image-size-from-url_spec.js
@@ -1,15 +1,11 @@
 const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
-const rewire = require('rewire');
-
-// Stuff we are testing
-const getCachedImageSizeFromUrl = rewire('../../../../core/server/lib/image/cached-image-size-from-url');
+const CachedImageSizeFromUrl = require('../../../../core/server/lib/image/cached-image-size-from-url');
 
 describe('lib/image: image size cache', function () {
     let sizeOfStub;
     let cachedImagedSize;
-    let revertGetCachedImageSizeFromUrl;
 
     beforeEach(function () {
         sizeOfStub = sinon.stub();
@@ -17,11 +13,6 @@ describe('lib/image: image size cache', function () {
 
     afterEach(function () {
         sinon.restore();
-        getCachedImageSizeFromUrl.__set__('cache', {});
-
-        if (revertGetCachedImageSizeFromUrl) {
-            revertGetCachedImageSizeFromUrl();
-        }
     });
 
     it('should read from cache, if dimensions for image are fetched already', function (done) {
@@ -35,34 +26,39 @@ describe('lib/image: image size cache', function () {
             type: 'jpg'
         }));
 
-        revertGetCachedImageSizeFromUrl = getCachedImageSizeFromUrl.__set__('imageSize.getImageSizeFromUrl', sizeOfStub);
+        const cachedImageSizeFromUrl = new CachedImageSizeFromUrl({logging: {
+            error: () => {}
+        }, imageSize: {
+            getImageSizeFromUrl: sizeOfStub
+        }});
 
-        imageSizeSpy = getCachedImageSizeFromUrl.__get__('imageSize.getImageSizeFromUrl');
+        imageSizeSpy = sizeOfStub;
 
-        cachedImagedSizeResult = Promise.resolve(getCachedImageSizeFromUrl(url));
+        cachedImagedSizeResult = Promise.resolve(cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url));
         cachedImagedSizeResult.then(function () {
             // first call to get result from `getImageSizeFromUrl`
-            cachedImagedSize = getCachedImageSizeFromUrl.__get__('cache');
+            cachedImagedSize = cachedImageSizeFromUrl.cache;
             should.exist(cachedImagedSize);
-            cachedImagedSize.should.have.property(url);
-            should.exist(cachedImagedSize[url].width);
-            cachedImagedSize[url].width.should.be.equal(50);
-            should.exist(cachedImagedSize[url].height);
-            cachedImagedSize[url].height.should.be.equal(50);
+            cachedImagedSize.has(url).should.be.true;
+            const image = cachedImagedSize.get(url);
+            should.exist(image.width);
+            image.width.should.be.equal(50);
+            should.exist(image.height);
+            image.height.should.be.equal(50);
 
             // second call to check if values get returned from cache
-            cachedImagedSizeResult = Promise.resolve(getCachedImageSizeFromUrl(url));
+            cachedImagedSizeResult = Promise.resolve(cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url));
             cachedImagedSizeResult.then(function () {
-                cachedImagedSize = getCachedImageSizeFromUrl.__get__('cache');
                 imageSizeSpy.calledOnce.should.be.true();
                 imageSizeSpy.calledTwice.should.be.false();
+                cachedImagedSize = cachedImageSizeFromUrl.cache;
                 should.exist(cachedImagedSize);
-                cachedImagedSize.should.have.property(url);
-                should.exist(cachedImagedSize[url].width);
-                cachedImagedSize[url].width.should.be.equal(50);
-                should.exist(cachedImagedSize[url].height);
-                cachedImagedSize[url].height.should.be.equal(50);
-
+                cachedImagedSize.has(url).should.be.true;
+                const image2 = cachedImagedSize.get(url);
+                should.exist(image2.width);
+                image2.width.should.be.equal(50);
+                should.exist(image2.height);
+                image2.height.should.be.equal(50);
                 done();
             });
         }).catch(done);
@@ -70,28 +66,34 @@ describe('lib/image: image size cache', function () {
 
     it('can handle image-size errors', function (done) {
         const url = 'http://mysite.com/content/image/mypostcoverimage.jpg';
-        let cachedImagedSizeResult;
+        let cachedImageSizeResult;
 
         sizeOfStub.returns(new Promise.reject('error'));
 
-        revertGetCachedImageSizeFromUrl = getCachedImageSizeFromUrl.__set__('imageSize.getImageSizeFromUrl', sizeOfStub);
+        const cachedImageSizeFromUrl = new CachedImageSizeFromUrl({logging: {
+            error: () => {}
+        }, imageSize: {
+            getImageSizeFromUrl: sizeOfStub
+        }});
 
-        cachedImagedSizeResult = Promise.resolve(getCachedImageSizeFromUrl(url));
-        cachedImagedSizeResult.then(function () {
-            cachedImagedSize = getCachedImageSizeFromUrl.__get__('cache');
+        cachedImageSizeResult = Promise.resolve(cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url));
+        cachedImageSizeResult.then(function () {
+            cachedImagedSize = cachedImageSizeFromUrl.cache;
             should.exist(cachedImagedSize);
-            cachedImagedSize.should.have.property(url);
-            should.not.exist(cachedImagedSize[url].width);
-            should.not.exist(cachedImagedSize[url].height);
+            cachedImagedSize.has(url).should.be.true;
+            const image = cachedImagedSize.get(url);
+            should.not.exist(image.width);
+            should.not.exist(image.height);
             done();
         }).catch(done);
     });
 
     it('should return null if url is undefined', function (done) {
+        const cachedImageSizeFromUrl = new CachedImageSizeFromUrl({logging: {}, imageSize: {}});
         const url = null;
         let result;
 
-        result = getCachedImageSizeFromUrl(url);
+        result = cachedImageSizeFromUrl.getCachedImageSizeFromUrl(url);
 
         should.not.exist(result);
         done();

--- a/test/unit/lib/request_spec.js
+++ b/test/unit/lib/request_spec.js
@@ -146,4 +146,26 @@ describe('Request', function () {
             err.body.should.match(/AWFUL_ERROR/);
         });
     });
+
+    it('[failure] should timeout when taking too long', function () {
+        const url = 'http://some-website.com/endpoint/';
+        const options = {
+            headers: {
+                'User-Agent': 'Mozilla/5.0'
+            },
+            timeout: 1,
+            retry: 0 // got retries by default so we're disabling this behavior
+        };
+
+        nock('http://some-website.com')
+            .get('/endpoint/')
+            .delay(20)
+            .reply(200, 'Response body');
+
+        return request(url, options).then(() => {
+            throw new Error('Should have timed out');
+        }, (err) => {
+            err.code.should.be.equal('ETIMEDOUT');
+        });
+    });
 });


### PR DESCRIPTION
no issue

The mains focus is to move the four `core/server/lib/image` modules to classes so that we can extract this module from the Ghost core repo.

# What was done

1. Refactor the four `core/server/lib/image/*` modules to four classes.
2. Create a fifth class called `ImageUtils` that regroups the four other classes under a common interface.
3. Update tests to not rely on anything external than the previously mentioned classes.

I've also moved the `CachedImageSizeFromUrl` caching datastructure from a js object to a Map to make it cleaner (Maps are stable since node 6 so it's ok to upgrade to Maps).

# Notes on tests

- I had to move the redirect test from the `image` tests to the `request` tests as we're using the `request` dependency in the `image` module.
- I also got rid of the `[success] can handle redirect (image-size)` test as it's already covered by the `request` test suite.
- In `test/unit/lib/image/image-size_spec.js`, I've decided to remove the `image-size` and `probe-image-size` spies as we can know which module is used based on whether we're stubbing the request dependency (for the `image-size` module) or the nock http mocking (for the `probe-image-size` module).
