### PR TITLE
Added cache control headers to members api

### DIFF
--- a/core/server/web/members/app.js
+++ b/core/server/web/members/app.js
@@ -15,6 +15,9 @@ module.exports = function setupMembersApp() {
     // send 503 json response in case of maintenance
     membersApp.use(shared.middlewares.maintenance);
 
+    // Members API shouldn't be cached
+    membersApp.use(shared.middlewares.cacheControl('private'));
+
     // Support CORS for requests from the frontend
     const siteUrl = new URL(urlUtils.getSiteUrl());
     membersApp.use(cors(siteUrl.origin));


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/846

- members api was missing cacheControl middleware to declare its cache control headers