### PR TITLE
Added initial match helper

### DIFF
--- a/core/frontend/helpers/match.js
+++ b/core/frontend/helpers/match.js
@@ -1,0 +1,85 @@
+const {logging, i18n, SafeString, labs} = require('../services/proxy');
+const _ = require('lodash');
+
+/**
+ * This is identical to the built-in if helper
+ */
+const handleConditional = (conditional, options) => {
+    if (_.isFunction(conditional)) {
+        conditional = conditional.call(this);
+    }
+
+    // Default behavior is to render the positive path if the value is truthy and not empty.
+    // The `includeZero` option may be set to treat the condtional as purely not empty based on the
+    // behavior of isEmpty. Effectively this determines if 0 is handled by the positive path or negative.
+    if ((!options.hash.includeZero && !conditional) || _.isEmpty(conditional)) {
+        return true;
+    } else {
+        return false;
+    }
+};
+
+const handleMatch = (data, operator, value) => {
+    let result;
+
+    switch (operator) {
+    case '!=':
+        result = data !== value;
+        break;
+    default:
+        result = data === value;
+    }
+
+    return result;
+};
+
+function match(...attrs) {
+    // options = options || {};
+    // options.hash = options.hash || {};
+    // options.data = options.data || {};
+
+    const options = attrs.pop();
+    const isBlock = _.has(options, 'fn');
+    let result;
+
+    if (_.isEmpty(attrs)) {
+        logging.warn(i18n.t('warnings.helpers.has.invalidAttribute'));
+        return;
+    }
+
+    if (attrs.length === 1) {
+        // If we only have one attribute, treat it as simple true/false (like the if helper)
+        result = handleConditional(attrs[0], options);
+    } else if (attrs.length === 3) {
+        result = handleMatch(attrs[0], attrs[1], attrs[2], options);
+    } else {
+        logging.warn(i18n.t('warnings.helpers.has.invalidAttribute'));
+        return;
+    }
+
+    // If we're in block mode, return the outcome from the fn/inverse functions
+    if (isBlock) {
+        if (result) {
+            return options.fn(this);
+        }
+
+        return options.inverse(this);
+    }
+
+    // Else return the result as a string
+    return new SafeString(result);
+}
+
+module.exports = function matchLabsWrapper() {
+    let self = this;
+    let args = arguments;
+
+    return labs.enabledHelper({
+        flagKey: 'matchHelper',
+        flagName: 'Match helper',
+        helperName: 'match',
+        helpUrl: 'https://ghost.org/docs/themes/'
+    }, () => {
+        return match.apply(self, args);
+    });
+};

--- a/core/frontend/services/theme-engine/handlebars/helpers.js
+++ b/core/frontend/services/theme-engine/handlebars/helpers.js
@@ -23,6 +23,7 @@ const registerAllCoreHelpers = function registerAllCoreHelpers() {
     registerThemeHelper('lang', coreHelpers.lang);
     registerThemeHelper('link', coreHelpers.link);
     registerThemeHelper('link_class', coreHelpers.link_class);
+    registerThemeHelper('match', coreHelpers.match);
     registerThemeHelper('meta_description', coreHelpers.meta_description);
     registerThemeHelper('meta_title', coreHelpers.meta_title);
     registerThemeHelper('navigation', coreHelpers.navigation);

--- a/core/server/services/labs.js
+++ b/core/server/services/labs.js
@@ -9,7 +9,8 @@ const settingsCache = require('../services/settings/cache');
 // NOTE: this allowlist is meant to be used to filter out any unexpected
 //       input for the "labs" setting value
 const WRITABLE_KEYS_ALLOWLIST = [
-    'activitypub'
+    'activitypub',
+    'matchHelper'
 ];
 
 module.exports.WRITABLE_KEYS_ALLOWLIST = WRITABLE_KEYS_ALLOWLIST;

--- a/test/unit/helpers/match_spec.js
+++ b/test/unit/helpers/match_spec.js
@@ -1,0 +1,127 @@
+const should = require('should');
+const sinon = require('sinon');
+const _ = require('lodash');
+const helpers = require('../../../core/frontend/helpers');
+const labs = require('../../../core/server/services/labs');
+const handlebars = require('../../../core/frontend/services/theme-engine/engine').handlebars;
+
+describe('Match helper', function () {
+    before(function () {
+        handlebars.registerHelper('match', helpers.match);
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    beforeEach(function () {
+        sinon.stub(labs, 'isSet').returns(true);
+    });
+
+    function shouldCompileToExpected(templateString, hash, expected) {
+        const template = handlebars.compile(templateString);
+        const result = template(hash);
+
+        result.should.eql(expected);
+    }
+
+    describe('{{#match}} (block)', function () {
+        before(function () {
+            handlebars.registerHelper('foreach', helpers.foreach);
+        });
+
+        it('{{#match title "=" "Hello World"}} works when true', function () {
+            const templateString = '{{#match title "=" "Hello World"}}true{{else}}false{{/match}}';
+            const hash = {
+                title: 'Hello World'
+            };
+
+            const expected = 'true';
+
+            shouldCompileToExpected(templateString, hash, expected);
+        });
+
+        it('{{#match title "=" "Hello World"}} works when false', function () {
+            const templateString = '{{#match title "=" "Hello World"}}true{{else}}false{{/match}}';
+            const hash = {
+                title: 'Goodbye World'
+            };
+
+            const expected = 'false';
+
+            shouldCompileToExpected(templateString, hash, expected);
+        });
+
+        it('{{#match title "!=" "Hello World"}} works when true', function () {
+            const templateString = '{{#match title "!=" "Hello World"}}true{{else}}false{{/match}}';
+            const hash = {
+                title: 'Goodbye World'
+            };
+
+            const expected = 'true';
+
+            shouldCompileToExpected(templateString, hash, expected);
+        });
+
+        it('{{#match title "!=" "Hello World"}} works when false', function () {
+            const templateString = '{{#match title "!=" "Hello World"}}true{{else}}false{{/match}}';
+            const hash = {
+                title: 'Hello World'
+            };
+
+            const expected = 'false';
+
+            shouldCompileToExpected(templateString, hash, expected);
+        });
+    });
+
+    describe('{{match}} (inline)', function () {
+        before(function () {
+            handlebars.registerHelper('foreach', helpers.foreach);
+        });
+
+        it('{{match title "=" "Hello World"}} works when true', function () {
+            const templateString = '{{match title "=" "Hello World"}}';
+            const hash = {
+                title: 'Hello World'
+            };
+
+            const expected = 'true';
+
+            shouldCompileToExpected(templateString, hash, expected);
+        });
+
+        it('{{match title "=" "Hello World"}} works when false', function () {
+            const templateString = '{{match title "=" "Hello World"}}';
+            const hash = {
+                title: 'Goodbye World'
+            };
+
+            const expected = 'false';
+
+            shouldCompileToExpected(templateString, hash, expected);
+        });
+
+        it('{{match title "!=" "Hello World"}} works when true', function () {
+            const templateString = '{{match title "!=" "Hello World"}}';
+            const hash = {
+                title: 'Goodbye World'
+            };
+
+            const expected = 'true';
+
+            shouldCompileToExpected(templateString, hash, expected);
+        });
+
+        it('{{match title "!=" "Hello World"}} works when false', function () {
+            const templateString = '{{match title "!=" "Hello World"}}';
+            const hash = {
+                title: 'Hello World'
+            };
+
+            const expected = 'false';
+
+            shouldCompileToExpected(templateString, hash, expected);
+        });
+    });
+});

--- a/test/unit/services/theme-engine/handlebars/helpers_spec.js
+++ b/test/unit/services/theme-engine/handlebars/helpers_spec.js
@@ -13,8 +13,9 @@ describe('Helpers', function () {
         'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'price', 'raw', 'reading_time', 't', 'tags', 'title', 'twitter_url',
         'url'
     ];
+    const experimentalHelpers = ['match'];
 
-    const expectedHelpers = _.concat(hbsHelpers, ghostHelpers);
+    const expectedHelpers = _.concat(hbsHelpers, ghostHelpers, experimentalHelpers);
 
     describe('Load Core Helpers', function () {
         before(function () {


### PR DESCRIPTION
refs: https://github.com/TryGhost/Team/issues/759

- wired up a matchHelper feature flag & used the labsEnabledHelper tool to gate the helper
- added a first version of the match helper, which is intended to replace the has helper
- this is an experimental helper and may or may not make it to GA
- match is a simple comparison helper, right now it does a very basic equals or not equals comparison
- much more functionality is needed to reach parity with has

