### PR TITLE
✨ Added ElasticSearch logging when available

### DIFF
--- a/core/shared/logging.js
+++ b/core/shared/logging.js
@@ -11,5 +11,6 @@ module.exports = logging({
     transports: config.get('logging:transports'),
     gelf: config.get('logging:gelf'),
     loggly: config.get('logging:loggly'),
+    elasticsearch: config.get('logging:elasticsearch'),
     rotation: config.get('logging:rotation')
 });


### PR DESCRIPTION
no issue

Ghost Ignition 4.4.4 includes ElasticSearch logging, this PR enables that feature by adding the config into the shared logger used within Ghost.