### PR TITLE
Used @tryghost/members-api Stripe disconnect logic

### DIFF
--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -192,19 +192,7 @@ module.exports = {
                 });
             }
 
-            /** Delete all Stripe data from DB */
-            await ghostBookshelf.knex.raw(`
-                UPDATE products SET monthly_price_id = null, yearly_price_id = null
-            `);
-            await ghostBookshelf.knex.raw(`
-                DELETE FROM stripe_prices
-            `);
-            await ghostBookshelf.knex.raw(`
-                DELETE FROM stripe_products
-            `);
-            await ghostBookshelf.knex.raw(`
-                DELETE FROM members_stripe_customers
-            `);
+            await membersService.api.disconnectStripe();
 
             return models.Settings.edit([{
                 key: 'stripe_connect_publishable_key',

--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -9,7 +9,6 @@ const {BadRequestError, NoPermissionError, NotFoundError} = require('@tryghost/e
 const settingsService = require('../../services/settings');
 const settingsCache = require('../../../shared/settings-cache');
 const membersService = require('../../services/members');
-const ghostBookshelf = require('../../models/base');
 
 module.exports = {
     docName: 'settings',

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@tryghost/limit-service": "0.6.1",
     "@tryghost/logging": "0.1.6",
     "@tryghost/magic-link": "1.0.11",
-    "@tryghost/members-api": "1.29.3",
+    "@tryghost/members-api": "1.31.0",
     "@tryghost/members-csv": "1.1.6",
     "@tryghost/members-importer": "0.3.1",
     "@tryghost/members-ssr": "1.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,10 +921,10 @@
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
 
-"@tryghost/members-api@1.29.3":
-  version "1.29.3"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.29.3.tgz#793d447ddb4c60efd4099a876ee9036d97f6efd9"
-  integrity sha512-NwKuUyuXvF0E4Xo/EYLSLfom8lWv+PydfU62mBBZjiGgAsT94xhs2PqOCL+aHzIxSxrW9phx5KlXK6cvk1wD0A==
+"@tryghost/members-api@1.31.0":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-1.31.0.tgz#ea4d2053201b1ebc1d3b88fc9444c784d474ee4a"
+  integrity sha512-lxHLfGjCDIRJEh9dzpaqynKx+J+NiDobj1MrgaMVR2Bu6fo/c13HQUN2gocXOaCmWzuvg/BBmnyEyRCEmwj4cw==
   dependencies:
     "@tryghost/debug" "^0.1.2"
     "@tryghost/errors" "^0.2.9"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1006

Moving the logic of disconnecting Stripe into the members-api module
decouples the Ghost API from the Members API internals. This method can
now be updated independently of Ghost, to implement the deletion of
webhooks from Stripe.