### PR TITLE
Exposed `tenorApiKey` via config endpoint if set

### DIFF
--- a/core/server/api/canary/utils/serializers/output/config.js
+++ b/core/server/api/canary/utils/serializers/output/config.js
@@ -1,25 +1,32 @@
 const _ = require('lodash');
+const labs = require('../../../../../../shared/labs');
 const debug = require('@tryghost/debug')('api:canary:utils:serializers:output:config');
 
 module.exports = {
     all(data, apiConfig, frame) {
         debug('all');
 
+        const keys = [
+            'version',
+            'environment',
+            'database',
+            'mail',
+            'useGravatar',
+            'labs',
+            'clientExtensions',
+            'enableDeveloperExperiments',
+            'stripeDirect',
+            'mailgunIsConfigured',
+            'emailAnalytics',
+            'hostSettings'
+        ];
+
+        if (labs.isSet('gifsCard')) {
+            keys.push('tenorApiKey');
+        }
+
         frame.response = {
-            config: _.pick(data, [
-                'version',
-                'environment',
-                'database',
-                'mail',
-                'useGravatar',
-                'labs',
-                'clientExtensions',
-                'enableDeveloperExperiments',
-                'stripeDirect',
-                'mailgunIsConfigured',
-                'emailAnalytics',
-                'hostSettings'
-            ])
+            config: _.pick(data, keys)
         };
     }
 };

--- a/core/server/services/public-config/config.js
+++ b/core/server/services/public-config/config.js
@@ -16,7 +16,8 @@ module.exports = function getConfigProperties() {
         stripeDirect: config.get('stripeDirect'),
         mailgunIsConfigured: config.get('bulkEmail') && config.get('bulkEmail').mailgun,
         emailAnalytics: config.get('emailAnalytics'),
-        hostSettings: config.get('hostSettings')
+        hostSettings: config.get('hostSettings'),
+        tenorApiKey: config.get('tenorApiKey')
     };
 
     const billingUrl = config.get('hostSettings:billing:enabled') ? config.get('hostSettings:billing:url') : '';

--- a/test/e2e-api/admin/config.test.js
+++ b/test/e2e-api/admin/config.test.js
@@ -3,6 +3,7 @@ const supertest = require('supertest');
 const testUtils = require('../../utils');
 const localUtils = require('./utils');
 const config = require('../../../core/shared/config');
+const configUtils = require('../../utils/configUtils');
 
 describe('Config API', function () {
     let request;
@@ -13,7 +14,14 @@ describe('Config API', function () {
         await localUtils.doAuth(request);
     });
 
+    afterEach(function () {
+        configUtils.set('tenorApiKey', undefined);
+    });
+
     it('can retrieve config and all expected properties', async function () {
+        // set any non-default keys so we can be sure they're exposed
+        configUtils.set('tenorApiKey', 'TENOR_KEY');
+
         const res = await request
             .get(localUtils.API.getApiQuery('config/'))
             .set('Origin', config.get('url'))

--- a/test/e2e-api/admin/utils.js
+++ b/test/e2e-api/admin/utils.js
@@ -29,7 +29,7 @@ const expectedProperties = {
 
     action: ['id', 'resource_type', 'actor_type', 'event', 'created_at', 'actor'],
 
-    config: ['version', 'environment', 'database', 'mail', 'labs', 'clientExtensions', 'enableDeveloperExperiments', 'useGravatar', 'stripeDirect', 'emailAnalytics'],
+    config: ['version', 'environment', 'database', 'mail', 'labs', 'clientExtensions', 'enableDeveloperExperiments', 'useGravatar', 'stripeDirect', 'emailAnalytics', 'tenorApiKey'],
 
     post: [
         'id',


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1217

- add `tenorApiKey` to `publicConfig.config()
- update canary config endpoint output serializer to include `tenorApiKey` when the `gifsCard` labs flag is enabled
