### PR TITLE
added healthcheck route #11181

### DIFF
--- a/core/server/web/api/app.js
+++ b/core/server/web/api/app.js
@@ -12,6 +12,9 @@ module.exports = function setupApiApp() {
         apiApp.use(require('./testmode')());
     }
 
+    // API healthcheck endpoint for load balancer
+    apiApp.get('/health', (req, res) => res.status(200).send('SUCCESS'));
+
     // Mount different API versions
     apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'content'}), require('./v2/content/app')());
     apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'admin'}), require('./v2/admin/app')());


### PR DESCRIPTION
Hello.

This healthcheck route is required for using Ghost behind a cloud-service load balancer which can not manually set "X-Forwarded-Proto: https".

Issue: https://github.com/TryGhost/Ghost/issues/11181

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)
