### PR TITLE
🐛 Fixed `__GHOST_URL__` appearing in sitemaps

### DIFF
--- a/core/frontend/apps/amp/lib/helpers/amp_content.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_content.js
@@ -119,9 +119,6 @@ function getAmperizeHTML(html, post) {
 
     amperize = amperize || new Amperize();
 
-    // make transform-ready URLs abolute
-    html = urlUtils.transformReadyToAbsolute(html);
-
     if (!amperizeCache[post.id] || moment(new Date(amperizeCache[post.id].updated_at)).diff(new Date(post.updated_at)) < 0) {
         return new Promise((resolve) => {
             amperize.parse(html, (err, res) => {

--- a/core/frontend/apps/amp/lib/helpers/amp_content.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_content.js
@@ -9,7 +9,7 @@
 const Promise = require('bluebird');
 
 const moment = require('moment');
-const {SafeString, logging, i18n, errors, urlUtils} = require('../../../../services/proxy');
+const {SafeString, logging, i18n, errors} = require('../../../../services/proxy');
 const amperizeCache = {};
 let allowedAMPTags = [];
 let allowedAMPAttributes = {};

--- a/core/frontend/services/sitemap/base-generator.js
+++ b/core/frontend/services/sitemap/base-generator.js
@@ -45,8 +45,15 @@ class BaseSiteMapGenerator {
             urlset: [XMLNS_DECLS].concat(urlElements)
         };
 
-        // Return the xml
-        return localUtils.getDeclarations() + xml(data);
+        // Generate full xml
+        let sitemapXml = localUtils.getDeclarations() + xml(data);
+
+        // Perform url transformatons
+        // - Necessary because sitemap data is supplied by the router which
+        //   uses knex directly bypassing model-layer attribute transforms
+        sitemapXml = urlUtils.transformReadyToAbsolute(sitemapXml);
+
+        return sitemapXml;
     }
 
     addUrl(url, datum) {

--- a/core/server/api/canary/utils/serializers/input/utils/url.js
+++ b/core/server/api/canary/utils/serializers/input/utils/url.js
@@ -8,7 +8,7 @@ const handleImageUrl = (imageUrl) => {
         const imagePathRe = new RegExp(`${subdir}/${urlUtils.STATIC_IMAGE_URL_PREFIX}`);
 
         if (imagePathRe.test(imageURL.pathname)) {
-            return urlUtils.toTransformReady(imageUrl);
+            return urlUtils.relativeToAbsolute(imageUrl);
         }
 
         return imageUrl;

--- a/core/server/api/canary/utils/serializers/output/snippets.js
+++ b/core/server/api/canary/utils/serializers/output/snippets.js
@@ -1,6 +1,5 @@
 //@ts-check
 const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:snippets');
-const urlUtils = require('../../../../../../shared/url-utils');
 
 module.exports = {
     browse: createSerializer('browse', paginatedSnippets),
@@ -67,7 +66,7 @@ function serializeSnippet(snippet, options) {
         id: json.id,
         name: json.name,
         // @ts-ignore
-        mobiledoc: urlUtils.transformReadyToAbsolute(json.mobiledoc),
+        mobiledoc: json.mobiledoc,
         created_at: json.created_at,
         updated_at: json.updated_at,
         created_by: json.created_by,

--- a/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/canary/utils/serializers/output/utils/extra-attrs.js
@@ -1,5 +1,4 @@
 const readingMinutes = require('@tryghost/helpers').utils.readingMinutes;
-const urlUtils = require('../../../../../../../shared/url-utils');
 
 module.exports.forPost = (frame, model, attrs) => {
     const _ = require('lodash');
@@ -10,7 +9,6 @@ module.exports.forPost = (frame, model, attrs) => {
             let plaintext = model.get('plaintext');
 
             if (plaintext) {
-                plaintext = urlUtils.transformReadyToAbsolute(plaintext);
                 attrs.excerpt = plaintext.substring(0, 500);
             } else {
                 attrs.excerpt = null;

--- a/core/server/api/canary/utils/serializers/output/utils/url.js
+++ b/core/server/api/canary/utils/serializers/output/utils/url.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const urlService = require('../../../../../../../frontend/services/url');
 const urlUtils = require('../../../../../../../shared/url-utils');
 const localUtils = require('../../../index');
@@ -30,13 +29,6 @@ const forPost = (id, attrs, frame) => {
         }
     }
 
-    ['mobiledoc', 'html', 'plaintext', 'codeinjection_head', 'codeinjection_foot', 'feature_image', 'canonical_url', 'posts_meta.og_image', 'posts_meta.twitter_image'].forEach((path) => {
-        const value = _.get(attrs, path);
-        if (value) {
-            _.set(attrs, path, urlUtils.transformReadyToAbsolute(value));
-        }
-    });
-
     if (frame.options.columns && !frame.options.columns.includes('url')) {
         delete attrs.url;
     }
@@ -49,12 +41,6 @@ const forUser = (id, attrs, options) => {
         attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
     }
 
-    ['profile_image', 'cover_image'].forEach((attr) => {
-        if (attrs[attr]) {
-            attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
-        }
-    });
-
     return attrs;
 };
 
@@ -62,12 +48,6 @@ const forTag = (id, attrs, options) => {
     if (!options.columns || (options.columns && options.columns.includes('url'))) {
         attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
     }
-
-    ['feature_image', 'og_image', 'twitter_image', 'codeinjection_head', 'codeinjection_foot'].forEach((attr) => {
-        if (attrs[attr]) {
-            attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
-        }
-    });
 
     return attrs;
 };

--- a/core/server/api/v2/utils/serializers/input/utils/url.js
+++ b/core/server/api/v2/utils/serializers/input/utils/url.js
@@ -8,7 +8,7 @@ const handleImageUrl = (imageUrl) => {
         const imagePathRe = new RegExp(`${subdir}/${urlUtils.STATIC_IMAGE_URL_PREFIX}`);
 
         if (imagePathRe.test(imageURL.pathname)) {
-            return urlUtils.toTransformReady(imageUrl);
+            return urlUtils.relativeToAbsolute(imageUrl);
         }
 
         return imageUrl;

--- a/core/server/api/v2/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/v2/utils/serializers/output/utils/extra-attrs.js
@@ -1,5 +1,3 @@
-const urlUtils = require('../../../../../../../shared/url-utils');
-
 module.exports.forPost = (frame, model, attrs) => {
     const _ = require('lodash');
 
@@ -9,7 +7,6 @@ module.exports.forPost = (frame, model, attrs) => {
             let plaintext = model.get('plaintext');
 
             if (plaintext) {
-                plaintext = urlUtils.transformReadyToAbsolute(plaintext);
                 attrs.excerpt = plaintext.substring(0, 500);
             } else {
                 attrs.excerpt = null;

--- a/core/server/api/v2/utils/serializers/output/utils/url.js
+++ b/core/server/api/v2/utils/serializers/output/utils/url.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const urlService = require('../../../../../../../frontend/services/url');
 const urlUtils = require('../../../../../../../shared/url-utils');
 const localUtils = require('../../../index');
@@ -30,21 +29,6 @@ const forPost = (id, attrs, frame) => {
         }
     }
 
-    const urlOptions = {};
-
-    // v2 only transforms asset URLS, v3 will transform all urls so that
-    // input/output transformations are balanced and all URLs are absolute
-    if (!frame.options.absolute_urls) {
-        urlOptions.assetsOnly = true;
-    }
-
-    ['mobiledoc', 'html', 'plaintext', 'codeinjection_head', 'codeinjection_foot', 'feature_image', 'canonical_url', 'posts_meta.og_image', 'posts_meta.twitter_image'].forEach((path) => {
-        const value = _.get(attrs, path);
-        if (value) {
-            _.set(attrs, path, urlUtils.transformReadyToAbsolute(value, urlOptions));
-        }
-    });
-
     if (frame.options.columns && !frame.options.columns.includes('url')) {
         delete attrs.url;
     }
@@ -57,12 +41,6 @@ const forUser = (id, attrs, options) => {
         attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
     }
 
-    ['profile_image', 'cover_image'].forEach((attr) => {
-        if (attrs[attr]) {
-            attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
-        }
-    });
-
     return attrs;
 };
 
@@ -70,12 +48,6 @@ const forTag = (id, attrs, options) => {
     if (!options.columns || (options.columns && options.columns.includes('url'))) {
         attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
     }
-
-    ['feature_image', 'og_image', 'twitter_image', 'codeinjection_head', 'codeinjection_foot'].forEach((attr) => {
-        if (attrs[attr]) {
-            attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
-        }
-    });
 
     return attrs;
 };

--- a/core/server/api/v3/utils/serializers/input/utils/url.js
+++ b/core/server/api/v3/utils/serializers/input/utils/url.js
@@ -8,7 +8,7 @@ const handleImageUrl = (imageUrl) => {
         const imagePathRe = new RegExp(`${subdir}/${urlUtils.STATIC_IMAGE_URL_PREFIX}`);
 
         if (imagePathRe.test(imageURL.pathname)) {
-            return urlUtils.toTransformReady(imageUrl);
+            return urlUtils.relativeToAbsolute(imageUrl);
         }
 
         return imageUrl;

--- a/core/server/api/v3/utils/serializers/output/snippets.js
+++ b/core/server/api/v3/utils/serializers/output/snippets.js
@@ -1,6 +1,5 @@
 //@ts-check
 const debug = require('ghost-ignition').debug('api:v3:utils:serializers:output:snippets');
-const urlUtils = require('../../../../../../shared/url-utils');
 
 module.exports = {
     browse: createSerializer('browse', paginatedSnippets),
@@ -67,7 +66,7 @@ function serializeSnippet(snippet, options) {
         id: json.id,
         name: json.name,
         // @ts-ignore
-        mobiledoc: urlUtils.transformReadyToAbsolute(json.mobiledoc),
+        mobiledoc: json.mobiledoc,
         created_at: json.created_at,
         updated_at: json.updated_at,
         created_by: json.created_by,

--- a/core/server/api/v3/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/v3/utils/serializers/output/utils/extra-attrs.js
@@ -1,5 +1,4 @@
 const readingMinutes = require('@tryghost/helpers').utils.readingMinutes;
-const urlUtils = require('../../../../../../../shared/url-utils');
 
 module.exports.forPost = (frame, model, attrs) => {
     const _ = require('lodash');
@@ -10,7 +9,6 @@ module.exports.forPost = (frame, model, attrs) => {
             let plaintext = model.get('plaintext');
 
             if (plaintext) {
-                plaintext = urlUtils.transformReadyToAbsolute(plaintext);
                 attrs.excerpt = plaintext.substring(0, 500);
             } else {
                 attrs.excerpt = null;

--- a/core/server/api/v3/utils/serializers/output/utils/url.js
+++ b/core/server/api/v3/utils/serializers/output/utils/url.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const urlService = require('../../../../../../../frontend/services/url');
 const urlUtils = require('../../../../../../../shared/url-utils');
 const localUtils = require('../../../index');
@@ -30,13 +29,6 @@ const forPost = (id, attrs, frame) => {
         }
     }
 
-    ['mobiledoc', 'html', 'plaintext', 'codeinjection_head', 'codeinjection_foot', 'feature_image', 'canonical_url', 'posts_meta.og_image', 'posts_meta.twitter_image'].forEach((path) => {
-        const value = _.get(attrs, path);
-        if (value) {
-            _.set(attrs, path, urlUtils.transformReadyToAbsolute(value));
-        }
-    });
-
     if (frame.options.columns && !frame.options.columns.includes('url')) {
         delete attrs.url;
     }
@@ -49,12 +41,6 @@ const forUser = (id, attrs, options) => {
         attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
     }
 
-    ['profile_image', 'cover_image'].forEach((attr) => {
-        if (attrs[attr]) {
-            attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
-        }
-    });
-
     return attrs;
 };
 
@@ -62,12 +48,6 @@ const forTag = (id, attrs, options) => {
     if (!options.columns || (options.columns && options.columns.includes('url'))) {
         attrs.url = urlService.getUrlByResourceId(id, {absolute: true});
     }
-
-    ['feature_image', 'og_image', 'twitter_image', 'codeinjection_head', 'codeinjection_foot'].forEach((attr) => {
-        if (attrs[attr]) {
-            attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
-        }
-    });
 
     return attrs;
 };

--- a/core/server/models/posts-meta.js
+++ b/core/server/models/posts-meta.js
@@ -4,28 +4,28 @@ const urlUtils = require('../../shared/url-utils');
 const PostsMeta = ghostBookshelf.Model.extend({
     tableName: 'posts_meta',
 
-    onSaving: function onSaving() {
-        const urlTransformMap = {
-            og_image: 'toTransformReady',
-            twitter_image: 'toTransformReady'
-        };
+    format() {
+        const attrs = ghostBookshelf.Model.prototype.format.apply(this, arguments);
 
-        Object.entries(urlTransformMap).forEach(([attr, transform]) => {
-            let method = transform;
-            let methodOptions = {};
-
-            if (typeof transform === 'object') {
-                method = transform.method;
-                methodOptions = transform.options || {};
-            }
-
-            if (this.hasChanged(attr) && this.get(attr)) {
-                const transformedValue = urlUtils[method](this.get(attr), methodOptions);
-                this.set(attr, transformedValue);
+        ['og_image', 'twitter_image'].forEach((attr) => {
+            if (attrs[attr]) {
+                attrs[attr] = urlUtils.toTransformReady(attrs[attr]);
             }
         });
 
-        ghostBookshelf.Model.prototype.onSaving.apply(this, arguments);
+        return attrs;
+    },
+
+    parse() {
+        const attrs = ghostBookshelf.Model.prototype.parse.apply(this, arguments);
+
+        ['og_image', 'twitter_image'].forEach((attr) => {
+            if (attrs[attr]) {
+                attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
+            }
+        });
+
+        return attrs;
     }
 }, {
     post() {

--- a/core/server/models/snippet.js
+++ b/core/server/models/snippet.js
@@ -4,27 +4,24 @@ const urlUtils = require('../../shared/url-utils');
 const Snippet = ghostBookshelf.Model.extend({
     tableName: 'snippets',
 
-    onSaving: function onSaving() {
-        const urlTransformMap = {
-            mobiledoc: 'mobiledocToTransformReady'
-        };
+    format() {
+        const attrs = ghostBookshelf.Model.prototype.format.apply(this, arguments);
 
-        Object.entries(urlTransformMap).forEach(([attr, transform]) => {
-            let method = transform;
-            let methodOptions = {};
+        if (attrs.mobiledoc) {
+            attrs.mobiledoc = urlUtils.mobiledocToTransformReady(attrs.mobiledoc);
+        }
 
-            if (typeof transform === 'object') {
-                method = transform.method;
-                methodOptions = transform.options || {};
-            }
+        return attrs;
+    },
 
-            if (this.hasChanged(attr) && this.get(attr)) {
-                const transformedValue = urlUtils[method](this.get(attr), methodOptions);
-                this.set(attr, transformedValue);
-            }
-        });
+    parse() {
+        const attrs = ghostBookshelf.Model.prototype.parse.apply(this, arguments);
 
-        ghostBookshelf.Model.prototype.onSaving.apply(this, arguments);
+        if (attrs.mobiledoc) {
+            attrs.mobiledoc = urlUtils.transformReadyToAbsolute(attrs.mobiledoc);
+        }
+
+        return attrs;
     }
 });
 

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -37,6 +37,38 @@ User = ghostBookshelf.Model.extend({
         };
     },
 
+    format(options) {
+        if (!_.isEmpty(options.website) &&
+            !validator.isURL(options.website, {
+                require_protocol: true,
+                protocols: ['http', 'https']
+            })) {
+            options.website = 'http://' + options.website;
+        }
+
+        const attrs = ghostBookshelf.Model.prototype.format.call(this, options);
+
+        ['profile_image', 'cover_image'].forEach((attr) => {
+            if (attrs[attr]) {
+                attrs[attr] = urlUtils.toTransformReady(attrs[attr]);
+            }
+        });
+
+        return attrs;
+    },
+
+    parse() {
+        const attrs = ghostBookshelf.Model.prototype.parse.apply(this, arguments);
+
+        ['profile_image', 'cover_image'].forEach((attr) => {
+            if (attrs[attr]) {
+                attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
+            }
+        });
+
+        return attrs;
+    },
+
     emitChange: function emitChange(event, options) {
         const eventToTrigger = 'user' + '.' + event;
         ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
@@ -114,26 +146,6 @@ User = ghostBookshelf.Model.extend({
         const self = this;
         const tasks = [];
         let passwordValidation = {};
-
-        const urlTransformMap = {
-            profile_image: 'toTransformReady',
-            cover_image: 'toTransformReady'
-        };
-
-        Object.entries(urlTransformMap).forEach(([urlAttr, transform]) => {
-            let method = transform;
-            let methodOptions = {};
-
-            if (typeof transform === 'object') {
-                method = transform.method;
-                methodOptions = transform.options || {};
-            }
-
-            if (this.hasChanged(urlAttr) && this.get(urlAttr)) {
-                const transformedValue = urlUtils[method](this.get(urlAttr), methodOptions);
-                this.set(urlAttr, transformedValue);
-            }
-        });
 
         ghostBookshelf.Model.prototype.onSaving.apply(this, arguments);
 
@@ -242,17 +254,6 @@ User = ghostBookshelf.Model.extend({
         delete attrs.password;
 
         return attrs;
-    },
-
-    format: function format(options) {
-        if (!_.isEmpty(options.website) &&
-            !validator.isURL(options.website, {
-                require_protocol: true,
-                protocols: ['http', 'https']
-            })) {
-            options.website = 'http://' + options.website;
-        }
-        return ghostBookshelf.Model.prototype.format.call(this, options);
     },
 
     posts: function posts() {

--- a/test/frontend-acceptance/default_routes_spec.js
+++ b/test/frontend-acceptance/default_routes_spec.js
@@ -72,6 +72,8 @@ describe('Default Frontend routing', function () {
             $('article.post').length.should.equal(7);
             $('article.tag-getting-started').length.should.equal(7);
 
+            res.text.should.not.containEql('__GHOST_URL__');
+
             doEnd(res);
         });
 
@@ -90,6 +92,8 @@ describe('Default Frontend routing', function () {
             $('article.post').length.should.equal(7);
             $('article.tag-getting-started').length.should.equal(7);
 
+            res.text.should.not.containEql('__GHOST_URL__');
+
             doEnd(res);
         });
 
@@ -107,6 +111,8 @@ describe('Default Frontend routing', function () {
             $('body.tag-template').length.should.equal(1);
             $('article.post').length.should.equal(7);
             $('article.tag-getting-started').length.should.equal(7);
+
+            res.text.should.not.containEql('__GHOST_URL__');
 
             doEnd(res);
         });
@@ -128,6 +134,8 @@ describe('Default Frontend routing', function () {
             $('body.tag-getting-started').length.should.equal(1);
             $('article.post').length.should.equal(2);
             $('article.tag-getting-started').length.should.equal(2);
+
+            res.text.should.not.containEql('__GHOST_URL__');
 
             doEnd(res);
         });
@@ -209,6 +217,8 @@ describe('Default Frontend routing', function () {
 
             res.text.should.containEql(':root {--ghost-accent-color: #FF1A75;}');
 
+            res.text.should.not.containEql('__GHOST_URL__');
+
             doEnd(res);
         });
 
@@ -250,6 +260,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8');
 
             res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
+            res.text.should.not.containEql('__GHOST_URL__');
             doEnd(res);
         });
 
@@ -260,6 +271,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8');
 
             res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
+            res.text.should.not.containEql('__GHOST_URL__');
             doEnd(res);
         });
 
@@ -270,6 +282,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8');
 
             res.text.should.match(/<!\[CDATA\[Start here for a quick overview of everything you need to know\]\]>/);
+            res.text.should.not.containEql('__GHOST_URL__');
             doEnd(res);
         });
     });
@@ -306,6 +319,7 @@ describe('Default Frontend routing', function () {
         before(async function () {
             await testUtils.clearData();
             await testUtils.initData();
+            await testUtils.initFixtures('posts');
         });
 
         it('should serve sitemap.xml', async function () {
@@ -315,6 +329,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8');
 
             res.text.should.match(/sitemapindex/);
+            res.text.should.not.containEql('__GHOST_URL__');
             doEnd(res);
         });
 
@@ -325,6 +340,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8');
 
             res.text.should.match(/urlset/);
+            res.text.should.not.containEql('__GHOST_URL__');
             doEnd(res);
         });
 
@@ -335,6 +351,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8');
 
             res.text.should.match(/urlset/);
+            res.text.should.not.containEql('__GHOST_URL__');
             doEnd(res);
         });
 
@@ -345,6 +362,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8');
 
             res.text.should.match(/urlset/);
+            res.text.should.not.containEql('__GHOST_URL__');
             doEnd(res);
         });
 
@@ -355,6 +373,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xml; charset=utf-8');
 
             res.text.should.match(/urlset/);
+            res.text.should.not.containEql('__GHOST_URL__');
             doEnd(res);
         });
 
@@ -365,6 +384,7 @@ describe('Default Frontend routing', function () {
                 .expect('Content-Type', 'text/xsl');
 
             res.text.should.match(/urlset/);
+            res.text.should.not.containEql('__GHOST_URL__');
             doEnd(res);
         });
     });

--- a/test/unit/api/canary/utils/serializers/output/utils/url_spec.js
+++ b/test/unit/api/canary/utils/serializers/output/utils/url_spec.js
@@ -9,7 +9,6 @@ describe('Unit: canary/utils/serializers/output/utils/url', function () {
     beforeEach(function () {
         sinon.stub(urlService, 'getUrlByResourceId').returns('getUrlByResourceId');
         sinon.stub(urlUtils, 'urlFor').returns('urlFor');
-        sinon.stub(urlUtils, 'transformReadyToAbsolute').returns('transformReadyToAbsolute');
     });
 
     afterEach(function () {
@@ -44,9 +43,6 @@ describe('Unit: canary/utils/serializers/output/utils/url', function () {
             urlUtil.forPost(post.id, post, {options: {}});
 
             post.hasOwnProperty('url').should.be.true();
-
-            // feature_image, og_image, twitter_image, canonical_url, mobiledoc, html, codeinjection_head, codeinjection_foot
-            urlUtils.transformReadyToAbsolute.callCount.should.eql(8);
 
             urlService.getUrlByResourceId.callCount.should.eql(1);
             urlService.getUrlByResourceId.getCall(0).args.should.eql(['id1', {absolute: true}]);

--- a/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
+++ b/test/unit/api/v2/utils/serializers/output/utils/url_spec.js
@@ -9,7 +9,6 @@ describe('Unit: v2/utils/serializers/output/utils/url', function () {
     beforeEach(function () {
         sinon.stub(urlService, 'getUrlByResourceId').returns('getUrlByResourceId');
         sinon.stub(urlUtils, 'urlFor').returns('urlFor');
-        sinon.stub(urlUtils, 'transformReadyToAbsolute').returns('transformReadyToAbsolute');
     });
 
     afterEach(function () {
@@ -44,15 +43,6 @@ describe('Unit: v2/utils/serializers/output/utils/url', function () {
             urlUtil.forPost(post.id, post, {options: {}});
 
             post.hasOwnProperty('url').should.be.true();
-
-            // feature_image, og_image, twitter_image, canonical_url, mobiledoc, html, codeinjection_head, codeinjection_foot
-            urlUtils.transformReadyToAbsolute.callCount.should.eql(8);
-
-            // html
-            urlUtils.transformReadyToAbsolute.getCall(1).args.should.eql([
-                'html',
-                {assetsOnly: true}
-            ]);
 
             urlService.getUrlByResourceId.callCount.should.eql(1);
             urlService.getUrlByResourceId.getCall(0).args.should.eql(['id1', {absolute: true}]);

--- a/test/unit/api/v3/utils/serializers/output/utils/url_spec.js
+++ b/test/unit/api/v3/utils/serializers/output/utils/url_spec.js
@@ -9,7 +9,6 @@ describe('Unit: v3/utils/serializers/output/utils/url', function () {
     beforeEach(function () {
         sinon.stub(urlService, 'getUrlByResourceId').returns('getUrlByResourceId');
         sinon.stub(urlUtils, 'urlFor').returns('urlFor');
-        sinon.stub(urlUtils, 'transformReadyToAbsolute').returns('transformReadyToAbsolute');
     });
 
     afterEach(function () {
@@ -44,9 +43,6 @@ describe('Unit: v3/utils/serializers/output/utils/url', function () {
             urlUtil.forPost(post.id, post, {options: {}});
 
             post.hasOwnProperty('url').should.be.true();
-
-            // feature_image, og_image, twitter_image, canonical_url, mobiledoc, html, codeinjection_head, codeinjection_foot
-            urlUtils.transformReadyToAbsolute.callCount.should.eql(8);
 
             urlService.getUrlByResourceId.callCount.should.eql(1);
             urlService.getUrlByResourceId.getCall(0).args.should.eql(['id1', {absolute: true}]);

--- a/test/unit/apps/amp/amp_content_spec.js
+++ b/test/unit/apps/amp/amp_content_spec.js
@@ -122,30 +122,6 @@ describe('{{amp_content}} helper', function () {
             ampContentHelper.__set__('amperizeCache', {});
         });
 
-        it('transforms URLs to absolute', function (done) {
-            const GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');
-
-            nock('https://ghost.org/blog/')
-                .get('/image.png')
-                .reply(200, GIF1x1);
-
-            const testData = {
-                html: '<a href="__GHOST_URL__/"><img src="__GHOST_URL__/image.png" alt="Test image" /></a>',
-                updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',
-                id: 1
-            };
-
-            const ampResult = ampContentHelper.call(testData);
-
-            ampResult.then(function (rendered) {
-                should.exist(rendered);
-                rendered.string.should.not.containEql('__GHOST_URL__');
-                rendered.string.should.containEql('href="https://ghost.org/blog/"');
-                rendered.string.should.containEql('src="https://ghost.org/blog/image.png"');
-                done();
-            }).catch(done);
-        });
-
         it('can transform img tags to amp-img', function (done) {
             const GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');
 
@@ -154,7 +130,7 @@ describe('{{amp_content}} helper', function () {
                 .reply(200, GIF1x1);
 
             const testData = {
-                html: '<img src="__GHOST_URL__/content/images/2019/06/test.jpg" alt="The Ghost Logo" />',
+                html: '<img src="https://ghost.org/blog/content/images/2019/06/test.jpg" alt="The Ghost Logo" />',
                 updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',
                 id: 1
             };
@@ -213,7 +189,7 @@ describe('{{amp_content}} helper', function () {
 
         it('removes inline style', function (done) {
             const testData = {
-                html: '<amp-img src="__GHOST_URL__/content/images/2016/08/aileen_small.jpg" style="border-radius: 50%"; !important' +
+                html: '<amp-img src="https://ghost.org/blog/content/images/2016/08/aileen_small.jpg" style="border-radius: 50%"; !important' +
                           'border="0" align="center" font="Arial" width="50" height="50" layout="responsive"></amp-img>' +
                           '<p align="right" style="color: red; !important" bgcolor="white">Hello</p>' +
                           '<table style="width:100%"><tr bgcolor="tomato" colspan="2"><th font="Arial">Name:</th> ' +
@@ -284,7 +260,7 @@ describe('{{amp_content}} helper', function () {
 
         it('can handle not existing img src by returning not Amperized HTML', function (done) {
             const testData = {
-                html: '<img src="__GHOST_URL__/content/images/does-not-exist.jpg" alt="The Ghost Logo" />',
+                html: '<img src="https://ghost.org/blog/content/images/does-not-exist.jpg" alt="The Ghost Logo" />',
                 updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',
                 id: 1
             };

--- a/test/unit/models/post_spec.js
+++ b/test/unit/models/post_spec.js
@@ -241,7 +241,7 @@ describe('Unit: models/post', function () {
 
         it('ensure mobiledoc revisions are never exposed', function () {
             const post = {
-                mobiledoc: 'test',
+                mobiledoc: '{}',
                 mobiledoc_revisions: []
             };
 

--- a/test/unit/services/rss/generate-feed_spec.js
+++ b/test/unit/services/rss/generate-feed_spec.js
@@ -218,11 +218,6 @@ describe('RSS: Generate Feed', function () {
         it('should process urls correctly', function (done) {
             data.posts = [posts[3]];
 
-            // raw data has __GHOST_URL__ urls but normally the API would have transformed those to absolute
-            let serializedPosts = JSON.stringify(data.posts);
-            serializedPosts = serializedPosts.replace(/__GHOST_URL__/g, 'http://my-ghost-blog.com');
-            data.posts = JSON.parse(serializedPosts);
-
             generateFeed(baseUrl, data).then(function (xmlData) {
                 should.exist(xmlData);
 
@@ -260,12 +255,7 @@ describe('RSS: Generate Feed', function () {
             data.posts = [posts[3]];
             data.meta = {pagination: {pages: 1}};
 
-            // raw data has __GHOST_URL__ urls but normally the API would have transformed those to absolute
-            let serializedData = JSON.stringify(data);
-            serializedData = serializedData.replace(/__GHOST_URL__/g, 'http://my-ghost-blog.com/blog');
-            const transformedData = JSON.parse(serializedData);
-
-            generateFeed(baseUrl, transformedData).then(function (xmlData) {
+            generateFeed(baseUrl, data).then(function (xmlData) {
                 should.exist(xmlData);
 
                 // anchor URL - <a href="#nowhere" title="Anchor URL">

--- a/test/unit/services/rss/generate-feed_spec.js
+++ b/test/unit/services/rss/generate-feed_spec.js
@@ -25,6 +25,15 @@ describe('RSS: Generate Feed', function () {
         _.each(posts, function (post) {
             post.url = '/' + post.slug + '/';
             post.primary_author = {name: 'Joe Bloggs'};
+
+            // data is from fixtures that are inserted directly into the database via knex
+            // that means it has raw __GHOST_URL__ values that would typically be modified by the model layer
+            // we're not using the model layer here so we need to transform manually
+            Object.entries(post).forEach(([key, value]) => {
+                if (value && typeof value === 'string') {
+                    post[key] = value.replace(/__GHOST_URL__/g, 'http://my-ghost-blog.com');
+                }
+            });
         });
     });
 
@@ -229,40 +238,6 @@ describe('RSS: Generate Feed', function () {
 
                 // protocol relative URL - <a href="//somewhere.com/link#nowhere" title="Protocol Relative URL">
                 xmlData.should.match(/<a href="\/\/somewhere.com\/link#nowhere" title="Protocol Relative URL">/);
-
-                // absolute URL - <a href="http://somewhere.com/link#nowhere" title="Absolute URL">
-                xmlData.should.match(/<a href="http:\/\/somewhere.com\/link#nowhere" title="Absolute URL">/);
-
-                done();
-            }).catch(done);
-        });
-    });
-
-    describe('with subdirectory', function () {
-        let sandbox;
-
-        beforeEach(function () {
-            sandbox = sinon.createSandbox();
-            urlUtils.stubUrlUtils({url: 'http://my-ghost-blog.com/blog/'}, sandbox);
-        });
-
-        afterEach(function () {
-            sandbox.restore();
-        });
-
-        it('should process urls correctly with subdirectory', function (done) {
-            baseUrl = '/blog/rss/';
-            data.posts = [posts[3]];
-            data.meta = {pagination: {pages: 1}};
-
-            generateFeed(baseUrl, data).then(function (xmlData) {
-                should.exist(xmlData);
-
-                // anchor URL - <a href="#nowhere" title="Anchor URL">
-                xmlData.should.match(/<a href="#nowhere" title="Anchor URL">/);
-
-                // relative URL - <a href="/about#nowhere" title="Relative URL">
-                xmlData.should.match(/<a href="http:\/\/my-ghost-blog.com\/blog\/about#nowhere" title="Relative URL">/);
 
                 // absolute URL - <a href="http://somewhere.com/link#nowhere" title="Absolute URL">
                 xmlData.should.match(/<a href="http:\/\/somewhere.com\/link#nowhere" title="Absolute URL">/);


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/552

Refactors URL transforms so they take place at the model layer rather than the API serializer layer. Continuation of the pattern created for the settings model in https://github.com/TryGhost/Ghost/pull/12738

- Added checks to all front-end tests to ensure output does not contain the magic replacement string
  - includes failing acceptance test for `__GHOST_URL__` appearing in sitemaps
- Removed all transform-ready URL transforms from API serializers
  - input serializers transform image urls relative->absolute to keep absolute-urls as the consistent "outside of the database" format
  - output serializers should not need to perform any URL transforms as that will be done at the model layer
- Added url transforms to models layer
  - removes knowledge from the API serializers which shouldn't need to know how data is stored internally in the database
  - makes absolute urls the consistent "outside of the database" URL format
  - adds transform step to the sitemap generator because the data used for that is fetched directly via knex which will not run through the bookshelf `parse()` methods