### PR TITLE
Fixed image and gallery cards not having srcset or sizes attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@tryghost/job-manager": "0.8.1",
     "@tryghost/kg-card-factory": "2.2.0",
     "@tryghost/kg-default-atoms": "2.0.4",
-    "@tryghost/kg-default-cards": "4.0.0",
+    "@tryghost/kg-default-cards": "4.0.1",
     "@tryghost/kg-markdown-html-renderer": "4.0.0",
     "@tryghost/kg-mobiledoc-html-renderer": "4.0.0",
     "@tryghost/limit-service": "0.3.0",

--- a/test/unit/lib/mobiledoc_spec.js
+++ b/test/unit/lib/mobiledoc_spec.js
@@ -106,6 +106,39 @@ describe('lib/mobiledoc', function () {
                 .should.eql('<!--kg-card-begin: markdown--><h1 id="header-one">Header One</h1>\n<!--kg-card-end: markdown--><h2 id="h%C3%A9ader-two">Héader Two</h2>');
         });
 
+        it('renders srcsets for __GHOST_URL__ relative images', function () {
+            let mobiledoc = {
+                version: '0.3.1',
+                atoms: [],
+                cards: [
+                    ['image', {
+                        cardWidth: 'wide',
+                        src: '__GHOST_URL__/content/images/2018/04/NatGeo06.jpg',
+                        width: 4000,
+                        height: 2000,
+                        caption: 'Birdies'
+                    }],
+                    ['gallery', {
+                        images: [{
+                            row: 0,
+                            fileName: 'test.png',
+                            src: '__GHOST_URL__/content/images/test.png',
+                            width: 1000,
+                            height: 500
+                        }]
+                    }]
+                ],
+                markups: [],
+                sections: [
+                    [10, 0],
+                    [10, 1]
+                ]
+            };
+
+            mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc)
+                .should.eql('<figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="__GHOST_URL__/content/images/2018/04/NatGeo06.jpg" class="kg-image" alt loading="lazy" width="2000" height="1000" srcset="__GHOST_URL__/content/images/size/w600/2018/04/NatGeo06.jpg 600w, __GHOST_URL__/content/images/size/w1000/2018/04/NatGeo06.jpg 1000w, __GHOST_URL__/content/images/size/w1600/2018/04/NatGeo06.jpg 1600w, __GHOST_URL__/content/images/size/w2400/2018/04/NatGeo06.jpg 2400w" sizes="(min-width: 1200px) 1200px"><figcaption>Birdies</figcaption></figure><figure class="kg-card kg-gallery-card kg-width-wide"><div class="kg-gallery-container"><div class="kg-gallery-row"><div class="kg-gallery-image"><img src="__GHOST_URL__/content/images/test.png" width="1000" height="500" loading="lazy" alt srcset="__GHOST_URL__/content/images/size/w600/test.png 600w, __GHOST_URL__/content/images/test.png 1000w" sizes="(min-width: 720px) 720px"></div></div></div></figure>');
+        });
+
         it('respects srcsets config', function () {
             configUtils.set('imageOptimization:srcsets', false);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -453,10 +453,10 @@
   resolved "https://registry.yarnpkg.com/@tryghost/kg-default-atoms/-/kg-default-atoms-2.0.4.tgz#0c7885343019bae8fffc01b95fb5ae0e8d463ba9"
   integrity sha512-IAqcbWpjtrS7z50DufQPBBS4c4/BL9SsYylHui2V1F5FBY9JxJTdq4fq3xlgg8bqSUwhWuBn1xGA07JX1dah1w==
 
-"@tryghost/kg-default-cards@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/kg-default-cards/-/kg-default-cards-4.0.0.tgz#1ca31545afc57ed06371852b75e03afede325588"
-  integrity sha512-gClxhMpT7uBWVompLdSh6gaMXfW4nmd65y2pscz2clKsh2iLhuWmLyQ8OANn6eH3/6yNJSHKHAb6NxHYm4YF3g==
+"@tryghost/kg-default-cards@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/kg-default-cards/-/kg-default-cards-4.0.1.tgz#bb63902f987e209b9572932f02a61d76adaf862e"
+  integrity sha512-aEyfVLLgcnePKUiUdqk1CutFp3eEVoNi5mIBi3vVjSsjIoXs7RZXlOd1wg4Ji1kr4AATYQS9GETDBFu9j8ziIA==
   dependencies:
     "@tryghost/kg-markdown-html-renderer" "^4.0.0"
     "@tryghost/url-utils" "^1.1.0-rc.1"


### PR DESCRIPTION
no issue

- we run raw mobiledoc through the mobiledoc-html renderer and we now store URLs in raw mobiledoc as `__GHOST_URL__` relative. Those URLs were not passing the "local image" check in the renderer for image optimisation availability meaning the srcset and sizes output was skipped
- bumped library version to include a fix for the optimisation check