### PR TITLE
Replaced i18n.t w/ tpl in core/server/api/v3/utils/validators/input/users.js

### DIFF
--- a/core/server/api/v3/utils/validators/input/users.js
+++ b/core/server/api/v3/utils/validators/input/users.js
@@ -1,7 +1,11 @@
 const Promise = require('bluebird');
 const debug = require('@tryghost/debug')('api:v3:utils:validators:input:users');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
+
+const messages = {
+    newPasswordsDoNotMatch: 'Your new passwords do not match'
+};
 
 module.exports = {
     changePassword(apiConfig, frame) {
@@ -11,7 +15,7 @@ module.exports = {
 
         if (data.newPassword !== data.ne2Password) {
             return Promise.reject(new errors.ValidationError({
-                message: i18n.t('errors.models.user.newPasswordsDoNotMatch')
+                message: tpl(messages.newPasswordsDoNotMatch)
             }));
         }
     }


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
