### PR TITLE
Added static transaction method to base model

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -63,6 +63,16 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         return true;
     }
+}, {
+    /**
+     * @template T
+     * @param {(transaction: import('knex').Transaction) => Promise<T>} fn
+     *
+     * @returns {Promise<T>}
+     */
+    transaction(fn) {
+        return ghostBookshelf.transaction(fn);
+    }
 });
 
 // Export ghostBookshelf for use elsewhere


### PR DESCRIPTION
no-issue

Writing code outside of Ghost which deals with the models is currently
done by passing the models which are needed to the external module,
rather than the instance of ghostBookshelf. This does not give us a way
to create transaction to run queries in. This method is designed as a
simple way to give all models the power to create a transaction for
themselves.

This will be used in @tryghost/members-api for example to ensure that
failures in communication with the Stripe API will rollback the related
inserts in the database.