### PR TITLE
🐛 Fixed Member model removing labels when unset

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -184,7 +184,7 @@ module.exports = {
         permissions: true,
         async query(frame) {
             try {
-                frame.options.withRelated = ['stripeSubscriptions'];
+                frame.options.withRelated = ['stripeSubscriptions', 'labels'];
                 const member = await membersService.api.members.update(frame.data.members[0], frame.options);
 
                 const hasCompedSubscription = !!member.related('stripeSubscriptions').find(sub => sub.get('plan_nickname') === 'Complimentary' && sub.get('status') === 'active');

--- a/core/server/models/member.js
+++ b/core/server/models/member.js
@@ -106,6 +106,11 @@ const Member = ghostBookshelf.Model.extend({
     onSaving: function onSaving(model, attr, options) {
         let labelsToSave = [];
 
+        if (_.isUndefined(this.get('labels'))) {
+            this.unset('labels');
+            return;
+        }
+
         // CASE: detect lowercase/uppercase label slugs
         if (!_.isUndefined(this.get('labels')) && !_.isNull(this.get('labels'))) {
             labelsToSave = [];


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12600

The bookshelf-relations plugin which we use will **remove** all
relations when they are set to an empty array, but will leave them alone
if it's set to undefined.

Our logic to deduplicate uppercase & lowercase version of the same label
was in advertently always setting the labels to an array, but when the
model was saved without passing the labels, this array would be empty.

Here we've added a check which will skip all label handling, if there
are no labels set.