### PR TITLE
Updated package-json lib to not need DI

### DIFF
--- a/core/server/lib/package-json.js
+++ b/core/server/lib/package-json.js
@@ -1,4 +1,0 @@
-const PackageJson = require('@tryghost/package-json');
-const i18n = require('../../shared/i18n');
-
-module.exports = new PackageJson({i18n});

--- a/core/server/services/themes/loader.js
+++ b/core/server/services/themes/loader.js
@@ -1,6 +1,6 @@
 const debug = require('ghost-ignition').debug('themes:loader');
 const config = require('../../../shared/config');
-const packageJSON = require('../../lib/package-json');
+const packageJSON = require('@tryghost/package-json');
 const themeList = require('./list');
 
 const loadAllThemes = function loadAllThemes() {

--- a/core/server/services/themes/to-json.js
+++ b/core/server/services/themes/to-json.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const themeList = require('./list');
 const bridge = require('../../../bridge');
-const packageJSON = require('../../lib/package-json');
+const packageJSON = require('@tryghost/package-json');
 const settingsCache = require('../settings/cache');
 
 /**
@@ -14,7 +14,7 @@ const settingsCache = require('../settings/cache');
  *
  * @param {string} [name] - the theme to output
  * @param {object} [checkedTheme] - a theme result from gscan
- * @return {*}
+ * @return {}
  */
 module.exports = function toJSON(name, checkedTheme) {
     let themeResult;

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@tryghost/members-csv": "1.0.0",
     "@tryghost/members-ssr": "1.0.3",
     "@tryghost/mw-session-from-token": "0.1.20",
-    "@tryghost/package-json": "0.1.1",
+    "@tryghost/package-json": "1.0.0",
     "@tryghost/promise": "0.1.8",
     "@tryghost/security": "0.2.8",
     "@tryghost/session-service": "0.1.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,6 +645,14 @@
     ghost-ignition "^4.6.1"
     lodash "^4.17.21"
 
+"@tryghost/errors@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-0.2.12.tgz#b88c5e09c62f97db97d6f1ebdbbd5dc37829a572"
+  integrity sha512-Ru/f66+PgnBGBvLtY74a/8iHkGjn/LOUM9u4nbHBHil3vB5FK4mGvPcD53Z7Ay6AeZkmt6bSGEnZHwhexJVdgg==
+  dependencies:
+    ghost-ignition "^4.6.1"
+    lodash "^4.17.21"
+
 "@tryghost/helpers@1.1.45":
   version "1.1.45"
   resolved "https://registry.yarnpkg.com/@tryghost/helpers/-/helpers-1.1.45.tgz#811c1d4c5a8a4f3e513b26dd893fa061d3c9afb1"
@@ -806,12 +814,13 @@
   resolved "https://registry.yarnpkg.com/@tryghost/mw-session-from-token/-/mw-session-from-token-0.1.20.tgz#82e72c5b1015438dc474dd85632736ce53623ae2"
   integrity sha512-w3yjYYwEMchkEZG/YE00b2dcJtf3WWJr2i9xVHQIr9ZnARHwrkVcDmbvGMunvbugVgfA00+u6MtEmZUl+r+brw==
 
-"@tryghost/package-json@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/package-json/-/package-json-0.1.1.tgz#fdb12be61e9bf51fb076694c2f868e07e40b15ac"
-  integrity sha512-04wOfvxrIqf0eJ4jx8hPtpFLFhsWGv9VdlMzwuNlsdMCAOMy+4eU1qUe4skLuatPNo/MAWTGM4jzcgyWFNGzMg==
+"@tryghost/package-json@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/package-json/-/package-json-1.0.0.tgz#62fe5a31dcfdb6d0fbe7661d69ca925280148402"
+  integrity sha512-JHDF6MdsJf60MucVt5x4lntFA6htmxNOD+oABdjTLpOsZcWP0lvq7YqKo4V/VK3x256uuzlKSaYE1+npVX8bsg==
   dependencies:
-    "@tryghost/errors" "^0.2.11"
+    "@tryghost/errors" "^0.2.12"
+    "@tryghost/tpl" "^0.1.1"
     bluebird "^3.7.2"
     fs-extra "^10.0.0"
     lodash "^4.17.21"
@@ -868,6 +877,14 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@tryghost/tpl/-/tpl-0.1.0.tgz#85eb583b593d3925ea894eda330d5de551b911cd"
   integrity sha512-zfsUCgyD62pkW01AzB0bksF8jzvk+Bt6RuYa46jUfAhD+LnDfkAPvaNqaYK8TV+dinnRPmwh0j20PJTeTayAqg==
+  dependencies:
+    c8 "^7.7.2"
+    lodash.template "^4.5.0"
+
+"@tryghost/tpl@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/tpl/-/tpl-0.1.1.tgz#41435d29cfd1cb3addd0edcd05083815a20b2ac2"
+  integrity sha512-R9tFhUAsqhdTZFaaQLfJb/eUDTp6TJpOPVKg5FarXxDmBdff1FlM/NpFI5MnHZlB/ojjNRvnTRau0yydH4U6zA==
   dependencies:
     c8 "^7.7.2"
     lodash.template "^4.5.0"


### PR DESCRIPTION
- The underlying package-json package has had i18n ripped out using the new tpl utility instead
- It's also then been refactored to not be a class that needs instantiating
- This means it can be required directly and its public interface methods used where needed
- This is a much nicer, neater pattern for what is a mature utility library :)


