### PR TITLE
🐛 fixed `name is not defined` error when uploading invalid theme

### DIFF
--- a/core/server/services/themes/validate.js
+++ b/core/server/services/themes/validate.js
@@ -6,7 +6,7 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 
 const messages = {
-    themeHasErrors: 'Theme {theme} is not compatible or contains errors.',
+    themeHasErrors: 'Theme "{theme}" is not compatible or contains errors.',
     activeThemeHasFatalErrors: 'The currently active theme "{theme}" has fatal errors.',
     activeThemeHasErrors: 'The currently active theme "{theme}" has errors, but will still work.'
 };

--- a/core/server/services/themes/validate.js
+++ b/core/server/services/themes/validate.js
@@ -6,7 +6,7 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 
 const messages = {
-    themeHasErrors: 'Theme {name} is not compatible or contains errors.',
+    themeHasErrors: 'Theme {theme} is not compatible or contains errors.',
     activeThemeHasFatalErrors: 'The currently active theme "{theme}" has fatal errors.',
     activeThemeHasErrors: 'The currently active theme "{theme}" has errors, but will still work.'
 };


### PR DESCRIPTION
initially reported in https://forum.ghost.org/t/name-is-not-defined-error-when-uploading-theme/24078

Lodash throws an error when the template has invalid interpolations.

Q: Should the interpolation be updated to be wrapped in quotes like the other messages (`"{theme}"`)?
