### PR TITLE
Exposed dummy subscriptions to theme layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@tryghost/limit-service": "0.6.1",
     "@tryghost/logging": "0.1.5",
     "@tryghost/magic-link": "1.0.10",
-    "@tryghost/members-api": "1.27.3",
+    "@tryghost/members-api": "1.28.0",
     "@tryghost/members-csv": "1.1.5",
     "@tryghost/members-importer": "0.3.1",
     "@tryghost/members-ssr": "1.0.11",

--- a/test/api-acceptance/admin/members.test.js
+++ b/test/api-acceptance/admin/members.test.js
@@ -118,7 +118,7 @@ describe('Members API', function () {
         should.exist(jsonResponse);
         should.exist(jsonResponse.members);
         jsonResponse.members.should.have.length(1);
-        localUtils.API.checkResponse(jsonResponse.members[0], 'member', 'subscriptions');
+        localUtils.API.checkResponse(jsonResponse.members[0], 'member', ['subscriptions', 'products']);
     });
 
     it('Can read and include email_recipients', async function () {
@@ -134,7 +134,7 @@ describe('Members API', function () {
         should.exist(jsonResponse);
         should.exist(jsonResponse.members);
         jsonResponse.members.should.have.length(1);
-        localUtils.API.checkResponse(jsonResponse.members[0], 'member', ['subscriptions', 'email_recipients']);
+        localUtils.API.checkResponse(jsonResponse.members[0], 'member', ['subscriptions', 'email_recipients', 'products']);
         jsonResponse.members[0].email_recipients.length.should.equal(1);
         localUtils.API.checkResponse(jsonResponse.members[0].email_recipients[0], 'email_recipient', ['email']);
         localUtils.API.checkResponse(jsonResponse.members[0].email_recipients[0].email, 'email');

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,10 +908,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@1.27.3":
-  version "1.27.3"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.27.3.tgz#04e32e785252131bdece6e9a759de0bc06d1c993"
-  integrity sha512-NnzZMJBPsifx35kf04VCjJTJO5KmH1qWky0/TchQOlQhfrZpNuA72sykVdFc/IPGseRGCu6ANMRUKBW8N8X/9w==
+"@tryghost/members-api@1.28.0":
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.28.0.tgz#97b4ebf826f0b6f34cd6eb4affe8ee77c369a2b6"
+  integrity sha512-1uEp3D47B+4574UPEhrquyXry6rMN6odl8N8uciu6zXvDDK6SDqnS68EevrerDJyT0nKd8cq4r+JBpr+kcUCfg==
   dependencies:
     "@tryghost/debug" "^0.1.2"
     "@tryghost/errors" "^0.2.9"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/986

This updates the @tryghost/members-api module to return the full member
object from getMemberIdentityData, which is used to populate req.member
used by themes to construct the `@member` template data.

The full object is read from the service which handles all additional
properties and logic for retrieving members, including the dummy
subscriptions for comped members.