### PR TITLE
Added @root-utils to the ghost-version module

### DIFF
--- a/core/server/lib/ghost-version.js
+++ b/core/server/lib/ghost-version.js
@@ -1,5 +1,7 @@
+const path = require('path');
 const semver = require('semver');
-const packageInfo = require('../../../package.json');
+const rootUtils = require('@tryghost/root-utils');
+const packageInfo = require(path.join(rootUtils.getProcessRoot(), 'package.json'));
 const version = packageInfo.version;
 const plainVersion = version.match(/^(\d+\.)?(\d+\.)?(\d+)/)[0];
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@tryghost/mw-session-from-token": "0.1.21",
     "@tryghost/package-json": "1.0.0",
     "@tryghost/promise": "0.1.9",
+    "@tryghost/root-utils": "0.1.0",
     "@tryghost/security": "0.2.9",
     "@tryghost/session-service": "0.1.23",
     "@tryghost/social-urls": "0.1.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,6 +840,14 @@
   dependencies:
     bluebird "^3.7.2"
 
+"@tryghost/root-utils@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.1.0.tgz#7578cb5e57953316fef58edd43a152a86b719a8f"
+  integrity sha512-zy3PSviwytjvjdMso86RYZLE2I4e2yL/s83fIEf/g17C8V8hsCcgE83cFOpCw3ISWDFX3Qi0IX9kI3or2pfGLg==
+  dependencies:
+    caller "^1.0.1"
+    find-root "^1.1.0"
+
 "@tryghost/security@0.2.9":
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@tryghost/security/-/security-0.2.9.tgz#1bc323b22774c122c54a1b43a2594cdc88feba71"
@@ -1922,7 +1930,7 @@ call-bind@^1.0.0:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-caller@1.0.1:
+caller@1.0.1, caller@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/caller/-/caller-1.0.1.tgz#b851860f70e195db3d277395aa1a7e23ea30ecf5"
   integrity sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU=
@@ -3956,7 +3964,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-root@1.1.0:
+find-root@1.1.0, find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==


### PR DESCRIPTION
no issue

Part of the effort to split ghost into smaller, decoupled parts. The @root-utils package lets us avoid hard-coding a path to package.json, and means that the ghost-version.js file could eventually be moved into a separate module.
