### PR TITLE
💡 Resolve orphaned webhooks

### DIFF
--- a/core/server/data/migrations/versions/4.0/21-solve-orphaned-webhooks.js
+++ b/core/server/data/migrations/versions/4.0/21-solve-orphaned-webhooks.js
@@ -1,0 +1,92 @@
+const {createIrreversibleMigration} = require('../../utils');
+const logging = require('../../../../../shared/logging');
+const ObjectID = require('bson-objectid');
+const crypto = require('crypto');
+
+// createSecret is copied from core/server/models/api-key.js
+const createSecret = (type) => {
+    const bytes = type === 'content' ? 13 : 32;
+    return crypto.randomBytes(bytes).toString('hex');
+};
+
+module.exports = createIrreversibleMigration(
+    async function up(knex) {
+        logging.info('Resolving the orphaned webhooks');
+
+        const orphanedWebhooks = await knex('webhooks')
+            .select('webhooks.id')
+            .leftJoin('integrations', 'integrations.id', 'webhooks.integration_id')
+            .where('integrations.id', null);
+
+        if (orphanedWebhooks.length === 0) {
+            logging.info('No orphaned webhooks found, skipping');
+            return;
+        }
+
+        const [role] = await knex('roles')
+            .select('roles.id')
+            .where('name', 'Admin Integration');
+
+        if (!role) {
+            logging.warn('Failed to apply migration because of missing role.');
+            return;
+        }
+
+        const now = knex.raw('CURRENT_TIMESTAMP');
+        const id = ObjectID.generate();
+
+        const integration = {
+            id: id,
+            type: 'custom',
+            name: `Legacy webhooks`,
+            slug: `legacy-webhooks-${id}`,
+            icon_image: null,
+            description: `This integration was created as part of the 4.0 migration. It contains all webhooks created via the API that weren't visible in the admin interface previously.`,
+            created_at: now,
+            created_by: 1,
+            updated_at: now,
+            updated_by: 1
+        };
+
+        await knex('integrations')
+            .insert(integration);
+
+        const contentKey = {
+            id: ObjectID.generate(),
+            type: 'content',
+            secret: createSecret('content'),
+            role_id: null,
+            integration_id: integration.id,
+            created_at: now,
+            created_by: 1,
+            updated_at: now,
+            updated_by: 1
+        };
+        await knex('api_keys').insert(contentKey);
+
+        const adminKey = {
+            id: ObjectID.generate(),
+            type: 'admin',
+            secret: createSecret('admin'),
+            role_id: role.id,
+            integration_id: integration.id,
+            created_at: now,
+            created_by: 1,
+            updated_at: now,
+            updated_by: 1
+        };
+        await knex('api_keys').insert(adminKey);
+
+        for (let i = 0; i < orphanedWebhooks.length; i++) {
+            const webhook = orphanedWebhooks[i];
+
+            await knex('webhooks')
+                .update({
+                    integration_id: integration.id
+                })
+                .where({
+                    id: webhook.id
+                });
+        }
+    }
+);


### PR DESCRIPTION
issue https://github.com/TryGhost/Ghost/issues/12567

1. Get the orphaned webhooks
2. Create new integrations for each orphaned webhook
3. Update each orphaned webhook with their new integration

An orphaned webhook is a webhook that has no matching integration, it was possible to create them before https://github.com/TryGhost/Team/issues/388. Resolving this issue enable users to see and manage these webhooks via the ghost admin interface.