### PR TITLE
Added price_id column to subscriptions table

### DIFF
--- a/core/server/data/migrations/versions/4.3/08-add-price-id-column-to-subscriptions-table.js
+++ b/core/server/data/migrations/versions/4.3/08-add-price-id-column-to-subscriptions-table.js
@@ -1,0 +1,10 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members_stripe_customers_subscriptions', 'price_id', {
+    type: 'string',
+    maxlength: 255,
+    nullable: false,
+    unique: false,
+    defaultTo: '',
+    references: 'stripe_prices.stripe_price_id'
+});

--- a/core/server/data/migrations/versions/4.3/09-populate-stripe-price-id-in-subscriptions.js
+++ b/core/server/data/migrations/versions/4.3/09-populate-stripe-price-id-in-subscriptions.js
@@ -1,0 +1,16 @@
+const logging = require('../../../../../shared/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Populating stripe price id from plan id in stripe customer subscriptions table');
+        await knex('members_stripe_customers_subscriptions')
+            .update({
+                price_id: knex.ref('plan_id')
+            });
+    },
+
+    async function down() {
+        // noop: no need to reset price_id to empty string
+    }
+);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -454,7 +454,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'members_stripe_customers.customer_id', cascadeDelete: true},
         subscription_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
-        plan_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
+        price_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'stripe_prices.stripe_price_id'},
         status: {type: 'string', maxlength: 50, nullable: false},
         cancel_at_period_end: {type: 'bool', nullable: false, defaultTo: false},
         cancellation_reason: {type: 'string', maxlength: 500, nullable: true},
@@ -465,7 +465,8 @@ module.exports = {
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true},
-        /* Below fields eventually should be normalised e.g. stripe_plans table, link to here on plan_id */
+        /* Below fields are now redundant as we link prie_id to stripe_prices table */
+        plan_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
         plan_nickname: {type: 'string', maxlength: 50, nullable: false},
         plan_interval: {type: 'string', maxlength: 50, nullable: false},
         plan_amount: {type: 'integer', nullable: false},

--- a/core/server/models/stripe-customer-subscription.js
+++ b/core/server/models/stripe-customer-subscription.js
@@ -6,6 +6,9 @@ const StripeCustomerSubscription = ghostBookshelf.Model.extend({
     customer() {
         return this.belongsTo('MemberStripeCustomer', 'customer_id', 'customer_id');
     },
+    stripePrice() {
+        return this.belongsTo('StripePrice', 'price_id', 'stripe_price_id');
+    },
 
     serialize(options) {
         const defaultSerializedObject = ghostBookshelf.Model.prototype.serialize.call(this, options);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/586

- Adds new `price_id` column which references `stripe_price_id` in `stripe_prices` table
- Makes `plan_*` columns in subscriptions table redundant
- Populates `price_id` column value to current `plan_id`