### PR TITLE
✨ Added ability for themes to define custom settings

### DIFF
--- a/core/shared/labs.js
+++ b/core/shared/labs.js
@@ -13,6 +13,11 @@ const messages = {
     errorHelp: 'See {url}'
 };
 
+// flags in this list always return `true`, allows quick global enable prior to full flag removal
+const GA_FEATURES = [
+    'customThemeSettings'
+];
+
 // NOTE: this allowlist is meant to be used to filter out any unexpected
 //       input for the "labs" setting value
 const BETA_FEATURES = [
@@ -22,11 +27,11 @@ const BETA_FEATURES = [
 
 const ALPHA_FEATURES = [
     'oauthLogin',
-    'customThemeSettings',
     'membersActivity',
     'offers'
 ];
 
+module.exports.GA_KEYS = [...GA_FEATURES];
 module.exports.WRITABLE_KEYS_ALLOWLIST = [...BETA_FEATURES, ...ALPHA_FEATURES];
 
 module.exports.getAll = () => {
@@ -36,6 +41,10 @@ module.exports.getAll = () => {
         if (labs[alphaKey] && !(config.get('enableDeveloperExperiments') || process.env.NODE_ENV.match(/^testing/))) {
             delete labs[alphaKey];
         }
+    });
+
+    GA_FEATURES.forEach((gaKey) => {
+        labs[gaKey] = true;
     });
 
     labs.members = settingsCache.get('members_signup_access') !== 'none';

--- a/test/unit/server/services/labs.test.js
+++ b/test/unit/server/services/labs.test.js
@@ -5,6 +5,16 @@ const configUtils = require('../../../utils/configUtils');
 const labs = require('../../../../core/shared/labs');
 const settingsCache = require('../../../../core/shared/settings-cache');
 
+function expectedLabsObject(obj) {
+    const withGA = Object.assign({}, obj);
+
+    labs.GA_KEYS.forEach((key) => {
+        withGA[key] = true;
+    });
+
+    return withGA;
+}
+
 describe('Labs Service', function () {
     afterEach(function () {
         sinon.restore();
@@ -12,9 +22,9 @@ describe('Labs Service', function () {
     });
 
     it('can getAll, even if empty with enabled members', function () {
-        labs.getAll().should.eql({
+        labs.getAll().should.eql(expectedLabsObject({
             members: true
-        });
+        }));
     });
 
     it('returns an alpha flag when dev experiments in toggled', function () {
@@ -27,10 +37,10 @@ describe('Labs Service', function () {
 
         // NOTE: this test should be rewritten to test the alpha flag independently of the internal ALPHA_FEATURES list
         //       otherwise we end up in the endless maintenance loop and need to update it every time a feature graduates from alpha
-        labs.getAll().should.eql({
+        labs.getAll().should.eql(expectedLabsObject({
             oauthLogin: true,
             members: true
-        });
+        }));
 
         labs.isSet('members').should.be.true;
         labs.isSet('oauthLogin').should.be.true;
@@ -46,9 +56,9 @@ describe('Labs Service', function () {
 
         // NOTE: this test should be rewritten to test the alpha flag independently of the internal ALPHA_FEATURES list
         //       otherwise we end up in the endless maintenance loop and need to update it every time a feature graduates from alpha
-        labs.getAll().should.eql({
+        labs.getAll().should.eql(expectedLabsObject({
             members: true
-        });
+        }));
 
         labs.isSet('members').should.be.true;
         labs.isSet('oauthLogin').should.be.false;
@@ -58,9 +68,9 @@ describe('Labs Service', function () {
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('members_signup_access').returns('all');
 
-        labs.getAll().should.eql({
+        labs.getAll().should.eql(expectedLabsObject({
             members: true
-        });
+        }));
 
         labs.isSet('members').should.be.true;
     });
@@ -72,10 +82,10 @@ describe('Labs Service', function () {
             activitypub: false
         });
 
-        labs.getAll().should.eql({
+        labs.getAll().should.eql(expectedLabsObject({
             members: true,
             activitypub: false
-        });
+        }));
 
         labs.isSet('members').should.be.true;
         labs.isSet('activitypub').should.be.false;
@@ -85,9 +95,9 @@ describe('Labs Service', function () {
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('members_signup_access').returns('none');
 
-        labs.getAll().should.eql({
+        labs.getAll().should.eql(expectedLabsObject({
             members: false
-        });
+        }));
 
         labs.isSet('members').should.be.false;
     });


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1164

Themes can now define custom settings via their `package.json` file, and use them in templates via `@custom.{setting}`. Values for custom settings can be changed by site owners through a redesigned "Design settings" area in the admin interface.

Full announcement, documentation, and examples will be made available soon.

Co-authored-by:
- Sanne de Vries (@sanne-san)
- Thibaut Patel (@tpatel)
