### PR TITLE
Ordered Products by their monthly price by default

### DIFF
--- a/core/server/models/product.js
+++ b/core/server/models/product.js
@@ -10,6 +10,12 @@ const Product = ghostBookshelf.Model.extend({
         benefits: 'benefits'
     },
 
+    applyCustomQuery() {
+        this.query((qb) => {
+            qb.leftJoin('stripe_prices', 'products.monthly_price_id', 'stripe_prices.id');
+        });
+    },
+
     async onSaving(model, _attr, options) {
         ghostBookshelf.Model.prototype.onSaving.apply(this, arguments);
 
@@ -120,6 +126,10 @@ const Product = ghostBookshelf.Model.extend({
 
     members() {
         return this.belongsToMany('Member', 'members_products', 'product_id', 'member_id');
+    }
+}, {
+    orderDefaultRaw() {
+        return 'stripe_prices.amount asc';
     }
 });
 

--- a/test/utils/fixture-utils.js
+++ b/test/utils/fixture-utils.js
@@ -462,7 +462,12 @@ const fixtures = {
             return models.Label.add(label, context.internal);
         }).then(function () {
             let productsToInsert = fixtureUtils.findModelFixtures('Product').entries;
-            return Promise.map(productsToInsert, product => models.Product.add(product, context.internal));
+            return Promise.map(productsToInsert, async (product) => {
+                const found = await models.Product.findOne(product, context.internal);
+                if (!found) {
+                    await models.Product.add(product, context.internal);
+                }
+            });
         }).then(function () {
             return models.Product.findOne({}, context.internal);
         }).then(function (product) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/714

In order to order products by their monthly price we need to apply a
join with the stripe_prices table when querying so we have access to the
amount column of stripe_prices.

As this ordering is core to how the tiers feature is intended to work,
we have added it as the default order. But this can be overriden by
manually passing the order option/