### PR TITLE
🐛 Fixed plaintext and excerpt fallbacks having incorrect URLs after domain change

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -110,7 +110,7 @@ Post = ghostBookshelf.Model.extend({
         const urlTransformMap = {
             mobiledoc: 'mobiledocToTransformReady',
             html: 'htmlToTransformReady',
-            plaintext: 'markdownToTransformReady',
+            plaintext: 'plaintextToTransformReady',
             custom_excerpt: 'htmlToTransformReady',
             codeinjection_head: 'htmlToTransformReady',
             codeinjection_foot: 'htmlToTransformReady',

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@tryghost/session-service": "0.1.17",
     "@tryghost/social-urls": "0.1.21",
     "@tryghost/string": "0.1.17",
-    "@tryghost/url-utils": "1.1.0",
+    "@tryghost/url-utils": "1.1.1",
     "@tryghost/vhost-middleware": "1.0.13",
     "@tryghost/zip": "1.1.10",
     "amperize": "0.6.1",

--- a/test/regression/models/model_posts_spec.js
+++ b/test/regression/models/model_posts_spec.js
@@ -1146,6 +1146,7 @@ describe('Post Model', function () {
                 models.Post.add(post, context).then((createdPost) => {
                     createdPost.get('mobiledoc').should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"http://127.0.0.1:2369/content/images/card.jpg"}]],"markups":[["a",["href","http://127.0.0.1:2369/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
                     createdPost.get('html').should.equal('<p><a href="http://127.0.0.1:2369/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="http://127.0.0.1:2369/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
+                    createdPost.get('plaintext').should.containEql('Testing [http://127.0.0.1:2369/test]');
                     createdPost.get('custom_excerpt').should.equal('Testing <a href="http://127.0.0.1:2369/internal">links</a> in custom excerpts');
                     createdPost.get('codeinjection_head').should.equal('<script src="http://127.0.0.1:2369/assets/head.js"></script>');
                     createdPost.get('codeinjection_foot').should.equal('<script src="http://127.0.0.1:2369/assets/foot.js"></script>');
@@ -1174,6 +1175,7 @@ describe('Post Model', function () {
                     const [knexPost] = knexResult;
                     knexPost.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"__GHOST_URL__/content/images/card.jpg"}]],"markups":[["a",["href","__GHOST_URL__/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
                     knexPost.html.should.equal('<p><a href="__GHOST_URL__/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="__GHOST_URL__/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
+                    knexPost.plaintext.should.containEql('Testing [__GHOST_URL__/test]');
                     knexPost.custom_excerpt.should.equal('Testing <a href="__GHOST_URL__/internal">links</a> in custom excerpts');
                     knexPost.codeinjection_head.should.equal('<script src="__GHOST_URL__/assets/head.js"></script>');
                     knexPost.codeinjection_foot.should.equal('<script src="__GHOST_URL__/assets/foot.js"></script>');

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,10 +682,10 @@
   dependencies:
     unidecode "^0.1.8"
 
-"@tryghost/url-utils@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/url-utils/-/url-utils-1.1.0.tgz#0a7dfbe7f7328aebd3fff2db153cd04d958c8608"
-  integrity sha512-gqHoJvgg8yzdEN7FhZLsckPbqWlKZZfxsneaf4X1Kad7l6pNkmmxwq2t67tvQLEVp6Nvvm8bFFmRVtYDpopVUw==
+"@tryghost/url-utils@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/url-utils/-/url-utils-1.1.1.tgz#a76f585aa67864ee2ae9cf88800993cfba2d49ca"
+  integrity sha512-foO7cGlFZ5NMWkVwYZ+ZiMvzNokPVlqmObjV9u6R/ZQ1PKU0t4n+flJ8THRKcELqU3PNZ4ucfaXxz8Rv/QnJRw==
   dependencies:
     cheerio "0.22.0"
     moment "2.27.0"


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/571

- `post.plaintext` values were being transformed with the markdown URL transformer but that wasn't picking up the link format used in our plaintext fields resulting in absolute URLs being stored in the database rather than `__GHOST_URL__` URLs
  - meant that if the `url` config is changed then plaintext and other calculated fields that used it would have URLs that referred to the old domain rather than the new one
  - re-saving the posts would have updated it but that's not feasible to do manually for large sites
- bumped `@tryghost/url-utils` to a version that has plaintext transform utils and updated the post model's transform map
