### PR TITLE
Added boot-time metric shipping

### DIFF
--- a/loggingrc.js
+++ b/loggingrc.js
@@ -8,6 +8,14 @@ module.exports = {
     mode: config.get('logging:mode'),
     level: config.get('logging:level'),
     transports: config.get('logging:transports'),
+    metrics: {
+        transports: config.get('logging:metrics:transports'),
+        metadata: {
+            // Undefined if unavailable
+            siteId: config.get('hostSettings:siteId'),
+            domain: config.get('url')
+        }
+    },
     gelf: config.get('logging:gelf'),
     loggly: config.get('logging:loggly'),
     elasticsearch: config.get('logging:elasticsearch'),

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@tryghost/members-importer": "0.3.3",
     "@tryghost/members-offers": "0.4.2",
     "@tryghost/members-ssr": "1.0.14",
+    "@tryghost/metrics": "0.2.0",
     "@tryghost/mw-session-from-token": "0.1.25",
     "@tryghost/nodemailer": "0.3.3",
     "@tryghost/package-json": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,6 +1631,13 @@
     leaky-bucket "^2.2.0"
     stripe "^8.174.0"
 
+"@tryghost/metrics@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/metrics/-/metrics-0.2.0.tgz#e44ddea0ffc6b4092a7dd83f12911f4e3d00812c"
+  integrity sha512-pym7A2BDjVCNj6LPlxPg5qPXbrZNSamXWqTF5PxeUSUhF6kZpYkxSVU1L3ADkQlG1UqYsJQuO4FrEf0DBuntJg==
+  dependencies:
+    "@tryghost/pretty-stream" "^0.1.1"
+
 "@tryghost/mobiledoc-kit@^0.12.4-ghost.1":
   version "0.12.4-ghost.1"
   resolved "https://registry.yarnpkg.com/@tryghost/mobiledoc-kit/-/mobiledoc-kit-0.12.4-ghost.1.tgz#32060242b4c7e787a9605ba856454c6a26141925"
@@ -1673,6 +1680,15 @@
   dependencies:
     chalk "^4.1.0"
     sywac "^1.3.0"
+
+"@tryghost/pretty-stream@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/pretty-stream/-/pretty-stream-0.1.1.tgz#8be18694f3081424c0efb832fa32469d5891356b"
+  integrity sha512-+FYAVozEmYctaVI+4xEhRnpep0xSnGL7FiT91dffxTLx2QVQxI1qADD9Dfb9EzIYIDRttUKoZJ4xzrVpnzD0WQ==
+  dependencies:
+    lodash "^4.17.21"
+    moment "^2.29.1"
+    prettyjson "^1.2.1"
 
 "@tryghost/promise@0.1.12":
   version "0.1.12"


### PR DESCRIPTION
Ghost already measures boot-time, which is awesome. To properly track boot-time as well as other performance metrics it would be beneficial to have a way to store and analyse this data.

The new @tryghost/metrics package follows the same patterns as @tryghost/logging, and uses the same configuration file (loggingrc.js in the root of the project). It plugs into multiple backends (stdout & elasticsearch for now) and transforms the metric into a format which is best processed by that backend.

When no metric transports are specified, nothing will change. Adding a transport will start shipping the boot-time metric to that backend. For backends which support it (currently just ElasticSearch), additional metadata is shipped alongside metric.
