### PR TITLE
🐛 Fixed members list not loading

### DIFF
--- a/core/server/models/stripe-customer-subscription.js
+++ b/core/server/models/stripe-customer-subscription.js
@@ -1,4 +1,5 @@
 const ghostBookshelf = require('./base');
+const _ = require('lodash');
 
 const StripeCustomerSubscription = ghostBookshelf.Model.extend({
     tableName: 'members_stripe_customers_subscriptions',
@@ -37,7 +38,7 @@ const StripeCustomerSubscription = ghostBookshelf.Model.extend({
             current_period_end: defaultSerializedObject.current_period_end
         };
 
-        if (defaultSerializedObject.stripePrice) {
+        if (!_.isEmpty(defaultSerializedObject.stripePrice)) {
             serialized.price = {
                 id: defaultSerializedObject.stripePrice.stripe_price_id,
                 nickname: defaultSerializedObject.stripePrice.nickname,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/660

In case stripe price for a subscription is missing in `stripe_prices` table, it will cause the API to load members list to fail with 500 as we try to serialize the stripe price on member subscription using empty object. This fixes the guard against populating price object for missing data in DB.

Note: This is only a short-term fix till we add a proper fix to cleanup the DB in the subsequent release.