### PR TITLE
🐛 Added translation for BookshelfRelationsError

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -499,6 +499,7 @@
                 "unknownProvider": "No provider found for supplied URL."
             },
             "userMessages": {
+                "BookshelfRelationsError": "Database error, cannot {action}.",
                 "InternalServerError": "Internal server error, cannot {action}.",
                 "IncorrectUsageError": "Incorrect usage error, cannot {action}.",
                 "NotFoundError": "Resource not found error, cannot {action}.",


### PR DESCRIPTION
refs #12493

This protects against accidental relation errors giving unfriendly
errors messages.