### PR TITLE
Replace the dependency i18n with tpl in all tags.js files

### DIFF
--- a/core/server/api/canary/tags.js
+++ b/core/server/api/canary/tags.js
@@ -1,9 +1,13 @@
 const Promise = require('bluebird');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.posts'];
+
+const messages = {
+    tagNotFound: 'Tag not found.'
+};
 
 module.exports = {
     docName: 'tags',
@@ -56,7 +60,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         return Promise.reject(new errors.NotFoundError({
-                            message: i18n.t('errors.api.tags.tagNotFound')
+                            message: tpl(messages.tagNotFound)
                         }));
                     }
 
@@ -108,7 +112,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         return Promise.reject(new errors.NotFoundError({
-                            message: i18n.t('errors.api.tags.tagNotFound')
+                            message: tpl(messages.tagNotFound)
                         }));
                     }
 
@@ -147,7 +151,7 @@ module.exports = {
                 .then(() => null)
                 .catch(models.Tag.NotFoundError, () => {
                     return Promise.reject(new errors.NotFoundError({
-                        message: i18n.t('errors.api.tags.tagNotFound')
+                        message: tpl(messages.tagNotFound)
                     }));
                 });
         }

--- a/core/server/api/v2/tags-public.js
+++ b/core/server/api/v2/tags-public.js
@@ -1,9 +1,13 @@
 const Promise = require('bluebird');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.posts'];
+
+const messages = {
+    tagNotFound: 'Tag not found.'
+};
 
 module.exports = {
     docName: 'tags',
@@ -56,7 +60,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         return Promise.reject(new errors.NotFoundError({
-                            message: i18n.t('errors.api.tags.tagNotFound')
+                            message: tpl(messages.tagNotFound)
                         }));
                     }
 

--- a/core/server/api/v2/tags.js
+++ b/core/server/api/v2/tags.js
@@ -1,9 +1,13 @@
 const Promise = require('bluebird');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.posts'];
+
+const messages = {
+    tagNotFound: 'Tag not found.'
+};
 
 module.exports = {
     docName: 'tags',
@@ -56,7 +60,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         return Promise.reject(new errors.NotFoundError({
-                            message: i18n.t('errors.api.tags.tagNotFound')
+                            message: tpl(messages.tagNotFound)
                         }));
                     }
 
@@ -108,7 +112,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         return Promise.reject(new errors.NotFoundError({
-                            message: i18n.t('errors.api.tags.tagNotFound')
+                            message: tpl(messages.tagNotFound)
                         }));
                     }
 
@@ -147,7 +151,7 @@ module.exports = {
                 .then(() => null)
                 .catch(models.Tag.NotFoundError, () => {
                     return Promise.reject(new errors.NotFoundError({
-                        message: i18n.t('errors.api.tags.tagNotFound')
+                        message: tpl(messages.tagNotFound)
                     }));
                 });
         }

--- a/core/server/api/v3/tags-public.js
+++ b/core/server/api/v3/tags-public.js
@@ -1,9 +1,13 @@
 const Promise = require('bluebird');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.posts'];
+
+const messages = {
+    tagNotFound: 'Tag not found.'
+};
 
 module.exports = {
     docName: 'tags',
@@ -56,7 +60,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         return Promise.reject(new errors.NotFoundError({
-                            message: i18n.t('errors.api.tags.tagNotFound')
+                            message: tpl(messages.tagNotFound)
                         }));
                     }
 

--- a/core/server/api/v3/tags.js
+++ b/core/server/api/v3/tags.js
@@ -1,9 +1,13 @@
 const Promise = require('bluebird');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 
 const ALLOWED_INCLUDES = ['count.posts'];
+
+const messages = {
+    tagNotFound: 'Tag not found.'
+};
 
 module.exports = {
     docName: 'tags',
@@ -56,7 +60,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         return Promise.reject(new errors.NotFoundError({
-                            message: i18n.t('errors.api.tags.tagNotFound')
+                            message: tpl(messages.tagNotFound)
                         }));
                     }
 
@@ -108,7 +112,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         return Promise.reject(new errors.NotFoundError({
-                            message: i18n.t('errors.api.tags.tagNotFound')
+                            message: tpl(messages.tagNotFound)
                         }));
                     }
 
@@ -147,7 +151,7 @@ module.exports = {
                 .then(() => null)
                 .catch(models.Tag.NotFoundError, () => {
                     return Promise.reject(new errors.NotFoundError({
-                        message: i18n.t('errors.api.tags.tagNotFound')
+                        message: tpl(messages.tagNotFound)
                     }));
                 });
         }


### PR DESCRIPTION
The i18n dependency is deprecated, it's being replaced by the tpl one.

The `tags.js` files changed is under the following folders:

- core/server/api/canary/
- core/server/api/v2/
- core/server/api/v3/

Refs #13380

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
