### PR TITLE
Updated stripe prices table schema

### DIFF
--- a/core/server/data/migrations/versions/4.3/06-add-stripe-prices-table.js
+++ b/core/server/data/migrations/versions/4.3/06-add-stripe-prices-table.js
@@ -5,12 +5,11 @@ module.exports = addTable('stripe_prices', {
     stripe_price_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
     stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'stripe_products.stripe_product_id'},
     active: {type: 'boolean', nullable: false},
-    livemode: {type: 'boolean', nullable: false},
     nickname: {type: 'string', maxlength: 50, nullable: true},
     currency: {type: 'string', maxLength: 3, nullable: false},
     amount: {type: 'integer', nullable: false},
     type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'recurring', validations: {isIn: [['recurring', 'one_time']]}},
-    interval: {type: 'string', maxlength: 50, nullable: false},
+    interval: {type: 'string', maxlength: 50, nullable: true},
     created_at: {type: 'dateTime', nullable: false},
     updated_at: {type: 'dateTime', nullable: true}
 });

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -490,12 +490,11 @@ module.exports = {
         stripe_price_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
         stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'stripe_products.stripe_product_id'},
         active: {type: 'boolean', nullable: false},
-        livemode: {type: 'boolean', nullable: false},
         nickname: {type: 'string', maxlength: 50, nullable: true},
         currency: {type: 'string', maxLength: 3, nullable: false},
         amount: {type: 'integer', nullable: false},
         type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'recurring', validations: {isIn: [['recurring', 'one_time']]}},
-        interval: {type: 'string', maxlength: 50, nullable: false},
+        interval: {type: 'string', maxlength: 50, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}
     },

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'a507f692edce7d13d1b75c124b3a30b7';
+    const currentSchemaHash = '19f3f2750320798dac398be2eb51d3e5';
     const currentFixturesHash = '779f29a247161414025637e10e99a278';
     const currentSettingsHash = '7ac732b994a5bb1565f88c8a84872964';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/586

- Change the interval column to be `nullable` as one time payments won't have any interval
- Remove the `livemode` column as we store the connected account's livemode status at top level
