### PR TITLE
🐛 Fixed saving Members with Complimentary plans

### DIFF
--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -79,6 +79,20 @@ function exportCSV(page, _apiConfig, frame) {
 function serializeMember(member, options) {
     const json = member.toJSON(options);
 
+    let comped = false;
+    if (json.subscriptions) {
+        const hasCompedSubscription = !!json.subscriptions.find(
+            /**
+             * @param {SerializedMemberStripeSubscription} sub
+             */
+            function (sub) {
+                return sub.plan.nickname === 'Complimentary' && sub.status === 'active';
+            }
+        );
+        if (hasCompedSubscription) {
+            comped = true;
+        }
+    }
     const subscriptions = json.subscriptions || [];
 
     const serialized = {
@@ -94,6 +108,7 @@ function serializeMember(member, options) {
         labels: json.labels,
         subscriptions: subscriptions,
         avatar_image: json.avatar_image,
+        comped: comped,
         email_count: json.email_count,
         email_opened_count: json.email_opened_count,
         email_open_rate: json.email_open_rate,
@@ -148,6 +163,7 @@ function createSerializer(debugString, serialize) {
  * @prop {SerializedMemberStripeSubscription[]} subscriptions
  * @prop {SerializedMemberProduct[]=} products
  * @prop {string} avatar_image
+ * @prop {boolean} comped
  * @prop {number} email_count
  * @prop {number} email_opened_count
  * @prop {number} email_open_rate

--- a/test/api-acceptance/admin/members_spec.js
+++ b/test/api-acceptance/admin/members_spec.js
@@ -358,6 +358,7 @@ describe('Members API', function () {
         importedMember1.subscribed.should.equal(true);
         importedMember1.labels.length.should.equal(1);
         testUtils.API.isISO8601(importedMember1.created_at).should.be.true();
+        importedMember1.comped.should.equal(false);
         importedMember1.subscriptions.should.not.be.undefined();
         importedMember1.subscriptions.length.should.equal(0);
 
@@ -369,6 +370,7 @@ describe('Members API', function () {
         importedMember2.labels.length.should.equal(2);
         testUtils.API.isISO8601(importedMember2.created_at).should.be.true();
         importedMember2.created_at.should.equal('1991-10-02T20:30:31.000Z');
+        importedMember2.comped.should.equal(false);
         importedMember2.subscriptions.should.not.be.undefined();
         importedMember2.subscriptions.length.should.equal(0);
     });

--- a/test/api-acceptance/admin/utils.js
+++ b/test/api-acceptance/admin/utils.js
@@ -127,6 +127,7 @@ const expectedProperties = {
     member: _(schema.members)
         .keys()
         .concat('avatar_image')
+        .concat('comped')
         .concat('labels')
     ,
     member_signin_url: ['member_id', 'url'],

--- a/test/regression/api/canary/admin/members_spec.js
+++ b/test/regression/api/canary/admin/members_spec.js
@@ -366,6 +366,7 @@ describe('Members API (canary)', function () {
                 should(importedMember1.name).equal(null);
                 should(importedMember1.note).equal(null);
                 importedMember1.subscribed.should.equal(true);
+                importedMember1.comped.should.equal(false);
                 importedMember1.subscriptions.should.not.be.undefined();
                 importedMember1.subscriptions.length.should.equal(0);
 
@@ -432,6 +433,7 @@ describe('Members API (canary)', function () {
                 should(importedMember1.name).equal('Hannah');
                 should(importedMember1.note).equal('no need to map me');
                 importedMember1.subscribed.should.equal(true);
+                importedMember1.comped.should.equal(false);
                 importedMember1.subscriptions.should.not.be.undefined();
                 importedMember1.subscriptions.length.should.equal(0);
                 importedMember1.labels.length.should.equal(1); // auto-generated import label
@@ -476,6 +478,7 @@ describe('Members API (canary)', function () {
                 should(defaultMember1.name).equal(null);
                 should(defaultMember1.note).equal(null);
                 defaultMember1.subscribed.should.equal(true);
+                defaultMember1.comped.should.equal(false);
                 defaultMember1.subscriptions.should.not.be.undefined();
                 defaultMember1.subscriptions.length.should.equal(0);
                 defaultMember1.labels.length.should.equal(1); // auto-generated import label

--- a/test/regression/api/canary/admin/utils.js
+++ b/test/regression/api/canary/admin/utils.js
@@ -118,6 +118,7 @@ const expectedProperties = {
         'created_at',
         'updated_at'
     ],
+
     member: [
         'id',
         'uuid',
@@ -133,7 +134,8 @@ const expectedProperties = {
         'created_at',
         'updated_at',
         'avatar_image',
-        'labels'
+        'labels',
+        'comped'
     ],
     member_signin_url: ['member_id', 'url'],
     role: ['id', 'name', 'description', 'created_at', 'updated_at'],

--- a/test/regression/api/canary/admin/utils.js
+++ b/test/regression/api/canary/admin/utils.js
@@ -118,7 +118,6 @@ const expectedProperties = {
         'created_at',
         'updated_at'
     ],
-
     member: [
         'id',
         'uuid',


### PR DESCRIPTION
Since 4.6 The Admin is using the comped flag again, rather than creating
subscriptions for zero-amount prices directly. With the `comped` flag
removed, the default state was for it to be falsy in the Admin, and when
saved would trigger the legacy comped flow, cancelling the subscription.
