### PR TITLE
Added ability to install themes directly from GitHub

### DIFF
--- a/core/server/analytics-events.js
+++ b/core/server/analytics-events.js
@@ -19,7 +19,10 @@ module.exports.init = function () {
         },
         {
             event: 'theme.uploaded',
-            name: 'Theme Uploaded'
+            name: 'Theme Uploaded',
+            // {keyOnSuppliedEventData: keyOnTrackedEventData}
+            // - used to extract specific properties from event data and give them meaningful names
+            data: {name: 'name'}
         },
         {
             event: 'integration.added',
@@ -28,8 +31,11 @@ module.exports.init = function () {
     ];
 
     _.each(toTrack, function (track) {
-        events.on(track.event, function () {
-            analytics.track(_.extend(trackDefaults, {event: prefix + track.name}));
+        events.on(track.event, function (eventData = {}) {
+            // extract desired properties from eventData and rename keys if necessary
+            const data = _.mapValues(track.data || {}, v => eventData[v]);
+
+            analytics.track(_.extend(trackDefaults, data, {event: prefix + track.name}));
         });
     });
 };

--- a/core/server/api/canary/themes.js
+++ b/core/server/api/canary/themes.js
@@ -56,9 +56,7 @@ module.exports = {
     },
 
     install: {
-        headers: {
-            cacheInvalidate: true
-        },
+        headers: {},
         options: [
             'source',
             'ref'
@@ -107,21 +105,10 @@ module.exports = {
                         path: downloadPath,
                         name: zipName
                     };
-                    let {theme, themeOverridden} = await themeService.storage.setFromZip(zip);
+                    const {theme, themeOverridden} = await themeService.storage.setFromZip(zip);
 
-                    // if we didn't overriding an active theme, activate it now
-                    if (!themeOverridden) {
-                        const newSettings = [{
-                            key: 'active_theme',
-                            value: repo
-                        }];
-
-                        const checkedTheme = await themeService.activate(repo);
-
-                        // @NOTE: we use the model, not the API here, as we don't want to trigger permissions
-                        await models.Settings.edit(newSettings, frame.options);
-
-                        theme = themeService.getJSON(repo, checkedTheme);
+                    if (themeOverridden) {
+                        this.headers.cacheInvalidate = true;
                     }
 
                     events.emit('theme.uploaded', {name: theme.name});

--- a/core/server/api/canary/themes.js
+++ b/core/server/api/canary/themes.js
@@ -6,6 +6,8 @@ const {events} = require('../../lib/common');
 const themeService = require('../../../frontend/services/themes');
 const models = require('../../models');
 const request = require('../../lib/request');
+const errors = require('@tryghost/errors/lib/errors');
+const i18n = require('../../lib/common/i18n');
 
 module.exports = {
     docName: 'themes',
@@ -109,6 +111,15 @@ module.exports = {
                     events.emit('theme.uploaded', {name: theme.name});
 
                     return theme;
+                } catch (e) {
+                    if (e.statusCode && e.statusCode === 404) {
+                        return Promise.reject(new errors.BadRequestError({
+                            message: i18n.t('errors.api.themes.repoDoesNotExist'),
+                            context: zipUrl
+                        }));
+                    }
+
+                    throw e;
                 } finally {
                     // clean up tmp dir with downloaded file
                     fs.remove(downloadBase);

--- a/core/server/api/canary/themes.js
+++ b/core/server/api/canary/themes.js
@@ -1,15 +1,11 @@
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
-const stream = require('stream');
-const util = require('util');
 const security = require('@tryghost/security');
 const {events} = require('../../lib/common');
 const themeService = require('../../../frontend/services/themes');
 const models = require('../../models');
 const request = require('../../lib/request');
-
-const finished = util.promisify(stream.finished);
 
 module.exports = {
     docName: 'themes',
@@ -89,16 +85,15 @@ module.exports = {
 
                 try {
                     // download zip file
-                    const download = request(zipUrl, {
+                    const response = await request(zipUrl, {
                         followRedirect: true,
                         headers: {
                             accept: 'application/vnd.github.v3+json'
                         },
-                        encoding: null,
-                        stream: true
-                    }).pipe(fs.createWriteStream(downloadPath));
+                        encoding: null
+                    });
 
-                    await finished(download);
+                    await fs.writeFile(downloadPath, response.body);
 
                     // install theme from zip
                     const zip = {

--- a/core/server/api/canary/utils/serializers/output/themes.js
+++ b/core/server/api/canary/utils/serializers/output/themes.js
@@ -12,6 +12,11 @@ module.exports = {
         this.browse(...arguments);
     },
 
+    install() {
+        debug('install');
+        this.browse(...arguments);
+    },
+
     activate() {
         debug('activate');
         this.browse(...arguments);

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -431,7 +431,8 @@
                 "invalidFile": "Please select a valid zip file.",
                 "overrideCasper": "Please rename your zip, it's not allowed to override the default casper theme.",
                 "destroyCasper": "Deleting the default casper theme is not allowed.",
-                "destroyActive": "Deleting the active theme is not allowed."
+                "destroyActive": "Deleting the active theme is not allowed.",
+                "repoDoesNotExist": "Supplied GitHub theme does not exist or is inaccessible"
             },
             "images": {
                 "missingFile": "Please select an image.",

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -142,6 +142,9 @@ module.exports = function apiRoutes() {
         http(apiCanary.themes.upload)
     );
 
+    // TODO: change to POST
+    router.get('/themes/install', mw.authAdminApi, http(apiCanary.themes.install));
+
     router.put('/themes/:name/activate',
         mw.authAdminApi,
         http(apiCanary.themes.activate)

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -142,8 +142,7 @@ module.exports = function apiRoutes() {
         http(apiCanary.themes.upload)
     );
 
-    // TODO: change to POST
-    router.get('/themes/install', mw.authAdminApi, http(apiCanary.themes.install));
+    router.post('/themes/install', mw.authAdminApi, http(apiCanary.themes.install));
 
     router.put('/themes/:name/activate',
         mw.authAdminApi,


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12608

- adds `/themes/install` endpoint to the Admin API
  - requires two query params. `source` must be set to "github". `ref` should refer to a GitHub repo in the format "{org}/{repo}"