### PR TITLE
Added migration to rename product as site title

### DIFF
--- a/core/server/data/migrations/versions/4.5/05-rename-default-product-to-site-title.js
+++ b/core/server/data/migrations/versions/4.5/05-rename-default-product-to-site-title.js
@@ -1,0 +1,38 @@
+const logging = require('../../../../../shared/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(connection) {
+        const defaultProduct = await connection('products')
+            .where({name: 'Default Product'})
+            .select('id')
+            .first();
+
+        const siteTitleSetting = await connection('settings')
+            .where('key', 'title')
+            .select('value')
+            .first();
+
+        if (!defaultProduct) {
+            logging.warn('Skipping rename of default product to site title, default product doesn\'t exist or already renamed');
+            return;
+        }
+
+        if (!siteTitleSetting || !siteTitleSetting.value) {
+            logging.warn('Skipping rename of default product to site title, no site title found');
+            return;
+        }
+        logging.info(`Renaming default product name to ${siteTitleSetting.value}`);
+        await connection('products')
+            .update({
+                name: siteTitleSetting.value
+            })
+            .where({
+                id: defaultProduct.id
+            });
+    },
+
+    async function down() {
+        // noop: We don't want to rename existing product back to 'Default Product'
+    }
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/667

On clean and existing installs, the default product created should be named the same as the site title in the first setup so the UX on Portal and everywhere is consistent. This change adds a migration to update existing sites which already have a default product created via fixture, and rename them to their current site title. The rename is only done if the Product name is still the same as in fixture - `Default Product`.