### PR TITLE
Added initial support for Members auto-login

### DIFF
--- a/core/shared/labs.js
+++ b/core/shared/labs.js
@@ -29,7 +29,8 @@ const BETA_FEATURES = [
 const ALPHA_FEATURES = [
     'oauthLogin',
     'membersActivity',
-    'cardSettingsPanel'
+    'cardSettingsPanel',
+    'membersAutoLogin'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@tryghost/limit-service": "1.0.0",
     "@tryghost/logging": "1.0.0",
     "@tryghost/magic-link": "1.0.14",
-    "@tryghost/members-api": "2.6.2",
+    "@tryghost/members-api": "2.7.0",
     "@tryghost/members-csv": "1.1.8",
     "@tryghost/members-importer": "0.3.4",
     "@tryghost/members-offers": "0.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,10 +1513,10 @@
     "@tryghost/domain-events" "^0.1.3"
     "@tryghost/member-events" "^0.3.1"
 
-"@tryghost/members-api@2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-2.6.2.tgz#c0cf6e4dfd0915fefc8f94b1f5bf9bdcebd85df0"
-  integrity sha512-SASb/HIoTexTYT3aYVqLNNWejb3xeSFE+rZtRHv1vYxuDCtpRbzM6NATAvJ5DGiL9o6BkS4G3fscHMviRxHOVw==
+"@tryghost/members-api@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-2.7.0.tgz#a6b09c3cb6fa315d3371a0180775288fcb9ece38"
+  integrity sha512-Obsg7AXbdnknaJtCs+kKXgSAtO1kgRWDyUQ7meoV70efoUzodK42ViXPPLxBwoS5+fdfkzmzWQY2JrLLx48POQ==
   dependencies:
     "@tryghost/debug" "^0.1.2"
     "@tryghost/domain-events" "^0.1.3"


### PR DESCRIPTION
refs TryGhost/Team#1067

When the `membersAutoLogin` labs flag is enabled this will override the
successful redirect URL from Stripe Checkout - and instead use a magic
link, which will log the Member in.

Note that this will only work for brand new members. This is to stop
unauthorized access of Member accounts.