### PR TITLE
Fixed labs.enabledMiddleware isSet reference

### DIFF
--- a/core/shared/labs.js
+++ b/core/shared/labs.js
@@ -103,7 +103,7 @@ module.exports.enabledHelper = function enabledHelper(options, callback) {
 };
 
 module.exports.enabledMiddleware = flag => (req, res, next) => {
-    if (this.isSet(flag) === true) {
+    if (module.exports.isSet(flag) === true) {
         return next();
     } else {
         return next(new errors.NotFoundError());


### PR DESCRIPTION
no-issue

The `this` used by enabledMiddleware is not bound to `module.exports`.
This updates the middleware to reference the `isSet` method correctly