### PR TITLE
Added migration to fix incorrect mrr events

### DIFF
--- a/core/server/data/migrations/versions/4.2/01-fix-incorrect-mrr-delta-events.js
+++ b/core/server/data/migrations/versions/4.2/01-fix-incorrect-mrr-delta-events.js
@@ -1,0 +1,34 @@
+const {createTransactionalMigration} = require('../../utils');
+const logging = require('../../../../../shared/logging');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Fixing incorrect mrr_delta in members_paid_subscription_events table');
+        const allIncorrectEvents = await knex
+            .select('id', 'mrr_delta')
+            .from('members_paid_subscription_events')
+            .where('from_plan', '=', knex.ref('to_plan'))
+            .where('mrr_delta', '<', 0);
+
+        const correctedEvents = allIncorrectEvents.filter(({mrr_delta: mrrDelta}) => {
+            return (mrrDelta % 2 === 0);
+        }).map(({id, mrr_delta: mrrDelta}) => {
+            return {
+                id,
+                mrrDelta: mrrDelta / 2
+            };
+        });
+
+        logging.info(`Updating mrr_delta for ${correctedEvents.length} events`);
+        for (const event of correctedEvents) {
+            await knex('members_paid_subscription_events')
+                .where({id: event.id})
+                .update({
+                    mrr_delta: event.mrrDelta
+                });
+        }
+    },
+    async function down() {
+        // noop
+    }
+);

--- a/core/server/data/migrations/versions/4.2/01-fix-incorrect-mrr-delta-events.js
+++ b/core/server/data/migrations/versions/4.2/01-fix-incorrect-mrr-delta-events.js
@@ -4,7 +4,7 @@ const logging = require('../../../../../shared/logging');
 module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Fixing incorrect mrr_delta in members_paid_subscription_events table');
-        await knex.raw('UPDATE members_paid_subscription_events SET mrr_delta = mrr_delta / 2 WHERE from_plan = to_plan');
+        await knex.raw('UPDATE members_paid_subscription_events SET mrr_delta = ROUND(mrr_delta / 2) WHERE from_plan = to_plan');
     },
     async function down() {
         // noop

--- a/core/server/data/migrations/versions/4.2/01-fix-incorrect-mrr-delta-events.js
+++ b/core/server/data/migrations/versions/4.2/01-fix-incorrect-mrr-delta-events.js
@@ -4,29 +4,7 @@ const logging = require('../../../../../shared/logging');
 module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Fixing incorrect mrr_delta in members_paid_subscription_events table');
-        const allIncorrectEvents = await knex
-            .select('id', 'mrr_delta')
-            .from('members_paid_subscription_events')
-            .where('from_plan', '=', knex.ref('to_plan'))
-            .where('mrr_delta', '<', 0);
-
-        const correctedEvents = allIncorrectEvents.filter(({mrr_delta: mrrDelta}) => {
-            return (mrrDelta % 2 === 0);
-        }).map(({id, mrr_delta: mrrDelta}) => {
-            return {
-                id,
-                mrrDelta: mrrDelta / 2
-            };
-        });
-
-        logging.info(`Updating mrr_delta for ${correctedEvents.length} events`);
-        for (const event of correctedEvents) {
-            await knex('members_paid_subscription_events')
-                .where({id: event.id})
-                .update({
-                    mrr_delta: event.mrrDelta
-                });
-        }
+        await knex.raw('UPDATE members_paid_subscription_events SET mrr_delta = mrr_delta / 2 WHERE from_plan = to_plan');
     },
     async function down() {
         // noop

--- a/core/server/data/migrations/versions/4.2/01-fix-incorrect-mrr-delta-events.js
+++ b/core/server/data/migrations/versions/4.2/01-fix-incorrect-mrr-delta-events.js
@@ -6,7 +6,8 @@ module.exports = createTransactionalMigration(
         logging.info('Fixing incorrect mrr_delta in members_paid_subscription_events table');
         await knex.raw('UPDATE members_paid_subscription_events SET mrr_delta = ROUND(mrr_delta / 2) WHERE from_plan = to_plan');
     },
-    async function down() {
-        // noop
+    async function down(knex) {
+        logging.info('Reverting mrr_delta to old value in members_paid_subscription_events table');
+        await knex.raw('UPDATE members_paid_subscription_events SET mrr_delta = ROUND(mrr_delta * 2) WHERE from_plan = to_plan');
     }
 );


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/595

Due to a bug in mrr_delta calculation, we ended up reducing the MRR delta by twice the original amount when a subscription goes from active to canceled and storing it in `members_paid_subscription_events` table, which is used to show the MRR chart on Dashboard. The way we identify the incorrect events in the table which got the double negative value is by checking if they match certain criteria - Both `from_plan` and `to_plan` have same value as this is the only case this bug always happens in since a subscription changes status on same plan.

This migration halves the `mrr_delta` for incorrect events to restore the correct MRR change for the site.
