### PR TITLE
🐛 Fixed potential for partial content re-generation in 4.0 migrations

### DIFF
--- a/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
+++ b/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
@@ -30,10 +30,12 @@ module.exports = createIrreversibleMigration(async (knex) => {
                 mobiledoc = JSON.parse(post.mobiledoc || null);
 
                 if (!mobiledoc) {
-                    return logging.warn(`No mobiledoc for ${id}. Skipping.`);
+                    logging.warn(`No mobiledoc for ${id}. Skipping.`);
+                    continue;
                 }
             } catch (err) {
-                return logging.warn(`Invalid JSON structure for ${id}. Skipping`);
+                logging.warn(`Invalid JSON structure for ${id}. Skipping`);
+                continue;
             }
 
             const html = mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc);


### PR DESCRIPTION
no issue

- incorrect syntax was used in the error handlers inside of the `for` loop, by using `return` when logging the whole for-loop was aborted whereas we want to log and continue processing the rest of the items
