### PR TITLE
Fixed imports for files missing the email_only key

### DIFF
--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -50,7 +50,9 @@ class PostsImporter extends BaseImporter {
      */
     sanitizePostsMeta(model) {
         let postsMetaFromFile = _.find(this.requiredFromFile.posts_meta, {post_id: model.id}) || _.pick(model, metaAttrs);
-        let postsMetaData = Object.assign({}, _.mapValues(postsMetaSchema, () => null), postsMetaFromFile);
+        let postsMetaData = Object.assign({}, _.mapValues(postsMetaSchema, (value) => {
+            return Reflect.has(value, 'defaultTo') ? value.defaultTo : null;
+        }), postsMetaFromFile);
         model.posts_meta = postsMetaData;
         _.each(metaAttrs, (attr) => {
             delete model[attr];


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1024

Our importer would set the default value of all posts_meta keys to
`null`. This is an invalid value for the `email_only` key which only
accepts booleans.

Since we are already looping over the schema to create the default
values, we can use the `defaultTo` property in the schema to use the
intended default, and fall back to `null` if it doesn't exist.

We've used the `Reflect.has` function to determine if the `defaultTo`
key exists, as opposed to a truthy check, because it's possible that a
falsy value (e.g. false, in the case of email_only) can be used as the
default.