### PR TITLE
Added userAuth brute middleware to members auth endpoint

### DIFF
--- a/core/server/web/members/app.js
+++ b/core/server/web/members/app.js
@@ -39,7 +39,7 @@ module.exports = function setupMembersApp() {
     membersApp.get('/api/site', middleware.getMemberSiteData);
 
     // NOTE: this is wrapped in a function to ensure we always go via the getter
-    membersApp.post('/api/send-magic-link', (req, res, next) => membersService.api.middleware.sendMagicLink(req, res, next));
+    membersApp.post('/api/send-magic-link', bodyParser.json(), shared.middlewares.brute.membersAuth, (req, res, next) => membersService.api.middleware.sendMagicLink(req, res, next));
     membersApp.post('/api/create-stripe-checkout-session', (req, res, next) => membersService.api.middleware.createCheckoutSession(req, res, next));
     membersApp.post('/api/create-stripe-update-session', (req, res, next) => membersService.api.middleware.createCheckoutSetupSession(req, res, next));
     membersApp.put('/api/subscriptions/:id', (req, res, next) => membersService.api.middleware.updateSubscription(req, res, next));

--- a/core/server/web/shared/middlewares/brute.js
+++ b/core/server/web/shared/middlewares/brute.js
@@ -94,5 +94,20 @@ module.exports = {
             }
             return next(err, ...rest);
         });
+    },
+
+    /**
+     */
+    membersAuth(req, res, next) {
+        return spamPrevention.userLogin().getMiddleware({
+            ignoreIP: false,
+            key(_req, _res, _next) {
+                if (_req.body.email) {
+                    return _next(`${_req.body.email}login`);
+                }
+
+                return _next();
+            }
+        })(req, res, next);
     }
 };


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/696

The userAuth spam prevention logic is reused, but a new piece of
middleware has to be created so that we can use a custom lookup key to
conatin the member email.

We must also add json parsing middleware to the route so that the brute
middleware can read the email.

The express body-parser middleware handles multiple instances on the
same route, so this doesn't cause problems upstream.

https://github.com/expressjs/body-parser/blob/1.19.0/lib/types/json.js#L99-L103