### PR TITLE
🐛 Fixed Ghost 4.3.0 migration that put all sites into "allow free members signup"

### DIFF
--- a/core/server/data/migrations/versions/4.3/08-migrate-members-signup-setting.js
+++ b/core/server/data/migrations/versions/4.3/08-migrate-members-signup-setting.js
@@ -20,7 +20,7 @@ module.exports = createTransactionalMigration(
             .select('value')
             .first();
 
-        const migrateValue = oldSetting.value ? 'all' : 'invite';
+        const migrateValue = oldSetting.value === 'true' ? 'all' : 'invite';
 
         if (newSetting) {
             // new setting already exists, *update* with migrated value
@@ -75,7 +75,7 @@ module.exports = createTransactionalMigration(
 
         // this can potentially be lossy if going from "nobody" but it matches to the
         // most appropriate setting available in earlier versions of Ghost
-        const rollbackValue = newSetting.value === 'all' ? true : false;
+        const rollbackValue = newSetting.value === 'all' ? 'true' : 'false';
 
         if (oldSetting) {
             logging.info('Updating `members_allow_free_signup` based on value from `members_signup_access`');


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/634

- the migration moving `members_allow_free_signup` to `members_signup_access` was expecting a raw boolean setting value but the actual value is a string so always evaluated as truthy making all sites look like they had "allow free members signup" toggled on when generating the new setting's value
- updated to check for an explicit string value in `up` and set an explicit string value in `down`
