### PR TITLE
Replaced i18n.t w/ tpl in core/server/api/v3/authentication.js

### DIFF
--- a/core/server/api/v3/authentication.js
+++ b/core/server/api/v3/authentication.js
@@ -1,11 +1,16 @@
 const api = require('./index');
 const config = require('../../../shared/config');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const web = require('../../web');
 const models = require('../../models');
 const auth = require('../../services/auth');
 const invitations = require('../../services/invitations');
+
+const messages = {
+    notTheBlogOwner: 'You are not the site owner.'
+};
+
 
 module.exports = {
     docName: 'authentication',
@@ -50,7 +55,7 @@ module.exports = {
             return models.User.findOne({role: 'Owner', status: 'all'})
                 .then((owner) => {
                     if (owner.id !== frame.options.context.user) {
-                        throw new errors.NoPermissionError({message: i18n.t('errors.api.authentication.notTheBlogOwner')});
+                        throw new errors.NoPermissionError({message: tpl(messages.notTheBlogOwner)});
                     }
                 });
         },


### PR DESCRIPTION
refs: #13380

- The i18n package is deprecated. It is being replaced with the tpl package.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
