### PR TITLE
🐛 Stopped Ghost crashing when sending bulk emails

### DIFF
--- a/core/server/services/bulk-email/mailgun.js
+++ b/core/server/services/bulk-email/mailgun.js
@@ -101,7 +101,7 @@ function send(message, recipientData, replacements) {
 
         return new Promise((resolve, reject) => {
             mailgunInstance.messages().send(messageData, (error, body) => {
-                if (error) {
+                if (error || !body) {
                     return reject(error);
                 }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12610
refs https://github.com/mailgun/mailgun-js-boland/blob/v0.22.0/lib/request.js#L285-L333

The mailgun domain is used by the mailgun API to construct the URL for
the API. e.g for a domain of "mg.example.com" the URL for the API
messages would look like:

https://api.mailgun.net/v3/mg.example.com/messages

One weird thing about the mailgun API is that if the path does not map
to an API endpoint, then instead of a 404, we get a 200, with a body of
"Mailgun Magnificent API".

The `mailgun-js` library which we use, expects a JSON response, and will
return a body of undefined if it does not get one.

This all resulted in us trying to read the property `id` of an undefined
`body` variable. The fix here is to reject the containing Promise, if
there is no body. So that the default error handling will kick in.