### PR TITLE
Simplified the config logic in loggingrc

### DIFF
--- a/loggingrc.js
+++ b/loggingrc.js
@@ -1,25 +1,24 @@
 const config = require('./core/shared/config');
 const ghostVersion = require('@tryghost/version');
 
-module.exports = {
-    name: config.get('logging:name'),
-    env: config.get('env'),
-    path: config.get('logging:path') || config.getContentPath('logs'),
+// Config for logging
+const loggingConfig = config.get('logging') || {};
+
+if (!loggingConfig.path) {
+    loggingConfig.path = config.getContentPath('logs');
+}
+
+// Additional values used by logging
+loggingConfig.env = config.get('env');
+loggingConfig.domain = config.get('url');
+
+// Config for metrics
+loggingConfig.metrics = config.get('logging:metrics') || {};
+loggingConfig.metrics.metadata = {
+    // Undefined if unavailable
+    siteId: config.get('hostSettings:siteId'),
     domain: config.get('url'),
-    mode: config.get('logging:mode'),
-    level: config.get('logging:level'),
-    transports: config.get('logging:transports'),
-    metrics: {
-        transports: config.get('logging:metrics:transports'),
-        metadata: {
-            // Undefined if unavailable
-            siteId: config.get('hostSettings:siteId'),
-            domain: config.get('url'),
-            version: ghostVersion.safe
-        }
-    },
-    gelf: config.get('logging:gelf'),
-    loggly: config.get('logging:loggly'),
-    elasticsearch: config.get('logging:elasticsearch'),
-    rotation: config.get('logging:rotation')
+    version: ghostVersion.safe
 };
+
+module.exports = loggingConfig;


### PR DESCRIPTION
- I have a hunch that config.get isn't that performant
- This calls config.get less times to hopefully get a tiny boost
- This probably isn't much more readable, but it is a lot less duplication... if it doesn't get us a slight perf boost its pure taste and can be put back