### PR TITLE
Removed portal-action and requestSrc 

### DIFF
--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -237,13 +237,12 @@ class MembersConfigProvider {
         };
     }
 
-    getSigninURL(token, type, requestSrc) {
+    getSigninURL(token, type) {
         const siteUrl = this._urlUtils.getSiteUrl();
         const signinURL = new URL(siteUrl);
         signinURL.pathname = path.join(signinURL.pathname, '/members/');
-        const actionParam = requestSrc === 'portal' ? 'portal-action' : 'action';
         signinURL.searchParams.set('token', token);
-        signinURL.searchParams.set(actionParam, type);
+        signinURL.searchParams.set('action', type);
         return signinURL.href;
     }
 }

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -138,7 +138,7 @@ const createSessionFromMagicLink = async function (req, res, next) {
         const member = await membersService.ssr.exchangeTokenForSession(req, res);
         const subscriptions = member && member.stripe && member.stripe.subscriptions || [];
 
-        const action = req.query.action || req.query['portal-action'];
+        const action = req.query.action;
 
         if (action === 'signup') {
             let customRedirect = '';


### PR DESCRIPTION
We added `portal-action` and `requestSrc` in 3.x to allow Portal to handle notifications only for auth actions trigged while using it directly, so that existing themes are not affected in any way. Going forward in 4.0, we don't want to have any special handling in backend for Portal but instead expect themes to handle any Portal specific behavior directly.

- Removes setting of `portal-action` for auth actions like signup
- Removes `requestSrc` being passed through to determine portal actions