### PR TITLE
Moved usage of preview options from globalTemplateOptions to localTemplateOptions

### DIFF
--- a/core/frontend/services/theme-engine/middleware.js
+++ b/core/frontend/services/theme-engine/middleware.js
@@ -87,11 +87,8 @@ async function getProductAndPricesData() {
     }
 }
 
-function getSiteData(req) {
+function getSiteData() {
     let siteData = settingsCache.getPublic();
-
-    // @TODO: it would be nicer if this was proper middleware somehow...
-    siteData = preview.handle(req, siteData);
 
     // theme-only computed property added to @site
     if (settingsCache.get('members_signup_access') === 'none') {
@@ -108,7 +105,7 @@ async function updateGlobalTemplateOptions(req, res, next) {
     // Static information, same for every request unless the settings change
     // @TODO: bind this once and then update based on events?
     // @TODO: decouple theme layer from settings cache using the Content API
-    const siteData = getSiteData(req);
+    const siteData = getSiteData();
     const labsData = labs.getAll();
 
     const themeData = {
@@ -157,9 +154,17 @@ function updateLocalTemplateData(req, res, next) {
 
 function updateLocalTemplateOptions(req, res, next) {
     const localTemplateOptions = hbs.getLocalTemplateOptions(res.locals);
+
+    // adjust @site.url for http/https based on the incoming request
     const siteData = {
         url: urlUtils.urlFor('home', {secure: req.secure, trailingSlash: false}, true)
     };
+
+    // @TODO: it would be nicer if this was proper middleware somehow...
+    const previewData = preview.handle(req);
+
+    // update site data with any preview values from the request
+    Object.assign(siteData, previewData);
 
     const member = req.member ? {
         uuid: req.member.uuid,

--- a/core/frontend/services/theme-engine/preview.js
+++ b/core/frontend/services/theme-engine/preview.js
@@ -14,7 +14,7 @@ function decodeValue(value) {
     return value;
 }
 
-function getPreviewData(previewHeader, siteData) {
+function getPreviewData(previewHeader) {
     // Keep the string shorter with short codes for certain parameters
     const supportedSettings = {
         c: 'accent_color',
@@ -25,23 +25,27 @@ function getPreviewData(previewHeader, siteData) {
 
     let opts = new URLSearchParams(previewHeader);
 
+    const previewData = {};
+
     opts.forEach((value, key) => {
         value = decodeValue(value);
         if (supportedSettings[key]) {
-            _.set(siteData, supportedSettings[key], value);
+            _.set(previewData, supportedSettings[key], value);
         }
     });
 
-    siteData._preview = previewHeader;
+    previewData._preview = previewHeader;
 
-    return siteData;
+    return previewData;
 }
 
 module.exports._PREVIEW_HEADER_NAME = PREVIEW_HEADER_NAME;
-module.exports.handle = (req, siteData) => {
+module.exports.handle = (req) => {
+    let previewData = {};
+
     if (req && req.header(PREVIEW_HEADER_NAME)) {
-        siteData = getPreviewData(req.header(PREVIEW_HEADER_NAME), siteData);
+        previewData = getPreviewData(req.header(PREVIEW_HEADER_NAME));
     }
 
-    return siteData;
+    return previewData;
 };

--- a/test/unit/services/theme-engine/middleware.test.js
+++ b/test/unit/services/theme-engine/middleware.test.js
@@ -66,6 +66,7 @@ describe('Themes middleware', function () {
             .returns(fakeSiteData);
 
         sandbox.stub(hbs, 'updateTemplateOptions');
+        sandbox.stub(hbs, 'updateLocalTemplateOptions');
     });
 
     it('mounts active theme if not yet mounted', function (done) {
@@ -194,7 +195,7 @@ describe('Themes middleware', function () {
     });
 
     describe('Preview Mode', function () {
-        it('calls updateTemplateOptions with correct data when one parameter is set', function (done) {
+        it('calls updateLocalTemplateOptions with correct data when one parameter is set', function (done) {
             const previewString = 'c=%23000fff';
             req.header = () => {
                 return previewString;
@@ -204,13 +205,11 @@ describe('Themes middleware', function () {
                 try {
                     should.not.exist(err);
 
-                    hbs.updateTemplateOptions.calledOnce.should.be.true();
-                    const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
+                    hbs.updateLocalTemplateOptions.calledOnce.should.be.true();
+                    const templateOptions = hbs.updateLocalTemplateOptions.firstCall.args[1];
                     const data = templateOptions.data;
 
-                    data.should.be.an.Object().with.properties('site', 'labs', 'config');
-
-                    should.equal(data.site, fakeSiteData);
+                    data.should.be.an.Object().with.properties('site');
 
                     data.site.should.be.an.Object().with.properties('accent_color', '_preview');
                     data.site._preview.should.eql(previewString);
@@ -223,7 +222,7 @@ describe('Themes middleware', function () {
             });
         });
 
-        it('calls updateTemplateOptions with correct data when two parameters are set', function (done) {
+        it('calls updateLocalTemplateOptions with correct data when two parameters are set', function (done) {
             const previewString = 'c=%23000fff&icon=%2Fcontent%2Fimages%2Fmyimg.png';
             req.header = () => {
                 return previewString;
@@ -233,13 +232,11 @@ describe('Themes middleware', function () {
                 try {
                     should.not.exist(err);
 
-                    hbs.updateTemplateOptions.calledOnce.should.be.true();
-                    const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
+                    hbs.updateLocalTemplateOptions.calledOnce.should.be.true();
+                    const templateOptions = hbs.updateLocalTemplateOptions.firstCall.args[1];
                     const data = templateOptions.data;
 
-                    data.should.be.an.Object().with.properties('site', 'labs', 'config');
-
-                    should.equal(data.site, fakeSiteData);
+                    data.should.be.an.Object().with.properties('site');
 
                     data.site.should.be.an.Object().with.properties('accent_color', 'icon', '_preview');
                     data.site._preview.should.eql(previewString);

--- a/test/unit/services/theme-engine/middleware.test.js
+++ b/test/unit/services/theme-engine/middleware.test.js
@@ -72,12 +72,16 @@ describe('Themes middleware', function () {
         fakeActiveTheme.mounted = false;
 
         executeMiddleware(middleware, req, res, function next(err) {
-            should.not.exist(err);
+            try {
+                should.not.exist(err);
 
-            fakeActiveTheme.mount.called.should.be.true();
-            fakeActiveTheme.mount.calledWith(req.app).should.be.true();
+                fakeActiveTheme.mount.called.should.be.true();
+                fakeActiveTheme.mount.calledWith(req.app).should.be.true();
 
-            done();
+                done();
+            } catch (error) {
+                done(error);
+            }
         });
     });
 
@@ -85,11 +89,15 @@ describe('Themes middleware', function () {
         fakeActiveTheme.mounted = true;
 
         executeMiddleware(middleware, req, res, function next(err) {
-            should.not.exist(err);
+            try {
+                should.not.exist(err);
 
-            fakeActiveTheme.mount.called.should.be.false();
+                fakeActiveTheme.mount.called.should.be.false();
 
-            done();
+                done();
+            } catch (error) {
+                done(error);
+            }
         });
     });
 
@@ -99,14 +107,18 @@ describe('Themes middleware', function () {
             .returns(undefined);
 
         executeMiddleware(middleware, req, res, function next(err) {
-            // Did throw an error
-            should.exist(err);
-            err.message.should.eql('The currently active theme "bacon-sensation" is missing.');
+            try {
+                // Did throw an error
+                should.exist(err);
+                err.message.should.eql('The currently active theme "bacon-sensation" is missing.');
 
-            activeTheme.get.called.should.be.true();
-            fakeActiveTheme.mount.called.should.be.false();
+                activeTheme.get.called.should.be.true();
+                fakeActiveTheme.mount.called.should.be.false();
 
-            done();
+                done();
+            } catch (error) {
+                done(error);
+            }
         });
     });
 
@@ -114,11 +126,15 @@ describe('Themes middleware', function () {
         req.secure = Math.random() < 0.5;
 
         executeMiddleware(middleware, req, res, function next(err) {
-            should.not.exist(err);
+            try {
+                should.not.exist(err);
 
-            should.equal(res.locals.secure, req.secure);
+                should.equal(res.locals.secure, req.secure);
 
-            done();
+                done();
+            } catch (error) {
+                done(error);
+            }
         });
     });
 
@@ -127,29 +143,33 @@ describe('Themes middleware', function () {
             const themeDataExpectedProps = ['posts_per_page', 'image_sizes'];
 
             executeMiddleware(middleware, req, res, function next(err) {
-                should.not.exist(err);
+                try {
+                    should.not.exist(err);
 
-                hbs.updateTemplateOptions.calledOnce.should.be.true();
-                const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
-                const data = templateOptions.data;
+                    hbs.updateTemplateOptions.calledOnce.should.be.true();
+                    const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
+                    const data = templateOptions.data;
 
-                data.should.be.an.Object().with.properties('site', 'labs', 'config');
+                    data.should.be.an.Object().with.properties('site', 'labs', 'config');
 
-                // Check Theme Config
-                data.config.should.be.an.Object()
-                    .with.properties(themeDataExpectedProps)
-                    .and.size(themeDataExpectedProps.length);
-                // posts per page should be set according to the stub
-                data.config.posts_per_page.should.eql(2);
+                    // Check Theme Config
+                    data.config.should.be.an.Object()
+                        .with.properties(themeDataExpectedProps)
+                        .and.size(themeDataExpectedProps.length);
+                    // posts per page should be set according to the stub
+                    data.config.posts_per_page.should.eql(2);
 
-                // Check labs config
-                should.deepEqual(data.labs, fakeLabsData);
+                    // Check labs config
+                    should.deepEqual(data.labs, fakeLabsData);
 
-                should.equal(data.site, fakeSiteData);
-                should.exist(data.site.signup_url);
-                data.site.signup_url.should.equal('#/portal');
+                    should.equal(data.site, fakeSiteData);
+                    should.exist(data.site.signup_url);
+                    data.site.signup_url.should.equal('#/portal');
 
-                done();
+                    done();
+                } catch (error) {
+                    done(error);
+                }
             });
         });
 
@@ -158,13 +178,17 @@ describe('Themes middleware', function () {
                 .withArgs('members_signup_access').returns('none');
 
             executeMiddleware(middleware, req, res, function next(err) {
-                const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
-                const data = templateOptions.data;
+                try {
+                    const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
+                    const data = templateOptions.data;
 
-                should.exist(data.site.signup_url);
-                data.site.signup_url.should.equal('https://feedly.com/i/subscription/feed/http%3A%2F%2F127.0.0.1%3A2369%2Frss%2F');
+                    should.exist(data.site.signup_url);
+                    data.site.signup_url.should.equal('https://feedly.com/i/subscription/feed/http%3A%2F%2F127.0.0.1%3A2369%2Frss%2F');
 
-                done();
+                    done();
+                } catch (error) {
+                    done(error);
+                }
             });
         });
     });
@@ -177,21 +201,25 @@ describe('Themes middleware', function () {
             };
 
             executeMiddleware(middleware, req, res, function next(err) {
-                should.not.exist(err);
+                try {
+                    should.not.exist(err);
 
-                hbs.updateTemplateOptions.calledOnce.should.be.true();
-                const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
-                const data = templateOptions.data;
+                    hbs.updateTemplateOptions.calledOnce.should.be.true();
+                    const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
+                    const data = templateOptions.data;
 
-                data.should.be.an.Object().with.properties('site', 'labs', 'config');
+                    data.should.be.an.Object().with.properties('site', 'labs', 'config');
 
-                should.equal(data.site, fakeSiteData);
+                    should.equal(data.site, fakeSiteData);
 
-                data.site.should.be.an.Object().with.properties('accent_color', '_preview');
-                data.site._preview.should.eql(previewString);
-                data.site.accent_color.should.eql('#000fff');
+                    data.site.should.be.an.Object().with.properties('accent_color', '_preview');
+                    data.site._preview.should.eql(previewString);
+                    data.site.accent_color.should.eql('#000fff');
 
-                done();
+                    done();
+                } catch (error) {
+                    done(error);
+                }
             });
         });
 
@@ -202,22 +230,26 @@ describe('Themes middleware', function () {
             };
 
             executeMiddleware(middleware, req, res, function next(err) {
-                should.not.exist(err);
+                try {
+                    should.not.exist(err);
 
-                hbs.updateTemplateOptions.calledOnce.should.be.true();
-                const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
-                const data = templateOptions.data;
+                    hbs.updateTemplateOptions.calledOnce.should.be.true();
+                    const templateOptions = hbs.updateTemplateOptions.firstCall.args[0];
+                    const data = templateOptions.data;
 
-                data.should.be.an.Object().with.properties('site', 'labs', 'config');
+                    data.should.be.an.Object().with.properties('site', 'labs', 'config');
 
-                should.equal(data.site, fakeSiteData);
+                    should.equal(data.site, fakeSiteData);
 
-                data.site.should.be.an.Object().with.properties('accent_color', 'icon', '_preview');
-                data.site._preview.should.eql(previewString);
-                data.site.accent_color.should.eql('#000fff');
-                data.site.icon.should.eql('/content/images/myimg.png');
+                    data.site.should.be.an.Object().with.properties('accent_color', 'icon', '_preview');
+                    data.site._preview.should.eql(previewString);
+                    data.site.accent_color.should.eql('#000fff');
+                    data.site.icon.should.eql('/content/images/myimg.png');
 
-                done();
+                    done();
+                } catch (error) {
+                    done(error);
+                }
             });
         });
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1097

globalTemplateOptions are supposed to be static with localTemplateOptions being merged in per-request, however the per-request preview data was being extracted and set in the global options. Comments suggest that the global data should be static and eventually updated via other means, the usage of the request object to get per-request preview data is working against that.

- adjusted the preview handler to return an object rather than changing properties by reference on a passed in object
- moved preview data fetching out of `getSiteData()` used in `updateGlobalTemplateOptions()` and into `updateLocalTemplateOptions()` so that we're not relying on the request object in `updateGlobalTemplateOptions()`
