### PR TITLE
Removed labels usage for content gating

### DIFF
--- a/core/server/services/members/content-gating.js
+++ b/core/server/services/members/content-gating.js
@@ -8,12 +8,6 @@ const BLOCK_ACCESS = false;
 
 // TODO: better place to store this?
 const MEMBER_NQL_EXPANSIONS = [{
-    key: 'labels',
-    replacement: 'labels.slug'
-}, {
-    key: 'label',
-    replacement: 'labels.slug'
-}, {
     key: 'products',
     replacement: 'products.slug'
 }, {

--- a/test/frontend-acceptance/members.test.js
+++ b/test/frontend-acceptance/members.test.js
@@ -140,7 +140,6 @@ describe('Front-end members behaviour', function () {
         let membersPost;
         let paidPost;
         let membersPostWithPaywallCard;
-        let labelPost;
         let productPost;
 
         before(function () {
@@ -170,12 +169,6 @@ describe('Front-end members behaviour', function () {
                 published_at: moment().add(5, 'seconds').toDate()
             });
 
-            labelPost = testUtils.DataGenerator.forKnex.createPost({
-                slug: 'thou-must-be-labelled-vip',
-                visibility: 'label:vip',
-                published_at: moment().toDate()
-            });
-
             productPost = testUtils.DataGenerator.forKnex.createPost({
                 slug: 'thou-must-have-default-product',
                 visibility: 'product:default-product',
@@ -187,7 +180,6 @@ describe('Front-end members behaviour', function () {
                 membersPost,
                 paidPost,
                 membersPostWithPaywallCard,
-                labelPost,
                 productPost
             ]);
         });
@@ -210,13 +202,6 @@ describe('Front-end members behaviour', function () {
             it('cannot read paid post content', async function () {
                 await request
                     .get('/thou-shalt-be-paid-for/')
-                    .expect(200)
-                    .expect(assertContentIsAbsent);
-            });
-
-            it('cannot read label-only post content', async function () {
-                await request
-                    .get('/thou-must-be-labelled-vip/')
                     .expect(200)
                     .expect(assertContentIsAbsent);
             });
@@ -255,31 +240,11 @@ describe('Front-end members behaviour', function () {
                     .expect(assertContentIsAbsent);
             });
 
-            it('cannot read label-only post content', async function () {
-                await request
-                    .get('/thou-must-be-labelled-vip/')
-                    .expect(200)
-                    .expect(assertContentIsAbsent);
-            });
-
             it('cannot read product-only post content', async function () {
                 await request
                     .get('/thou-must-have-default-product/')
                     .expect(200)
                     .expect(assertContentIsAbsent);
-            });
-        });
-
-        describe('as free member with vip label', function () {
-            before(async function () {
-                await loginAsMember('vip@test.com');
-            });
-
-            it('can read label-only post content', async function () {
-                await request
-                    .get('/thou-must-be-labelled-vip/')
-                    .expect(200)
-                    .expect(assertContentIsPresent);
             });
         });
 
@@ -325,31 +290,11 @@ describe('Front-end members behaviour', function () {
                     .expect(assertContentIsPresent);
             });
 
-            it('cannot read label-only post content', async function () {
-                await request
-                    .get('/thou-must-be-labelled-vip/')
-                    .expect(200)
-                    .expect(assertContentIsAbsent);
-            });
-
             it('cannot read product-only post content', async function () {
                 await request
                     .get('/thou-must-have-default-product/')
                     .expect(200)
                     .expect(assertContentIsAbsent);
-            });
-        });
-
-        describe('as paid member with vip label', function () {
-            before(async function () {
-                await loginAsMember('vip-paid@test.com');
-            });
-
-            it('can read label-only post content', async function () {
-                await request
-                    .get('/thou-must-be-labelled-vip/')
-                    .expect(200)
-                    .expect(assertContentIsPresent);
             });
         });
 
@@ -377,13 +322,6 @@ describe('Front-end members behaviour', function () {
                     .get('/thou-shalt-be-paid-for/')
                     .expect(200)
                     .expect(assertContentIsPresent);
-            });
-
-            it('cannot read label-only post content', async function () {
-                await request
-                    .get('/thou-must-be-labelled-vip/')
-                    .expect(200)
-                    .expect(assertContentIsAbsent);
             });
 
             it('cannot read product-only post content', async function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/909
refs https://github.com/TryGhost/Ghost/commit/c36e749820bae58309791f969c67c12f387b96b8

Content gating by labels was previously added as an alpha feature that allowed Admins to filter post access via both label and product segments. Going forward, we don't want to use labels for content segmentation and instead only use products. This change cleans up usage of `labels` for content gating, which allows us to remove unnecessary `labels` data/query on fetching a member identity by Portal on each page load.
