### PR TITLE
Removed NOT NULL constraint from portal_title

### DIFF
--- a/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
+++ b/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
@@ -1,5 +1,6 @@
 const logging = require('@tryghost/logging');
 const {createNonTransactionalMigration} = require('../../utils');
+const {addUnique} = require('../../../schema/commands');
 
 module.exports = createNonTransactionalMigration(
     async function up(knex) {
@@ -12,6 +13,10 @@ module.exports = createNonTransactionalMigration(
         await knex.schema.table('offers', function (table) {
             table.string('portal_title', 191).nullable();
         });
+
+        for (const column of ['name', 'code', 'stripe_coupon_id']) {
+            await addUnique('offers', column, knex);
+        }
     },
     async function down(knex) {
         logging.info('Adding NOT NULL constraint for: portal_title in table: offers');
@@ -23,6 +28,10 @@ module.exports = createNonTransactionalMigration(
         await knex.schema.table('offers', function (table) {
             table.string('portal_title', 191).notNullable();
         });
+
+        for (const column of ['name', 'code', 'stripe_coupon_id']) {
+            await addUnique('offers', column, knex);
+        }
     }
 );
 

--- a/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
+++ b/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
@@ -14,8 +14,10 @@ module.exports = createNonTransactionalMigration(
             table.string('portal_title', 191).nullable();
         });
 
-        for (const column of ['name', 'code', 'stripe_coupon_id']) {
-            await addUnique('offers', column, knex);
+        if (knex.client.config.client === 'sqlite3') {
+            for (const column of ['name', 'code', 'stripe_coupon_id']) {
+                await addUnique('offers', column, knex);
+            }
         }
     },
     async function down(knex) {
@@ -29,8 +31,10 @@ module.exports = createNonTransactionalMigration(
             table.string('portal_title', 191).notNullable();
         });
 
-        for (const column of ['name', 'code', 'stripe_coupon_id']) {
-            await addUnique('offers', column, knex);
+        if (knex.client.config.client === 'sqlite3') {
+            for (const column of ['name', 'code', 'stripe_coupon_id']) {
+                await addUnique('offers', column, knex);
+            }
         }
     }
 );

--- a/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
+++ b/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
@@ -1,0 +1,28 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info('Dropping NOT NULL constraint for: portal_title in table: offers');
+
+        await knex.schema.table('offers', function (table) {
+            table.dropColumn('portal_title');
+        });
+
+        await knex.schema.table('offers', function (table) {
+            table.string('portal_title', 191).nullable();
+        });
+    },
+    async function down(knex) {
+        logging.info('Adding NOT NULL constraint for: portal_title in table: offers');
+
+        await knex.schema.table('offers', function (table) {
+            table.dropColumn('portal_title');
+        });
+
+        await knex.schema.table('offers', function (table) {
+            table.string('portal_title', 191).notNullable();
+        });
+    }
+);
+

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -397,7 +397,7 @@ module.exports = {
         discount_amount: {type: 'integer', nullable: false},
         duration: {type: 'string', maxlength: 50, nullable: false},
         duration_in_months: {type: 'integer', nullable: true},
-        portal_title: {type: 'string', maxlength: 191, nullable: false},
+        portal_title: {type: 'string', maxlength: 191, nullable: true},
         portal_description: {type: 'string', maxlength: 2000, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -34,7 +34,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '06c1007b471faba9bb82d053f6ba6cc1';
+    const currentSchemaHash = 'e649797a5de92d417744f6f2623c79cf';
     const currentFixturesHash = '07d4b0c4cf159b34344a6b5e88c74e9f';
     const currentSettingsHash = 'aa3fcbc8ab119b630aeda7366ead5493';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1163

We want to make the title for Offers optional, our nullable validation
means that we cannot store an empty string, so we must remove the NOT
NULL constraint from the column if we want to store either an empty
value or null.
