### PR TITLE
Lazy loaded `cheerio` dependency

### DIFF
--- a/core/frontend/services/rss/generate-feed.js
+++ b/core/frontend/services/rss/generate-feed.js
@@ -1,6 +1,5 @@
 const downsize = require('downsize');
 const Promise = require('bluebird');
-const cheerio = require('cheerio');
 const RSS = require('rss');
 const urlUtils = require('../../../shared/url-utils');
 const {routerManager} = require('../routing');
@@ -19,6 +18,8 @@ const generateTags = function generateTags(data) {
 };
 
 const generateItem = function generateItem(post, secure) {
+    const cheerio = require('cheerio');
+
     const itemUrl = routerManager.getUrlByResourceId(post.id, {secure, absolute: true});
     const htmlContent = cheerio.load(post.html || '');
     const item = {

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -3,7 +3,6 @@ const template = require('./template');
 const settingsCache = require('../../../shared/settings-cache');
 const urlUtils = require('../../../shared/url-utils');
 const moment = require('moment-timezone');
-const cheerio = require('cheerio');
 const api = require('../../api');
 const {URL} = require('url');
 const mobiledocLib = require('../../lib/mobiledoc');
@@ -24,6 +23,8 @@ const formatHtmlForEmail = function formatHtmlForEmail(html) {
 
     // convert juiced HTML to a DOM-like interface for further manipulation
     // happens after inlining of CSS so we can change element types without worrying about styling
+
+    const cheerio = require('cheerio');
     const _cheerio = cheerio.load(juicedHtml);
 
     // force all links to open in new tab
@@ -243,6 +244,7 @@ const serialize = async (postModel, options = {isBrowserPreview: false, apiVersi
 
     // perform any email specific adjustments to the mobiledoc->HTML render output
     // body wrapper is required so we can get proper top-level selections
+    const cheerio = require('cheerio');
     let _cheerio = cheerio.load(`<body>${post.html}</body>`);
     // remove leading/trailing HRs
     _cheerio(`
@@ -311,6 +313,8 @@ const serialize = async (postModel, options = {isBrowserPreview: false, apiVersi
 };
 
 function renderEmailForSegment(email, memberSegment) {
+    const cheerio = require('cheerio');
+
     const result = {...email};
     const $ = cheerio.load(result.html);
 

--- a/core/server/services/mega/segment-parser.js
+++ b/core/server/services/mega/segment-parser.js
@@ -1,6 +1,5 @@
-const cheerio = require('cheerio');
-
 const getSegmentsFromHtml = (html) => {
+    const cheerio = require('cheerio');
     const $ = cheerio.load(html);
 
     const allSegments = $('[data-gh-segment]')


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/136

- `cheerio` isn't needed during the boot but it takes time and memory to
  load the library
- this commit moves `cheerio` requires later into the code to when they
  are needed