### PR TITLE
Fixed inconsistent theme settings state after toggling customThemeSettings labs flag

### DIFF
--- a/core/server/services/themes/index.js
+++ b/core/server/services/themes/index.js
@@ -6,12 +6,33 @@ const installer = require('./installer');
 
 const settingsCache = require('../../../shared/settings-cache');
 
+// Needed for theme re-activation after customThemeSettings flag is toggled
+// @TODO: remove when customThemeSettings flag is removed
+const labs = require('../../../shared/labs');
+const events = require('../../lib/common/events');
+let _lastLabsValue;
+
 module.exports = {
     /*
      * Load the currently active theme
      */
     init: async () => {
         const themeName = settingsCache.get('active_theme');
+
+        /**
+         * When customThemeSettings labs flag is toggled we need to re-validate and activate
+         * the active theme so that it's settings are read and synced
+         *
+         * @TODO: remove when customThemeSettings labs flag is removed
+         */
+        _lastLabsValue = labs.isSet('customThemeSettings');
+        events.on('settings.labs.edited', () => {
+            if (labs.isSet('customThemeSettings') !== _lastLabsValue) {
+                _lastLabsValue = labs.isSet('customThemeSettings');
+
+                activate.activate(settingsCache.get('active_theme'));
+            }
+        });
 
         return activate.loadAndActivate(themeName);
     },


### PR DESCRIPTION
no issue

If Ghost was booted or a theme activated with the `customThemeSettings` flag disabled but with a theme that has custom settings, enabling the flag later on wouldn't show the settings in Admin or make the settings available in the front-end. Similarly, disabling `customThemeSettings` when Ghost had been booted/or theme activated with it enabled meant that settings were still available on the front-end.

- added an event listener for `settings.labs.edited` that fully re-activates a theme so that it's passed through gscan again and the custom theme settings passed back are included/excluded based on the flag value and any required settings sync with the database is performed
