### PR TITLE
Added portal url to config

### DIFF
--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -40,8 +40,8 @@ function getMembersHelper() {
     const stripeDirectSecretKey = settingsCache.get('stripe_secret_key');
     const stripeDirectPublishableKey = settingsCache.get('stripe_publishable_key');
     const stripeConnectAccountId = settingsCache.get('stripe_connect_account_id');
-
-    let membersHelper = `<script defer src="https://unpkg.com/@tryghost/portal@~1.0.0-rc/umd/portal.min.js" data-ghost="${urlUtils.getSiteUrl()}"></script>`;
+    const portalUrl = config.get('portal:url');
+    let membersHelper = `<script defer src="${portalUrl}" data-ghost="${urlUtils.getSiteUrl()}"></script>`;
     membersHelper += (`<style> ${templateStyles}</style>`);
     if ((!!stripeDirectSecretKey && !!stripeDirectPublishableKey) || !!stripeConnectAccountId) {
         membersHelper += '<script async src="https://js.stripe.com/v3/"></script>';

--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -119,5 +119,9 @@
     "emailAnalytics": true,
     "backgroundJobs": {
         "emailAnalytics": true
+    },
+    "portal": {
+        "url": "https://unpkg.com/@tryghost/portal@~1.0.0-rc/umd/portal.min.js",
+        "version": "~1.0.0-rc"
     }
 }


### PR DESCRIPTION
no issue

The Portal URL that is shipped with every Ghost version is so far hardcoded in `ghost_head` and updated everytime we ship a new Portal minor/major change. This change brings the Portal URL inside the default Ghost config, which has few advantages -
- Allows easier access/managing of active Portal url/version
- Allows override for Portal URL for development/other purposes, where `config.*.json` allows using a Portal URL pointing to locally built copy for testing
