### PR TITLE
Replaced i18n.t w/ tpl in middleware.js for `canary`, `v2`, and `v3`

### DIFF
--- a/core/server/web/api/canary/admin/middleware.js
+++ b/core/server/web/api/canary/admin/middleware.js
@@ -1,8 +1,12 @@
 const errors = require('@tryghost/errors');
-const i18n = require('../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const auth = require('../../../../services/auth');
 const shared = require('../../../shared');
 const apiMw = require('../../middleware');
+
+const messages = {
+    notImplemented: 'The server does not support the functionality required to fulfill the request.'
+};
 
 const notImplemented = function (req, res, next) {
     // CASE: user is logged in, allow
@@ -42,7 +46,7 @@ const notImplemented = function (req, res, next) {
 
     next(new errors.GhostError({
         errorType: 'NotImplementedError',
-        message: i18n.t('errors.api.common.notImplemented'),
+        message: tpl(messages.notImplemented),
         statusCode: '501'
     }));
 };

--- a/core/server/web/api/v2/admin/middleware.js
+++ b/core/server/web/api/v2/admin/middleware.js
@@ -1,8 +1,12 @@
 const errors = require('@tryghost/errors');
-const i18n = require('../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const auth = require('../../../../services/auth');
 const shared = require('../../../shared');
 const apiMw = require('../../middleware');
+
+const messages = {
+    notImplemented: 'The server does not support the functionality required to fulfill the request.'
+};
 
 const notImplemented = function (req, res, next) {
     // CASE: user is logged in, allow
@@ -38,7 +42,7 @@ const notImplemented = function (req, res, next) {
 
     next(new errors.GhostError({
         errorType: 'NotImplementedError',
-        message: i18n.t('errors.api.common.notImplemented'),
+        message: tpl(messages.notImplemented),
         statusCode: '501'
     }));
 };

--- a/core/server/web/api/v3/admin/middleware.js
+++ b/core/server/web/api/v3/admin/middleware.js
@@ -1,8 +1,12 @@
 const errors = require('@tryghost/errors');
-const i18n = require('../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const auth = require('../../../../services/auth');
 const shared = require('../../../shared');
 const apiMw = require('../../middleware');
+
+const messages = {
+    notImplemented: 'The server does not support the functionality required to fulfill the request.'
+};
 
 const notImplemented = function (req, res, next) {
     // CASE: user is logged in, allow
@@ -42,7 +46,7 @@ const notImplemented = function (req, res, next) {
 
     next(new errors.GhostError({
         errorType: 'NotImplementedError',
-        message: i18n.t('errors.api.common.notImplemented'),
+        message: tpl(messages.notImplemented),
         statusCode: '501'
     }));
 };


### PR DESCRIPTION
refs: #13380

- The i18n package is deprecated. It is being replaced with the tpl package.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
