### PR TITLE
Feature: Allow themes to have any configuration properties in package…

### DIFF
--- a/core/frontend/services/themes/config/index.js
+++ b/core/frontend/services/themes/config/index.js
@@ -1,12 +1,12 @@
 const _ = require('lodash');
 const defaultConfig = require('./defaults');
-const allowedKeys = ['posts_per_page', 'image_sizes'];
+//const allowedKeys = ['posts_per_page', 'image_sizes'];
 
 module.exports.create = function configLoader(packageJson) {
     let config = _.cloneDeep(defaultConfig);
 
     if (packageJson && Object.prototype.hasOwnProperty.call(packageJson, 'config')) {
-        config = _.assign(config, _.pick(packageJson.config, allowedKeys));
+        //config = _.assign(config, _.pick(packageJson.config, allowedKeys));
     }
 
     return config;


### PR DESCRIPTION
….json

Provide a way so that theme authors can make their themes configurable.
For example: A theme might offer the possibility to optionally show a tag cloud. 
There should be a way so that the theme user can easily configure this.

And actually there already would be such a way. It's just simple forbidden in the current code. There already is a `config` section in the themes package.json  But the code filters and only allows the attributes `posts_per_page` [as documented](https://ghost.org/docs/themes/helpers/config/) and `image_sizes`. Themes can directly access these variables as `{{@config.posts_per_page}}

Why restrict this to just these two variables. Allow any variables for theme authors.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
