### PR TITLE
Removed "object" as a valid value for settings type

### DIFF
--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -175,6 +175,7 @@ module.exports = {
             }
         },
         key: {type: 'string', maxlength: 50, nullable: false, unique: true},
+        // NOTE: as JSON objects are no longer stored in `value` we could pottentialy reduce the maxlength
         value: {type: 'text', maxlength: 65535, nullable: true},
         type: {
             type: 'string',
@@ -185,9 +186,7 @@ module.exports = {
                     'array',
                     'string',
                     'number',
-                    'boolean',
-                    // TODO: `object` type needs to be removed once all existing object settings are removed
-                    'object'
+                    'boolean'
                 ]]
             }
         },


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/10318

- Storing JSON object in settings has caused multiple bugs in the past and was considered an antipattern
- This is a last bit in the long process of getting rid of "object" settings in the database. At this point there should be no settings with this type. Yey!
- Also left a note for future improvements in table structure

@daniellockyer @tpatel @rishabhgrg the PR is more of a formality as it changes the schema validation. Also, good to note for everyone we are now all done with the pesky "objects" in the settings table :laughing:  
