### PR TITLE
Removed use of `new Error()` in migrations

### DIFF
--- a/core/server/data/migrations/utils.js
+++ b/core/server/data/migrations/utils.js
@@ -1,9 +1,15 @@
 const ObjectId = require('bson-objectid').default;
 const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
 const commands = require('../schema').commands;
 const Promise = require('bluebird');
 
 const MIGRATION_USER = 1;
+
+const messages = {
+    permissionRoleActionError: 'Cannot {action} permission({permission}) with role({role}) - {resource} does not exist'
+};
 
 /**
  * Creates a migrations which will add a new table from schema.js to the database
@@ -138,9 +144,14 @@ function addPermissionToRole(config) {
             }).first();
 
             if (!permission) {
-                throw new Error(
-                    `Cannot add permission(${config.permission}) to role(${config.role}) - permission does not exist`
-                );
+                throw new errors.GhostError({
+                    message: tpl(messages.permissionRoleActionError, {
+                        action: 'add',
+                        permission: config.permission,
+                        role: config.role,
+                        resource: 'permission'
+                    })
+                });
             }
 
             const role = await connection('roles').where({
@@ -148,9 +159,14 @@ function addPermissionToRole(config) {
             }).first();
 
             if (!role) {
-                throw new Error(
-                    `Cannot add permission(${config.permission}) to role(${config.role}) - role does not exist`
-                );
+                throw new errors.GhostError({
+                    message: tpl(messages.permissionRoleActionError, {
+                        action: 'add',
+                        permission: config.permission,
+                        role: config.role,
+                        resource: 'role'
+                    })
+                });
             }
 
             const existingRelation = await connection('permissions_roles').where({
@@ -176,9 +192,14 @@ function addPermissionToRole(config) {
             }).first();
 
             if (!permission) {
-                throw new Error(
-                    `Cannot remove permission(${config.permission}) from role(${config.role}) - permission does not exist`
-                );
+                throw new errors.GhostError({
+                    message: tpl(messages.permissionRoleActionError, {
+                        action: 'remove',
+                        permission: config.permission,
+                        role: config.role,
+                        resource: 'permission'
+                    })
+                });
             }
 
             const role = await connection('roles').where({
@@ -186,9 +207,14 @@ function addPermissionToRole(config) {
             }).first();
 
             if (!role) {
-                throw new Error(
-                    `Cannot remove permission(${config.permission}) from role(${config.role}) - role does not exist`
-                );
+                throw new errors.GhostError({
+                    message: tpl(messages.permissionRoleActionError, {
+                        action: 'remove',
+                        permission: config.permission,
+                        role: config.role,
+                        resource: 'role'
+                    })
+                });
             }
 
             const existingRelation = await connection('permissions_roles').where({

--- a/core/server/data/migrations/versions/4.0/25-populate-members-paid-subscription-events-table.js
+++ b/core/server/data/migrations/versions/4.0/25-populate-members-paid-subscription-events-table.js
@@ -2,6 +2,12 @@ const {chunk} = require('lodash');
 const ObjectID = require('bson-objectid');
 const {createTransactionalMigration} = require('../../utils');
 const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    unknownSubscriptionIntervalError: 'Unknown Subscription interval "{interval}" found.'
+};
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
@@ -38,7 +44,11 @@ module.exports = createTransactionalMigration(
                 return amount * 30;
             }
 
-            throw new Error(`Unknown Subscription interval "${interval}" found.`);
+            throw new errors.GhostError({
+                message: tpl(messages.unknownSubscriptionIntervalError , {
+                    interval
+                })
+            });
         }
 
         const allEvents = allSubscriptions.reduce((allEventsAcc, subscription) => {

--- a/test/unit/data/schema/commands.test.js
+++ b/test/unit/data/schema/commands.test.js
@@ -1,0 +1,36 @@
+const should = require('should');
+const errors = require('@tryghost/errors');
+
+const commands = require('../../../../core/server/data/schema/commands');
+
+describe('schema commands', function () {
+    it('_hasForeignSQLite throws when knex is nox configured to use sqlite3', async function () {
+        const Knex = require('knex');
+        const knex = Knex({
+            client: 'mysql'
+        });
+
+        try {
+            await commands._hasForeignSQLite({transaction: knex});
+            should.fail('addForeign did not throw');
+        } catch (err) {
+            should.equal(err instanceof errors.GhostError, true);
+            err.message.should.equal('Must use hasForeignSQLite3 on an SQLite3 database');
+        }
+    });
+
+    it('_hasPrimaryKeySQLite throws when knex is configured to use sqlite', async function () {
+        const Knex = require('knex');
+        const knex = Knex({
+            client: 'mysql'
+        });
+
+        try {
+            await commands._hasPrimaryKeySQLite(null, knex);
+            should.fail('hasPrimaryKeySQLite did not throw');
+        } catch (err) {
+            should.equal(err instanceof errors.GhostError, true);
+            err.message.should.equal('Must use hasPrimaryKeySQLite on an SQLite3 database');
+        }
+    });
+});


### PR DESCRIPTION
:building_construction: @daniellockyer not a big change, just following our review principles ;) 