### PR TITLE
Updated labs service with alpha feature option

### DIFF
--- a/core/server/services/labs.js
+++ b/core/server/services/labs.js
@@ -5,6 +5,7 @@ const errors = require('@tryghost/errors');
 const i18n = require('../../shared/i18n');
 const logging = require('../../shared/logging');
 const settingsCache = require('../services/settings/cache');
+const config = require('../../shared/config');
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
 //       input for the "labs" setting value
@@ -24,10 +25,13 @@ module.exports.getAll = () => {
     return labs;
 };
 
-module.exports.isSet = function isSet(flag) {
+module.exports.isSet = function isSet(flag, options = {}) {
     const labsConfig = module.exports.getAll();
-
-    return !!(labsConfig && labsConfig[flag] && labsConfig[flag] === true);
+    const hasFlag = !!(labsConfig && labsConfig[flag] && labsConfig[flag] === true);
+    if (options.alpha) {
+        return hasFlag && config.get('enableDeveloperExperiments');
+    }
+    return hasFlag;
 };
 
 module.exports.enabledHelper = function enabledHelper(options, callback) {


### PR DESCRIPTION
no refs

- Extends `labs.isSet` method with an alpha option to determine if an alpha feature is active.
- Alpha feature needs both labs flag as well as developer experiments flag enabled

As new alpha features get added, this allows us to verify if they are enabled via a single method instead of checking both `labs.isSet` and `config.get(enableDeveloperExperiments)` at each place in the code, and also make it easy to remove the dev exp check when feature goes into beta.

Its inspired by similar option in Admin [here](https://github.com/TryGhost/Admin/blob/69cc319306e31c6da9f0c0ad292b57d1f83865d4/app/services/feature.js#L25-L260) that allows marking a feature as alpha and needs a single change to switch it to beta.
