### PR TITLE
🐛 Fixed EADDRINUSE error handling on >=13 NodeJS

### DIFF
--- a/core/server/ghost-server.js
+++ b/core/server/ghost-server.js
@@ -86,7 +86,7 @@ class GhostServer {
             self.httpServer.on('error', function (error) {
                 let ghostError;
 
-                if (error.errno === 'EADDRINUSE') {
+                if (error.code === 'EADDRINUSE') {
                     ghostError = new errors.GhostError({
                         message: i18n.t('errors.httpServer.addressInUse.error'),
                         context: i18n.t('errors.httpServer.addressInUse.context', {port: config.get('server').port}),


### PR DESCRIPTION
closes #12562

From NodeJS v13 `error.errno` returns error code instead of a string.  Because of that user-friendly "port is already in use" message did not work anymore. 

**12 NodeJS ([docs](https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_error_errno)):**
> The `error.errno` property is a number or a string. If it is a number, it is a negative value which corresponds to the error code defined in libuv Error handling. **In case of a string, it is the same as `error.code`.**

**13 NodeJS ([docs](https://nodejs.org/docs/latest-v13.x/api/errors.html#errors_error_errno)):**
> The `error.errno` property is a negative number which corresponds to the error code defined in libuv Error handling.

As 12 Node states: In case of a string, it is the same as `error.code`.  So I have changed to use `error.code` which acts the same way as `error.errno` in older NodeJS versions (in this case).

**Tested on:** v14. v12, v10
