### PR TITLE
Added Tenor integration settings

### DIFF
--- a/core/server/api/v2/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -14,7 +14,8 @@ const groupTypeMapping = {
     newsletter: 'newsletter',
     firstpromoter: 'firstpromoter',
     oauth: 'oauth',
-    editor: 'editor'
+    editor: 'editor',
+    tenor: 'tenor'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/api/v3/utils/serializers/output/utils/settings-type-group-mapper.js
+++ b/core/server/api/v3/utils/serializers/output/utils/settings-type-group-mapper.js
@@ -14,7 +14,8 @@ const groupTypeMapping = {
     newsletter: 'newsletter',
     firstpromoter: 'firstpromoter',
     oauth: 'oauth',
-    editor: 'editor'
+    editor: 'editor',
+    tenor: 'tenor'
 };
 
 const mapGroupToType = (group) => {

--- a/core/server/data/migrations/versions/4.23/01-add-tenor-settings.js
+++ b/core/server/data/migrations/versions/4.23/01-add-tenor-settings.js
@@ -1,0 +1,22 @@
+const {addSetting, combineTransactionalMigrations} = require('../../utils.js');
+
+module.exports = combineTransactionalMigrations(
+    addSetting({
+        key: 'tenor_api_key',
+        value: null,
+        type: 'string',
+        group: 'tenor'
+    }),
+    addSetting({
+        key: 'tenor_enabled',
+        value: 'true',
+        type: 'boolean',
+        group: 'tenor'
+    }),
+    addSetting({
+        key: 'tenor_contentfilter',
+        value: 'off',
+        type: 'string',
+        group: 'tenor'
+    })
+);

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -452,6 +452,28 @@
             "type": "boolean"
         }
     },
+    "tenor": {
+        "tenor_api_key": {
+            "defaultValue": null,
+            "type": "string"
+        },
+        "tenor_enabled": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
+        },
+        "tenor_contentfilter": {
+            "defaultValue": "off",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["off", "low", "medium", "high"]]
+            },
+            "type": "string"
+        }
+    },
     "views": {
         "shared_views": {
             "defaultValue": "[]",

--- a/test/regression/api/canary/admin/settings.test.js
+++ b/test/regression/api/canary/admin/settings.test.js
@@ -434,6 +434,21 @@ const defaultSettingsKeyTypes = [
         key: 'labs',
         type: 'object',
         group: 'labs'
+    },
+    {
+        key: 'tenor_api_key',
+        type: 'string',
+        group: 'tenor'
+    },
+    {
+        key: 'tenor_enabled',
+        type: 'boolean',
+        group: 'tenor'
+    },
+    {
+        key: 'tenor_contentfilter',
+        type: 'string',
+        group: 'tenor'
     }
 ];
 

--- a/test/regression/api/v2/admin/settings.test.js
+++ b/test/regression/api/v2/admin/settings.test.js
@@ -88,7 +88,10 @@ const defaultSettingsKeyTypes = [
     {key: 'editor_default_email_recipients_filter', type: 'editor'},
     {key: 'editor_is_launch_complete', type: 'editor'},
     {key: 'labs', type: 'blog'},
-    {key: 'email_verification_required', type: 'bulk_email'}
+    {key: 'email_verification_required', type: 'bulk_email'},
+    {key: 'tenor_api_key', type: 'tenor'},
+    {key: 'tenor_enabled', type: 'tenor'},
+    {key: 'tenor_contentfilter', type: 'tenor'}
 ];
 
 describe('Settings API (v2)', function () {

--- a/test/regression/api/v3/admin/settings.test.js
+++ b/test/regression/api/v3/admin/settings.test.js
@@ -92,7 +92,10 @@ const defaultSettingsKeyTypes = [
     {key: 'editor_default_email_recipients_filter', type: 'editor'},
     {key: 'editor_is_launch_complete', type: 'editor'},
     {key: 'labs', type: 'blog'},
-    {key: 'email_verification_required', type: 'bulk_email'}
+    {key: 'email_verification_required', type: 'bulk_email'},
+    {key: 'tenor_api_key', type: 'tenor'},
+    {key: 'tenor_enabled', type: 'tenor'},
+    {key: 'tenor_contentfilter', type: 'tenor'}
 ];
 
 describe('Settings API (v3)', function () {

--- a/test/regression/models/model_settings.test.js
+++ b/test/regression/models/model_settings.test.js
@@ -17,7 +17,7 @@ describe('Settings Model', function () {
             await models.Settings.populateDefaults();
 
             const settingsPopulated = await models.Settings.findAll();
-            settingsPopulated.length.should.equal(94);
+            settingsPopulated.length.should.equal(97);
         });
 
         it('doesn\'t overwrite any existing settings', async function () {
@@ -42,7 +42,7 @@ describe('Settings Model', function () {
             await models.Settings.populateDefaults();
 
             const settingsPopulated = await models.Settings.findAll();
-            settingsPopulated.length.should.equal(94);
+            settingsPopulated.length.should.equal(97);
 
             const titleSetting = settingsPopulated.models.find(s => s.get('key') === 'title');
             titleSetting.get('value').should.equal('Testing Defaults');

--- a/test/unit/server/data/exporter/index.test.js
+++ b/test/unit/server/data/exporter/index.test.js
@@ -199,7 +199,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 84;
+            const allowedKeysLength = 87;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'e649797a5de92d417744f6f2623c79cf';
     const currentFixturesHash = '07d4b0c4cf159b34344a6b5e88c74e9f';
-    const currentSettingsHash = 'b06316ebbf62381158e1c46c97c0b77a';
+    const currentSettingsHash = '41f31cb8988985239dd6f3f729c2001f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1220

- `tenor_api_key` is required to use the Tenor GIFS integration if it's not provided via config
- `tenor_enabled` allows for the integration to be turned on/off, whether the API key is provided via config or settings
- `tenor_contentfilter` corresponds to Tenor API's content filtering options (see https://tenor.com/gifapi/documentation#contentfilter)
