### PR TITLE
✨ Added support for gating content by member labels and products

### DIFF
--- a/core/server/api/canary/utils/validators/input/pages.js
+++ b/core/server/api/canary/utils/validators/input/pages.js
@@ -11,7 +11,7 @@ const validateVisibility = async function (frame) {
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.pages[0].visibility;
     if (visibility) {
-        if (!['public', 'members', 'paid'].includes('visibility')) {
+        if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
                 await models.Member.findPage({filter: visibility, limit: 1});

--- a/core/server/api/canary/utils/validators/input/pages.js
+++ b/core/server/api/canary/utils/validators/input/pages.js
@@ -1,6 +1,42 @@
 const jsonSchema = require('../utils/json-schema');
+const models = require('../../../../../models');
+const {ValidationError} = require('@tryghost/errors');
+const i18n = require('../../../../../../shared/i18n');
+
+const validateVisibility = async function (frame) {
+    if (!frame.data.pages || !frame.data.pages[0]) {
+        return Promise.resolve();
+    }
+
+    // validate visibility - not done at schema level because this can be an NQL query so needs model access
+    const visibility = frame.data.pages[0].visibility;
+    if (visibility) {
+        if (!['public', 'members', 'paid'].includes('visibility')) {
+            // check filter is valid
+            try {
+                await models.Member.findPage({filter: visibility, limit: 1});
+                return Promise.resolve();
+            } catch (err) {
+                return Promise.reject(new ValidationError({
+                    message: i18n.t('errors.api.pages.invalidVisibilityFilter'),
+                    property: 'visibility'
+                }));
+            }
+        }
+
+        return Promise.resolve();
+    }
+};
 
 module.exports = {
-    add: jsonSchema.validate,
-    edit: jsonSchema.validate
+    add(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    },
+    edit(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    }
 };

--- a/core/server/api/canary/utils/validators/input/posts.js
+++ b/core/server/api/canary/utils/validators/input/posts.js
@@ -11,7 +11,7 @@ const validateVisibility = async function (frame) {
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.posts[0].visibility;
     if (visibility) {
-        if (!['public', 'members', 'paid'].includes('visibility')) {
+        if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
                 await models.Member.findPage({filter: visibility, limit: 1});

--- a/core/server/api/canary/utils/validators/input/posts.js
+++ b/core/server/api/canary/utils/validators/input/posts.js
@@ -1,6 +1,42 @@
 const jsonSchema = require('../utils/json-schema');
+const models = require('../../../../../models');
+const {ValidationError} = require('@tryghost/errors');
+const i18n = require('../../../../../../shared/i18n');
+
+const validateVisibility = async function (frame) {
+    if (!frame.data.posts || !frame.data.posts[0]) {
+        return Promise.resolve();
+    }
+
+    // validate visibility - not done at schema level because this can be an NQL query so needs model access
+    const visibility = frame.data.posts[0].visibility;
+    if (visibility) {
+        if (!['public', 'members', 'paid'].includes('visibility')) {
+            // check filter is valid
+            try {
+                await models.Member.findPage({filter: visibility, limit: 1});
+                return Promise.resolve();
+            } catch (err) {
+                return Promise.reject(new ValidationError({
+                    message: i18n.t('errors.api.posts.invalidVisibilityFilter'),
+                    property: 'visibility'
+                }));
+            }
+        }
+
+        return Promise.resolve();
+    }
+};
 
 module.exports = {
-    add: jsonSchema.validate,
-    edit: jsonSchema.validate
+    add(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    },
+    edit(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    }
 };

--- a/core/server/api/v2/utils/validators/input/pages.js
+++ b/core/server/api/v2/utils/validators/input/pages.js
@@ -11,7 +11,7 @@ const validateVisibility = async function (frame) {
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.pages[0].visibility;
     if (visibility) {
-        if (!['public', 'members', 'paid'].includes('visibility')) {
+        if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
                 await models.Member.findPage({filter: visibility, limit: 1});

--- a/core/server/api/v2/utils/validators/input/pages.js
+++ b/core/server/api/v2/utils/validators/input/pages.js
@@ -1,6 +1,42 @@
 const jsonSchema = require('../utils/json-schema');
+const models = require('../../../../../models');
+const {ValidationError} = require('@tryghost/errors');
+const i18n = require('../../../../../../shared/i18n');
+
+const validateVisibility = async function (frame) {
+    if (!frame.data.pages || !frame.data.pages[0]) {
+        return Promise.resolve();
+    }
+
+    // validate visibility - not done at schema level because this can be an NQL query so needs model access
+    const visibility = frame.data.pages[0].visibility;
+    if (visibility) {
+        if (!['public', 'members', 'paid'].includes('visibility')) {
+            // check filter is valid
+            try {
+                await models.Member.findPage({filter: visibility, limit: 1});
+                return Promise.resolve();
+            } catch (err) {
+                return Promise.reject(new ValidationError({
+                    message: i18n.t('errors.api.pages.invalidVisibilityFilter'),
+                    property: 'visibility'
+                }));
+            }
+        }
+
+        return Promise.resolve();
+    }
+};
 
 module.exports = {
-    add: jsonSchema.validate,
-    edit: jsonSchema.validate
+    add(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    },
+    edit(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    }
 };

--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -11,7 +11,7 @@ const validateVisibility = async function (frame) {
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.posts[0].visibility;
     if (visibility) {
-        if (!['public', 'members', 'paid'].includes('visibility')) {
+        if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
                 await models.Member.findPage({filter: visibility, limit: 1});

--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -1,6 +1,42 @@
 const jsonSchema = require('../utils/json-schema');
+const models = require('../../../../../models');
+const {ValidationError} = require('@tryghost/errors');
+const i18n = require('../../../../../../shared/i18n');
+
+const validateVisibility = async function (frame) {
+    if (!frame.data.posts || !frame.data.posts[0]) {
+        return Promise.resolve();
+    }
+
+    // validate visibility - not done at schema level because this can be an NQL query so needs model access
+    const visibility = frame.data.posts[0].visibility;
+    if (visibility) {
+        if (!['public', 'members', 'paid'].includes('visibility')) {
+            // check filter is valid
+            try {
+                await models.Member.findPage({filter: visibility, limit: 1});
+                return Promise.resolve();
+            } catch (err) {
+                return Promise.reject(new ValidationError({
+                    message: i18n.t('errors.api.posts.invalidVisibilityFilter'),
+                    property: 'visibility'
+                }));
+            }
+        }
+
+        return Promise.resolve();
+    }
+};
 
 module.exports = {
-    add: jsonSchema.validate,
-    edit: jsonSchema.validate
+    add(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    },
+    edit(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    }
 };

--- a/core/server/api/v3/utils/validators/input/pages.js
+++ b/core/server/api/v3/utils/validators/input/pages.js
@@ -11,7 +11,7 @@ const validateVisibility = async function (frame) {
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.pages[0].visibility;
     if (visibility) {
-        if (!['public', 'members', 'paid'].includes('visibility')) {
+        if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
                 await models.Member.findPage({filter: visibility, limit: 1});

--- a/core/server/api/v3/utils/validators/input/pages.js
+++ b/core/server/api/v3/utils/validators/input/pages.js
@@ -1,6 +1,42 @@
 const jsonSchema = require('../utils/json-schema');
+const models = require('../../../../../models');
+const {ValidationError} = require('@tryghost/errors');
+const i18n = require('../../../../../../shared/i18n');
+
+const validateVisibility = async function (frame) {
+    if (!frame.data.pages || !frame.data.pages[0]) {
+        return Promise.resolve();
+    }
+
+    // validate visibility - not done at schema level because this can be an NQL query so needs model access
+    const visibility = frame.data.pages[0].visibility;
+    if (visibility) {
+        if (!['public', 'members', 'paid'].includes('visibility')) {
+            // check filter is valid
+            try {
+                await models.Member.findPage({filter: visibility, limit: 1});
+                return Promise.resolve();
+            } catch (err) {
+                return Promise.reject(new ValidationError({
+                    message: i18n.t('errors.api.pages.invalidVisibilityFilter'),
+                    property: 'visibility'
+                }));
+            }
+        }
+
+        return Promise.resolve();
+    }
+};
 
 module.exports = {
-    add: jsonSchema.validate,
-    edit: jsonSchema.validate
+    add(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    },
+    edit(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    }
 };

--- a/core/server/api/v3/utils/validators/input/posts.js
+++ b/core/server/api/v3/utils/validators/input/posts.js
@@ -11,7 +11,7 @@ const validateVisibility = async function (frame) {
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.posts[0].visibility;
     if (visibility) {
-        if (!['public', 'members', 'paid'].includes('visibility')) {
+        if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
                 await models.Member.findPage({filter: visibility, limit: 1});

--- a/core/server/api/v3/utils/validators/input/posts.js
+++ b/core/server/api/v3/utils/validators/input/posts.js
@@ -1,6 +1,42 @@
 const jsonSchema = require('../utils/json-schema');
+const models = require('../../../../../models');
+const {ValidationError} = require('@tryghost/errors');
+const i18n = require('../../../../../../shared/i18n');
+
+const validateVisibility = async function (frame) {
+    if (!frame.data.posts || !frame.data.posts[0]) {
+        return Promise.resolve();
+    }
+
+    // validate visibility - not done at schema level because this can be an NQL query so needs model access
+    const visibility = frame.data.posts[0].visibility;
+    if (visibility) {
+        if (!['public', 'members', 'paid'].includes('visibility')) {
+            // check filter is valid
+            try {
+                await models.Member.findPage({filter: visibility, limit: 1});
+                return Promise.resolve();
+            } catch (err) {
+                return Promise.reject(new ValidationError({
+                    message: i18n.t('errors.api.posts.invalidVisibilityFilter'),
+                    property: 'visibility'
+                }));
+            }
+        }
+
+        return Promise.resolve();
+    }
+};
 
 module.exports = {
-    add: jsonSchema.validate,
-    edit: jsonSchema.validate
+    add(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    },
+    edit(apiConfig, frame) {
+        return jsonSchema.validate(...arguments).then(() => {
+            return validateVisibility(frame);
+        });
+    }
 };

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -27,8 +27,7 @@ module.exports = {
             type: 'string',
             maxlength: 50,
             nullable: false,
-            defaultTo: 'public',
-            validations: {isIn: [['public', 'members', 'paid']]}
+            defaultTo: 'public'
         },
         email_recipient_filter: {
             type: 'string',

--- a/core/server/services/members/content-gating.js
+++ b/core/server/services/members/content-gating.js
@@ -1,3 +1,5 @@
+const nql = require('@nexes/nql');
+
 // @ts-check
 /** @typedef { boolean } AccessFlag */
 
@@ -23,7 +25,9 @@ function checkPostAccess(post, member) {
         return PERMIT_ACCESS;
     }
 
-    if (post.visibility === 'paid' && (member.status === 'paid' || member.status === 'comped' || member.comped)) {
+    const visibility = post.visibility === 'paid' ? 'status:-free' : post.visibility;
+
+    if (visibility && member.status && nql(visibility).queryJSON(member)) {
         return PERMIT_ACCESS;
     }
 

--- a/core/server/services/members/content-gating.js
+++ b/core/server/services/members/content-gating.js
@@ -6,6 +6,21 @@ const nql = require('@nexes/nql');
 const PERMIT_ACCESS = true;
 const BLOCK_ACCESS = false;
 
+// TODO: better place to store this?
+const MEMBER_NQL_EXPANSIONS = [{
+    key: 'labels',
+    replacement: 'labels.slug'
+}, {
+    key: 'label',
+    replacement: 'labels.slug'
+}, {
+    key: 'products',
+    replacement: 'products.slug'
+}, {
+    key: 'product',
+    replacement: 'products.slug'
+}];
+
 /**
  * @param {object} post - A post object to check access to
  * @param {object} member - The member whos access should be checked
@@ -27,7 +42,7 @@ function checkPostAccess(post, member) {
 
     const visibility = post.visibility === 'paid' ? 'status:-free' : post.visibility;
 
-    if (visibility && member.status && nql(visibility).queryJSON(member)) {
+    if (visibility && member.status && nql(visibility, {expansions: MEMBER_NQL_EXPANSIONS}).queryJSON(member)) {
         return PERMIT_ACCESS;
     }
 

--- a/core/shared/i18n/translations/en.json
+++ b/core/shared/i18n/translations/en.json
@@ -356,13 +356,15 @@
             },
             "posts": {
                 "postNotFound": "Post not found.",
-                "invalidEmailRecipientFilter": "Invalid filter in email_recipient_filter param."
+                "invalidEmailRecipientFilter": "Invalid filter in email_recipient_filter param.",
+                "invalidVisibilityFilter": "Invalid filter in visibility property"
             },
             "authors": {
                 "notFound": "Author not found."
             },
             "pages": {
-                "pageNotFound": "Page not found."
+                "pageNotFound": "Page not found.",
+                "invalidVisibilityFilter": "Invalid filter in visibility property"
             },
             "job": {
                 "notFound": "Job not found.",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nexes/nql": "0.5.2",
     "@sentry/node": "6.3.6",
     "@tryghost/adapter-manager": "0.2.12",
-    "@tryghost/admin-api-schema": "2.2.0",
+    "@tryghost/admin-api-schema": "2.2.1",
     "@tryghost/bootstrap-socket": "0.2.8",
     "@tryghost/constants": "0.1.7",
     "@tryghost/email-analytics-provider-mailgun": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@tryghost/kg-mobiledoc-html-renderer": "4.0.0",
     "@tryghost/limit-service": "0.5.0",
     "@tryghost/magic-link": "1.0.2",
-    "@tryghost/members-api": "1.4.0",
+    "@tryghost/members-api": "1.5.0",
     "@tryghost/members-csv": "1.0.0",
     "@tryghost/members-ssr": "1.0.2",
     "@tryghost/mw-session-from-token": "0.1.20",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nexes/nql": "0.5.2",
     "@sentry/node": "6.3.6",
     "@tryghost/adapter-manager": "0.2.12",
-    "@tryghost/admin-api-schema": "2.1.1",
+    "@tryghost/admin-api-schema": "2.2.0",
     "@tryghost/bootstrap-socket": "0.2.8",
     "@tryghost/constants": "0.1.7",
     "@tryghost/email-analytics-provider-mailgun": "1.0.0",

--- a/test/api-acceptance/admin/members_spec.js
+++ b/test/api-acceptance/admin/members_spec.js
@@ -35,7 +35,7 @@ describe('Members API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.members);
-        jsonResponse.members.should.have.length(5);
+        jsonResponse.members.should.have.length(8);
         localUtils.API.checkResponse(jsonResponse.members[0], 'member', 'subscriptions');
 
         testUtils.API.isISO8601(jsonResponse.members[0].created_at).should.be.true();
@@ -44,7 +44,7 @@ describe('Members API', function () {
         jsonResponse.meta.pagination.should.have.property('page', 1);
         jsonResponse.meta.pagination.should.have.property('limit', 15);
         jsonResponse.meta.pagination.should.have.property('pages', 1);
-        jsonResponse.meta.pagination.should.have.property('total', 5);
+        jsonResponse.meta.pagination.should.have.property('total', 8);
         jsonResponse.meta.pagination.should.have.property('next', null);
         jsonResponse.meta.pagination.should.have.property('prev', null);
     });
@@ -98,7 +98,7 @@ describe('Members API', function () {
         const jsonResponse = res.body;
         should.exist(jsonResponse);
         should.exist(jsonResponse.members);
-        jsonResponse.members.should.have.length(2);
+        jsonResponse.members.should.have.length(4);
         jsonResponse.members[0].email.should.equal('paid@test.com');
         jsonResponse.members[1].email.should.equal('trialing@test.com');
         localUtils.API.checkResponse(jsonResponse, 'members');

--- a/test/frontend-acceptance/members_spec.js
+++ b/test/frontend-acceptance/members_spec.js
@@ -437,7 +437,7 @@ describe('Front-end members behaviour', function () {
                 await loginAsMember('with-product@test.com');
             });
 
-            it.only('can read product-only post content', function () {
+            it('can read product-only post content', function () {
                 return request
                     .get('/thou-must-have-ghost-product/')
                     .expect(200)

--- a/test/frontend-acceptance/members_spec.js
+++ b/test/frontend-acceptance/members_spec.js
@@ -172,8 +172,8 @@ describe('Front-end members behaviour', function () {
             });
 
             productPost = testUtils.DataGenerator.forKnex.createPost({
-                slug: 'thou-must-have-ghost-product',
-                visibility: 'product:ghost-product',
+                slug: 'thou-must-have-default-product',
+                visibility: 'product:default-product',
                 published_at: moment().toDate()
             });
 
@@ -226,7 +226,7 @@ describe('Front-end members behaviour', function () {
 
             it('cannot read product-only post content', function () {
                 return request
-                    .get('/thou-must-have-ghost-product/')
+                    .get('/thou-must-have-default-product/')
                     .expect(200)
                     .then((res) => {
                         res.text.should.not.containEql('<h2 id="markdown">markdown</h2>');
@@ -277,7 +277,7 @@ describe('Front-end members behaviour', function () {
 
             it('cannot read product-only post content', function () {
                 return request
-                    .get('/thou-must-have-ghost-product/')
+                    .get('/thou-must-have-default-product/')
                     .expect(200)
                     .then((res) => {
                         res.text.should.not.containEql('<h2 id="markdown">markdown</h2>');
@@ -359,7 +359,7 @@ describe('Front-end members behaviour', function () {
 
             it('cannot read product-only post content', function () {
                 return request
-                    .get('/thou-must-have-ghost-product/')
+                    .get('/thou-must-have-default-product/')
                     .expect(200)
                     .then((res) => {
                         res.text.should.not.containEql('<h2 id="markdown">markdown</h2>');
@@ -425,7 +425,7 @@ describe('Front-end members behaviour', function () {
 
             it('cannot read product-only post content', function () {
                 return request
-                    .get('/thou-must-have-ghost-product/')
+                    .get('/thou-must-have-default-product/')
                     .expect(200)
                     .then((res) => {
                         res.text.should.not.containEql('<h2 id="markdown">markdown</h2>');
@@ -440,7 +440,7 @@ describe('Front-end members behaviour', function () {
 
             it('can read product-only post content', function () {
                 return request
-                    .get('/thou-must-have-ghost-product/')
+                    .get('/thou-must-have-default-product/')
                     .expect(200)
                     .then((res) => {
                         res.text.should.containEql('<h2 id="markdown">markdown</h2>');

--- a/test/frontend-acceptance/members_spec.js
+++ b/test/frontend-acceptance/members_spec.js
@@ -114,9 +114,10 @@ describe('Front-end members behaviour', function () {
         });
     });
 
-    describe('Price data', function () {
+    describe.only('Price data', function () {
         it('Can be used as a number, and with the price helper', async function () {
             const res = await request.get('/');
+            console.log(res.text);
 
             // Check out test/utils/fixtures/themes/price-data-test-theme/index.hbs
             // To see where this is coming from.

--- a/test/frontend-acceptance/members_spec.js
+++ b/test/frontend-acceptance/members_spec.js
@@ -114,10 +114,9 @@ describe('Front-end members behaviour', function () {
         });
     });
 
-    describe.only('Price data', function () {
+    describe('Price data', function () {
         it('Can be used as a number, and with the price helper', async function () {
             const res = await request.get('/');
-            console.log(res.text);
 
             // Check out test/utils/fixtures/themes/price-data-test-theme/index.hbs
             // To see where this is coming from.

--- a/test/regression/api/canary/admin/members_spec.js
+++ b/test/regression/api/canary/admin/members_spec.js
@@ -13,7 +13,7 @@ const ghost = testUtils.startGhost;
 
 let request;
 
-describe('Members API', function () {
+describe('Members API (canary)', function () {
     before(function () {
         sinon.stub(labs, 'isSet').withArgs('members').returns(true);
     });
@@ -96,7 +96,7 @@ describe('Members API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.members);
                 localUtils.API.checkResponse(jsonResponse, 'members');
-                jsonResponse.members.should.have.length(5);
+                jsonResponse.members.should.have.length(8);
 
                 jsonResponse.members[0].email.should.equal('paid@test.com');
                 jsonResponse.members[0].email_open_rate.should.equal(80);
@@ -117,7 +117,7 @@ describe('Members API', function () {
             .then((res) => {
                 const jsonResponse = res.body;
                 localUtils.API.checkResponse(jsonResponse, 'members');
-                jsonResponse.members.should.have.length(5);
+                jsonResponse.members.should.have.length(8);
 
                 jsonResponse.members[0].email.should.equal('member2@test.com');
                 jsonResponse.members[0].email_open_rate.should.equal(50);

--- a/test/regression/api/v3/admin/members_spec.js
+++ b/test/regression/api/v3/admin/members_spec.js
@@ -96,7 +96,7 @@ describe('Members API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.members);
                 localUtils.API.checkResponse(jsonResponse, 'members');
-                jsonResponse.members.should.have.length(5);
+                jsonResponse.members.should.have.length(8);
 
                 jsonResponse.members[0].email.should.equal('paid@test.com');
                 jsonResponse.members[0].email_open_rate.should.equal(80);
@@ -117,7 +117,7 @@ describe('Members API', function () {
             .then((res) => {
                 const jsonResponse = res.body;
                 localUtils.API.checkResponse(jsonResponse, 'members');
-                jsonResponse.members.should.have.length(5);
+                jsonResponse.members.should.have.length(8);
 
                 jsonResponse.members[0].email.should.equal('member2@test.com');
                 jsonResponse.members[0].email_open_rate.should.equal(50);
@@ -635,8 +635,8 @@ describe('Members API', function () {
                 should.exist(jsonResponse.total_on_date);
                 should.exist(jsonResponse.new_today);
 
-                // 5 from fixtures and 6 imported in previous tests
-                jsonResponse.total.should.equal(11);
+                // 8 from fixtures and 6 imported in previous tests
+                jsonResponse.total.should.equal(14);
             });
     });
 
@@ -659,8 +659,8 @@ describe('Members API', function () {
                 should.exist(jsonResponse.total_on_date);
                 should.exist(jsonResponse.new_today);
 
-                // 5 from fixtures and 6 imported in previous tests
-                jsonResponse.total.should.equal(11);
+                // 8 from fixtures and 6 imported in previous tests
+                jsonResponse.total.should.equal(14);
             });
     });
 
@@ -683,8 +683,8 @@ describe('Members API', function () {
                 should.exist(jsonResponse.total_on_date);
                 should.exist(jsonResponse.new_today);
 
-                // 5 from fixtures and 6 imported in previous tests
-                jsonResponse.total.should.equal(11);
+                // 8 from fixtures and 6 imported in previous tests
+                jsonResponse.total.should.equal(14);
             });
     });
 

--- a/test/unit/api/canary/utils/validators/input/pages_spec.js
+++ b/test/unit/api/canary/utils/validators/input/pages_spec.js
@@ -11,6 +11,11 @@ describe('Unit: canary/utils/validators/input/pages', function () {
         return models.init();
     });
 
+    beforeEach(function () {
+        const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
+        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());
+    });
+
     afterEach(function () {
         sinon.restore();
     });

--- a/test/unit/api/canary/utils/validators/input/pages_spec.js
+++ b/test/unit/api/canary/utils/validators/input/pages_spec.js
@@ -4,8 +4,13 @@ const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/canary/utils/validators');
+const models = require('../../../../../../../core/server/models');
 
 describe('Unit: canary/utils/validators/input/pages', function () {
+    before(function () {
+        return models.init();
+    });
+
     afterEach(function () {
         sinon.restore();
     });
@@ -179,6 +184,21 @@ describe('Unit: canary/utils/validators/input/pages', function () {
 
                     return Promise.all(checks);
                 });
+            });
+
+            it('should pass for valid NQL visibility', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}],
+                            visibility: 'label:vip'
+                        }]
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame);
             });
         });
 

--- a/test/unit/api/canary/utils/validators/input/posts_spec.js
+++ b/test/unit/api/canary/utils/validators/input/posts_spec.js
@@ -4,8 +4,13 @@ const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/canary/utils/validators');
+const models = require('../../../../../../../core/server/models');
 
 describe('Unit: canary/utils/validators/input/posts', function () {
+    before(function () {
+        return models.init();
+    });
+
     afterEach(function () {
         sinon.restore();
     });
@@ -179,6 +184,21 @@ describe('Unit: canary/utils/validators/input/posts', function () {
 
                     return Promise.all(checks);
                 });
+            });
+
+            it('should pass for valid NQL visibility', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}],
+                            visibility: 'label:vip'
+                        }]
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame);
             });
         });
 

--- a/test/unit/api/canary/utils/validators/input/posts_spec.js
+++ b/test/unit/api/canary/utils/validators/input/posts_spec.js
@@ -8,7 +8,12 @@ const models = require('../../../../../../../core/server/models');
 
 describe('Unit: canary/utils/validators/input/posts', function () {
     before(function () {
-        return models.init();
+        models.init();
+    });
+
+    beforeEach(function () {
+        const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
+        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());
     });
 
     afterEach(function () {

--- a/test/unit/api/v2/utils/validators/input/pages_spec.js
+++ b/test/unit/api/v2/utils/validators/input/pages_spec.js
@@ -11,6 +11,11 @@ describe('Unit: v2/utils/validators/input/pages', function () {
         return models.init();
     });
 
+    beforeEach(function () {
+        const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
+        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());
+    });
+
     afterEach(function () {
         sinon.restore();
     });

--- a/test/unit/api/v2/utils/validators/input/pages_spec.js
+++ b/test/unit/api/v2/utils/validators/input/pages_spec.js
@@ -4,8 +4,13 @@ const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/v2/utils/validators');
+const models = require('../../../../../../../core/server/models');
 
 describe('Unit: v2/utils/validators/input/pages', function () {
+    before(function () {
+        return models.init();
+    });
+
     afterEach(function () {
         sinon.restore();
     });
@@ -179,6 +184,21 @@ describe('Unit: v2/utils/validators/input/pages', function () {
 
                     return Promise.all(checks);
                 });
+            });
+
+            it('should pass for valid NQL visibility', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}],
+                            visibility: 'label:vip'
+                        }]
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame);
             });
         });
 

--- a/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -11,6 +11,11 @@ describe('Unit: v2/utils/validators/input/posts', function () {
         return models.init();
     });
 
+    beforeEach(function () {
+        const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
+        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());
+    });
+
     afterEach(function () {
         sinon.restore();
     });

--- a/test/unit/api/v2/utils/validators/input/posts_spec.js
+++ b/test/unit/api/v2/utils/validators/input/posts_spec.js
@@ -4,8 +4,13 @@ const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/v2/utils/validators');
+const models = require('../../../../../../../core/server/models');
 
 describe('Unit: v2/utils/validators/input/posts', function () {
+    before(function () {
+        return models.init();
+    });
+
     afterEach(function () {
         sinon.restore();
     });
@@ -179,6 +184,21 @@ describe('Unit: v2/utils/validators/input/posts', function () {
 
                     return Promise.all(checks);
                 });
+            });
+
+            it('should pass for valid NQL visibility', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}],
+                            visibility: 'label:vip'
+                        }]
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame);
             });
         });
 

--- a/test/unit/api/v3/utils/validators/input/pages_spec.js
+++ b/test/unit/api/v3/utils/validators/input/pages_spec.js
@@ -4,8 +4,13 @@ const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/v3/utils/validators');
+const models = require('../../../../../../../core/server/models');
 
 describe('Unit: v3/utils/validators/input/pages', function () {
+    before(function () {
+        return models.init();
+    });
+
     afterEach(function () {
         sinon.restore();
     });
@@ -179,6 +184,21 @@ describe('Unit: v3/utils/validators/input/pages', function () {
 
                     return Promise.all(checks);
                 });
+            });
+
+            it('should pass for valid NQL visibility', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        pages: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}],
+                            visibility: 'label:vip'
+                        }]
+                    }
+                };
+
+                return validators.input.pages.add(apiConfig, frame);
             });
         });
 

--- a/test/unit/api/v3/utils/validators/input/pages_spec.js
+++ b/test/unit/api/v3/utils/validators/input/pages_spec.js
@@ -11,6 +11,11 @@ describe('Unit: v3/utils/validators/input/pages', function () {
         return models.init();
     });
 
+    beforeEach(function () {
+        const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
+        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());
+    });
+
     afterEach(function () {
         sinon.restore();
     });

--- a/test/unit/api/v3/utils/validators/input/posts_spec.js
+++ b/test/unit/api/v3/utils/validators/input/posts_spec.js
@@ -11,6 +11,11 @@ describe('Unit: v3/utils/validators/input/posts', function () {
         return models.init();
     });
 
+    beforeEach(function () {
+        const memberFindPageStub = sinon.stub(models.Member, 'findPage').returns(Promise.reject());
+        memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).returns(Promise.resolve());
+    });
+
     afterEach(function () {
         sinon.restore();
     });

--- a/test/unit/api/v3/utils/validators/input/posts_spec.js
+++ b/test/unit/api/v3/utils/validators/input/posts_spec.js
@@ -4,8 +4,13 @@ const should = require('should');
 const sinon = require('sinon');
 const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/v3/utils/validators');
+const models = require('../../../../../../../core/server/models');
 
 describe('Unit: v3/utils/validators/input/posts', function () {
+    before(function () {
+        return models.init();
+    });
+
     afterEach(function () {
         sinon.restore();
     });
@@ -179,6 +184,21 @@ describe('Unit: v3/utils/validators/input/posts', function () {
 
                     return Promise.all(checks);
                 });
+            });
+
+            it('should pass for valid NQL visibility', function () {
+                const frame = {
+                    options: {},
+                    data: {
+                        posts: [{
+                            title: 'pass',
+                            authors: [{id: 'correct'}],
+                            visibility: 'label:vip'
+                        }]
+                    }
+                };
+
+                return validators.input.posts.add(apiConfig, frame);
             });
         });
 

--- a/test/utils/fixture-utils.js
+++ b/test/utils/fixture-utils.js
@@ -461,35 +461,36 @@ const fixtures = {
         return Promise.map(DataGenerator.forKnex.labels, function (label) {
             return models.Label.add(label, context.internal);
         }).then(function () {
-            return Promise.each(_.cloneDeep(DataGenerator.forKnex.members), function (member) {
-                let memberLabelRelations = _.filter(DataGenerator.forKnex.members_labels, {member_id: member.id});
-
-                memberLabelRelations = _.map(memberLabelRelations, function (memberLabelRelation) {
-                    return _.find(DataGenerator.forKnex.labels, {id: memberLabelRelation.label_id});
-                });
-
-                member.labels = memberLabelRelations;
-
-                // TODO: replace with full member/product associations
-                if (member.email === 'with-product@test.com') {
-                    member.products = [{slug: 'default-product'}];
-                }
-
-                return models.Member.add(member, context.internal);
-            });
-        }).then(function (member) {
-            return Promise.each(_.cloneDeep(DataGenerator.forKnex.members_stripe_customers), function (customer) {
-                return models.MemberStripeCustomer.add(customer, context.internal);
-            });
-        }).then(function () {
             let productsToInsert = fixtureUtils.findModelFixtures('Product').entries;
             return Promise.map(productsToInsert, product => models.Product.add(product, context.internal));
         }).then(function () {
             return models.Product.findOne({}, context.internal);
         }).then(function (product) {
-            return Promise.each(_.cloneDeep(DataGenerator.forKnex.stripe_products), function (stripeProduct) {
-                stripeProduct.product_id = product.id;
-                return models.StripeProduct.add(stripeProduct, context.internal);
+            return Promise.props({
+                stripeProducts: Promise.each(_.cloneDeep(DataGenerator.forKnex.stripe_products), function (stripeProduct) {
+                    stripeProduct.product_id = product.id;
+                    return models.StripeProduct.add(stripeProduct, context.internal);
+                }),
+                members: Promise.each(_.cloneDeep(DataGenerator.forKnex.members), function (member) {
+                    let memberLabelRelations = _.filter(DataGenerator.forKnex.members_labels, {member_id: member.id});
+
+                    memberLabelRelations = _.map(memberLabelRelations, function (memberLabelRelation) {
+                        return _.find(DataGenerator.forKnex.labels, {id: memberLabelRelation.label_id});
+                    });
+
+                    member.labels = memberLabelRelations;
+
+                    // TODO: replace with full member/product associations
+                    if (member.email === 'with-product@test.com') {
+                        member.products = [{slug: product.get('slug')}];
+                    }
+
+                    return models.Member.add(member, context.internal);
+                })
+            });
+        }).then(function () {
+            return Promise.each(_.cloneDeep(DataGenerator.forKnex.members_stripe_customers), function (customer) {
+                return models.MemberStripeCustomer.add(customer, context.internal);
             });
         }).then(function () {
             return Promise.each(_.cloneDeep(DataGenerator.forKnex.stripe_prices), function (stripePrice) {

--- a/test/utils/fixture-utils.js
+++ b/test/utils/fixture-utils.js
@@ -475,20 +475,13 @@ const fixtures = {
                 return models.StripePrice.add(stripePrice, context.internal);
             });
         }).then(function () {
-            return Promise.map(DataGenerator.forKnex.products, function (product) {
-                return models.Product.add(product, context.internal);
-            });
-        }).then(function () {
             return Promise.each(_.cloneDeep(DataGenerator.forKnex.members), function (member) {
                 let memberLabelRelations = _.filter(DataGenerator.forKnex.members_labels, {member_id: member.id});
-                let memberProductRelations = _.filter(DataGenerator.forKnex.members_products, {member_id: member.id});
 
                 memberLabelRelations = _.map(memberLabelRelations, function (memberLabelRelation) {
                     return _.find(DataGenerator.forKnex.labels, {id: memberLabelRelation.label_id});
                 });
-                memberProductRelations = _.map(memberProductRelations, function (memberProductRelation) {
-                    return _.find(DataGenerator.forKnex.products, {id: memberProductRelation.product_id});
-                });
+                const memberProductRelations = [{slug: 'default-product'}];
 
                 member.labels = memberLabelRelations;
                 member.products = memberProductRelations;

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -341,6 +341,27 @@ DataGenerator.Content = {
             name: 'Vinz Clortho',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b344',
             status: 'comped'
+        },
+        {
+            id: ObjectId().toHexString(),
+            email: 'vip@test.com',
+            name: 'Winston Zeddemore',
+            uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b345',
+            status: 'free'
+        },
+        {
+            id: ObjectId().toHexString(),
+            email: 'vip-paid@test.com',
+            name: 'Peter Venkman',
+            uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b346',
+            status: 'paid'
+        },
+        {
+            id: ObjectId().toHexString(),
+            email: 'with-product@test.com',
+            name: 'Dana Barrett',
+            uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b347',
+            status: 'paid'
         }
     ],
 
@@ -362,6 +383,11 @@ DataGenerator.Content = {
             id: ObjectId().toHexString(),
             name: 'Label 2',
             slug: 'label-2'
+        },
+        {
+            id: ObjectId().toHexString(),
+            name: 'VIP',
+            slug: 'vip'
         }
     ],
 
@@ -381,10 +407,25 @@ DataGenerator.Content = {
             email: 'trialing@test.com'
         },
         {
+            id: ObjectId().toHexString(),
             member_id: null, // relation added later
             customer_id: 'cus_HR3tBmNhx4QsZ0',
             name: 'Vinz Clortho',
             email: 'comped@test.com'
+        },
+        {
+            id: ObjectId().toHexString(),
+            member_id: null, // relation added later
+            customer_id: 'cus_HR3tBmNhx4QsZ1',
+            name: 'Peter Venkman',
+            email: 'vip-paid@test.com'
+        },
+        {
+            id: ObjectId().toHexString(),
+            member_id: null, // relation added later
+            customer_id: 'cus_HR3tBmNhx4QsZ2',
+            name: 'Dana Barrett',
+            email: 'with-product@test.com'
         }
     ],
 
@@ -643,6 +684,8 @@ DataGenerator.Content.email_recipients[3].member_id = DataGenerator.Content.memb
 DataGenerator.Content.members_stripe_customers[0].member_id = DataGenerator.Content.members[2].id;
 DataGenerator.Content.members_stripe_customers[1].member_id = DataGenerator.Content.members[3].id;
 DataGenerator.Content.members_stripe_customers[2].member_id = DataGenerator.Content.members[4].id;
+DataGenerator.Content.members_stripe_customers[3].member_id = DataGenerator.Content.members[6].id;
+DataGenerator.Content.members_stripe_customers[4].member_id = DataGenerator.Content.members[7].id;
 
 DataGenerator.forKnex = (function () {
     function createBasic(overrides) {
@@ -847,6 +890,15 @@ DataGenerator.forKnex = (function () {
             id: ObjectId().toHexString(),
             product_id,
             stripe_product_id
+        };
+    }
+
+    function createMembersProduct(member_id, product_id, sort_order = 0) {
+        return {
+            id: ObjectId().toHexString(),
+            member_id,
+            product_id,
+            sort_order
         };
     }
 
@@ -1166,17 +1218,29 @@ DataGenerator.forKnex = (function () {
         createMember(DataGenerator.Content.members[1]),
         createMember(DataGenerator.Content.members[2]),
         createMember(DataGenerator.Content.members[3]),
-        createMember(DataGenerator.Content.members[4])
+        createMember(DataGenerator.Content.members[4]),
+        createMember(DataGenerator.Content.members[5]),
+        createMember(DataGenerator.Content.members[6]),
+        createMember(DataGenerator.Content.members[7])
     ];
 
     const labels = [
-        createLabel(DataGenerator.Content.labels[0])
+        createLabel(DataGenerator.Content.labels[0]),
+        createLabel(DataGenerator.Content.labels[2])
     ];
 
     const members_labels = [
         createMembersLabels(
             DataGenerator.Content.members[0].id,
             DataGenerator.Content.labels[0].id
+        ),
+        createMembersLabels(
+            DataGenerator.Content.members[5].id,
+            DataGenerator.Content.labels[2].id
+        ),
+        createMembersLabels(
+            DataGenerator.Content.members[6].id,
+            DataGenerator.Content.labels[2].id
         )
     ];
 
@@ -1187,13 +1251,22 @@ DataGenerator.forKnex = (function () {
     const members_stripe_customers = [
         createBasic(DataGenerator.Content.members_stripe_customers[0]),
         createBasic(DataGenerator.Content.members_stripe_customers[1]),
-        createBasic(DataGenerator.Content.members_stripe_customers[2])
+        createBasic(DataGenerator.Content.members_stripe_customers[2]),
+        createBasic(DataGenerator.Content.members_stripe_customers[3]),
+        createBasic(DataGenerator.Content.members_stripe_customers[4])
     ];
 
     const stripe_products = [
         createStripeProduct(
             DataGenerator.Content.products[0].id,
             DataGenerator.Content.stripe_products[0].stripe_product_id
+        )
+    ];
+
+    const members_products = [
+        createMembersProduct(
+            DataGenerator.Content.members[7].id,
+            DataGenerator.Content.products[0].id
         )
     ];
 
@@ -1233,6 +1306,7 @@ DataGenerator.forKnex = (function () {
         createMembersLabels,
         createMembersStripeCustomer: createBasic,
         createStripeCustomerSubscription: createBasic,
+        createMembersProduct,
         createInvite,
         createWebhook,
         createIntegration,
@@ -1258,6 +1332,7 @@ DataGenerator.forKnex = (function () {
         products,
         members_labels,
         members_stripe_customers,
+        members_products,
         stripe_customer_subscriptions,
         stripe_prices,
         stripe_products,

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -893,15 +893,6 @@ DataGenerator.forKnex = (function () {
         };
     }
 
-    function createMembersProduct(member_id, product_id, sort_order = 0) {
-        return {
-            id: ObjectId().toHexString(),
-            member_id,
-            product_id,
-            sort_order
-        };
-    }
-
     function createSetting(overrides) {
         const newObj = _.cloneDeep(overrides);
 
@@ -1263,13 +1254,6 @@ DataGenerator.forKnex = (function () {
         )
     ];
 
-    const members_products = [
-        createMembersProduct(
-            DataGenerator.Content.members[7].id,
-            DataGenerator.Content.products[0].id
-        )
-    ];
-
     const stripe_prices = [
         createBasic(DataGenerator.Content.stripe_prices[0]),
         createBasic(DataGenerator.Content.stripe_prices[1]),
@@ -1306,7 +1290,6 @@ DataGenerator.forKnex = (function () {
         createMembersLabels,
         createMembersStripeCustomer: createBasic,
         createStripeCustomerSubscription: createBasic,
-        createMembersProduct,
         createInvite,
         createWebhook,
         createIntegration,
@@ -1332,7 +1315,6 @@ DataGenerator.forKnex = (function () {
         products,
         members_labels,
         members_stripe_customers,
-        members_products,
         stripe_customer_subscriptions,
         stripe_prices,
         stripe_products,

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,10 +732,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.4.0.tgz#4e801156e2bf1fa1f2917ab73ec6a14afefad183"
-  integrity sha512-Wi0yKY1XHuYNR9CFsQD6Iro4gjHC++iZkQt5hYTCUrsTni7wK2B1dAtVcbq7/HdOoRJn2t4t7n1WmN3jsKbT9A==
+"@tryghost/members-api@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.5.0.tgz#f58fe7184283bda21f63f881f03a36cac8e1a7b9"
+  integrity sha512-MLYRNE/BAG5pz7wAYY1PIzHTMG1pJ0SEzUhtI2ylAwq+QZWIvN/Hr62pMTXpxzCe1kCCI+Irw9lZlYnrbQDt8Q==
   dependencies:
     "@tryghost/errors" "^0.2.9"
     "@tryghost/magic-link" "^1.0.2"
@@ -748,7 +748,7 @@
     jsonwebtoken "^8.5.1"
     leaky-bucket "2.2.0"
     lodash "^4.17.11"
-    node-jose "^1.1.3"
+    node-jose "^2.0.0"
     stripe "^8.142.0"
 
 "@tryghost/members-csv@1.0.0":
@@ -1639,13 +1639,6 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
-
-browserify-zlib@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
-  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
-  dependencies:
-    pako "~1.0.5"
 
 browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.0:
   version "4.16.6"
@@ -6877,11 +6870,6 @@ node-forge@^0.10.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
-node-forge@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"
-  integrity sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==
-
 node-gyp@3.x:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
@@ -6916,7 +6904,7 @@ node-gyp@^7.1.2:
     tar "^6.0.2"
     which "^2.0.2"
 
-node-jose@2.0.0:
+node-jose@2.0.0, node-jose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/node-jose/-/node-jose-2.0.0.tgz#541c6b52c387a3f18fc06cd502baad759af9c470"
   integrity sha512-j8zoFze1gijl8+DK/dSXXqX7+o2lMYv1XS+ptnXgGV/eloQaqq1YjNtieepbKs9jBS4WTnMOqyKSaQuunJzx0A==
@@ -6929,22 +6917,6 @@ node-jose@2.0.0:
     node-forge "^0.10.0"
     pako "^1.0.11"
     process "^0.11.10"
-    uuid "^3.3.3"
-
-node-jose@^1.1.3:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/node-jose/-/node-jose-1.1.4.tgz#af3f44a392e586d26b123b0e12dc09bef1e9863b"
-  integrity sha512-L31IFwL3pWWcMHxxidCY51ezqrDXMkvlT/5pLTfNw5sXmmOLJuN6ug7txzF/iuZN55cRpyOmoJrotwBQIoo5Lw==
-  dependencies:
-    base64url "^3.0.1"
-    browserify-zlib "^0.2.0"
-    buffer "^5.5.0"
-    es6-promise "^4.2.8"
-    lodash "^4.17.15"
-    long "^4.0.0"
-    node-forge "^0.8.5"
-    process "^0.11.10"
-    react-zlib-js "^1.0.4"
     uuid "^3.3.3"
 
 node-loggly-bulk@^2.2.4:
@@ -7347,7 +7319,7 @@ pac-resolver@^3.0.0:
     netmask "^1.0.6"
     thunkify "^2.1.2"
 
-pako@^1.0.11, pako@~1.0.5:
+pako@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -8144,11 +8116,6 @@ re2@^1.15.9:
     install-artifact-from-github "^1.2.0"
     nan "^2.14.2"
     node-gyp "^7.1.2"
-
-react-zlib-js@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/react-zlib-js/-/react-zlib-js-1.0.5.tgz#7bb433e1a4ae53a8e6f361b3d36166baf5bbc60f"
-  integrity sha512-TLcPdmqhIl+ylwOwlfm1WUuI7NVvhAv3L74d1AabhjyaAbmLOROTA/Q4EQ/UMCFCOjIkVim9fT3UZOQSFk/mlA==
 
 read-pkg-up@^7.0.1:
   version "7.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,10 +564,10 @@
   dependencies:
     "@tryghost/errors" "^0.2.11"
 
-"@tryghost/admin-api-schema@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-2.2.0.tgz#fdf8c7a686f026e777db19cb6bc11b87fd0ad997"
-  integrity sha512-qH9ZbgQuqw967eatc4wrzTXGTQRKU8/ynkvtzhaFTcfoHbuOaaiIlz1Q7dTIywwzEAtaQHTluWNiqxhAvTDU4w==
+"@tryghost/admin-api-schema@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-2.2.1.tgz#5d31abd194a5742d30b17ca230438a353b05b1aa"
+  integrity sha512-FDNYefBGsCdJ0Y/Suil8snye+cchl5B/sU5gJ25rLBRrN2AD9zAJM0N27R1+6R93MUlwsggEKM7T/6GxNhMudQ==
   dependencies:
     "@tryghost/errors" "^0.2.10"
     bluebird "^3.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,10 +564,10 @@
   dependencies:
     "@tryghost/errors" "^0.2.11"
 
-"@tryghost/admin-api-schema@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-2.1.1.tgz#98670e9b1dfa028b14abf542a57b3d7caf26cab6"
-  integrity sha512-UsYEggVR4X7oje+fMfizkSv+ThcAC/S9LtOcqbShhgI+xqNwQkueoQAQVpcHfA6y9kK/9wwGpJXaT5rM89WRjw==
+"@tryghost/admin-api-schema@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-2.2.0.tgz#fdf8c7a686f026e777db19cb6bc11b87fd0ad997"
+  integrity sha512-qH9ZbgQuqw967eatc4wrzTXGTQRKU8/ynkvtzhaFTcfoHbuOaaiIlz1Q7dTIywwzEAtaQHTluWNiqxhAvTDU4w==
   dependencies:
     "@tryghost/errors" "^0.2.10"
     bluebird "^3.5.3"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/581
closes https://github.com/TryGhost/Team/issues/582

Emails can now be sent to members with specific associated labels or products by specifying an NQL string. We want to bring the same members segment feature to content by allowing `visibility` to be an NQL filter string on top of the `public/members/paid` special-case strings.

As an example it's possible to set `posts.visibility` to `label:vip` to make a post available only to those members with the `vip` label.

- removed enum validations for `visibility` so it now accepts any string or `null`
    - bumped `@tryghost/admin-api-schema` for API-level validation changes
- added nql validation to API input validators by running the visibility query against the members model
- added transform of NQL to special-case visibility values when saving post model
    - ensures there's a single way of representing "members" and "paid" where NQL gives multiple ways of representing the same segment
    - useful for keeping theme-level checks such as `{{#has visibility="paid"}}` working as expected
- updated content-gating to parse nql from post's visibility and use it to query the currently logged in member to see if there's a match
    - bumped @tryghost/members-api to include label and product data when loading member

TODO:
- [x] fetch associated label and product data when fetching logged in member
  - [x] release and bump `@tryghost/members-api`
- [x] update content gating to run an NQL against the logged in member object
  - [x] tests
- [x] remove API schema validations to let NQL through in `visibility`
  - [x] release and bump `@tryghost/admin-api-schema`
- [x] validate NQL when saving a post
- [x] ~update `foreach` and `has` helpers to support NQL values~ (not necessary, exact matching still works. Advanced NQL parse+match is a separate issue)
- [x] transform NQL query values to known special cases on save (eg, `status:-free` to `paid` or `status:free,status:-free` to `members`)
- [x] ~update default content CTA wording to handle custom segments~ (re-visiting later if needed)

NOTE:
- transform of `paid` to `status:-free` has not been done here as it has a wider impact on API compatibility, for now it's kept as a special-case as per `public` and `members` (both similar to the special-case "all" in `posts.email_recipient_filter`)