### PR TITLE
🏗 Dropped deprecated locale columns in posts and users tables

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -64,7 +64,6 @@ const author = (attrs, frame) => {
 
     // @NOTE: unused fields
     delete attrs.visibility;
-    delete attrs.locale;
 
     return attrs;
 };
@@ -120,7 +119,6 @@ const post = (attrs, frame) => {
         delete attrs.primary_author;
     }
 
-    delete attrs.locale;
     delete attrs.author;
     delete attrs.type;
 

--- a/core/server/api/v2/utils/serializers/output/utils/clean.js
+++ b/core/server/api/v2/utils/serializers/output/utils/clean.js
@@ -86,7 +86,6 @@ const author = (attrs, frame) => {
 
     // @NOTE: unused fields
     delete attrs.visibility;
-    delete attrs.locale;
 
     return attrs;
 };
@@ -130,7 +129,6 @@ const post = (attrs, frame) => {
         }
     }
 
-    delete attrs.locale;
     delete attrs.author;
     delete attrs.type;
 

--- a/core/server/api/v3/utils/serializers/output/utils/clean.js
+++ b/core/server/api/v3/utils/serializers/output/utils/clean.js
@@ -64,7 +64,6 @@ const author = (attrs, frame) => {
 
     // @NOTE: unused fields
     delete attrs.visibility;
-    delete attrs.locale;
 
     return attrs;
 };
@@ -120,7 +119,6 @@ const post = (attrs, frame) => {
         delete attrs.primary_author;
     }
 
-    delete attrs.locale;
     delete attrs.author;
     delete attrs.type;
 

--- a/core/server/data/migrations/versions/4.0/08-remove-posts-locale-column.js
+++ b/core/server/data/migrations/versions/4.0/08-remove-posts-locale-column.js
@@ -1,0 +1,14 @@
+const {combineNonTransactionalMigrations, createDropColumnMigration} = require('../../utils');
+
+module.exports = combineNonTransactionalMigrations(
+    createDropColumnMigration('posts', 'locale', {
+        type: 'string',
+        nullable: true,
+        maxlength: 6
+    }),
+    createDropColumnMigration('users', 'locale', {
+        type: 'string',
+        nullable: true,
+        maxlength: 6
+    })
+);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -21,7 +21,6 @@ module.exports = {
         featured: {type: 'bool', nullable: false, defaultTo: false},
         type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'post', validations: {isIn: [['post', 'page']]}},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'draft'},
-        locale: {type: 'string', maxlength: 6, nullable: true},
         visibility: {
             type: 'string',
             maxlength: 50,
@@ -86,7 +85,6 @@ module.exports = {
         twitter: {type: 'string', maxlength: 2000, nullable: true},
         accessibility: {type: 'text', maxlength: 65535, nullable: true},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},
-        locale: {type: 'string', maxlength: 6, nullable: true},
         visibility: {
             type: 'string',
             maxlength: 50,

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '0970e14fcf8d91daaf636da382e3da29';
+    const currentSchemaHash = '4b247f536fd6560ce107bfae00da9eb2';
     const currentFixturesHash = '370d0da0ab7c45050b2ff30bce8896ba';
     const currentSettingsHash = '162f9294cc427eb32bc0577006c385ce';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12567

- Locale columns have been deprecated and unused since API v2, it's safe to remove them now
