### PR TITLE
Added migration review checklist

### DIFF
--- a/.github/workflows/migration-review.yml
+++ b/.github/workflows/migration-review.yml
@@ -1,0 +1,45 @@
+name: Migration Review
+on:
+  pull_request_target:
+    types: [opened]
+    paths:
+      - 'core/server/data/schema/**'
+      - 'core/server/data/migrations/versions/**'
+jobs:
+  createComment:
+    runs-on: ubuntu-latest
+    name: Create checklist comment
+    steps:
+      - uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            It looks like this PR contains a migration 👀
+            Here's the checklist for reviewing migrations:
+
+            ### General requirements
+
+            - [ ]  Satisfies idempotency requirement (both `up()` and `down()`)
+            - [ ]  Does not reference models
+            - [ ]  Filename is in the correct format
+            - [ ]  Targets the next minor version
+            - [ ]  All code paths have appropriate log messages
+            - [ ]  Uses the correct utils
+            - [ ]  Contains a minimal changeset
+            - [ ]  Does not mix DDL/DML operations
+
+            ### Schema changes
+
+            - [ ]  Both schema change and related migration have been implemented
+            - [ ]  For column changes: indexes have been recreated for sqlite
+            - [ ]  For index changes: has been performance tested for large tables
+            - [ ]  For new tables/columns: fields use the appropriate predefined field lengths
+            - [ ]  For new tables/columns: field names follow the appropriate conventions
+            - [ ]  Does not drop a non-alpha table outside of a major version
+
+            ### Data changes
+
+            - [ ]  Mass updates/inserts are batched appropriately
+            - [ ]  Does not loop over large tables/datasets
+            - [ ]  Defends against missing or invalid data
+            - [ ]  For settings updates: follows the appropriate guidelines


### PR DESCRIPTION
Migrations are dangerous and need to be treated with a great deal of care. This workflow adds a comment to PRs containing migrations with a checklist for the reviewer to complete, which covers known pitfalls with migrations that may compromise correctness, performance, or safety.

It runs on the `pull_request_target` event because `pull_request` events run in the context of the fork rather than the base repo, and don't have access to comment on the PR.