### PR TITLE
Migrated comped members to 'comped' status

### DIFF
--- a/core/server/data/migrations/versions/4.9/06-add-comped-status.js
+++ b/core/server/data/migrations/versions/4.9/06-add-comped-status.js
@@ -1,0 +1,46 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils.js');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const compedMemberIds = (await knex('members')
+            .select('members.id')
+            .innerJoin(
+                'members_stripe_customers',
+                'members.id',
+                'members_stripe_customers.member_id'
+            ).innerJoin(
+                'members_stripe_customers_subscriptions',
+                function () {
+                    this.on(
+                        'members_stripe_customers.customer_id',
+                        'members_stripe_customers_subscriptions.customer_id'
+                    ).onIn(
+                        'members_stripe_customers_subscriptions.status',
+                        ['active', 'trialing', 'past_due', 'unpaid']
+                    );
+                }
+            ).where(
+                'members_stripe_customers_subscriptions.plan_nickname',
+                '=',
+                'Complimentary'
+            )).map(({id}) => id);
+
+        if (compedMemberIds.length === 0) {
+            logging.info('No Members found with Complimentary subscriptions');
+            return;
+        }
+
+        logging.info(`Updating ${compedMemberIds.length} Members status from 'paid' -> 'comped'`);
+
+        await knex('members')
+            .update('status', 'comped')
+            .whereIn('id', compedMemberIds);
+    },
+    async function down(knex) {
+        logging.info('Updating all member "comped" statuses to "paid"');
+        await knex('members')
+            .update('status', 'paid')
+            .where('status', 'comped');
+    }
+);

--- a/core/server/data/migrations/versions/4.9/07-update-comped-members-status-events.js
+++ b/core/server/data/migrations/versions/4.9/07-update-comped-members-status-events.js
@@ -1,0 +1,38 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils.js');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Updating members_status_events for comped members');
+        const compedMembers = await knex('members')
+            .select('id')
+            .where('status', 'comped');
+
+        if (compedMembers.length === 0) {
+            logging.info('No comped members found - skipping migration');
+            return;
+        } else {
+            logging.info(`Found ${compedMembers.length} comped members - checking members_status_events`);
+        }
+
+        for (const member of compedMembers) {
+            const mostRecentStatusEvent = await knex('members_status_events')
+                .select('*')
+                .where('member_id', member.id)
+                .orderBy('created_at', 'desc')
+                .limit(1)
+                .first();
+
+            if (!mostRecentStatusEvent) {
+                logging.warn(`Could not find a status event for member ${member.id} - skipping this member`);
+            } else if (mostRecentStatusEvent.to_status !== 'comped') {
+                logging.info(`Updating members_status_event ${mostRecentStatusEvent.id}`);
+                await knex('members_status_events')
+                    .update('to_status', 'comped')
+                    .where('id', mostRecentStatusEvent.id);
+            }
+        }
+    },
+    async function down() {}
+);
+


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/790

**Migration 4.9/06:**
In order to track when a member was comped, as well as to differentiate
paid members from comped, we are reintroducing the 'comped' status. This
migration will updated members with a Complimentary Stripe Subscription
to a status of 'comped'. It is essentially a reversal of the 4.6
migration.

**Migration 4.9/07:**
Since version 4.6 the 'comped' status has not been used. Any members
which were given complimentary plans since then will have had a `status`
of 'paid', and therefore the corresponding members_status_events row
would have a `to_status` of 'paid'.

This migration is designed to fix these members_status_events rows by
ensuring that the last (chronologically) members_status_event row for a
comped member has a to status of 'comped'.

Unfortunately this migration loses information which makes writing a
perfect inverse migration impossible. Alternative down migrations were
considered, but these would lose further information.