### PR TITLE
Add mexican peso currency

### DIFF
--- a/core/frontend/services/themes/middleware.js
+++ b/core/frontend/services/themes/middleware.js
@@ -51,6 +51,7 @@ function haxGetMembersPriceData() {
         USD: '$',
         AUD: '$',
         CAD: '$',
+        MXN: '$',
         GBP: '£',
         EUR: '€',
         INR: '₹'

--- a/core/server/models/stripe-customer-subscription.js
+++ b/core/server/models/stripe-customer-subscription.js
@@ -4,6 +4,7 @@ const CURRENCY_SYMBOLS = {
     usd: '$',
     aud: '$',
     cad: '$',
+    mxn: '$',
     gbp: '£',
     eur: '€',
     inr: '₹'

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -63,6 +63,7 @@ class MembersConfigProvider {
             USD: '$',
             AUD: '$',
             CAD: '$',
+            MXN: '$',
             GBP: '£',
             EUR: '€',
             INR: '₹'


### PR DESCRIPTION
Added Mexican Peso currency and abbreviations to enable currency in Stripe.