### PR TITLE
⚡ Improved Ghost boot time and memory usage by lazy loading routes

### DIFF
--- a/core/server/web/api/app.js
+++ b/core/server/web/api/app.js
@@ -12,18 +12,17 @@ module.exports = function setupApiApp() {
         apiApp.use(require('./testmode')());
     }
 
-    // Mount different API versions
-    apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'content'}), require('./v2/content/app')());
-    apiApp.use(urlUtils.getVersionPath({version: 'v2', type: 'admin'}), require('./v2/admin/app')());
+    apiApp.lazyUse(urlUtils.getVersionPath({version: 'v2', type: 'content'}), require('./v2/content/app'));
+    apiApp.lazyUse(urlUtils.getVersionPath({version: 'v2', type: 'admin'}), require('./v2/admin/app'));
 
-    apiApp.use(urlUtils.getVersionPath({version: 'v3', type: 'content'}), require('./v3/content/app')());
-    apiApp.use(urlUtils.getVersionPath({version: 'v3', type: 'admin'}), require('./v3/admin/app')());
+    apiApp.lazyUse(urlUtils.getVersionPath({version: 'v3', type: 'content'}), require('./v3/content/app'));
+    apiApp.lazyUse(urlUtils.getVersionPath({version: 'v3', type: 'admin'}), require('./v3/admin/app'));
 
-    apiApp.use(urlUtils.getVersionPath({version: 'v4', type: 'content'}), require('./canary/content/app')());
-    apiApp.use(urlUtils.getVersionPath({version: 'v4', type: 'admin'}), require('./canary/admin/app')());
+    apiApp.lazyUse(urlUtils.getVersionPath({version: 'v4', type: 'content'}), require('./canary/content/app'));
+    apiApp.lazyUse(urlUtils.getVersionPath({version: 'v4', type: 'admin'}), require('./canary/admin/app'));
 
-    apiApp.use(urlUtils.getVersionPath({version: 'canary', type: 'content'}), require('./canary/content/app')());
-    apiApp.use(urlUtils.getVersionPath({version: 'canary', type: 'admin'}), require('./canary/admin/app')());
+    apiApp.lazyUse(urlUtils.getVersionPath({version: 'canary', type: 'content'}), require('./canary/content/app'));
+    apiApp.lazyUse(urlUtils.getVersionPath({version: 'canary', type: 'admin'}), require('./canary/admin/app'));
 
     // Error handling for requests to non-existent API versions
     apiApp.use(errorHandler.resourceNotFound);

--- a/core/server/web/parent/backend.js
+++ b/core/server/web/parent/backend.js
@@ -10,9 +10,9 @@ module.exports = () => {
     // BACKEND
     // Wrap the admin and API apps into a single express app for use with vhost
     const backendApp = express('backend');
-    backendApp.use('/ghost/api', require('../api')());
-    backendApp.use('/ghost/oauth', require('../oauth')());
-    backendApp.use('/ghost/.well-known', require('../well-known')());
+    backendApp.lazyUse('/ghost/api', require('../api'));
+    backendApp.lazyUse('/ghost/oauth', require('../oauth'));
+    backendApp.lazyUse('/ghost/.well-known', require('../well-known'));
     backendApp.use('/ghost', require('../../services/auth/session').createSessionFromToken, require('../admin')());
 
     return backendApp;

--- a/core/server/web/parent/frontend.js
+++ b/core/server/web/parent/frontend.js
@@ -18,7 +18,7 @@ module.exports = (options) => {
     // otherwise we serve assets/pages with http. This can cause mixed content warnings in the admin client.
     frontendApp.use(shared.middlewares.urlRedirects.frontendSSLRedirect);
 
-    frontendApp.use('/members', require('../members')());
+    frontendApp.lazyUse('/members', require('../members'));
     frontendApp.use('/', require('../site')(options));
 
     return frontendApp;

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "express-brute": "1.0.1",
     "express-hbs": "2.4.0",
     "express-jwt": "6.1.0",
+    "express-lazy-router": "1.0.4",
     "express-query-boolean": "2.0.0",
     "express-session": "1.17.2",
     "fs-extra": "10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4475,6 +4475,11 @@ express-jwt@6.1.0:
     jsonwebtoken "^8.1.0"
     lodash.set "^4.0.0"
 
+express-lazy-router@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/express-lazy-router/-/express-lazy-router-1.0.4.tgz#c3a95e76c95c757422b566646999e6375255349e"
+  integrity sha512-LXy1toGlUciLD7Bo5Ug7WpfrIBpw1FmqLdxDhGfhHdFbgmocCbUdBVD7FECXoDsWiZQ80EgHC28hJyebpQCINQ==
+
 express-query-boolean@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/express-query-boolean/-/express-query-boolean-2.0.0.tgz#ea56ac8138e2b95b171b8eee2af88738302941c3"


### PR DESCRIPTION
no issue

- right now, we mount all API endpoints (v2, v3 and canary), alongside some
  other routes, when Ghost is booting. This is wasteful because we don't
  necessarily need any of the endpoints to get Ghost up and running
- even when Admin is used, it uses `canary` so `v2` and `v3` sit in memory
- the better approach here is to lazy load these endpoints, so they only
  get mounted when needed
- this commit adds the `lazyUse` function into our Express lib,
  which takes a mount path and a module function to execute down the
  line. This gets passed to the wonderful `express-lazy-router` lib which
  detects when we're calling an unmounted module and will mount it for
  us
- from local testing, this speeds up boot time by about 18% and reduces
  initial memory usage by about 6% 🚀