### PR TITLE
Added metrics for test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,9 @@ jobs:
           mysql root password: 'root'
 
       - run: yarn
+
+      - run: date +%s > ${{ runner.temp }}/startTime # Get start time for test suite
+
       - run: yarn test:e2e
         env:
           database__connection__filename: /dev/shm/ghost-test.db
@@ -115,6 +118,34 @@ jobs:
       - run: yarn test:regression
         env:
           database__connection__filename: /dev/shm/ghost-test.db
+
+      # Get time in seconds for test suite
+      - run: |
+          startTime="$(cat ${{ runner.temp }}/startTime)"
+          endTime="$(date +%s)"
+          echo "test_time=$(($endTime-$startTime))" >> $GITHUB_ENV
+
+      # Connect to Tailscale to access ElasticSearch
+      - uses: tailscale/github-action@v1
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+
+      # Report time taken to metrics service
+      - uses: sam-lord/action-trigger-metric
+        with:
+          metricName: 'test-time'
+          metricValue: ${{ env.test_time }}
+          config: |
+            {
+              "metrics": {
+                "transports": ["elasticsearch"]
+              },
+              "elasticsearch": {
+                "host": "${{ secrets.ELASTICSEARCH_HOST }}",
+                "username": "${{ secrets.ELASTICSEARCH_USERNAME }}",
+                "password": "${{ secrets.ELSATICSEARCH_PASSWORD }}"
+              }
+            }
 
       - name: Unit test coverage
         run: yarn cov:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,9 +126,18 @@ jobs:
           echo "test_time=$(($endTime-$startTime))" >> $GITHUB_ENV
 
       # Connect to Tailscale to access ElasticSearch
-      - uses: tailscale/github-action@v1
-        with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+      - run: |
+          VERSION=1.16.1
+          curl "https://pkgs.tailscale.com/stable/tailscale_${VERSION}_amd64.tgz" -o "${{ runner.temp }}/tailscale.tgz"
+          tar -C ${{ runner.temp }} -xzf tailscale.tgz
+          rm ${{ runner.temp }}/tailscale.tgz
+          TSPATH=${{ runner.temp }}/tailscale_${VERSION}_amd64
+          mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
+
+      - run: |
+          HOSTNAME="github-$(cat /etc/hostname)"
+          tailscaled --tun=userspace-networking --outbound-http-proxy-listen=localhost:1055
+          tailscale up --authkey ${{ secrets.TAILSCALE_AUTHKEY }} --hostname=${HOSTNAME}
 
       # Report time taken to metrics service
       - uses: sam-lord/action-trigger-metric@main
@@ -143,7 +152,8 @@ jobs:
               "elasticsearch": {
                 "host": "${{ secrets.ELASTICSEARCH_HOST }}",
                 "username": "${{ secrets.ELASTICSEARCH_USERNAME }}",
-                "password": "${{ secrets.ELSATICSEARCH_PASSWORD }}"
+                "password": "${{ secrets.ELSATICSEARCH_PASSWORD }}",
+                "proxy": "http://localhost:1055"
               }
             }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,11 @@ jobs:
           configuration: |
             {
               "metrics": {
-                "transports": ["elasticsearch"]
+                "transports": ["elasticsearch"],
+                "metadata": {
+                  "database": "${{ matrix.env.DB }}",
+                  "node": "${{ matric.node }}"
+                }
               },
               "elasticsearch": {
                 "host": "${{ secrets.ELASTICSEARCH_HOST }}",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           database__connection__filename: /dev/shm/ghost-test.db
 
-      # Get time in seconds for test suite
+      # Get runtime in seconds for test suite
       - run: |
           startTime="$(cat ${{ runner.temp }}/startTime)"
           endTime="$(date +%s)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
       - run: |
           VERSION=1.16.1
           curl "https://pkgs.tailscale.com/stable/tailscale_${VERSION}_amd64.tgz" -o "${{ runner.temp }}/tailscale.tgz"
-          tar -C ${{ runner.temp }} -xzf tailscale.tgz
+          tar -C ${{ runner.temp }} -xzf "${{ runner.temp }}/tailscale.tgz"
           rm ${{ runner.temp }}/tailscale.tgz
           TSPATH=${{ runner.temp }}/tailscale_${VERSION}_amd64
           mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,9 +115,9 @@ jobs:
         env:
           database__connection__filename: /dev/shm/ghost-test.db
       - run: yarn test:unit
-      # - run: yarn test:regression
-      #   env:
-      #     database__connection__filename: /dev/shm/ghost-test.db
+      - run: yarn test:regression
+        env:
+          database__connection__filename: /dev/shm/ghost-test.db
 
       # Get runtime in seconds for test suite
       - run: |
@@ -129,8 +129,6 @@ jobs:
         uses: tailscale/github-action@v1
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-
-      - run: cat ~/tailscaled.log
 
       # Report time taken to metrics service
       - uses: sam-lord/action-trigger-metric@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,9 +115,9 @@ jobs:
         env:
           database__connection__filename: /dev/shm/ghost-test.db
       - run: yarn test:unit
-      - run: yarn test:regression
-        env:
-          database__connection__filename: /dev/shm/ghost-test.db
+      # - run: yarn test:regression
+      #   env:
+      #     database__connection__filename: /dev/shm/ghost-test.db
 
       # Get runtime in seconds for test suite
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,8 @@ jobs:
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
+      - run: cat ~/tailscale.log
+
       # Report time taken to metrics service
       - uses: sam-lord/action-trigger-metric@main
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           metricName: 'test-time'
           metricValue: ${{ env.test_time }}
-          config: |
+          configuration: |
             {
               "metrics": {
                 "transports": ["elasticsearch"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,19 +125,10 @@ jobs:
           endTime="$(date +%s)"
           echo "test_time=$(($endTime-$startTime))" >> $GITHUB_ENV
 
-      # Connect to Tailscale to access ElasticSearch
-      - run: |
-          VERSION=1.16.1
-          curl "https://pkgs.tailscale.com/stable/tailscale_${VERSION}_amd64.tgz" -o "${{ runner.temp }}/tailscale.tgz"
-          tar -C ${{ runner.temp }} -xzf "${{ runner.temp }}/tailscale.tgz"
-          rm ${{ runner.temp }}/tailscale.tgz
-          TSPATH=${{ runner.temp }}/tailscale_${VERSION}_amd64
-          sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
-
-      - run: |
-          HOSTNAME="github-$(cat /etc/hostname)"
-          sudo tailscaled --tun=userspace-networking --outbound-http-proxy-listen=localhost:1055 &
-          sudo tailscale up --authkey ${{ secrets.TAILSCALE_AUTHKEY }} --hostname=${HOSTNAME}
+      - name: Tailscale Action
+        uses: tailscale/github-action@v1
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
       # Report time taken to metrics service
       - uses: sam-lord/action-trigger-metric@main
@@ -156,8 +147,7 @@ jobs:
               "elasticsearch": {
                 "host": "${{ secrets.ELASTICSEARCH_HOST }}",
                 "username": "${{ secrets.ELASTICSEARCH_USERNAME }}",
-                "password": "${{ secrets.ELASTICSEARCH_PASSWORD }}",
-                "proxy": "http://localhost:1055"
+                "password": "${{ secrets.ELASTICSEARCH_PASSWORD }}"
               }
             }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,16 +108,16 @@ jobs:
 
       - run: date +%s > ${{ runner.temp }}/startTime # Get start time for test suite
 
-      # - run: yarn test:e2e
-      #   env:
-      #     database__connection__filename: /dev/shm/ghost-test.db
-      # - run: yarn test:integration
-      #   env:
-      #     database__connection__filename: /dev/shm/ghost-test.db
-      # - run: yarn test:unit
-      # - run: yarn test:regression
-      #   env:
-      #     database__connection__filename: /dev/shm/ghost-test.db
+      - run: yarn test:e2e
+        env:
+          database__connection__filename: /dev/shm/ghost-test.db
+      - run: yarn test:integration
+        env:
+          database__connection__filename: /dev/shm/ghost-test.db
+      - run: yarn test:unit
+      - run: yarn test:regression
+        env:
+          database__connection__filename: /dev/shm/ghost-test.db
 
       # Get runtime in seconds for test suite
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
-      - run: cat ~/tailscale.log
+      - run: cat ~/tailscaled.log
 
       # Report time taken to metrics service
       - uses: sam-lord/action-trigger-metric@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
       # Report time taken to metrics service
-      - uses: sam-lord/action-trigger-metric
+      - uses: sam-lord/action-trigger-metric@main
         with:
           metricName: 'test-time'
           metricValue: ${{ env.test_time }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,16 +108,16 @@ jobs:
 
       - run: date +%s > ${{ runner.temp }}/startTime # Get start time for test suite
 
-      - run: yarn test:e2e
-        env:
-          database__connection__filename: /dev/shm/ghost-test.db
-      - run: yarn test:integration
-        env:
-          database__connection__filename: /dev/shm/ghost-test.db
-      - run: yarn test:unit
-      - run: yarn test:regression
-        env:
-          database__connection__filename: /dev/shm/ghost-test.db
+      # - run: yarn test:e2e
+      #   env:
+      #     database__connection__filename: /dev/shm/ghost-test.db
+      # - run: yarn test:integration
+      #   env:
+      #     database__connection__filename: /dev/shm/ghost-test.db
+      # - run: yarn test:unit
+      # - run: yarn test:regression
+      #   env:
+      #     database__connection__filename: /dev/shm/ghost-test.db
 
       # Get runtime in seconds for test suite
       - run: |
@@ -136,7 +136,7 @@ jobs:
 
       - run: |
           HOSTNAME="github-$(cat /etc/hostname)"
-          sudo tailscaled --tun=userspace-networking --outbound-http-proxy-listen=localhost:1055
+          sudo tailscaled --tun=userspace-networking --outbound-http-proxy-listen=localhost:1055 &
           sudo tailscale up --authkey ${{ secrets.TAILSCALE_AUTHKEY }} --hostname=${HOSTNAME}
 
       # Report time taken to metrics service

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,12 +132,12 @@ jobs:
           tar -C ${{ runner.temp }} -xzf "${{ runner.temp }}/tailscale.tgz"
           rm ${{ runner.temp }}/tailscale.tgz
           TSPATH=${{ runner.temp }}/tailscale_${VERSION}_amd64
-          mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
+          sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
 
       - run: |
           HOSTNAME="github-$(cat /etc/hostname)"
-          tailscaled --tun=userspace-networking --outbound-http-proxy-listen=localhost:1055
-          tailscale up --authkey ${{ secrets.TAILSCALE_AUTHKEY }} --hostname=${HOSTNAME}
+          sudo tailscaled --tun=userspace-networking --outbound-http-proxy-listen=localhost:1055
+          sudo tailscale up --authkey ${{ secrets.TAILSCALE_AUTHKEY }} --hostname=${HOSTNAME}
 
       # Report time taken to metrics service
       - uses: sam-lord/action-trigger-metric@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
                 "transports": ["elasticsearch"],
                 "metadata": {
                   "database": "${{ matrix.env.DB }}",
-                  "node": "${{ matric.node }}"
+                  "node": "${{ matrix.node }}"
                 }
               },
               "elasticsearch": {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
               "elasticsearch": {
                 "host": "${{ secrets.ELASTICSEARCH_HOST }}",
                 "username": "${{ secrets.ELASTICSEARCH_USERNAME }}",
-                "password": "${{ secrets.ELSATICSEARCH_PASSWORD }}",
+                "password": "${{ secrets.ELASTICSEARCH_PASSWORD }}",
                 "proxy": "http://localhost:1055"
               }
             }


### PR DESCRIPTION
CORE-120

Added new metric action which can send custom metrics through to configurable backends. This is a bit of an unknown due to the nature of modifying code in Github Actions - but should allow test runs to pipe metrics into various systems.

