### PR TITLE
Added offer_id column to subscriptions table

### DIFF
--- a/core/server/data/migrations/versions/4.18/01-add-offer-id-to-subscriptions.js
+++ b/core/server/data/migrations/versions/4.18/01-add-offer-id-to-subscriptions.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members_stripe_customers_subscriptions', 'offer_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true,
+    references: 'offers.id'
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -511,6 +511,7 @@ module.exports = {
         customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'members_stripe_customers.customer_id', cascadeDelete: true},
         subscription_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
         stripe_price_id: {type: 'string', maxlength: 255, nullable: false, unique: false, index: true, defaultTo: ''},
+        offer_id: {type: 'string', maxlength: 24, nullable: true, references: 'offers.id'},
         status: {type: 'string', maxlength: 50, nullable: false},
         cancel_at_period_end: {type: 'bool', nullable: false, defaultTo: false},
         cancellation_reason: {type: 'string', maxlength: 500, nullable: true},

--- a/test/unit/data/schema/integrity.test.js
+++ b/test/unit/data/schema/integrity.test.js
@@ -32,7 +32,7 @@ const defaultSettings = require('../../../../core/server/data/schema/default-set
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c1c45b460f39504a01b26fcd7a62f395';
+    const currentSchemaHash = '4e22c6adb85e2ab23a4047d6f61c41aa';
     const currentFixturesHash = 'c064a1b57c594e6a8d36f9e884df0a2a';
     const currentSettingsHash = 'aa3fcbc8ab119b630aeda7366ead5493';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1092

In order to associate subscriptions with offers we must link them, a
foreign key in the subscription table is the most effecient way to do
this.
