### PR TITLE
Removed settings populateDefaults pre-migration

### DIFF
--- a/core/server/data/migrations/hooks/migrate/before.js
+++ b/core/server/data/migrations/hooks/migrate/before.js
@@ -3,8 +3,5 @@ const models = require('../../../../models');
 
 module.exports = function before() {
     models.init();
-    return dbBackup.backup().then(() => {
-        // ensure that our default settings are created to limit possible db states in migrations
-        return models.Settings.populateDefaults();
-    });
+    return dbBackup.backup();
 };


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12568
refs https://github.com/TryGhost/Ghost/commit/5fbc40430bde2e2f975d95e7beb4f9ac2a546ccf
reincarnation :zombie: of https://github.com/TryGhost/Ghost/pull/12587

Having populateDefaults run before migrations creates a chicken and egg problem where populate defaults can create records that are "non-migratable" as happened in https://github.com/TryGhost/Ghost/issues/12026.

Note fore reviewers. This is not a small change (see references)! I have tested it when creating a new instance with clean 4.0, when migrating from 3.21 to 4.0 and also when migrating from 3.21 to 4.0 with disabled [migration in 3.23](https://github.com/TryGhost/Ghost/commit/5fbc40430bde2e2f975d95e7beb4f9ac2a546ccf). Imo we could remove the mentioned migration, but it doesn't harm to stay and would keep the history clean.

Note no. 2. The only place that is now executing populateDefaults is during `settings.init` method execution (server boot). This should always happens **after** the migrations are done. This way the main **source of truth is migrations**.