### PR TITLE
🐛 Fixed perms error when building public assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ projectFilesBackup
 /content/images/**/*
 /content/media/**/*
 /content/files/**/*
+/content/public/*
 /content/adapters/storage/**/*
 /content/adapters/scheduling/**/*
 !/content/themes/casper
@@ -125,8 +126,6 @@ test/coverage
 # Built asset files
 /core/built
 /core/server/web/admin/views/*.html
-/core/frontend/public/*.min.css
-/core/frontend/public/*.min.js
 
 # Caddyfile - for local development with ssl + caddy
 Caddyfile

--- a/.npmignore
+++ b/.npmignore
@@ -13,6 +13,8 @@ content/adapters/**
 !content/adapters/README.md
 content/apps/**
 !content/apps/README.md
+content/public/**
+!content/public/README.md
 content/data/**
 !content/data/README.md
 content/images/**

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,6 @@ module.exports = function (grunt) {
                     'core/shared/**/*.js',
                     'core/frontend/**/*.js',
                     'core/frontend/src/**/*.css',
-                    '!core/frontend/public/**',
                     'core/*.js',
                     'index.js',
                     'config.*.json',

--- a/content/public/README.md
+++ b/content/public/README.md
@@ -1,0 +1,3 @@
+# Content / Public
+
+Ghost will store any built assets here. This goes hand in hand with core/frontend/public where static assets are stored.

--- a/core/frontend/services/card-assets/service.js
+++ b/core/frontend/services/card-assets/service.js
@@ -3,12 +3,12 @@ const _ = require('lodash');
 const path = require('path');
 const fs = require('fs').promises;
 const logging = require('@tryghost/logging');
+const config = require('../../../shared/config');
 
 class CardAssetService {
     constructor(options = {}) {
-        // @TODO: use our config paths concept
-        this.src = options.src || path.join(__dirname, '../../src/cards');
-        this.dest = options.dest || path.join(__dirname, '../../public');
+        this.src = options.src || path.join(config.get('paths').assetSrc, 'cards');
+        this.dest = options.dest || config.getContentPath('public');
         this.minifier = new Minifier({src: this.src, dest: this.dest});
 
         if ('config' in options) {
@@ -90,12 +90,12 @@ class CardAssetService {
     /**
      * A theme can declare which cards it supports, and we'll do the rest
      *
-     * @param {Array|boolean} config
+     * @param {Array|boolean} cardAssetConfig
      * @returns
      */
-    async load(config) {
-        if (config) {
-            this.config = config;
+    async load(cardAssetConfig) {
+        if (cardAssetConfig) {
+            this.config = cardAssetConfig;
         }
 
         await this.clearFiles();

--- a/core/frontend/web/site.js
+++ b/core/frontend/web/site.js
@@ -104,15 +104,15 @@ module.exports = function setupSiteApp(options = {}) {
     siteApp.use(mw.serveFavicon());
 
     // Serve sitemap.xsl file
-    siteApp.use(mw.servePublicFile('sitemap.xsl', 'text/xsl', constants.ONE_DAY_S));
+    siteApp.use(mw.servePublicFile('static', 'sitemap.xsl', 'text/xsl', constants.ONE_DAY_S));
 
     // Serve stylesheets for default templates
-    siteApp.use(mw.servePublicFile('public/ghost.css', 'text/css', constants.ONE_HOUR_S));
-    siteApp.use(mw.servePublicFile('public/ghost.min.css', 'text/css', constants.ONE_YEAR_S));
+    siteApp.use(mw.servePublicFile('static', 'public/ghost.css', 'text/css', constants.ONE_HOUR_S));
+    siteApp.use(mw.servePublicFile('static', 'public/ghost.min.css', 'text/css', constants.ONE_YEAR_S));
 
     // Card assets
-    siteApp.use(mw.servePublicFile('public/cards.min.css', 'text/css', constants.ONE_YEAR_S));
-    siteApp.use(mw.servePublicFile('public/cards.min.js', 'text/js', constants.ONE_YEAR_S));
+    siteApp.use(mw.servePublicFile('built', 'public/cards.min.css', 'text/css', constants.ONE_YEAR_S));
+    siteApp.use(mw.servePublicFile('built', 'public/cards.min.js', 'text/js', constants.ONE_YEAR_S));
 
     // Serve blog images using the storage adapter
     siteApp.use(STATIC_IMAGE_URL_PREFIX, mw.handleImageSizes, storage.getStorage('images').serve());
@@ -147,7 +147,7 @@ module.exports = function setupSiteApp(options = {}) {
     debug('Themes done');
 
     // Serve robots.txt if not found in theme
-    siteApp.use(mw.servePublicFile('robots.txt', 'text/plain', constants.ONE_HOUR_S));
+    siteApp.use(mw.servePublicFile('static', 'robots.txt', 'text/plain', constants.ONE_HOUR_S));
 
     // site map - this should probably be refactored to be an internal app
     sitemapHandler(siteApp);

--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -16,7 +16,8 @@
     "useMinFiles": true,
     "paths": {
         "contentPath": "content/",
-        "fixtures": "core/server/data/schema/fixtures/fixtures"
+        "fixtures": "core/server/data/schema/fixtures/fixtures",
+        "assetSrc": "core/frontend/src"
     },
     "adapters": {
         "sso": {

--- a/core/shared/config/helpers.js
+++ b/core/shared/config/helpers.js
@@ -84,6 +84,8 @@ const getContentPath = function getContentPath(type) {
         return path.join(this.get('paths:contentPath'), 'data/');
     case 'settings':
         return path.join(this.get('paths:contentPath'), 'settings/');
+    case 'public':
+        return path.join(this.get('paths:contentPath'), 'public/');
     default:
         // new Error is allowed here, as we do not want config to depend on @tryghost/error
         // @TODO: revisit this decision when @tryghost/error is no longer dependent on all of ghost-ignition

--- a/test/unit/frontend/services/card-assets.test.js
+++ b/test/unit/frontend/services/card-assets.test.js
@@ -73,6 +73,19 @@ describe('Card Asset Service', function () {
         cardAssets.files.should.eql(['cards.min.css']);
     });
 
+    it('can correctly load nothing when config is false', async function () {
+        const cardAssets = new CardAssetService({
+            src: srcDir,
+            dest: destDir
+        });
+
+        await fs.writeFile(path.join(srcDir, 'css', 'test.css'), '.test { color: #fff }');
+
+        await cardAssets.load(false);
+
+        cardAssets.files.should.eql([]);
+    });
+
     it('can clearFiles', async function () {
         const cardAssets = new CardAssetService({
             src: srcDir,

--- a/test/unit/shared/config/loader.test.js
+++ b/test/unit/shared/config/loader.test.js
@@ -96,6 +96,7 @@ describe('Config Loader', function () {
             Object.keys(pathConfig).should.eql([
                 'contentPath',
                 'fixtures',
+                'assetSrc',
                 'appRoot',
                 'corePath',
                 'clientAssets',


### PR DESCRIPTION
closes: https://github.com/TryGhost/Ghost/issues/13739

- Ghost cannot write to the core folder in correctly configured production installations
- Built assets therefore need to be written to the content directory
- Ghost does not overwrite anything in the content folder as part of an upgrade, therefore static files that are provided by Ghost
  must still live inside /core
- So as a result, we now have core/frontend/public and content/public



