### PR TITLE
Fixed max-api-complexity linting warnings for site and config APIs

### DIFF
--- a/core/server/api/canary/config.js
+++ b/core/server/api/canary/config.js
@@ -1,7 +1,4 @@
-const {isPlainObject} = require('lodash');
-const config = require('../../../shared/config');
-const labs = require('../../services/labs');
-const ghostVersion = require('../../lib/ghost-version');
+const publicConfig = require('../../services/public-config');
 
 module.exports = {
     docName: 'config',
@@ -9,21 +6,7 @@ module.exports = {
     read: {
         permissions: false,
         query() {
-            const response = {
-                version: ghostVersion.full,
-                environment: config.get('env'),
-                database: config.get('database').client,
-                mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
-                useGravatar: !config.isPrivacyDisabled('useGravatar'),
-                labs: labs.getAll(),
-                clientExtensions: config.get('clientExtensions') || {},
-                enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
-                stripeDirect: config.get('stripeDirect'),
-                mailgunIsConfigured: config.get('bulkEmail') && config.get('bulkEmail').mailgun,
-                emailAnalytics: config.get('emailAnalytics'),
-                hostSettings: config.get('hostSettings')
-            };
-            return response;
+            return publicConfig.config;
         }
     }
 };

--- a/core/server/api/canary/site.js
+++ b/core/server/api/canary/site.js
@@ -1,6 +1,4 @@
-const ghostVersion = require('../../lib/ghost-version');
-const settingsCache = require('../../services/settings/cache');
-const urlUtils = require('../../../shared/url-utils');
+const publicConfig = require('../../services/public-config');
 
 const site = {
     docName: 'site',
@@ -8,21 +6,7 @@ const site = {
     read: {
         permissions: false,
         query() {
-            const response = {
-                title: settingsCache.get('title'),
-                description: settingsCache.get('description'),
-                logo: settingsCache.get('logo'),
-                icon: settingsCache.get('icon'),
-                accent_color: settingsCache.get('accent_color'),
-                url: urlUtils.urlFor('home', true),
-                version: ghostVersion.safe
-            };
-            if (settingsCache.get('oauth_client_id') && settingsCache.get('oauth_client_secret')) {
-                // Only set the oauth flag if oauth is enabled to avoid API changes
-                response.oauth = true;
-            }
-
-            return response;
+            return publicConfig.site;
         }
     }
 };

--- a/core/server/api/canary/utils/serializers/output/config.js
+++ b/core/server/api/canary/utils/serializers/output/config.js
@@ -1,10 +1,25 @@
+const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:config');
 
 module.exports = {
     all(data, apiConfig, frame) {
         debug('all');
+
         frame.response = {
-            config: data
+            config: _.pick(data, [
+                'version',
+                'environment',
+                'database',
+                'mail',
+                'useGravatar',
+                'labs',
+                'clientExtensions',
+                'enableDeveloperExperiments',
+                'stripeDirect',
+                'mailgunIsConfigured',
+                'emailAnalytics',
+                'hostSettings'
+            ])
         };
     }
 };

--- a/core/server/api/canary/utils/serializers/output/site.js
+++ b/core/server/api/canary/utils/serializers/output/site.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:canary:utils:serializers:output:site');
 
 module.exports = {
@@ -5,7 +6,16 @@ module.exports = {
         debug('read');
 
         frame.response = {
-            site: data
+            site: _.pick(data, [
+                'title',
+                'description',
+                'logo',
+                'icon',
+                'accent_color',
+                'url',
+                'version',
+                'oauth'
+            ])
         };
     }
 };

--- a/core/server/api/v2/config.js
+++ b/core/server/api/v2/config.js
@@ -1,7 +1,4 @@
-const {isPlainObject} = require('lodash');
-const config = require('../../../shared/config');
-const labs = require('../../services/labs');
-const ghostVersion = require('../../lib/ghost-version');
+const publicConfig = require('../../services/public-config');
 
 module.exports = {
     docName: 'config',
@@ -9,16 +6,7 @@ module.exports = {
     read: {
         permissions: false,
         query() {
-            return {
-                version: ghostVersion.full,
-                environment: config.get('env'),
-                database: config.get('database').client,
-                mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
-                useGravatar: !config.isPrivacyDisabled('useGravatar'),
-                labs: labs.getAll(),
-                clientExtensions: config.get('clientExtensions') || {},
-                enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false
-            };
+            return publicConfig.config;
         }
     }
 };

--- a/core/server/api/v2/site.js
+++ b/core/server/api/v2/site.js
@@ -1,6 +1,4 @@
-const ghostVersion = require('../../lib/ghost-version');
-const settingsCache = require('../../services/settings/cache');
-const urlUtils = require('../../../shared/url-utils');
+const publicConfig = require('../../services/public-config');
 
 const site = {
     docName: 'site',
@@ -8,11 +6,7 @@ const site = {
     read: {
         permissions: false,
         query() {
-            return {
-                title: settingsCache.get('title'),
-                url: urlUtils.urlFor('home', true),
-                version: ghostVersion.safe
-            };
+            return publicConfig.site;
         }
     }
 };

--- a/core/server/api/v2/utils/serializers/output/config.js
+++ b/core/server/api/v2/utils/serializers/output/config.js
@@ -1,10 +1,21 @@
+const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:output:config');
 
 module.exports = {
     all(data, apiConfig, frame) {
         debug('all');
+
         frame.response = {
-            config: data
+            config: _.pick(data, [
+                'version',
+                'environment',
+                'database',
+                'mail',
+                'useGravatar',
+                'labs',
+                'clientExtensions',
+                'enableDeveloperExperiments'
+            ])
         };
     }
 };

--- a/core/server/api/v2/utils/serializers/output/site.js
+++ b/core/server/api/v2/utils/serializers/output/site.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:output:site');
 
 module.exports = {
@@ -5,7 +6,11 @@ module.exports = {
         debug('read');
 
         frame.response = {
-            site: data
+            site: _.pick(data, [
+                'title',
+                'url',
+                'version'
+            ])
         };
     }
 };

--- a/core/server/api/v3/config.js
+++ b/core/server/api/v3/config.js
@@ -1,7 +1,4 @@
-const {isPlainObject} = require('lodash');
-const config = require('../../../shared/config');
-const labs = require('../../services/labs');
-const ghostVersion = require('../../lib/ghost-version');
+const publicConfig = require('../../services/public-config');
 
 module.exports = {
     docName: 'config',
@@ -9,24 +6,7 @@ module.exports = {
     read: {
         permissions: false,
         query() {
-            const billingUrl = config.get('hostSettings:billing:enabled') ? config.get('hostSettings:billing:url') : '';
-            const response = {
-                version: ghostVersion.full,
-                environment: config.get('env'),
-                database: config.get('database').client,
-                mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
-                useGravatar: !config.isPrivacyDisabled('useGravatar'),
-                labs: labs.getAll(),
-                clientExtensions: config.get('clientExtensions') || {},
-                enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
-                stripeDirect: config.get('stripeDirect'),
-                mailgunIsConfigured: config.get('bulkEmail') && config.get('bulkEmail').mailgun,
-                emailAnalytics: config.get('emailAnalytics')
-            };
-            if (billingUrl) {
-                response.billingUrl = billingUrl;
-            }
-            return response;
+            return publicConfig.config;
         }
     }
 };

--- a/core/server/api/v3/site.js
+++ b/core/server/api/v3/site.js
@@ -1,6 +1,4 @@
-const ghostVersion = require('../../lib/ghost-version');
-const settingsCache = require('../../services/settings/cache');
-const urlUtils = require('../../../shared/url-utils');
+const publicConfig = require('../../services/public-config');
 
 const site = {
     docName: 'site',
@@ -8,16 +6,7 @@ const site = {
     read: {
         permissions: false,
         query() {
-            const response = {
-                title: settingsCache.get('title'),
-                description: settingsCache.get('description'),
-                logo: settingsCache.get('logo'),
-                accent_color: settingsCache.get('accent_color'),
-                url: urlUtils.urlFor('home', true),
-                version: ghostVersion.safe
-            };
-
-            return response;
+            return publicConfig.site;
         }
     }
 };

--- a/core/server/api/v3/utils/serializers/output/config.js
+++ b/core/server/api/v3/utils/serializers/output/config.js
@@ -1,10 +1,25 @@
+const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v3:utils:serializers:output:config');
 
 module.exports = {
     all(data, apiConfig, frame) {
         debug('all');
+
         frame.response = {
-            config: data
+            config: _.pick(data, [
+                'version',
+                'environment',
+                'database',
+                'mail',
+                'useGravatar',
+                'labs',
+                'clientExtensions',
+                'enableDeveloperExperiments',
+                'stripeDirect',
+                'mailgunIsConfigured',
+                'emailAnalytics',
+                'billingUrl'
+            ])
         };
     }
 };

--- a/core/server/api/v3/utils/serializers/output/site.js
+++ b/core/server/api/v3/utils/serializers/output/site.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v3:utils:serializers:output:site');
 
 module.exports = {
@@ -5,7 +6,14 @@ module.exports = {
         debug('read');
 
         frame.response = {
-            site: data
+            site: _.pick(data, [
+                'title',
+                'description',
+                'logo',
+                'accent_color',
+                'url',
+                'version'
+            ])
         };
     }
 };

--- a/core/server/services/public-config/config.js
+++ b/core/server/services/public-config/config.js
@@ -1,0 +1,28 @@
+const {isPlainObject} = require('lodash');
+const config = require('../../../shared/config');
+const labs = require('../labs');
+const ghostVersion = require('../../lib/ghost-version');
+
+module.exports = function getConfigProperties() {
+    const configProperties = {
+        version: ghostVersion.full,
+        environment: config.get('env'),
+        database: config.get('database').client,
+        mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
+        useGravatar: !config.isPrivacyDisabled('useGravatar'),
+        labs: labs.getAll(),
+        clientExtensions: config.get('clientExtensions') || {},
+        enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
+        stripeDirect: config.get('stripeDirect'),
+        mailgunIsConfigured: config.get('bulkEmail') && config.get('bulkEmail').mailgun,
+        emailAnalytics: config.get('emailAnalytics'),
+        hostSettings: config.get('hostSettings')
+    };
+
+    const billingUrl = config.get('hostSettings:billing:enabled') ? config.get('hostSettings:billing:url') : '';
+    if (billingUrl) {
+        configProperties.billingUrl = billingUrl;
+    }
+
+    return configProperties;
+};

--- a/core/server/services/public-config/index.js
+++ b/core/server/services/public-config/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+    get config() {
+        return require('./config')();
+    },
+    get site() {
+        return require('./site')();
+    }
+};

--- a/core/server/services/public-config/site.js
+++ b/core/server/services/public-config/site.js
@@ -1,0 +1,22 @@
+const ghostVersion = require('../../lib/ghost-version');
+const settingsCache = require('../settings/cache');
+const urlUtils = require('../../../shared/url-utils');
+
+module.exports = function getSiteProperties() {
+    const siteProperties = {
+        title: settingsCache.get('title'),
+        description: settingsCache.get('description'),
+        logo: settingsCache.get('logo'),
+        icon: settingsCache.get('icon'),
+        accent_color: settingsCache.get('accent_color'),
+        url: urlUtils.urlFor('home', true),
+        version: ghostVersion.safe
+    };
+
+    if (settingsCache.get('oauth_client_id') && settingsCache.get('oauth_client_secret')) {
+        // Only set the oauth flag if oauth is enabled to avoid API changes
+        siteProperties.oauth = true;
+    }
+
+    return siteProperties;
+};


### PR DESCRIPTION
no issue

- moved `config` and `site` API output generation to a `public-config` service allowing all API versions to use `publicConfig.config` or `publicConfig.site` in their query methods
- updated `config` and `site` API output serializers to use an allow-list that limits the data returned for each API version
