### PR TITLE
Added default email recipients settings

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -13,7 +13,8 @@ const groupTypeMapping = {
     email: 'bulk_email',
     newsletter: 'newsletter',
     firstpromoter: 'firstpromoter',
-    oauth: 'oauth'
+    oauth: 'oauth',
+    editor: 'editor'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/api/v2/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -13,7 +13,8 @@ const groupTypeMapping = {
     email: 'bulk_email',
     newsletter: 'newsletter',
     firstpromoter: 'firstpromoter',
-    oauth: 'oauth'
+    oauth: 'oauth',
+    editor: 'editor'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/api/v3/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/v3/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -13,7 +13,8 @@ const groupTypeMapping = {
     email: 'bulk_email',
     newsletter: 'newsletter',
     firstpromoter: 'firstpromoter',
-    oauth: 'oauth'
+    oauth: 'oauth',
+    editor: 'editor'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -477,5 +477,23 @@
             "defaultValue": null,
             "type": "string"
         }
+    },
+    "editor": {
+        "editor_default_email_recipients": {
+            "defaultValue": "visibility",
+            "type": "string",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [[
+                    "disabled",
+                    "visibility",
+                    "filter"
+                ]]
+            }
+        },
+        "editor_default_email_recipients_filter": {
+            "defaultValue": "all",
+            "type": "string"
+        }
     }
 }

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -79,7 +79,9 @@ const defaultSettingsKeyTypes = [
     {key: 'firstpromoter', type: 'firstpromoter'},
     {key: 'firstpromoter_id', type: 'firstpromoter'},
     {key: 'oauth_client_id', type: 'oauth'},
-    {key: 'oauth_client_secret', type: 'oauth'}
+    {key: 'oauth_client_secret', type: 'oauth'},
+    {key: 'editor_default_email_recipients', type: 'editor'},
+    {key: 'editor_default_email_recipients_filter', type: 'editor'}
 ];
 
 describe('Settings API (canary)', function () {

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -73,7 +73,9 @@ const defaultSettingsKeyTypes = [
     {key: 'firstpromoter', type: 'firstpromoter'},
     {key: 'firstpromoter_id', type: 'firstpromoter'},
     {key: 'oauth_client_id', type: 'oauth'},
-    {key: 'oauth_client_secret', type: 'oauth'}
+    {key: 'oauth_client_secret', type: 'oauth'},
+    {key: 'editor_default_email_recipients', type: 'editor'},
+    {key: 'editor_default_email_recipients_filter', type: 'editor'}
 ];
 
 describe('Settings API (v2)', function () {

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -77,7 +77,9 @@ const defaultSettingsKeyTypes = [
     {key: 'firstpromoter', type: 'firstpromoter'},
     {key: 'firstpromoter_id', type: 'firstpromoter'},
     {key: 'oauth_client_id', type: 'oauth'},
-    {key: 'oauth_client_secret', type: 'oauth'}
+    {key: 'oauth_client_secret', type: 'oauth'},
+    {key: 'editor_default_email_recipients', type: 'editor'},
+    {key: 'editor_default_email_recipients_filter', type: 'editor'}
 ];
 
 describe('Settings API (v3)', function () {

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -34,7 +34,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'b7bca80554f3946cd2f83e0e99ff3532';
     const currentFixturesHash = 'b24801cf9f819e4c127316021877ad70';
-    const currentSettingsHash = 'b943cc3956eee3dd042f8394b2701d21';
+    const currentSettingsHash = 'c202cf5780aa77d8730a82680e2b142e';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/496

We want to give more control over the default selection of email recipients when publishing a post, to do that we need somewhere to store those settings. These settings are site-wide and intended for use by admins to control the default editor behaviour for all staff users. They _do not_ control API behaviour, if you want to send email when publishing via the API it's still necessary to explicitly opt in to that using the `?email_recipient_filter=` query param.

- new `editor` settings group to indicate that these settings only affect the UI rather than the API
- `editor_default_email_recipients` controls overall behaviour, string/enum with these allowed values:
  - `'disabled'`: no option to send email is shown in the editor's publishing dropdown
  - `'visibility'`: (default) selected member segment is dynamic and matches the post visibility filter
  - `'filter'`: specific member filter defined in `editor_default_email_recipients_filter` setting
- `editor_default_email_recipients_filter` is an NQL string for selecting members, used when `editor_default_email_recipients` is set to `'filter'`
  - default value is `'all'`
  - the segment string can be any valid NQL filter with the additional special-case values of `'all'` and `'none'`