### PR TITLE
Fixed editors not being able to read labels when assigning member segments

### DIFF
--- a/core/server/data/migrations/versions/4.5/03-give-label-read-permissions-to-editors.js
+++ b/core/server/data/migrations/versions/4.5/03-give-label-read-permissions-to-editors.js
@@ -1,0 +1,14 @@
+const {combineTransactionalMigrations, addPermissionWithRoles} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse labels',
+        action: 'browse',
+        object: 'label'
+    }, ['Editor']),
+    addPermissionWithRoles({
+        name: 'Read labels',
+        action: 'read',
+        object: 'label'
+    }, ['Editor'])
+);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -773,6 +773,7 @@
                     "email_preview": "all",
                     "email": "all",
                     "snippet": "all",
+                    "label": ["browse", "read"],
                     "product": ["browse", "read"]
                 },
                 "Author": {

--- a/test/regression/migrations/migration_spec.js
+++ b/test/regression/migrations/migration_spec.js
@@ -131,11 +131,11 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Add snippets', ['Administrator', 'Editor', 'Admin Integration']);
             permissions.should.havePermission('Delete snippets', ['Administrator', 'Editor', 'Admin Integration']);
 
-            permissions.should.havePermission('Browse labels');
-            permissions.should.havePermission('Read labels');
-            permissions.should.havePermission('Edit labels');
-            permissions.should.havePermission('Add labels');
-            permissions.should.havePermission('Delete labels');
+            permissions.should.havePermission('Browse labels', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Read labels', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Edit labels', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Add labels', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Delete labels', ['Administrator', 'Admin Integration']);
 
             permissions.should.havePermission('Read member signin urls');
             permissions.should.havePermission('Read identities');

--- a/test/unit/data/schema/fixtures/utils_spec.js
+++ b/test/unit/data/schema/fixtures/utils_spec.js
@@ -160,19 +160,19 @@ describe('Migration Fixture Utils', function () {
             fixtureUtils.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
-                result.should.have.property('expected', 77);
-                result.should.have.property('done', 77);
+                result.should.have.property('expected', 78);
+                result.should.have.property('done', 78);
 
                 // Permissions & Roles
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(77);
+                dataMethodStub.filter.callCount.should.eql(78);
                 dataMethodStub.find.callCount.should.eql(7);
-                baseUtilAttachStub.callCount.should.eql(77);
+                baseUtilAttachStub.callCount.should.eql(78);
 
-                fromItem.related.callCount.should.eql(77);
-                fromItem.findWhere.callCount.should.eql(77);
-                toItem[0].get.callCount.should.eql(154);
+                fromItem.related.callCount.should.eql(78);
+                fromItem.findWhere.callCount.should.eql(78);
+                toItem[0].get.callCount.should.eql(156);
 
                 done();
             }).catch(done);

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -33,7 +33,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'b7bca80554f3946cd2f83e0e99ff3532';
-    const currentFixturesHash = 'b24801cf9f819e4c127316021877ad70';
+    const currentFixturesHash = '8671672598d2a62e53418c4b91aa79a3';
     const currentSettingsHash = 'c202cf5780aa77d8730a82680e2b142e';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/581

Editors are allowed to restrict post visibility and send emails to particular member segments, they need to be able to read labels so that they can select them in a member segment.
