### PR TITLE
✨Feature Request: Add Containerized Development environment.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:lts
+
+# Make sure we can get to the app from the normal port
+EXPOSE 2368
+
+# Make the default folder for the application
+RUN mkdir /ghost
+
+# Set the working directory for any subsequent commands to the app directory
+WORKDIR /ghost
+
+# Expose a voume for the app directory
+VOLUME /ghost
+
+# Copy over an initial setup script
+COPY setup.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/setup.sh
+
+# Copy over a new default config so we can expose the app on 0.0.0.0
+COPY config.development.json /usr/local/
+
+# Run the script to configure git and install project and keep the container alive by running bash
+CMD /usr/local/bin/setup.sh && /bin/bash

--- a/.devcontainer/config.development.json
+++ b/.devcontainer/config.development.json
@@ -1,0 +1,7 @@
+{
+    "enableDeveloperExperiments": true,
+    "server": {
+        "host": "0.0.0.0",
+        "port": 2368
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.154.2/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "ghost-container",
+	"dockerComposeFile": "./docker-compose.yaml",
+	"service": "ghost",
+	"workspaceFolder": "/ghost",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": null
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [2368]
+	// Add the IDs of extensions you want installed when the container is created.
+	// "extensions": []
+}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  ghost:
+    build: .
+    env_file:
+      - ghost.env
+    volumes:
+      - ../:/ghost
+    ports:
+      - '2368:2368'
+    tty: true

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -ea
+
+if [ ! -d "node_modules" ] || [ ! "$(ls -qAL node_modules 2>/dev/null)" ]; then
+
+echo "node_modules not installed, assuming a fresh install. Performing initial setup..."
+    # Make sure dependencies are installed
+    echo "Installing global dependencies"
+    yarn global add knex-migrator grunt-cli ember-cli
+
+    # Set Ghost origin as upstream
+    echo "Setting Ghost origin as upstream"
+    git remote rename origin upstream
+
+    # Set your Ghost fork as the origin
+    echo "Setting your fork as origin"
+    git remote add origin $GHOST_FORK_NAME
+
+    cd /ghost/core/client
+
+    # Set Ghost origin as upstream
+    echo "Setting Ghost-Admin origin as upstream"
+    git remote rename origin upstream
+
+    # Set your Ghost-Admin fork as the origin
+    echo "Setting your fork as origin"
+    git remote add origin $GHOST_ADMIN_FORK_NAME
+
+    cd /ghost/content/themes/casper
+
+    # Set Ghost origin as upstream
+    echo "Setting Casper origin as upstream"
+    git remote rename origin upstream
+
+    # Set your Ghost Casper theme fork as the origin
+    echo "Setting your fork as origin"
+    git remote add origin $GHOST_CASPER_FORK_NAME
+
+    cd /ghost
+
+    # Install project depedencies, perform initial setup
+    echo "Performing initial install and setup"
+    yarn install && yarn setup
+
+    echo "Setting ghost config to listen on 0.0.0.0"
+    cp /usr/local/config.development.json /ghost/
+
+    echo "Initial configuration complete. Run grunt dev to get started..."
+fi
+
+exec "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ test/coverage
 /core/built
 /core/server/web/admin/views/*.html
 /core/server/public/ghost.min.css
+
+#Ignore development container config
+/.devcontainer/ghost.env


### PR DESCRIPTION
*Hi all I am creating this PR as a Proof of Concept / place for discussion about whether the Ghost development team (or community) would support maintaining an out-of-the-box containerized development environment. I appreciate that the forums are where we should be adding new feature requests but this is dev specific and I wanted to show some code / effort along with the idea so show it's been thought through somewhat. If this isn't the right place for this discussion let me know and I can move it.*

# Rationale

While the Ghost [Install From Source](https://ghost.org/docs/install/source/) documentation is thorough it contains a large number of manual steps to scaffold up a new project. In addition (especially for Open Source developers) the overhead of having to manage global dependencies, and multiple node versions, through tools like nvm can be a burden.

By providing a containerized environment for development users can:
- More easily sandbox their relative dependencies
- Have an easier onboarding developer experience
- Perform less manual setup
- Have a known working environment from which to start development

# Proposed Solution

Create a `.devcontainer` in the project root for developers to leverage [Developing in Containers with VS Code](https://code.visualstudio.com/docs/remote/containers). This is a purely additive feature that does not preclude developers from running an install on their host machine. The proposed solution scripts out basic one-time setup for a user and configures Ghost to be usable from a container.

## Current development container workflow

1. Follow steps from [Installing From Source](https://ghost.org/docs/install/source/) to fork `Ghost`, `Ghost-Admin` and `Casper`.
2. On your host machine clone the Ghost repository as per the following command `git clone --recurse-submodules git@github.com:TryGhost/Ghost && cd Ghost`.
3. Open the repository in VSCode
4. Install the extension `Remote - Containers`.
5. In the `.devcontainer` folder create a new file called `ghost.env` adding the following content.
```
GHOST_FORK_NAME=git@github.com:<YOURUSERNAME>/Ghost.git
GHOST_ADMIN_FORK_NAME=git@github.com:<YOURUSERNAME>/Ghost-Admin.git
GHOST_CASPER_FORK_NAME=git@github.com:<YOURUSERNAME>/Casper.git
```
6. Select `Reopen Folder inside Container` from the Command Pallete`.
7. Wait *(a fairly long time)* for the containers to be pulled, built, and the container to pull down all relevant dependencies...Seriously go get a ☕
8. Once the log says Ghost is configured to listen on ` 0.0.0.0` run a `grunt dev` like normal and code away in the container without needing any dependencies on your host machine. Nice!

## Known caveats of current example
- The dev container uses a root user, this doesn't bother me personally but Linux best practice would be to create a non-root user to do this all I guess.
- The command `grunt master` won't work. The current work flow assumes that you'll dev in the container but still do your git stuff on the host machine. Everyone's git setup is different so perhaps an addendum to pass in ssh keys or something if you like in doco would be sufficient, I think trying to cater to all use cases here would be tricky...
- A first time install will override the `config.development.json` file with the correct listen host. I am not sure if this is desirable or not.
- To save going overboard with configuration I have left the current setup script is fairly simple. For example if you delete your `node_modules` but have set your upstreams the setup file will crash. It should ideally self heal or just ignore errors to make rebuilding a little easier if you need to update packages or something...?

# Feedback

In general I would love feedback on whether this is something the Ghost team would be willing to support or if there was other community interest in it. If this is something the community sees as valuable I'd love some discussion around some best-practice, where you expect to see uplift in the current solution and any other advice you can provide.
