### PR TITLE
🏗  Altered posts' canonical_url field to be of type text

### DIFF
--- a/core/server/data/migrations/versions/4.0/09-alter-posts-canonical-url-type.js
+++ b/core/server/data/migrations/versions/4.0/09-alter-posts-canonical-url-type.js
@@ -1,0 +1,39 @@
+const {createNonTransactionalMigration} = require('../../utils');
+const logging = require('../../../../../shared/logging');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        if (knex.client.config.client === 'mysql') {
+            logging.info('Altering canonical_url type from text to string');
+            await knex.schema.alterTable('posts', (table) => {
+                table.string('canonical_url', 2000).nullable().alter();
+            });
+        } else {
+            // TODO: this column creation dance should become a utility
+            await knex.schema.alterTable('posts', (table) => {
+                table.string('canonical_url_tmp', 2000).nullable();
+            });
+
+            await knex('posts')
+                .update('canonical_url_tmp', knex.ref('canonical_url'));
+
+            await knex.schema.table('posts', (table) => {
+                table.dropColumn('canonical_url');
+            });
+
+            await knex.schema.alterTable('posts', (table) => {
+                table.string('canonical_url', 2000).nullable();
+            });
+
+            await knex('posts')
+                .update('canonical_url', knex.ref('canonical_url_tmp'));
+
+            await knex.schema.table('posts', (table) => {
+                table.dropColumn('canonical_url_tmp');
+            });
+        }
+    },
+    async function down() {
+        // noop - we can't add a not null constraint after some of the columns have been nulled
+    }
+);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -57,7 +57,7 @@ module.exports = {
         codeinjection_head: {type: 'text', maxlength: 65535, nullable: true},
         codeinjection_foot: {type: 'text', maxlength: 65535, nullable: true},
         custom_template: {type: 'string', maxlength: 100, nullable: true},
-        canonical_url: {type: 'text', maxlength: 2000, nullable: true}
+        canonical_url: {type: 'string', maxlength: 2000, nullable: true}
     },
     posts_meta: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12567
refs https://github.com/TryGhost/Ghost/pull/11102

- After extracting some of the fields out of posts table in https://github.com/TryGhost/Ghost/pull/11102, there's now space to have in the table to have variable length field instead of text. This gives an advantage of being able to have nullable field and follows closer the convention other tables are using
- After calculating available table space there is enough space to make this transition

:warning:  SQLite migration needs good testing! :construction: 

This change is postponed till 5.0, could serve as a reference point in the future when the migration is done.