### PR TITLE
Replaced i18n.t w/ tpl in core/server/api/v2/utils/validators/input/settings.js

### DIFF
--- a/core/server/api/v2/utils/validators/input/settings.js
+++ b/core/server/api/v2/utils/validators/input/settings.js
@@ -1,7 +1,13 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const {BadRequestError, ValidationError} = require('@tryghost/errors');
+
+const messages = {
+    error: 'Attempted to change active_theme via settings API',
+    help: 'Please activate theme via the themes API endpoints instead',
+    schemaValidationFailed: 'Validation failed for \'{key}\'.'
+};
 
 module.exports = {
     edit(apiConfig, frame) {
@@ -12,8 +18,8 @@ module.exports = {
                 // @NOTE: active theme has to be changed via theme endpoints
                 errors.push(
                     new BadRequestError({
-                        message: i18n.t('errors.api.settings.activeThemeSetViaAPI.error'),
-                        help: i18n.t('errors.api.settings.activeThemeSetViaAPI.help')
+                        message: tpl(messages.error),
+                        help: tpl(messages.help)
                     })
                 );
             }
@@ -25,7 +31,7 @@ module.exports = {
                 } catch (e) {
                     errors.push(
                         new ValidationError({
-                            message: i18n.t('notices.data.validation.index.schemaValidationFailed', {
+                            message: tpl(messages.schemaValidationFailed, {
                                 key: 'unsplash'
                             }),
                             property: 'unsplash'


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
