### PR TITLE
Reworked init migrations to use async/await

### DIFF
--- a/core/server/data/migrations/init/1-create-tables.js
+++ b/core/server/data/migrations/init/1-create-tables.js
@@ -4,27 +4,26 @@ const schema = require('../../schema').tables;
 const logging = require('@tryghost/logging');
 const schemaTables = Object.keys(schema);
 
-module.exports.up = function createTables(options) {
+module.exports.up = async (options) => {
     const connection = options.connection;
 
-    return Promise.mapSeries(schemaTables, function createTable(table) {
+    await Promise.mapSeries(schemaTables, async (table) => {
         logging.info('Creating table: ' + table);
-        return commands.createTable(table, connection);
+        await commands.createTable(table, connection);
     });
 };
 
 /**
- *
  @TODO: This works, but is very dangerous in the current state of the knex-migrator v3.
- @TODO: Enable if knex-migrator v3 is stable.
- module.exports.down = function dropTables(options) {
+ @TODO: Decide if we should enable or delete this
+ module.exports.down = async (options) => {
         var connection = options.connection;
 
         // Reference between tables!
         schemaTables.reverse();
-        return Promise.mapSeries(schemaTables, function dropTable(table) {
+        await Promise.mapSeries(schemaTables, async (table) => {
             logging.info('Drop table: ' + table);
-            return commands.deleteTable(table, connection);
+            await commands.deleteTable(table, connection);
         });
     };
  */

--- a/core/server/data/migrations/init/2-create-fixtures.js
+++ b/core/server/data/migrations/init/2-create-fixtures.js
@@ -7,20 +7,20 @@ module.exports.config = {
     transaction: true
 };
 
-module.exports.up = function insertFixtures(options) {
+module.exports.up = async (options) => {
     const localOptions = _.merge({
         context: {internal: true},
         migrating: true
     }, options);
 
-    return Promise.mapSeries(fixtures.models, function (model) {
+    await Promise.mapSeries(fixtures.models, async (model) => {
         logging.info('Model: ' + model.name);
 
-        return fixtures.utils.addFixturesForModel(model, localOptions);
-    }).then(function () {
-        return Promise.mapSeries(fixtures.relations, function (relation) {
-            logging.info('Relation: ' + relation.from.model + ' to ' + relation.to.model);
-            return fixtures.utils.addFixturesForRelation(relation, localOptions);
-        });
+        await fixtures.utils.addFixturesForModel(model, localOptions);
+    });
+
+    await Promise.mapSeries(fixtures.relations, async (relation) => {
+        logging.info('Relation: ' + relation.from.model + ' to ' + relation.to.model);
+        await fixtures.utils.addFixturesForRelation(relation, localOptions);
     });
 };


### PR DESCRIPTION
- use async/await and fat arrow syntax
- makes it easier to refactor later as "this" context is then reliable

