### PR TITLE
Forced Offers feature flag to GA status

### DIFF
--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -7,7 +7,6 @@ const urlUtils = require('../../../../shared/url-utils');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const redirectsService = require('../../../services/redirects');
-const labsService = require('../../../../shared/labs');
 
 const messages = {
     customRedirectsRegistrationFailure: 'Could not register custom redirects.'
@@ -26,13 +25,6 @@ let customRedirectsRouter;
  */
 _private.registerRoutes = (router, redirects) => {
     debug('redirects loading');
-
-    if (labsService.isSet('offers')) {
-        redirects.unshift({
-            from: '/zimo50',
-            to: '/#/portal/offers/abcdefuckoff'
-        });
-    }
 
     redirects.forEach((redirect) => {
         /**

--- a/core/shared/labs.js
+++ b/core/shared/labs.js
@@ -15,7 +15,8 @@ const messages = {
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
-    'customThemeSettings'
+    'customThemeSettings',
+    'offers'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -27,8 +28,7 @@ const BETA_FEATURES = [
 
 const ALPHA_FEATURES = [
     'oauthLogin',
-    'membersActivity',
-    'offers'
+    'membersActivity'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];
@@ -86,7 +86,7 @@ module.exports.enabledHelper = function enabledHelper(options, callback) {
     }
 
     // Else, the helper is not active and we need to handle this as an error
-    errDetails.message = tpl(options.errorMessage || messages.errorMessage, {helperName: options.helperName}),
+    errDetails.message = tpl(options.errorMessage || messages.errorMessage, {helperName: options.helperName});
     errDetails.context = tpl(options.errorContext || messages.errorContext, {
         helperName: options.helperName,
         flagName: options.flagName

--- a/test/unit/frontend/services/theme-engine/middleware.test.js
+++ b/test/unit/frontend/services/theme-engine/middleware.test.js
@@ -55,7 +55,8 @@ describe('Themes middleware', function () {
             // if we want to compare it
             // we will need some unique content
             members: true,
-            customThemeSettings: true
+            customThemeSettings: true,
+            offers: true
         };
 
         fakeCustomThemeSettingsData = {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1115

This means that we don't have to do as much prep to switch features
from alpha/beta -> GA - we can add them to the GA_FEATURES list to force
them on, and delete the toggle from the labs section.

During cleanup we're then able to clean up the loose conditionals.