### PR TITLE
Updated ghost-storage-base to v0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "express-query-boolean": "2.0.0",
     "express-session": "1.17.2",
     "fs-extra": "10.0.0",
-    "ghost-storage-base": "0.0.4",
+    "ghost-storage-base": "0.0.6",
     "glob": "7.1.7",
     "got": "9.6.0",
     "gscan": "4.2.1",

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
   ],
   "ignoreDeps": [
       "got",
-      "ghost-storage-base",
       "intl-messageformat",
       "moment",
       "moment-timezone",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4535,12 +4535,12 @@ ghost-ignition@4.6.3, ghost-ignition@^4.2.4:
     prettyjson "1.2.1"
     uuid "8.3.2"
 
-ghost-storage-base@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/ghost-storage-base/-/ghost-storage-base-0.0.4.tgz#c5badcab13d1763febc8eb3b293e1eb3a5e511e1"
-  integrity sha512-OWL/ONgP24r5s64eH25u8Nb36+MkQALvaeANByaEZlVYXJGkbt+lX+KMmkWMaC9bVpMRTc+ZZE1q/V3V0B0PXQ==
+ghost-storage-base@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/ghost-storage-base/-/ghost-storage-base-0.0.6.tgz#b390e6a501af31ec8463aafa3286a25de6da08c8"
+  integrity sha512-7t77iWWZA1Pk7X5O9cemMRb+DDisljUN2NEd06GNZ+Q43DtCkfLuTkoj0KRkT8bJf2yapsaVtXu5sIRYql4g0Q==
   dependencies:
-    moment "2.24.0"
+    moment "2.27.0"
 
 github-from-package@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
no issue

- this package has been bumped to support Node 12 + 14
- AFAICT I added it to the Renovate list back when we had some timezone
  issues with moment, but we've since pinned the version of moment so we
  shouldn't experience that now
- therefore this commit also removes it from the Renovate ignore list