### PR TITLE
Refactored migration to run faster

### DIFF
--- a/core/server/data/migrations/versions/4.14/02-fix-free-members-status-events.js
+++ b/core/server/data/migrations/versions/4.14/02-fix-free-members-status-events.js
@@ -30,7 +30,7 @@ module.exports = createTransactionalMigration(
             const events = eventsByMember[memberId];
 
             events.sort((a, b) => {
-                return new Date(b) - new Date(a);
+                return new Date(b.created_at) - new Date(a.created_at);
             });
 
             const mostRecentStatusEvent = events[0];

--- a/core/server/data/migrations/versions/4.14/02-fix-free-members-status-events.js
+++ b/core/server/data/migrations/versions/4.14/02-fix-free-members-status-events.js
@@ -19,6 +19,11 @@ module.exports = createTransactionalMigration(
             )
             .where('members.status', 'free');
 
+        if (freeMemberEvents.length === 0) {
+            logging.info('No free members found - skipping migration');
+            return;
+        }
+
         const eventsByMember = _.groupBy(freeMemberEvents, 'member_id');
 
         const eventsToUpdate = Object.keys(eventsByMember).reduce((incorrectEvents, memberId) => {


### PR DESCRIPTION
no-issue

We're seeing problems with large sites taking a long time to run this
migration. The aim here is to refactor it so that it is faster to run.

We've achieved that by reducing the number of database queries needed,
firstly by selecting members with a join to their events (rather than
fetching the events on a member-by-member basis) we also batch the
necessary updates to further reduce db query time.
