### PR TITLE
Added {monthly,yearly}_price columns to products 

### DIFF
--- a/core/server/data/migrations/versions/4.7/01-add-monthly-price-column-to-products.js
+++ b/core/server/data/migrations/versions/4.7/01-add-monthly-price-column-to-products.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('products', 'monthly_price_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true
+});

--- a/core/server/data/migrations/versions/4.7/02-add-yearly-price-column-to-products.js
+++ b/core/server/data/migrations/versions/4.7/02-add-yearly-price-column-to-products.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('products', 'yearly_price_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -364,6 +364,8 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         name: {type: 'string', maxlength: 191, nullable: false},
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
+        monthly_price_id: {type: 'string', maxlength: 24, nullable: true},
+        yearly_price_id: {type: 'string', maxlength: 24, nullable: true},
         description: {type: 'string', maxlength: 191, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'ffa4eec4208614b93b6b8fb68b55f126';
+    const currentSchemaHash = '2099a4ba6b9462c5a0aa36a434139e8b';
     const currentFixturesHash = '8671672598d2a62e53418c4b91aa79a3';
     const currentSettingsHash = '8a3f69dfa11d56a6c630456a67f3a59a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs TryGhost/Team#710

Products will now have a single monthly and yearly price which will be
used throughout Themes, Portal & Admin. These columns will be used to
track the current prices for each of them, and will update anytime we
change the pricing of a product.

These columns do not have foreign key constraints due to a circular table
dependency when initialising the database. This will be considered tech
debt and fixed during cleanup 