### PR TITLE
🏗  Removed labs from settings table

### DIFF
--- a/core/server/api/canary/utils/serializers/input/settings.js
+++ b/core/server/api/canary/utils/serializers/input/settings.js
@@ -5,7 +5,8 @@ const settingsCache = require('../../../../../services/settings/cache');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
-    'slack'
+    'slack',
+    'labs'
 ];
 
 const deprecatedSupportedSettingsOneToManyMap = {

--- a/core/server/api/v2/utils/serializers/input/settings.js
+++ b/core/server/api/v2/utils/serializers/input/settings.js
@@ -5,7 +5,8 @@ const settingsCache = require('../../../../../services/settings/cache');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
-    'slack'
+    'slack',
+    'labs'
 ];
 
 const deprecatedSupportedSettingsOneToManyMap = {

--- a/core/server/api/v3/utils/serializers/input/settings.js
+++ b/core/server/api/v3/utils/serializers/input/settings.js
@@ -5,7 +5,8 @@ const settingsCache = require('../../../../../services/settings/cache');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
-    'slack'
+    'slack',
+    'labs'
 ];
 
 const deprecatedSupportedSettingsOneToManyMap = {

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -4,11 +4,9 @@ const ObjectId = require('bson-objectid').default;
 const _ = require('lodash');
 const BaseImporter = require('./base');
 const models = require('../../../../models');
-const defaultSettings = require('../../../schema').defaultSettings;
 const keyGroupMapper = require('../../../../api/shared/serializers/input/utils/settings-key-group-mapper');
 const keyTypeMapper = require('../../../../api/shared/serializers/input/utils/settings-key-type-mapper');
 
-const labsDefaults = JSON.parse(defaultSettings.labs.labs.defaultValue);
 const ignoredSettings = ['slack_url', 'members_from_address', 'members_support_address'];
 
 // NOTE: drop support in Ghost 5.0
@@ -73,7 +71,6 @@ class SettingsImporter extends BaseImporter {
 
     /**
      * - 'core' and 'theme' are blacklisted
-     * - handle labs setting
      */
     beforeImport() {
         debug('beforeImport');
@@ -183,12 +180,6 @@ class SettingsImporter extends BaseImporter {
         }
 
         _.each(this.dataToImport, (obj) => {
-            if (obj.key === 'labs' && obj.value) {
-                // Overwrite the labs setting with our current defaults
-                // Ensures things that are enabled in new versions, are turned on
-                obj.value = JSON.stringify(_.assign({}, JSON.parse(obj.value), labsDefaults));
-            }
-
             // CASE: we do not import "from address" for members settings as that needs to go via validation with magic link
             if ((obj.key === 'members_from_address') || (obj.key === 'members_support_address')) {
                 obj.value = null;

--- a/core/server/data/migrations/versions/4.0/19-remove-labs-members-setting.js
+++ b/core/server/data/migrations/versions/4.0/19-remove-labs-members-setting.js
@@ -1,0 +1,10 @@
+const logging = require('../../../../../shared/logging');
+const {createIrreversibleMigration} = require('../../utils');
+
+module.exports = createIrreversibleMigration(async (knex) => {
+    logging.info('Deleting labs from settings table');
+
+    await knex('settings')
+        .where('key', '=', 'labs')
+        .del();
+});

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -394,12 +394,6 @@
             "type": "string"
         }
     },
-    "labs": {
-        "labs": {
-            "defaultValue": "{}",
-            "type": "object"
-        }
-    },
     "slack": {
         "slack_url": {
             "defaultValue": "",

--- a/core/server/services/labs.js
+++ b/core/server/services/labs.js
@@ -1,21 +1,13 @@
-const settingsCache = require('./settings/cache');
 const _ = require('lodash');
 const Promise = require('bluebird');
 const SafeString = require('../../frontend/services/themes/engine').SafeString;
 const errors = require('@tryghost/errors');
 const {i18n} = require('../lib/common');
 const logging = require('../../shared/logging');
-const deprecatedFeatures = ['subscribers', 'publicAPI'];
 
-module.exports.getAll = () => {
-    let labs = _.cloneDeep(settingsCache.get('labs')) || {};
-    // Remove old labs flags that should always be false now
-    deprecatedFeatures.forEach((feature) => {
-        delete labs[feature];
-    });
-
-    return labs;
-};
+module.exports.getAll = () => ({
+    members: true
+});
 
 module.exports.isSet = function isSet(flag) {
     const labsConfig = module.exports.getAll();

--- a/test/api-acceptance/admin/settings_spec.js
+++ b/test/api-acceptance/admin/settings_spec.js
@@ -139,10 +139,6 @@ describe('Settings API', function () {
                     value: 'twitter description'
                 },
                 {
-                    key: 'labs',
-                    value: '{"subscribers":false,"members":true}'
-                },
-                {
                     key: 'lang',
                     value: 'ua'
                 },
@@ -211,14 +207,11 @@ describe('Settings API', function () {
         putBody.settings[12].key.should.eql('twitter_description');
         should.equal(putBody.settings[12].value, 'twitter description');
 
-        putBody.settings[13].key.should.eql('labs');
-        should.equal(putBody.settings[13].value, '{"subscribers":false,"members":true}');
+        putBody.settings[13].key.should.eql('lang');
+        should.equal(putBody.settings[13].value, 'ua');
 
-        putBody.settings[14].key.should.eql('lang');
-        should.equal(putBody.settings[14].value, 'ua');
-
-        putBody.settings[15].key.should.eql('timezone');
-        should.equal(putBody.settings[15].value, 'Pacific/Auckland');
+        putBody.settings[14].key.should.eql('timezone');
+        should.equal(putBody.settings[14].value, 'Pacific/Auckland');
 
         putBody.settings[16].key.should.eql('slack');
         should.equal(putBody.settings[16].value, JSON.stringify([{

--- a/test/api-acceptance/admin/settings_spec.js
+++ b/test/api-acceptance/admin/settings_spec.js
@@ -143,6 +143,10 @@ describe('Settings API', function () {
                     value: 'ua'
                 },
                 {
+                    key: 'labs',
+                    value: JSON.stringify({members: true})
+                },
+                {
                     key: 'timezone',
                     value: 'Pacific/Auckland'
                 }
@@ -163,7 +167,8 @@ describe('Settings API', function () {
         headers['x-cache-invalidate'].should.eql('/*');
         should.exist(putBody);
 
-        putBody.settings.length.should.equal(17);
+        // NOTE: -1 for ignored labs setting
+        putBody.settings.length.should.equal(settingToChange.settings.length - 1);
 
         putBody.settings[0].key.should.eql('title');
         putBody.settings[0].value.should.eql(JSON.stringify(changedValue));
@@ -213,8 +218,8 @@ describe('Settings API', function () {
         putBody.settings[14].key.should.eql('timezone');
         should.equal(putBody.settings[14].value, 'Pacific/Auckland');
 
-        putBody.settings[16].key.should.eql('slack');
-        should.equal(putBody.settings[16].value, JSON.stringify([{
+        putBody.settings[15].key.should.eql('slack');
+        should.equal(putBody.settings[15].value, JSON.stringify([{
             url: 'https://overrides.tld',
             username: 'New Slack Username'
         }]));

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -247,6 +247,21 @@ describe('Settings API (canary)', function () {
                 });
         });
 
+        it('Can\'t read labs dropped in v4', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/labs/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    done();
+                });
+        });
+
         it('Can read deprecated default_locale', function (done) {
             request.get(localUtils.API.getApiQuery('settings/default_locale/'))
                 .set('Origin', config.get('url'))
@@ -455,6 +470,33 @@ describe('Settings API (canary)', function () {
                     if (err) {
                         return done(err);
                     }
+
+                    done();
+                });
+        });
+
+        it('Can\'t edit labs dropped in v4', function (done) {
+            const settingToChange = {
+                settings: [{key: 'labs', value: JSON.stringify({members: false})}]
+            };
+
+            request.put(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .send(settingToChange)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const jsonResponse = res.body;
+
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.settings);
+
+                    jsonResponse.settings.length.should.eql(0);
 
                     done();
                 });

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -62,7 +62,6 @@ const defaultSettingsKeyTypes = [
     {key: 'email_track_opens', type: 'bulk_email'},
     {key: 'amp', type: 'blog'},
     {key: 'amp_gtag_id', type: 'blog'},
-    {key: 'labs', type: 'blog'},
     {key: 'slack', type: 'blog'},
     {key: 'slack_url', type: 'blog'},
     {key: 'slack_username', type: 'blog'},
@@ -190,7 +189,7 @@ describe('Settings API (canary)', function () {
                     jsonResponse.settings.should.be.an.Object();
                     const settings = jsonResponse.settings;
 
-                    Object.keys(settings).length.should.equal(68);
+                    Object.keys(settings).length.should.equal(defaultSettingsKeyTypes.length);
 
                     localUtils.API.checkResponse(jsonResponse, 'settings');
                 });

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -253,6 +253,21 @@ describe('Settings API (v2)', function () {
                 });
         });
 
+        it('Can\'t read labs dropped in v4', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/labs/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    done();
+                });
+        });
+
         it('Can read default_locale deprecated in v3', function (done) {
             request.get(localUtils.API.getApiQuery('settings/default_locale/'))
                 .set('Origin', config.get('url'))
@@ -423,6 +438,33 @@ describe('Settings API (v2)', function () {
                     if (err) {
                         return done(err);
                     }
+
+                    done();
+                });
+        });
+
+        it('Can\'t edit labs dropped in v4', function (done) {
+            const settingToChange = {
+                settings: [{key: 'labs', value: JSON.stringify({members: false})}]
+            };
+
+            request.put(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .send(settingToChange)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const jsonResponse = res.body;
+
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.settings);
+
+                    jsonResponse.settings.length.should.eql(0);
 
                     done();
                 });

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -59,7 +59,6 @@ const defaultSettingsKeyTypes = [
     {key: 'email_track_opens', type: 'bulk_email'},
     {key: 'amp', type: 'blog'},
     {key: 'amp_gtag_id', type: 'blog'},
-    {key: 'labs', type: 'blog'},
     {key: 'slack', type: 'blog'},
     {key: 'unsplash', type: 'blog'},
     {key: 'shared_views', type: 'blog'},

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -62,7 +62,6 @@ const defaultSettingsKeyTypes = [
     {key: 'email_track_opens', type: 'bulk_email'},
     {key: 'amp', type: 'blog'},
     {key: 'amp_gtag_id', type: 'blog'},
-    {key: 'labs', type: 'blog'},
     {key: 'slack', type: 'blog'},
     {key: 'slack_url', type: 'blog'},
     {key: 'slack_username', type: 'blog'},

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -270,6 +270,21 @@ describe('Settings API (v3)', function () {
                 });
         });
 
+        it('Can\'t read labs dropped in v4', function (done) {
+            request.get(localUtils.API.getApiQuery('settings/labs/'))
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    done();
+                });
+        });
+
         it('Can read deprecated default_locale', function (done) {
             request.get(localUtils.API.getApiQuery('settings/default_locale/'))
                 .set('Origin', config.get('url'))
@@ -429,6 +444,33 @@ describe('Settings API (v3)', function () {
 
                     testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'group', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
                     jsonResponse.settings[0].key.should.eql('slack');
+                    done();
+                });
+        });
+
+        it('Can\'t edit labs dropped in v4', function (done) {
+            const settingToChange = {
+                settings: [{key: 'labs', value: JSON.stringify({members: false})}]
+            };
+
+            request.put(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .send(settingToChange)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    const jsonResponse = res.body;
+
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.settings);
+
+                    jsonResponse.settings.length.should.eql(0);
+
                     done();
                 });
         });

--- a/test/regression/importer/importer_spec.js
+++ b/test/regression/importer/importer_spec.js
@@ -113,7 +113,7 @@ const exportedLegacyBody = () => {
 };
 
 // Tests in here do an import for each test
-describe.only('Integration: Importer', function () {
+describe('Integration: Importer', function () {
     before(testUtils.teardownDb);
 
     beforeEach(function () {

--- a/test/regression/importer/importer_spec.js
+++ b/test/regression/importer/importer_spec.js
@@ -113,7 +113,7 @@ const exportedLegacyBody = () => {
 };
 
 // Tests in here do an import for each test
-describe('Integration: Importer', function () {
+describe.only('Integration: Importer', function () {
     before(testUtils.teardownDb);
 
     beforeEach(function () {
@@ -909,6 +909,24 @@ describe('Integration: Importer', function () {
 
                     posts[0].tags.length.should.eql(1);
                     tags[0].slug.should.eql('tag-1');
+                });
+        });
+
+        it('does not import settings: labs', function () {
+            const exportData = exportedLatestBody().db[0];
+
+            exportData.data.settings[0] = testUtils.DataGenerator.forKnex.createSetting({
+                key: 'labs',
+                value: JSON.stringify({members: true})
+            });
+
+            return dataImporter.doImport(exportData, importOptions)
+                .then(function (imported) {
+                    imported.problems.length.should.eql(0);
+                    return models.Settings.findOne(_.merge({key: 'labs'}, testUtils.context.internal));
+                })
+                .then(function (result) {
+                    should.equal(result, null);
                 });
         });
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -34,7 +34,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '5861ed57418a0195ea01e431b8b55335';
     const currentFixturesHash = '370d0da0ab7c45050b2ff30bce8896ba';
-    const currentSettingsHash = '24453dc02be9df7284acf1748862a545';
+    const currentSettingsHash = '6db8d92f1b76b43946bf75fbac78599d';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/test/unit/services/labs_spec.js
+++ b/test/unit/services/labs_spec.js
@@ -1,51 +1,26 @@
 const should = require('should');
 const sinon = require('sinon');
-const settingsCache = require('../../../core/server/services/settings/cache');
 
 const labs = require('../../../core/server/services/labs');
 
 describe('Labs Service', function () {
-    let labsCacheStub;
-
-    beforeEach(function () {
-        labsCacheStub = sinon.stub(settingsCache, 'get').withArgs('labs');
-    });
-
     afterEach(function () {
         sinon.restore();
     });
 
-    it('can getAll, even if empty', function () {
-        labs.getAll().should.eql({});
-    });
+    it('always returns members true flag', function () {
+        labs.getAll().should.eql({
+            members: true
+        });
 
-    it('can getAll from cache', function () {
-        labsCacheStub.returns({members: true, foo: 'bar'});
-
-        labs.getAll().should.eql({members: true, foo: 'bar'});
-    });
-
-    it('can getAll from cache, ignoring deprecated', function () {
-        labsCacheStub.returns({members: true, foo: 'bar', subscribers: false, publicAPI: true});
-
-        labs.getAll().should.eql({members: true, foo: 'bar'});
-    });
-
-    it('isSet returns true string flag', function () {
-        labsCacheStub.returns({foo: 'bar'});
-
-        labs.isSet('foo').should.be.true;
+        labs.isSet('members').should.be.true;
     });
 
     it('isSet returns false for undefined', function () {
-        labsCacheStub.returns({foo: 'bar'});
-
         labs.isSet('bar').should.be.false;
     });
 
     it('isSet always returns false for deprecated', function () {
-        labsCacheStub.returns({subscribers: true, publicAPI: true});
-
         labs.isSet('subscribers').should.be.false;
         labs.isSet('publicAPI').should.be.false;
     });

--- a/test/unit/services/themes/middleware_spec.js
+++ b/test/unit/services/themes/middleware_spec.js
@@ -53,7 +53,7 @@ describe('Themes middleware', function () {
             // labs data is deep cloned,
             // if we want to compare it
             // we will need some unique content
-            '@@REQUIRED@@': true
+            members: true
         };
 
         sandbox.stub(activeTheme, 'get')


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/332

By default members will be always "on" starting Ghost 4.0, so there's no need for this flag anymore. 

Note for reviewers. the migration under review here is - https://github.com/TryGhost/Ghost/pull/12639/commits/c86e674a3507f037fdce79646b017dd87600b4bf#diff-0c3b0fd661dd42a7397fbd89076b436b028481c32ea5f169b022b6508def52ae. 

The rest of changes are needed because the migration breaks quite a lot of tests after execution. 
