### PR TITLE
Added {monthly,yearly}_price columns to products

### DIFF
--- a/core/server/data/migrations/versions/4.7/01-add-monthly-price-column-to-products.js
+++ b/core/server/data/migrations/versions/4.7/01-add-monthly-price-column-to-products.js
@@ -1,6 +1,6 @@
 const {createAddColumnMigration} = require('../../utils');
 
-module.exports = createAddColumnMigration('products', 'monthly_price', {
+module.exports = createAddColumnMigration('products', 'monthly_price_id', {
     type: 'string',
     maxlength: 24,
     references: 'stripe_prices.id',

--- a/core/server/data/migrations/versions/4.7/01-add-monthly-price-column-to-products.js
+++ b/core/server/data/migrations/versions/4.7/01-add-monthly-price-column-to-products.js
@@ -1,8 +1,8 @@
-const {createAddColumnMigration} = require('../../utils')
+const {createAddColumnMigration} = require('../../utils');
 
 module.exports = createAddColumnMigration('products', 'monthly_price', {
     type: 'string',
     maxlength: 24,
     references: 'stripe_prices.id',
     nullable: true
-})
+});

--- a/core/server/data/migrations/versions/4.7/01-add-monthly-price-column-to-products.js
+++ b/core/server/data/migrations/versions/4.7/01-add-monthly-price-column-to-products.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils')
+
+module.exports = createAddColumnMigration('products', 'monthly_price', {
+    type: 'string',
+    maxlength: 24,
+    references: 'stripe_prices.id',
+    nullable: true
+})

--- a/core/server/data/migrations/versions/4.7/02-add-yearly-price-column-to-products.js
+++ b/core/server/data/migrations/versions/4.7/02-add-yearly-price-column-to-products.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils')
+
+module.exports = createAddColumnMigration('products', 'yearly_price', {
+    type: 'string',
+    maxlength: 24,
+    references: 'stripe_prices.id',
+    nullable: true
+})

--- a/core/server/data/migrations/versions/4.7/02-add-yearly-price-column-to-products.js
+++ b/core/server/data/migrations/versions/4.7/02-add-yearly-price-column-to-products.js
@@ -1,6 +1,6 @@
 const {createAddColumnMigration} = require('../../utils');
 
-module.exports = createAddColumnMigration('products', 'yearly_price', {
+module.exports = createAddColumnMigration('products', 'yearly_price_id', {
     type: 'string',
     maxlength: 24,
     references: 'stripe_prices.id',

--- a/core/server/data/migrations/versions/4.7/02-add-yearly-price-column-to-products.js
+++ b/core/server/data/migrations/versions/4.7/02-add-yearly-price-column-to-products.js
@@ -1,8 +1,8 @@
-const {createAddColumnMigration} = require('../../utils')
+const {createAddColumnMigration} = require('../../utils');
 
 module.exports = createAddColumnMigration('products', 'yearly_price', {
     type: 'string',
     maxlength: 24,
     references: 'stripe_prices.id',
     nullable: true
-})
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -364,6 +364,8 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         name: {type: 'string', maxlength: 191, nullable: false},
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
+        monthly_price: {type: 'string', maxlength: 24, nullable: true, references: 'stripe_prices.id'},
+        yearly_price: {type: 'string', maxlength: 24, nullable: true, references: 'stripe_prices.id'},
         description: {type: 'string', maxlength: 191, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -364,8 +364,8 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         name: {type: 'string', maxlength: 191, nullable: false},
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
-        monthly_price: {type: 'string', maxlength: 24, nullable: true, references: 'stripe_prices.id'},
-        yearly_price: {type: 'string', maxlength: 24, nullable: true, references: 'stripe_prices.id'},
+        monthly_price_id: {type: 'string', maxlength: 24, nullable: true, references: 'stripe_prices.id'},
+        yearly_price_id: {type: 'string', maxlength: 24, nullable: true, references: 'stripe_prices.id'},
         description: {type: 'string', maxlength: 191, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/710

Products will now have a single monthly and yearly price which will be
used throughout Themes, Portal & Admin. These columns will be used to
track the current prices for each of them, and will update anytime we
change the pricing of a product.