### PR TITLE
Fixed settings images (cover_image, logo, etc) having wrong URL

### DIFF
--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -8,6 +8,7 @@ const ghostBookshelf = require('./base');
 const {i18n} = require('../lib/common');
 const errors = require('@tryghost/errors');
 const validation = require('../data/validation');
+const urlUtils = require('../../shared/url-utils');
 const internalContext = {context: {internal: true}};
 let Settings;
 let defaultSettings;
@@ -144,7 +145,6 @@ Settings = ghostBookshelf.Model.extend({
                 attrs.value = attrs.value.toString();
             }
         }
-
         return attrs;
     },
 
@@ -160,6 +160,11 @@ Settings = ghostBookshelf.Model.extend({
         // transform "false" to false for boolean type
         if (settingType === 'boolean' && (attrs.value === 'false' || attrs.value === 'true')) {
             attrs.value = JSON.parse(attrs.value);
+        }
+
+        // transform URLs from __GHOST_URL__ to absolute
+        if (['cover_image', 'logo', 'icon', 'portal_button_icon', 'og_image', 'twitter_image'].includes(attrs.key)) {
+            attrs.value = urlUtils.transformReadyToAbsolute(attrs.value);
         }
 
         return attrs;

--- a/test/unit/models/settings_spec.js
+++ b/test/unit/models/settings_spec.js
@@ -205,6 +205,24 @@ describe('Unit: models/settings', function () {
 
             returns = setting.parse({key: 'something', value: 'null'});
             should.equal(returns.value, 'null');
+
+            returns = setting.parse({key: 'cover_image', value: '__GHOST_URL__/cover_image.png'});
+            should.equal(returns.value, 'http://127.0.0.1:2369/cover_image.png');
+
+            returns = setting.parse({key: 'logo', value: '__GHOST_URL__/logo.png'});
+            should.equal(returns.value, 'http://127.0.0.1:2369/logo.png');
+
+            returns = setting.parse({key: 'icon', value: '__GHOST_URL__/icon.png'});
+            should.equal(returns.value, 'http://127.0.0.1:2369/icon.png');
+
+            returns = setting.parse({key: 'portal_button_icon', value: '__GHOST_URL__/portal_button_icon.png'});
+            should.equal(returns.value, 'http://127.0.0.1:2369/portal_button_icon.png');
+
+            returns = setting.parse({key: 'og_image', value: '__GHOST_URL__/og_image.png'});
+            should.equal(returns.value, 'http://127.0.0.1:2369/og_image.png');
+
+            returns = setting.parse({key: 'twitter_image', value: '__GHOST_URL__/twitter_image.png'});
+            should.equal(returns.value, 'http://127.0.0.1:2369/twitter_image.png');
         });
     });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/467
refs https://github.com/TryGhost/Ghost/pull/12731

- settings are mostly fetched directly from the settings cache rather than via the API so they aren't subject to the API-level output serializers that transform URLs meaning that URLs in the front-end ended up with raw `__GHOST_URL__` replacement strings
- added images to the Settings model's `parse()` method so they are transformed immediately when fetching from the database