### PR TITLE
Added migration to remove surrounding <> in email_batches.provider_id

### DIFF
--- a/core/server/data/migrations/versions/4.0/21-sanitize-email-batches-provider-id.js
+++ b/core/server/data/migrations/versions/4.0/21-sanitize-email-batches-provider-id.js
@@ -1,0 +1,8 @@
+const logging = require('../../../../../shared/logging');
+const {createIrreversibleMigration} = require('../../utils');
+
+module.exports = createIrreversibleMigration(async (knex) => {
+    logging.info('Sanitizing provider_id values in email_batches');
+
+    await knex.raw('UPDATE email_batches SET provider_id = REPLACE(REPLACE(provider_id, "<", ""), ">", "")');
+});

--- a/core/server/services/bulk-email/index.js
+++ b/core/server/services/bulk-email/index.js
@@ -168,7 +168,7 @@ module.exports = {
             // update batch success status
             return await emailBatchModel.save({
                 status: 'submitted',
-                provider_id: sendResponse.id
+                provider_id: sendResponse.id.trim().replace(/^<|>$/g, '')
             }, Object.assign({}, knexOptions, {patch: true}));
         } catch (error) {
             // update batch failed status

--- a/core/server/services/email-analytics/providers/mailgun.js
+++ b/core/server/services/email-analytics/providers/mailgun.js
@@ -114,11 +114,7 @@ class EmailAnalyticsMailgunProvider {
     }
 
     normalizeEvent(event) {
-        // TODO: clean up the <> surrounding email_batches.provider_id values
         let providerId = event.message && event.message.headers && event.message.headers['message-id'];
-        if (providerId) {
-            providerId = `<${providerId}>`;
-        }
 
         return {
             type: event.event,

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -478,8 +478,7 @@ DataGenerator.Content = {
         {
             id: ObjectId.generate(),
             email_id: null, // emails[0] relation added later
-            // TODO: cleanup <> in provider_id
-            provider_id: '<email1@testing.mailgun.net>',
+            provider_id: 'email1@testing.mailgun.net',
             status: 'submitted'
         }
     ],


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/221#issuecomment-759105424

- Mailgun responds to an email send with a provider id in the format `<x@y.com>` but everywhere else it's used in their API it uses the format `x@y.com`
- updates email batch save to strip the brackets, and migration removes brackets from existing records so we no longer have to add special handling for the stored id any time we use it