### PR TITLE
Updated WEBHOOK_SECRET check to warn rather than error

### DIFF
--- a/core/server/services/members/service.js
+++ b/core/server/services/members/service.js
@@ -68,7 +68,8 @@ const membersService = {
 
         if (env !== 'production') {
             if (!process.env.WEBHOOK_SECRET && membersConfig.isStripeConnected()) {
-                throw new Error('Cannot use remote webhooks in development. Please restart in production mode or see https://ghost.org/docs/webhooks/#stripe-webhooks for developing with Stripe.');
+                process.env.WEBHOOK_SECRET = 'DEFAULT_WEBHOOK_SECRET';
+                logging.warn('Cannot use remote webhooks in development. See https://ghost.org/docs/webhooks/#stripe-webhooks for developing with Stripe.');
             }
 
             if (paymentConfig && paymentConfig.secretKey.startsWith('sk_live')) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/841

When using our development tooling Ghost should always start, instead of
exiting with an error. This check for the WEBHOOK_SECRET env var was the
primary cause of Ghost erroring in development, so it's been switched
with a warning.