### PR TITLE
Added invite only handling to Portal

### DIFF
--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -122,6 +122,6 @@
     },
     "portal": {
         "url": "https://unpkg.com/@tryghost/portal@~1.1.0/umd/portal.min.js",
-        "version": "~1.1.0"
+        "version": "~1.2.0"
     }
 }


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/579

Updates Portal to handle the new members_signup_access setting and explicitly handle the `invite` option to make Portal work in invite only mode if selected