### PR TITLE
Split the "Too many requests" error in ping service

### DIFF
--- a/core/server/services/xmlrpc.js
+++ b/core/server/services/xmlrpc.js
@@ -82,12 +82,21 @@ function ping(post) {
                 }
             })
             .catch(function (err) {
-                logging.error(new errors.GhostError({
-                    err: err,
-                    message: err.message,
-                    context: i18n.t('errors.services.ping.requestFailed.error', {service: 'xmlrpc'}),
-                    help: i18n.t('errors.services.ping.requestFailed.help', {url: 'https://ghost.org/docs/'})
-                }));
+                if (err.statusCode === 429) {
+                    logging.error(new errors.TooManyRequestsError({
+                        err,
+                        message: err.message,
+                        context: i18n.t('errors.services.ping.requestFailed.error', {service: 'xmlrpc'}),
+                        help: i18n.t('errors.services.ping.requestFailed.help', {url: 'https://ghost.org/docs/'})
+                    }));
+                } else {
+                    logging.error(new errors.GhostError({
+                        err: err,
+                        message: err.message,
+                        context: i18n.t('errors.services.ping.requestFailed.error', {service: 'xmlrpc'}),
+                        help: i18n.t('errors.services.ping.requestFailed.help', {url: 'https://ghost.org/docs/'})
+                    }));
+                }
             });
     });
 }

--- a/test/unit/services/xmlrpc_spec.js
+++ b/test/unit/services/xmlrpc_spec.js
@@ -255,5 +255,20 @@ describe('XMLRPC', function () {
                 setTimeout(retry, 100);
             }());
         });
+
+        it('should behave correctly when getting a 429', function (done) {
+            const ping1 = nock('http://rpc.pingomatic.com').post('/').reply(429);
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+
+            ping(testPost);
+
+            (function retry() {
+                if (ping1.isDone()) {
+                    return done();
+                }
+
+                setTimeout(retry, 100);
+            }());
+        });
     });
 });


### PR DESCRIPTION
issue https://github.com/TryGhost/Team/issues/362

It prevents the "429 Too many requests" http errors to generate 500 http errors in ghost logs.