### PR TITLE
🎨 Added `{{#has members="all|invite|none|true|false"}}`

### DIFF
--- a/core/frontend/helpers/has.js
+++ b/core/frontend/helpers/has.js
@@ -4,9 +4,9 @@
 //
 // Checks if a post has a particular property
 
-const {logging, i18n} = require('../services/proxy');
+const {logging, i18n, settingsCache} = require('../services/proxy');
 const _ = require('lodash');
-const validAttrs = ['tag', 'author', 'slug','visibility', 'id', 'number', 'index', 'any', 'all'];
+const validAttrs = ['tag', 'author', 'slug','visibility', 'id', 'number', 'index', 'any', 'all', 'members'];
 
 function handleCount(ctxAttr, data) {
     if (!data || !_.isFinite(data.length)) {
@@ -113,6 +113,20 @@ function evaluateList(type, expr, obj, data) {
     });
 }
 
+function evaluateMembersMatch(value) {
+    const membersSignupAccess = settingsCache.get('members_signup_access');
+
+    if (value === 'true') {
+        return ['all', 'invite'].includes(membersSignupAccess);
+    }
+
+    if (value === 'false') {
+        return membersSignupAccess === 'none';
+    }
+
+    return value === membersSignupAccess;
+}
+
 module.exports = function has(options) {
     options = options || {};
     options.hash = options.hash || {};
@@ -149,6 +163,9 @@ module.exports = function has(options) {
         },
         all: function () {
             return attrs.all && evaluateList('every', attrs.all, self, data) || false;
+        },
+        members: function () {
+            return attrs.members && evaluateMembersMatch(attrs.members) || false;
         }
     };
 

--- a/test/unit/helpers/has_spec.js
+++ b/test/unit/helpers/has_spec.js
@@ -3,6 +3,8 @@ const sinon = require('sinon');
 
 // Stuff we are testing
 const helpers = require('../../../core/frontend/helpers');
+const proxy = require('../../../core/frontend/services/proxy');
+const settingsCache = proxy.settingsCache;
 
 describe('{{#has}} helper', function () {
     let fn;
@@ -27,6 +29,8 @@ describe('{{#has}} helper', function () {
             fn: fn,
             inverse: inverse
         };
+
+        sinon.stub(settingsCache, 'get');
     });
 
     function callHasHelper(context, hash) {
@@ -840,6 +844,56 @@ describe('{{#has}} helper', function () {
 
             fn.called.should.be.false();
             inverse.called.should.be.true();
+        });
+    });
+
+    describe('members signup access match', function () {
+        it('matches "all"', function () {
+            settingsCache.get.withArgs('members_signup_access').returns('all');
+
+            callHasHelper(thisCtx, {members: 'all'});
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('matches "invite"', function () {
+            settingsCache.get.withArgs('members_signup_access').returns('invite');
+
+            callHasHelper(thisCtx, {members: 'invite'});
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('matches "none"', function () {
+            settingsCache.get.withArgs('members_signup_access').returns('none');
+
+            callHasHelper(thisCtx, {members: 'none'});
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('matches "true" with "invite"', function () {
+            settingsCache.get.withArgs('members_signup_access').returns('invite');
+
+            callHasHelper(thisCtx, {members: 'true'});
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('matches "true" with "all"', function () {
+            settingsCache.get.withArgs('members_signup_access').returns('all');
+
+            callHasHelper(thisCtx, {members: 'true'});
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('matches "false" with "none"', function () {
+            settingsCache.get.withArgs('members_signup_access').returns('none');
+
+            callHasHelper(thisCtx, {members: 'false'});
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
         });
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/626
refs https://github.com/TryGhost/Team/issues/579

We've introduced some new options for members signup access which allows for explicitly turning members off altogether or turning off signup to make an invite-only site.

Previously `@labs.members` was used to determine if members was enabled or disabled but that setting is deprecated and will be removed in the next major Ghost release. Instead the `{{#has}}` helper has been extended to provide more granular conditionals for themes.

Usage:
`{{#has members="true"}}` - members is active with either all functionality or sign-in only
`{{#has members="all"}}` - members is active with sign-in and sign-up enabled
`{{#has members="invite"}}` - members is active with only sign-in enabled
`{{#has members="false/none"}}` - all members functionality is disabled
