### PR TITLE
Removed hardcoded accent color fallbacks

### DIFF
--- a/core/frontend/helpers/content.js
+++ b/core/frontend/helpers/content.js
@@ -19,7 +19,7 @@ function restrictedCta(options) {
     options = options || {};
     options.data = options.data || {};
     _.merge(this, {
-        accentColor: (options.data.site && options.data.site.accent_color) || '#15171A'
+        accentColor: (options.data.site && options.data.site.accent_color)
     });
     const data = createFrame(options.data);
     return templates.execute('content-cta', this, {data});

--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -133,7 +133,7 @@ function createApiInstance(config) {
                 const siteUrl = urlUtils.urlFor('home', true);
                 const domain = urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
                 const siteDomain = (domain && domain[1]);
-                const accentColor = settingsCache.get('accent_color') || '#15212A';
+                const accentColor = settingsCache.get('accent_color');
                 switch (type) {
                 case 'subscribe':
                     return subscribeEmail({url, email, siteTitle, accentColor, siteDomain, siteUrl});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/536

From 4.0, we ensure and require that accent colour is always set. This change removes hardcoded accent color fallbacks to avoid confusion as well as cause accidental fallback that is undesired causing themes to look different
