### PR TITLE
🐛 Fixed performance regression

### DIFF
--- a/core/server/models/posts-meta.js
+++ b/core/server/models/posts-meta.js
@@ -4,9 +4,7 @@ const urlUtils = require('../../shared/url-utils');
 const PostsMeta = ghostBookshelf.Model.extend({
     tableName: 'posts_meta',
 
-    format() {
-        const attrs = ghostBookshelf.Model.prototype.format.apply(this, arguments);
-
+    formatOnWrite(attrs) {
         ['og_image', 'twitter_image'].forEach((attr) => {
             if (attrs[attr]) {
                 attrs[attr] = urlUtils.toTransformReady(attrs[attr]);

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -146,6 +146,10 @@ Settings = ghostBookshelf.Model.extend({
             }
         }
 
+        return attrs;
+    },
+
+    formatOnWrite(attrs) {
         if (attrs.value && ['cover_image', 'logo', 'icon', 'portal_button_icon', 'og_image', 'twitter_image'].includes(attrs.key)) {
             attrs.value = urlUtils.toTransformReady(attrs.value);
         }

--- a/core/server/models/snippet.js
+++ b/core/server/models/snippet.js
@@ -4,9 +4,7 @@ const urlUtils = require('../../shared/url-utils');
 const Snippet = ghostBookshelf.Model.extend({
     tableName: 'snippets',
 
-    format() {
-        const attrs = ghostBookshelf.Model.prototype.format.apply(this, arguments);
-
+    formatOnWrite(attrs) {
         if (attrs.mobiledoc) {
             attrs.mobiledoc = urlUtils.mobiledocToTransformReady(attrs.mobiledoc);
         }

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -16,9 +16,7 @@ Tag = ghostBookshelf.Model.extend({
         };
     },
 
-    format() {
-        const attrs = ghostBookshelf.Model.prototype.format.apply(this, arguments);
-
+    formatOnWrite(attrs) {
         const urlTransformMap = {
             feature_image: 'toTransformReady',
             og_image: 'toTransformReady',

--- a/test/regression/models/model_posts_spec.js
+++ b/test/regression/models/model_posts_spec.js
@@ -1128,7 +1128,7 @@ describe('Post Model', function () {
                     }).catch(done);
             });
 
-            it('uses parse/transform to store urls as transform-ready and read as absolute ', function (done) {
+            it('it stores urls as transform-ready and reads as absolute', function (done) {
                 const post = {
                     title: 'Absolute->Transform-ready URL Transform Test',
                     mobiledoc: '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"http://127.0.0.1:2369/content/images/card.jpg"}]],"markups":[["a",["href","http://127.0.0.1:2369/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}',

--- a/test/unit/models/settings_spec.js
+++ b/test/unit/models/settings_spec.js
@@ -185,22 +185,22 @@ describe('Unit: models/settings', function () {
         it('transforms urls when persisting to db', function () {
             const setting = models.Settings.forge();
 
-            let returns = setting.format({key: 'cover_image', value: 'http://127.0.0.1:2369/cover_image.png', type: 'string'});
+            let returns = setting.formatOnWrite({key: 'cover_image', value: 'http://127.0.0.1:2369/cover_image.png', type: 'string'});
             should.equal(returns.value, '__GHOST_URL__/cover_image.png');
 
-            returns = setting.format({key: 'logo', value: 'http://127.0.0.1:2369/logo.png', type: 'string'});
+            returns = setting.formatOnWrite({key: 'logo', value: 'http://127.0.0.1:2369/logo.png', type: 'string'});
             should.equal(returns.value, '__GHOST_URL__/logo.png');
 
-            returns = setting.format({key: 'icon', value: 'http://127.0.0.1:2369/icon.png', type: 'string'});
+            returns = setting.formatOnWrite({key: 'icon', value: 'http://127.0.0.1:2369/icon.png', type: 'string'});
             should.equal(returns.value, '__GHOST_URL__/icon.png');
 
-            returns = setting.format({key: 'portal_button_icon', value: 'http://127.0.0.1:2369/portal_button_icon.png', type: 'string'});
+            returns = setting.formatOnWrite({key: 'portal_button_icon', value: 'http://127.0.0.1:2369/portal_button_icon.png', type: 'string'});
             should.equal(returns.value, '__GHOST_URL__/portal_button_icon.png');
 
-            returns = setting.format({key: 'og_image', value: 'http://127.0.0.1:2369/og_image.png', type: 'string'});
+            returns = setting.formatOnWrite({key: 'og_image', value: 'http://127.0.0.1:2369/og_image.png', type: 'string'});
             should.equal(returns.value, '__GHOST_URL__/og_image.png');
 
-            returns = setting.format({key: 'twitter_image', value: 'http://127.0.0.1:2369/twitter_image.png', type: 'string'});
+            returns = setting.formatOnWrite({key: 'twitter_image', value: 'http://127.0.0.1:2369/twitter_image.png', type: 'string'});
             should.equal(returns.value, '__GHOST_URL__/twitter_image.png');
         });
     });


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12791
closes https://github.com/TryGhost/Team/issues/566

https://github.com/TryGhost/Ghost/pull/12787 introduced a significant performance regression due to a misunderstanding of when Bookshelf calls `.format()` ([related upstream issue](https://github.com/bookshelf/bookshelf/issues/668)). We expected `.format()` to only be called on save but it's also called when Bookshelf performs fetching and eager loading which happens frequently. `.format()` can be a heavy method as it needs to parse and serialize html and markdown so it should be performed as infrequently as possible.

- override `sync()` in the base model so we can call our own `.formatOnWrite()` method to transform attributes on `update` and `insert` operations
  - this was the only feasible location in Bookshelf I could find that is low enough level to not require modifying model instance attributes
  - gives models the option to perform heavy transform operations only when writing to the database compared to the usual `.format()` method that is also called on fetch in many situations