### PR TITLE
Added HSL color output in head style tag

### DIFF
--- a/core/frontend/apps/amp/lib/helpers/amp_style.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_style.js
@@ -1,8 +1,15 @@
 const {SafeString, escapeExpression} = require('../../../../services/proxy');
+/*
+ * @TODO:
+ *  replace with Ghost util when https://github.com/TryGhost/Admin/blob/main/app/utils/color.js
+ *  has been refactored into a module
+*/
+const convert = require('color-convert');
 
 module.exports = function amp_style(options) { // eslint-disable-line camelcase
     if (options.data.site.accent_color) {
         const accentColor = escapeExpression(options.data.site.accent_color);
-        return new SafeString(`:root {--ghost-accent-color: ${accentColor};}`);
+        const accentColorHSL = convert.rgb.hsl(convert.hex.rgb(options.data.site.accent_color));
+        return new SafeString(`:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL[0]};--ghost-accent-s: ${accentColorHSL[1]};--ghost-accent-l: ${accentColorHSL[2]};}`);
     }
 };

--- a/core/frontend/apps/amp/lib/helpers/amp_style.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_style.js
@@ -1,15 +1,10 @@
 const {SafeString, escapeExpression} = require('../../../../services/proxy');
-/*
- * @TODO:
- *  replace with Ghost util when https://github.com/TryGhost/Admin/blob/main/app/utils/color.js
- *  has been refactored into a module
-*/
-const convert = require('color-convert');
+const color = require('color');
 
 module.exports = function amp_style(options) { // eslint-disable-line camelcase
     if (options.data.site.accent_color) {
         const accentColor = escapeExpression(options.data.site.accent_color);
-        const accentColorHSL = convert.rgb.hsl(convert.hex.rgb(options.data.site.accent_color));
-        return new SafeString(`:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL[0]};--ghost-accent-s: ${accentColorHSL[1]}%;--ghost-accent-l: ${accentColorHSL[2]}%;}`);
+        const accentColorHSL = color(options.data.site.accent_color).hsl().round();
+        return new SafeString(`:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL.hue()};--ghost-accent-s: ${accentColorHSL.saturationl()}%;--ghost-accent-l: ${accentColorHSL.lightness()}%;}`);
     }
 };

--- a/core/frontend/apps/amp/lib/helpers/amp_style.js
+++ b/core/frontend/apps/amp/lib/helpers/amp_style.js
@@ -10,6 +10,6 @@ module.exports = function amp_style(options) { // eslint-disable-line camelcase
     if (options.data.site.accent_color) {
         const accentColor = escapeExpression(options.data.site.accent_color);
         const accentColorHSL = convert.rgb.hsl(convert.hex.rgb(options.data.site.accent_color));
-        return new SafeString(`:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL[0]};--ghost-accent-s: ${accentColorHSL[1]};--ghost-accent-l: ${accentColorHSL[2]};}`);
+        return new SafeString(`:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL[0]};--ghost-accent-s: ${accentColorHSL[1]}%;--ghost-accent-l: ${accentColorHSL[2]}%;}`);
     }
 };

--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -6,6 +6,12 @@ const {metaData, escapeExpression, SafeString, logging, settingsCache, config, b
 const _ = require('lodash');
 const debug = require('@tryghost/debug')('ghost_head');
 const templateStyles = require('./tpl/styles');
+/*
+ * @TODO:
+ *  replace with Ghost util when https://github.com/TryGhost/Admin/blob/main/app/utils/color.js
+ *  has been refactored into a module
+*/
+const convert = require('color-convert');
 
 const getMetaData = metaData.get;
 
@@ -200,7 +206,8 @@ module.exports = function ghost_head(options) { // eslint-disable-line camelcase
             // AMP template has style injected directly because there can only be one <style amp-custom> tag
             if (options.data.site.accent_color && !_.includes(context, 'amp')) {
                 const accentColor = escapeExpression(options.data.site.accent_color);
-                const styleTag = `<style>:root {--ghost-accent-color: ${accentColor};}</style>`;
+                const accentColorHSL = convert.rgb.hsl(convert.hex.rgb(options.data.site.accent_color));
+                const styleTag = `<style>:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL[0]};--ghost-accent-s: ${accentColorHSL[1]};--ghost-accent-l: ${accentColorHSL[2]};}</style>`;
                 const existingScriptIndex = _.findLastIndex(head, str => str.match(/<\/(style|script)>/));
 
                 if (existingScriptIndex !== -1) {

--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -6,12 +6,7 @@ const {metaData, escapeExpression, SafeString, logging, settingsCache, config, b
 const _ = require('lodash');
 const debug = require('@tryghost/debug')('ghost_head');
 const templateStyles = require('./tpl/styles');
-/*
- * @TODO:
- *  replace with Ghost util when https://github.com/TryGhost/Admin/blob/main/app/utils/color.js
- *  has been refactored into a module
-*/
-const convert = require('color-convert');
+const color = require('color');
 
 const getMetaData = metaData.get;
 
@@ -206,8 +201,8 @@ module.exports = function ghost_head(options) { // eslint-disable-line camelcase
             // AMP template has style injected directly because there can only be one <style amp-custom> tag
             if (options.data.site.accent_color && !_.includes(context, 'amp')) {
                 const accentColor = escapeExpression(options.data.site.accent_color);
-                const accentColorHSL = convert.rgb.hsl(convert.hex.rgb(options.data.site.accent_color));
-                const styleTag = `<style>:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL[0]};--ghost-accent-s: ${accentColorHSL[1]}%;--ghost-accent-l: ${accentColorHSL[2]}%;}</style>`;
+                const accentColorHSL = color(options.data.site.accent_color).hsl().round();
+                const styleTag = `<style>:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL.hue()};--ghost-accent-s: ${accentColorHSL.saturationl()}%;--ghost-accent-l: ${accentColorHSL.lightness()}%;}</style>`;
                 const existingScriptIndex = _.findLastIndex(head, str => str.match(/<\/(style|script)>/));
 
                 if (existingScriptIndex !== -1) {

--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -207,7 +207,7 @@ module.exports = function ghost_head(options) { // eslint-disable-line camelcase
             if (options.data.site.accent_color && !_.includes(context, 'amp')) {
                 const accentColor = escapeExpression(options.data.site.accent_color);
                 const accentColorHSL = convert.rgb.hsl(convert.hex.rgb(options.data.site.accent_color));
-                const styleTag = `<style>:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL[0]};--ghost-accent-s: ${accentColorHSL[1]};--ghost-accent-l: ${accentColorHSL[2]};}</style>`;
+                const styleTag = `<style>:root {--ghost-accent-color: ${accentColor};--ghost-accent-h: ${accentColorHSL[0]};--ghost-accent-s: ${accentColorHSL[1]}%;--ghost-accent-l: ${accentColorHSL[2]}%;}</style>`;
                 const existingScriptIndex = _.findLastIndex(head, str => str.match(/<\/(style|script)>/));
 
                 if (existingScriptIndex !== -1) {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "bson-objectid": "2.0.1",
     "bthreads": "0.5.1",
     "cheerio": "0.22.0",
+    "color-convert": "^1.9.3",
     "compression": "1.7.4",
     "connect-slashes": "1.4.0",
     "cookie-session": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "bson-objectid": "2.0.1",
     "bthreads": "0.5.1",
     "cheerio": "0.22.0",
-    "color-convert": "^1.9.3",
+    "color": "^3.2.1",
     "compression": "1.7.4",
     "connect-slashes": "1.4.0",
     "cookie-session": "1.4.0",

--- a/test/frontend-acceptance/default_routes.test.js
+++ b/test/frontend-acceptance/default_routes.test.js
@@ -208,7 +208,7 @@ describe('Default Frontend routing', function () {
 
                     $('style[amp-custom]').length.should.equal(1);
 
-                    res.text.should.containEql(':root {--ghost-accent-color: #FF1A75;}');
+                    res.text.should.containEql(':root {--ghost-accent-color: #FF1A75;--ghost-accent-h: 336;--ghost-accent-s: 100;--ghost-accent-l: 55;}');
 
                     res.text.should.not.containEql('__GHOST_URL__');
                 });

--- a/test/frontend-acceptance/default_routes.test.js
+++ b/test/frontend-acceptance/default_routes.test.js
@@ -208,7 +208,7 @@ describe('Default Frontend routing', function () {
 
                     $('style[amp-custom]').length.should.equal(1);
 
-                    res.text.should.containEql(':root {--ghost-accent-color: #FF1A75;--ghost-accent-h: 336;--ghost-accent-s: 100;--ghost-accent-l: 55;}');
+                    res.text.should.containEql(':root {--ghost-accent-color: #FF1A75;--ghost-accent-h: 336;--ghost-accent-s: 100%;--ghost-accent-l: 55%;}');
 
                     res.text.should.not.containEql('__GHOST_URL__');
                 });

--- a/test/unit/helpers/ghost_head.test.js
+++ b/test/unit/helpers/ghost_head.test.js
@@ -1537,7 +1537,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             })).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.containEql('<style>:root {--ghost-accent-color: #123456;--ghost-accent-h: 210;--ghost-accent-s: 65;--ghost-accent-l: 20;}</style>');
+                rendered.string.should.containEql('<style>:root {--ghost-accent-color: #123456;--ghost-accent-h: 210;--ghost-accent-s: 65%;--ghost-accent-l: 20%;}</style>');
                 done();
             }).catch(done);
         });
@@ -1615,7 +1615,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             })).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.containEql('<style>:root {--ghost-accent-color: #123456;--ghost-accent-h: 210;--ghost-accent-s: 65;--ghost-accent-l: 20;}</style>');
+                rendered.string.should.containEql('<style>:root {--ghost-accent-color: #123456;--ghost-accent-h: 210;--ghost-accent-s: 65%;--ghost-accent-l: 20%;}</style>');
                 done();
             }).catch(done);
         });

--- a/test/unit/helpers/ghost_head.test.js
+++ b/test/unit/helpers/ghost_head.test.js
@@ -1537,7 +1537,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             })).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.containEql('<style>:root {--ghost-accent-color: #123456;}</style>');
+                rendered.string.should.containEql('<style>:root {--ghost-accent-color: #123456;--ghost-accent-h: 210;--ghost-accent-s: 65;--ghost-accent-l: 20;}</style>');
                 done();
             }).catch(done);
         });
@@ -1615,7 +1615,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             })).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.containEql('<style>:root {--ghost-accent-color: #123456;}</style>');
+                rendered.string.should.containEql('<style>:root {--ghost-accent-color: #123456;--ghost-accent-h: 210;--ghost-accent-s: 65;--ghost-accent-l: 20;}</style>');
                 done();
             }).catch(done);
         });


### PR DESCRIPTION
no-issue

Outputs the accent colour as HSL values in addition to the existing hex value to allow theme developers to make use of pure CSS color transforms as requested by @minimaluminium - for example:

![image](https://user-images.githubusercontent.com/3798302/126486723-f1c1bb0b-bae5-4889-ac11-cd62df6d50a1.png)

I've used the `color-convert` module which is already present as a dependency until https://github.com/TryGhost/Admin/blob/main/app/utils/color.js is refactored into a module.