### PR TITLE
🐛 Fixed email permissions for all roles

### DIFF
--- a/core/server/data/migrations/versions/4.0/24-add-missing-email-permissions.js
+++ b/core/server/data/migrations/versions/4.0/24-add-missing-email-permissions.js
@@ -1,0 +1,36 @@
+const {
+    addPermissionWithRoles,
+    combineTransactionalMigrations
+} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Read emails',
+        action: 'read',
+        object: 'email'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor',
+        'Author',
+        'Contributor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Browse emails',
+        action: 'browse',
+        object: 'email'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Retry emails',
+        action: 'retry',
+        object: 'email'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor'
+    ])
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/494

The migrations in 3.1.0 which added email permissions did not add those
permissions to the roles. This means that whilst we have the permissions
in the database, only the Owner role could use any of them.

This migration ensures that the email related permissions are added to
the correct roles.