### PR TITLE
Added member relation to events

### DIFF
--- a/core/server/models/member-email-change-event.js
+++ b/core/server/models/member-email-change-event.js
@@ -2,7 +2,11 @@ const errors = require('@tryghost/errors');
 const ghostBookshelf = require('./base');
 
 const MemberEmailChangeEvent = ghostBookshelf.Model.extend({
-    tableName: 'members_email_change_events'
+    tableName: 'members_email_change_events',
+
+    member() {
+        return this.belongsTo('Member', 'member_id', 'id');
+    }
 }, {
     async edit() {
         throw new errors.IncorrectUsageError('Cannot edit MemberEmailChangeEvent');

--- a/core/server/models/member-login-event.js
+++ b/core/server/models/member-login-event.js
@@ -2,7 +2,11 @@ const errors = require('@tryghost/errors');
 const ghostBookshelf = require('./base');
 
 const MemberLoginEvent = ghostBookshelf.Model.extend({
-    tableName: 'members_login_events'
+    tableName: 'members_login_events',
+
+    member() {
+        return this.belongsTo('Member', 'member_id', 'id');
+    }
 }, {
     async edit() {
         throw new errors.IncorrectUsageError('Cannot edit MemberLoginEvent');

--- a/core/server/models/member-paid-subscription-event.js
+++ b/core/server/models/member-paid-subscription-event.js
@@ -3,6 +3,11 @@ const ghostBookshelf = require('./base');
 
 const MemberPaidSubscriptionEvent = ghostBookshelf.Model.extend({
     tableName: 'members_paid_subscription_events',
+
+    member() {
+        return this.belongsTo('Member', 'member_id', 'id');
+    },
+
     customQuery(qb, options) {
         if (options.aggregateMRRDeltas) {
             if (options.limit || options.filter) {

--- a/core/server/models/member-payment-event.js
+++ b/core/server/models/member-payment-event.js
@@ -3,6 +3,11 @@ const ghostBookshelf = require('./base');
 
 const MemberPaymentEvent = ghostBookshelf.Model.extend({
     tableName: 'members_payment_events',
+
+    member() {
+        return this.belongsTo('Member', 'member_id', 'id');
+    },
+
     customQuery(qb, options) {
         if (options.aggregatePaymentVolume) {
             if (options.limit || options.filter) {

--- a/core/server/models/member-status-event.js
+++ b/core/server/models/member-status-event.js
@@ -3,6 +3,11 @@ const ghostBookshelf = require('./base');
 
 const MemberStatusEvent = ghostBookshelf.Model.extend({
     tableName: 'members_status_events',
+
+    member() {
+        return this.belongsTo('Member', 'member_id', 'id');
+    },
+
     customQuery(qb, options) {
         if (options.aggregateStatusCounts) {
             if (options.limit || options.filter) {

--- a/core/server/models/member-subscribe-event.js
+++ b/core/server/models/member-subscribe-event.js
@@ -3,6 +3,11 @@ const ghostBookshelf = require('./base');
 
 const MemberSubscribeEvent = ghostBookshelf.Model.extend({
     tableName: 'members_subscribe_events',
+
+    member() {
+        return this.belongsTo('Member', 'member_id', 'id');
+    },
+
     customQuery(qb, options) {
         if (options.aggregateSubscriptionDeltas) {
             if (options.limit || options.filter) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12602

When listing site-wide event, we want to include member information so
that we can contextualise the event when displaying it.