### PR TITLE
✨ Added ability to send a newsletter to members with a certain label or product

### DIFF
--- a/core/server/api/canary/utils/serializers/input/posts.js
+++ b/core/server/api/canary/utils/serializers/input/posts.js
@@ -102,6 +102,15 @@ const forceStatusFilter = (frame) => {
     }
 };
 
+const transformLegacyEmailRecipientFilters = (frame) => {
+    if (frame.options.email_recipient_filter === 'free') {
+        frame.options.email_recipient_filter = 'status:free';
+    }
+    if (frame.options.email_recipient_filter === 'paid') {
+        frame.options.email_recipient_filter = 'status:-free';
+    }
+};
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
@@ -196,6 +205,7 @@ module.exports = {
             });
         }
 
+        transformLegacyEmailRecipientFilters(frame);
         handlePostsMeta(frame);
         defaultFormat(frame);
         defaultRelations(frame);
@@ -205,6 +215,7 @@ module.exports = {
         debug('edit');
         this.add(apiConfig, frame, {add: false});
 
+        transformLegacyEmailRecipientFilters(frame);
         handlePostsMeta(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);

--- a/core/server/api/v3/utils/serializers/input/posts.js
+++ b/core/server/api/v3/utils/serializers/input/posts.js
@@ -102,6 +102,15 @@ const forceStatusFilter = (frame) => {
     }
 };
 
+const transformLegacyEmailRecipientFilters = (frame) => {
+    if (frame.options.email_recipient_filter === 'free') {
+        frame.options.email_recipient_filter = 'status:free';
+    }
+    if (frame.options.email_recipient_filter === 'paid') {
+        frame.options.email_recipient_filter = 'status:-free';
+    }
+};
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
@@ -204,6 +213,7 @@ module.exports = {
             });
         }
 
+        transformLegacyEmailRecipientFilters(frame);
         handlePostsMeta(frame);
         defaultFormat(frame);
         defaultRelations(frame);
@@ -213,6 +223,7 @@ module.exports = {
         debug('edit');
         this.add(apiConfig, frame, {add: false});
 
+        transformLegacyEmailRecipientFilters(frame);
         handlePostsMeta(frame);
         forceStatusFilter(frame);
         forcePageFilter(frame);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -34,8 +34,7 @@ module.exports = {
             type: 'string',
             maxlength: 50,
             nullable: false,
-            defaultTo: 'none',
-            validations: {isIn: [['none', 'all', 'free', 'paid']]}
+            defaultTo: 'none'
         },
         /**
          * @deprecated: single authors was superceded by multiple authors in Ghost 1.22.0
@@ -529,8 +528,7 @@ module.exports = {
             type: 'string',
             maxlength: 50,
             nullable: false,
-            defaultTo: 'paid',
-            validations: {isIn: [['all', 'free', 'paid']]}
+            defaultTo: 'status:-free'
         },
         error: {type: 'string', maxlength: 2000, nullable: true},
         error_data: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},

--- a/core/server/models/email.js
+++ b/core/server/models/email.js
@@ -8,7 +8,7 @@ const Email = ghostBookshelf.Model.extend({
         return {
             uuid: uuid.v4(),
             status: 'pending',
-            recipient_filter: 'paid',
+            recipient_filter: 'status:-free',
             track_opens: false,
             delivered_count: 0,
             opened_count: 0,
@@ -16,12 +16,40 @@ const Email = ghostBookshelf.Model.extend({
         };
     },
 
+    parse() {
+        const attrs = ghostBookshelf.Model.prototype.parse.apply(this, arguments);
+
+        // update legacy recipient_filter values to proper NQL
+        if (attrs.recipient_filter === 'free') {
+            attrs.recipient_filter = 'status:free';
+        }
+        if (attrs.recipient_filter === 'paid') {
+            attrs.recipient_filter = 'status:-free';
+        }
+
+        return attrs;
+    },
+
+    formatOnWrite(attrs) {
+        // update legacy recipient_filter values to proper NQL
+        if (attrs.recipient_filter === 'free') {
+            attrs.recipient_filter = 'status:free';
+        }
+        if (attrs.recipient_filter === 'paid') {
+            attrs.recipient_filter = 'status:-free';
+        }
+
+        return attrs;
+    },
+
     post() {
         return this.belongsTo('Post', 'post_id');
     },
+
     emailBatches() {
         return this.hasMany('EmailBatch', 'email_id');
     },
+
     recipients() {
         return this.hasMany('EmailRecipient', 'email_id');
     },

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -101,6 +101,14 @@ Post = ghostBookshelf.Model.extend({
             }
         });
 
+        // update legacy email_recipient_filter values to proper NQL
+        if (attrs.email_recipient_filter === 'free') {
+            attrs.email_recipient_filter = 'status:free';
+        }
+        if (attrs.email_recipient_filter === 'paid') {
+            attrs.email_recipient_filter = 'status:-free';
+        }
+
         return attrs;
     },
 
@@ -138,6 +146,14 @@ Post = ghostBookshelf.Model.extend({
                 attrs[attrToTransform] = urlUtils[method](attrs[attrToTransform], transformOptions);
             }
         });
+
+        // update legacy email_recipient_filter values to proper NQL
+        if (attrs.email_recipient_filter === 'free') {
+            attrs.email_recipient_filter = 'status:free';
+        }
+        if (attrs.email_recipient_filter === 'paid') {
+            attrs.email_recipient_filter = 'status:-free';
+        }
 
         return attrs;
     },

--- a/core/shared/i18n/translations/en.json
+++ b/core/shared/i18n/translations/en.json
@@ -355,7 +355,8 @@
                 "notificationDoesNotExist": "Notification does not exist."
             },
             "posts": {
-                "postNotFound": "Post not found."
+                "postNotFound": "Post not found.",
+                "invalidEmailRecipientFilter": "Invalid filter in email_recipient_filter param."
             },
             "authors": {
                 "notFound": "Author not found."

--- a/test/regression/api/canary/admin/posts_spec.js
+++ b/test/regression/api/canary/admin/posts_spec.js
@@ -604,6 +604,40 @@ describe('Posts API (canary)', function () {
                     should.equal(res.body.posts[0].plaintext, undefined);
                 });
         });
+
+        it('errors with invalid email recipient filter', function () {
+            return request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Ready to be emailed',
+                        status: 'draft'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201)
+                .then((res) => {
+                    return request
+                        .put(`${localUtils.API.getApiQuery(`posts/${res.body.posts[0].id}/`)}?email_recipient_filter=not a filter`)
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                title: res.body.posts[0].title,
+                                mobilecdoc: res.body.posts[0].mobilecdoc,
+                                updated_at: res.body.posts[0].updated_at,
+                                status: 'published'
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(400);
+                })
+                .then((res) => {
+                    res.text.should.match(/invalid filter/i);
+                });
+        });
     });
 
     describe('Destroy', function () {

--- a/test/regression/api/v3/admin/posts_spec.js
+++ b/test/regression/api/v3/admin/posts_spec.js
@@ -604,6 +604,40 @@ describe('Posts API (v3)', function () {
                     should.equal(res.body.posts[0].plaintext, undefined);
                 });
         });
+
+        it('errors with invalid email recipient filter', function () {
+            return request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Ready to be emailed',
+                        status: 'draft'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201)
+                .then((res) => {
+                    return request
+                        .put(`${localUtils.API.getApiQuery(`posts/${res.body.posts[0].id}/`)}?email_recipient_filter=not a filter`)
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                title: res.body.posts[0].title,
+                                mobilecdoc: res.body.posts[0].mobilecdoc,
+                                updated_at: res.body.posts[0].updated_at,
+                                status: 'published'
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(400);
+                })
+                .then((res) => {
+                    res.text.should.match(/invalid filter/i);
+                });
+        });
     });
 
     describe('Destroy', function () {

--- a/test/unit/api/canary/utils/serializers/input/posts_spec.js
+++ b/test/unit/api/canary/utils/serializers/input/posts_spec.js
@@ -361,5 +361,71 @@ describe('Unit: canary/utils/serializers/input/posts', function () {
                 frame.data.posts[0].tags.should.eql([{name: 'name1'}, {name: 'name2'}]);
             });
         });
+
+        describe('transforms legacy email recipient filter values', function () {
+            it('free becomes status:free', function () {
+                const frame = {
+                    options: {
+                        email_recipient_filter: 'free'
+                    },
+                    data: {
+                        posts: [{id: '1'}]
+                    }
+                };
+
+                serializers.input.posts.edit({}, frame);
+
+                frame.options.email_recipient_filter.should.eql('status:free');
+            });
+
+            it('paid becomes status:-free', function () {
+                const frame = {
+                    options: {
+                        email_recipient_filter: 'paid'
+                    },
+                    data: {
+                        posts: [{id: '1'}]
+                    }
+                };
+
+                serializers.input.posts.edit({}, frame);
+
+                frame.options.email_recipient_filter.should.eql('status:-free');
+            });
+        });
+    });
+
+    describe('add', function () {
+        describe('transforms legacy email recipient filter values', function () {
+            it('free becomes status:free', function () {
+                const frame = {
+                    options: {
+                        email_recipient_filter: 'free'
+                    },
+                    data: {
+                        posts: [{id: '1'}]
+                    }
+                };
+
+                serializers.input.posts.add({}, frame);
+
+                frame.options.email_recipient_filter.should.eql('status:free');
+            });
+
+            it('paid becomes status:-free', function () {
+                const frame = {
+                    options: {
+                        email_recipient_filter: 'paid'
+                    },
+                    data: {
+                        posts: [{id: '1'}]
+                    }
+                };
+
+                serializers.input.posts.add({}, frame);
+
+                frame.options.email_recipient_filter.should.eql('status:-free');
+            });
+        });
     });
 });

--- a/test/unit/api/v3/utils/serializers/input/posts_spec.js
+++ b/test/unit/api/v3/utils/serializers/input/posts_spec.js
@@ -361,5 +361,71 @@ describe('Unit: v3/utils/serializers/input/posts', function () {
                 frame.data.posts[0].tags.should.eql([{name: 'name1'}, {name: 'name2'}]);
             });
         });
+
+        describe('transforms legacy email recipient filter values', function () {
+            it('free becomes status:free', function () {
+                const frame = {
+                    options: {
+                        email_recipient_filter: 'free'
+                    },
+                    data: {
+                        posts: [{id: '1'}]
+                    }
+                };
+
+                serializers.input.posts.edit({}, frame);
+
+                frame.options.email_recipient_filter.should.eql('status:free');
+            });
+
+            it('paid becomes status:-free', function () {
+                const frame = {
+                    options: {
+                        email_recipient_filter: 'paid'
+                    },
+                    data: {
+                        posts: [{id: '1'}]
+                    }
+                };
+
+                serializers.input.posts.edit({}, frame);
+
+                frame.options.email_recipient_filter.should.eql('status:-free');
+            });
+        });
+    });
+
+    describe('add', function () {
+        describe('transforms legacy email recipient filter values', function () {
+            it('free becomes status:free', function () {
+                const frame = {
+                    options: {
+                        email_recipient_filter: 'free'
+                    },
+                    data: {
+                        posts: [{id: '1'}]
+                    }
+                };
+
+                serializers.input.posts.add({}, frame);
+
+                frame.options.email_recipient_filter.should.eql('status:free');
+            });
+
+            it('paid becomes status:-free', function () {
+                const frame = {
+                    options: {
+                        email_recipient_filter: 'paid'
+                    },
+                    data: {
+                        posts: [{id: '1'}]
+                    }
+                };
+
+                serializers.input.posts.add({}, frame);
+
+                frame.options.email_recipient_filter.should.eql('status:-free');
+            });
+        });
     });
 });

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'b7bca80554f3946cd2f83e0e99ff3532';
+    const currentSchemaHash = 'bcb57235883ddb9765f9abf8ab878cd7';
     const currentFixturesHash = '8671672598d2a62e53418c4b91aa79a3';
     const currentSettingsHash = 'c202cf5780aa77d8730a82680e2b142e';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team#581
refs https://github.com/TryGhost/Team#582

When publishing a post via the API it was possible to send it using `?email_recipient_filter=all/free/paid` which allowed you to send to members only based on their payment status which is quite limiting for some sites.

This PR updates the `?email_recipient_filter` query param to support Ghost's `?filter` param syntax which enables more specific recipient lists, eg:

`?email_recipient_filter=status:free` = free members only
`?email_recipient_filter=status:paid` = paid members only
`?email_recipient_filter=label:vip` = members that have the `vip` label attached
`?email_recipient_filter=status:paid,label:vip` = paid members and members that have the `vip` label attached

`'all'` and `'none'` are special-case filter values that are handled by the API and `mega` service.

The older `free/paid` values are still supported by the API for backwards compatibility.

---

- updates `Post` and `Email` models to transform legacy `free` and `paid` values to their NQL equivalents on read/write
  - lets us not worry about supporting legacy values elsewhere in the code
  - cleanup migration to transform all rows slated for a later major release
- removes schema and API `isIn` validations for recipient filters so allow free-form filters
- updates posts API input serializers to transform `free` and `paid` values in the `?email_recipient_filter` param to their NQL equivalents for backwards compatibility
- updates Post API controllers `edit` methods to run a query using the supplied filter to verify that it's valid
- updates `mega` service to use the filter directly when selecting recipients