### PR TITLE
Added a URL Service boot log

### DIFF
--- a/core/server/services/url/UrlService.js
+++ b/core/server/services/url/UrlService.js
@@ -27,6 +27,7 @@ class UrlService {
     constructor({urlCachePath} = {}) {
         this.utils = urlUtils;
         this.urlCachePath = urlCachePath;
+        this.onFinished = null;
         this.finished = false;
         this.urlGenerators = [];
 
@@ -76,6 +77,9 @@ class UrlService {
     _onQueueEnded(event) {
         if (event === 'init') {
             this.finished = true;
+            if (this.onFinished) {
+                this.onFinished();
+            }
         }
     }
 
@@ -307,8 +311,12 @@ class UrlService {
 
     /**
      * @description Initializes components needed for the URL Service to function
+     * @param {Object} options
+     * @param {Function} [options.onFinished] - callback when url generation is finished
      */
-    async init() {
+    async init(options = {}) {
+        this.onFinished = options.onFinished;
+
         this.resources.initResourceConfig();
         this.resources.initEvenListeners();
 
@@ -317,7 +325,7 @@ class UrlService {
             this.urls = new Urls({
                 urls: persistedUrls
             });
-            this.finished = true;
+            this._onQueueEnded('init');
         } else {
             await this.resources.fetchResources();
         }


### PR DESCRIPTION
- At the moment there's no way to see in the logs when the URL Service finally finishes
- This is the moment when Ghost stops serving 503s
- Adding this log line so it's clear to see, which migh be useful whilst were refactorising

This is here for review from @naz 

@naz - I did this the other day when wondering about boot times / taking screenshots for the all hands. I didn't wanna push it in case it trampled on some work you were doing, but if you like please feel free to use your merge finger.