### PR TITLE
🐛 Fixed Admin redirect for newsletter/support email update

### DIFF
--- a/core/server/services/members/settings.js
+++ b/core/server/services/members/settings.js
@@ -103,7 +103,7 @@ function createSettingsInstance(config) {
 
     const getAdminRedirectLink = ({type}) => {
         const adminUrl = urlUtils.urlFor('admin', true);
-        return urlUtils.urlJoin(adminUrl, `#/settings/labs/members/?${type}=success`);
+        return urlUtils.urlJoin(adminUrl, `#/settings/members-email/?${type}=success`);
     };
 
     return {


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/570

When site owner/admin updates their newsletter/support email address from settings, they receive an email with confirmation link which on success takes them to Ghost Admin on email settings screen with a toast about success. Since the path for email settings in Ghost Admin changed in v4, the fix updates the redirect link to new Admin settings URL.
