### PR TITLE
Removed logging require in `db/connection.js`

### DIFF
--- a/core/server/data/db/connection.js
+++ b/core/server/data/db/connection.js
@@ -1,7 +1,5 @@
 const knex = require('knex');
 const config = require('../../../shared/config');
-const logging = require('../../../shared/logging');
-const errors = require('@tryghost/errors');
 let knexInstance;
 
 // @TODO:
@@ -24,12 +22,18 @@ function configure(dbConfig) {
         dbConfig.connection.timezone = 'UTC';
         dbConfig.connection.charset = 'utf8mb4';
 
-        dbConfig.connection.loggingHook = function loggingHook(err) {
-            logging.error(new errors.InternalServerError({
-                code: 'MYSQL_LOGGING_HOOK',
-                err: err
-            }));
-        };
+        // NOTE: disabled so that worker processes can use the db without
+        // requiring logging and causing file desriptor leaks.
+        // See https://github.com/TryGhost/Ghost/issues/12496
+        //
+        // const logging = require('../../../shared/logging');
+        // const errors = require('@tryghost/errors');
+        // dbConfig.connection.loggingHook = function loggingHook(err) {
+        //     logging.error(new errors.InternalServerError({
+        //         code: 'MYSQL_LOGGING_HOOK',
+        //         err: err
+        //     }));
+        // };
     }
 
     return dbConfig;


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12496

- having the logging require here means that workers wanting to use the db are unable to do so without requiring logging as a side-effect
- `connection.loggingHook` does not appear to be widely used for anything outside of specific debugging scenarios when using MySQL so it should be safe to disable until a proper fix is found for workers+logging leaking file descriptors