### PR TITLE
Replaced moment with luxon in core/frontend/helpers/prev_post.js

### DIFF
--- a/core/frontend/helpers/prev_post.js
+++ b/core/frontend/helpers/prev_post.js
@@ -9,7 +9,7 @@ const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const get = require('lodash/get');
 const Promise = require('bluebird');
-const moment = require('moment');
+const {DateTime} = require('luxon');
 
 const messages = {
     mustBeCalledAsBlock: 'The {\\{{helperName}}} helper must be called as a block. E.g. {{#{helperName}}}...{{/{helperName}}}'
@@ -18,7 +18,7 @@ const messages = {
 const createFrame = hbs.handlebars.createFrame;
 
 const buildApiOptions = function buildApiOptions(options, post) {
-    const publishedAt = moment(post.published_at).format('YYYY-MM-DD HH:mm:ss');
+    const publishedAt = DateTime.fromJSDate(post.published_at).toFormat('YYYY-MM-DD HH:mm:ss');
     const slug = post.slug;
     const op = options.name === 'prev_post' ? '<=' : '>';
     const order = options.name === 'prev_post' ? 'desc' : 'asc';


### PR DESCRIPTION
refs: #13648
Moment is in maintenance mode and is no longer recommended for use

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test` and `yarn lint`)

