### PR TITLE
Re-enabled Ghost-CLI upgrade tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,23 +135,23 @@ jobs:
           DIR=$(mktemp -d)
           ghost install local -d $DIR --zip $GITHUB_WORKSPACE/ghost.zip
 
-      #- name: Latest Release
-      #  run: |
-      #    DIR=$(mktemp -d)
-      #    ghost install local -d $DIR
-      #    ghost update -d $DIR --zip $GITHUB_WORKSPACE/ghost.zip
+      - name: Latest Release
+        run: |
+          DIR=$(mktemp -d)
+          ghost install local -d $DIR
+          ghost update -d $DIR --zip $GITHUB_WORKSPACE/ghost.zip
 
-      # - name: Upgrade from latest v1
-      #   run: |
-      #     DIR=$(mktemp -d)
-      #     ghost install v1 --local -d $DIR
-      #     ghost update -f -d $DIR --zip $GITHUB_WORKSPACE/ghost.zip
+      - name: Upgrade from latest v1
+        run: |
+          DIR=$(mktemp -d)
+          ghost install v1 --local -d $DIR
+          ghost update -f -d $DIR --zip $GITHUB_WORKSPACE/ghost.zip
 
-      # - name: Upgrade from latest v2
-      #   run: |
-      #     DIR=$(mktemp -d)
-      #     ghost install v2 --local -d $DIR
-      #     ghost update -f -d $DIR --zip $GITHUB_WORKSPACE/ghost.zip
+      - name: Upgrade from latest v2
+        run: |
+          DIR=$(mktemp -d)
+          ghost install v2 --local -d $DIR
+          ghost update -f -d $DIR --zip $GITHUB_WORKSPACE/ghost.zip
 
       - uses: daniellockyer/action-slack-build@master
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
no issue

- now GScan has been updated to support v4, we should be able to run these tests again