### PR TITLE
Added API endpoint for browsing custom theme settings 

### DIFF
--- a/core/server/api/canary/custom-theme-settings.js
+++ b/core/server/api/canary/custom-theme-settings.js
@@ -1,0 +1,12 @@
+const customThemeSettingsService = require('../../services/custom-theme-settings');
+
+module.exports = {
+    docName: 'custom_theme_settings',
+
+    browse: {
+        permissions: true,
+        query() {
+            return customThemeSettingsService.listSettings();
+        }
+    }
+};

--- a/core/server/api/canary/index.js
+++ b/core/server/api/canary/index.js
@@ -153,6 +153,10 @@ module.exports = {
         return shared.pipeline(require('./snippets'), localUtils);
     },
 
+    get customThemeSettings() {
+        return shared.pipeline(require('./custom-theme-settings'), localUtils);
+    },
+
     get serializers() {
         return require('./utils/serializers');
     },

--- a/core/server/api/canary/utils/serializers/output/custom-theme-settings.js
+++ b/core/server/api/canary/utils/serializers/output/custom-theme-settings.js
@@ -1,0 +1,7 @@
+module.exports = {
+    browse(models, apiConfig, frame) {
+        frame.response = {
+            customThemeSettings: models
+        };
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/index.js
+++ b/core/server/api/canary/utils/serializers/output/index.js
@@ -139,5 +139,9 @@ module.exports = {
 
     get snippets() {
         return require('./snippets');
+    },
+
+    get custom_theme_settings() {
+        return require('./custom-theme-settings');
     }
 };

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -273,5 +273,8 @@ module.exports = function apiRoutes() {
     router.put('/snippets/:id', mw.authAdminApi, http(api.snippets.edit));
     router.del('/snippets/:id', mw.authAdminApi, http(api.snippets.destroy));
 
+    // ## Custom theme settings
+    router.get('/custom_theme_settings', mw.authAdminApi, labs.enabledMiddleware('customThemeSettings'), http(api.customThemeSettings.browse));
+
     return router;
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@tryghost/color-utils": "0.1.2",
     "@tryghost/config-url-helpers": "0.1.1",
     "@tryghost/constants": "0.1.9",
-    "@tryghost/custom-theme-settings-service": "0.0.2",
+    "@tryghost/custom-theme-settings-service": "0.0.4",
     "@tryghost/debug": "0.1.5",
     "@tryghost/email-analytics-provider-mailgun": "1.0.1",
     "@tryghost/email-analytics-service": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,10 +1265,10 @@
   resolved "https://registry.yarnpkg.com/@tryghost/constants/-/constants-0.1.9.tgz#1c3ecb42feffdff4cb2ad684938a209ac69ebeaf"
   integrity sha512-tCRFl+d5tYUyAHKGXt+eEm7f7Vpb0a8VXGenpo1q20PEPY7lVsHkFJ+8mwebQWUmELrXKfYkDgjuQDZizQxArA==
 
-"@tryghost/custom-theme-settings-service@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/custom-theme-settings-service/-/custom-theme-settings-service-0.0.2.tgz#a017fe7ca5bc0a3b9c603e5177b4f6ac5692f49c"
-  integrity sha512-TOwUeN7H/h+lr3tU3RwEUy21gAImQ/MQsk147DNs8mXm4efw32VOHp/NskM0ZQoDU9wi9gyK9fA/CZ5rgNRPDA==
+"@tryghost/custom-theme-settings-service@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@tryghost/custom-theme-settings-service/-/custom-theme-settings-service-0.0.4.tgz#6eae410db3b7ab5d0faa4c0de991ff26e90e340e"
+  integrity sha512-78ck4xeDECJN+KNO3yXx5VsvdAhofMaLnPRrWSRWE1Qk6sgQw5yaoFk9kNkOrWksJn++O6Zx95MdiRgqPKTRqA==
   dependencies:
     "@tryghost/debug" "^0.1.5"
     "@tryghost/errors" "^0.2.14"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1070

- bumped `@tryghost/custom-theme-settings-service` to get access to `.listSettings()` method
- added `GET /api/canary/admin/theme_settings/` route behind `'customThemeSettings'` feature flag that uses the custom theme settings service to return settings resources that are a combination of the theme-provided definition and the saved value