### PR TITLE
Fixed order of flatten/clean operations in posts output serializers

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -47,6 +47,15 @@ const mapPost = (model, frame) => {
         gating.forPost(jsonModel, frame);
     }
 
+    // Transforms post/page metadata to flat structure
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    _(metaAttrs).filter((k) => {
+        return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
+    }).each((attr) => {
+        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+    });
+    delete jsonModel.posts_meta;
+
     clean.post(jsonModel, frame);
 
     if (frame.options && frame.options.withRelated) {
@@ -71,15 +80,6 @@ const mapPost = (model, frame) => {
             }
         });
     }
-
-    // Transforms post/page metadata to flat structure
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    _(metaAttrs).filter((k) => {
-        return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
-    }).each((attr) => {
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
-    });
-    delete jsonModel.posts_meta;
 
     return jsonModel;
 };

--- a/core/server/api/v2/utils/serializers/output/utils/clean.js
+++ b/core/server/api/v2/utils/serializers/output/utils/clean.js
@@ -133,6 +133,9 @@ const post = (attrs, frame) => {
     delete attrs.locale;
     delete attrs.author;
     delete attrs.type;
+    delete attrs.send_email_when_published;
+    delete attrs.email_recipient_filter;
+    delete attrs.email_subject;
 
     return attrs;
 };

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -50,6 +50,15 @@ const mapPost = (model, frame) => {
         gating.forPost(jsonModel, frame);
     }
 
+    // Transforms post/page metadata to flat structure
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    _(metaAttrs).filter((k) => {
+        return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
+    }).each((attr) => {
+        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+    });
+    delete jsonModel.posts_meta;
+
     clean.post(jsonModel, frame);
 
     if (frame.options && frame.options.withRelated) {
@@ -66,19 +75,6 @@ const mapPost = (model, frame) => {
             }
         });
     }
-
-    // Transforms post/page metadata to flat structure
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    _(metaAttrs).filter((k) => {
-        return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
-    }).each((attr) => {
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
-    });
-
-    delete jsonModel.posts_meta;
-    delete jsonModel.send_email_when_published;
-    delete jsonModel.email_recipient_filter;
-    delete jsonModel.email_subject;
 
     return jsonModel;
 };

--- a/core/server/api/v3/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v3/utils/serializers/output/utils/mapper.js
@@ -55,6 +55,15 @@ const mapPost = (model, frame) => {
         jsonModel.send_email_when_published = true;
     }
 
+    // Transforms post/page metadata to flat structure
+    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
+    _(metaAttrs).filter((k) => {
+        return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
+    }).each((attr) => {
+        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+    });
+    delete jsonModel.posts_meta;
+
     clean.post(jsonModel, frame);
 
     if (frame.options && frame.options.withRelated) {
@@ -79,15 +88,6 @@ const mapPost = (model, frame) => {
             }
         });
     }
-
-    // Transforms post/page metadata to flat structure
-    let metaAttrs = _.keys(_.omit(postsMetaSchema, ['id', 'post_id']));
-    _(metaAttrs).filter((k) => {
-        return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
-    }).each((attr) => {
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
-    });
-    delete jsonModel.posts_meta;
 
     return jsonModel;
 };


### PR DESCRIPTION
no issue

`post.clean()` implementation was expecting a flat structure representing final API output but was being called before the flatten operation for `posts_meta` meaning the structure looked like `attrs.posts_meta.property` instead

- adjusted order in output serializers to call `clean()` after flattening the `posts_meta` object
- in `v2` output serializer, moved removal of properties from the serializer into `clean()` for consistency
