### PR TITLE
Replaced i18n.t w/ tpl helper in serve-public-file.js

### DIFF
--- a/core/server/web/site/middleware/serve-public-file.js
+++ b/core/server/web/site/middleware/serve-public-file.js
@@ -4,7 +4,11 @@ const path = require('path');
 const errors = require('@tryghost/errors');
 const config = require('../../../../shared/config');
 const urlUtils = require('../../../../shared/url-utils');
-const i18n = require('../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+  imageNotFound: 'Image not found'
+};
 
 function createPublicFileMiddleware(file, type, maxAge) {
     let content;
@@ -24,7 +28,7 @@ function createPublicFileMiddleware(file, type, maxAge) {
                 if (err && err.status === 404) {
                     // ensure we're triggering basic asset 404 and not a templated 404
                     return next(new errors.NotFoundError({
-                        message: i18n.t('errors.errors.imageNotFound'),
+                        message: tpl(messages.imageNotFound),
                         code: 'STATIC_FILE_NOT_FOUND',
                         property: err.path
                     }));

--- a/core/server/web/site/middleware/serve-public-file.js
+++ b/core/server/web/site/middleware/serve-public-file.js
@@ -7,7 +7,7 @@ const urlUtils = require('../../../../shared/url-utils');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
-  imageNotFound: 'Image not found'
+    imageNotFound: 'Image not found'
 };
 
 function createPublicFileMiddleware(file, type, maxAge) {


### PR DESCRIPTION
Replaced in: - core/server/web/site/middleware/serve-public-file.js

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
