### PR TITLE
Unskipped and fixed a test suite for post models' findPage

### DIFF
--- a/test/regression/models/model_posts_spec.js
+++ b/test/regression/models/model_posts_spec.js
@@ -84,12 +84,14 @@ describe('Post Model', function () {
             });
 
             describe('findPage', function () {
-                // @TODO: this test case fails for mysql currently if you run all regression tests, the test does not fail if you run this as a single test
-                describe.skip('with more posts/tags', function () {
+                describe('with more posts/tags', function () {
                     beforeEach(function () {
                         return testUtils.truncate('posts_tags')
                             .then(function () {
                                 return testUtils.truncate('tags');
+                            })
+                            .then(function () {
+                                return testUtils.truncate('posts_meta');
                             })
                             .then(function () {
                                 return testUtils.truncate('posts');


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/694

- Unskipping the test does not seem to be causing a failure any longer. Removed the skip as it would be causing linting errors as we tighten up the `.skip` rules

:warning: this PR is here solely to test if the regression suite passes on all environments
