### PR TITLE
Added members signup access setting to Portal

### DIFF
--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -96,6 +96,7 @@ const getMemberSiteData = async function (req, res) {
         version: ghostVersion.safe,
         plans: membersService.config.getPublicPlans(),
         allow_self_signup: membersService.config.getAllowSelfSignup(),
+        members_signup_access: settingsCache.get('members_signup_access'),
         is_stripe_configured: isStripeConfigured,
         portal_button: settingsCache.get('portal_button'),
         portal_name: settingsCache.get('portal_name'),


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/579

The new signup access setting allows site owner to set the type of access level allowed for a member which Portal needs to handle