### PR TITLE
🐛  Fixed incorrect @price data in themes

### DIFF
--- a/core/frontend/services/theme-engine/middleware.js
+++ b/core/frontend/services/theme-engine/middleware.js
@@ -76,6 +76,9 @@ async function haxGetMembersPriceData() {
 
         const defaultProduct = products[0];
 
+        const monthlyPriceId = settingsCache.get('members_monthly_price_id');
+        const yearlyPriceId = settingsCache.get('members_yearly_price_id');
+
         const activePrices = defaultProduct.stripe_prices.filter((price) => {
             return price.active;
         });
@@ -85,15 +88,11 @@ async function haxGetMembersPriceData() {
         });
 
         const monthlyPrice = nonZeroPrices.find((price) => {
-            return price.nickname === 'Monthly';
-        }) || nonZeroPrices.find((price) => {
-            return price.interval === 'month';
+            return price.id === monthlyPriceId;
         });
 
         const yearlyPrice = nonZeroPrices.find((price) => {
-            return price.nickname === 'Yearly';
-        }) || nonZeroPrices.find((price) => {
-            return price.interval === 'year';
+            return price.id === yearlyPriceId;
         });
 
         const priceData = {

--- a/test/frontend-acceptance/members_spec.js
+++ b/test/frontend-acceptance/members_spec.js
@@ -44,6 +44,15 @@ describe('Front-end members behaviour', function () {
                 return 'price-data-test-theme';
             }
 
+            const stripePrices = testUtils.DataGenerator.forKnex.stripe_prices;
+            if (key === 'members_monthly_price_id') {
+                return stripePrices[1].id;
+            }
+
+            if (key === 'members_yearly_price_id') {
+                return stripePrices[2].id;
+            }
+
             return originalSettingsCacheGetFn(key, options);
         });
         await testUtils.startGhost();
@@ -121,8 +130,8 @@ describe('Front-end members behaviour', function () {
             // Check out test/utils/fixtures/themes/price-data-test-theme/index.hbs
             // To see where this is coming from.
             //
-            const legacyUse = /You can use the price data as a number: 5/;
-            const withPriceHelper = /You can pass price data to the price helper: \$5/;
+            const legacyUse = /You can use the price data as a number: 12/;
+            const withPriceHelper = /You can pass price data to the price helper: \$12/;
 
             should.exist(res.text.match(legacyUse));
             should.exist(res.text.match(withPriceHelper));

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -482,34 +482,45 @@ DataGenerator.Content = {
     stripe_prices: [
         {
             id: ObjectId().toHexString(),
-            stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb8',
+            stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730b12',
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
-            active: 1,
+            active: true,
             nickname: 'Monthly',
             currency: 'USD',
-            amount: 500,
+            amount: 5000,
             type: 'recurring',
             interval: 'month'
         },
         {
             id: ObjectId().toHexString(),
-            stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb9',
+            stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb8',
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
-            active: 1,
-            nickname: 'Yearly',
+            active: true,
+            nickname: 'Monthly',
             currency: 'USD',
-            amount: 1500,
+            amount: 1200,
             type: 'recurring',
-            interval: 'year'
+            interval: 'month'
         },
         {
             id: ObjectId().toHexString(),
             stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730ba0',
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
-            active: 1,
+            active: true,
             nickname: 'Yearly',
             currency: 'USD',
-            amount: 2400,
+            amount: 12000,
+            type: 'recurring',
+            interval: 'year'
+        },
+        {
+            id: ObjectId().toHexString(),
+            stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb9',
+            stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
+            active: true,
+            nickname: 'Yearly',
+            currency: 'USD',
+            amount: 15000,
             type: 'recurring',
             interval: 'year'
         }
@@ -1257,7 +1268,8 @@ DataGenerator.forKnex = (function () {
     const stripe_prices = [
         createBasic(DataGenerator.Content.stripe_prices[0]),
         createBasic(DataGenerator.Content.stripe_prices[1]),
-        createBasic(DataGenerator.Content.stripe_prices[2])
+        createBasic(DataGenerator.Content.stripe_prices[2]),
+        createBasic(DataGenerator.Content.stripe_prices[3])
     ];
 
     const stripe_customer_subscriptions = [


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12980
closes https://github.com/TryGhost/Team/issues/730

As part of changes in 4.6, the default price ids for monthly/yearly prices are stored in new settings - `members_monthly_price_id`, `members_yearly_price_id` - which are used to determine current active prices for the site from list of all existing prices. The `@price` helper was incorrectly still relying on the old logic for active monthly/yearly price using the first active price with matching nickname, and resulted in showing incorrect price data on the theme.
