### PR TITLE
Replaced i18n.t w/ tpl helper in v2/utils/validators/input/setup.js

### DIFF
--- a/core/server/api/v2/utils/validators/input/setup.js
+++ b/core/server/api/v2/utils/validators/input/setup.js
@@ -1,13 +1,17 @@
 const debug = require('@tryghost/debug')('api:v2:utils:validators:input:updateSetup');
-const i18n = require('../../../../../../shared/i18n');
+const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
+
+const messages = {
+    notTheBlogOwner: 'You are not the site owner.'
+};
 
 module.exports = {
     updateSetup(apiConfig, frame) {
         debug('resetPassword');
 
         if (!frame.options.context || !frame.options.context.user) {
-            throw new errors.NoPermissionError({message: i18n.t('errors.api.authentication.notTheBlogOwner')});
+            throw new errors.NoPermissionError({message: tpl(messages.notTheBlogOwner)});
         }
     }
 };


### PR DESCRIPTION
refs: #13380

replaced i18n.t w/ tpl helper in v2/utils/validators/input/setup.js

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
