### PR TITLE
Fixed Complimentary subscriptions being created twice

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -124,8 +124,10 @@ module.exports = {
                     }, frame.options);
                 }
 
-                if (frame.data.members[0].comped) {
-                    await membersService.api.members.setComplimentarySubscription(member);
+                if (!labsService.isSet('multipleProducts')) {
+                    if (frame.data.members[0].comped) {
+                        await membersService.api.members.setComplimentarySubscription(member);
+                    }
                 }
 
                 if (frame.options.send_email) {
@@ -188,14 +190,16 @@ module.exports = {
 
                 const hasCompedSubscription = !!member.related('stripeSubscriptions').find(sub => sub.get('plan_nickname') === 'Complimentary' && sub.get('status') === 'active');
 
-                if (typeof frame.data.members[0].comped === 'boolean') {
-                    if (frame.data.members[0].comped && !hasCompedSubscription) {
-                        await membersService.api.members.setComplimentarySubscription(member);
-                    } else if (!(frame.data.members[0].comped) && hasCompedSubscription) {
-                        await membersService.api.members.cancelComplimentarySubscription(member);
-                    }
+                if (!labsService.isSet('multipleProducts')) {
+                    if (typeof frame.data.members[0].comped === 'boolean') {
+                        if (frame.data.members[0].comped && !hasCompedSubscription) {
+                            await membersService.api.members.setComplimentarySubscription(member);
+                        } else if (!(frame.data.members[0].comped) && hasCompedSubscription) {
+                            await membersService.api.members.cancelComplimentarySubscription(member);
+                        }
 
-                    await member.load(['stripeSubscriptions', 'products', 'stripeSubscriptions.stripePrice', 'stripeSubscriptions.stripePrice.stripeProduct']);
+                        await member.load(['stripeSubscriptions', 'products', 'stripeSubscriptions.stripePrice', 'stripeSubscriptions.stripePrice.stripeProduct']);
+                    }
                 }
 
                 await member.load(['stripeSubscriptions.customer', 'stripeSubscriptions.stripePrice', 'stripeSubscriptions.stripePrice.stripeProduct']);

--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -252,8 +252,8 @@ module.exports = {
                     'stripe_connect_account_id',
                     'stripe_connect_display_name'
                 ].includes(setting.key)
-                // Remove obfuscated settings
-                && !(setting.value === settingsService.obfuscatedSetting && settingsService.isSecretSetting(setting));
+                    // Remove obfuscated settings
+                    && !(setting.value === settingsService.obfuscatedSetting && settingsService.isSecretSetting(setting));
             });
 
             const getSetting = setting => settingsCache.get(setting.key, {resolve: false});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1030

The usage of `setComplimentarySubscription` is for pre-Tiers enabled
sites only. We didn't see this issue before because the `comped` flag
was incorrectly being set to `false` by default. Since it was fixed in
https://github.com/TryGhost/Ghost/commit/ae844db60 the `comped` flag was
then getting sent up, and creating the subscription.

We've moved the usage of `setComplimentarySubscription` to behind the
feature flag so that we do not use old behaviour when Tiers are enabled
