### PR TITLE
Fixed migrations to 4.x from 1.x

### DIFF
--- a/core/server/data/migrations/versions/4.0/16-refactor-slack-setting.js
+++ b/core/server/data/migrations/versions/4.0/16-refactor-slack-setting.js
@@ -41,8 +41,8 @@ module.exports = createIrreversibleMigration(async (knex) => {
         // }]
         const value = JSON.parse(slackSetting.value)[0];
 
-        slackUrl = value.url;
-        slackUsername = value.username;
+        slackUrl = value.url || '';
+        slackUsername = value.username || 'Ghost';
     } catch (err) {
         slackUrl = '';
         slackUsername = 'Ghost';


### PR DESCRIPTION
no-issue

The slack setting in 1.x did not have a `username` property. When
updating from 1.x, the migration to move the slack setting from a JSON
blob to two individual settings, would assume that the setting in the
database would have a value for the `username` property. This resulted
in errors on SQLite "sqlite does not support inserting default values."

The fix here is to add defaults when reading from the database, meaning
that we will _never_ attempt to insert `undefined`