### PR TITLE
Added settings keys to store OAuth related data

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -12,7 +12,8 @@ const groupTypeMapping = {
     portal: 'portal',
     email: 'bulk_email',
     newsletter: 'newsletter',
-    firstpromoter: 'firstpromoter'
+    firstpromoter: 'firstpromoter',
+    oauth: 'oauth'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/api/v2/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -12,7 +12,8 @@ const groupTypeMapping = {
     portal: 'portal',
     email: 'bulk_email',
     newsletter: 'newsletter',
-    firstpromoter: 'firstpromoter'
+    firstpromoter: 'firstpromoter',
+    oauth: 'oauth'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/api/v3/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/v3/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -12,7 +12,8 @@ const groupTypeMapping = {
     portal: 'portal',
     email: 'bulk_email',
     newsletter: 'newsletter',
-    firstpromoter: 'firstpromoter'
+    firstpromoter: 'firstpromoter',
+    oauth: 'oauth'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/data/exporter/index.js
+++ b/core/server/data/exporter/index.js
@@ -69,7 +69,9 @@ const SETTING_KEYS_BLOCKLIST = [
     'stripe_secret_key',
     'stripe_publishable_key',
     'members_stripe_webhook_id',
-    'members_stripe_webhook_secret'
+    'members_stripe_webhook_secret',
+    'oauth_client_id',
+    'oauth_client_secret'
 ];
 
 const modelOptions = {context: {internal: true}};

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -467,5 +467,15 @@
             "defaultValue": "",
             "type": "string"
         }
+    },
+    "oauth": {
+        "oauth_client_id" : {
+            "defaultValue": null,
+            "type": "string"
+        },
+        "oauth_client_secret" : {
+            "defaultValue": null,
+            "type": "string"
+        }
     }
 }

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -77,7 +77,9 @@ const defaultSettingsKeyTypes = [
     {key: 'newsletter_body_font_category', type: 'newsletter'},
     {key: 'newsletter_footer_content', type: 'newsletter'},
     {key: 'firstpromoter', type: 'firstpromoter'},
-    {key: 'firstpromoter_id', type: 'firstpromoter'}
+    {key: 'firstpromoter_id', type: 'firstpromoter'},
+    {key: 'oauth_client_id', type: 'oauth'},
+    {key: 'oauth_client_secret', type: 'oauth'}
 ];
 
 describe('Settings API (canary)', function () {

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -71,7 +71,9 @@ const defaultSettingsKeyTypes = [
     {key: 'newsletter_footer_content', type: 'newsletter'},
     {key: 'newsletter_body_font_category', type: 'newsletter'},
     {key: 'firstpromoter', type: 'firstpromoter'},
-    {key: 'firstpromoter_id', type: 'firstpromoter'}
+    {key: 'firstpromoter_id', type: 'firstpromoter'},
+    {key: 'oauth_client_id', type: 'oauth'},
+    {key: 'oauth_client_secret', type: 'oauth'}
 ];
 
 describe('Settings API (v2)', function () {

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -75,7 +75,9 @@ const defaultSettingsKeyTypes = [
     {key: 'newsletter_body_font_category', type: 'newsletter'},
     {key: 'newsletter_footer_content', type: 'newsletter'},
     {key: 'firstpromoter', type: 'firstpromoter'},
-    {key: 'firstpromoter_id', type: 'firstpromoter'}
+    {key: 'firstpromoter_id', type: 'firstpromoter'},
+    {key: 'oauth_client_id', type: 'oauth'},
+    {key: 'oauth_client_secret', type: 'oauth'}
 ];
 
 describe('Settings API (v3)', function () {

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -34,7 +34,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '19f3f2750320798dac398be2eb51d3e5';
     const currentFixturesHash = '3dc9747eadecec34958dfba14c5332db';
-    const currentSettingsHash = '7ac732b994a5bb1565f88c8a84872964';
+    const currentSettingsHash = 'b7c859988a6195db8daf8cfa8a65b171';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/618

- The `oauth_client_id` and `oauth_client_secret` are placeholders to store OAuths related data.
- The flag for `oauth_enabled` or anything along those lines was not added intentionally in favour of checking if the `oauth_client_id` & `oauth_client_secret` are null.

WIP:
- need to reconfirm if creating a new group `sso` (or maybe named in a different way) is a right way to go
- need to double check if we are still meant to do an `update` on the migration level or `create` after the [split in the initialization sequence](https://github.com/TryGhost/Ghost/pull/12595) has happened