### PR TITLE
Added cascade delete for stripe products and prices

### DIFF
--- a/core/server/data/migrations/versions/4.3/05-add-stripe-products-table.js
+++ b/core/server/data/migrations/versions/4.3/05-add-stripe-products-table.js
@@ -2,7 +2,7 @@ const {addTable} = require('../../utils');
 
 module.exports = addTable('stripe_products', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-    product_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'products.id'},
+    product_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'products.id', cascadeDelete: true},
     stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
     created_at: {type: 'dateTime', nullable: false},
     updated_at: {type: 'dateTime', nullable: true}

--- a/core/server/data/migrations/versions/4.3/06-add-stripe-prices-table.js
+++ b/core/server/data/migrations/versions/4.3/06-add-stripe-prices-table.js
@@ -3,7 +3,7 @@ const {addTable} = require('../../utils');
 module.exports = addTable('stripe_prices', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     stripe_price_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
-    stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'stripe_products.stripe_product_id'},
+    stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'stripe_products.stripe_product_id', cascadeDelete: true},
     active: {type: 'boolean', nullable: false},
     nickname: {type: 'string', maxlength: 50, nullable: true},
     currency: {type: 'string', maxLength: 3, nullable: false},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -488,7 +488,7 @@ module.exports = {
     stripe_prices: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         stripe_price_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
-        stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'stripe_products.stripe_product_id'},
+        stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'stripe_products.stripe_product_id', cascadeDelete: true},
         active: {type: 'boolean', nullable: false},
         nickname: {type: 'string', maxlength: 50, nullable: true},
         currency: {type: 'string', maxLength: 3, nullable: false},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -480,7 +480,7 @@ module.exports = {
     },
     stripe_products: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        product_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'products.id'},
+        product_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'products.id', cascadeDelete: true},
         stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '19f3f2750320798dac398be2eb51d3e5';
+    const currentSchemaHash = 'b94aa62d6e50eb42280837605e3f4a66';
     const currentFixturesHash = '3dc9747eadecec34958dfba14c5332db';
     const currentSettingsHash = 'b943cc3956eee3dd042f8394b2701d21';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/586

If a product inside Ghost is deleted, we want to cascade delete all associated Stripe products and prices as they need to refer to a ghost product. Adds cascade delete for products -> stripe_products -> stripe_prices -> members_stripe_customers_subscriptions to avoid broken states
