### PR TITLE
Replaced i18n.t with tpl in core/server/services/bulk-email and core/server/services/permissions

### DIFF
--- a/core/server/services/bulk-email/bulk-email-processor.js
+++ b/core/server/services/bulk-email/bulk-email-processor.js
@@ -2,13 +2,17 @@ const _ = require('lodash');
 const Promise = require('bluebird');
 const moment = require('moment-timezone');
 const errors = require('@tryghost/errors');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const models = require('../../models');
 const mailgunProvider = require('./mailgun');
 const sentry = require('../../../shared/sentry');
 const debug = require('@tryghost/debug')('mega');
 const postEmailSerializer = require('../mega/post-email-serializer');
+
+const messages = {
+    error: 'The email service was unable to send an email batch.'
+};
 
 const BATCH_SIZE = mailgunProvider.BATCH_SIZE;
 
@@ -239,7 +243,7 @@ module.exports = {
             // REF: possible mailgun errors https://documentation.mailgun.com/en/latest/api-intro.html#errors
             let ghostError = new errors.EmailError({
                 err: error,
-                context: i18n.t('errors.services.mega.requestFailed.error'),
+                context: tpl(messages.error),
                 code: 'BULK_EMAIL_SEND_FAILED'
             });
 

--- a/core/server/services/permissions/public.js
+++ b/core/server/services/permissions/public.js
@@ -1,9 +1,13 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
 const errors = require('@tryghost/errors');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const parseContext = require('./parse-context');
 const _private = {};
+
+const messages = {
+    error: 'You do not have permission to retrieve {docName} with that status'
+};
 
 /**
  * @TODO:
@@ -17,7 +21,7 @@ const _private = {};
  * - public context cannot fetch draft/scheduled posts
  */
 _private.applyStatusRules = function applyStatusRules(docName, method, opts) {
-    const err = new errors.NoPermissionError({message: i18n.t('errors.permissions.applyStatusRules.error', {docName: docName})});
+    const err = new errors.NoPermissionError({message: tpl(messages.error, {docName: docName})});
 
     // Enforce status 'active' for users
     if (docName === 'users') {


### PR DESCRIPTION
refs: #13380
`i18n.t` is being deprecated and is being replaced with `tpl`

There are a few more files in `core/server/services/*` that include references to `i18n.t`. I have left these out as there are other PRs open for those files.

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

