### PR TITLE
Added members_product_events table

### DIFF
--- a/core/server/data/exporter/table-lists.js
+++ b/core/server/data/exporter/table-lists.js
@@ -35,7 +35,8 @@ const BACKUP_TABLES = [
     'members_email_change_events',
     'members_status_events',
     'members_paid_subscription_events',
-    'members_subscribe_events'
+    'members_subscribe_events',
+    'members_product_events'
 ];
 
 // NOTE: exposing only tables which are going to be included in a "default" export file

--- a/core/server/data/migrations/versions/4.13/02-add-members-products-events-table.js
+++ b/core/server/data/migrations/versions/4.13/02-add-members-products-events-table.js
@@ -1,0 +1,33 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('members_product_events', {
+  id: {
+    type: 'string',
+    maxlength: 24,
+    nullable: false,
+    primary: true
+  },
+  member_id: {
+    type: 'string',
+    maxlength: 24,
+    nullable: false,
+    references: 'members.id',
+    cascadeDelete: true
+  },
+  product_id: {
+    type: 'string',
+    maxlength: 24,
+    nullable: false,
+    references: 'products.id',
+    cascadeDelete: false
+  },
+  action: {
+    type: 'string',
+    maxlength: 50,
+    nullable: true
+  },
+  created_at: {
+    type: 'dateTime',
+    nullable: false
+  }
+});

--- a/core/server/data/migrations/versions/4.13/02-add-members-products-events-table.js
+++ b/core/server/data/migrations/versions/4.13/02-add-members-products-events-table.js
@@ -1,33 +1,33 @@
 const {addTable} = require('../../utils');
 
 module.exports = addTable('members_product_events', {
-  id: {
-    type: 'string',
-    maxlength: 24,
-    nullable: false,
-    primary: true
-  },
-  member_id: {
-    type: 'string',
-    maxlength: 24,
-    nullable: false,
-    references: 'members.id',
-    cascadeDelete: true
-  },
-  product_id: {
-    type: 'string',
-    maxlength: 24,
-    nullable: false,
-    references: 'products.id',
-    cascadeDelete: false
-  },
-  action: {
-    type: 'string',
-    maxlength: 50,
-    nullable: true
-  },
-  created_at: {
-    type: 'dateTime',
-    nullable: false
-  }
+    id: {
+        type: 'string',
+        maxlength: 24,
+        nullable: false,
+        primary: true
+    },
+    member_id: {
+        type: 'string',
+        maxlength: 24,
+        nullable: false,
+        references: 'members.id',
+        cascadeDelete: true
+    },
+    product_id: {
+        type: 'string',
+        maxlength: 24,
+        nullable: false,
+        references: 'products.id',
+        cascadeDelete: false
+    },
+    action: {
+        type: 'string',
+        maxlength: 50,
+        nullable: true
+    },
+    created_at: {
+        type: 'dateTime',
+        nullable: false
+    }
 });

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -438,6 +438,17 @@ module.exports = {
         },
         created_at: {type: 'dateTime', nullable: false}
     },
+    members_product_events: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+        product_id: {type: 'string', maxlength: 24, nullable: false, references: 'products.id', cascadeDelete: false},
+        action: {
+            type: 'string', maxlength: 50, nullable: true, validations: {
+                isIn: [['add', 'remove']]
+            }
+        },
+        created_at: {type: 'dateTime', nullable: false}
+    },
     members_paid_subscription_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -444,7 +444,7 @@ module.exports = {
         product_id: {type: 'string', maxlength: 24, nullable: false, references: 'products.id', cascadeDelete: false},
         action: {
             type: 'string', maxlength: 50, nullable: true, validations: {
-                isIn: [['add', 'remove']]
+                isIn: [['added', 'removed']]
             }
         },
         created_at: {type: 'dateTime', nullable: false}

--- a/test/regression/exporter/exporter.test.js
+++ b/test/regression/exporter/exporter.test.js
@@ -39,6 +39,7 @@ describe('Exporter', function () {
                 'members_payment_events',
                 'members_products',
                 'members_status_events',
+                'members_product_events',
                 'members_stripe_customers',
                 'members_stripe_customers_subscriptions',
                 'members_subscribe_events',

--- a/test/unit/data/schema/integrity.test.js
+++ b/test/unit/data/schema/integrity.test.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '6becb030fb054078d95f927bcfcd4f5e';
+    const currentSchemaHash = '98f6433d608dd44a30f59c243091f6aa';
     const currentFixturesHash = '97283c575b1f6c84c27db6e1b1be21d4';
     const currentSettingsHash = 'aa3fcbc8ab119b630aeda7366ead5493';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/873

This table is to track events related to members be given or having
removed access to products. It will allow us to provide start dates for
access for complimentary members, as well as being able to track access
to products over time, either for individual members or for aggregates.