### PR TITLE
Replaced i18n.t w/ tpl in core/server/api/v2/utils/validators/input/invites.js

### DIFF
--- a/core/server/api/v2/utils/validators/input/invites.js
+++ b/core/server/api/v2/utils/validators/input/invites.js
@@ -1,7 +1,11 @@
 const Promise = require('bluebird');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../../../../models');
+
+const messages = {
+    userAlreadyRegistered: "User is already registered.",
+}
 
 module.exports = {
     add(apiConfig, frame) {
@@ -9,7 +13,7 @@ module.exports = {
             .then((user) => {
                 if (user) {
                     return Promise.reject(new errors.ValidationError({
-                        message: i18n.t('errors.api.users.userAlreadyRegistered')
+                        message: tpl(messages.userAlreadyRegistered)
                     }));
                 }
             });


### PR DESCRIPTION

The i18n package is deprecated. It is being replaced with the tpl package.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
