### PR TITLE
Replace i18n with tpl in some files under core/server/api/v2

### DIFF
--- a/core/server/api/v2/authors-public.js
+++ b/core/server/api/v2/authors-public.js
@@ -1,8 +1,12 @@
 const Promise = require('bluebird');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 const ALLOWED_INCLUDES = ['count.posts'];
+
+const messages = {
+    authorsNotFound: 'Author not found.'
+};
 
 module.exports = {
     docName: 'authors',
@@ -54,7 +58,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         return Promise.reject(new errors.NotFoundError({
-                            message: i18n.t('errors.api.authors.notFound')
+                            message: tpl(messages.authorsNotFound)
                         }));
                     }
 

--- a/core/server/api/v2/pages-public.js
+++ b/core/server/api/v2/pages-public.js
@@ -1,7 +1,11 @@
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 const ALLOWED_INCLUDES = ['tags', 'authors'];
+
+const messages = {
+    pageNotFound: 'Page not found'
+};
 
 module.exports = {
     docName: 'pages',
@@ -63,7 +67,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         throw new errors.NotFoundError({
-                            message: i18n.t('errors.api.pages.pageNotFound')
+                            message: tpl(messages.pageNotFound)
                         });
                     }
 

--- a/core/server/api/v2/session.js
+++ b/core/server/api/v2/session.js
@@ -1,9 +1,13 @@
 const Promise = require('bluebird');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 const auth = require('../../services/auth');
 const api = require('./index');
+
+const messages = {
+    authAccessDenied: 'Access denied.'
+};
 
 const session = {
     read(frame) {
@@ -20,7 +24,7 @@ const session = {
 
         if (!object || !object.username || !object.password) {
             return Promise.reject(new errors.UnauthorizedError({
-                message: i18n.t('errors.middleware.auth.accessDenied')
+                message: tpl(messages.authAccessDenied)
             }));
         }
 
@@ -40,7 +44,7 @@ const session = {
         }).catch(async (err) => {
             if (!errors.utils.isIgnitionError(err)) {
                 throw new errors.UnauthorizedError({
-                    message: i18n.t('errors.middleware.auth.accessDenied'),
+                    message: tpl(messages.authAccessDenied),
                     err
                 });
             }


### PR DESCRIPTION
Replace the deprecated dependency `i18n` with `tpl` in the following files under `core/server/api/v2/`:

- authors-public.js
- pages-public.js
- session.js

Refs #13380

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
