### PR TITLE
Enabled all labs flags when testing

### DIFF
--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -187,7 +187,8 @@ module.exports = {
                     'array',
                     'string',
                     'number',
-                    'boolean'
+                    'boolean',
+                    'object'
                 ]]
             }
         },

--- a/core/server/services/labs.js
+++ b/core/server/services/labs.js
@@ -24,7 +24,7 @@ module.exports.getAll = () => {
     const labs = _.cloneDeep(settingsCache.get('labs')) || {};
 
     ALPHA_FEATURES.forEach((alphaKey) => {
-        if (labs[alphaKey] && !(config.get('enableDeveloperExperiments'))) {
+        if (labs[alphaKey] && !(config.get('enableDeveloperExperiments') || process.env.NODE_ENV.match(/^testing/))) {
             delete labs[alphaKey];
         }
     });

--- a/test/regression/api/canary/admin/settings_spec.js
+++ b/test/regression/api/canary/admin/settings_spec.js
@@ -677,8 +677,10 @@ describe('Settings API (canary)', function () {
 
             jsonResponse.settings.length.should.eql(1);
             testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'group', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
+
+            const jsonObjectRegex = /^\{.*\}$/; // '{...}'
             jsonResponse.settings[0].key.should.eql('labs');
-            jsonResponse.settings[0].value.should.eql(JSON.stringify({}));
+            jsonResponse.settings[0].value.should.match(jsonObjectRegex);
         });
 
         it('Can read deprecated default_locale', function (done) {

--- a/test/regression/api/v2/admin/settings_spec.js
+++ b/test/regression/api/v2/admin/settings_spec.js
@@ -286,8 +286,10 @@ describe('Settings API (v2)', function () {
 
             jsonResponse.settings.length.should.eql(1);
             testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
+
+            const jsonObjectRegex = /^\{.*\}$/; // '{...}'
             jsonResponse.settings[0].key.should.eql('labs');
-            jsonResponse.settings[0].value.should.eql(JSON.stringify({}));
+            jsonResponse.settings[0].value.should.match(jsonObjectRegex);
         });
 
         it('Can read default_locale deprecated in v3', function (done) {

--- a/test/regression/api/v3/admin/settings_spec.js
+++ b/test/regression/api/v3/admin/settings_spec.js
@@ -303,8 +303,10 @@ describe('Settings API (v3)', function () {
 
             jsonResponse.settings.length.should.eql(1);
             testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'group', 'key', 'value', 'type', 'flags', 'created_at', 'updated_at']);
+
+            const jsonObjectRegex = /^\{.*\}$/; // '{...}'
             jsonResponse.settings[0].key.should.eql('labs');
-            jsonResponse.settings[0].value.should.eql(JSON.stringify({}));
+            jsonResponse.settings[0].value.should.match(jsonObjectRegex);
         });
 
         it('Can read deprecated default_locale', function (done) {

--- a/test/unit/services/labs_spec.js
+++ b/test/unit/services/labs_spec.js
@@ -19,6 +19,7 @@ describe('Labs Service', function () {
 
     it('returns an alpha flag when dev experiments in toggled', function () {
         configUtils.set('enableDeveloperExperiments', true);
+        sinon.stub(process.env, 'NODE_ENV').value('production');
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('labs').returns({
             multipleProducts: true
@@ -35,6 +36,7 @@ describe('Labs Service', function () {
 
     it('returns a falsy alpha flag when dev experiments in NOT toggled', function () {
         configUtils.set('enableDeveloperExperiments', false);
+        sinon.stub(process.env, 'NODE_ENV').value('production');
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('labs').returns({
             multipleProducts: true


### PR DESCRIPTION
no issue

Shows impact of new code behind labs flags through the existing acceptance/regression tests. Allows for existing tests to be updated to match new behaviour rather than requiring separate tests with individual flags enabled. Should result in minimal test updating once code reaches GA.

- adds a forced `'labs:enabled'` fixture op that edits the `labs` setting to enable all flags then restarts the settings service to pick up the new setting
- modifies labs service to not remove ALPHA_FEATURE labs settings when running in a testing environment