### PR TITLE
Added @tryghost/root-utils to the ghost-version module

### DIFF
--- a/core/server/lib/ghost-version.js
+++ b/core/server/lib/ghost-version.js
@@ -1,5 +1,7 @@
+const path = require('path');
 const semver = require('semver');
-const packageInfo = require('../../../package.json');
+const rootUtils = require('@tryghost/root-utils');
+const packageInfo = require(path.join(rootUtils.getProcessRoot(), 'package.json'));
 const version = packageInfo.version;
 const plainVersion = version.match(/^(\d+\.)?(\d+\.)?(\d+)/)[0];
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@tryghost/mw-session-from-token": "0.1.21",
     "@tryghost/package-json": "1.0.0",
     "@tryghost/promise": "0.1.9",
+    "@tryghost/root-utils": "0.3.0",
     "@tryghost/security": "0.2.9",
     "@tryghost/session-service": "0.1.23",
     "@tryghost/social-urls": "0.1.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,6 +933,14 @@
   dependencies:
     bluebird "^3.7.2"
 
+"@tryghost/root-utils@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.3.0.tgz#94565b5063c296b7493e3a635f9b77a8f917076b"
+  integrity sha512-4OaSksIjR5RVAYXXfhTlNbt/gbj9mG/qxW0Kn6uoq8RWSBaV/Hjh7wdw+ptCJ7WPT87bFO7A6uZz29AjDeNGow==
+  dependencies:
+    caller "^1.0.1"
+    find-root "^1.1.0"
+
 "@tryghost/root-utils@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.1.0.tgz#7578cb5e57953316fef58edd43a152a86b719a8f"


### PR DESCRIPTION
no issue

Part of the effort to split ghost into smaller, decoupled parts. The @root-utils package lets us avoid hard-coding a path to package.json, and means that the ghost-version.js file could eventually be moved into a separate module.

This commit uses a patched version of @tryghost/root-utils which checks for the existence of a `current` directory, as used in Ghost-CLI. Since this is very specific to Ghost and Ghost CLI, there's a new method called "getGhostRoot" for this purpose.
