### PR TITLE
Added support for canceling subscriptions

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -229,7 +229,8 @@ module.exports = {
             'subscription_id'
         ],
         data: [
-            'cancel_at_period_end'
+            'cancel_at_period_end',
+            'status'
         ],
         validation: {
             options: {
@@ -243,6 +244,9 @@ module.exports = {
             data: {
                 cancel_at_period_end: {
                     required: true
+                },
+                status: {
+                    values: ['canceled']
                 }
             }
         },
@@ -250,13 +254,22 @@ module.exports = {
             method: 'edit'
         },
         async query(frame) {
-            await membersService.api.members.updateSubscription({
-                id: frame.options.id,
-                subscription: {
-                    subscription_id: frame.options.subscription_id,
-                    cancel_at_period_end: frame.data.cancel_at_period_end
-                }
-            });
+            if (frame.data.status === 'canceled') {
+                await membersService.api.members.cancelSubscription({
+                    id: frame.options.id,
+                    subscription: {
+                        subscription_id: frame.options.subscription_id
+                    }
+                });
+            } else {
+                await membersService.api.members.updateSubscription({
+                    id: frame.options.id,
+                    subscription: {
+                        subscription_id: frame.options.subscription_id,
+                        cancel_at_period_end: frame.data.cancel_at_period_end
+                    }
+                });
+            }
             let model = await membersService.api.members.get({id: frame.options.id}, {
                 withRelated: ['labels', 'products', 'stripeSubscriptions', 'stripeSubscriptions.customer', 'stripeSubscriptions.stripePrice', 'stripeSubscriptions.stripePrice.stripeProduct']
             });

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@tryghost/limit-service": "0.6.1",
     "@tryghost/logging": "0.1.0",
     "@tryghost/magic-link": "1.0.3",
-    "@tryghost/members-api": "1.13.1",
+    "@tryghost/members-api": "1.14.0",
     "@tryghost/members-csv": "1.0.1",
     "@tryghost/members-ssr": "1.0.3",
     "@tryghost/mw-session-from-token": "0.1.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,10 +880,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@1.13.1":
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.13.1.tgz#534478c89bcfa8bc75c7f8726651164ba9d7ea4b"
-  integrity sha512-qUjfMXotdRAiHPorx0omt3wUIv/cUl21z1Wy0SMJimBLRpaencruU7mBuicwA53P4uoV6vzbQFgy8Ce9hLm6Ig==
+"@tryghost/members-api@1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.14.0.tgz#83fa4d3a10194f8980bc3d187d97bf13bf37d94f"
+  integrity sha512-10tQMkkdXkVECKN7ruoCKUn9Z+DhjKXNiamDs66ltSAuLgumwci8OX3gcSN5JB9v8mdCA54N8KtcZqmLkg+QYA==
   dependencies:
     "@tryghost/errors" "^0.2.9"
     "@tryghost/magic-link" "^1.0.3"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/775

As we currently do not delete canceled subscriptions and they are
exposed via the API, this functionality has been added to the
editSubscription controller method under the PUT HTTP method.

The cancelSubscription method in @tryghost/members-api was updated to
handle deleting by member id