### PR TITLE
🏗  Altered slug unique constraint in posts table

### DIFF
--- a/core/server/data/migrations/versions/4.0/07-alter-unique-constraint-for-posts-slug.js
+++ b/core/server/data/migrations/versions/4.0/07-alter-unique-constraint-for-posts-slug.js
@@ -1,0 +1,7 @@
+const {createIrreversibleMigration} = require('../../utils');
+const {addUnique, dropUnique} = require('../../../schema/commands');
+
+module.exports = createIrreversibleMigration(async (knex) => {
+    await dropUnique('posts', 'slug', knex);
+    await addUnique('posts', ['slug', 'type'], knex);
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -12,7 +12,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         uuid: {type: 'string', maxlength: 36, nullable: false, validations: {isUUID: true}},
         title: {type: 'string', maxlength: 2000, nullable: false, validations: {isLength: {max: 255}}},
-        slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
+        slug: {type: 'string', maxlength: 191, nullable: false},
         mobiledoc: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         html: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         comment_id: {type: 'string', maxlength: 50, nullable: true},
@@ -57,7 +57,10 @@ module.exports = {
         codeinjection_head: {type: 'text', maxlength: 65535, nullable: true},
         codeinjection_foot: {type: 'text', maxlength: 65535, nullable: true},
         custom_template: {type: 'string', maxlength: 100, nullable: true},
-        canonical_url: {type: 'text', maxlength: 2000, nullable: true}
+        canonical_url: {type: 'text', maxlength: 2000, nullable: true},
+        '@@UNIQUE_CONSTRAINTS@@': [
+            ['slug', 'type']
+        ]
     },
     posts_meta: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/test/api-acceptance/admin/utils.js
+++ b/test/api-acceptance/admin/utils.js
@@ -28,11 +28,12 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
+        .filter(key => key.indexOf('@@') === -1)
         // by default we only return mobildoc
         .without('html', 'plaintext')
         .without('locale')
         .without('page')
-        // v2 API doesn't return new type field
+        // API should not return type field
         .without('type')
         // deprecated
         .without('author_id', 'author')
@@ -48,6 +49,7 @@ const expectedProperties = {
 
     page: _(schema.posts)
         .keys()
+        .filter(key => key.indexOf('@@') === -1)
         // by default we only return mobildoc
         .without('html', 'plaintext')
         .without('locale')

--- a/test/api-acceptance/content/utils.js
+++ b/test/api-acceptance/content/utils.js
@@ -13,6 +13,7 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
+        .filter(key => key.indexOf('@@') === -1)
         // by default we only return html
         .without('mobiledoc', 'plaintext')
         // v2 doesn't return author_id OR author

--- a/test/regression/api/canary/admin/utils.js
+++ b/test/regression/api/canary/admin/utils.js
@@ -21,6 +21,7 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
+        .filter(key => key.indexOf('@@') === -1)
         // by default we only return mobiledoc
         .without('html', 'plaintext')
         .without('locale')

--- a/test/regression/api/canary/content/utils.js
+++ b/test/regression/api/canary/content/utils.js
@@ -13,6 +13,7 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
+        .filter(key => key.indexOf('@@') === -1)
         // by default we only return html
         .without('mobiledoc', 'plaintext')
         // canary doesn't return author_id OR author

--- a/test/regression/api/v2/admin/utils.js
+++ b/test/regression/api/v2/admin/utils.js
@@ -20,6 +20,7 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
+        .filter(key => key.indexOf('@@') === -1)
         // by default we only return mobiledoc
         .without('html', 'plaintext')
         .without('visibility')

--- a/test/regression/api/v2/content/utils.js
+++ b/test/regression/api/v2/content/utils.js
@@ -13,6 +13,7 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
+        .filter(key => key.indexOf('@@') === -1)
         // by default we only return html
         .without('mobiledoc', 'plaintext')
         // v2 doesn't return author_id OR author

--- a/test/regression/api/v3/admin/utils.js
+++ b/test/regression/api/v3/admin/utils.js
@@ -21,6 +21,7 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
+        .filter(key => key.indexOf('@@') === -1)
         // by default we only return mobiledoc
         .without('html', 'plaintext')
         .without('locale')

--- a/test/regression/api/v3/content/utils.js
+++ b/test/regression/api/v3/content/utils.js
@@ -13,6 +13,7 @@ const expectedProperties = {
 
     post: _(schema.posts)
         .keys()
+        .filter(key => key.indexOf('@@') === -1)
         // by default we only return html
         .without('mobiledoc', 'plaintext')
         // v3 doesn't return author_id OR author

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '41fb7edf55c023f7b21fc5f3b7899d0f';
+    const currentSchemaHash = '7aa70515d52a2d55805ebe272e491db7';
     const currentFixturesHash = '370d0da0ab7c45050b2ff30bce8896ba';
     const currentSettingsHash = '162f9294cc427eb32bc0577006c385ce';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12567

- Changing unique constraint from `slug` to `slug+type` should allow for posts and pages to be created with the same slug
- The constraint will be present on application layer for API v4 while we figure out how to deal with it in API v5

Migrations! Migrations! Migrations!

:warning:  SQLite should be checked with special attention :building_construction: 

:bulb: pro tip, to check unique constraints in SQLite use: `pragma index_list('posts');`, for MySQL: `SHOW CREATE TABLE posts`