### PR TITLE
Update @tryghost/portal from 1.0.0 to 1.0.2

### DIFF
--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -121,7 +121,7 @@
         "emailAnalytics": true
     },
     "portal": {
-        "url": "https://unpkg.com/@tryghost/portal@~1.0.0/umd/portal.min.js",
-        "version": "~1.0.0"
+        "url": "https://unpkg.com/@tryghost/portal@1.0.2/umd/portal.min.js",
+        "version": "~1.0.2"
     }
 }


### PR DESCRIPTION
Updated https://unpkg.com/@tryghost/portal to use the latest [Portal](https://github.com/TryGhost/portal) version.

Currently an unnecessary 302 redirect is occurring, as the old version (1.0.0) is being used.

---------------------------------------
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
