### PR TITLE
🐛 Fixed comped flag for members

### DIFF
--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -79,7 +79,7 @@ function serializeMember(member, options) {
              * @param {SerializedMemberStripeSubscription} sub
              */
             function (sub) {
-                return sub.plan.nickname === 'Complimentary';
+                return sub.plan.nickname === 'Complimentary' && sub.status === 'active';
             }
         );
         if (hasCompedSubscription) {


### PR DESCRIPTION
no-issue

We now include all subscriptions as part of the member, so we need to
ensure the comped flag is only true if the member has an **active**
complimentary plan