### PR TITLE
Replaced i18n.t w/ tpl helper in import-manager.js

### DIFF
--- a/core/server/data/importer/import-manager.js
+++ b/core/server/data/importer/import-manager.js
@@ -7,7 +7,7 @@ const glob = require('glob');
 const uuid = require('uuid');
 const {extract} = require('@tryghost/zip');
 const {pipeline, sequence} = require('@tryghost/promise');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const ImageHandler = require('./handlers/image');
@@ -22,6 +22,18 @@ const ROOT_ONLY = 0;
 const ROOT_OR_SINGLE_DIR = 1;
 const ALL_DIRS = 2;
 let defaults;
+
+const messages = {
+    couldNotCleanUpFile: {
+        error: 'Import could not clean up file ',
+        context: 'Your site will continue to work as expected'
+    },
+    unsupportedRoonExport: 'Your zip file looks like an old format Roon export, please re-export your Roon blog and try again.',
+    noContentToImport: 'Zip did not include any content to import.',
+    invalidZipStructure: 'Invalid zip file structure.',
+    invalidZipFileBaseDirectory: 'Invalid zip file: base directory read failed',
+    zipContainsMultipleDataFormats: 'Zip file contains multiple data formats. Please split up and import separately.'
+};
 
 defaults = {
     extensions: ['.zip'],
@@ -113,8 +125,8 @@ class ImportManager {
             if (err) {
                 logging.error(new errors.GhostError({
                     err: err,
-                    context: i18n.t('errors.data.importer.index.couldNotCleanUpFile.error'),
-                    help: i18n.t('errors.data.importer.index.couldNotCleanUpFile.context')
+                    context: tpl(messages.couldNotCleanUpFile.error),
+                    help: tpl(messages.couldNotCleanUpFile.context)
                 }));
             }
 
@@ -155,7 +167,7 @@ class ImportManager {
 
         // This is a temporary extra message for the old format roon export which doesn't work with Ghost
         if (oldRoonMatches.length > 0) {
-            throw new errors.UnsupportedMediaTypeError({message: i18n.t('errors.data.importer.index.unsupportedRoonExport')});
+            throw new errors.UnsupportedMediaTypeError({message: tpl(messages.unsupportedRoonExport)});
         }
 
         // If this folder contains importable files or a content or images directory
@@ -164,10 +176,10 @@ class ImportManager {
         }
 
         if (extMatchesAll.length < 1) {
-            throw new errors.UnsupportedMediaTypeError({message: i18n.t('errors.data.importer.index.noContentToImport')});
+            throw new errors.UnsupportedMediaTypeError({message: tpl(messages.noContentToImport)});
         }
 
-        throw new errors.UnsupportedMediaTypeError({message: i18n.t('errors.data.importer.index.invalidZipStructure')});
+        throw new errors.UnsupportedMediaTypeError({message: tpl(messages.invalidZipStructure)});
     }
 
     /**
@@ -219,7 +231,7 @@ class ImportManager {
             this.getExtensionGlob(this.getExtensions(), ALL_DIRS), {cwd: directory}
         );
         if (extMatchesAll.length < 1 || extMatchesAll[0].split('/') < 1) {
-            throw new errors.ValidationError({message: i18n.t('errors.data.importer.index.invalidZipFileBaseDirectory')});
+            throw new errors.ValidationError({message: tpl(messages.invalidZipFileBaseDirectory)});
         }
 
         return extMatchesAll[0].split('/')[0];
@@ -249,7 +261,7 @@ class ImportManager {
                 if (Object.prototype.hasOwnProperty.call(importData, handler.type)) {
                     // This limitation is here to reduce the complexity of the importer for now
                     return Promise.reject(new errors.UnsupportedMediaTypeError({
-                        message: i18n.t('errors.data.importer.index.zipContainsMultipleDataFormats')
+                        message: tpl(messages.zipContainsMultipleDataFormats)
                     }));
                 }
 
@@ -266,7 +278,7 @@ class ImportManager {
 
             if (ops.length === 0) {
                 return Promise.reject(new errors.UnsupportedMediaTypeError({
-                    message: i18n.t('errors.data.importer.index.noContentToImport')
+                    message: tpl(messages.noContentToImport)
                 }));
             }
 


### PR DESCRIPTION
refs: TryGhost#13380

The i18n package is deprecated. It is being replaced with the tpl package.
This PR should wrap up the i18n.t to tpl refactor under 
core/server/data/importer/import-manager.js

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
