### PR TITLE
Added OAuth user data

### DIFF
--- a/core/server/data/exporter/table-lists.js
+++ b/core/server/data/exporter/table-lists.js
@@ -14,6 +14,7 @@ const BACKUP_TABLES = [
     'members_stripe_customers_subscriptions',
     'migrations',
     'migrations_lock',
+    'oauth',
     'permissions',
     'permissions_roles',
     'permissions_users',

--- a/core/server/data/migrations/versions/4.11/01-add-oauth-user-data.js
+++ b/core/server/data/migrations/versions/4.11/01-add-oauth-user-data.js
@@ -1,0 +1,12 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('oauth', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    provider: {type: 'string', maxlength: 50, nullable: false},
+    provider_id: {type: 'string', maxlength: 191, nullable: false},
+    access_token: {type: 'text', maxlength: 65535, nullable: true},
+    refresh_token: {type: 'text', maxlength: 2000, nullable: true},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: true},
+    user_id: {type: 'string', maxlength: 24, nullable: false, references: 'users.id'}
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -112,6 +112,16 @@ module.exports = {
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true}
     },
+    oauth: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        provider: {type: 'string', maxlength: 50, nullable: false},
+        provider_id: {type: 'string', maxlength: 191, nullable: false},
+        access_token: {type: 'text', maxlength: 65535, nullable: true},
+        refresh_token: {type: 'text', maxlength: 2000, nullable: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: true},
+        user_id: {type: 'string', maxlength: 24, nullable: false, references: 'users.id'}
+    },
     posts_authors: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id'},

--- a/test/regression/exporter/exporter.test.js
+++ b/test/regression/exporter/exporter.test.js
@@ -45,6 +45,7 @@ describe('Exporter', function () {
                 'migrations',
                 'migrations_lock',
                 'mobiledoc_revisions',
+                'oauth',
                 'permissions',
                 'permissions_roles',
                 'permissions_users',

--- a/test/unit/data/schema/integrity.test.js
+++ b/test/unit/data/schema/integrity.test.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '32e92f2cf2874d6d8ac68bfdc97cd885';
+    const currentSchemaHash = 'a2248eaa72a9d08c3753b90a9436dbe3';
     const currentFixturesHash = '97283c575b1f6c84c27db6e1b1be21d4';
     const currentSettingsHash = 'dd0a0a08e66b252e7704bb7e346a8c20';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
issue https://github.com/TryGhost/Team/issues/614

## String field sizes

The sizes are picked from the [Ghost string sizes](https://github.com/TryGhost/Ghost/blob/49f48c0f09ba2b07c0af9725ca24941fa2144ce3/core/server/data/schema/schema.js#L1-L9).

- `id` is a standard ID, so it gets the standard size (24)
- `user_id` is a foreign key so it gets the same size as the other column
- `provider` is a simple string that contains a provider name like `google`, `github`... From the [grant npm module](https://www.npmjs.com/package/grant) (compatible with 200+ oauth providers), the longest provider string is 16 chars, so we should be good with 50 characters.
- `provider_id` is an arbitrary string provided by the oauth provider. It's hard to find accurate data outside of [Twitter](https://developer.twitter.com/en/docs/twitter-ids), which has 64-bits unsigned integers user ids (max 19 characters). Given the magnitude of twitter, 191 characters to store user ids seems very safe. A recent google id example was 21 characters-long (all digits) so it confirms the 191-characters length.
- `access_token` from [google can be up to 2048 bytes](https://developers.google.com/identity/protocols/oauth2#size) so it get a 65535 length
- `refresh_token` from [google can be up to 512 bytes](https://developers.google.com/identity/protocols/oauth2#size), so it gets a 200 length