### PR TITLE
Fixed MemberStatusEvents for free members

### DIFF
--- a/core/server/data/migrations/versions/4.14/02-fix-free-members-status-events.js
+++ b/core/server/data/migrations/versions/4.14/02-fix-free-members-status-events.js
@@ -1,0 +1,37 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils.js');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Updating members_status_events for free members');
+        const freeMembers = await knex('members')
+            .select('id')
+            .where('status', 'free');
+
+        if (freeMembers.length === 0) {
+            logging.info('No free members found - skipping migration');
+            return;
+        } else {
+            logging.info(`Found ${freeMembers.length} free members - checking members_status_events`);
+        }
+
+        for (const member of freeMembers) {
+            const mostRecentStatusEvent = await knex('members_status_events')
+                .select('*')
+                .where('member_id', member.id)
+                .orderBy('created_at', 'desc')
+                .limit(1)
+                .first();
+
+            if (!mostRecentStatusEvent) {
+                logging.warn(`Could not find a status event for member ${member.id} - skipping this member`);
+            } else if (mostRecentStatusEvent.to_status !== 'free') {
+                logging.info(`Updating members_status_event ${mostRecentStatusEvent.id}`);
+                await knex('members_status_events')
+                    .update('to_status', 'free')
+                    .where('id', mostRecentStatusEvent.id);
+            }
+        }
+    },
+    async function down() {}
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1000

Some free members were created with a status of 'comped', this resulted
in MemberStatusEvents being created with a `to_status` of 'comped'.

In 4.12 we fixed the status for all free members, but we did not update
the associated member_status_event.