### PR TITLE
Reduced unnecessary DB queries during init

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "juice": "8.0.0",
     "keypair": "1.0.4",
     "knex": "0.21.21",
-    "knex-migrator": "4.1.1",
+    "knex-migrator": "4.1.2",
     "lodash": "4.17.21",
     "luxon": "2.1.1",
     "mailgun-js": "0.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7199,10 +7199,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-knex-migrator@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/knex-migrator/-/knex-migrator-4.1.1.tgz#6415e96fc5bec1bc2aaa3be43e2c4a5ff66a967f"
-  integrity sha512-OgFDKCZT8Sx46HDhvEmc4EgxfM5AzwzjYbEUk+cJdtOW/ohxoIXa4E2eojvZ1SIVUr9C6GEtsAd0tZsF4bpNAg==
+knex-migrator@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/knex-migrator/-/knex-migrator-4.1.2.tgz#acb4d6a63f9120dc6b883bf516521ab95bd4b798"
+  integrity sha512-XWwuDzOlLj3BAPkFhBItg38FsFxV01J7g7rKlk3foFf5+T1QqtRa8FYV4hoAG4dJiKuQ5IK++nSbb2xvWrnGeQ==
   dependencies:
     bluebird "3.7.2"
     commander "5.1.0"


### PR DESCRIPTION
refs https://github.com/TryGhost/knex-migrator/commit/8d9a561cab0b7b7f5745dd36bcfb7a06568d2311

- see referenced commit for context but we were doing unnecessary SELECT
  queries when initializing the DB and the commit reduces this by half
- this commit updates `knex-migrator` to that containing the commit