### PR TITLE
Replaced i18n.t w/ tpl in core/server/api/v3/utils/validators/input/oembed.js

### DIFF
--- a/core/server/api/v3/utils/validators/input/oembed.js
+++ b/core/server/api/v3/utils/validators/input/oembed.js
@@ -1,12 +1,16 @@
 const Promise = require('bluebird');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
+
+const messages = {
+    noUrlProvided: 'No url provided.'
+};
 
 module.exports = {
     read(apiConfig, frame) {
         if (!frame.data.url || !frame.data.url.trim()) {
             return Promise.reject(new errors.BadRequestError({
-                message: i18n.t('errors.api.oembed.noUrlProvided')
+                message: tpl(messages.noUrlProvided)
             }));
         }
     }


### PR DESCRIPTION
refs #13380
This is a refactor to do everywhere

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
