### PR TITLE
Fixed usage of linkStripeCustomer for v3 API

### DIFF
--- a/core/server/api/v3/members.js
+++ b/core/server/api/v3/members.js
@@ -125,7 +125,10 @@ module.exports = {
                 member = await membersService.api.members.create(frame.data.members[0], frame.options);
 
                 if (frame.data.members[0].stripe_customer_id) {
-                    await membersService.api.members.linkStripeCustomer(frame.data.members[0].stripe_customer_id, member);
+                    await membersService.api.members.linkStripeCustomer({
+                        customer_id: frame.data.members[0].stripe_customer_id,
+                        member_id: member.id
+                    });
                 }
 
                 if (frame.data.members[0].comped) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/12942

The function signature of this method has changed, and was only updated
in the canary API. This meant that API requests attempting to link a
stripe customer to a member would error.
