### PR TITLE
🏗 Cleanedup  app-related settings

### DIFF
--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -8,7 +8,8 @@ const keyGroupMapper = require('../../../../api/shared/serializers/input/utils/s
 const keyTypeMapper = require('../../../../api/shared/serializers/input/utils/settings-key-type-mapper');
 
 const labsDefaults = JSON.parse(defaultSettings.labs.labs.defaultValue);
-const ignoredSettings = ['active_apps', 'installed_apps', 'members_from_address', 'members_support_address'];
+const ignoredSettings = ['members_from_address', 'members_support_address'];
+// NOTE: drop support in Ghost 5.0
 const deprecatedSupportedSettingsMap = {
     default_locale: 'lang',
     active_timezone: 'timezone',

--- a/core/server/data/migrations/versions/4.0/05-delete-apps-related-settings-keys.js
+++ b/core/server/data/migrations/versions/4.0/05-delete-apps-related-settings-keys.js
@@ -1,10 +1,8 @@
+const {createTransactionalMigration} = require('../../utils');
 const logging = require('../../../../../shared/logging');
 
-module.exports = {
-    config: {
-        transaction: true
-    },
-    async up({transacting: knex}){
+module.exports = createTransactionalMigration(
+    async function up(knex){
         const settingsKeys = ['installed_apps', 'active_apps'];
         logging.info(`Removing ${settingsKeys.join(',')} from "settings" table.`);
 
@@ -12,7 +10,7 @@ module.exports = {
             .whereIn('key', settingsKeys)
             .del();
     },
-    async down() {
+    async function down() {
         // noop: no need to recreate any apps as it's a cleanup in major version migration
     }
-};
+);

--- a/core/server/data/migrations/versions/4.0/05-delete-apps-related-settings-keys.js
+++ b/core/server/data/migrations/versions/4.0/05-delete-apps-related-settings-keys.js
@@ -1,0 +1,18 @@
+const logging = require('../../../../../shared/logging');
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+    async up({transacting: knex}){
+        const settingsKeys = ['installed_apps', 'active_apps'];
+        logging.info(`Removing ${settingsKeys.join(',')} from "settings" table.`);
+
+        await knex('settings')
+            .whereIn('key', settingsKeys)
+            .del();
+    },
+    async down() {
+        // noop: no need to recreate any apps as it's a cleanup in major version migration
+    }
+};


### PR DESCRIPTION
reincarnation :zombie: of https://github.com/TryGhost/Ghost/pull/12593

Fields removed in this migrations should have been cleaned up as a result of changed done in https://github.com/TryGhost/Ghost/commit/f74d459dad68ad23a5229cfce3ab9bcde76f5802

@daniellockyer @allouis have refactored the migration to use `createTransactionalMigration` [as suggested](https://github.com/TryGhost/Ghost/pull/12593#issuecomment-771525503) :wink: 