### PR TITLE
Fixed 404 error when email only posts have been enabled

### DIFF
--- a/core/frontend/services/routing/controllers/email-post.js
+++ b/core/frontend/services/routing/controllers/email-post.js
@@ -3,6 +3,7 @@ const config = require('../../../../shared/config');
 const urlService = require('../../url');
 const urlUtils = require('../../../../shared/url-utils');
 const helpers = require('../helpers');
+const labs = require('../../../../shared/labs');
 
 /**
  * @description Email Post Controller.
@@ -11,7 +12,7 @@ const helpers = require('../helpers');
  * @param {Function} next
  * @returns {Promise}
  */
-module.exports = function emailPostController(req, res, next) {
+module.exports = [labs.enabledMiddleware('emailOnlyPosts'), function emailPostController(req, res, next) {
     debug('emailPostController');
 
     const api = require('../../proxy').api[res.locals.apiVersion];
@@ -62,4 +63,4 @@ module.exports = function emailPostController(req, res, next) {
             return renderer(post);
         })
         .catch(helpers.handleError(next));
-};
+}];


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/990
refs https://linear.app/tryghost/issue/CORE-25

- It used to be required remembering to restart the ghost process/routing after switching the email-only flag for the change to take effect. It was often forgotten and caused confusion.