### PR TITLE
replaced i18n with tpl

### DIFF
--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -2,7 +2,7 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 const models = require('../../models');
 const routeSettings = require('../../services/route-settings');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const {BadRequestError} = require('@tryghost/errors');
 const settingsService = require('../../services/settings');
 const membersService = require('../../services/members');
@@ -109,7 +109,7 @@ module.exports = {
             } catch (err) {
                 throw new BadRequestError({
                     err,
-                    message: i18n.t('errors.mail.failedSendingEmail.error')
+                    message: tpl(messages.failedSendingEmail)
                 });
             }
         }

--- a/core/server/api/canary/settings.js
+++ b/core/server/api/canary/settings.js
@@ -9,6 +9,11 @@ const membersService = require('../../services/members');
 
 const settingsBREADService = settingsService.getSettingsBREADServiceInstance();
 
+const messages = {
+    failedSendingEmail: 'Failed Sending Email'
+    
+};
+
 module.exports = {
     docName: 'settings',
 


### PR DESCRIPTION
replaced i18n with tpl in core/server/api/canary/settings.js

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
