### PR TITLE
Updated `tmp` dependency to v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "should": "13.2.3",
     "sinon": "10.0.0",
     "supertest": "6.1.3",
-    "tmp": "0.0.33"
+    "tmp": "0.2.1"
   },
   "resolutions": {
     "moment": "2.24.0",

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,6 @@
       "moment",
       "moment-timezone",
       "nodemailer",
-      "tmp",
       "validator",
       "simple-dom"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8343,7 +8343,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.2, rimraf@~3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2, rimraf@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -9302,7 +9302,14 @@ tlds@^1.203.0:
   resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.207.0.tgz#459264e644cf63ddc0965fece3898913286b1afd"
   integrity sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg==
 
-tmp@0.0.33, tmp@^0.0.33:
+tmp@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
+
+tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==


### PR DESCRIPTION
no issue

- `tmp` 0.1.0 was broken and I added `tmp` to the Renovate ignore list
  to stop it creating PRs - https://github.com/TryGhost/Ghost/commit/082160106ae4fbedcf7de99b671d42e001ca2a89
- 0.2.1 is fixed again so we can merge the update and remove it from the
  list