### PR TITLE
Ignored @tryghost/members-api for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,8 @@
       "moment",
       "moment-timezone",
       "nodemailer",
-      "simple-dom"
+      "simple-dom",
+      "@tryghost/members-api"
     ],
   "ignorePaths": ["test"],
   "packageRules": [


### PR DESCRIPTION
no-issue

This module never needs to be bumped by renovate and causes noise
for @daniellockyer. Removing it means that we won't get automated PR's
and it will be bumped manually by whoever made the changes to the package.