### PR TITLE
Removed unique constraint from Product names

### DIFF
--- a/core/server/data/migrations/versions/4.5/04-remove-unique-constraint-from-product-name.js
+++ b/core/server/data/migrations/versions/4.5/04-remove-unique-constraint-from-product-name.js
@@ -1,0 +1,13 @@
+const {createNonTransactionalMigration} = require('../../utils');
+const {dropUnique} = require('../../../schema/commands');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        return await dropUnique('products', 'name', knex);
+    },
+    async function down() {
+        // We cannot roll back this migration because adding a unique constraint
+        // could error if we have duplicate names already in the table.
+        return;
+    }
+);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -363,7 +363,7 @@ module.exports = {
     },
     products: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        name: {type: 'string', maxlength: 191, nullable: false, unique: true},
+        name: {type: 'string', maxlength: 191, nullable: false},
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
         description: {type: 'string', maxlength: 191, nullable: true},
         created_at: {type: 'dateTime', nullable: false},

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'bcb57235883ddb9765f9abf8ab878cd7';
+    const currentSchemaHash = '7886f066821a240b85c6b61ba2dcff65';
     const currentFixturesHash = '8671672598d2a62e53418c4b91aa79a3';
     const currentSettingsHash = 'c202cf5780aa77d8730a82680e2b142e';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/586

A discussion in the Members team resulted in us determining that we do
not need to enforce unique names for Products. Stripe does not enforce
uniqueness for their Products, and we feel it's not necessary for us to.