### PR TITLE
Replaced i18n.t w/ tpl helper in validators/input/

### DIFF
--- a/core/server/api/shared/validators/input/all.js
+++ b/core/server/api/shared/validators/input/all.js
@@ -34,7 +34,7 @@ const GLOBAL_VALIDATORS = {
 const validate = (config, attrs) => {
     let errors = [];
 
-    _.each(config, (value, key) => {``
+    _.each(config, (value, key) => {
         if (value.required && !attrs[key]) {
             errors.push(new ValidationError({
                 message: tpl(messages.validationFailed, {

--- a/core/server/api/shared/validators/input/all.js
+++ b/core/server/api/shared/validators/input/all.js
@@ -1,9 +1,15 @@
 const debug = require('@tryghost/debug')('api:shared:validators:input:all');
 const _ = require('lodash');
 const Promise = require('bluebird');
-const i18n = require('../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const {BadRequestError, ValidationError} = require('@tryghost/errors');
 const validator = require('@tryghost/validator');
+
+const messages = {
+    validationFailed: 'Validation ({validationName}) failed for {key}',
+    noRootKeyProvided: 'No root key (\'{docName}\') provided.',
+    invalidIdProvided: 'Invalid id provided.'
+};
 
 const GLOBAL_VALIDATORS = {
     id: {matches: /^[a-f\d]{24}$|^1$|me/i},
@@ -28,10 +34,10 @@ const GLOBAL_VALIDATORS = {
 const validate = (config, attrs) => {
     let errors = [];
 
-    _.each(config, (value, key) => {
+    _.each(config, (value, key) => {``
         if (value.required && !attrs[key]) {
             errors.push(new ValidationError({
-                message: i18n.t('notices.data.validation.index.validationFailed', {
+                message: tpl(messages.validationFailed, {
                     validationName: 'FieldIsRequired',
                     key: key
                 })
@@ -71,7 +77,7 @@ const validate = (config, attrs) => {
                     }
 
                     errors.push(new ValidationError({
-                        message: i18n.t('notices.data.validation.index.validationFailed', {
+                        message: tpl(messages.validationFailed, {
                             validationName: 'AllowedValues',
                             key: key
                         })
@@ -124,7 +130,7 @@ module.exports = {
         if (!['posts', 'tags'].includes(apiConfig.docName)) {
             if (_.isEmpty(frame.data) || _.isEmpty(frame.data[apiConfig.docName]) || _.isEmpty(frame.data[apiConfig.docName][0])) {
                 return Promise.reject(new BadRequestError({
-                    message: i18n.t('errors.api.utils.noRootKeyProvided', {docName: apiConfig.docName})
+                    message: tpl(messages.noRootKeyProvided, {docName: apiConfig.docName})
                 }));
             }
         }
@@ -145,7 +151,7 @@ module.exports = {
 
             if (missedDataProperties.length) {
                 return Promise.reject(new ValidationError({
-                    message: i18n.t('notices.data.validation.index.validationFailed', {
+                    message: tpl(messages.validationFailed, {
                         validationName: 'FieldIsRequired',
                         key: JSON.stringify(missedDataProperties)
                     })
@@ -154,7 +160,7 @@ module.exports = {
 
             if (nilDataProperties.length) {
                 return Promise.reject(new ValidationError({
-                    message: i18n.t('notices.data.validation.index.validationFailed', {
+                    message: tpl(messages.validationFailed, {
                         validationName: 'FieldIsInvalid',
                         key: JSON.stringify(nilDataProperties)
                     })
@@ -179,7 +185,7 @@ module.exports = {
             if (frame.options.id && frame.data[apiConfig.docName][0].id
                 && frame.options.id !== frame.data[apiConfig.docName][0].id) {
                 return Promise.reject(new BadRequestError({
-                    message: i18n.t('errors.api.utils.invalidIdProvided')
+                    message: tpl(messages.invalidIdProvided)
                 }));
             }
         }


### PR DESCRIPTION
refs: #13380

The i18n package is deprecated. It is being replaced with the tpl package.
This PR should wrap up the i18n.t to tpl refactor under core/server/api/validators/input/

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
