### PR TITLE
🐛 Added pagination to sitemap.xml to avoid max 50,000 entries limit

### DIFF
--- a/core/frontend/services/sitemap/handler.js
+++ b/core/frontend/services/sitemap/handler.js
@@ -5,7 +5,8 @@ const manager = new Manager();
 // Responsible for handling requests for sitemap files
 module.exports = function handler(siteApp) {
     const verifyResourceType = function verifyResourceType(req, res, next) {
-        if (!Object.prototype.hasOwnProperty.call(manager, req.params.resource)) {
+        const resourceWithoutPage = req.params.resource.replace(/-\d+$/, '');
+        if (!Object.prototype.hasOwnProperty.call(manager, resourceWithoutPage)) {
             return res.sendStatus(404);
         }
 
@@ -22,8 +23,9 @@ module.exports = function handler(siteApp) {
     });
 
     siteApp.get('/sitemap-:resource.xml', verifyResourceType, function sitemapResourceXML(req, res) {
-        const type = req.params.resource;
-        const page = 1;
+        const type = req.params.resource.replace(/-\d+$/, '');
+        const pageParam = (req.params.resource.match(/-(\d+)$/) || [null, null])[1];
+        const page = pageParam ? parseInt(pageParam, 10) : 1;
 
         res.set({
             'Cache-Control': 'public, max-age=' + config.get('caching:sitemap:maxAge'),

--- a/core/frontend/services/sitemap/index-generator.js
+++ b/core/frontend/services/sitemap/index-generator.js
@@ -14,6 +14,7 @@ class SiteMapIndexGenerator {
     constructor(options) {
         options = options || {};
         this.types = options.types;
+        this.maxPerPage = options.maxPerPage;
     }
 
     getXml() {
@@ -30,16 +31,25 @@ class SiteMapIndexGenerator {
 
     generateSiteMapUrlElements() {
         return _.map(this.types, (resourceType) => {
-            const url = urlUtils.urlFor({relativeUrl: '/sitemap-' + resourceType.name + '.xml'}, true);
-            const lastModified = resourceType.lastModified;
+            // `|| 1` = even if there are no items we still have an empty sitemap file
+            const noOfPages = Math.ceil(Object.keys(resourceType.nodeLookup).length / this.maxPerPage) || 1;
+            const pages = [];
 
-            return {
-                sitemap: [
-                    {loc: url},
-                    {lastmod: moment(lastModified).toISOString()}
-                ]
-            };
-        });
+            for (let i = 0; i < noOfPages; i++) {
+                const page = i === 0 ? '' : `-${i + 1}`;
+                const url = urlUtils.urlFor({relativeUrl: '/sitemap-' + resourceType.name + page + '.xml'}, true);
+                const lastModified = resourceType.lastModified;
+
+                pages.push({
+                    sitemap: [
+                        {loc: url},
+                        {lastmod: moment(lastModified).toISOString()}
+                    ]
+                });
+            }
+
+            return pages;
+        }).flat();
     }
 }
 

--- a/core/frontend/services/sitemap/manager.js
+++ b/core/frontend/services/sitemap/manager.js
@@ -11,11 +11,13 @@ class SiteMapManager {
     constructor(options) {
         options = options || {};
 
+        options.maxPerPage = options.maxPerPage || 50000;
+
         this.pages = options.pages || this.createPagesGenerator(options);
         this.posts = options.posts || this.createPostsGenerator(options);
         this.users = this.authors = options.authors || this.createUsersGenerator(options);
         this.tags = options.tags || this.createTagsGenerator(options);
-        this.index = options.index || this.createIndexGenerator();
+        this.index = options.index || this.createIndexGenerator(options);
 
         events.on('router.created', (router) => {
             if (router.name === 'StaticRoutesRouter') {
@@ -43,14 +45,15 @@ class SiteMapManager {
         });
     }
 
-    createIndexGenerator() {
+    createIndexGenerator(options) {
         return new IndexMapGenerator({
             types: {
                 pages: this.pages,
                 posts: this.posts,
                 authors: this.authors,
                 tags: this.tags
-            }
+            },
+            maxPerPage: options.maxPerPage
         });
     }
 
@@ -74,8 +77,8 @@ class SiteMapManager {
         return this.index.getXml();
     }
 
-    getSiteMapXml(type) {
-        return this[type].getXml();
+    getSiteMapXml(type, page) {
+        return this[type].getXml(page);
     }
 }
 

--- a/test/unit/services/sitemap/generator.test.js
+++ b/test/unit/services/sitemap/generator.test.js
@@ -60,7 +60,8 @@ describe('Generators', function () {
                     pages: new PageGenerator(),
                     tags: new TagGenerator(),
                     authors: new UserGenerator()
-                }
+                },
+                maxPerPage: 50
             });
         });
 
@@ -100,9 +101,9 @@ describe('Generators', function () {
 
             it('get cached xml', function () {
                 sinon.spy(generator, 'generateXmlFromNodes');
-                generator.siteMapContent = 'something';
+                generator.siteMapContent.set(1, 'something');
                 generator.getXml().should.eql('something');
-                generator.siteMapContent = null;
+                generator.siteMapContent.clear();
                 generator.generateXmlFromNodes.called.should.eql(false);
             });
 
@@ -198,12 +199,12 @@ describe('Generators', function () {
 
                 generator.getXml();
 
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/home/</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/magic/</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/subscribe/</loc>');
+                generator.siteMapContent.get(1).should.containEql('<loc>http://my-ghost-blog.com/home/</loc>');
+                generator.siteMapContent.get(1).should.containEql('<loc>http://my-ghost-blog.com/magic/</loc>');
+                generator.siteMapContent.get(1).should.containEql('<loc>http://my-ghost-blog.com/subscribe/</loc>');
 
                 // <loc> should exist exactly one time
-                generator.siteMapContent.match(/<loc>/g).length.should.eql(3);
+                generator.siteMapContent.get(1).match(/<loc>/g).length.should.eql(3);
             });
         });
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1044

Google will only accept sitemaps with 50,000 entries or less per sitemap file but were outputting all posts into a single file that prevented very large sites from having their sitemap indexed.

- updated the sitemap index generator to output `sitemap-{type}-{page}.xml` files for each page over the max-per-page limit
- updated the base resource generator to use a `Map` keyed by page for storing a cache of each pages contents and then spliced the nodes array when generating the content to match the requested page
- completed the `page` handling in the sitemap resource handler so the requested page is extracted and passed through to the manager

TODO:
- [ ] fix `sitemap-posts.xml` and `sitemap-posts-1.xml` outputting the same data (`*-1.xml` should 404?)
- [ ] fix `sitemap-posts-{n}.xml` outputting a blank sitemap where there are insufficient entries for `n` to be present (should 404)