### PR TITLE
Handle new visibility filter changes for post access

### DIFF
--- a/core/frontend/helpers/tpl/content-cta.hbs
+++ b/core/frontend/helpers/tpl/content-cta.hbs
@@ -7,6 +7,9 @@
         {{#has visibility="members"}}
             <h2>This post is for subscribers only</h2>
         {{/has}}
+        {{#has visibility="filter"}}
+            <h2>This post is for subscribers on specific product only</h2>
+        {{/has}}
         {{#if @member}}
             <a class="gh-btn" data-portal="account/plans" style="color:{{accentColor}}">Upgrade your account</a>
         {{else}}

--- a/core/server/api/canary/utils/serializers/input/posts.js
+++ b/core/server/api/canary/utils/serializers/input/posts.js
@@ -111,6 +111,13 @@ const transformLegacyEmailRecipientFilters = (frame) => {
     }
 };
 
+const transformPostVisibilityFilters = (frame) => {
+    if (frame.data.posts[0].visibility === 'filter' && frame.data.posts[0].visibility_filter) {
+        frame.data.posts[0].visibility = frame.data.posts[0].visibility_filter;
+    }
+    delete frame.data.posts[0].visibility_filter;
+};
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
@@ -205,6 +212,7 @@ module.exports = {
             });
         }
 
+        transformPostVisibilityFilters(frame);
         transformLegacyEmailRecipientFilters(frame);
         handlePostsMeta(frame);
         defaultFormat(frame);

--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const localUtils = require('../../../index');
+const labsService = require('../../../../../../services/labs');
 
 const tag = (attrs, frame) => {
     if (localUtils.isContentAPI(frame)) {
@@ -118,6 +119,14 @@ const post = (attrs, frame) => {
 
     if (!attrs.authors) {
         delete attrs.primary_author;
+    }
+
+    // Handles visibility filter for multiple products
+    if (attrs.visibility && labsService.isSet('multipleProducts')) {
+        if (!['members', 'public', 'paid'].includes(attrs.visibility)) {
+            attrs.visibility_filter = attrs.visibility;
+            attrs.visibility = 'filter';
+        }
     }
 
     delete attrs.locale;

--- a/core/server/api/canary/utils/validators/input/pages.js
+++ b/core/server/api/canary/utils/validators/input/pages.js
@@ -1,7 +1,11 @@
 const jsonSchema = require('../utils/json-schema');
 const models = require('../../../../../models');
 const {ValidationError} = require('@tryghost/errors');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+};
 
 const validateVisibility = async function (frame) {
     if (!frame.data.pages || !frame.data.pages[0]) {
@@ -10,16 +14,17 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.pages[0].visibility;
+    const visibilityFilter = frame.data.pages[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibility, limit: 1});
+                await models.Member.findPage({filter: visibilityFilter, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
-                    message: i18n.t('errors.api.pages.invalidVisibilityFilter'),
-                    property: 'visibility'
+                    message: tpl(messages.invalidVisibilityFilter),
+                    property: 'visibility_filter'
                 }));
             }
         }

--- a/core/server/api/canary/utils/validators/input/posts.js
+++ b/core/server/api/canary/utils/validators/input/posts.js
@@ -1,7 +1,11 @@
 const jsonSchema = require('../utils/json-schema');
 const models = require('../../../../../models');
 const {ValidationError} = require('@tryghost/errors');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+};
 
 const validateVisibility = async function (frame) {
     if (!frame.data.posts || !frame.data.posts[0]) {
@@ -10,16 +14,17 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.posts[0].visibility;
+    const visibilityFilter = frame.data.posts[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibility, limit: 1});
+                await models.Member.findPage({filter: visibilityFilter, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
-                    message: i18n.t('errors.api.posts.invalidVisibilityFilter'),
-                    property: 'visibility'
+                    message: tpl(messages.invalidVisibilityFilter),
+                    property: 'visibility_filter'
                 }));
             }
         }

--- a/core/server/api/v2/utils/validators/input/pages.js
+++ b/core/server/api/v2/utils/validators/input/pages.js
@@ -1,7 +1,11 @@
 const jsonSchema = require('../utils/json-schema');
 const models = require('../../../../../models');
 const {ValidationError} = require('@tryghost/errors');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+};
 
 const validateVisibility = async function (frame) {
     if (!frame.data.pages || !frame.data.pages[0]) {
@@ -10,16 +14,17 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.pages[0].visibility;
+    const visibilityFilter = frame.data.pages[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibility, limit: 1});
+                await models.Member.findPage({filter: visibilityFilter, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
-                    message: i18n.t('errors.api.pages.invalidVisibilityFilter'),
-                    property: 'visibility'
+                    message: tpl(messages.invalidVisibilityFilter),
+                    property: 'visibility_filter'
                 }));
             }
         }

--- a/core/server/api/v2/utils/validators/input/pages.js
+++ b/core/server/api/v2/utils/validators/input/pages.js
@@ -4,7 +4,7 @@ const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
-    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+    invalidVisibilityFilter: 'Invalid filter in visibility property'
 };
 
 const validateVisibility = async function (frame) {
@@ -14,17 +14,16 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.pages[0].visibility;
-    const visibilityFilter = frame.data.pages[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibilityFilter, limit: 1});
+                await models.Member.findPage({filter: visibility, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
                     message: tpl(messages.invalidVisibilityFilter),
-                    property: 'visibility_filter'
+                    property: 'visibility'
                 }));
             }
         }

--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -4,7 +4,7 @@ const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
-    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+    invalidVisibilityFilter: 'Invalid filter in visibility property'
 };
 
 const validateVisibility = async function (frame) {
@@ -14,17 +14,16 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.posts[0].visibility;
-    const visibilityFilter = frame.data.posts[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibilityFilter, limit: 1});
+                await models.Member.findPage({filter: visibility, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
                     message: tpl(messages.invalidVisibilityFilter),
-                    property: 'visibility_filter'
+                    property: 'visibility'
                 }));
             }
         }

--- a/core/server/api/v2/utils/validators/input/posts.js
+++ b/core/server/api/v2/utils/validators/input/posts.js
@@ -1,7 +1,11 @@
 const jsonSchema = require('../utils/json-schema');
 const models = require('../../../../../models');
 const {ValidationError} = require('@tryghost/errors');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+};
 
 const validateVisibility = async function (frame) {
     if (!frame.data.posts || !frame.data.posts[0]) {
@@ -10,16 +14,17 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.posts[0].visibility;
+    const visibilityFilter = frame.data.posts[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibility, limit: 1});
+                await models.Member.findPage({filter: visibilityFilter, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
-                    message: i18n.t('errors.api.posts.invalidVisibilityFilter'),
-                    property: 'visibility'
+                    message: tpl(messages.invalidVisibilityFilter),
+                    property: 'visibility_filter'
                 }));
             }
         }

--- a/core/server/api/v3/utils/serializers/output/utils/clean.js
+++ b/core/server/api/v3/utils/serializers/output/utils/clean.js
@@ -96,6 +96,11 @@ const post = (attrs, frame) => {
         if (attrs.og_description === '') {
             attrs.og_description = null;
         }
+        // Note: If visibility is set to a specific filter in v4, we want to return paid in v3
+        if (attrs.visibility && !['public', 'members', 'paid'].includes(attrs.visibility)) {
+            attrs.visibility = 'paid';
+        }
+
         // NOTE: the visibility column has to be always present in Content API response to perform content gating
         if (columns && columns.includes('visibility') && fields && !fields.includes('visibility')) {
             delete attrs.visibility;

--- a/core/server/api/v3/utils/validators/input/pages.js
+++ b/core/server/api/v3/utils/validators/input/pages.js
@@ -1,7 +1,11 @@
 const jsonSchema = require('../utils/json-schema');
 const models = require('../../../../../models');
 const {ValidationError} = require('@tryghost/errors');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+};
 
 const validateVisibility = async function (frame) {
     if (!frame.data.pages || !frame.data.pages[0]) {
@@ -10,16 +14,17 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.pages[0].visibility;
+    const visibilityFilter = frame.data.pages[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibility, limit: 1});
+                await models.Member.findPage({filter: visibilityFilter, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
-                    message: i18n.t('errors.api.pages.invalidVisibilityFilter'),
-                    property: 'visibility'
+                    message: tpl(messages.invalidVisibilityFilter),
+                    property: 'visibility_filter'
                 }));
             }
         }

--- a/core/server/api/v3/utils/validators/input/pages.js
+++ b/core/server/api/v3/utils/validators/input/pages.js
@@ -4,7 +4,7 @@ const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
-    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+    invalidVisibilityFilter: 'Invalid filter in visibility property'
 };
 
 const validateVisibility = async function (frame) {
@@ -14,17 +14,16 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.pages[0].visibility;
-    const visibilityFilter = frame.data.pages[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibilityFilter, limit: 1});
+                await models.Member.findPage({filter: visibility, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
                     message: tpl(messages.invalidVisibilityFilter),
-                    property: 'visibility_filter'
+                    property: 'visibility'
                 }));
             }
         }

--- a/core/server/api/v3/utils/validators/input/posts.js
+++ b/core/server/api/v3/utils/validators/input/posts.js
@@ -4,7 +4,7 @@ const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
-    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+    invalidVisibilityFilter: 'Invalid filter in visibility property'
 };
 
 const validateVisibility = async function (frame) {
@@ -14,17 +14,16 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.posts[0].visibility;
-    const visibilityFilter = frame.data.posts[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibilityFilter, limit: 1});
+                await models.Member.findPage({filter: visibility, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
                     message: tpl(messages.invalidVisibilityFilter),
-                    property: 'visibility_filter'
+                    property: 'visibility'
                 }));
             }
         }

--- a/core/server/api/v3/utils/validators/input/posts.js
+++ b/core/server/api/v3/utils/validators/input/posts.js
@@ -1,7 +1,11 @@
 const jsonSchema = require('../utils/json-schema');
 const models = require('../../../../../models');
 const {ValidationError} = require('@tryghost/errors');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+};
 
 const validateVisibility = async function (frame) {
     if (!frame.data.posts || !frame.data.posts[0]) {
@@ -10,16 +14,17 @@ const validateVisibility = async function (frame) {
 
     // validate visibility - not done at schema level because this can be an NQL query so needs model access
     const visibility = frame.data.posts[0].visibility;
+    const visibilityFilter = frame.data.posts[0].visibility_filter;
     if (visibility) {
         if (!['public', 'members', 'paid'].includes(visibility)) {
             // check filter is valid
             try {
-                await models.Member.findPage({filter: visibility, limit: 1});
+                await models.Member.findPage({filter: visibilityFilter, limit: 1});
                 return Promise.resolve();
             } catch (err) {
                 return Promise.reject(new ValidationError({
-                    message: i18n.t('errors.api.posts.invalidVisibilityFilter'),
-                    property: 'visibility'
+                    message: tpl(messages.invalidVisibilityFilter),
+                    property: 'visibility_filter'
                 }));
             }
         }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nexes/nql": "0.5.2",
     "@sentry/node": "6.8.0",
     "@tryghost/adapter-manager": "0.2.14",
-    "@tryghost/admin-api-schema": "2.4.0",
+    "@tryghost/admin-api-schema": "2.5.0",
     "@tryghost/bookshelf-plugins": "0.1.3",
     "@tryghost/bootstrap-socket": "0.2.9",
     "@tryghost/config-url-helpers": "0.1.0",

--- a/test/unit/api/canary/utils/validators/input/pages_spec.js
+++ b/test/unit/api/canary/utils/validators/input/pages_spec.js
@@ -198,7 +198,8 @@ describe('Unit: canary/utils/validators/input/pages', function () {
                         pages: [{
                             title: 'pass',
                             authors: [{id: 'correct'}],
-                            visibility: 'label:vip'
+                            visibility: 'filter',
+                            visibility_filter: 'label:vip'
                         }]
                     }
                 };

--- a/test/unit/api/canary/utils/validators/input/posts_spec.js
+++ b/test/unit/api/canary/utils/validators/input/posts_spec.js
@@ -198,7 +198,8 @@ describe('Unit: canary/utils/validators/input/posts', function () {
                         posts: [{
                             title: 'pass',
                             authors: [{id: 'correct'}],
-                            visibility: 'label:vip'
+                            visibility: 'filter',
+                            visibility_filter: 'label:vip'
                         }]
                     }
                 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,14 +598,12 @@
   dependencies:
     "@tryghost/errors" "^0.2.13"
 
-"@tryghost/admin-api-schema@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-2.4.0.tgz#d84885ba138d7da709f8934f18abe3a4635e6f09"
-  integrity sha512-A1b/lohwKmR2u26ycQvvSzC9MrRwk3ZLvHPPbHeFxH4g2yH2N3JX420WHvi4Vk0e2E5gFzir2e7itG9BJ9SaoQ==
+"@tryghost/admin-api-schema@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-2.5.0.tgz#8ac3dccff3428197745032e4fda07d781464397f"
+  integrity sha512-8LyI2/weIN8js3Wg+LIfPygG/tSRijqrBEbJ0bEroPkm+27oF7MfAj+vSAzHj65G6cBP8lIUetGPNO2U+nHjPw==
   dependencies:
     "@tryghost/errors" "^0.2.10"
-    bluebird "^3.5.3"
-    ghost-ignition "^4.6.2"
     lodash "^4.17.11"
 
 "@tryghost/bookshelf-collision@^0.1.1":


### PR DESCRIPTION
With multiple products we'll re-enable segmentation by product for posts, which also means we need to add a new option to the default post access setting in Membership settings. This PR handles the new `visibility_filter` attribute in post/page api that handles any custom filters set on post access behind the `multipleProducts` flag.

Note: PR is waiting on successful tests for merge