### PR TITLE
Fixed circular dependency warning for the proxy service

### DIFF
--- a/core/frontend/services/themes/handlebars/template.js
+++ b/core/frontend/services/themes/handlebars/template.js
@@ -3,7 +3,7 @@ const templates = {};
 const _ = require('lodash');
 const errors = require('@tryghost/errors');
 const hbs = require('../engine');
-const {i18n} = require('../../proxy');
+const {i18n} = require('../../../../server/lib/common');
 
 // Execute a template helper
 // All template helpers are register as partial view.

--- a/test/unit/services/themes/handlebars/template_spec.js
+++ b/test/unit/services/themes/handlebars/template_spec.js
@@ -1,12 +1,11 @@
 const should = require('should');
-const hbs = require('../../../../../core/frontend/services/themes/engine');
-const template = require('../../../../../core/frontend/services/themes/handlebars/template');
+const proxy = require('../../../../../core/frontend/services/proxy');
 
 describe('Helpers Template', function () {
     it('can execute a template', function () {
-        hbs.registerPartial('test', '<h1>Hello {{name}}</h1>');
+        proxy.hbs.registerPartial('test', '<h1>Hello {{name}}</h1>');
 
-        const safeString = template.execute('test', {name: 'world'});
+        const safeString = proxy.templates.execute('test', {name: 'world'});
 
         should.exist(safeString);
         safeString.should.have.property('string').and.equal('<h1>Hello world</h1>');

--- a/test/unit/services/themes/handlebars/template_spec.js
+++ b/test/unit/services/themes/handlebars/template_spec.js
@@ -1,4 +1,5 @@
 const should = require('should');
+const errors = require('@tryghost/errors');
 const proxy = require('../../../../../core/frontend/services/proxy');
 
 describe('Helpers Template', function () {
@@ -9,5 +10,11 @@ describe('Helpers Template', function () {
 
         should.exist(safeString);
         safeString.should.have.property('string').and.equal('<h1>Hello world</h1>');
+    });
+
+    it('will throw an IncorrectUsageError if the partial does not exist', function () {
+        should.throws(() => {
+            proxy.templates.execute('non-existent');
+        }, errors.IncorrectUsageError);
     });
 });


### PR DESCRIPTION
no-issue

The handlebars template module is required by the proxy service, as part
of the definition of the proxy service's `module.exports`. By
destructuring the `i18n` property from the proxy service at the time the
template module is loaded, the i18n property was always undefined, as the
`module.exports` of the proxy service had not been set.

This adds a breaking test to show that the functionality is not as expected
due to this circular dependency.

Bypassing the proxy, and requiring the i18n module directly eliminates the
circular dependency, and fixes the test.