### PR TITLE
Fixed handling of labs flag for Offers

### DIFF
--- a/core/server/api/canary/offers.js
+++ b/core/server/api/canary/offers.js
@@ -27,6 +27,9 @@ module.exports = {
     edit: {
         options: ['id'],
         permissions: true,
+        headers: {
+            cacheInvalidate: true
+        },
         async query(frame) {
             const offer = await offersService.api.updateOffer({
                 ...frame.data.offers[0],
@@ -40,6 +43,9 @@ module.exports = {
 
     add: {
         permissions: true,
+        headers: {
+            cacheInvalidate: true
+        },
         async query(frame) {
             const offer = await offersService.api.createOffer(frame.data.offers[0]);
             frame.response = {

--- a/core/server/services/offers/service.js
+++ b/core/server/services/offers/service.js
@@ -25,15 +25,22 @@ module.exports = {
         this.api = offersModule.api;
         this.repository = offersModule.repository;
 
+        let initCalled = false;
         if (labs.isSet('offers')) {
             // handles setting up redirects
-            await offersModule.init();
+            const promise = offersModule.init();
+            initCalled = true;
+            await promise;
         }
 
         // TODO: Delete after GA
         let offersEnabled = labs.isSet('offers');
         events.on('settings.labs.edited', async () => {
-            if (labs.isSet('offers') !== offersEnabled) {
+            if (labs.isSet('offers') && !initCalled) {
+                const promise = offersModule.init();
+                initCalled = true;
+                await promise;
+            } else if (labs.isSet('offers') !== offersEnabled) {
                 offersEnabled = labs.isSet('offers');
 
                 if (offersEnabled) {


### PR DESCRIPTION
no-issue

Because we only called `init` if the labs flag is enabled, when starting
up a site without the flag enabled - the listener for adding redirects
wasn't active. So new Offers would not have their redirects setup.
