### PR TITLE
Removed stripe keys and analytics data from export

### DIFF
--- a/core/server/data/exporter/index.js
+++ b/core/server/data/exporter/index.js
@@ -61,7 +61,7 @@ const exportTable = function exportTable(tableName, options) {
 };
 
 const getSettingsTableData = function getSettingsTableData(settingsData) {
-    return settingsData.filter((setting) => {
+    return settingsData && settingsData.filter((setting) => {
         return !EXCLUDED_SETTING_KEYS.includes(setting.key);
     });
 };

--- a/core/server/data/exporter/index.js
+++ b/core/server/data/exporter/index.js
@@ -14,7 +14,9 @@ const EXCLUDED_SETTING_KEYS = [
     'stripe_connect_secret_key',
     'stripe_connect_account_id',
     'stripe_secret_key',
-    'stripe_publishable_key'
+    'stripe_publishable_key',
+    'members_stripe_webhook_id',
+    'members_stripe_webhook_secret'
 ];
 
 const modelOptions = {context: {internal: true}};

--- a/core/server/data/exporter/index.js
+++ b/core/server/data/exporter/index.js
@@ -8,7 +8,14 @@ const logging = require('../../../shared/logging');
 const errors = require('@tryghost/errors');
 const security = require('@tryghost/security');
 const models = require('../../models');
-const EXCLUDED_TABLES = ['sessions', 'mobiledoc_revisions'];
+const EXCLUDED_TABLES = ['sessions', 'mobiledoc_revisions', 'email_batches', 'email_recipients'];
+const EXCLUDED_SETTING_KEYS = [
+    'stripe_connect_publishable_key',
+    'stripe_connect_secret_key',
+    'stripe_connect_account_id',
+    'stripe_secret_key',
+    'stripe_publishable_key'
+];
 
 const modelOptions = {context: {internal: true}};
 
@@ -53,6 +60,12 @@ const exportTable = function exportTable(tableName, options) {
     }
 };
 
+const getSettingsTableData = function getSettingsTableData(settingsData) {
+    return settingsData.filter((setting) => {
+        return !EXCLUDED_SETTING_KEYS.includes(setting.key);
+    });
+};
+
 const doExport = function doExport(options) {
     options = options || {include: []};
 
@@ -78,7 +91,11 @@ const doExport = function doExport(options) {
         };
 
         _.each(tables, function (name, i) {
-            exportData.data[name] = tableData[i];
+            if (name === 'settings') {
+                exportData.data[name] = getSettingsTableData(tableData[i]);
+            } else {
+                exportData.data[name] = tableData[i];
+            }
         });
 
         return exportData;

--- a/test/api-acceptance/admin/db_spec.js
+++ b/test/api-acceptance/admin/db_spec.js
@@ -47,7 +47,7 @@ describe('DB API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse.db);
         jsonResponse.db.should.have.length(1);
-        Object.keys(jsonResponse.db[0].data).length.should.eql(34);
+        Object.keys(jsonResponse.db[0].data).length.should.eql(32);
     });
 
     it('Can import a JSON database', async function () {


### PR DESCRIPTION
no issue

We’re starting to bump into errors with our current exporter due to the size of some of the tables in the db and hitting an issue with Ghost running out of memory during export. The intention for the export/import is not to be backup/restore functionality, but for exporting content and authors.

In addition, exporting Stripe secret/publishable keys can cause potential security loopholes for sites by making them easily accessible. This change -

- Removes `email_batches` and `email_recipients` tables from export data to reduce export size due to large amount of analytics data
- Removes `stripe_secret/publishable*` keys to avoid unexpected security lapse with stripe keys
