### PR TITLE
Fixed handling of Complimentary Stripe subscriptions

### DIFF
--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -102,7 +102,7 @@ function exportCSV(page, _apiConfig, frame) {
 function serializeMember(member, options) {
     const json = member.toJSON ? member.toJSON(options) : member;
 
-    let comped = false;
+    let comped = json.status === 'comped';
     if (json.subscriptions) {
         const hasCompedSubscription = !!json.subscriptions.find(
             /**

--- a/core/server/api/canary/utils/serializers/output/members.js
+++ b/core/server/api/canary/utils/serializers/output/members.js
@@ -102,20 +102,8 @@ function exportCSV(page, _apiConfig, frame) {
 function serializeMember(member, options) {
     const json = member.toJSON ? member.toJSON(options) : member;
 
-    let comped = json.status === 'comped';
-    if (json.subscriptions) {
-        const hasCompedSubscription = !!json.subscriptions.find(
-            /**
-             * @param {SerializedMemberStripeSubscription} sub
-             */
-            function (sub) {
-                return sub.plan.nickname === 'Complimentary' && sub.status === 'active';
-            }
-        );
-        if (hasCompedSubscription) {
-            comped = true;
-        }
-    }
+    const comped = json.status === 'comped';
+
     const subscriptions = json.subscriptions || [];
 
     const serialized = {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@tryghost/limit-service": "0.6.1",
     "@tryghost/logging": "0.1.6",
     "@tryghost/magic-link": "1.0.11",
-    "@tryghost/members-api": "1.29.2",
+    "@tryghost/members-api": "1.29.3",
     "@tryghost/members-csv": "1.1.6",
     "@tryghost/members-importer": "0.3.1",
     "@tryghost/members-ssr": "1.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,10 +921,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@1.29.2":
-  version "1.29.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.29.2.tgz#e5c01085482d490e5d703b7568105fccee7409da"
-  integrity sha512-fCJytSDDflVGC20IpL+8YGrLL2Fb7AEYSIbPPt3vL4gDjh+6+2LGlhkGoYoj2EciLI1J1niT4pOave1fldxWQQ==
+"@tryghost/members-api@1.29.3":
+  version "1.29.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.29.3.tgz#793d447ddb4c60efd4099a876ee9036d97f6efd9"
+  integrity sha512-NwKuUyuXvF0E4Xo/EYLSLfom8lWv+PydfU62mBBZjiGgAsT94xhs2PqOCL+aHzIxSxrW9phx5KlXK6cvk1wD0A==
   dependencies:
     "@tryghost/debug" "^0.1.2"
     "@tryghost/errors" "^0.2.9"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/995

Since we reintroduced the comped status, we did not update the
subscription handling to correctly set members to a status of comped
when they were on a 'Complimentary' plan. This meant that 'comped' members
had a status of 'paid'. The changes here ensure that handling
subscriptions going forward will not result in this error.