### PR TITLE
Replaced i18n.t with tpl in core/server/api/v3/email.js

### DIFF
--- a/core/server/api/v3/email.js
+++ b/core/server/api/v3/email.js
@@ -1,7 +1,12 @@
 const models = require('../../models');
-const i18n = require('../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const megaService = require('../../services/mega');
+
+const messages = {
+    emailNotFound: 'Email not found.',
+    retryNotAllowed: 'Only failed emails can be retried'
+};
 
 module.exports = {
     docName: 'emails',
@@ -24,7 +29,7 @@ module.exports = {
                 .then((model) => {
                     if (!model) {
                         throw new errors.NotFoundError({
-                            message: i18n.t('errors.models.email.emailNotFound')
+                            message: tpl(messages.emailNotFound)
                         });
                     }
 
@@ -43,13 +48,13 @@ module.exports = {
                 .then(async (model) => {
                     if (!model) {
                         throw new errors.NotFoundError({
-                            message: i18n.t('errors.models.email.emailNotFound')
+                            message: tpl(messages.emailNotFound)
                         });
                     }
 
                     if (model.get('status') !== 'failed') {
                         throw new errors.IncorrectUsageError({
-                            message: i18n.t('errors.models.email.retryNotAllowed')
+                            message: tpl(messages.retryNotAllowed)
                         });
                     }
 


### PR DESCRIPTION
refs: #13380
The i18n package is deprecated. It is being replaced with the tpl package.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
