### PR TITLE
Added temporary database table for analytic events

### DIFF
--- a/core/server/data/migrations/versions/4.15/01-add-temp-members-analytic-events-table.js
+++ b/core/server/data/migrations/versions/4.15/01-add-temp-members-analytic-events-table.js
@@ -1,0 +1,12 @@
+const utils = require('../../utils');
+
+module.exports = utils.addTable('temp_member_analytic_events', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    event_name: {type: 'string', maxlength: 50, nullable: false},
+    created_at: {type: 'dateTime', nullable: false},
+    member_id: {type: 'string', maxlength: 24, nullable: false},
+    member_status: {type: 'string', maxlength: 50, nullable: false},
+    entry_id: {type: 'string', maxlength: 24, nullable: true},
+    source_url: {type: 'string', maxlength: 2000, nullable: true},
+    metadata: {type: 'string', maxlength: 191, nullable: true}
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -633,5 +633,15 @@ module.exports = {
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true}
+    },
+    temp_member_analytic_events: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        event_name: {type: 'string', maxlength: 50, nullable: false},
+        created_at: {type: 'dateTime', nullable: false},
+        member_id: {type: 'string', maxlength: 24, nullable: false},
+        member_status: {type: 'string', maxlength: 50, nullable: false},
+        entry_id: {type: 'string', maxlength: 24, nullable: true},
+        source_url: {type: 'string', maxlength: 2000, nullable: true},
+        metadata: {type: 'string', maxlength: 191, nullable: true}
     }
 };

--- a/core/server/models/member-analytic-event.js
+++ b/core/server/models/member-analytic-event.js
@@ -1,0 +1,9 @@
+const ghostBookshelf = require('./base');
+
+const MemberAnalyticEvent = ghostBookshelf.Model.extend({
+    tableName: 'temp_member_analytic_events'
+});
+
+module.exports = {
+    MemberAnalyticEvent: ghostBookshelf.model('MemberAnalyticEvent', MemberAnalyticEvent)
+};

--- a/test/regression/exporter/exporter.test.js
+++ b/test/regression/exporter/exporter.test.js
@@ -43,6 +43,7 @@ describe('Exporter', function () {
                 'members_stripe_customers',
                 'members_stripe_customers_subscriptions',
                 'members_subscribe_events',
+                'temp_member_analytic_events',
                 'migrations',
                 'migrations_lock',
                 'mobiledoc_revisions',

--- a/test/unit/data/exporter/index.test.js
+++ b/test/unit/data/exporter/index.test.js
@@ -173,10 +173,16 @@ describe('Exporter', function () {
             } = require('../../../../core/server/data/exporter/table-lists.js');
 
             const nonSchemaTables = ['migrations', 'migrations_lock'];
+            const requiredTables = schemaTables.concat(nonSchemaTables);
+            // NOTE: You should not add tables to this list unless they are temporary
+            const ignoredTables = ['temp_member_analytic_events'];
+
+            const expectedTables = requiredTables.filter(table => !ignoredTables.includes(table)).sort();
+            const actualTables = BACKUP_TABLES.concat(TABLES_ALLOWLIST).sort();
 
             // NOTE: this test is serving a role of a reminder to have a look into exported tables allowlists
             //       if it failed you probably need to add or remove a table entry from table-lists module
-            [...Object.keys(schema.tables), ...nonSchemaTables].sort().should.eql([...BACKUP_TABLES, ...TABLES_ALLOWLIST].sort());
+            should.deepEqual(actualTables, expectedTables);
         });
 
         it('should be fixed when default settings is changed', function () {

--- a/test/unit/data/schema/integrity.test.js
+++ b/test/unit/data/schema/integrity.test.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '98f6433d608dd44a30f59c243091f6aa';
+    const currentSchemaHash = '939c4993e183e0664362383a875cfc2d';
     const currentFixturesHash = '8e04dbcb4b8e429e70989572fc9c67b9';
     const currentSettingsHash = 'aa3fcbc8ab119b630aeda7366ead5493';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1053

This table is going to be completely deleted at some point in the
future. It serves as a persistent datastore for a spike into collection
analytic events for members. We've opted for a generic table, rather
than a table for each event, so that we can push the DB to the limit in
terms of the length of the table, and find out performance issues A$AP