### PR TITLE
🐛 Updated gscan to 3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "ghost-storage-base": "0.0.4",
     "glob": "7.1.6",
     "got": "9.6.0",
-    "gscan": "3.6.0",
+    "gscan": "3.6.1",
     "html-to-text": "5.1.1",
     "image-size": "0.8.3",
     "intl": "1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,17 +138,6 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@sentry/core@5.26.0":
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.26.0.tgz#9b5fe4de8a869d733ebcc77f5ec9c619f8717a51"
-  integrity sha512-Ubrw7K52orTVsaxpz8Su40FPXugKipoQC+zPrXcH+JIMB+o18kutF81Ae4WzuUqLfP7YB91eAlRrP608zw0EXA==
-  dependencies:
-    "@sentry/hub" "5.26.0"
-    "@sentry/minimal" "5.26.0"
-    "@sentry/types" "5.26.0"
-    "@sentry/utils" "5.26.0"
-    tslib "^1.9.3"
-
 "@sentry/core@5.29.0":
   version "5.29.0"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.29.0.tgz#4410ca0dc5785abf3df02fa23c18e83ad90d7cda"
@@ -160,15 +149,6 @@
     "@sentry/utils" "5.29.0"
     tslib "^1.9.3"
 
-"@sentry/hub@5.26.0":
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.26.0.tgz#b2bbd8128cd5915f2ee59cbc29fff30272d74ec5"
-  integrity sha512-lAYeWvvhGYS6eQ5d0VEojw0juxGc3v4aAu8VLvMKWcZ1jXD13Bhc46u9Nvf4qAY6BAQsJDQcpEZLpzJu1bk1Qw==
-  dependencies:
-    "@sentry/types" "5.26.0"
-    "@sentry/utils" "5.26.0"
-    tslib "^1.9.3"
-
 "@sentry/hub@5.29.0":
   version "5.29.0"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.29.0.tgz#d018b978fdffc6c8261744b0d08e8d25a3f4dc58"
@@ -178,15 +158,6 @@
     "@sentry/utils" "5.29.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.26.0":
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.26.0.tgz#851dea3644153ed3ac4837fa8ed5661d94e7a313"
-  integrity sha512-mdFo3FYaI1W3KEd8EHATYx8mDOZIxeoUhcBLlH7Iej6rKvdM7p8GoECrmHPU1l6sCCPtBuz66QT5YeXc7WILsA==
-  dependencies:
-    "@sentry/hub" "5.26.0"
-    "@sentry/types" "5.26.0"
-    tslib "^1.9.3"
-
 "@sentry/minimal@5.29.0":
   version "5.29.0"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.29.0.tgz#bd8b52f388abcec2234dbbc6d6721ff65aa30e35"
@@ -194,21 +165,6 @@
   dependencies:
     "@sentry/hub" "5.29.0"
     "@sentry/types" "5.29.0"
-    tslib "^1.9.3"
-
-"@sentry/node@5.26.0":
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.26.0.tgz#d3ed5856bc5f30b13435be4c569d6c72746cf286"
-  integrity sha512-BuN9c84f8MxGhYZl+JgVsORh3GiDmuyG9QjawVQ2fmJKVxQ+fcNvde/wq5z7jEca4Z8FrNLa+DHb4c8Fl8gz8g==
-  dependencies:
-    "@sentry/core" "5.26.0"
-    "@sentry/hub" "5.26.0"
-    "@sentry/tracing" "5.26.0"
-    "@sentry/types" "5.26.0"
-    "@sentry/utils" "5.26.0"
-    cookie "^0.4.1"
-    https-proxy-agent "^5.0.0"
-    lru_map "^0.3.3"
     tslib "^1.9.3"
 
 "@sentry/node@5.29.0":
@@ -226,17 +182,6 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/tracing@5.26.0":
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.26.0.tgz#33ee0426da14836e54e7b9a8838e4d7d0cb14b70"
-  integrity sha512-N9qWGmKrFJYKFTZBe8zVT3Qiju0+9bbNJuyun69T+fqP3PCDh+aRlRiP+OKTJyeCZjNG5HIvIlU8wTVUDoYfjQ==
-  dependencies:
-    "@sentry/hub" "5.26.0"
-    "@sentry/minimal" "5.26.0"
-    "@sentry/types" "5.26.0"
-    "@sentry/utils" "5.26.0"
-    tslib "^1.9.3"
-
 "@sentry/tracing@5.29.0":
   version "5.29.0"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.29.0.tgz#8ed515b3f9d409137357c38c8622858f9e684e4a"
@@ -248,23 +193,10 @@
     "@sentry/utils" "5.29.0"
     tslib "^1.9.3"
 
-"@sentry/types@5.26.0":
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.26.0.tgz#b0cbacb0b24cd86620fb296b46cf7277bb004a3e"
-  integrity sha512-ugpa1ePOhK55pjsyutAsa2tiJVQEyGYCaOXzaheg/3+EvhMdoW+owiZ8wupfvPhtZFIU3+FPOVz0d5k9K5d1rw==
-
 "@sentry/types@5.29.0":
   version "5.29.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.29.0.tgz#af5cec98cde54316c14df3121f0e8106e56b578e"
   integrity sha512-iDkxT/9sT3UF+Xb+JyLjZ5caMXsgLfRyV9VXQEiR2J6mgpMielj184d9jeF3bm/VMuAf/VFFqrHlcVsVgmrrMw==
-
-"@sentry/utils@5.26.0":
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.26.0.tgz#09a3d01d91747f38f796cafeb24f8fd86e4fa05f"
-  integrity sha512-F2gnHIAWbjiowcAgxz3VpKxY/NQ39NTujEd/NPnRTWlRynLFg3bAV+UvZFXljhYJeN3b/zRlScNDcpCWTrtZGw==
-  dependencies:
-    "@sentry/types" "5.26.0"
-    tslib "^1.9.3"
 
 "@sentry/utils@5.29.0":
   version "5.29.0"
@@ -570,10 +502,10 @@
   resolved "https://registry.yarnpkg.com/@tryghost/mw-session-from-token/-/mw-session-from-token-0.1.12.tgz#9aee7babad449afba29064f186d67066bc21dd6d"
   integrity sha512-HtDJZ7OBwVqXwfFsDRBrXkigeoKp0zd09SLIUNLNRv3tRqHx3kxrWmgnMVghL97374eYKF7moK2MkobfmxYtEQ==
 
-"@tryghost/pretty-cli@1.2.10":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@tryghost/pretty-cli/-/pretty-cli-1.2.10.tgz#0ef57f4fea794cda7a612b2b6225612f13028195"
-  integrity sha512-sjX6QlLTxBxqoWA13p0WR4eRgCgCRajBTYVgcTewzMocf3jnZDF/7czxArxPjbJB3weT/B+BJZ0hwre/4hLqRQ==
+"@tryghost/pretty-cli@1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@tryghost/pretty-cli/-/pretty-cli-1.2.11.tgz#feb98e176261c0e3e20039b8341cce8ade77383a"
+  integrity sha512-qQrKceGDIe/ab3gInnqD8zGz3PKaJIGc9a1/iHZrhhGZOCPmLtuY/o5pTh8g84U3PWJUpPkX3BFuypFidSrUXw==
   dependencies:
     chalk "4.1.0"
     sywac "1.3.0"
@@ -646,16 +578,6 @@
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/@tryghost/vhost-middleware/-/vhost-middleware-1.0.10.tgz#17818bd1bf2606f56cc11271f4358a86c9b8626f"
   integrity sha512-88pwLDGY0u1F9tFgTg/6lramGAs8LQDs/o08Km4qocM5sASHmwEAtIaC9kC97gnM3PIpya7Il1IRxVgQUt2yMg==
-
-"@tryghost/zip@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@tryghost/zip/-/zip-1.1.4.tgz#1f196881ea35917bcbbdf8ad335f4b460f15178c"
-  integrity sha512-S/dYOsUxLzl6F7GqV10vmdPxO7TiAcnG6eSd1N9X7mJ4GQbwoSE3cB8alb7H5LRgaT9/jmNtvvysxzwCGsZEJw==
-  dependencies:
-    archiver "4.0.1"
-    bluebird "3.7.2"
-    extract-zip "2.0.0"
-    fs-extra "9.0.1"
 
 "@tryghost/zip@1.1.6":
   version "1.1.6"
@@ -4294,29 +4216,29 @@ grunt@1.3.0:
     nopt "~3.0.6"
     rimraf "~3.0.2"
 
-gscan@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/gscan/-/gscan-3.6.0.tgz#ca8f7865d50529a2ac844fc7c586aa78e20b4e7a"
-  integrity sha512-hpyeIM0QQMQ+DBEO2qkdHrt0RqooydGC4XIUGgQP3PxFjCQ97bMkazyHsr+ElBUhnQQaW8emHNk9fMolaWZKKw==
+gscan@3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/gscan/-/gscan-3.6.1.tgz#fb8a2caae25203fd2524a0c1371f7c62ebebb052"
+  integrity sha512-quWlziqqfkRptngIf8oT2SU95oNwzwAhaXtpkEEa17qIV9OOta5SKXM7JmHGN6fN+aiI2xcPIfpyt70ydu/OLA==
   dependencies:
-    "@sentry/node" "5.26.0"
-    "@tryghost/pretty-cli" "1.2.10"
-    "@tryghost/zip" "1.1.4"
+    "@sentry/node" "5.29.0"
+    "@tryghost/pretty-cli" "1.2.11"
+    "@tryghost/zip" "1.1.6"
     bluebird "3.7.2"
     chalk "4.1.0"
     common-tags "1.8.0"
     express "4.17.1"
     express-hbs "2.3.4"
     fs-extra "9.0.1"
-    ghost-ignition "4.2.2"
+    ghost-ignition "4.2.4"
     glob "7.1.6"
     lodash "4.17.20"
     multer "1.4.2"
     pluralize "8.0.0"
     require-dir "1.2.0"
-    semver "7.3.2"
+    semver "7.3.4"
     upath "1.2.0"
-    uuid "8.3.1"
+    uuid "8.3.2"
     validator "13.0.0"
 
 gzip-size@^5.1.1:
@@ -8300,11 +8222,6 @@ secure-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/secure-keys/-/secure-keys-1.0.0.tgz#f0c82d98a3b139a8776a8808050b824431087fca"
   integrity sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=
 
-semver@7.3.2, semver@^7.2.1, semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
-
 semver@7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
@@ -8321,6 +8238,11 @@ semver@^6.1.2:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.2.1, semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 send@0.17.1:
   version "0.17.1"


### PR DESCRIPTION
no issue

Fixes an issue with zip files parsing (https://github.com/TryGhost/gscan/pull/367).