### PR TITLE
Removed `snippetReplacements` labs flag

### DIFF
--- a/core/shared/labs.js
+++ b/core/shared/labs.js
@@ -29,8 +29,7 @@ const ALPHA_FEATURES = [
     'oauthLogin',
     'membersFiltering',
     'emailOnlyPosts',
-    'dashboardTwo',
-    'snippetReplacements'
+    'dashboardTwo'
 ];
 
 module.exports.WRITABLE_KEYS_ALLOWLIST = [...BETA_FEATURES, ...ALPHA_FEATURES];


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1008
reqs https://github.com/TryGhost/Admin/pull/2073

- flag is no longer used by Admin as the feature is out of labs
