### PR TITLE
🏗 Added "labs" setting enabling feature flags

### DIFF
--- a/core/server/api/canary/utils/serializers/input/settings.js
+++ b/core/server/api/canary/utils/serializers/input/settings.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const url = require('./utils/url');
 const typeGroupMapper = require('../../../../shared/serializers/input/utils/settings-filter-type-group-mapper');
 const settingsCache = require('../../../../../services/settings/cache');
+const {WRITABLE_KEYS_ALLOWLIST} = require('../../../../../services/labs');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
@@ -156,6 +157,19 @@ module.exports = {
 
             if (setting.key === 'locale') {
                 setting.key = 'lang';
+            }
+
+            if (setting.key === 'labs') {
+                const inputLabsValue = JSON.parse(setting.value);
+                const filteredLabsValue = {};
+
+                for (const flag in inputLabsValue) {
+                    if (WRITABLE_KEYS_ALLOWLIST.includes(flag)) {
+                        filteredLabsValue[flag] = inputLabsValue[flag];
+                    }
+                }
+
+                setting.value = JSON.stringify(filteredLabsValue);
             }
 
             setting = url.forSetting(setting);

--- a/core/server/api/canary/utils/serializers/input/settings.js
+++ b/core/server/api/canary/utils/serializers/input/settings.js
@@ -5,8 +5,7 @@ const settingsCache = require('../../../../../services/settings/cache');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
-    'slack',
-    'labs'
+    'slack'
 ];
 
 const deprecatedSupportedSettingsOneToManyMap = {

--- a/core/server/api/v2/utils/serializers/input/settings.js
+++ b/core/server/api/v2/utils/serializers/input/settings.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const url = require('./utils/url');
 const typeGroupMapper = require('../../../../shared/serializers/input/utils/settings-filter-type-group-mapper');
 const settingsCache = require('../../../../../services/settings/cache');
+const {WRITABLE_KEYS_ALLOWLIST} = require('../../../../../services/labs');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
@@ -136,6 +137,19 @@ module.exports = {
 
             if (setting.key === 'unsplash') {
                 setting.value = JSON.parse(setting.value).isActive;
+            }
+
+            if (setting.key === 'labs') {
+                const inputLabsValue = JSON.parse(setting.value);
+                const filteredLabsValue = {};
+
+                for (const value in inputLabsValue) {
+                    if (WRITABLE_KEYS_ALLOWLIST.includes(value)) {
+                        filteredLabsValue[value] = inputLabsValue[value];
+                    }
+                }
+
+                setting.value = JSON.stringify(filteredLabsValue);
             }
 
             setting = url.forSetting(setting);

--- a/core/server/api/v2/utils/serializers/input/settings.js
+++ b/core/server/api/v2/utils/serializers/input/settings.js
@@ -5,8 +5,7 @@ const settingsCache = require('../../../../../services/settings/cache');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
-    'slack',
-    'labs'
+    'slack'
 ];
 
 const deprecatedSupportedSettingsOneToManyMap = {

--- a/core/server/api/v3/utils/serializers/input/settings.js
+++ b/core/server/api/v3/utils/serializers/input/settings.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const url = require('./utils/url');
 const typeGroupMapper = require('../../../../shared/serializers/input/utils/settings-filter-type-group-mapper');
 const settingsCache = require('../../../../../services/settings/cache');
-const {WRITABLE_KEYS_ALLOWLIST} = require('../../../../../services/labs');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
@@ -95,11 +94,12 @@ module.exports = {
         }
         const settings = settingsCache.getAll();
 
-        // Ignore and drop all values with Read-only flag
         frame.data.settings = frame.data.settings.filter((setting) => {
             const settingFlagsStr = settings[setting.key] ? settings[setting.key].flags : '';
             const settingFlagsArr = settingFlagsStr ? settingFlagsStr.split(',') : [];
-            return !settingFlagsArr.includes('RO');
+
+            // Ignore and drop all values with Read-only flag AND 'labs' setting
+            return !settingFlagsArr.includes('RO') && (setting.key !== 'labs');
         });
 
         const mappedDeprecatedSettings = getMappedDeprecatedSettings(frame.data.settings);
@@ -153,19 +153,6 @@ module.exports = {
 
             if (setting.key === 'unsplash') {
                 setting.value = JSON.parse(setting.value).isActive;
-            }
-
-            if (setting.key === 'labs') {
-                const inputLabsValue = JSON.parse(setting.value);
-                const filteredLabsValue = {};
-
-                for (const value in inputLabsValue) {
-                    if (WRITABLE_KEYS_ALLOWLIST.includes(value)) {
-                        filteredLabsValue[value] = inputLabsValue[value];
-                    }
-                }
-
-                setting.value = JSON.stringify(filteredLabsValue);
             }
 
             setting = url.forSetting(setting);

--- a/core/server/api/v3/utils/serializers/input/settings.js
+++ b/core/server/api/v3/utils/serializers/input/settings.js
@@ -5,8 +5,7 @@ const settingsCache = require('../../../../../services/settings/cache');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
-    'slack',
-    'labs'
+    'slack'
 ];
 
 const deprecatedSupportedSettingsOneToManyMap = {

--- a/core/server/api/v3/utils/serializers/input/settings.js
+++ b/core/server/api/v3/utils/serializers/input/settings.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const url = require('./utils/url');
 const typeGroupMapper = require('../../../../shared/serializers/input/utils/settings-filter-type-group-mapper');
 const settingsCache = require('../../../../../services/settings/cache');
+const {WRITABLE_KEYS_ALLOWLIST} = require('../../../../../services/labs');
 
 const DEPRECATED_SETTINGS = [
     'bulk_email_settings',
@@ -152,6 +153,19 @@ module.exports = {
 
             if (setting.key === 'unsplash') {
                 setting.value = JSON.parse(setting.value).isActive;
+            }
+
+            if (setting.key === 'labs') {
+                const inputLabsValue = JSON.parse(setting.value);
+                const filteredLabsValue = {};
+
+                for (const value in inputLabsValue) {
+                    if (WRITABLE_KEYS_ALLOWLIST.includes(value)) {
+                        filteredLabsValue[value] = inputLabsValue[value];
+                    }
+                }
+
+                setting.value = JSON.stringify(filteredLabsValue);
             }
 
             setting = url.forSetting(setting);

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -4,9 +4,11 @@ const ObjectId = require('bson-objectid').default;
 const _ = require('lodash');
 const BaseImporter = require('./base');
 const models = require('../../../../models');
+const defaultSettings = require('../../../schema').defaultSettings;
 const keyGroupMapper = require('../../../../api/shared/serializers/input/utils/settings-key-group-mapper');
 const keyTypeMapper = require('../../../../api/shared/serializers/input/utils/settings-key-type-mapper');
 
+const labsDefaults = JSON.parse(defaultSettings.labs.labs.defaultValue);
 const ignoredSettings = ['slack_url', 'members_from_address', 'members_support_address'];
 
 // NOTE: drop support in Ghost 5.0
@@ -204,6 +206,12 @@ class SettingsImporter extends BaseImporter {
         }
 
         _.each(this.dataToImport, (obj) => {
+            if (obj.key === 'labs' && obj.value) {
+                // Overwrite the labs setting with our current defaults
+                // Ensures things that are enabled in new versions, are turned on
+                obj.value = JSON.stringify(_.assign({}, JSON.parse(obj.value), labsDefaults));
+            }
+
             // CASE: we do not import "from address" for members settings as that needs to go via validation with magic link
             if ((obj.key === 'members_from_address') || (obj.key === 'members_support_address')) {
                 obj.value = null;

--- a/core/server/data/migrations/versions/4.7/03-add-labs-setting.js
+++ b/core/server/data/migrations/versions/4.7/03-add-labs-setting.js
@@ -1,0 +1,42 @@
+const ObjectID = require('bson-objectid');
+const logging = require('../../../../../shared/logging');
+const {createTransactionalMigration} = require('../../utils.js');
+
+const MIGRATION_USER = 1;
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const labsExists = await knex('settings')
+            .where('key', '=', 'labs')
+            .first();
+
+        if (!labsExists) {
+            logging.info('Adding "labs" record to "settings" table');
+
+            const now = knex.raw('CURRENT_TIMESTAMP');
+
+            await knex('settings')
+                .insert({
+                    id: ObjectID().toHexString(),
+                    key: 'labs',
+                    value: JSON.stringify({}),
+                    group: 'labs',
+                    type: 'object',
+                    created_at: now,
+                    created_by: MIGRATION_USER,
+                    updated_at: now,
+                    updated_by: MIGRATION_USER
+                });
+        } else {
+            logging.warn('Skipped adding "labs" record to "settings" table. Record already exists!');
+        }
+    },
+
+    async function down(knex) {
+        logging.info('Removing "labs" record from "settings" table');
+
+        await knex('settings')
+            .where('key', '=', 'labs')
+            .del();
+    }
+);

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -413,6 +413,12 @@
             "type": "string"
         }
     },
+    "labs": {
+        "labs": {
+            "defaultValue": "{}",
+            "type": "object"
+        }
+    },
     "slack": {
         "slack_url": {
             "defaultValue": "",

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -9,6 +9,8 @@ const i18n = require('../../shared/i18n');
 const errors = require('@tryghost/errors');
 const validation = require('../data/validation');
 const urlUtils = require('../../shared/url-utils');
+const {WRITABLE_KEYS_ALLOWLIST} = require('../services/labs');
+
 const internalContext = {context: {internal: true}};
 let Settings;
 let defaultSettings;
@@ -339,6 +341,17 @@ Settings = ghostBookshelf.Model.extend({
 
             if (validationErrors.length) {
                 throw new errors.ValidationError(validationErrors.join('\n'));
+            }
+        },
+        async labs(model) {
+            const flags = JSON.parse(model.get('value'));
+
+            for (const flag in flags) {
+                if (!WRITABLE_KEYS_ALLOWLIST.includes(flag)) {
+                    throw new errors.ValidationError({
+                        message: `Settings lab value cannot have value other then ${WRITABLE_KEYS_ALLOWLIST.join(', ')}`
+                    });
+                }
             }
         },
         async stripe_plans(model, options) {

--- a/core/server/services/labs.js
+++ b/core/server/services/labs.js
@@ -6,6 +6,14 @@ const i18n = require('../../shared/i18n');
 const logging = require('../../shared/logging');
 const settingsCache = require('../services/settings/cache');
 
+// NOTE: this allowlist is meant to be used to filter out any unexpected
+//       input for the "labs" setting value
+const WRITABLE_KEYS_ALLOWLIST = [
+    'activitypub'
+];
+
+module.exports.WRITABLE_KEYS_ALLOWLIST = WRITABLE_KEYS_ALLOWLIST;
+
 module.exports.getAll = () => ({
     members: settingsCache.get('members_signup_access') !== 'none'
 });

--- a/test/api-acceptance/admin/settings_spec.js
+++ b/test/api-acceptance/admin/settings_spec.js
@@ -144,7 +144,7 @@ describe('Settings API', function () {
                 },
                 {
                     key: 'labs',
-                    value: JSON.stringify({members: true})
+                    value: JSON.stringify({})
                 },
                 {
                     key: 'timezone',
@@ -171,8 +171,7 @@ describe('Settings API', function () {
         headers['x-cache-invalidate'].should.eql('/*');
         should.exist(putBody);
 
-        // NOTE: -1 for ignored labs setting
-        putBody.settings.length.should.equal(settingToChange.settings.length - 1);
+        putBody.settings.length.should.equal(settingToChange.settings.length);
 
         putBody.settings[0].key.should.eql('title');
         putBody.settings[0].value.should.eql(JSON.stringify(changedValue));
@@ -219,14 +218,17 @@ describe('Settings API', function () {
         putBody.settings[13].key.should.eql('lang');
         should.equal(putBody.settings[13].value, 'ua');
 
-        putBody.settings[14].key.should.eql('timezone');
-        should.equal(putBody.settings[14].value, 'Pacific/Auckland');
+        putBody.settings[14].key.should.eql('labs');
+        should.equal(putBody.settings[14].value, JSON.stringify({}));
 
-        putBody.settings[15].key.should.eql('unsplash');
-        should.equal(putBody.settings[15].value, false);
+        putBody.settings[15].key.should.eql('timezone');
+        should.equal(putBody.settings[15].value, 'Pacific/Auckland');
 
-        putBody.settings[16].key.should.eql('slack');
-        should.equal(putBody.settings[16].value, JSON.stringify([{
+        putBody.settings[16].key.should.eql('unsplash');
+        should.equal(putBody.settings[16].value, false);
+
+        putBody.settings[17].key.should.eql('slack');
+        should.equal(putBody.settings[17].value, JSON.stringify([{
             url: 'https://overrides.tld',
             username: 'New Slack Username'
         }]));

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -85,7 +85,8 @@ const defaultSettingsKeyTypes = [
     {key: 'oauth_client_id', type: 'oauth'},
     {key: 'oauth_client_secret', type: 'oauth'},
     {key: 'editor_default_email_recipients', type: 'editor'},
-    {key: 'editor_default_email_recipients_filter', type: 'editor'}
+    {key: 'editor_default_email_recipients_filter', type: 'editor'},
+    {key: 'labs', type: 'blog'}
 ];
 
 describe('Settings API (canary)', function () {
@@ -320,19 +321,23 @@ describe('Settings API (canary)', function () {
                 });
         });
 
-        it('Can\'t read labs dropped in v4', function (done) {
-            request.get(localUtils.API.getApiQuery('settings/labs/'))
+        it('Can read labs', async function () {
+            const res = await request.get(localUtils.API.getApiQuery('settings/labs/'))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(404)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
+                .expect(200);
 
-                    done();
-                });
+            should.not.exist(res.headers['x-cache-invalidate']);
+            const jsonResponse = res.body;
+
+            should.exist(jsonResponse);
+            should.exist(jsonResponse.settings);
+
+            jsonResponse.settings.length.should.eql(1);
+            testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'group', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
+            jsonResponse.settings[0].key.should.eql('labs');
+            jsonResponse.settings[0].value.should.eql(JSON.stringify({}));
         });
 
         it('Can read deprecated default_locale', function (done) {
@@ -648,31 +653,35 @@ describe('Settings API (canary)', function () {
                 });
         });
 
-        it('Can\'t edit labs dropped in v4', function (done) {
+        it('Can edit labs', async function () {
             const settingToChange = {
-                settings: [{key: 'labs', value: JSON.stringify({members: false})}]
+                settings: [{
+                    key: 'labs',
+                    value: JSON.stringify({
+                        matchHelper: true
+                    })
+                }]
             };
 
-            request.put(localUtils.API.getApiQuery('settings/'))
+            const res = await request.put(localUtils.API.getApiQuery('settings/'))
                 .set('Origin', config.get('url'))
                 .send(settingToChange)
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
+                .expect(200);
 
-                    const jsonResponse = res.body;
+            const jsonResponse = res.body;
 
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.settings);
+            should.exist(jsonResponse);
+            should.exist(jsonResponse.settings);
 
-                    jsonResponse.settings.length.should.eql(0);
+            jsonResponse.settings.length.should.eql(1);
+            testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'group', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
+            jsonResponse.settings[0].key.should.eql('labs');
 
-                    done();
-                });
+            jsonResponse.settings[0].value.should.eql(JSON.stringify({
+                matchHelper: true
+            }));
         });
 
         it('Can\'t edit non existent setting', function () {

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -653,12 +653,13 @@ describe('Settings API (canary)', function () {
                 });
         });
 
-        it('Can edit labs', async function () {
+        it('Can edit only allowed labs keys', async function () {
             const settingToChange = {
                 settings: [{
                     key: 'labs',
                     value: JSON.stringify({
-                        matchHelper: true
+                        activitypub: true,
+                        gibberish: true
                     })
                 }]
             };
@@ -680,7 +681,7 @@ describe('Settings API (canary)', function () {
             jsonResponse.settings[0].key.should.eql('labs');
 
             jsonResponse.settings[0].value.should.eql(JSON.stringify({
-                matchHelper: true
+                activitypub: true
             }));
         });
 

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -521,7 +521,7 @@ describe('Settings API (v2)', function () {
                 });
         });
 
-        it('Can edit only allowed labs keys', async function () {
+        it('Cannot edit labs keys', async function () {
             const settingToChange = {
                 settings: [{
                     key: 'labs',
@@ -544,13 +544,7 @@ describe('Settings API (v2)', function () {
             should.exist(jsonResponse);
             should.exist(jsonResponse.settings);
 
-            jsonResponse.settings.length.should.eql(1);
-            testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
-            jsonResponse.settings[0].key.should.eql('labs');
-
-            jsonResponse.settings[0].value.should.eql(JSON.stringify({
-                activitypub: true
-            }));
+            jsonResponse.settings.length.should.eql(0);
         });
 
         it('Can\'t edit non existent setting', function () {

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -521,12 +521,13 @@ describe('Settings API (v2)', function () {
                 });
         });
 
-        it('Can edit labs', async function () {
+        it('Can edit only allowed labs keys', async function () {
             const settingToChange = {
                 settings: [{
                     key: 'labs',
                     value: JSON.stringify({
-                        matchHelper: true
+                        activitypub: true,
+                        gibberish: true
                     })
                 }]
             };
@@ -548,7 +549,7 @@ describe('Settings API (v2)', function () {
             jsonResponse.settings[0].key.should.eql('labs');
 
             jsonResponse.settings[0].value.should.eql(JSON.stringify({
-                matchHelper: true
+                activitypub: true
             }));
         });
 

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -464,12 +464,13 @@ describe('Settings API (v3)', function () {
                 });
         });
 
-        it('Can edit labs', async function () {
+        it('Can edit only allowed labs keys', async function () {
             const settingToChange = {
                 settings: [{
                     key: 'labs',
                     value: JSON.stringify({
-                        matchHelper: true
+                        activitypub: true,
+                        gibberish: true
                     })
                 }]
             };
@@ -491,7 +492,7 @@ describe('Settings API (v3)', function () {
             jsonResponse.settings[0].key.should.eql('labs');
 
             jsonResponse.settings[0].value.should.eql(JSON.stringify({
-                matchHelper: true
+                activitypub: true
             }));
         });
 

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -464,7 +464,7 @@ describe('Settings API (v3)', function () {
                 });
         });
 
-        it('Can edit only allowed labs keys', async function () {
+        it('Cannot edit labs keys', async function () {
             const settingToChange = {
                 settings: [{
                     key: 'labs',
@@ -487,13 +487,7 @@ describe('Settings API (v3)', function () {
             should.exist(jsonResponse);
             should.exist(jsonResponse.settings);
 
-            jsonResponse.settings.length.should.eql(1);
-            testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'group', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
-            jsonResponse.settings[0].key.should.eql('labs');
-
-            jsonResponse.settings[0].value.should.eql(JSON.stringify({
-                activitypub: true
-            }));
+            jsonResponse.settings.length.should.eql(0);
         });
 
         it('Can\'t read non existent setting', function (done) {

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -83,7 +83,8 @@ const defaultSettingsKeyTypes = [
     {key: 'oauth_client_id', type: 'oauth'},
     {key: 'oauth_client_secret', type: 'oauth'},
     {key: 'editor_default_email_recipients', type: 'editor'},
-    {key: 'editor_default_email_recipients_filter', type: 'editor'}
+    {key: 'editor_default_email_recipients_filter', type: 'editor'},
+    {key: 'labs', type: 'blog'}
 ];
 
 describe('Settings API (v3)', function () {
@@ -281,19 +282,23 @@ describe('Settings API (v3)', function () {
                 });
         });
 
-        it('Can\'t read labs dropped in v4', function (done) {
-            request.get(localUtils.API.getApiQuery('settings/labs/'))
+        it('Can read labs', async function () {
+            const res = await request.get(localUtils.API.getApiQuery('settings/labs/'))
                 .set('Origin', config.get('url'))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(404)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
+                .expect(200);
 
-                    done();
-                });
+            should.not.exist(res.headers['x-cache-invalidate']);
+            const jsonResponse = res.body;
+
+            should.exist(jsonResponse);
+            should.exist(jsonResponse.settings);
+
+            jsonResponse.settings.length.should.eql(1);
+            testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'group', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
+            jsonResponse.settings[0].key.should.eql('labs');
+            jsonResponse.settings[0].value.should.eql(JSON.stringify({}));
         });
 
         it('Can read deprecated default_locale', function (done) {
@@ -459,31 +464,35 @@ describe('Settings API (v3)', function () {
                 });
         });
 
-        it('Can\'t edit labs dropped in v4', function (done) {
+        it('Can edit labs', async function () {
             const settingToChange = {
-                settings: [{key: 'labs', value: JSON.stringify({members: false})}]
+                settings: [{
+                    key: 'labs',
+                    value: JSON.stringify({
+                        matchHelper: true
+                    })
+                }]
             };
 
-            request.put(localUtils.API.getApiQuery('settings/'))
+            const res = await request.put(localUtils.API.getApiQuery('settings/'))
                 .set('Origin', config.get('url'))
                 .send(settingToChange)
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
+                .expect(200);
 
-                    const jsonResponse = res.body;
+            const jsonResponse = res.body;
 
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.settings);
+            should.exist(jsonResponse);
+            should.exist(jsonResponse.settings);
 
-                    jsonResponse.settings.length.should.eql(0);
+            jsonResponse.settings.length.should.eql(1);
+            testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'group', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
+            jsonResponse.settings[0].key.should.eql('labs');
 
-                    done();
-                });
+            jsonResponse.settings[0].value.should.eql(JSON.stringify({
+                matchHelper: true
+            }));
         });
 
         it('Can\'t read non existent setting', function (done) {

--- a/test/regression/importer/v2_spec.js
+++ b/test/regression/importer/v2_spec.js
@@ -821,12 +821,12 @@ describe('Integration: Importer', function () {
                 });
         });
 
-        it('does not import settings: labs', function () {
+        it('does import settings: labs', function () {
             const exportData = exportedBodyV2().db[0];
 
             exportData.data.settings[0] = testUtils.DataGenerator.forKnex.createSetting({
                 key: 'labs',
-                value: JSON.stringify({members: true})
+                value: JSON.stringify({activitypub: true})
             });
 
             return dataImporter.doImport(exportData, importOptions)
@@ -835,7 +835,29 @@ describe('Integration: Importer', function () {
                     return models.Settings.findOne(_.merge({key: 'labs'}, testUtils.context.internal));
                 })
                 .then(function (result) {
-                    should.equal(result, null);
+                    should.equal(result.attributes.key, 'labs');
+                    should.equal(result.attributes.group, 'labs');
+                    should.equal(result.attributes.value, '{"activitypub":true}');
+                });
+        });
+
+        it('does not import unknown settings: labs', function () {
+            const exportData = exportedBodyV2().db[0];
+
+            exportData.data.settings[0] = testUtils.DataGenerator.forKnex.createSetting({
+                key: 'labs',
+                value: JSON.stringify({gibberish: true})
+            });
+
+            return dataImporter.doImport(exportData, importOptions)
+                .then(function (imported) {
+                    imported.problems.length.should.eql(0);
+                    return models.Settings.findOne(_.merge({key: 'labs'}, testUtils.context.internal));
+                })
+                .then(function (result) {
+                    should.equal(result.attributes.key, 'labs');
+                    should.equal(result.attributes.group, 'labs');
+                    should.equal(result.attributes.value, '{}');
                 });
         });
 

--- a/test/unit/data/exporter/index_spec.js
+++ b/test/unit/data/exporter/index_spec.js
@@ -190,7 +190,8 @@ describe('Exporter', function () {
             }, 0);
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
-            const allowedKeysLength = 76;
+            //       This is a reminder to think about the importer/exporter scenarios ;)
+            const allowedKeysLength = 77;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/test/unit/data/schema/integrity_spec.js
+++ b/test/unit/data/schema/integrity_spec.js
@@ -34,7 +34,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '2099a4ba6b9462c5a0aa36a434139e8b';
     const currentFixturesHash = '8671672598d2a62e53418c4b91aa79a3';
-    const currentSettingsHash = '8a3f69dfa11d56a6c630456a67f3a59a';
+    const currentSettingsHash = '4f7fa90d4d545b9ec7eb0b86aa8f15ab';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/757
refs https://github.com/TryGhost/Team/issues/332
refs https://github.com/TryGhost/Ghost/commit/ea6d656457eb9088c5a121fc8b3a4920a4e1b903

- We have a need a quick way to add features behind flags. The old way of "labs" is the quickest way to achieve this. It has ready tooling around it and well understood pitfalls. This change reintroduces "labs" group & key in settings table in the same shape it used to be (see reffed commit)
- Next step will be introducing very basic guard rails to protect from pitfalls previous implementation of "labs" had. This will include an allow-list based input validation for lab's object's data
-  The labs being an "object" type is an EXCEPTION. Even though it's an anti-pattern we aim to move away from, for now it's the lowest impact solution that will unblock the use of flags in the system. A proper solution will come at some point.

This PR contains a [migration](https://github.com/TryGhost/Ghost/pull/13009/commits/caf9761b0a83af4b3f35fb7ac8cb66f5a075013e) modifying settings table would appreciate a review :pray:  Above are the details of why and what is being changed :wink: 

### TODO:
- [x] remove `labs` write support from non-canary endpoints as per https://github.com/TryGhost/Ghost/pull/13009#discussion_r646412031