### PR TITLE
Added Product, StripeProduct & StripePrice relations

### DIFF
--- a/core/server/models/product.js
+++ b/core/server/models/product.js
@@ -25,7 +25,22 @@ const Product = ghostBookshelf.Model.extend({
         }
     },
 
-    members: function members() {
+    stripeProducts() {
+        return this.hasMany('StripeProduct', 'product_id', 'id');
+    },
+
+    stripePrices() {
+        return this.belongsToMany(
+            'StripePrice',
+            'stripe_products',
+            'product_id',
+            'stripe_product_id',
+            'id',
+            'stripe_product_id'
+        );
+    },
+
+    members() {
         return this.belongsToMany('Member', 'members_products', 'product_id', 'member_id');
     }
 });

--- a/core/server/models/stripe-product.js
+++ b/core/server/models/stripe-product.js
@@ -5,6 +5,10 @@ const StripeProduct = ghostBookshelf.Model.extend({
 
     product() {
         return this.belongsTo('Product', 'product_id', 'id');
+    },
+
+    stripePrices() {
+        return this.hasMany('StripePrice', 'stripe_product_id', 'stripe_product_id');
     }
 
 }, {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/586

We have to use `belongsToMany` because of the way bookshelf relations
work. In reality the relationship is 'hasMany', e.g. a Product has many
Stripe Prices.

These relations are the minimal needed to satisfy the following
relationships without transforming the results. (e.g. flattening the
StripePrices from a list of StripeProducts for a Product)

```
Product -> StripeProduct:       product.related('stripeProducts')
StripeProduct -> StripePrice:   stripeProduct.related('stripePrices');
Product -> StripePrice:         product.related('stripePrices');
StripePrice -> Product:         stripePrice.related('stripeProduct.product');
```