### PR TITLE
✨ Added `{{products}}` helper for list of products with access to post

### DIFF
--- a/core/frontend/helpers/products.js
+++ b/core/frontend/helpers/products.js
@@ -1,0 +1,68 @@
+// # Products Helper
+// Usage: `{{products}}`, `{{products separator=' - '}}`
+//
+// Returns a string of the products with access to the post.
+// By default, products are separated by commas.
+
+const nql = require('@nexes/nql');
+const isString = require('lodash/isString');
+const {SafeString, labs} = require('../services/proxy');
+
+function products(options = {}) {
+    options = options || {};
+    options.hash = options.hash || {};
+
+    const separator = isString(options.hash.separator) ? options.hash.separator : '';
+    let output = '';
+
+    let productsList = [];
+    if (options.data.product) {
+        productsList = [options.data.product];
+    }
+    if (options.data.products) {
+        productsList = options.data.products;
+    }
+    let accessProductsList = [];
+
+    if (['members', 'paid', 'public'].includes(this.visibility)) {
+        accessProductsList = productsList;
+    }
+
+    if (this.visibility === 'filter') {
+        const nqlFilter = nql(this.visibility_filter);
+        accessProductsList = productsList.filter((product) => {
+            return nqlFilter.queryJSON({product: product.slug});
+        });
+    }
+
+    if (accessProductsList.length > 0) {
+        const productNames = accessProductsList.map(product => product.name);
+        if (accessProductsList.length === 1) {
+            output = productNames[0] + ' tier';
+        } else {
+            if (separator) {
+                output = productNames.join(separator) + ' tiers';
+            } else {
+                const firsts = productNames.slice(0, productNames.length - 1);
+                const last = productNames[productNames.length - 1];
+                output = firsts.join(', ') + ' and ' + last + ' tiers';
+            }
+        }
+    }
+
+    return new SafeString(output);
+}
+
+module.exports = function productsLabsWrapper() {
+    let self = this;
+    let args = arguments;
+
+    return labs.enabledHelper({
+        flagKey: 'multipleProducts',
+        flagName: 'Tiers',
+        helperName: 'products',
+        helpUrl: 'https://ghost.org/docs/themes/'
+    }, () => {
+        return products.apply(self, args);
+    });
+};

--- a/core/frontend/helpers/tpl/content-cta.hbs
+++ b/core/frontend/helpers/tpl/content-cta.hbs
@@ -8,7 +8,7 @@
             <h2>This post is for subscribers only</h2>
         {{/has}}
         {{#has visibility="filter"}}
-            <h2>This post is for subscribers on a higher tier only</h2>
+            <h2>This post is for subscribers on the {{products}} only </h2>
         {{/has}}
         {{#if @member}}
             <a class="gh-btn" data-portal="account/plans" style="color:{{accentColor}}">Upgrade your account</a>

--- a/core/frontend/services/theme-engine/handlebars/helpers.js
+++ b/core/frontend/services/theme-engine/handlebars/helpers.js
@@ -12,6 +12,7 @@ const registerAllCoreHelpers = function registerAllCoreHelpers() {
     registerThemeHelper('cancel_link', coreHelpers.cancel_link);
     registerThemeHelper('concat', coreHelpers.concat);
     registerThemeHelper('content', coreHelpers.content);
+    registerThemeHelper('products', coreHelpers.products);
     registerThemeHelper('date', coreHelpers.date);
     registerThemeHelper('encode', coreHelpers.encode);
     registerThemeHelper('excerpt', coreHelpers.excerpt);

--- a/test/unit/services/theme-engine/handlebars/helpers.test.js
+++ b/test/unit/services/theme-engine/handlebars/helpers.test.js
@@ -13,7 +13,7 @@ describe('Helpers', function () {
         'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'price', 'raw', 'reading_time', 't', 'tags', 'title', 'twitter_url',
         'url'
     ];
-    const experimentalHelpers = ['match'];
+    const experimentalHelpers = ['match', 'products'];
 
     const expectedHelpers = _.concat(hbsHelpers, ghostHelpers, experimentalHelpers);
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1004

- adds new `{{products}}` helper that outputs a string with list of products that have access to specific post when used in a post context in theme
- outputs empty string when used out of a post context and without access to `visibility` property
- uses all available posts for a site via the global products data

Note: The `{{products}}` helper in the current form is good for Beta version, but can have breaking changes for the final GA version
