### PR TITLE
Revert "Updated tiers as a beta feature from alpha"

### DIFF
--- a/core/shared/labs.js
+++ b/core/shared/labs.js
@@ -18,11 +18,11 @@ const messages = {
 //       input for the "labs" setting value
 const BETA_FEATURES = [
     'activitypub',
-    'matchHelper',
-    'multipleProducts'
+    'matchHelper'
 ];
 
 const ALPHA_FEATURES = [
+    'multipleProducts',
     'oauthLogin',
     'membersFiltering',
     'emailOnlyPosts',


### PR DESCRIPTION
This reverts commit 025eb8bd79e10944573960455e5c99b8052b6f54.

We do not want to release the tiers feature as a beta feature just yet