### PR TITLE
Replaced i18n.t w/ tpl in core/server/api/v3/utils/validators/input/passwordreset.js

### DIFF
--- a/core/server/api/v3/utils/validators/input/passwordreset.js
+++ b/core/server/api/v3/utils/validators/input/passwordreset.js
@@ -1,8 +1,13 @@
 const Promise = require('bluebird');
 const validator = require('@tryghost/validator');
 const debug = require('@tryghost/debug')('api:v3:utils:validators:input:passwordreset');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
+
+const messages = {
+    newPasswordsDoNotMatch: 'Your new passwords do not match',
+    invalidEmailReceived: 'The server did not receive a valid email'
+};
 
 module.exports = {
     resetPassword(apiConfig, frame) {
@@ -12,7 +17,7 @@ module.exports = {
 
         if (data.newPassword !== data.ne2Password) {
             return Promise.reject(new errors.ValidationError({
-                message: i18n.t('errors.models.user.newPasswordsDoNotMatch')
+                message: tpl(messages.newPasswordsDoNotMatch)
             }));
         }
     },
@@ -24,7 +29,7 @@ module.exports = {
 
         if (typeof email !== 'string' || !validator.isEmail(email)) {
             throw new errors.BadRequestError({
-                message: i18n.t('errors.api.authentication.invalidEmailReceived')
+                message: tpl(messages.invalidEmailReceived)
             });
         }
     }


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
