### PR TITLE
Fixed typo in migration to add backupContent permission

### DIFF
--- a/core/server/data/migrations/versions/2.28/1-add-db-backup-content-permission.js
+++ b/core/server/data/migrations/versions/2.28/1-add-db-backup-content-permission.js
@@ -4,6 +4,6 @@ const {
 
 module.exports = addPermission({
     name: 'Backup database',
-    action: 'backupContect',
+    action: 'backupContent',
     object: 'db'
 });

--- a/core/server/data/migrations/versions/4.1/01-fix-backup-content-permission-typo.js
+++ b/core/server/data/migrations/versions/4.1/01-fix-backup-content-permission-typo.js
@@ -1,0 +1,15 @@
+const logging = require('../../../../../shared/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(async function up(knex) {
+    const typoedPermisson = await knex.select('*').from('permissions').where('action_type', 'backupContect').first();
+
+    if (!typoedPermisson) {
+        return logging.warn('Not updating permissions, no typo found');
+    }
+
+    logging.info('Updating permissions, fixing typo by renaming "backupContect" to "backupContent"');
+    await knex('permissions').update('action_type', 'backupContent').where('action_type', 'backupContect');
+}, function down() {
+    // noop
+});

--- a/core/server/data/migrations/versions/4.1/01-fix-backup-content-permission-typo.js
+++ b/core/server/data/migrations/versions/4.1/01-fix-backup-content-permission-typo.js
@@ -2,9 +2,9 @@ const logging = require('../../../../../shared/logging');
 const {createTransactionalMigration} = require('../../utils');
 
 module.exports = createTransactionalMigration(async function up(knex) {
-    const typoedPermisson = await knex.select('*').from('permissions').where('action_type', 'backupContect').first();
+    const typoedPermission = await knex.select('*').from('permissions').where('action_type', 'backupContect').first();
 
-    if (!typoedPermisson) {
+    if (!typoedPermission) {
         return logging.warn('Not updating permissions, no typo found');
     }
 

--- a/core/server/data/migrations/versions/4.1/01-fix-backup-content-permission-typo.js
+++ b/core/server/data/migrations/versions/4.1/01-fix-backup-content-permission-typo.js
@@ -10,6 +10,6 @@ module.exports = createTransactionalMigration(async function up(knex) {
 
     logging.info('Updating permissions, fixing typo by renaming "backupContect" to "backupContent"');
     await knex('permissions').update('action_type', 'backupContent').where('action_type', 'backupContect');
-}, function down() {
+}, async function down() {
     // noop
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/553


A typo in a permission migration was introduced in https://github.com/TryGhost/Ghost/commit/79c3709f

This fixes the migration, and adds a new migration to fix affected sites

