### PR TITLE
Update migration to use standard SQL strings instead of double quoted column names

### DIFF
--- a/core/server/data/migrations/versions/4.0/21-sanitize-email-batches-provider-id.js
+++ b/core/server/data/migrations/versions/4.0/21-sanitize-email-batches-provider-id.js
@@ -4,5 +4,5 @@ const {createIrreversibleMigration} = require('../../utils');
 module.exports = createIrreversibleMigration(async (knex) => {
     logging.info('Sanitizing provider_id values in email_batches');
 
-    await knex.raw('UPDATE email_batches SET provider_id = REPLACE(REPLACE(provider_id, "<", ""), ">", "")');
+    await knex.raw('UPDATE email_batches SET provider_id = REPLACE(REPLACE(provider_id, ?, ?), ?, ?)', '<', '', '<', '');
 });


### PR DESCRIPTION
Double quoted strings are used to indicate column names in standard SQL, may cause problems for some databases, and MySQL using strict settings. For example, the migration caused issues with hosted MySQL in digital ocean.

Also could someone take a look at the test failure? I'm not sure why this failure is happening

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
