### PR TITLE
Added email_only column to posts_meta table

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/clean.js
+++ b/core/server/api/canary/utils/serializers/output/utils/clean.js
@@ -77,6 +77,7 @@ const post = (attrs, frame) => {
         // @TODO: https://github.com/TryGhost/Ghost/issues/10335
         // delete attrs.page;
         delete attrs.status;
+        delete attrs.email_only;
 
         // We are standardising on returning null from the Content API for any empty values
         if (attrs.twitter_title === '') {

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -52,6 +52,9 @@ const mapPost = (model, frame) => {
     _(metaAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
+        // NOTE: the default of `email_only` is `false` which is why we default to `false` instead of `null`
+        //       The undefined value is possible because `posts_meta` table is lazily created only one of the
+        //       values is assigned.
         const defaultValue = (attr === 'email_only') ? false : null;
         jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || defaultValue;
     });

--- a/core/server/api/canary/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/canary/utils/serializers/output/utils/mapper.js
@@ -52,7 +52,8 @@ const mapPost = (model, frame) => {
     _(metaAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+        const defaultValue = (attr === 'email_only') ? false : null;
+        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || defaultValue;
     });
     delete jsonModel.posts_meta;
 
@@ -89,6 +90,7 @@ const mapPage = (model, frame) => {
 
     delete jsonModel.email_subject;
     delete jsonModel.email_recipient_filter;
+    delete jsonModel.email_only;
 
     return jsonModel;
 };

--- a/core/server/api/v2/utils/serializers/output/utils/clean.js
+++ b/core/server/api/v2/utils/serializers/output/utils/clean.js
@@ -96,6 +96,7 @@ const post = (attrs, frame) => {
         // @TODO: https://github.com/TryGhost/Ghost/issues/10335
         // delete attrs.page;
         delete attrs.status;
+        delete attrs.email_only;
 
         // We are standardising on returning null from the Content API for any empty values
         if (attrs.twitter_title === '') {

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -55,7 +55,9 @@ const mapPost = (model, frame) => {
     _(metaAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+        if (!(attr === 'email_only')) {
+            jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+        }
     });
     delete jsonModel.posts_meta;
 

--- a/core/server/api/v3/utils/serializers/output/utils/clean.js
+++ b/core/server/api/v3/utils/serializers/output/utils/clean.js
@@ -76,6 +76,7 @@ const post = (attrs, frame) => {
         // @TODO: https://github.com/TryGhost/Ghost/issues/10335
         // delete attrs.page;
         delete attrs.status;
+        delete attrs.email_only;
 
         // We are standardising on returning null from the Content API for any empty values
         if (attrs.twitter_title === '') {

--- a/core/server/api/v3/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v3/utils/serializers/output/utils/mapper.js
@@ -60,7 +60,9 @@ const mapPost = (model, frame) => {
     _(metaAttrs).filter((k) => {
         return (!frame.options.columns || (frame.options.columns && frame.options.columns.includes(k)));
     }).each((attr) => {
-        jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+        if (!(attr === 'email_only')) {
+            jsonModel[attr] = _.get(jsonModel.posts_meta, attr) || null;
+        }
     });
     delete jsonModel.posts_meta;
 

--- a/core/server/data/migrations/versions/4.12/01-add-email-only-column-to-posts-meta-table.js
+++ b/core/server/data/migrations/versions/4.12/01-add-email-only-column-to-posts-meta-table.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('posts_meta', 'email_only', {
+    type: 'bool',
+    nullable: false,
+    defaultTo: false
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -74,7 +74,8 @@ module.exports = {
         email_subject: {type: 'string', maxlength: 300, nullable: true},
         frontmatter: {type: 'text', maxlength: 65535, nullable: true},
         feature_image_alt: {type: 'string', maxlength: 191, nullable: true, validations: {isLength: {max: 125}}},
-        feature_image_caption: {type: 'text', maxlength: 65535, nullable: true}
+        feature_image_caption: {type: 'text', maxlength: 65535, nullable: true},
+        email_only: {type: 'bool', nullable: false, defaultTo: false}
     },
     users: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/core/server/models/posts-meta.js
+++ b/core/server/models/posts-meta.js
@@ -4,6 +4,12 @@ const urlUtils = require('../../shared/url-utils');
 const PostsMeta = ghostBookshelf.Model.extend({
     tableName: 'posts_meta',
 
+    defaults: function defaults() {
+        return {
+            email_only: false
+        };
+    },
+
     formatOnWrite(attrs) {
         ['og_image', 'twitter_image'].forEach((attr) => {
             if (attrs[attr]) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@nexes/nql": "0.6.0",
     "@sentry/node": "6.10.0",
     "@tryghost/adapter-manager": "0.2.14",
-    "@tryghost/admin-api-schema": "2.5.0",
+    "@tryghost/admin-api-schema": "2.5.2",
     "@tryghost/bookshelf-plugins": "0.3.0",
     "@tryghost/bootstrap-socket": "0.2.9",
     "@tryghost/color-utils": "^0.1.0",

--- a/test/api-acceptance/admin/posts.test.js
+++ b/test/api-acceptance/admin/posts.test.js
@@ -39,6 +39,8 @@ describe('Posts API', function () {
         localUtils.API.checkResponse(jsonResponse.posts[0], 'post');
         localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
         _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+        _.isBoolean(jsonResponse.posts[0].email_only).should.eql(true);
+        jsonResponse.posts[0].email_only.should.eql(false);
 
         // Ensure default order
         jsonResponse.posts[0].slug.should.eql('scheduled-post');

--- a/test/api-acceptance/admin/utils.js
+++ b/test/api-acceptance/admin/utils.js
@@ -69,7 +69,8 @@ const expectedProperties = {
         'meta_title',
         'meta_description',
         'email_subject',
-        'frontmatter'
+        'frontmatter',
+        'email_only'
     ],
 
     page: [

--- a/test/regression/api/canary/admin/posts.test.js
+++ b/test/regression/api/canary/admin/posts.test.js
@@ -600,6 +600,35 @@ describe('Posts API (canary)', function () {
                 });
         });
 
+        it('can edit post_meta field that has default value and no previously created posts_meta relation', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    should.equal(res.body.posts[0].email_only, false);
+
+                    return request
+                        .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[1].id + '/'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                email_only: true,
+                                updated_at: res.body.posts[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200);
+                })
+                .then((res) => {
+                    should.exist(res.headers['x-cache-invalidate']);
+
+                    should.exist(res.body.posts);
+                    should.equal(res.body.posts[0].email_only, true);
+                });
+        });
+
         it('saving post with no modbiledoc content doesn\t trigger cache invalidation', function () {
             return request
                 .post(localUtils.API.getApiQuery('posts/'))

--- a/test/regression/api/canary/admin/utils.js
+++ b/test/regression/api/canary/admin/utils.js
@@ -64,7 +64,8 @@ const expectedProperties = {
         'meta_title',
         'meta_description',
         'email_subject',
-        'frontmatter'
+        'frontmatter',
+        'email_only'
     ],
     user: [
         'id',

--- a/test/regression/api/v2/admin/posts.test.js
+++ b/test/regression/api/v2/admin/posts.test.js
@@ -399,6 +399,29 @@ describe('Posts API (v2)', function () {
                     res.body.posts[0].visibility.should.equal('members');
                 });
         });
+
+        it('cannot edit post_meta field that was introduced in API v4', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    should.equal(res.body.posts[0].email_only, undefined);
+
+                    return request
+                        .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[1].id + '/'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                email_only: true,
+                                updated_at: res.body.posts[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(422);
+                });
+        });
     });
 
     describe('Destroy', function () {

--- a/test/regression/api/v3/admin/posts.test.js
+++ b/test/regression/api/v3/admin/posts.test.js
@@ -592,6 +592,29 @@ describe('Posts API (v3)', function () {
                 });
         });
 
+        it('cannot edit post_meta field that was introduced in API v4', function () {
+            return request
+                .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
+                .set('Origin', config.get('url'))
+                .expect(200)
+                .then((res) => {
+                    should.equal(res.body.posts[0].email_only, undefined);
+
+                    return request
+                        .put(localUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[1].id + '/'))
+                        .set('Origin', config.get('url'))
+                        .send({
+                            posts: [{
+                                email_only: true,
+                                updated_at: res.body.posts[0].updated_at
+                            }]
+                        })
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(422);
+                });
+        });
+
         it('saving post with no modbiledoc content doesn\t trigger cache invalidation', function () {
             return request
                 .post(localUtils.API.getApiQuery('posts/'))

--- a/test/unit/data/schema/integrity.test.js
+++ b/test/unit/data/schema/integrity.test.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'a2248eaa72a9d08c3753b90a9436dbe3';
+    const currentSchemaHash = '6becb030fb054078d95f927bcfcd4f5e';
     const currentFixturesHash = '97283c575b1f6c84c27db6e1b1be21d4';
     const currentSettingsHash = 'aa3fcbc8ab119b630aeda7366ead5493';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,10 +530,10 @@
   dependencies:
     "@tryghost/errors" "^0.2.13"
 
-"@tryghost/admin-api-schema@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-2.5.0.tgz#8ac3dccff3428197745032e4fda07d781464397f"
-  integrity sha512-8LyI2/weIN8js3Wg+LIfPygG/tSRijqrBEbJ0bEroPkm+27oF7MfAj+vSAzHj65G6cBP8lIUetGPNO2U+nHjPw==
+"@tryghost/admin-api-schema@2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-2.5.2.tgz#633b4d9043753ec39ae9086dd22c3ef4ba6423da"
+  integrity sha512-rYHu4Sb7hFwgDs/5zdxsSSDjVIyKagmF1mhrARO1/pe0it3H+iUJ7gC9aVX3dgRXiV6qOPvY2K15PmkXd2b0fQ==
   dependencies:
     "@tryghost/errors" "^0.2.10"
     lodash "^4.17.11"


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/893
closes https://github.com/TryGhost/Team/issues/894

Reviewers, the only commit for review here is the very first one containing a migration "Added email_only column to posts_meta table " [8729eb2](https://github.com/TryGhost/Ghost/pull/13201/commits/8729eb253f7b266771fa91145cb67ed251873df4). Thanks :pray: 