### PR TITLE
Added permissions for the Products resource

### DIFF
--- a/core/server/data/migrations/versions/4.3/07-add-products-permissions.js
+++ b/core/server/data/migrations/versions/4.3/07-add-products-permissions.js
@@ -5,25 +5,25 @@ module.exports = combineTransactionalMigrations(
         name: 'Browse Products',
         action: 'browse',
         object: 'product'
-    }, ['Admin']),
+    }, ['Administrator']),
     addPermissionWithRoles({
         name: 'Read Products',
         action: 'read',
         object: 'product'
-    }, ['Admin']),
+    }, ['Administrator']),
     addPermissionWithRoles({
         name: 'Edit Products',
         action: 'edit',
         object: 'product'
-    }, ['Admin']),
+    }, ['Administrator']),
     addPermissionWithRoles({
         name: 'Add Products',
         action: 'add',
         object: 'product'
-    }, ['Admin']),
+    }, ['Administrator']),
     addPermissionWithRoles({
         name: 'Delete Products',
         action: 'destroy',
         object: 'product'
-    }, ['Admin'])
+    }, ['Administrator'])
 );

--- a/core/server/data/migrations/versions/4.3/07-add-products-permissions.js
+++ b/core/server/data/migrations/versions/4.3/07-add-products-permissions.js
@@ -1,0 +1,29 @@
+const {combineTransactionalMigrations, addPermissionWithRoles} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse Products',
+        action: 'browse',
+        object: 'product'
+    }, ['Admin']),
+    addPermissionWithRoles({
+        name: 'Read Products',
+        action: 'read',
+        object: 'product'
+    }, ['Admin']),
+    addPermissionWithRoles({
+        name: 'Edit Products',
+        action: 'edit',
+        object: 'product'
+    }, ['Admin']),
+    addPermissionWithRoles({
+        name: 'Add Products',
+        action: 'add',
+        object: 'product'
+    }, ['Admin']),
+    addPermissionWithRoles({
+        name: 'Delete Products',
+        action: 'destroy',
+        object: 'product'
+    }, ['Admin'])
+);

--- a/core/server/data/migrations/versions/4.3/07-add-products-permissions.js
+++ b/core/server/data/migrations/versions/4.3/07-add-products-permissions.js
@@ -5,12 +5,12 @@ module.exports = combineTransactionalMigrations(
         name: 'Browse Products',
         action: 'browse',
         object: 'product'
-    }, ['Administrator']),
+    }, ['Administrator', 'Editor', 'Author']),
     addPermissionWithRoles({
         name: 'Read Products',
         action: 'read',
         object: 'product'
-    }, ['Administrator']),
+    }, ['Administrator', 'Editor', 'Author']),
     addPermissionWithRoles({
         name: 'Edit Products',
         action: 'edit',

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -354,6 +354,31 @@
                     "object_type": "member"
                 },
                 {
+                    "name": "Browse Products",
+                    "action_type": "browse",
+                    "object_type": "product"
+                },
+                {
+                    "name": "Read Products",
+                    "action_type": "read",
+                    "object_type": "product"
+                },
+                {
+                    "name": "Edit Products",
+                    "action_type": "edit",
+                    "object_type": "product"
+                },
+                {
+                    "name": "Add Products",
+                    "action_type": "add",
+                    "object_type": "product"
+                },
+                {
+                    "name": "Delete Products",
+                    "action_type": "destroy",
+                    "object_type": "product"
+                },
+                {
                     "name": "Publish posts",
                     "action_type": "publish",
                     "object_type": "post"
@@ -693,6 +718,7 @@
                     "api_key": "all",
                     "action": "all",
                     "member": "all",
+                    "product": "all",
                     "label": "all",
                     "email_preview": "all",
                     "email": "all",

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -763,7 +763,8 @@
                     "theme": ["browse"],
                     "email_preview": "all",
                     "email": "all",
-                    "snippet": "all"
+                    "snippet": "all",
+                    "product": ["browse", "read"]
                 },
                 "Author": {
                     "post": ["browse", "read", "add"],
@@ -775,7 +776,8 @@
                     "theme": ["browse"],
                     "email_preview": "read",
                     "email": "read",
-                    "snippet": ["browse", "read"]
+                    "snippet": ["browse", "read"],
+                    "product": ["browse", "read"]
                 },
                 "Contributor": {
                     "post": ["browse", "read", "add"],

--- a/test/regression/migrations/migration_spec.js
+++ b/test/regression/migrations/migration_spec.js
@@ -28,203 +28,121 @@ describe('Database Migration (special functions)', function () {
             roleNames.should.eql(roles);
         });
 
+        should.Assertion.add('havePermission', function (name, roles = null) {
+            const permission = this.obj.find((permission) => {
+                return permission.name === name;
+            });
+            should.exist(permission, `Could not find permission ${name}`);
+
+            if (roles) {
+                permission.should.be.AssignedToRoles(roles);
+            }
+        });
+
         // Custom assertion to wrap all permissions
         should.Assertion.add('CompletePermissions', function () {
             this.params = {operator: 'to have a complete set of permissions'};
             const permissions = this.obj;
 
-            // DB
-            permissions[0].name.should.eql('Export database');
-            permissions[0].should.be.AssignedToRoles(['Administrator', 'DB Backup Integration']);
-            permissions[1].name.should.eql('Import database');
-            permissions[1].should.be.AssignedToRoles(['Administrator', 'DB Backup Integration']);
-            permissions[2].name.should.eql('Delete all content');
-            permissions[2].should.be.AssignedToRoles(['Administrator', 'DB Backup Integration']);
+            permissions.should.havePermission('Export database', ['Administrator', 'DB Backup Integration']);
+            permissions.should.havePermission('Import database', ['Administrator', 'DB Backup Integration']);
+            permissions.should.havePermission('Delete all content', ['Administrator', 'DB Backup Integration']);
+            permissions.should.havePermission('Backup database', ['Administrator', 'DB Backup Integration']);
 
-            // Mail
-            permissions[3].name.should.eql('Send mail');
-            permissions[3].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Send mail', ['Administrator', 'Admin Integration']);
 
-            // Notifications
-            permissions[4].name.should.eql('Browse notifications');
-            permissions[4].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[5].name.should.eql('Add notifications');
-            permissions[5].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[6].name.should.eql('Delete notifications');
-            permissions[6].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Browse notifications', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Add notifications', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Delete notifications', ['Administrator', 'Editor', 'Admin Integration']);
 
-            // Posts
-            permissions[7].name.should.eql('Browse posts');
-            permissions[7].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[8].name.should.eql('Read posts');
-            permissions[8].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[9].name.should.eql('Edit posts');
-            permissions[9].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[10].name.should.eql('Add posts');
-            permissions[10].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[11].name.should.eql('Delete posts');
-            permissions[11].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Browse posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Read posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Edit posts', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Add posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Delete posts', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Publish posts', ['Administrator', 'Editor', 'Admin Integration', 'Scheduler Integration']);
 
-            // Settings
-            permissions[12].name.should.eql('Browse settings');
-            permissions[12].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[13].name.should.eql('Read settings');
-            permissions[13].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[14].name.should.eql('Edit settings');
-            permissions[14].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Browse settings', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Read settings', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Edit settings', ['Administrator', 'Admin Integration']);
 
-            // Slugs
-            permissions[15].name.should.eql('Generate slugs');
-            permissions[15].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Generate slugs', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
 
-            // Tags
-            permissions[16].name.should.eql('Browse tags');
-            permissions[16].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[17].name.should.eql('Read tags');
-            permissions[17].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[18].name.should.eql('Edit tags');
-            permissions[18].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[19].name.should.eql('Add tags');
-            permissions[19].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Admin Integration']);
-            permissions[20].name.should.eql('Delete tags');
-            permissions[20].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Browse tags', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Read tags', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Edit tags', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Add tags', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
+            permissions.should.havePermission('Delete tags', ['Administrator', 'Editor', 'Admin Integration']);
 
-            // Themes
-            permissions[21].name.should.eql('Browse themes');
-            permissions[21].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[22].name.should.eql('Edit themes');
-            permissions[22].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
-            permissions[23].name.should.eql('Activate themes');
-            permissions[23].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
-            permissions[24].name.should.eql('Upload themes');
-            permissions[24].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
-            permissions[25].name.should.eql('Download themes');
-            permissions[25].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
-            permissions[26].name.should.eql('Delete themes');
-            permissions[26].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Browse themes', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Edit themes', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Activate themes', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Upload themes', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Download themes', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Delete themes', ['Administrator', 'Admin Integration']);
 
-            // Users
-            permissions[27].name.should.eql('Browse users');
-            permissions[27].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[28].name.should.eql('Read users');
-            permissions[28].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[29].name.should.eql('Edit users');
-            permissions[29].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[30].name.should.eql('Add users');
-            permissions[30].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[31].name.should.eql('Delete users');
-            permissions[31].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Browse users', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Read users', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Edit users', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Add users', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Delete users', ['Administrator', 'Editor', 'Admin Integration']);
 
-            // Roles
-            permissions[32].name.should.eql('Assign a role');
-            permissions[32].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[33].name.should.eql('Browse roles');
-            permissions[33].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Assign a role', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Browse roles', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Browse invites', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Read invites', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Edit invites', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Add invites', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Delete invites', ['Administrator', 'Editor', 'Admin Integration']);
 
-            // Invites
-            permissions[34].name.should.eql('Browse invites');
-            permissions[34].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[35].name.should.eql('Read invites');
-            permissions[35].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[36].name.should.eql('Edit invites');
-            permissions[36].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[37].name.should.eql('Add invites');
-            permissions[37].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[38].name.should.eql('Delete invites');
-            permissions[38].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Download redirects', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Upload redirects', ['Administrator', 'Admin Integration']);
 
-            // Redirects
-            permissions[39].name.should.eql('Download redirects');
-            permissions[39].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
-            permissions[40].name.should.eql('Upload redirects');
-            permissions[40].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Add webhooks', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Edit webhooks', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Delete webhooks', ['Administrator', 'Admin Integration']);
 
-            // Webhooks
-            permissions[41].name.should.eql('Add webhooks');
-            permissions[41].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
-            permissions[42].name.should.eql('Edit webhooks');
-            permissions[42].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
-            permissions[43].name.should.eql('Delete webhooks');
-            permissions[43].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Browse integrations', ['Administrator']);
+            permissions.should.havePermission('Read integrations', ['Administrator']);
+            permissions.should.havePermission('Edit integrations', ['Administrator']);
+            permissions.should.havePermission('Add integrations', ['Administrator']);
+            permissions.should.havePermission('Delete integrations', ['Administrator']);
 
-            // Integrations
-            permissions[44].name.should.eql('Browse integrations');
-            permissions[44].should.be.AssignedToRoles(['Administrator']);
-            permissions[45].name.should.eql('Read integrations');
-            permissions[45].should.be.AssignedToRoles(['Administrator']);
-            permissions[46].name.should.eql('Edit integrations');
-            permissions[46].should.be.AssignedToRoles(['Administrator']);
-            permissions[47].name.should.eql('Add integrations');
-            permissions[47].should.be.AssignedToRoles(['Administrator']);
-            permissions[48].name.should.eql('Delete integrations');
-            permissions[48].should.be.AssignedToRoles(['Administrator']);
+            permissions.should.havePermission('Browse API keys', ['Administrator']);
+            permissions.should.havePermission('Read API keys', ['Administrator']);
+            permissions.should.havePermission('Edit API keys', ['Administrator']);
+            permissions.should.havePermission('Add API keys', ['Administrator']);
+            permissions.should.havePermission('Delete API keys', ['Administrator']);
 
-            // API Keys
-            permissions[49].name.should.eql('Browse API keys');
-            permissions[49].should.be.AssignedToRoles(['Administrator']);
-            permissions[50].name.should.eql('Read API keys');
-            permissions[50].should.be.AssignedToRoles(['Administrator']);
-            permissions[51].name.should.eql('Edit API keys');
-            permissions[51].should.be.AssignedToRoles(['Administrator']);
-            permissions[52].name.should.eql('Add API keys');
-            permissions[52].should.be.AssignedToRoles(['Administrator']);
-            permissions[53].name.should.eql('Delete API keys');
-            permissions[53].should.be.AssignedToRoles(['Administrator']);
+            permissions.should.havePermission('Browse Actions', ['Administrator', 'Admin Integration']);
 
-            // Actions
-            permissions[54].name.should.eql('Browse Actions');
-            permissions[54].should.be.AssignedToRoles(['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Email preview', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Send test email', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Browse emails', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Read emails', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Retry emails', ['Administrator', 'Editor', 'Admin Integration']);
 
-            // Members
-            permissions[55].name.should.eql('Browse Members');
-            permissions[56].name.should.eql('Read Members');
-            permissions[57].name.should.eql('Edit Members');
-            permissions[58].name.should.eql('Add Members');
-            permissions[59].name.should.eql('Delete Members');
+            permissions.should.havePermission('Browse snippets', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Read snippets', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Edit snippets', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Add snippets', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Delete snippets', ['Administrator', 'Editor', 'Admin Integration']);
 
-            // Posts
-            permissions[60].name.should.eql('Publish posts');
-            permissions[60].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration', 'Scheduler Integration']);
+            permissions.should.havePermission('Browse labels');
+            permissions.should.havePermission('Read labels');
+            permissions.should.havePermission('Edit labels');
+            permissions.should.havePermission('Add labels');
+            permissions.should.havePermission('Delete labels');
 
-            // DB
-            permissions[61].name.should.eql('Backup database');
-            permissions[61].should.be.AssignedToRoles(['Administrator', 'DB Backup Integration']);
+            permissions.should.havePermission('Read member signin urls');
+            permissions.should.havePermission('Read identities');
+            permissions.should.havePermission('Auth Stripe Connect for Members');
 
-            // Bulk Email
-            permissions[62].name.should.eql('Email preview');
-            permissions[62].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[63].name.should.eql('Send test email');
-            permissions[63].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[64].name.should.eql('Browse emails');
-            permissions[64].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[65].name.should.eql('Read emails');
-            permissions[65].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[66].name.should.eql('Retry emails');
-            permissions[66].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-
-            // Labels
-            permissions[67].name.should.eql('Browse labels');
-            permissions[68].name.should.eql('Read labels');
-            permissions[69].name.should.eql('Edit labels');
-            permissions[70].name.should.eql('Add labels');
-            permissions[71].name.should.eql('Delete labels');
-
-            // Member auth
-            permissions[72].name.should.eql('Read member signin urls');
-            permissions[73].name.should.eql('Read identities');
-            permissions[74].name.should.eql('Auth Stripe Connect for Members');
-
-            // Snippets
-            permissions[75].name.should.eql('Browse snippets');
-            permissions[75].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[76].name.should.eql('Read snippets');
-            permissions[76].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions[77].name.should.eql('Edit snippets');
-            permissions[77].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[78].name.should.eql('Add snippets');
-            permissions[78].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
-            permissions[79].name.should.eql('Delete snippets');
-            permissions[79].should.be.AssignedToRoles(['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Browse Members');
+            permissions.should.havePermission('Read Members');
+            permissions.should.havePermission('Edit Members');
+            permissions.should.havePermission('Add Members');
+            permissions.should.havePermission('Delete Members');
         });
 
         describe('Populate', function () {

--- a/test/regression/migrations/migration_spec.js
+++ b/test/regression/migrations/migration_spec.js
@@ -29,8 +29,8 @@ describe('Database Migration (special functions)', function () {
         });
 
         should.Assertion.add('havePermission', function (name, roles = null) {
-            const permission = this.obj.find((permission) => {
-                return permission.name === name;
+            const permission = this.obj.find((p) => {
+                return p.name === name;
             });
             should.exist(permission, `Could not find permission ${name}`);
 

--- a/test/regression/migrations/migration_spec.js
+++ b/test/regression/migrations/migration_spec.js
@@ -44,6 +44,9 @@ describe('Database Migration (special functions)', function () {
             this.params = {operator: 'to have a complete set of permissions'};
             const permissions = this.obj;
 
+            // If you have to change this number, please add the relevant `havePermission` checks below
+            permissions.length.should.eql(85);
+
             permissions.should.havePermission('Export database', ['Administrator', 'DB Backup Integration']);
             permissions.should.havePermission('Import database', ['Administrator', 'DB Backup Integration']);
             permissions.should.havePermission('Delete all content', ['Administrator', 'DB Backup Integration']);
@@ -143,6 +146,12 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Edit Members');
             permissions.should.havePermission('Add Members');
             permissions.should.havePermission('Delete Members');
+
+            permissions.should.havePermission('Browse Products', ['Administrator', 'Editor', 'Author']);
+            permissions.should.havePermission('Read Products', ['Administrator', 'Editor', 'Author']);
+            permissions.should.havePermission('Edit Products', ['Administrator']);
+            permissions.should.havePermission('Add Products', ['Administrator']);
+            permissions.should.havePermission('Delete Products', ['Administrator']);
         });
 
         describe('Populate', function () {

--- a/test/regression/migrations/migration_spec.js
+++ b/test/regression/migrations/migration_spec.js
@@ -282,7 +282,7 @@ describe('Database Migration (special functions)', function () {
                     result.roles.at(7).get('name').should.eql('Scheduler Integration');
 
                     // Permissions
-                    result.permissions.length.should.eql(80);
+                    result.permissions.length.should.eql(85);
                     result.permissions.toJSON().should.be.CompletePermissions();
                 });
             });

--- a/test/unit/data/schema/fixtures/utils_spec.js
+++ b/test/unit/data/schema/fixtures/utils_spec.js
@@ -152,19 +152,19 @@ describe('Migration Fixture Utils', function () {
             fixtureUtils.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
-                result.should.have.property('expected', 75);
-                result.should.have.property('done', 75);
+                result.should.have.property('expected', 77);
+                result.should.have.property('done', 77);
 
                 // Permissions & Roles
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(75);
+                dataMethodStub.filter.callCount.should.eql(77);
                 dataMethodStub.find.callCount.should.eql(7);
-                baseUtilAttachStub.callCount.should.eql(75);
+                baseUtilAttachStub.callCount.should.eql(77);
 
-                fromItem.related.callCount.should.eql(75);
-                fromItem.findWhere.callCount.should.eql(75);
-                toItem[0].get.callCount.should.eql(150);
+                fromItem.related.callCount.should.eql(77);
+                fromItem.findWhere.callCount.should.eql(77);
+                toItem[0].get.callCount.should.eql(154);
 
                 done();
             }).catch(done);

--- a/test/unit/data/schema/fixtures/utils_spec.js
+++ b/test/unit/data/schema/fixtures/utils_spec.js
@@ -152,19 +152,19 @@ describe('Migration Fixture Utils', function () {
             fixtureUtils.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
-                result.should.have.property('expected', 74);
-                result.should.have.property('done', 74);
+                result.should.have.property('expected', 75);
+                result.should.have.property('done', 75);
 
                 // Permissions & Roles
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(74);
+                dataMethodStub.filter.callCount.should.eql(75);
                 dataMethodStub.find.callCount.should.eql(7);
-                baseUtilAttachStub.callCount.should.eql(74);
+                baseUtilAttachStub.callCount.should.eql(75);
 
-                fromItem.related.callCount.should.eql(74);
-                fromItem.findWhere.callCount.should.eql(74);
-                toItem[0].get.callCount.should.eql(148);
+                fromItem.related.callCount.should.eql(75);
+                fromItem.findWhere.callCount.should.eql(75);
+                toItem[0].get.callCount.should.eql(150);
 
                 done();
             }).catch(done);

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -33,7 +33,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '19f3f2750320798dac398be2eb51d3e5';
-    const currentFixturesHash = '779f29a247161414025637e10e99a278';
+    const currentFixturesHash = '8832ea095928f72e0d8c41815cc9b2e4';
     const currentSettingsHash = '7ac732b994a5bb1565f88c8a84872964';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -33,7 +33,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '19f3f2750320798dac398be2eb51d3e5';
-    const currentFixturesHash = '8832ea095928f72e0d8c41815cc9b2e4';
+    const currentFixturesHash = '3dc9747eadecec34958dfba14c5332db';
     const currentSettingsHash = '7ac732b994a5bb1565f88c8a84872964';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/616

This adds the BREAD permissions for the Product resource, which'll be used by the Admin API.

We currently give `Administrator` and `Owner` all of these permissions, as discussed with Zimo.

It may be that the "read" permissions need more roles attached