### PR TITLE
Revert "Revert "Ensured that the new content/public dir exists""

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@tryghost/members-offers": "0.10.2",
     "@tryghost/members-ssr": "1.0.15",
     "@tryghost/metrics": "1.0.1",
-    "@tryghost/minifier": "0.1.0",
+    "@tryghost/minifier": "0.1.1",
     "@tryghost/mw-session-from-token": "0.1.26",
     "@tryghost/nodemailer": "0.3.7",
     "@tryghost/package-json": "1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,10 +1965,10 @@
   optionalDependencies:
     promise.allsettled "^1.0.5"
 
-"@tryghost/minifier@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/minifier/-/minifier-0.1.0.tgz#121f30694c5a0e3755dfe77a1d5df6dd5191e862"
-  integrity sha512-ofP+wuYV/je7IrfzwYQVR7FGtsXNSHrjpTxcqIvP6SuNhJu0npob6k/67T+95sOyy+Qu24HK8su277azmgDxXA==
+"@tryghost/minifier@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/minifier/-/minifier-0.1.1.tgz#2e7550f417effcdb7dc445e14b5e000556318d87"
+  integrity sha512-vNRYoUGYVy95PVoL6OTOL4Oekz71VAGyEorP6gvmAv5SHUh8aXkkU4I5Thw9TzAVGkqhLvN7CL3AE4oW9csusg==
   dependencies:
     "@tryghost/debug" "^0.1.8"
     "@tryghost/errors" "^0.2.16"


### PR DESCRIPTION
This reverts commit 1c36d3941f042b1e2b379f57aa31f1d2e7eabb72.

For some reason, the build failed on this twice, so I reverted it due to the proximity to the release.

However, I can't see any reason why this change would cause the failures, and renovate has successfully opened a PR to do the same thing: https://github.com/TryGhost/Ghost/pull/13770