### PR TITLE
Bumped @tryghost/members-api & Portal versions

### DIFF
--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -121,7 +121,7 @@
         "emailAnalytics": true
     },
     "portal": {
-        "url": "https://unpkg.com/@tryghost/portal@~1.0.0/umd/portal.min.js",
-        "version": "~1.0.0"
+        "url": "https://unpkg.com/@tryghost/portal@~1.1.0/umd/portal.min.js",
+        "version": "~1.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@tryghost/kg-mobiledoc-html-renderer": "4.0.0",
     "@tryghost/limit-service": "0.3.0",
     "@tryghost/magic-link": "1.0.0",
-    "@tryghost/members-api": "1.0.0",
+    "@tryghost/members-api": "1.1.0",
     "@tryghost/members-csv": "1.0.0",
     "@tryghost/members-ssr": "1.0.0",
     "@tryghost/mw-session-from-token": "0.1.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -576,10 +576,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.0.0.tgz#b85de9ae3bc1b47eb352bd314a35b054dcf8f7dc"
-  integrity sha512-DSPWk/hZKmvLvWMB2dMJvFOHlZVfEjszE+nGSd3tISzYH83PUxp1SsZZhZGiETz5knEVxwxwXVxux8Q9QLTJlw==
+"@tryghost/members-api@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.1.0.tgz#0fa563a9eb7028929b358d819c4943c4fc6dd8cf"
+  integrity sha512-7kfcqiHB9aH7PAiApUncHPfZPEZv9MMztmzLmMRosXT2NBcCWjdxEY/YWou9DVLgcPKhxsQIKWKyHlruTTx6Gg==
   dependencies:
     "@tryghost/errors" "^0.2.9"
     "@tryghost/magic-link" "^1.0.0"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/530

This adds support for the smart_cancel option when cancelling
subscriptions, which will cancel the subscription immediately if it is
in an "overdue" state. The update to Portal wires up this behaviour for
members.