### PR TITLE
Updated `email_change_event` db to capture previous email

### DIFF
--- a/core/server/data/migrations/versions/4.0/09-add-members-email-change-events-table.js
+++ b/core/server/data/migrations/versions/4.0/09-add-members-email-change-events-table.js
@@ -3,7 +3,7 @@ const {addTable} = require('../../utils');
 module.exports = addTable('members_email_change_events', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-    email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
-    previous_email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
+    to_email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
+    from_email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
     created_at: {type: 'dateTime', nullable: false}
 });

--- a/core/server/data/migrations/versions/4.0/09-add-members-email-change-events-table.js
+++ b/core/server/data/migrations/versions/4.0/09-add-members-email-change-events-table.js
@@ -4,5 +4,6 @@ module.exports = addTable('members_email_change_events', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
     email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
+    previous_email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
     created_at: {type: 'dateTime', nullable: false}
 });

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -372,8 +372,8 @@ module.exports = {
     members_email_change_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-        email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
-        previous_email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
+        to_email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
+        from_email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
         created_at: {type: 'dateTime', nullable: false}
     },
     members_status_events: {

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -373,6 +373,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
         email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
+        previous_email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
         created_at: {type: 'dateTime', nullable: false}
     },
     members_status_events: {

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '860fafa2fc5f78df158ddd8254d4993b';
+    const currentSchemaHash = '3f88f2c34001cc34d74d945dbf4f0bb5';
     const currentFixturesHash = '370d0da0ab7c45050b2ff30bce8896ba';
     const currentSettingsHash = '162f9294cc427eb32bc0577006c385ce';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12602

- Added `from_email` and updated current email to `to_email` in email_change schema/migration which allows us to capture previous email value on a change
