### PR TITLE
Replaced i18n.t w/ tpl in core/server/api/v2/utils/serializers/output/authentication.js

### DIFF
--- a/core/server/api/v2/utils/serializers/output/authentication.js
+++ b/core/server/api/v2/utils/serializers/output/authentication.js
@@ -1,6 +1,12 @@
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const mapper = require('./utils/mapper');
 const debug = require('@tryghost/debug')('api:v2:utils:serializers:output:authentication');
+
+const messages = {
+    checkEmailForInstructions: "Check your email for further instructions.",
+    passwordChanged: "Password changed successfully.",
+    invitationAccepted: "Invitation accepted.",
+}
 
 module.exports = {
     setup(user, apiConfig, frame) {
@@ -28,7 +34,7 @@ module.exports = {
     generateResetToken(data, apiConfig, frame) {
         frame.response = {
             passwordreset: [{
-                message: i18n.t('common.api.authentication.mail.checkEmailForInstructions')
+                message: tpl(messages.checkEmailForInstructions)
             }]
         };
     },
@@ -36,7 +42,7 @@ module.exports = {
     resetPassword(data, apiConfig, frame) {
         frame.response = {
             passwordreset: [{
-                message: i18n.t('common.api.authentication.mail.passwordChanged')
+                message: tpl(messages.passwordChanged)
             }]
         };
     },
@@ -46,7 +52,7 @@ module.exports = {
 
         frame.response = {
             invitation: [
-                {message: i18n.t('common.api.authentication.mail.invitationAccepted')}
+                {message: tpl(messages.invitationAccepted)}
             ]
         };
     },


### PR DESCRIPTION
ref: #13380

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
