### PR TITLE
Migrated Offers to have name less than 40 characters

### DIFF
--- a/core/server/data/migrations/versions/4.23/01-truncate-offer-names.js
+++ b/core/server/data/migrations/versions/4.23/01-truncate-offer-names.js
@@ -10,11 +10,9 @@ const {createTransactionalMigration} = require('../../utils');
  * @returns {string}
  */
 function getUnique(exists, requested, attempt = requested, n = 1) {
-    console.log('attempt', attempt);
     if (!exists(attempt)) {
         return attempt;
     }
-    console.log('attempt exists');
     const newAttempt = requested.slice(0, -n.toString().length) + n;
     return getUnique(exists, requested, newAttempt, n + 1);
 }

--- a/core/server/data/migrations/versions/4.23/01-truncate-offer-names.js
+++ b/core/server/data/migrations/versions/4.23/01-truncate-offer-names.js
@@ -1,0 +1,60 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+/**
+ * @param {(val: string) => boolean} exists
+ * @param {string} requested
+ * @param {string} attempt
+ * @param {number} n
+ *
+ * @returns {string}
+ */
+function getUnique(exists, requested, attempt = requested, n = 1) {
+    console.log('attempt', attempt);
+    if (!exists(attempt)) {
+        return attempt;
+    }
+    console.log('attempt exists');
+    const newAttempt = requested.slice(0, -n.toString().length) + n;
+    return getUnique(exists, requested, newAttempt, n + 1);
+}
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const allOffers = await knex
+            .select('id', 'name')
+            .from('offers');
+
+        const offersNeedingTrunctation = allOffers.filter((row) => {
+            return row.name.length > 40;
+        });
+
+        if (offersNeedingTrunctation.length === 0) {
+            logging.warn('No Offers found needing truncation');
+            return;
+        } else {
+            logging.info(`Found ${offersNeedingTrunctation.length} Offers needing truncation`);
+        }
+
+        const truncatedOffers = offersNeedingTrunctation.reduce((offers, row) => {
+            function exists(name) {
+                return offers.find(offer => offer.name === name) !== undefined;
+            }
+
+            const updatedRow = {
+                id: row.id,
+                name: getUnique(exists, row.name.slice(0, 40))
+            };
+
+            return offers.concat(updatedRow);
+        }, []);
+
+        for (const truncatedOffer of truncatedOffers) {
+            await knex('offers')
+                .update('name', truncatedOffer.name)
+                .where('id', truncatedOffer.id);
+        }
+    },
+    // no-op we've lost the data required to roll this back
+    async function down() {}
+);

--- a/core/server/data/migrations/versions/4.23/01-truncate-offer-names.js
+++ b/core/server/data/migrations/versions/4.23/01-truncate-offer-names.js
@@ -24,7 +24,7 @@ module.exports = createTransactionalMigration(
             .from('offers');
 
         const offersNeedingTrunctation = allOffers.filter((row) => {
-            return row.name.length > 40;
+            return row.name.length >= 40;
         });
 
         if (offersNeedingTrunctation.length === 0) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1236

We use Offer names for the Stripe Coupon name - which has a limit of 40
characters. We are now introducing a limit of 40 characters to Offer
names too.
