### PR TITLE
Added new browse email endpoint

### DIFF
--- a/core/server/api/canary/email.js
+++ b/core/server/api/canary/email.js
@@ -6,6 +6,20 @@ const megaService = require('../../services/mega');
 module.exports = {
     docName: 'emails',
 
+    browse: {
+        options: [
+            'limit',
+            'fields',
+            'filter',
+            'order',
+            'page'
+        ],
+        permissions: true,
+        async query(frame) {
+            return await models.Email.findPage(frame.options);
+        }
+    },
+
     read: {
         options: [
             'fields'

--- a/core/server/api/canary/utils/serializers/output/emails.js
+++ b/core/server/api/canary/utils/serializers/output/emails.js
@@ -7,6 +7,15 @@ module.exports = {
         };
     },
 
+    browse(page, apiConfig, frame) {
+        const data = {
+            emails: page.data.map(model => mapper.mapEmail(model, frame)),
+            meta: page.meta
+        };
+
+        frame.response = data;
+    },
+
     get retry() {
         return this.read;
     }

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -261,6 +261,7 @@ module.exports = function apiRoutes() {
     router.post('/email_preview/posts/:id', mw.authAdminApi, http(apiCanary.email_preview.sendTestEmail));
 
     // ## Emails
+    router.get('/emails', mw.authAdminApi, http(apiCanary.emails.browse));
     router.get('/emails/:id', mw.authAdminApi, http(apiCanary.emails.read));
     router.put('/emails/:id/retry', mw.authAdminApi, http(apiCanary.emails.retry));
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12633

Adds new `browse` endpoint for emails that allows Admin to check performance of newsletters over time and show stats on dashboard as primary usecase
