### PR TITLE
🐛 Fixed incorrect `@price.currency` value in themes

### DIFF
--- a/core/frontend/services/theme-engine/middleware.js
+++ b/core/frontend/services/theme-engine/middleware.js
@@ -98,7 +98,7 @@ async function haxGetMembersPriceData() {
         const priceData = {
             monthly: makePriceObject(monthlyPrice || defaultPrice),
             yearly: makePriceObject(yearlyPrice || defaultPrice),
-            currency: nonZeroPrices[0].currency
+            currency: monthlyPrice ? monthlyPrice.currency : defaultPrice.currency
         };
 
         return priceData;

--- a/test/frontend-acceptance/members_spec.js
+++ b/test/frontend-acceptance/members_spec.js
@@ -130,8 +130,8 @@ describe('Front-end members behaviour', function () {
             // Check out test/utils/fixtures/themes/price-data-test-theme/index.hbs
             // To see where this is coming from.
             //
-            const legacyUse = /You can use the price data as a number: 12/;
-            const withPriceHelper = /You can pass price data to the price helper: \$12/;
+            const legacyUse = /You can use the price data as a number and currency: £12/;
+            const withPriceHelper = /You can pass price data to the price helper: £12/;
 
             should.exist(res.text.match(legacyUse));
             should.exist(res.text.match(withPriceHelper));

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -497,7 +497,7 @@ DataGenerator.Content = {
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
             active: true,
             nickname: 'Monthly',
-            currency: 'USD',
+            currency: 'GBP',
             amount: 1200,
             type: 'recurring',
             interval: 'month'
@@ -508,7 +508,7 @@ DataGenerator.Content = {
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
             active: true,
             nickname: 'Yearly',
-            currency: 'USD',
+            currency: 'GBP',
             amount: 12000,
             type: 'recurring',
             interval: 'year'
@@ -519,7 +519,7 @@ DataGenerator.Content = {
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
             active: true,
             nickname: 'Yearly',
-            currency: 'USD',
+            currency: 'GBP',
             amount: 15000,
             type: 'recurring',
             interval: 'year'

--- a/test/utils/fixtures/themes/price-data-test-theme/index.hbs
+++ b/test/utils/fixtures/themes/price-data-test-theme/index.hbs
@@ -1,5 +1,5 @@
 <p class="number">
-    You can use the price data as a number: {{@price.monthly}}
+    You can use the price data as a number and currency: {{price currency=@price.currency}}{{@price.monthly}}
 </p>
 <p class="with-price-helper">
     You can pass price data to the price helper: {{price @price.monthly}}


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/12986
refs https://github.com/TryGhost/Ghost/commit/1345268089f5ca275e8592953be429f02f1d3b19

As part of changes in 4.6, the default price ids for monthly/yearly prices are stored in new settings - `members_monthly_price_id`, `members_yearly_price_id` - which are used to determine current active prices for the site from list of all existing prices. While the last commit updated the prices to use the settings, the data for currency was still used from non-zero prices instead of the new settings value.

- Updated tests to check price currency