### PR TITLE
Replaced i18n.t w/ tpl in upload and version-match middleware

### DIFF
--- a/core/server/web/api/middleware/upload.js
+++ b/core/server/web/api/middleware/upload.js
@@ -4,8 +4,35 @@ const multer = require('multer');
 const fs = require('fs-extra');
 const errors = require('@tryghost/errors');
 const config = require('../../../../shared/config');
-const i18n = require('../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
+
+const messages = {
+    db: {
+        missingFile: 'Please select a database file to import.',
+        invalidFile: 'Unsupported file. Please try any of the following formats: {extensions}'
+    },
+    redirects: {
+        missingFile: 'Please select a JSON file.',
+        invalidFile: 'Please select a valid JSON file to import.'
+    },
+    routes: {
+        missingFile: 'Please select a YAML file.',
+        invalidFile: 'Please select a valid YAML file to import.'
+    },
+    themes: {
+        missingFile: 'Please select a theme.',
+        invalidFile: 'Please select a valid zip file.'
+    },
+    images: {
+        missingFile: 'Please select an image.',
+        invalidFile: 'Please select a valid image.'
+    },
+    icons: {
+        missingFile: 'Please select an icon.',
+        invalidFile: 'Icon must be a square .ico or .png file between 60px – 1,000px, under 100kb.'
+    }
+};
 
 const upload = {
     enabledClear: config.get('uploadClear') || true,
@@ -72,7 +99,7 @@ const validation = function (options) {
         // Check if a file was provided
         if (!checkFileExists(req.file)) {
             return next(new errors.ValidationError({
-                message: i18n.t(`errors.api.${type}.missingFile`)
+                message: tpl(messages[type].missingFile)
             }));
         }
 
@@ -81,7 +108,7 @@ const validation = function (options) {
         // Check if the file is valid
         if (!checkFileIsValid(req.file, contentTypes, extensions)) {
             return next(new errors.UnsupportedMediaTypeError({
-                message: i18n.t(`errors.api.${type}.invalidFile`, {extensions: extensions})
+                message: tpl(messages[type].invalidFile, {extensions: extensions})
             }));
         }
 

--- a/core/server/web/api/middleware/version-match.js
+++ b/core/server/web/api/middleware/version-match.js
@@ -1,6 +1,10 @@
 const semver = require('semver');
 const errors = require('@tryghost/errors');
-const i18n = require('../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    versionMismatch: 'Client request for {clientVersion} does not match server version {serverVersion}.'
+};
 
 function checkVersionMatch(req, res, next) {
     const clientVersion = req.get('X-Ghost-Version');
@@ -14,7 +18,7 @@ function checkVersionMatch(req, res, next) {
 
     if (clientVersion && !semver.satisfies(serverVersion, constraint)) {
         return next(new errors.VersionMismatchError({
-            message: i18n.t('errors.middleware.api.versionMismatch', {
+            message: tpl(messages.versionMismatch, {
                 clientVersion: clientVersion,
                 serverVersion: serverVersion
             })


### PR DESCRIPTION
refs: TryGhost#13380
The i18n package is deprecated. It is being replaced with the tpl package.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
