### PR TITLE
Replaced i18n.t w/ tpl helper in scheduler-intergation

### DIFF
--- a/core/server/adapters/scheduling/post-scheduling/scheduler-intergation.js
+++ b/core/server/adapters/scheduling/post-scheduling/scheduler-intergation.js
@@ -1,6 +1,10 @@
 const models = require('../../../models');
-const i18n = require('../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
+
+const messages = {
+    resourceNotFound: '{resource} not found.'
+};
 
 /**
  * @description Load the internal scheduler integration
@@ -12,9 +16,7 @@ const getSchedulerIntegration = function () {
         .then((integration) => {
             if (!integration) {
                 throw new errors.NotFoundError({
-                    message: i18n.t('errors.api.resource.resourceNotFound', {
-                        resource: 'Integration'
-                    })
+                    message: tpl(messages.resourceNotFound, {resource: 'Integration'})
                 });
             }
             return integration.toJSON();


### PR DESCRIPTION
refs: #13380
The i18n package is deprecated. It is being replaced with the tpl package.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [X] There's a clear use-case for this code change
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
