### PR TITLE
Update dependency knex to 0.95.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "jsonwebtoken": "8.5.1",
     "juice": "8.0.0",
     "keypair": "1.0.4",
-    "knex": "0.21.21",
+    "knex": "0.95.11",
     "knex-migrator": "4.0.5",
     "lodash": "4.17.21",
     "mailgun-js": "0.22.0",


### PR DESCRIPTION
Fixed 2 vulnerabilities by updating knex package to 0.95.11 by running `npm audit fix`:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution in set-value                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ set-value                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ knex                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ knex > liftoff > findup-sync > micromatch > snapdragon >     │
│               │ base > cache-base > set-value                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-4jqc-8m5r-9rpr            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution in set-value                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ set-value                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ knex                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ knex > liftoff > findup-sync > micromatch > braces >         │
│               │ snapdragon > base > cache-base > set-value                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-4jqc-8m5r-9rpr            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```