### PR TITLE
Set global Luxon timezone override to UTC

### DIFF
--- a/core/server/overrides.js
+++ b/core/server/overrides.js
@@ -5,13 +5,17 @@
  */
 process.env.BLUEBIRD_DEBUG = 0;
 
+const luxon = require('luxon');
 const moment = require('moment-timezone');
 
 /**
  * force UTC
- *   - you can require moment or moment-timezone, both is configured to UTC
+ *   - old way: you can require moment or moment-timezone
+ *   - new way: you should use Luxon - work is in progress to switch from moment.
+ *
  *   - you are allowed to use new Date() to instantiate datetime values for models, because they are transformed into UTC in the model layer
  *   - be careful when not working with models, every value from the native JS Date is local TZ
- *   - be careful when you work with date operations, therefor always wrap a date into moment
+ *   - be careful when you work with date operations, therefore always wrap a date with our timezone library
  */
+luxon.Settings.defaultZone = 'UTC';
 moment.tz.setDefault('UTC');

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "knex": "0.21.21",
     "knex-migrator": "4.0.5",
     "lodash": "4.17.21",
+    "luxon": "2.0.2",
     "mailgun-js": "0.22.0",
     "metascraper": "5.24.9",
     "metascraper-author": "5.24.9",

--- a/test/unit/server/overrides.test.js
+++ b/test/unit/server/overrides.test.js
@@ -1,0 +1,10 @@
+const should = require('should');
+const luxon = require('luxon');
+
+require('../../../core/server/overrides');
+
+describe('Overrides', function () {
+    it('sets global timezone to UTC', function () {
+        should.equal(luxon.DateTime.local().zoneName, 'UTC');
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7107,6 +7107,11 @@ lru_map@^0.3.3:
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
+luxon@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.0.2.tgz#11f2cd4a11655fdf92e076b5782d7ede5bcdd133"
+  integrity sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg==
+
 luxon@^1.26.0:
   version "1.28.0"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.28.0.tgz#e7f96daad3938c06a62de0fb027115d251251fbf"


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/CORE-113/start-off-luxon-refactor

- we're planning on switching to Luxon for our date/timezone library,
  eventually replacing `moment` and `moment-timezone`
- the first step is to set the global timezone override to UTC, which is
  done in `core/server/overrides.js`
- also adds a test to ensure we're setting the timezone correctly
- this was mostly pulled from https://moment.github.io/luxon/#/zones?id=changing-the-default-zone