### PR TITLE
Added Default Product fixture

### DIFF
--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -1,6 +1,15 @@
 {
     "models": [
         {
+            "name": "Product",
+            "entries": [
+                {
+                    "name":             "Default Product",
+                    "slug":             "default-product"
+                }
+            ]
+        },
+        {
             "name": "Tag",
             "entries": [
                 {

--- a/test/unit/data/schema/fixtures/utils_spec.js
+++ b/test/unit/data/schema/fixtures/utils_spec.js
@@ -100,7 +100,11 @@ describe('Migration Fixture Utils', function () {
             const postOneStub = sinon.stub(models.Post, 'findOne').returns(Promise.resolve());
             const postAddStub = sinon.stub(models.Post, 'add').returns(Promise.resolve({}));
 
-            fixtureUtils.addFixturesForModel(fixtures.models[4]).then(function (result) {
+            const postFixtures = fixtures.models.find((modelFixture) => {
+                return modelFixture.name === 'Post';
+            });
+
+            fixtureUtils.addFixturesForModel(postFixtures).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', 11);
@@ -117,7 +121,11 @@ describe('Migration Fixture Utils', function () {
             const postOneStub = sinon.stub(models.Post, 'findOne').returns(Promise.resolve({}));
             const postAddStub = sinon.stub(models.Post, 'add').returns(Promise.resolve({}));
 
-            fixtureUtils.addFixturesForModel(fixtures.models[4]).then(function (result) {
+            const postFixtures = fixtures.models.find((modelFixture) => {
+                return modelFixture.name === 'Post';
+            });
+
+            fixtureUtils.addFixturesForModel(postFixtures).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', 11);

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -33,7 +33,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'c31e5e88461bbc015a9e50561d07f6f7';
-    const currentFixturesHash = '3dc9747eadecec34958dfba14c5332db';
+    const currentFixturesHash = 'b24801cf9f819e4c127316021877ad70';
     const currentSettingsHash = 'b943cc3956eee3dd042f8394b2701d21';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/619

As part of the Custom Products work, we are linking members to products
when updating their subscriptions. This requires that we have at least
one product in the database. For existing sites that are using Members
this is handled by the v4.3 03 migration. But for new sites we must
include a fixture.