### PR TITLE
Added createdAtVersion property to newly received notifications

### DIFF
--- a/core/server/api/canary/utils/serializers/output/notifications.js
+++ b/core/server/api/canary/utils/serializers/output/notifications.js
@@ -19,6 +19,7 @@ module.exports = {
             delete notification.seen;
             delete notification.seenBy;
             delete notification.addedAt;
+            delete notification.createdAtVersion;
         });
 
         frame.response = {

--- a/core/server/api/v2/utils/serializers/output/notifications.js
+++ b/core/server/api/v2/utils/serializers/output/notifications.js
@@ -19,6 +19,7 @@ module.exports = {
             delete notification.seen;
             delete notification.seenBy;
             delete notification.addedAt;
+            delete notification.createdAtVersion;
         });
 
         frame.response = {

--- a/core/server/api/v3/utils/serializers/output/notifications.js
+++ b/core/server/api/v3/utils/serializers/output/notifications.js
@@ -19,6 +19,7 @@ module.exports = {
             delete notification.seen;
             delete notification.seenBy;
             delete notification.addedAt;
+            delete notification.createdAtVersion;
         });
 
         frame.response = {

--- a/core/server/services/notifications/notifications.js
+++ b/core/server/services/notifications/notifications.js
@@ -123,7 +123,8 @@ class Notifications {
             dismissible: true,
             location: 'bottom',
             status: 'alert',
-            id: ObjectId().toHexString()
+            id: ObjectId().toHexString(),
+            createdAtVersion: this.ghostVersion.full
         };
 
         const overrides = {

--- a/test/unit/server/services/notifications/notifications.test.js
+++ b/test/unit/server/services/notifications/notifications.test.js
@@ -194,6 +194,7 @@ describe('Notifications Service', function () {
             createdNotification.dismissible.should.be.false();
             createdNotification.top.should.be.true();
             createdNotification.message.should.equal('Hello test world!');
+            createdNotification.createdAtVersion.should.equal('4.1.0');
         });
     });
 

--- a/test/unit/server/services/notifications/notifications.test.js
+++ b/test/unit/server/services/notifications/notifications.test.js
@@ -175,7 +175,7 @@ describe('Notifications Service', function () {
                     createdAt: moment().toDate(),
                     status: 'alert',
                     type: 'info',
-                    dismissible: true,
+                    dismissible: false,
                     top: true,
                     message: 'Hello test world!'
                 }]
@@ -183,6 +183,17 @@ describe('Notifications Service', function () {
 
             allNotifications.length.should.equal(0);
             notificationsToAdd.length.should.equal(1);
+
+            const createdNotification = notificationsToAdd[0];
+
+            createdNotification.id.should.not.be.undefined();
+            createdNotification.custom.should.be.true();
+            createdNotification.createdAt.should.not.be.undefined();
+            createdNotification.status.should.equal('alert');
+            createdNotification.type.should.equal('info');
+            createdNotification.dismissible.should.be.false();
+            createdNotification.top.should.be.true();
+            createdNotification.message.should.equal('Hello test world!');
         });
     });
 


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/CORE-64/resolve-undissmissable-update-notification-banners

This is a PART 1 of the changes needed to distinguish notifications that no longer should be displayed. It persists necessary version for the notification only. The follow up change will do the filtering of outdated notifications