### PR TITLE
Exposed Members pub keys on /members/.well-known/

### DIFF
--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -15,7 +15,7 @@ const sitemapHandler = require('../../../frontend/services/sitemap/handler');
 const appService = require('../../../frontend/services/apps');
 const themeEngine = require('../../../frontend/services/theme-engine');
 const themeMiddleware = themeEngine.middleware;
-const membersMiddleware = require('../../services/members').middleware;
+const membersService = require('../../services/members');
 const siteRoutes = require('./routes');
 const shared = require('../shared');
 const mw = require('./middleware');
@@ -118,7 +118,8 @@ module.exports = function setupSiteApp(options = {}) {
     debug('Helpers done');
 
     // Global handling for member session, ensures a member is logged in to the frontend
-    siteApp.use(membersMiddleware.loadMemberSession);
+    siteApp.use(membersService.middleware.loadMemberSession);
+    siteApp.use('/members/.well-known', (req, res, next) => membersService.api.middleware.wellKnown(req, res, next));
 
     // Theme middleware
     // This should happen AFTER any shared assets are served, as it only changes things to do with templates

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@tryghost/limit-service": "0.6.1",
     "@tryghost/logging": "0.1.4",
     "@tryghost/magic-link": "1.0.7",
-    "@tryghost/members-api": "1.21.0",
+    "@tryghost/members-api": "1.22.0",
     "@tryghost/members-csv": "1.1.2",
     "@tryghost/members-ssr": "1.0.7",
     "@tryghost/mw-session-from-token": "0.1.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,10 +891,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.21.0.tgz#e16494c8659d17d76cf6cd4dd6448d50a19251f3"
-  integrity sha512-1cozYWkcZiDxNT/0vDYhVwfBuJyNJ/7iKqbDp/KgbO4bjyC89LfhznTKBDoEGEaMgNZMr+t7qYxT6rNIqPDSaw==
+"@tryghost/members-api@1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.22.0.tgz#2309d5f562c2c84783cf5470b0e336eb624264ea"
+  integrity sha512-zZ6th/zugVuL3iIFUWrBVy9HhZG5gjTOWSNO6rMJbt7pugzCuwJiYgk0BR9j6uuEkNhc9BAju6a24WnP3Tg+WQ==
   dependencies:
     "@tryghost/debug" "^0.1.2"
     "@tryghost/errors" "^0.2.9"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/664

The new WellKnownController and middleware handles exposing a JSON Web
Key Set for us.

In order to serve the keys on /members/.well-known/jwks.json without a
trailing slash, we must mount the wellKnown middleware before the
frontend.