### PR TITLE
Renamed "posts_meta" table to "metadata"

### DIFF
--- a/core/server/api/canary/email-preview.js
+++ b/core/server/api/canary/email-preview.js
@@ -21,7 +21,7 @@ module.exports = {
         ],
         permissions: true,
         query(frame) {
-            const options = Object.assign(frame.options, {formats: 'html,plaintext', withRelated: ['authors', 'posts_meta']});
+            const options = Object.assign(frame.options, {formats: 'html,plaintext', withRelated: ['authors', 'metadata']});
             const data = Object.assign(frame.data, {status: 'all'});
             return models.Post.findOne(data, options)
                 .then((model) => {

--- a/core/server/api/canary/utils/serializers/input/pages.js
+++ b/core/server/api/canary/utils/serializers/input/pages.js
@@ -5,7 +5,7 @@ const mobiledoc = require('../../../../../lib/mobiledoc');
 const url = require('./utils/url');
 const slugFilterOrder = require('./utils/slug-filter-order');
 const localUtils = require('../../index');
-const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
+const metadataSchema = require('../../../../../data/schema').tables.metadata;
 
 const replacePageWithType = mapNQLKeyValues({
     key: {
@@ -72,10 +72,10 @@ function defaultFormat(frame) {
     frame.options.formats = 'mobiledoc';
 }
 
-function handlePostsMeta(frame) {
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    let meta = _.pick(frame.data.pages[0], metaAttrs);
-    frame.data.pages[0].posts_meta = meta;
+function handleMetadata(frame) {
+    let metadataAttrs = _.keys(_.omit(metadataSchema, ['id', 'post_id']));
+    let metadata = _.pick(frame.data.pages[0], metadataAttrs);
+    frame.data.pages[0].metadata = metadata;
 }
 
 /**
@@ -180,7 +180,7 @@ module.exports = {
             });
         }
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -189,7 +189,7 @@ module.exports = {
         debug('edit');
         this.add(...arguments, {add: false});
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/canary/utils/serializers/input/posts.js
+++ b/core/server/api/canary/utils/serializers/input/posts.js
@@ -5,7 +5,7 @@ const url = require('./utils/url');
 const slugFilterOrder = require('./utils/slug-filter-order');
 const localUtils = require('../../index');
 const mobiledoc = require('../../../../../lib/mobiledoc');
-const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
+const metadataSchema = require('../../../../../data/schema').tables.metadata;
 
 const replacePageWithType = mapNQLKeyValues({
     key: {
@@ -72,10 +72,10 @@ function defaultFormat(frame) {
     frame.options.formats = 'mobiledoc';
 }
 
-function handlePostsMeta(frame) {
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    let meta = _.pick(frame.data.posts[0], metaAttrs);
-    frame.data.posts[0].posts_meta = meta;
+function handleMetadata(frame) {
+    let metadataAttrs = _.keys(_.omit(metadataSchema, ['id', 'post_id']));
+    let metadata = _.pick(frame.data.posts[0], metadataAttrs);
+    frame.data.posts[0].metadata = metadata;
 }
 
 /**
@@ -196,7 +196,7 @@ module.exports = {
             });
         }
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -205,7 +205,7 @@ module.exports = {
         debug('edit');
         this.add(apiConfig, frame, {add: false});
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -5,7 +5,7 @@ const date = require('./date');
 const gating = require('./post-gating');
 const clean = require('./clean');
 const extraAttrs = require('./extra-attrs');
-const postsMetaSchema = require('../../../../../../data/schema').tables.posts_meta;
+const metadataSchema = require('../../../../../../data/schema').tables.metadata;
 const mega = require('../../../../../../services/mega');
 
 const mapUser = (model, frame) => {
@@ -73,13 +73,13 @@ const mapPost = (model, frame) => {
     }
 
     // Transforms post/page metadata to flat structure
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    _(metaAttrs).filter((k) => {
+    let metadataAttrs = _.keys(_.omit(metadataSchema, ['id', 'post_id']));
+    _(metadataAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+        jsonModel[attr] = _.get(jsonModel.metadata, attr) || null;
     });
-    delete jsonModel.posts_meta;
+    delete jsonModel.metadata;
 
     return jsonModel;
 };

--- a/core/server/api/canary/utils/serializers/output/utils/url.js
+++ b/core/server/api/canary/utils/serializers/output/utils/url.js
@@ -46,7 +46,7 @@ const forPost = (id, attrs, frame) => {
         }
     });
 
-    ['feature_image', 'canonical_url', 'posts_meta.og_image', 'posts_meta.twitter_image'].forEach((path) => {
+    ['feature_image', 'canonical_url', 'metadata.og_image', 'metadata.twitter_image'].forEach((path) => {
         const value = _.get(attrs, path);
         if (value) {
             _.set(attrs, path, urlUtils.relativeToAbsolute(value));

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -4,7 +4,7 @@ const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:pa
 const mobiledoc = require('../../../../../lib/mobiledoc');
 const url = require('./utils/url');
 const localUtils = require('../../index');
-const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
+const metadataSchema = require('../../../../../data/schema').tables.metadata;
 
 const replacePageWithType = mapNQLKeyValues({
     key: {
@@ -67,10 +67,10 @@ function defaultFormat(frame) {
     frame.options.formats = 'mobiledoc';
 }
 
-function handlePostsMeta(frame) {
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    let meta = _.pick(frame.data.pages[0], metaAttrs);
-    frame.data.pages[0].posts_meta = meta;
+function handleMetadata(frame) {
+    let metadataAttrs = _.keys(_.omit(metadataSchema, ['id', 'post_id']));
+    let metadata = _.pick(frame.data.pages[0], metadataAttrs);
+    frame.data.pages[0].metadata = metadata;
 }
 
 /**
@@ -175,7 +175,7 @@ module.exports = {
             });
         }
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -185,7 +185,7 @@ module.exports = {
 
         this.add(...arguments, {add: false});
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -4,7 +4,7 @@ const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:po
 const url = require('./utils/url');
 const localUtils = require('../../index');
 const mobiledoc = require('../../../../../lib/mobiledoc');
-const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
+const metadataSchema = require('../../../../../data/schema').tables.metadata;
 
 const replacePageWithType = mapNQLKeyValues({
     key: {
@@ -67,10 +67,10 @@ function defaultFormat(frame) {
     frame.options.formats = 'mobiledoc';
 }
 
-function handlePostsMeta(frame) {
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    let meta = _.pick(frame.data.posts[0], metaAttrs);
-    frame.data.posts[0].posts_meta = meta;
+function handleMetadata(frame) {
+    let metadataAttrs = _.keys(_.omit(metadataSchema, ['id', 'post_id']));
+    let metadata = _.pick(frame.data.posts[0], metadataAttrs);
+    frame.data.posts[0].metadata = metadata;
 }
 
 /**
@@ -191,7 +191,7 @@ module.exports = {
             });
         }
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -200,7 +200,7 @@ module.exports = {
         debug('edit');
         this.add(apiConfig, frame, {add: false});
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -5,7 +5,7 @@ const date = require('./date');
 const gating = require('./post-gating');
 const clean = require('./clean');
 const extraAttrs = require('./extra-attrs');
-const postsMetaSchema = require('../../../../../../data/schema').tables.posts_meta;
+const metadataSchema = require('../../../../../../data/schema').tables.metadata;
 
 const mapUser = (model, frame) => {
     const jsonModel = model.toJSON ? model.toJSON(frame.options) : model;
@@ -68,14 +68,14 @@ const mapPost = (model, frame) => {
     }
 
     // Transforms post/page metadata to flat structure
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    let metaAttrs = _.keys(_.omit(metadataSchema, ['id', 'post_id']));
     _(metaAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+        jsonModel[attr] = _.get(jsonModel.metadata, attr) || null;
     });
 
-    delete jsonModel.posts_meta;
+    delete jsonModel.metadata;
     delete jsonModel.send_email_when_published;
     delete jsonModel.email_recipient_filter;
     delete jsonModel.email_subject;

--- a/core/server/api/v2/utils/serializers/output/utils/url.js
+++ b/core/server/api/v2/utils/serializers/output/utils/url.js
@@ -56,7 +56,7 @@ const forPost = (id, attrs, frame) => {
         }
     });
 
-    ['feature_image', 'canonical_url', 'posts_meta.og_image', 'posts_meta.twitter_image'].forEach((path) => {
+    ['feature_image', 'canonical_url', 'metadata.og_image', 'metadata.twitter_image'].forEach((path) => {
         const value = _.get(attrs, path);
         if (value) {
             _.set(attrs, path, urlUtils.relativeToAbsolute(value));

--- a/core/server/api/v3/email-preview.js
+++ b/core/server/api/v3/email-preview.js
@@ -21,7 +21,7 @@ module.exports = {
         ],
         permissions: true,
         query(frame) {
-            const options = Object.assign(frame.options, {formats: 'html,plaintext', withRelated: ['authors', 'posts_meta']});
+            const options = Object.assign(frame.options, {formats: 'html,plaintext', withRelated: ['authors', 'metadata']});
             const data = Object.assign(frame.data, {status: 'all'});
             return models.Post.findOne(data, options)
                 .then((model) => {

--- a/core/server/api/v3/utils/serializers/input/pages.js
+++ b/core/server/api/v3/utils/serializers/input/pages.js
@@ -5,7 +5,7 @@ const mobiledoc = require('../../../../../lib/mobiledoc');
 const url = require('./utils/url');
 const slugFilterOrder = require('./utils/slug-filter-order');
 const localUtils = require('../../index');
-const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
+const metadataSchema = require('../../../../../data/schema').tables.metadata;
 
 const replacePageWithType = mapNQLKeyValues({
     key: {
@@ -72,10 +72,10 @@ function defaultFormat(frame) {
     frame.options.formats = 'mobiledoc';
 }
 
-function handlePostsMeta(frame) {
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    let meta = _.pick(frame.data.pages[0], metaAttrs);
-    frame.data.pages[0].posts_meta = meta;
+function handleMetadata(frame) {
+    let metadataAttrs = _.keys(_.omit(metadataSchema, ['id', 'post_id']));
+    let metadata = _.pick(frame.data.pages[0], metadataAttrs);
+    frame.data.pages[0].metadata = metadata;
 }
 
 /**
@@ -180,7 +180,7 @@ module.exports = {
             });
         }
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -189,7 +189,7 @@ module.exports = {
         debug('edit');
         this.add(...arguments, {add: false});
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/v3/utils/serializers/input/posts.js
+++ b/core/server/api/v3/utils/serializers/input/posts.js
@@ -5,7 +5,7 @@ const url = require('./utils/url');
 const slugFilterOrder = require('./utils/slug-filter-order');
 const localUtils = require('../../index');
 const mobiledoc = require('../../../../../lib/mobiledoc');
-const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
+const metadataSchema = require('../../../../../data/schema').tables.metadata;
 
 const replacePageWithType = mapNQLKeyValues({
     key: {
@@ -72,10 +72,10 @@ function defaultFormat(frame) {
     frame.options.formats = 'mobiledoc';
 }
 
-function handlePostsMeta(frame) {
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    let meta = _.pick(frame.data.posts[0], metaAttrs);
-    frame.data.posts[0].posts_meta = meta;
+function handleMetadata(frame) {
+    let metadataAttrs = _.keys(_.omit(metadataSchema, ['id', 'post_id']));
+    let metadata = _.pick(frame.data.posts[0], metadataAttrs);
+    frame.data.posts[0].metadata = metadata;
 }
 
 /**
@@ -204,7 +204,7 @@ module.exports = {
             });
         }
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         defaultFormat(frame);
         defaultRelations(frame);
     },
@@ -213,7 +213,7 @@ module.exports = {
         debug('edit');
         this.add(apiConfig, frame, {add: false});
 
-        handlePostsMeta(frame);
+        handleMetadata(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);
     },

--- a/core/server/api/v3/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v3/utils/serializers/output/utils/mapper.js
@@ -5,7 +5,7 @@ const date = require('./date');
 const gating = require('./post-gating');
 const clean = require('./clean');
 const extraAttrs = require('./extra-attrs');
-const postsMetaSchema = require('../../../../../../data/schema').tables.posts_meta;
+const metadataSchema = require('../../../../../../data/schema').tables.metadata;
 const mega = require('../../../../../../services/mega');
 
 const mapUser = (model, frame) => {
@@ -81,13 +81,13 @@ const mapPost = (model, frame) => {
     }
 
     // Transforms post/page metadata to flat structure
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    let metaAttrs = _.keys(_.omit(metadataSchema, ['id', 'post_id']));
     _(metaAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+        jsonModel[attr] = _.get(jsonModel.metadata, attr) || null;
     });
-    delete jsonModel.posts_meta;
+    delete jsonModel.metadata;
 
     return jsonModel;
 };

--- a/core/server/api/v3/utils/serializers/output/utils/url.js
+++ b/core/server/api/v3/utils/serializers/output/utils/url.js
@@ -46,7 +46,7 @@ const forPost = (id, attrs, frame) => {
         }
     });
 
-    ['feature_image', 'canonical_url', 'posts_meta.og_image', 'posts_meta.twitter_image'].forEach((path) => {
+    ['feature_image', 'canonical_url', 'metadata.og_image', 'metadata.twitter_image'].forEach((path) => {
         const value = _.get(attrs, path);
         if (value) {
             _.set(attrs, path, urlUtils.relativeToAbsolute(value));

--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -4,15 +4,15 @@ const uuid = require('uuid');
 const BaseImporter = require('./base');
 const mobiledocLib = require('../../../../lib/mobiledoc');
 const validation = require('../../../validation');
-const postsMetaSchema = require('../../../schema').tables.posts_meta;
-const metaAttrs = _.keys(_.omit(postsMetaSchema, ['id']));
+const metadataSchema = require('../../../schema').tables.metadata;
+const metaAttrs = _.keys(_.omit(metadataSchema, ['id']));
 
 class PostsImporter extends BaseImporter {
     constructor(allDataFromFile) {
         super(allDataFromFile, {
             modelName: 'Post',
             dataKeyToImport: 'posts',
-            requiredFromFile: ['posts', 'tags', 'posts_tags', 'posts_authors', 'posts_meta'],
+            requiredFromFile: ['posts', 'tags', 'posts_tags', 'posts_authors', 'metadata'],
             requiredImportedData: ['tags'],
             requiredExistingData: ['tags']
         });
@@ -48,10 +48,10 @@ class PostsImporter extends BaseImporter {
     /**
      * Sanitizes post metadata, picking data from sepearate table(for >= v3) or post itself(for < v3)
      */
-    sanitizePostsMeta(model) {
-        let postsMetaFromFile = _.find(this.requiredFromFile.posts_meta, {post_id: model.id}) || _.pick(model, metaAttrs);
-        let postsMetaData = Object.assign({}, _.mapValues(postsMetaSchema, () => null), postsMetaFromFile);
-        model.posts_meta = postsMetaData;
+    sanitizeMetadata(model) {
+        let metadataFromFile = _.find(this.requiredFromFile.metadata, {post_id: model.id}) || _.pick(model, metaAttrs);
+        let metadataMetaData = Object.assign({}, _.mapValues(metadataSchema, () => null), metadataFromFile);
+        model.metadata = metadataMetaData;
         _.each(metaAttrs, (attr) => {
             delete model[attr];
         });
@@ -238,7 +238,7 @@ class PostsImporter extends BaseImporter {
                 model.mobiledoc = JSON.stringify(mobiledoc);
                 model.html = mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(model.mobiledoc));
             }
-            this.sanitizePostsMeta(model);
+            this.sanitizeMetadata(model);
         });
 
         // NOTE: We only support removing duplicate posts within the file to import.

--- a/core/server/data/migrations/versions/4.0/24-rename-post-meta-table.js
+++ b/core/server/data/migrations/versions/4.0/24-rename-post-meta-table.js
@@ -1,0 +1,21 @@
+const {renameTable} = require('../../utils');
+
+const fromTable = 'posts_meta';
+const toTable = 'metadata';
+
+const postsMetaTableSpec = {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', unique: true},
+    og_image: {type: 'string', maxlength: 2000, nullable: true},
+    og_title: {type: 'string', maxlength: 300, nullable: true},
+    og_description: {type: 'string', maxlength: 500, nullable: true},
+    twitter_image: {type: 'string', maxlength: 2000, nullable: true},
+    twitter_title: {type: 'string', maxlength: 300, nullable: true},
+    twitter_description: {type: 'string', maxlength: 500, nullable: true},
+    meta_title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
+    meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
+    email_subject: {type: 'string', maxlength: 300, nullable: true},
+    frontmatter: {type: 'text', maxlength: 65535, nullable: true}
+};
+
+module.exports = renameTable(fromTable, toTable, postsMetaTableSpec);

--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -185,6 +185,22 @@ function getTables(transaction) {
     return Promise.reject(i18n.t('notices.data.utils.index.noSupportForDatabase', {client: client}));
 }
 
+/**
+ * Copies all data from one table to another. The schemas of the tables have to be identical
+ *
+ * @param {string} from from table name
+ * @param {string} to name of the table to copy to
+ * @param {Object} connection  knex instance
+ */
+async function copyTableData(from, to, transaction) {
+    const knex = (transaction || db.knex);
+
+    await knex.raw(`
+        INSERT INTO ${to}
+        SELECT * FROM ${from};`
+    );
+}
+
 function getIndexes(table, transaction) {
     const client = (transaction || db.knex).client.config.client;
 
@@ -247,6 +263,7 @@ module.exports = {
     createTable: createTable,
     deleteTable: deleteTable,
     getTables: getTables,
+    copyTableData: copyTableData,
     getIndexes: getIndexes,
     addUnique: addUnique,
     dropUnique: dropUnique,

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -62,7 +62,7 @@ module.exports = {
             ['slug', 'type']
         ]
     },
-    posts_meta: {
+    metadata: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', unique: true},
         og_image: {type: 'string', maxlength: 2000, nullable: true},

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -34,7 +34,7 @@ const models = [
     'member-email-change-event',
     'member-payment-event',
     'member-status-event',
-    'posts-meta',
+    'metadata',
     'member-stripe-customer',
     'stripe-customer-subscription',
     'email',

--- a/core/server/models/metadata.js
+++ b/core/server/models/metadata.js
@@ -1,8 +1,8 @@
 const ghostBookshelf = require('./base');
 const urlUtils = require('../../shared/url-utils');
 
-const PostsMeta = ghostBookshelf.Model.extend({
-    tableName: 'posts_meta',
+const Metadata = ghostBookshelf.Model.extend({
+    tableName: 'metadata',
 
     onSaving: function onSaving() {
         const urlTransformMap = {
@@ -34,5 +34,5 @@ const PostsMeta = ghostBookshelf.Model.extend({
 });
 
 module.exports = {
-    PostsMeta: ghostBookshelf.model('PostsMeta', PostsMeta)
+    Metadata: ghostBookshelf.model('Metadata', Metadata)
 };

--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -25,8 +25,8 @@ const RELATIONS = {
         joinFrom: 'member_id',
         joinTo: 'label_id'
     },
-    posts_meta: {
-        tableName: 'posts_meta',
+    metadata: {
+        tableName: 'metadata',
         type: 'oneToOne',
         joinFrom: 'post_id'
     }

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -128,8 +128,8 @@ const serialize = async (postModel, options = {isBrowserPreview: false}) => {
     post.published_at = momentDate.tz(timezone).format('DD MMM YYYY');
 
     post.authors = post.authors && post.authors.map(author => author.name).join(',');
-    if (post.posts_meta) {
-        post.email_subject = post.posts_meta.email_subject;
+    if (post.metadata) {
+        post.email_subject = post.metadata.email_subject;
     }
 
     // we use post.excerpt as a hidden piece of text that is picked up by some email

--- a/test/api-acceptance/admin/utils.js
+++ b/test/api-acceptance/admin/utils.js
@@ -41,9 +41,9 @@ const expectedProperties = {
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         // returned by default
         .concat('tags', 'authors', 'email')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys().without('post_id', 'id')
+            ..._(schema.metadata).keys().without('post_id', 'id')
         )
     ,
 
@@ -64,9 +64,9 @@ const expectedProperties = {
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         // returned by default
         .concat('tags', 'authors')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys()
+            ..._(schema.metadata).keys()
                 .without('post_id', 'id')
                 // pages are not sent as emails
                 .without('email_subject')

--- a/test/api-acceptance/admin/utils_v3.js
+++ b/test/api-acceptance/admin/utils_v3.js
@@ -40,9 +40,9 @@ const expectedProperties = {
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         // returned by default
         .concat('tags', 'authors', 'email')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys().without('post_id', 'id')
+            ..._(schema.metadata).keys().without('post_id', 'id')
         )
         .concat('send_email_when_published')
     ,
@@ -63,9 +63,9 @@ const expectedProperties = {
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         // returned by default
         .concat('tags', 'authors')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys()
+            ..._(schema.metadata).keys()
                 .without('post_id', 'id')
                 // pages are not sent as emails
                 .without('email_subject')

--- a/test/api-acceptance/content/utils.js
+++ b/test/api-acceptance/content/utils.js
@@ -32,9 +32,9 @@ const expectedProperties = {
         .concat('excerpt')
         // Access is a calculated property in >= v3
         .concat('access')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys().without('post_id', 'id')
+            ..._(schema.metadata).keys().without('post_id', 'id')
         )
         .concat('reading_time')
     ,

--- a/test/api-acceptance/content/utils_v3.js
+++ b/test/api-acceptance/content/utils_v3.js
@@ -31,9 +31,9 @@ const expectedProperties = {
         .concat('excerpt')
         // Access is a calculated property in >= v3
         .concat('access')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys().without('post_id', 'id')
+            ..._(schema.metadata).keys().without('post_id', 'id')
         )
         .concat('reading_time')
         .concat('send_email_when_published')

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -91,7 +91,7 @@ describe('Posts API', function () {
                 });
         });
 
-        it('can filter by fields coming from posts_meta table non null meta_description', function (done) {
+        it('can filter by fields coming from metadata table non null meta_description', function (done) {
             request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:-null`))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
@@ -122,7 +122,7 @@ describe('Posts API', function () {
                 });
         });
 
-        it('can filter by fields coming from posts_meta table by value', function (done) {
+        it('can filter by fields coming from metadata table by value', function (done) {
             request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:'meta description for short and sweet'`))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
@@ -152,7 +152,7 @@ describe('Posts API', function () {
                 });
         });
 
-        it('can order by fields coming from posts_meta table', function (done) {
+        it('can order by fields coming from metadata table', function (done) {
             request.get(localUtils.API.getApiQuery('posts/?order=meta_description%20ASC'))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)

--- a/test/regression/api/canary/admin/utils.js
+++ b/test/regression/api/canary/admin/utils.js
@@ -33,9 +33,9 @@ const expectedProperties = {
         // only because authors and tags are always included
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         .concat('authors', 'tags', 'email')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys().without('post_id', 'id')
+            ..._(schema.metadata).keys().without('post_id', 'id')
         )
     ,
     user: _(schema.users)

--- a/test/regression/api/canary/content/utils.js
+++ b/test/regression/api/canary/content/utils.js
@@ -31,9 +31,9 @@ const expectedProperties = {
         .concat('excerpt')
         // Access is a calculated property in >= v3
         .concat('access')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys().without('post_id', 'id')
+            ..._(schema.metadata).keys().without('post_id', 'id')
         )
         .concat('reading_time')
     ,

--- a/test/regression/api/v2/admin/utils.js
+++ b/test/regression/api/v2/admin/utils.js
@@ -32,9 +32,9 @@ const expectedProperties = {
         // always returns computed properties
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         .concat('authors', 'tags')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys()
+            ..._(schema.metadata).keys()
                 .without('post_id', 'id')
                 // emails are not supported in API v2
                 .without('email_subject')

--- a/test/regression/api/v2/content/utils.js
+++ b/test/regression/api/v2/content/utils.js
@@ -30,9 +30,9 @@ const expectedProperties = {
         .without('type')
         // v2 returns a calculated excerpt field
         .concat('excerpt')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys()
+            ..._(schema.metadata).keys()
                 .without('post_id', 'id')
                 // emails are not supported in API v2
                 .without('email_subject')

--- a/test/regression/api/v3/admin/posts_spec.js
+++ b/test/regression/api/v3/admin/posts_spec.js
@@ -91,7 +91,7 @@ describe('Posts API', function () {
                 });
         });
 
-        it('can filter by fields coming from posts_meta table non null meta_description', function (done) {
+        it('can filter by fields coming from metadata table non null meta_description', function (done) {
             request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:-null`))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
@@ -122,7 +122,7 @@ describe('Posts API', function () {
                 });
         });
 
-        it('can filter by fields coming from posts_meta table by value', function (done) {
+        it('can filter by fields coming from metadata table by value', function (done) {
             request.get(localUtils.API.getApiQuery(`posts/?filter=meta_description:'meta description for short and sweet'`))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
@@ -152,7 +152,7 @@ describe('Posts API', function () {
                 });
         });
 
-        it('can order by fields coming from posts_meta table', function (done) {
+        it('can order by fields coming from metadata table', function (done) {
             request.get(localUtils.API.getApiQuery('posts/?order=meta_description%20ASC'))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)

--- a/test/regression/api/v3/admin/utils.js
+++ b/test/regression/api/v3/admin/utils.js
@@ -33,9 +33,9 @@ const expectedProperties = {
         // only because authors and tags are always included
         .concat('url', 'primary_tag', 'primary_author', 'excerpt')
         .concat('authors', 'tags', 'email')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys().without('post_id', 'id')
+            ..._(schema.metadata).keys().without('post_id', 'id')
         )
         .concat('send_email_when_published')
     ,

--- a/test/regression/api/v3/content/utils.js
+++ b/test/regression/api/v3/content/utils.js
@@ -31,9 +31,9 @@ const expectedProperties = {
         .concat('excerpt')
         // Access is a calculated property in >= v3
         .concat('access')
-        // returns meta fields from `posts_meta` schema
+        // returns meta fields from `metadata` schema
         .concat(
-            ..._(schema.posts_meta).keys().without('post_id', 'id')
+            ..._(schema.metadata).keys().without('post_id', 'id')
         )
         .concat('reading_time')
         .concat('send_email_when_published')

--- a/test/regression/models/model_posts_spec.js
+++ b/test/regression/models/model_posts_spec.js
@@ -55,7 +55,7 @@ describe('Post Model', function () {
                         return testUtils.truncate('posts');
                     })
                     .then(function () {
-                        return testUtils.truncate('posts_meta');
+                        return testUtils.truncate('metadata');
                     });
             });
 
@@ -184,7 +184,7 @@ describe('Post Model', function () {
                         return testUtils.truncate('posts');
                     })
                     .then(function () {
-                        return testUtils.truncate('posts_meta');
+                        return testUtils.truncate('metadata');
                     });
             });
 
@@ -705,7 +705,7 @@ describe('Post Model', function () {
                         return testUtils.truncate('posts');
                     })
                     .then(function () {
-                        return testUtils.truncate('posts_meta');
+                        return testUtils.truncate('metadata');
                     });
             });
 
@@ -1136,7 +1136,7 @@ describe('Post Model', function () {
                     codeinjection_foot: '<script src="http://127.0.0.1:2369/assets/foot.js"></script>',
                     feature_image: 'http://127.0.0.1:2369/content/images/feature.png',
                     canonical_url: 'http://127.0.0.1:2369/canonical',
-                    posts_meta: {
+                    metadata: {
                         og_image: 'http://127.0.0.1:2369/content/images/og.png',
                         twitter_image: 'http://127.0.0.1:2369/content/images/twitter.png'
                     }
@@ -1151,10 +1151,10 @@ describe('Post Model', function () {
                     createdPost.get('feature_image').should.equal('/content/images/feature.png');
                     createdPost.get('canonical_url').should.equal('/canonical');
 
-                    const postMeta = createdPost.relations.posts_meta;
+                    const metadata = createdPost.relations.metadata;
 
-                    postMeta.get('og_image').should.equal('/content/images/og.png');
-                    postMeta.get('twitter_image').should.equal('/content/images/twitter.png');
+                    metadata.get('og_image').should.equal('/content/images/og.png');
+                    metadata.get('twitter_image').should.equal('/content/images/twitter.png');
 
                     // ensure canonical_url is not transformed when protocol does not match
                     return createdPost.save({
@@ -1183,7 +1183,7 @@ describe('Post Model', function () {
                         return testUtils.truncate('posts');
                     })
                     .then(function () {
-                        return testUtils.truncate('posts_meta');
+                        return testUtils.truncate('metadata');
                     });
             });
 
@@ -1368,7 +1368,7 @@ describe('Post Model', function () {
                         return testUtils.truncate('posts');
                     })
                     .then(function () {
-                        return testUtils.truncate('posts_meta');
+                        return testUtils.truncate('metadata');
                     });
             });
 
@@ -1609,7 +1609,7 @@ describe('Post Model', function () {
                     return testUtils.truncate('posts');
                 })
                 .then(function () {
-                    return testUtils.truncate('posts_meta');
+                    return testUtils.truncate('metadata');
                 });
         });
 

--- a/test/unit/api/canary/utils/serializers/output/utils/url_spec.js
+++ b/test/unit/api/canary/utils/serializers/output/utils/url_spec.js
@@ -36,7 +36,7 @@ describe('Unit: canary/utils/serializers/output/utils/url', function () {
                 codeinjection_head: 'codeinjectionHead',
                 codeinjection_foot: 'codeinjectionFoot',
                 feature_image: 'featureImage',
-                posts_meta: {
+                metadata: {
                     og_image: 'ogImage',
                     twitter_image: 'twitterImage'
                 },

--- a/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
+++ b/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
@@ -36,7 +36,7 @@ describe('Unit: v2/utils/serializers/output/utils/url', function () {
                 codeinjection_head: 'codeinjectionHead',
                 codeinjection_foot: 'codeinjectionFoot',
                 feature_image: 'featureImage',
-                posts_meta: {
+                metadata: {
                     og_image: 'ogImage',
                     twitter_image: 'twitterImage'
                 },

--- a/test/unit/api/v3/utils/serializers/output/utils/url_spec.js
+++ b/test/unit/api/v3/utils/serializers/output/utils/url_spec.js
@@ -36,7 +36,7 @@ describe('Unit: v3/utils/serializers/output/utils/url', function () {
                 codeinjection_head: 'codeinjectionHead',
                 codeinjection_foot: 'codeinjectionFoot',
                 feature_image: 'featureImage',
-                posts_meta: {
+                metadata: {
                     og_image: 'ogImage',
                     twitter_image: 'twitterImage'
                 },

--- a/test/unit/data/exporter/index_spec.js
+++ b/test/unit/data/exporter/index_spec.js
@@ -60,7 +60,7 @@ describe('Exporter', function () {
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
 
                 knexMock.getCall(0).args[0].should.eql('posts');
-                knexMock.getCall(1).args[0].should.eql('posts_meta');
+                knexMock.getCall(1).args[0].should.eql('metadata');
                 knexMock.getCall(2).args[0].should.eql('users');
                 knexMock.getCall(3).args[0].should.eql('posts_authors');
                 knexMock.getCall(4).args[0].should.eql('roles');
@@ -98,7 +98,7 @@ describe('Exporter', function () {
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
 
                 knexMock.getCall(0).args[0].should.eql('posts');
-                knexMock.getCall(1).args[0].should.eql('posts_meta');
+                knexMock.getCall(1).args[0].should.eql('metadata');
                 knexMock.getCall(2).args[0].should.eql('users');
                 knexMock.getCall(3).args[0].should.eql('posts_authors');
                 knexMock.getCall(4).args[0].should.eql('roles');

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '5861ed57418a0195ea01e431b8b55335';
+    const currentSchemaHash = 'ceeb5e445af71900360ddd65aeabfc1d';
     const currentFixturesHash = '370d0da0ab7c45050b2ff30bce8896ba';
     const currentSettingsHash = 'e1f85186a7c7ed76064b6026f68c6321';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/test/utils/fixture-utils.js
+++ b/test/utils/fixture-utils.js
@@ -56,8 +56,8 @@ const fixtures = {
                 });
             })
             .then(function () {
-                return Promise.map(DataGenerator.forKnex.posts_meta, function (postMeta) {
-                    return models.PostsMeta.add(postMeta, context.internal);
+                return Promise.map(DataGenerator.forKnex.metadata, function (metadata) {
+                    return models.Metadata.add(metadata, context.internal);
                 });
             });
     },

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -916,7 +916,7 @@ DataGenerator.forKnex = (function () {
         }
     ];
 
-    const posts_meta = [
+    const metadata = [
         {
             id: ObjectId.generate(),
             post_id: DataGenerator.Content.posts[2].id,
@@ -1130,7 +1130,7 @@ DataGenerator.forKnex = (function () {
         invites,
         posts,
         tags,
-        posts_meta,
+        metadata,
         posts_tags,
         posts_authors,
         roles,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/452
supersedes https://github.com/TryGhost/Ghost/pull/12669

Renames `posts_meta` table to a more generic `metadata`. This table will be used by other than `post` resources in the future.

Note for reviewers: a8f9e51 and 1d8c338 commits are of interest here, 1st one contains new migration utility for table rename and 2nd contains the migration itself. The last commit is a generic rename in the codebase. There is be a [follow up PR](https://github.com/TryGhost/Ghost/pull/12695) fixing 3.x migrations where `posts_meta` schema is referenced directly.

@daniellockyer one area I'm not sure about for this migration is stress testing with large amounts of `posts_meta` records. Do you have utilities to generate such datasets?

### Index problem illustrated
The native knex table rename migration was messing up indexes in the table. Here is an example of what was happening in SQLit using native rename and then using the utility:

```
-- migrated table schema

sqlite> .schema posts_meta
CREATE TABLE `posts_meta` (`id` varchar(24) not null, `post_id` varchar(24) not null, `og_image` varchar(2000) null, `og_title` varchar(300) null, `og_description` varchar(500) null, `twitter_image` varchar(2000) null, `twitter_title` varchar(300) null, `twitter_description` varchar(500) null, `meta_title` varchar(2000) null, `meta_description` varchar(2000) null, `email_subject` varchar(300) null, `frontmatter` text null, foreign key(`post_id`) references `posts`(`id`), primary key (`id`));
CREATE UNIQUE INDEX `posts_meta_post_id_unique` on `posts_meta` (`post_id`);

sqlite> PRAGMA index_list('posts_meta');
0|posts_meta_post_id_unique|1|c|0
1|sqlite_autoindex_posts_meta_1|1|pk|0

--- AFTER native table rename migration 

sqlite> .schema metadata
CREATE TABLE IF NOT EXISTS "metadata" (`id` varchar(24) not null, `post_id` varchar(24) not null, `og_image` varchar(2000) null, `og_title` varchar(300) null, `og_description` varchar(500) null, `twitter_image` varchar(2000) null, `twitter_title` varchar(300) null, `twitter_description` varchar(500) null, `meta_title` varchar(2000) null, `meta_description` varchar(2000) null, `email_subject` varchar(300) null, `frontmatter` text null, foreign key(`post_id`) references `posts`(`id`), primary key (`id`));
CREATE UNIQUE INDEX `posts_meta_post_id_unique` on "metadata" (`post_id`);

sqlite> PRAGMA index_list('metadata');
0|posts_meta_post_id_unique|1|c|0
1|sqlite_autoindex_metadata_1|1|pk|0

-- AFTER table rename migration using our own utility

sqlite> .schema metadata
CREATE TABLE `metadata` (`id` varchar(24) not null, `post_id` varchar(24) not null, `og_image` varchar(2000) null, `og_title` varchar(300) null, `og_description` varchar(500) null, `twitter_image` varchar(2000) null, `twitter_title` varchar(300) null, `twitter_description` varchar(500) null, `meta_title` varchar(2000) null, `meta_description` varchar(2000) null, `email_subject` varchar(300) null, `frontmatter` text null, foreign key(`post_id`) references `posts`(`id`), primary key (`id`));
CREATE UNIQUE INDEX `metadata_post_id_unique` on `metadata` (`post_id`);

sqlite> PRAGMA index_list('metadata');
0|metadata_post_id_unique|1|c|0
1|sqlite_autoindex_metadata_1|1|pk|0

```