### PR TITLE
🐛 Fixed 500 chars of members-only content appearing in excerpt field

### DIFF
--- a/core/server/api/canary/email-preview.js
+++ b/core/server/api/canary/email-preview.js
@@ -21,7 +21,7 @@ module.exports = {
         ],
         permissions: true,
         query(frame) {
-            const options = Object.assign(frame.options, {formats: 'html,plaintext', withRelated: ['authors', 'posts_meta']});
+            const options = Object.assign(frame.options, {withRelated: ['authors', 'posts_meta']});
             const data = Object.assign(frame.data, {status: 'all'});
             return models.Post.findOne(data, options)
                 .then((model) => {

--- a/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
@@ -1,12 +1,14 @@
 const readingMinutes = require('@tryghost/helpers').utils.readingMinutes;
 
-module.exports.forPost = (frame, model, attrs) => {
+module.exports.postExcerpt = (frame, model, attrs) => {
     const _ = require('lodash');
 
-    if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') ||
-        (frame.options.columns.includes('excerpt') && frame.options.formats && frame.options.formats.includes('plaintext'))) {
+    if (
+        !Object.prototype.hasOwnProperty.call(frame.options, 'columns')
+        || (frame.options.columns.includes('excerpt') && frame.options.formats && frame.options.formats.includes('plaintext'))
+    ) {
         if (_.isEmpty(attrs.custom_excerpt)) {
-            const plaintext = model.get('plaintext');
+            const plaintext = attrs.plaintext;
 
             if (plaintext) {
                 attrs.excerpt = plaintext.substring(0, 500);
@@ -17,9 +19,13 @@ module.exports.forPost = (frame, model, attrs) => {
             attrs.excerpt = attrs.custom_excerpt;
         }
     }
+};
 
-    if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') ||
-    (frame.options.columns.includes('reading_time'))) {
+module.exports.postReadingTime = (frame, model, attrs) => {
+    if (
+        !Object.prototype.hasOwnProperty.call(frame.options, 'columns')
+        || (frame.options.columns.includes('reading_time'))
+    ) {
         if (attrs.html) {
             let additionalImages = 0;
 

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -36,7 +36,8 @@ const mapPost = (model, frame) => {
 
     url.forPost(model.id, jsonModel, frame);
 
-    extraAttrs.forPost(frame, model, jsonModel);
+    // add reading time before html is stripped/truncated by content gating
+    extraAttrs.postReadingTime(frame, model, jsonModel);
 
     if (utils.isContentAPI(frame)) {
         // Content api v2 still expects page prop
@@ -46,6 +47,9 @@ const mapPost = (model, frame) => {
         date.forPost(jsonModel);
         gating.forPost(jsonModel, frame);
     }
+
+    // add excerpt after content gating to avoid leaking members-only content
+    extraAttrs.postExcerpt(frame, model, jsonModel);
 
     clean.post(jsonModel, frame);
 

--- a/core/server/api/v2/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/v2/utils/serializers/output/utils/extra-attrs.js
@@ -1,10 +1,12 @@
-module.exports.forPost = (frame, model, attrs) => {
+module.exports.postExcerpt = (frame, model, attrs) => {
     const _ = require('lodash');
 
-    if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') ||
-        (frame.options.columns.includes('excerpt') && frame.options.formats && frame.options.formats.includes('plaintext'))) {
+    if (
+        !Object.prototype.hasOwnProperty.call(frame.options, 'columns')
+        || (frame.options.columns.includes('excerpt') && frame.options.formats && frame.options.formats.includes('plaintext'))
+    ) {
         if (_.isEmpty(attrs.custom_excerpt)) {
-            const plaintext = model.get('plaintext');
+            const plaintext = attrs.plaintext;
 
             if (plaintext) {
                 attrs.excerpt = plaintext.substring(0, 500);

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -48,7 +48,9 @@ const mapPost = (model, frame) => {
         gating.forPost(jsonModel, frame);
     }
 
-    extraAttrs.forPost(frame, model, jsonModel);
+    // add excerpt after content gating to avoid leaking members-only content
+    extraAttrs.postExcerpt(frame, model, jsonModel);
+
     clean.post(jsonModel, frame);
 
     if (frame.options && frame.options.withRelated) {

--- a/core/server/api/v3/email-preview.js
+++ b/core/server/api/v3/email-preview.js
@@ -21,7 +21,7 @@ module.exports = {
         ],
         permissions: true,
         query(frame) {
-            const options = Object.assign(frame.options, {formats: 'html,plaintext', withRelated: ['authors', 'posts_meta']});
+            const options = Object.assign(frame.options, {withRelated: ['authors', 'posts_meta']});
             const data = Object.assign(frame.data, {status: 'all'});
             return models.Post.findOne(data, options)
                 .then((model) => {

--- a/core/server/api/v3/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/v3/utils/serializers/output/utils/extra-attrs.js
@@ -1,12 +1,14 @@
 const readingMinutes = require('@tryghost/helpers').utils.readingMinutes;
 
-module.exports.forPost = (frame, model, attrs) => {
+module.exports.postExcerpt = (frame, model, attrs) => {
     const _ = require('lodash');
 
-    if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') ||
-        (frame.options.columns.includes('excerpt') && frame.options.formats && frame.options.formats.includes('plaintext'))) {
+    if (
+        !Object.prototype.hasOwnProperty.call(frame.options, 'columns')
+        || (frame.options.columns.includes('excerpt') && frame.options.formats && frame.options.formats.includes('plaintext'))
+    ) {
         if (_.isEmpty(attrs.custom_excerpt)) {
-            const plaintext = model.get('plaintext');
+            const plaintext = attrs.plaintext;
 
             if (plaintext) {
                 attrs.excerpt = plaintext.substring(0, 500);
@@ -17,9 +19,13 @@ module.exports.forPost = (frame, model, attrs) => {
             attrs.excerpt = attrs.custom_excerpt;
         }
     }
+};
 
-    if (!Object.prototype.hasOwnProperty.call(frame.options, 'columns') ||
-    (frame.options.columns.includes('reading_time'))) {
+module.exports.postReadingTime = (frame, model, attrs) => {
+    if (
+        !Object.prototype.hasOwnProperty.call(frame.options, 'columns')
+        || (frame.options.columns.includes('reading_time'))
+    ) {
         if (attrs.html) {
             let additionalImages = 0;
 

--- a/core/server/api/v3/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v3/utils/serializers/output/utils/mapper.js
@@ -36,7 +36,8 @@ const mapPost = (model, frame) => {
 
     url.forPost(model.id, jsonModel, frame);
 
-    extraAttrs.forPost(frame, model, jsonModel);
+    // add reading time before html is stripped/truncated by content gating
+    extraAttrs.postReadingTime(frame, model, jsonModel);
 
     if (utils.isContentAPI(frame)) {
         // Content api v2 still expects page prop
@@ -46,6 +47,9 @@ const mapPost = (model, frame) => {
         date.forPost(jsonModel);
         gating.forPost(jsonModel, frame);
     }
+
+    // add excerpt after content gating to avoid leaking members-only content
+    extraAttrs.postExcerpt(frame, model, jsonModel);
 
     if (typeof jsonModel.email_recipient_filter === 'undefined') {
         jsonModel.send_email_when_published = null;

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -132,13 +132,6 @@ const serialize = async (postModel, options = {isBrowserPreview: false}) => {
         post.email_subject = post.posts_meta.email_subject;
     }
 
-    // we use post.excerpt as a hidden piece of text that is picked up by some email
-    // clients as a "preview" when listing emails. Our current plaintext/excerpt
-    // generation outputs links as "Link [https://url/]" which isn't desired in the preview
-    if (!post.custom_excerpt && post.excerpt) {
-        post.excerpt = post.excerpt.replace(/\s\[http(.*?)\]/g, '');
-    }
-
     post.html = mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(post.mobiledoc), {target: 'email'});
     // same options as used in Post model for generating plaintext but without `wordwrap: 80`
     // to avoid replacement strings being split across lines and for mail clients to handle
@@ -151,6 +144,15 @@ const serialize = async (postModel, options = {isBrowserPreview: false}) => {
         returnDomByDefault: true,
         uppercaseHeadings: false
     });
+
+    if (post.custom_excerpt) {
+        post.excerpt = post.custom_excerpt;
+    } else {
+        // we use post.excerpt as a hidden piece of text that is picked up by some email
+        // clients as a "preview" when listing emails. Our plaintext generation
+        // outputs links as "Link [https://url/]" which isn't desired in the preview
+        post.excerpt = post.plaintext.replace(/\s\[http(.*?)\]/g, '').substring(0, 500);
+    }
 
     const templateSettings = {
         showSiteHeader: settingsCache.get('newsletter_show_header'),

--- a/test/api-acceptance/admin/email_preview_spec.js
+++ b/test/api-acceptance/admin/email_preview_spec.js
@@ -100,8 +100,8 @@ describe('Email Preview API', function () {
                 title: 'Post with email-only card',
                 slug: 'email-only-card',
                 mobiledoc: '{"version":"0.3.1","atoms":[],"cards":[],"markups":[["a",["href","https://ghost.org"]]],"sections":[[1,"p",[[0,[],0,"Testing "],[0,[0],1,"links"],[0,[],0," in email excerpt and apostrophes \'"]]]]}',
-                html: '<p>This is the actual post content...</p>',
-                plaintext: 'This is the actual post content...',
+                html: '<p>Testing <a href="https://ghost.org">links</a> in email excerpt and apostrophes \'</p>',
+                plaintext: 'Testing links [https://ghost.org] in email excerpt and apostrophes \'',
                 status: 'draft',
                 uuid: 'd52c42ae-2755-455c-80ec-70b2ec55c904'
             });

--- a/test/regression/api/canary/content/posts_spec.js
+++ b/test/regression/api/canary/content/posts_spec.js
@@ -333,6 +333,7 @@ describe('api/canary/content/posts', function () {
                     localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-not-be-seen');
                     post.html.should.eql('');
+                    should.equal(post.excerpt, null);
                 });
         });
 
@@ -351,6 +352,7 @@ describe('api/canary/content/posts', function () {
                     localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-be-paid-for');
                     post.html.should.eql('');
+                    should.equal(post.excerpt, null);
                 });
         });
 
@@ -374,7 +376,7 @@ describe('api/canary/content/posts', function () {
 
         it('can read "free" html and plaintext content of members post when using paywall card', function () {
             return request
-                .get(localUtils.API.getApiQuery(`posts/${membersPostWithPaywallCard.id}/?key=${validKey}&formats=html,plaintext&fields=html,plaintext`))
+                .get(localUtils.API.getApiQuery(`posts/${membersPostWithPaywallCard.id}/?key=${validKey}&formats=html,plaintext`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
@@ -384,14 +386,15 @@ describe('api/canary/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', null, null, ['id', 'html', 'plaintext']);
+                    localUtils.API.checkResponse(post, 'post', ['plaintext'], null);
                     post.html.should.eql('<p>Free content</p>');
                     post.plaintext.should.eql('Free content');
+                    post.excerpt.should.eql('Free content');
                 });
         });
 
         it('cannot browse members only posts content', function () {
-            return request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}`))
+            return request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&formats=html,plaintext`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
@@ -405,7 +408,7 @@ describe('api/canary/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(15);
-                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, null);
+                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['plaintext'], null);
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 
@@ -421,6 +424,12 @@ describe('api/canary/content/posts', function () {
                     jsonResponse.posts[2].html.should.not.eql('');
                     jsonResponse.posts[3].html.should.not.eql('');
                     jsonResponse.posts[8].html.should.not.eql('');
+
+                    should.equal(jsonResponse.posts[0].excerpt, null);
+                    should.equal(jsonResponse.posts[1].excerpt, null);
+                    should.notEqual(jsonResponse.posts[2].excerpt, null);
+                    should.notEqual(jsonResponse.posts[3].excerpt, null);
+                    should.notEqual(jsonResponse.posts[8].excerpt, null);
 
                     // check meta response for this test
                     jsonResponse.meta.pagination.page.should.eql(1);

--- a/test/regression/api/v2/content/posts_spec.js
+++ b/test/regression/api/v2/content/posts_spec.js
@@ -326,7 +326,7 @@ describe('api/v2/content/posts', function () {
 
         it('can read "free" html and plaintext content of members post when using paywall card', function () {
             return request
-                .get(localUtils.API.getApiQuery(`posts/${membersPostWithPaywallCard.id}/?key=${validKey}&formats=html,plaintext&fields=html,plaintext`))
+                .get(localUtils.API.getApiQuery(`posts/${membersPostWithPaywallCard.id}/?key=${validKey}&formats=html,plaintext`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
@@ -336,7 +336,7 @@ describe('api/v2/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', null, null, ['id', 'html', 'plaintext']);
+                    localUtils.API.checkResponse(post, 'post', ['plaintext'], null);
                     post.html.should.eql('<p>Free content</p>');
                     post.plaintext.should.eql('Free content');
                     post.excerpt.should.eql('Free content');
@@ -344,7 +344,7 @@ describe('api/v2/content/posts', function () {
         });
 
         it('cannot browse members only posts content', function () {
-            return request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}`))
+            return request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&formats=html,plaintext`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
@@ -358,7 +358,7 @@ describe('api/v2/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(15);
-                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['plaintext']);
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 

--- a/test/regression/api/v2/content/posts_spec.js
+++ b/test/regression/api/v2/content/posts_spec.js
@@ -283,6 +283,7 @@ describe('api/v2/content/posts', function () {
                     localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-not-be-seen');
                     post.html.should.eql('');
+                    should.equal(post.excerpt, null);
                 });
         });
 
@@ -301,6 +302,7 @@ describe('api/v2/content/posts', function () {
                     localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-be-paid-for');
                     post.html.should.eql('');
+                    should.equal(post.excerpt, null);
                 });
         });
 
@@ -337,6 +339,7 @@ describe('api/v2/content/posts', function () {
                     localUtils.API.checkResponse(post, 'post', null, null, ['id', 'html', 'plaintext']);
                     post.html.should.eql('<p>Free content</p>');
                     post.plaintext.should.eql('Free content');
+                    post.excerpt.should.eql('Free content');
                 });
         });
 
@@ -371,6 +374,12 @@ describe('api/v2/content/posts', function () {
                     jsonResponse.posts[2].html.should.not.eql('');
                     jsonResponse.posts[3].html.should.not.eql('');
                     jsonResponse.posts[8].html.should.not.eql('');
+
+                    should.equal(jsonResponse.posts[0].excerpt, null);
+                    should.equal(jsonResponse.posts[1].excerpt, null);
+                    should.notEqual(jsonResponse.posts[2].excerpt, null);
+                    should.notEqual(jsonResponse.posts[3].excerpt, null);
+                    should.notEqual(jsonResponse.posts[8].excerpt, null);
 
                     // check meta response for this test
                     jsonResponse.meta.pagination.page.should.eql(1);

--- a/test/regression/api/v3/content/posts_spec.js
+++ b/test/regression/api/v3/content/posts_spec.js
@@ -333,6 +333,7 @@ describe('api/v3/content/posts', function () {
                     localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-not-be-seen');
                     post.html.should.eql('');
+                    should.equal(post.excerpt, null);
                 });
         });
 
@@ -351,6 +352,7 @@ describe('api/v3/content/posts', function () {
                     localUtils.API.checkResponse(post, 'post', null, null);
                     post.slug.should.eql('thou-shalt-be-paid-for');
                     post.html.should.eql('');
+                    should.equal(post.excerpt, null);
                 });
         });
 
@@ -374,7 +376,7 @@ describe('api/v3/content/posts', function () {
 
         it('can read "free" html and plaintext content of members post when using paywall card', function () {
             return request
-                .get(localUtils.API.getApiQuery(`posts/${membersPostWithPaywallCard.id}/?key=${validKey}&formats=html,plaintext&fields=html,plaintext`))
+                .get(localUtils.API.getApiQuery(`posts/${membersPostWithPaywallCard.id}/?key=${validKey}&formats=html,plaintext`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
@@ -384,14 +386,15 @@ describe('api/v3/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     const post = jsonResponse.posts[0];
 
-                    localUtils.API.checkResponse(post, 'post', null, null, ['id', 'html', 'plaintext']);
+                    localUtils.API.checkResponse(post, 'post', ['plaintext'], null);
                     post.html.should.eql('<p>Free content</p>');
                     post.plaintext.should.eql('Free content');
+                    post.excerpt.should.eql('Free content');
                 });
         });
 
         it('cannot browse members only posts content', function () {
-            return request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}`))
+            return request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&formats=html,plaintext`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
@@ -405,7 +408,7 @@ describe('api/v3/content/posts', function () {
                     should.exist(jsonResponse.posts);
                     localUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(15);
-                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', null, null);
+                    localUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['plaintext'], null);
                     localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 
@@ -420,6 +423,12 @@ describe('api/v3/content/posts', function () {
                     jsonResponse.posts[1].html.should.eql('');
                     jsonResponse.posts[2].html.should.not.eql('');
                     jsonResponse.posts[8].html.should.not.eql('');
+
+                    should.equal(jsonResponse.posts[0].excerpt, null);
+                    should.equal(jsonResponse.posts[1].excerpt, null);
+                    should.notEqual(jsonResponse.posts[2].excerpt, null);
+                    should.notEqual(jsonResponse.posts[3].excerpt, null);
+                    should.notEqual(jsonResponse.posts[8].excerpt, null);
 
                     // check meta response for this test
                     jsonResponse.meta.pagination.page.should.eql(1);

--- a/test/unit/api/canary/utils/serializers/output/utils/extra-attrs_spec.js
+++ b/test/unit/api/canary/utils/serializers/output/utils/extra-attrs_spec.js
@@ -11,36 +11,35 @@ describe('Unit: canary/utils/serializers/output/utils/extra-attrs', function () 
 
     beforeEach(function () {
         model = sinon.stub();
-        model.get = sinon.stub();
-        model.get.withArgs('plaintext').returns(new Array(5000).join('A'));
     });
 
-    describe('for post', function () {
+    describe('postExcerpt', function () {
         it('respects custom excerpt', function () {
-            const attrs = {custom_excerpt: 'custom excerpt'};
+            const attrs = {
+                custom_excerpt: 'custom excerpt'
+            };
 
-            extraAttrsUtil.forPost(frame, model, attrs);
-            model.get.called.should.be.false();
+            extraAttrsUtil.postExcerpt(frame, model, attrs);
 
             attrs.excerpt.should.eql(attrs.custom_excerpt);
         });
 
         it('no custom excerpt', function () {
-            const attrs = {};
+            const attrs = {
+                plaintext: (new Array(501)).join('A')
+            };
 
-            extraAttrsUtil.forPost(frame, model, attrs);
-            model.get.called.should.be.true();
+            extraAttrsUtil.postExcerpt(frame, model, attrs);
 
             attrs.excerpt.should.eql(new Array(501).join('A'));
         });
 
         it('has excerpt when plaintext is null', function () {
-            model.get.withArgs('plaintext').returns(null);
+            const attrs = {
+                plaintext: null
+            };
 
-            const attrs = {};
-
-            extraAttrsUtil.forPost(frame, model, attrs);
-            model.get.called.should.be.true();
+            extraAttrsUtil.postExcerpt(frame, model, attrs);
 
             attrs.should.have.property('excerpt');
             (attrs.excerpt === null).should.be.true();

--- a/test/unit/api/canary/utils/serializers/output/utils/mapper_spec.js
+++ b/test/unit/api/canary/utils/serializers/output/utils/mapper_spec.js
@@ -15,7 +15,8 @@ describe('Unit: canary/utils/serializers/output/utils/mapper', function () {
         sinon.stub(urlUtil, 'forTag').returns({});
         sinon.stub(urlUtil, 'forUser').returns({});
 
-        sinon.stub(extraAttrsUtils, 'forPost').returns({});
+        sinon.stub(extraAttrsUtils, 'postExcerpt').returns({});
+        sinon.stub(extraAttrsUtils, 'postReadingTime').returns({});
 
         sinon.stub(cleanUtil, 'post').returns({});
         sinon.stub(cleanUtil, 'tag').returns({});
@@ -67,7 +68,8 @@ describe('Unit: canary/utils/serializers/output/utils/mapper', function () {
 
             dateUtil.forPost.callCount.should.equal(1);
 
-            extraAttrsUtils.forPost.callCount.should.equal(1);
+            extraAttrsUtils.postExcerpt.callCount.should.equal(1);
+            extraAttrsUtils.postReadingTime.callCount.should.equal(1);
 
             cleanUtil.post.callCount.should.eql(1);
             cleanUtil.tag.callCount.should.eql(1);

--- a/test/unit/api/v2/utils/serializers/output/utils/extra-attrs_spec.js
+++ b/test/unit/api/v2/utils/serializers/output/utils/extra-attrs_spec.js
@@ -11,36 +11,35 @@ describe('Unit: v2/utils/serializers/output/utils/extra-attrs', function () {
 
     beforeEach(function () {
         model = sinon.stub();
-        model.get = sinon.stub();
-        model.get.withArgs('plaintext').returns(new Array(5000).join('A'));
     });
 
-    describe('for post', function () {
+    describe('postExcerpt', function () {
         it('respects custom excerpt', function () {
-            const attrs = {custom_excerpt: 'custom excerpt'};
+            const attrs = {
+                custom_excerpt: 'custom excerpt'
+            };
 
-            extraAttrsUtil.forPost(frame, model, attrs);
-            model.get.called.should.be.false();
+            extraAttrsUtil.postExcerpt(frame, model, attrs);
 
             attrs.excerpt.should.eql(attrs.custom_excerpt);
         });
 
         it('no custom excerpt', function () {
-            const attrs = {};
+            const attrs = {
+                plaintext: (new Array(501)).join('A')
+            };
 
-            extraAttrsUtil.forPost(frame, model, attrs);
-            model.get.called.should.be.true();
+            extraAttrsUtil.postExcerpt(frame, model, attrs);
 
             attrs.excerpt.should.eql(new Array(501).join('A'));
         });
 
         it('has excerpt when plaintext is null', function () {
-            model.get.withArgs('plaintext').returns(null);
+            const attrs = {
+                plaintext: null
+            };
 
-            const attrs = {};
-
-            extraAttrsUtil.forPost(frame, model, attrs);
-            model.get.called.should.be.true();
+            extraAttrsUtil.postExcerpt(frame, model, attrs);
 
             attrs.should.have.property('excerpt');
             (attrs.excerpt === null).should.be.true();

--- a/test/unit/api/v2/utils/serializers/output/utils/mapper_spec.js
+++ b/test/unit/api/v2/utils/serializers/output/utils/mapper_spec.js
@@ -15,7 +15,8 @@ describe('Unit: v2/utils/serializers/output/utils/mapper', function () {
         sinon.stub(urlUtil, 'forTag').returns({});
         sinon.stub(urlUtil, 'forUser').returns({});
 
-        sinon.stub(extraAttrsUtils, 'forPost').returns({});
+        sinon.stub(extraAttrsUtils, 'postExcerpt').returns({});
+        sinon.stub(extraAttrsUtils, 'postReadingTime').returns({});
 
         sinon.stub(cleanUtil, 'post').returns({});
         sinon.stub(cleanUtil, 'tag').returns({});
@@ -67,7 +68,7 @@ describe('Unit: v2/utils/serializers/output/utils/mapper', function () {
 
             dateUtil.forPost.callCount.should.equal(1);
 
-            extraAttrsUtils.forPost.callCount.should.equal(1);
+            extraAttrsUtils.postExcerpt.callCount.should.equal(1);
 
             cleanUtil.post.callCount.should.eql(1);
             cleanUtil.tag.callCount.should.eql(1);

--- a/test/unit/api/v2/utils/serializers/output/utils/mapper_spec.js
+++ b/test/unit/api/v2/utils/serializers/output/utils/mapper_spec.js
@@ -16,7 +16,6 @@ describe('Unit: v2/utils/serializers/output/utils/mapper', function () {
         sinon.stub(urlUtil, 'forUser').returns({});
 
         sinon.stub(extraAttrsUtils, 'postExcerpt').returns({});
-        sinon.stub(extraAttrsUtils, 'postReadingTime').returns({});
 
         sinon.stub(cleanUtil, 'post').returns({});
         sinon.stub(cleanUtil, 'tag').returns({});

--- a/test/unit/api/v3/utils/serializers/output/utils/extra-attrs_spec.js
+++ b/test/unit/api/v3/utils/serializers/output/utils/extra-attrs_spec.js
@@ -11,36 +11,35 @@ describe('Unit: v3/utils/serializers/output/utils/extra-attrs', function () {
 
     beforeEach(function () {
         model = sinon.stub();
-        model.get = sinon.stub();
-        model.get.withArgs('plaintext').returns(new Array(5000).join('A'));
     });
 
-    describe('for post', function () {
+    describe('postExcerpt', function () {
         it('respects custom excerpt', function () {
-            const attrs = {custom_excerpt: 'custom excerpt'};
+            const attrs = {
+                custom_excerpt: 'custom excerpt'
+            };
 
-            extraAttrsUtil.forPost(frame, model, attrs);
-            model.get.called.should.be.false();
+            extraAttrsUtil.postExcerpt(frame, model, attrs);
 
             attrs.excerpt.should.eql(attrs.custom_excerpt);
         });
 
         it('no custom excerpt', function () {
-            const attrs = {};
+            const attrs = {
+                plaintext: (new Array(501)).join('A')
+            };
 
-            extraAttrsUtil.forPost(frame, model, attrs);
-            model.get.called.should.be.true();
+            extraAttrsUtil.postExcerpt(frame, model, attrs);
 
             attrs.excerpt.should.eql(new Array(501).join('A'));
         });
 
         it('has excerpt when plaintext is null', function () {
-            model.get.withArgs('plaintext').returns(null);
+            const attrs = {
+                plaintext: null
+            };
 
-            const attrs = {};
-
-            extraAttrsUtil.forPost(frame, model, attrs);
-            model.get.called.should.be.true();
+            extraAttrsUtil.postExcerpt(frame, model, attrs);
 
             attrs.should.have.property('excerpt');
             (attrs.excerpt === null).should.be.true();

--- a/test/unit/api/v3/utils/serializers/output/utils/mapper_spec.js
+++ b/test/unit/api/v3/utils/serializers/output/utils/mapper_spec.js
@@ -15,7 +15,8 @@ describe('Unit: v3/utils/serializers/output/utils/mapper', function () {
         sinon.stub(urlUtil, 'forTag').returns({});
         sinon.stub(urlUtil, 'forUser').returns({});
 
-        sinon.stub(extraAttrsUtils, 'forPost').returns({});
+        sinon.stub(extraAttrsUtils, 'postExcerpt').returns({});
+        sinon.stub(extraAttrsUtils, 'postReadingTime').returns({});
 
         sinon.stub(cleanUtil, 'post').returns({});
         sinon.stub(cleanUtil, 'tag').returns({});
@@ -67,7 +68,8 @@ describe('Unit: v3/utils/serializers/output/utils/mapper', function () {
 
             dateUtil.forPost.callCount.should.equal(1);
 
-            extraAttrsUtils.forPost.callCount.should.equal(1);
+            extraAttrsUtils.postExcerpt.callCount.should.equal(1);
+            extraAttrsUtils.postReadingTime.callCount.should.equal(1);
 
             cleanUtil.post.callCount.should.eql(1);
             cleanUtil.tag.callCount.should.eql(1);


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/468

- split `extraAttrs.forPost` into separate functions (`postReadingTime`, `postExcerpt`) to allow better ordering in post mapper
- updated `extraAttrs.postExcerpt` to read plaintext from attrs rather than directly from the model
- moved `extraAttrs.postExcerpt` call to be made after the post gating call to ensure the plaintext attr contains the gated contents from which to generate the excerpt