### PR TITLE
Added `yarn` cache to CI workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,6 +16,7 @@ jobs:
           FORCE_COLOR: 0
         with:
           node-version: '14.17.0'
+          cache: yarn
 
       - name: Set up Git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
           FORCE_COLOR: 0
         with:
           node-version: '14'
+          cache: yarn
 
       - run: yarn
       - run: grunt release --skip-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           FORCE_COLOR: 0
         with:
           node-version: '14.17.0'
+          cache: yarn
       - run: yarn
       - run: yarn lint
       - uses: daniellockyer/action-slack-build@master
@@ -55,6 +56,7 @@ jobs:
           FORCE_COLOR: 0
         with:
           node-version: '14.17.0'
+          cache: yarn
 
       - name: Shutdown MySQL
         run: sudo service mysql stop
@@ -98,6 +100,7 @@ jobs:
           FORCE_COLOR: 0
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
 
       - name: Shutdown MySQL
         run: sudo service mysql stop
@@ -184,6 +187,7 @@ jobs:
           FORCE_COLOR: 0
         with:
           node-version: '12.22.1'
+          cache: yarn
       - run: npm install -g ghost-cli@latest
       - run: npm --no-git-tag-version version minor # We need to artificially bump the minor version to get migrations to run
 


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

Re-generated PR from https://github.com/TryGhost/Ghost/pull/13597

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
