### PR TITLE
🏗  Inlined "posts_meta" table in pre 4.0 migrations

### DIFF
--- a/core/server/data/migrations/versions/3.0/04-add-posts-meta-table.js
+++ b/core/server/data/migrations/versions/3.0/04-add-posts-meta-table.js
@@ -1,2 +1,19 @@
 const {addTable} = require('../../utils');
-module.exports = addTable('posts_meta');
+
+// Schema snapshot from v4.0
+const postsMetaSchema = {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', unique: true},
+    og_image: {type: 'string', maxlength: 2000, nullable: true},
+    og_title: {type: 'string', maxlength: 300, nullable: true},
+    og_description: {type: 'string', maxlength: 500, nullable: true},
+    twitter_image: {type: 'string', maxlength: 2000, nullable: true},
+    twitter_title: {type: 'string', maxlength: 300, nullable: true},
+    twitter_description: {type: 'string', maxlength: 500, nullable: true},
+    meta_title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
+    meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
+    email_subject: {type: 'string', maxlength: 300, nullable: true},
+    frontmatter: {type: 'text', maxlength: 65535, nullable: true}
+};
+
+module.exports = addTable('posts_meta', postsMetaSchema);

--- a/core/server/data/migrations/versions/3.0/05-populate-posts-meta-table.js
+++ b/core/server/data/migrations/versions/3.0/05-populate-posts-meta-table.js
@@ -1,5 +1,4 @@
 const Promise = require('bluebird');
-const postsMetaSchema = require('../../../schema').tables.posts_meta;
 const ObjectId = require('bson-objectid');
 const _ = require('lodash');
 const models = require('../../../../models');
@@ -7,6 +6,22 @@ const logging = require('../../../../../shared/logging');
 
 module.exports.config = {
     transaction: true
+};
+
+// Schema snapshot from v4.0
+const postsMetaSchema = {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', unique: true},
+    og_image: {type: 'string', maxlength: 2000, nullable: true},
+    og_title: {type: 'string', maxlength: 300, nullable: true},
+    og_description: {type: 'string', maxlength: 500, nullable: true},
+    twitter_image: {type: 'string', maxlength: 2000, nullable: true},
+    twitter_title: {type: 'string', maxlength: 300, nullable: true},
+    twitter_description: {type: 'string', maxlength: 500, nullable: true},
+    meta_title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
+    meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
+    email_subject: {type: 'string', maxlength: 300, nullable: true},
+    frontmatter: {type: 'text', maxlength: 65535, nullable: true}
 };
 
 module.exports.up = (options) => {


### PR DESCRIPTION
:no_entry: blocked by https://github.com/TryGhost/Ghost/pull/12674
refs https://github.com/TryGhost/Team/issues/452

- "posts_meta" table is renamed in Ghost 4.0 and because the schema is directly referenced from the migration it would result in not creating a `posts_meta` table when migrating from Ghost pre 3.0
- The rule for migrations which needed to consider for this fix was: "You can always upgrade direct **from any major version to the very latest version** of Ghost, but you must be on the latest version of your particular major stream."

Note for reviewers, this PR is related and blocked by this one - https://github.com/TryGhost/Ghost/pull/12674, please review that one first and apply this one on top of it. 

For reference, an error one would get if this fix is not applied and would migrate from 2.x to 4.x would be something along the lines:
```
[2021-02-23 02:43:05] ERROR Cannot convert undefined or null to object

Cannot convert undefined or null to object

{"config":{"transaction":false},"name":"04-add-posts-meta-table.js"}
"Error occurred while executing the following migration: 04-add-posts-meta-table.js"

Error ID:
    300

----------------------------------------

MigrationScriptError: Cannot convert undefined or null to object
    at MigrationScriptError.KnexMigrateError (/home/naz/Workspace/Ghost/Ghost/node_modules/knex-migrator/lib/errors.js:7:26)
    at new MigrationScriptError (/home/naz/Workspace/Ghost/Ghost/node_modules/knex-migrator/lib/errors.js:25:26)
    at /home/naz/Workspace/Ghost/Ghost/node_modules/knex-migrator/lib/index.js:1055:19
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

TypeError: Cannot convert undefined or null to object
    at Function.get (/home/naz/Workspace/Ghost/Ghost/node_modules/knex-migrator/node_modules/knex/lib/util/make-knex.js:42:26)
    at /home/naz/Workspace/Ghost/Ghost/core/server/data/schema/commands.js:159:45
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Object.up (/home/naz/Workspace/Ghost/Ghost/core/server/data/migrations/utils.js:239:13
```
