### PR TITLE
Replaced i18n.t w/ tpl in image.js, invitations.js, and invites.js for `canary`

### DIFF
--- a/core/server/api/canary/utils/validators/input/images.js
+++ b/core/server/api/canary/utils/validators/input/images.js
@@ -1,8 +1,13 @@
 const jsonSchema = require('../utils/json-schema');
 const config = require('../../../../../../shared/config');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const {imageSize, blogIcon} = require('../../../../../lib/image');
+
+const messages = {
+    isNotSquare: 'Please select a valid image file with square dimensions.',
+    invalidFile: 'Icon must be a square .ico or .png file between 60px – 1,000px, under 100kb.'
+};
 
 const profileImage = (frame) => {
     return imageSize.getImageSizeFromPath(frame.file.path).then((response) => {
@@ -12,7 +17,7 @@ const profileImage = (frame) => {
         // CASE: file needs to be a square
         if (frame.file.dimensions.width !== frame.file.dimensions.height) {
             return Promise.reject(new errors.ValidationError({
-                message: i18n.t('errors.api.images.isNotSquare')
+                message: tpl(messages.isNotSquare)
             }));
         }
     });
@@ -28,7 +33,7 @@ const icon = (frame) => {
     // CASE: file should not be larger than 100kb
     if (!validIconFileSize(frame.file.size)) {
         return Promise.reject(new errors.ValidationError({
-            message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+            message: tpl(messages.invalidFile, {extensions: iconExtensions})
         }));
     }
 
@@ -39,7 +44,7 @@ const icon = (frame) => {
         // CASE: file needs to be a square
         if (frame.file.dimensions.width !== frame.file.dimensions.height) {
             return Promise.reject(new errors.ValidationError({
-                message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+                message: tpl(messages.invalidFile, {extensions: iconExtensions})
             }));
         }
 
@@ -47,14 +52,14 @@ const icon = (frame) => {
         // .ico files can contain multiple sizes, we need at least a minimum of 60px (16px is ok, as long as 60px are present as well)
         if (frame.file.dimensions.width < 60) {
             return Promise.reject(new errors.ValidationError({
-                message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+                message: tpl(messages.invalidFile, {extensions: iconExtensions})
             }));
         }
 
         // CASE: icon needs to be smaller than or equal to 1000px
         if (frame.file.dimensions.width > 1000) {
             return Promise.reject(new errors.ValidationError({
-                message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})
+                message: tpl(messages.invalidFile, {extensions: iconExtensions})
             }));
         }
     });

--- a/core/server/api/canary/utils/validators/input/invitations.js
+++ b/core/server/api/canary/utils/validators/input/invitations.js
@@ -1,8 +1,16 @@
 const Promise = require('bluebird');
 const validator = require('@tryghost/validator');
 const debug = require('@tryghost/debug')('api:canary:utils:validators:input:invitation');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
+
+const messages = {
+    noEmailProvided: 'No email provided.',
+    noNameProvided: 'No name provided.',
+    noPasswordProvided: 'No password provided.',
+    noTokenProvided: 'No token provided.',
+    invalidEmailReceived: 'The server did not receive a valid email'
+};
 
 module.exports = {
     acceptInvitation(apiConfig, frame) {
@@ -11,19 +19,19 @@ module.exports = {
         const data = frame.data.invitation[0];
 
         if (!data.token) {
-            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noTokenProvided')}));
+            return Promise.reject(new errors.ValidationError({message: tpl(messages.noTokenProvided)}));
         }
 
         if (!data.email) {
-            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noEmailProvided')}));
+            return Promise.reject(new errors.ValidationError({message: tpl(messages.noEmailProvided)}));
         }
 
         if (!data.password) {
-            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noPasswordProvided')}));
+            return Promise.reject(new errors.ValidationError({message: tpl(messages.noPasswordProvided)}));
         }
 
         if (!data.name) {
-            return Promise.reject(new errors.ValidationError({message: i18n.t('errors.api.authentication.noNameProvided')}));
+            return Promise.reject(new errors.ValidationError({message: tpl(messages.noNameProvided)}));
         }
     },
 
@@ -34,7 +42,7 @@ module.exports = {
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
             throw new errors.BadRequestError({
-                message: i18n.t('errors.api.authentication.invalidEmailReceived')
+                message: tpl(messages.invalidEmailReceived)
             });
         }
     }

--- a/core/server/api/canary/utils/validators/input/invites.js
+++ b/core/server/api/canary/utils/validators/input/invites.js
@@ -1,7 +1,11 @@
 const Promise = require('bluebird');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../../../../models');
+
+const messages = {
+    userAlreadyRegistered: 'User is already registered.'
+};
 
 module.exports = {
     add(apiConfig, frame) {
@@ -9,7 +13,7 @@ module.exports = {
             .then((user) => {
                 if (user) {
                     return Promise.reject(new errors.ValidationError({
-                        message: i18n.t('errors.api.users.userAlreadyRegistered')
+                        message: tpl(messages.userAlreadyRegistered)
                     }));
                 }
             });


### PR DESCRIPTION
refs: #13380

The i18n package is deprecated. It is being replaced with the tpl package.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
