### PR TITLE
🐛 Replace __GHOST_URL__ imageUrl in sitemap-posts

### DIFF
--- a/core/frontend/services/sitemap/base-generator.js
+++ b/core/frontend/services/sitemap/base-generator.js
@@ -119,6 +119,9 @@ class BaseSiteMapGenerator {
 
         // Grab the image url
         imageUrl = urlUtils.urlFor('image', {image: image}, true);
+        
+        // Replace __GHOST_URL__
+        imageUrl = urlUtils.transformReadyToAbsolute(imageUrl);
 
         // Verify the url structure
         if (!this.validateImageUrl(imageUrl)) {


### PR DESCRIPTION
Ensures we get the actual ghost url instead of the placeholder string in the sitemap.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [X] There's a clear use-case for this code change
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
