### PR TITLE
Prevent Tailscale running in PRs on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,14 +126,14 @@ jobs:
           echo "test_time=$(($endTime-$startTime))" >> $GITHUB_ENV
 
       - name: Tailscale Action
-        if: github.repository_owner == 'TryGhost'
+        if: github.event_name == 'push' || startsWith(github.head_ref, 'TryGhost/')
         uses: tailscale/github-action@v1
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
       # Report time taken to metrics service
       - uses: sam-lord/action-trigger-metric@main
-        if: github.repository_owner == 'TryGhost'
+        if: github.event_name == 'push' || startsWith(github.head_ref, 'TryGhost/')
         with:
           metricName: 'test-time'
           metricValue: ${{ env.test_time }}


### PR DESCRIPTION
refs: https://github.com/TryGhost/Toolbox/issues/118

Should prevent Tailscale action from running in PR context from forks.