### PR TITLE
Replaced usage of Error with @tryghost/errors

### DIFF
--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -1,7 +1,13 @@
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
 const {URL} = require('url');
 const crypto = require('crypto');
 const createKeypair = require('keypair');
 const path = require('path');
+
+const messages = {
+    incorrectKeyType: 'type must be one of "direct" or "connect".'
+};
 
 class MembersConfigProvider {
     /**
@@ -92,7 +98,7 @@ class MembersConfigProvider {
      */
     getStripeKeys(type) {
         if (type !== 'direct' && type !== 'connect') {
-            throw new Error();
+            throw new errors.IncorrectUsageError(tpl(messages.incorrectKeyType));
         }
 
         const secretKey = this._settingsCache.get(`stripe_${type === 'connect' ? 'connect_' : ''}secret_key`);

--- a/core/server/services/members/importer/importer.js
+++ b/core/server/services/members/importer/importer.js
@@ -185,8 +185,8 @@ module.exports = class MembersCSVImporter {
                 };
             } catch (error) {
                 // The model layer can sometimes throw arrays of errors
-                const errors = [].concat(error);
-                const errorMessage = errors.map(({message}) => message).join(', ');
+                const errorList = [].concat(error);
+                const errorMessage = errorList.map(({message}) => message).join(', ');
                 await trx.rollback();
                 return {
                     ...resultAccumulator,

--- a/core/server/services/members/stripe-connect.js
+++ b/core/server/services/members/stripe-connect.js
@@ -1,6 +1,12 @@
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
 const {Buffer} = require('buffer');
 const {randomBytes} = require('crypto');
 const {URL} = require('url');
+
+const messages = {
+    incorrectState: 'State did not match.'
+};
 
 const STATE_PROP = 'stripe-connect-state';
 
@@ -45,7 +51,7 @@ async function getStripeConnectOAuthUrl(setSessionProp, mode = 'live') {
  * @param {string} encodedData - A string encoding the response from Stripe Connect
  * @param {(prop: string) => Promise<any>} getSessionProp - A function to retrieve data from the current session
  *
- * @returns {Promise<{secret_key: string, public_key: string, livemode: boolean}>}
+ * @returns {Promise<{secret_key: string, public_key: string, livemode: boolean, display_name: string, account_id: string}>}
  */
 async function getStripeConnectTokenData(encodedData, getSessionProp) {
     const data = JSON.parse(Buffer.from(encodedData, 'base64').toString());
@@ -53,7 +59,7 @@ async function getStripeConnectTokenData(encodedData, getSessionProp) {
     const state = await getSessionProp(STATE_PROP);
 
     if (state !== data.s) {
-        throw new Error('State did not match');
+        throw new errors.NoPermissionError(tpl(messages.incorrectState));
     }
 
     return {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/2f1123d6ca7894fc21499739f46f0ae5c9eda73a

Usage of the raw Error class has been deprecated in favour of our own
errors, which are more descriptive and have built in HTTP status codes.

This also updates the same errors to use @tryghost/tpl for the error
messages, which is the new pattern we are following in order for us to
deprecate the i18n module.