### PR TITLE
Switched CI to using v4 Casper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,10 @@ jobs:
           node-version: '10.13.0'
       - run: npm install -g ghost-cli@latest
       - run: npm --no-git-tag-version version minor # We need to artificially bump the minor version to get migrations to run
+
+      - run: git checkout 4.0
+        working-directory: content/themes/casper
+
       - run: zip -r ghost.zip .
 
       - name: Clean Install


### PR DESCRIPTION
no issue

- some new GScan changes mean that CI now throws a warning when using v3
  Casper, which causes tests to fail
- we need to switch to v4 to get the tests to pass
- we can't put v4 Casper in `main` because it'll autodeploy and be
  unusable for anyone downloading until Ghost 4.0 is released
