### PR TITLE
🐛 Fixed reply-to address not set for newsletters

### DIFF
--- a/core/server/services/bulk-email/mailgun.js
+++ b/core/server/services/bulk-email/mailgun.js
@@ -72,7 +72,7 @@ function send(message, recipientData, replacements) {
         messageData = {
             to: Object.keys(recipientData),
             from: message.from,
-            'h:Reply-To': message.replyTo,
+            'h:Reply-To': message.replyTo || message.reply_to,
             subject: messageContent.subject,
             html: messageContent.html,
             text: messageContent.plaintext,


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12492

The changes to email processing models had set replyTo address for an email batch as `reply_to` instead of `replyTo` which was not picked by mailgun service for setting newsletter reply address
