### PR TITLE
Added FirstPromoter Integration

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -11,7 +11,8 @@ const groupTypeMapping = {
     private: 'private',
     portal: 'portal',
     email: 'bulk_email',
-    newsletter: 'newsletter'
+    newsletter: 'newsletter',
+    firstpromoter: 'firstpromoter'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/api/v2/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -11,7 +11,8 @@ const groupTypeMapping = {
     private: 'private',
     portal: 'portal',
     email: 'bulk_email',
-    newsletter: 'newsletter'
+    newsletter: 'newsletter',
+    firstpromoter: 'firstpromoter'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/data/migrations/versions/3.41/01-add-firstpromoter-settings.js
+++ b/core/server/data/migrations/versions/3.41/01-add-firstpromoter-settings.js
@@ -1,0 +1,16 @@
+const logging = require('../../../../../shared/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+
+    async function up(connection) {
+        logging.info('Updating FirstPromoter settings -  firstpromoter, firstpromoter_id');
+        await connection('settings')
+            .whereIn('key', ['firstpromoter', 'firstpromoter_id'])
+            .update({
+                group: 'firstpromoter'
+            });
+    },
+
+    async function down() { }
+);

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -376,6 +376,24 @@
             "type": "string"
         }
     },
+    "firstpromoter": {
+        "firstpromoter": {
+            "defaultValue": "false",
+            "validations": {
+                "isIn": [
+                    [
+                        "true",
+                        "false"
+                    ]
+                ]
+            },
+            "type": "boolean"
+        },
+        "firstpromoter_id": {
+            "defaultValue": null,
+            "type": "string"
+        }
+    },
     "labs": {
         "labs": {
             "defaultValue": "{}",

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -72,7 +72,9 @@ const defaultSettingsKeyTypes = [
     {key: 'newsletter_show_badge', type: 'newsletter'},
     {key: 'newsletter_show_header', type: 'newsletter'},
     {key: 'newsletter_body_font_category', type: 'newsletter'},
-    {key: 'newsletter_footer_content', type: 'newsletter'}
+    {key: 'newsletter_footer_content', type: 'newsletter'},
+    {key: 'firstpromoter', type: 'firstpromoter'},
+    {key: 'firstpromoter_id', type: 'firstpromoter'}
 ];
 
 describe('Settings API (canary)', function () {

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -70,7 +70,9 @@ const defaultSettingsKeyTypes = [
     {key: 'newsletter_show_badge', type: 'newsletter'},
     {key: 'newsletter_show_header', type: 'newsletter'},
     {key: 'newsletter_footer_content', type: 'newsletter'},
-    {key: 'newsletter_body_font_category', type: 'newsletter'}
+    {key: 'newsletter_body_font_category', type: 'newsletter'},
+    {key: 'firstpromoter', type: 'firstpromoter'},
+    {key: 'firstpromoter_id', type: 'firstpromoter'}
 ];
 
 describe('Settings API (v2)', function () {

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -34,7 +34,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'c61ecbc8c11f62d1d350c66ee1ac3151';
     const currentFixturesHash = 'd46d696c94d03e41a5903500547fea77';
-    const currentSettingsHash = 'd3821715e4b34d92d6ba6ed0d4918f5c';
+    const currentSettingsHash = '162f9294cc427eb32bc0577006c385ce';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
FirstPromoter allows a site to build a referral program and ask other members to promote your work to other people. Currently, to integrate FirstPromoter on a site, it needs steps from the guide [here](https://ghost.org/integrations/firstpromoter/). 
The new native integration with FirstPromoter makes it easy for as site to enable FirstPromoter referral program on their site, by only needing to add their FirstPromoter Tracking ID and enabling it

- [x] Adds new FirstPromoter settings
- [x] Update tests