### PR TITLE
Updated monthly/yearly data in price helper

### DIFF
--- a/core/frontend/services/theme-engine/middleware.js
+++ b/core/frontend/services/theme-engine/middleware.js
@@ -71,33 +71,18 @@ async function haxGetMembersPriceData() {
 
     try {
         const {products} = await api.canary.products.browse({
-            include: 'stripe_prices'
+            include: ['monthly_price','yearly_price']
         });
 
         const defaultProduct = products[0];
 
-        const monthlyPriceId = settingsCache.get('members_monthly_price_id');
-        const yearlyPriceId = settingsCache.get('members_yearly_price_id');
+        const monthlyPrice = makePriceObject(defaultProduct.monthly_price || defaultPrice);
 
-        const activePrices = defaultProduct.stripe_prices.filter((price) => {
-            return price.active;
-        });
-
-        const nonZeroPrices = activePrices.filter((price) => {
-            return price.amount !== 0;
-        });
-
-        const monthlyPrice = nonZeroPrices.find((price) => {
-            return price.id === monthlyPriceId;
-        });
-
-        const yearlyPrice = nonZeroPrices.find((price) => {
-            return price.id === yearlyPriceId;
-        });
+        const yearlyPrice = makePriceObject(defaultProduct.yearly_price || defaultPrice);
 
         const priceData = {
-            monthly: makePriceObject(monthlyPrice || defaultPrice),
-            yearly: makePriceObject(yearlyPrice || defaultPrice),
+            monthly: monthlyPrice,
+            yearly: yearlyPrice,
             currency: monthlyPrice ? monthlyPrice.currency : defaultPrice.currency
         };
 

--- a/test/frontend-acceptance/members_spec.js
+++ b/test/frontend-acceptance/members_spec.js
@@ -49,15 +49,6 @@ describe('Front-end members behaviour', function () {
                 return 'price-data-test-theme';
             }
 
-            const stripePrices = testUtils.DataGenerator.forKnex.stripe_prices;
-            if (key === 'members_monthly_price_id') {
-                return stripePrices[1].id;
-            }
-
-            if (key === 'members_yearly_price_id') {
-                return stripePrices[2].id;
-            }
-
             return originalSettingsCacheGetFn(key, options);
         });
         await testUtils.startGhost();

--- a/test/utils/fixture-utils.js
+++ b/test/utils/fixture-utils.js
@@ -496,6 +496,14 @@ const fixtures = {
             return Promise.each(_.cloneDeep(DataGenerator.forKnex.stripe_prices), function (stripePrice) {
                 return models.StripePrice.add(stripePrice, context.internal);
             });
+        }).then(async function () {
+            // Add monthly/yearly prices to default product for testing
+            const defaultProduct = await models.Product.findOne({slug: 'default-product'}, context.internal);
+            return models.Product.edit({
+                ...defaultProduct.toJSON(),
+                monthly_price_id: DataGenerator.forKnex.stripe_prices[1].id,
+                yearly_price_id: DataGenerator.forKnex.stripe_prices[2].id
+            }, _.merge({id: defaultProduct.id}, context.internal));
         }).then(function () {
             return Promise.each(_.cloneDeep(DataGenerator.forKnex.stripe_customer_subscriptions), function (subscription) {
                 return models.StripeCustomerSubscription.add(subscription, context.internal);


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/761

With multiple products, each product can have an active monthly/yearly price, so we no longer store the monthly/yearly price ids in global settings but instead store them in product table directly. This means we need to update our global `@price` helper to also use the updated schema and use the monthly/yearly prices from product table instead of settings data.
