### PR TITLE
Add lint rules for migrations folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,38 @@ module.exports = {
             }
         },
         {
+            files: 'core/server/data/migrations/versions/**',
+            excludedFiles: [
+                'core/server/data/migrations/versions/1.*/*',
+                'core/server/data/migrations/versions/2.*/*',
+                'core/server/data/migrations/versions/3.*/*'
+            ]
+        },
+        {
+            files: 'core/server/data/migrations/versions/**',
+            rules: {
+                'no-restricted-syntax': ['warn', {
+                    selector: 'ForStatement',
+                    message: 'For statements can perform badly in migrations'
+                }, {
+                    selector: 'WhileStatement',
+                    message: 'While statements can perform badly in migrations'
+                }, {
+                    selector: 'CallExpression[callee.property.name=\'forEach\']',
+                    message: 'Loop constructs like forEach can perform badly in migrations'
+                }, {
+                    selector: 'CallExpression[callee.object.name=\'_\'][callee.property.name=\'each\']',
+                    message: 'Loop constructs like _.each can perform badly in migrations'
+                }, {
+                    selector: 'ForStatement ReturnStatement',
+                    message: 'Invalid use of a return statement within for-loop in a migration'
+                }, {
+                    selector: 'CallExpression[callee.property.name=/join|innerJoin|leftJoin/] CallExpression[callee.property.name=/join|innerJoin|leftJoin/] CallExpression[callee.name=\'knex\']',
+                    message: 'Use of multiple join statements in a single knex block'
+                }]
+            }
+        },
+        {
             files: 'core/shared/**',
             rules: {
                 'ghost/node/no-restricted-require': ['error', [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,13 +28,22 @@ module.exports = {
                 'core/server/data/migrations/versions/1.*/*',
                 'core/server/data/migrations/versions/2.*/*',
                 'core/server/data/migrations/versions/3.*/*'
-            ]
+            ],
+            rules: {
+                'ghost/filenames/match-regex': ['error', '^(?:\\d{2}|\\d{4}(?:-\\d{2}){4})(?:-[a-zA-Z]+)+$', true]
+            }
         },
         {
             files: 'core/server/data/migrations/versions/**',
             rules: {
                 'no-restricted-syntax': ['warn', {
                     selector: 'ForStatement',
+                    message: 'For statements can perform badly in migrations'
+                }, {
+                    selector: 'ForOfStatement',
+                    message: 'For statements can perform badly in migrations'
+                }, {
+                    selector: 'ForInStatement',
                     message: 'For statements can perform badly in migrations'
                 }, {
                     selector: 'WhileStatement',
@@ -46,12 +55,10 @@ module.exports = {
                     selector: 'CallExpression[callee.object.name=\'_\'][callee.property.name=\'each\']',
                     message: 'Loop constructs like _.each can perform badly in migrations'
                 }, {
-                    selector: 'ForStatement ReturnStatement',
-                    message: 'Invalid use of a return statement within for-loop in a migration'
-                }, {
                     selector: 'CallExpression[callee.property.name=/join|innerJoin|leftJoin/] CallExpression[callee.property.name=/join|innerJoin|leftJoin/] CallExpression[callee.name=\'knex\']',
                     message: 'Use of multiple join statements in a single knex block'
-                }]
+                }],
+                'ghost/no-return-in-loop/no-return-in-loop': ['error']
             }
         },
         {

--- a/core/server/data/migrations/versions/1.25/1-update-koenig-beta-html.js
+++ b/core/server/data/migrations/versions/1.25/1-update-koenig-beta-html.js
@@ -45,6 +45,7 @@ module.exports.up = function regenerateKoenigBetaHTML(options) {
                     || (mobiledoc && !mobiledocIsCompatibleWithV1(mobiledoc))
                 ) {
                     // change imagecard.payload.imageStyle to imagecard.payload.cardWidth
+                    // eslint-disable-next-line no-restricted-syntax
                     mobiledoc.cards.forEach((card) => {
                         if (card[0] === 'image') {
                             card[1].cardWidth = card[1].imageStyle;

--- a/core/server/data/migrations/versions/3.1/08-add-uuid-values-to-members.js
+++ b/core/server/data/migrations/versions/3.1/08-add-uuid-values-to-members.js
@@ -12,6 +12,7 @@ module.exports = {
 
         logging.info(`Adding uuid field value to ${membersWithoutUUID.length} members.`);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const member of membersWithoutUUID) {
             await conn('members').update('uuid', uuid.v4()).where('id', member.id);
         }

--- a/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
+++ b/core/server/data/migrations/versions/3.22/02-settings-key-renames.js
@@ -35,6 +35,7 @@ module.exports = {
     },
 
     async up(options) {
+        // eslint-disable-next-line no-restricted-syntax
         for (const renameMapping of renameMappings) {
             const oldSetting = await options.transacting('settings')
                 .where('key', renameMapping.from)
@@ -61,6 +62,7 @@ module.exports = {
     },
 
     async down(options) {
+        // eslint-disable-next-line no-restricted-syntax
         for (const renameMapping of renameMappings) {
             const newSetting = await options.transacting('settings')
                 .where('key', renameMapping.to)

--- a/core/server/data/migrations/versions/3.22/05-migrate-members-subscription-settings.js
+++ b/core/server/data/migrations/versions/3.22/05-migrate-members-subscription-settings.js
@@ -24,6 +24,7 @@ module.exports = {
             key: 'stripe_plans'
         }];
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const operation of defaultOperations) {
             logging.info(`Updating ${operation.key} setting group,type,flags`);
             await knex('settings')
@@ -86,6 +87,7 @@ module.exports = {
             value: JSON.stringify(stripePlans)
         }];
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const operation of valueOperations) {
             logging.info(`Updating ${operation.key} setting value`);
             await knex('settings')
@@ -170,6 +172,7 @@ module.exports = {
             'stripe_secret_key'
         ];
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const setting of settingsToDelete) {
             logging.info(`Deleting ${setting} setting`);
         }

--- a/core/server/data/migrations/versions/3.22/06-migrate-stripe-connect-settings.js
+++ b/core/server/data/migrations/versions/3.22/06-migrate-stripe-connect-settings.js
@@ -20,6 +20,7 @@ module.exports = {
             key: 'stripe_connect_account_id'
         }];
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const operation of defaultOperations) {
             logging.info(`Updating ${operation.key} setting group,type,flags`);
             await knex('settings')
@@ -62,6 +63,7 @@ module.exports = {
             value: stripeConnectIntegration.account_id || ''
         }];
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const operation of valueOperations) {
             logging.info(`Updating ${operation.key} setting value`);
             await knex('settings')

--- a/core/server/data/migrations/versions/3.23/01-migrate-bulk-email-settings.js
+++ b/core/server/data/migrations/versions/3.23/01-migrate-bulk-email-settings.js
@@ -35,6 +35,7 @@ module.exports = {
             value: bulkEmailSettings.baseUrl
         }];
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const operation of operations) {
             logging.info(`Updating ${operation.key} setting's value, group, type & flags.`);
             await knex('settings')

--- a/core/server/data/migrations/versions/3.29/01-remove-duplicate-subscriptions.js
+++ b/core/server/data/migrations/versions/3.29/01-remove-duplicate-subscriptions.js
@@ -23,6 +23,7 @@ module.exports = {
         }
 
         logging.info(`Found ${duplicates.length} duplicate stripe subscriptions`);
+        // eslint-disable-next-line no-restricted-syntax
         for (const duplicate of duplicates) {
             const subscriptions = await knex('members_stripe_customers_subscriptions')
                 .select()
@@ -36,6 +37,7 @@ module.exports = {
 
             logging.info(`Keeping newest subscription ${newestSubscription.id} - ${newestSubscription.subscription_id}, last updated at ${newestSubscription.updated_at}`);
 
+            // eslint-disable-next-line no-restricted-syntax
             for (const subscriptionToDelete of olderSubscriptions) {
                 logging.info(`Deleting duplicate subscription ${subscriptionToDelete.id} - ${subscriptionToDelete.subscription_id}, last updated at ${subscriptionToDelete.updated_at}`);
                 await knex('members_stripe_customers_subscriptions')

--- a/core/server/data/migrations/versions/3.29/02-remove-duplicate-customers.js
+++ b/core/server/data/migrations/versions/3.29/02-remove-duplicate-customers.js
@@ -23,6 +23,7 @@ module.exports = {
         }
 
         logging.info(`Found ${duplicates.length} duplicate stripe customers`);
+        // eslint-disable-next-line no-restricted-syntax
         for (const duplicate of duplicates) {
             const customers = await knex('members_stripe_customers')
                 .select()
@@ -36,6 +37,7 @@ module.exports = {
 
             logging.info(`Keeping newest customer ${newestCustomer.id} - ${newestCustomer.customer_id}, last updated at ${newestCustomer.updated_at}`);
 
+            // eslint-disable-next-line no-restricted-syntax
             for (const customerToDelete of olderCustomers) {
                 logging.info(`Deleting duplicate customer ${customerToDelete.id} - ${customerToDelete.customer_id}, last updated at ${customerToDelete.updated_at}`);
                 await knex('members_stripe_customers')

--- a/core/server/data/migrations/versions/3.38/04-populate-recipient-filter-column.js
+++ b/core/server/data/migrations/versions/3.38/04-populate-recipient-filter-column.js
@@ -25,12 +25,14 @@ module.exports = createTransactionalMigration(
         const paidPostIdChunks = chunk(paidPostIds, chunkSize);
         const membersAndPublicPostIdChunks = chunk(membersPostIds.concat(publicPostIds), chunkSize);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const paidPostIdsChunk of paidPostIdChunks) {
             await connection('emails')
                 .update('recipient_filter', 'paid')
                 .whereIn('post_id', paidPostIdsChunk);
         }
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const membersAndPublicPostIdsChunk of membersAndPublicPostIdChunks) {
             await connection('emails')
                 .update('recipient_filter', 'all')

--- a/core/server/data/migrations/versions/4.0/01-update-mobiledoc.js
+++ b/core/server/data/migrations/versions/4.0/01-update-mobiledoc.js
@@ -15,6 +15,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
         // pushing all queries into the query builder buffer in parallel
         // https://stackoverflow.com/questions/54105280/how-to-loop-through-multi-line-sql-query-and-use-them-in-knex-transactions
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const postIdRow of postIdRows) {
             const {id} = postIdRow;
             const [{mobiledoc: mobiledocJson}] = await knex('posts')
@@ -31,6 +32,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
             }
 
             if (mobiledoc.cards) {
+                // eslint-disable-next-line no-restricted-syntax
                 mobiledoc.cards.forEach((card) => {
                     // card-markdown card was used in 1.0 and aliased to markdown in 2.0 onwards
                     // clean it up here whilst we're already modifying mobiledoc

--- a/core/server/data/migrations/versions/4.0/03-populate-status-column-for-members.js
+++ b/core/server/data/migrations/versions/4.0/03-populate-status-column-for-members.js
@@ -5,6 +5,7 @@ const logging = require('@tryghost/logging');
 module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Updating members.status based on members_stripe_customers_subscriptions.status');
+        // eslint-disable-next-line no-restricted-syntax
         const paidMemberIds = (await knex('members')
             .select('members.id')
             .innerJoin(
@@ -24,6 +25,7 @@ module.exports = createTransactionalMigration(
                 }
             )).map(({id}) => id);
 
+        // eslint-disable-next-line no-restricted-syntax
         const compedMemberIds = (await knex('members')
             .select('members.id')
             .innerJoin(
@@ -54,6 +56,7 @@ module.exports = createTransactionalMigration(
 
         const paidMemberIdChunks = chunk(paidMemberIds, chunkSize);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const paidMemberIdsChunk of paidMemberIdChunks) {
             await knex('members')
                 .update('status', 'paid')
@@ -62,6 +65,7 @@ module.exports = createTransactionalMigration(
 
         const compedMemberIdChunks = chunk(compedMemberIds, chunkSize);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const compedMemberIdsChunk of compedMemberIdChunks) {
             await knex('members')
                 .update('status', 'comped')

--- a/core/server/data/migrations/versions/4.0/06-populate-members-subscribe-events-table.js
+++ b/core/server/data/migrations/versions/4.0/06-populate-members-subscribe-events-table.js
@@ -42,6 +42,7 @@ module.exports = createTransactionalMigration(
 
         const eventChunks = chunk(allEvents, chunkSize);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const events of eventChunks) {
             await knex.insert(events).into('members_subscribe_events');
         }

--- a/core/server/data/migrations/versions/4.0/17-populate-members-status-events-table.js
+++ b/core/server/data/migrations/versions/4.0/17-populate-members-status-events-table.js
@@ -28,6 +28,7 @@ module.exports = createTransactionalMigration(
 
         const eventChunks = chunk(membersStatusEvents, chunkSize);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const events of eventChunks) {
             await knex.insert(events).into('members_status_events');
         }

--- a/core/server/data/migrations/versions/4.0/18-transform-urls-absolute-to-transform-ready.js
+++ b/core/server/data/migrations/versions/4.0/18-transform-urls-absolute-to-transform-ready.js
@@ -18,6 +18,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
         // pushing all queries into the query builder buffer in parallel
         // https://stackoverflow.com/questions/54105280/how-to-loop-through-multi-line-sql-query-and-use-them-in-knex-transactions
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const postIdRow of postIdRows) {
             const {id} = postIdRow;
             const [post] = await knex('posts')
@@ -80,6 +81,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
             .forUpdate()
             .select('id');
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const userIdRow of userIdRows) {
             const {id} = userIdRow;
             const [user] = await knex('users')
@@ -108,6 +110,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
             .forUpdate()
             .select('id');
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const tagIdRow of tagIdRows) {
             const {id} = tagIdRow;
             const [tag] = await knex('tags')
@@ -148,6 +151,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
             .forUpdate()
             .select('id');
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const snippetIdRow of snippetIdRows) {
             const {id} = snippetIdRow;
             const [snippet] = await knex('snippets')
@@ -180,6 +184,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
                 'twitter_image'
             ]);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const settingRow of settingsRows) {
             let {key, value} = settingRow;
 

--- a/core/server/data/migrations/versions/4.0/22-solve-orphaned-webhooks.js
+++ b/core/server/data/migrations/versions/4.0/22-solve-orphaned-webhooks.js
@@ -77,6 +77,7 @@ module.exports = createIrreversibleMigration(
         };
         await knex('api_keys').insert(adminKey);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (let i = 0; i < orphanedWebhooks.length; i++) {
             const webhook = orphanedWebhooks[i];
 

--- a/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
+++ b/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
@@ -17,6 +17,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
         // pushing all queries into the query builder buffer in parallel
         // https://stackoverflow.com/questions/54105280/how-to-loop-through-multi-line-sql-query-and-use-them-in-knex-transactions
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const postIdRow of postIdRows) {
             const {id} = postIdRow;
             const [post] = await knex('posts')

--- a/core/server/data/migrations/versions/4.0/25-populate-members-paid-subscription-events-table.js
+++ b/core/server/data/migrations/versions/4.0/25-populate-members-paid-subscription-events-table.js
@@ -116,6 +116,7 @@ module.exports = createTransactionalMigration(
 
         const eventChunks = chunk(allEvents, chunkSize);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const events of eventChunks) {
             await knex.insert(events).into('members_paid_subscription_events');
         }

--- a/core/server/data/migrations/versions/4.12/02-fix-member-statuses.js
+++ b/core/server/data/migrations/versions/4.12/02-fix-member-statuses.js
@@ -26,6 +26,7 @@ module.exports = createTransactionalMigration(
 
         const chunks = chunkArray(freeMembersIds, chunkSize);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const chunk of chunks) {
             await knex('members')
                 .update('status', 'free')

--- a/core/server/data/migrations/versions/4.14/01-fix-comped-member-statuses.js
+++ b/core/server/data/migrations/versions/4.14/01-fix-comped-member-statuses.js
@@ -3,6 +3,7 @@ const {createTransactionalMigration} = require('../../utils');
 const logging = require('@tryghost/logging');
 
 module.exports = createTransactionalMigration(async function up(knex) {
+    // eslint-disable-next-line no-restricted-syntax
     const compedMemberIds = (await knex('members')
         .select('members.id')
         .innerJoin(
@@ -44,12 +45,14 @@ module.exports = createTransactionalMigration(async function up(knex) {
 
     const compedMemberIdChunks = chunk(compedMemberIds, chunkSize);
 
+    // eslint-disable-next-line no-restricted-syntax
     for (const compedMemberIdsChunk of compedMemberIdChunks) {
         await knex('members')
             .update('status', 'comped')
             .whereIn('id', compedMemberIdsChunk);
     }
 
+    // eslint-disable-next-line no-restricted-syntax
     for (const memberId of compedMemberIds) {
         const mostRecentStatusEvent = await knex('members_status_events')
             .select('*')

--- a/core/server/data/migrations/versions/4.14/02-fix-free-members-status-events.js
+++ b/core/server/data/migrations/versions/4.14/02-fix-free-members-status-events.js
@@ -49,6 +49,7 @@ module.exports = createTransactionalMigration(
         // and so we're left with 998 for our WHERE IN clause values
         const chunkedEventsToUpdate = _.chunk(eventsToUpdate, 998);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const chunk of chunkedEventsToUpdate) {
             logging.info(`Updating a chunk of ${chunk.length} member status events`);
             await knex('members_status_events')

--- a/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
+++ b/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
@@ -15,6 +15,7 @@ module.exports = createNonTransactionalMigration(
         });
 
         if (knex.client.config.client === 'sqlite3') {
+            // eslint-disable-next-line no-restricted-syntax
             for (const column of ['name', 'code', 'stripe_coupon_id']) {
                 await addUnique('offers', column, knex);
             }
@@ -32,6 +33,7 @@ module.exports = createNonTransactionalMigration(
         });
 
         if (knex.client.config.client === 'sqlite3') {
+            // eslint-disable-next-line no-restricted-syntax
             for (const column of ['name', 'code', 'stripe_coupon_id']) {
                 await addUnique('offers', column, knex);
             }

--- a/core/server/data/migrations/versions/4.23/01-truncate-offer-names.js
+++ b/core/server/data/migrations/versions/4.23/01-truncate-offer-names.js
@@ -47,6 +47,7 @@ module.exports = createTransactionalMigration(
             return offers.concat(updatedRow);
         }, []);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const truncatedOffer of truncatedOffers) {
             await knex('offers')
                 .update('name', truncatedOffer.name)

--- a/core/server/data/migrations/versions/4.3/04-attach-members-to-product.js
+++ b/core/server/data/migrations/versions/4.3/04-attach-members-to-product.js
@@ -38,6 +38,7 @@ module.exports = createTransactionalMigration(
         const chunkSize = 333;
         const memberProductRelationsChunks = chunk(memberProductRelations, chunkSize);
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const relations of memberProductRelationsChunks) {
             await knex.insert(relations).into('members_products');
         }

--- a/core/server/data/migrations/versions/4.4/01-restore-free-members-signup-setting-from-backup.js
+++ b/core/server/data/migrations/versions/4.4/01-restore-free-members-signup-setting-from-backup.js
@@ -63,6 +63,7 @@ module.exports = createTransactionalMigration(
 
         let hasRestored = false;
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const backupFile of backupFiles) {
             try {
                 const backup = require(path.join(dataPath, backupFile));

--- a/core/server/data/migrations/versions/4.6/01-remove-comped-status.js
+++ b/core/server/data/migrations/versions/4.6/01-remove-comped-status.js
@@ -9,6 +9,7 @@ module.exports = createTransactionalMigration(
             .where('status', 'comped');
     },
     async function down(knex) {
+        // eslint-disable-next-line no-restricted-syntax
         const compedMemberIds = (await knex('members')
             .select('members.id')
             .innerJoin(

--- a/core/server/data/migrations/versions/4.8/04-migrate-show-newsletter-header-setting.js
+++ b/core/server/data/migrations/versions/4.8/04-migrate-show-newsletter-header-setting.js
@@ -27,6 +27,7 @@ module.exports = createTransactionalMigration(
             const newSettingKeys = ['newsletter_show_header_title', 'newsletter_show_header_icon'];
             const now = connection.raw('CURRENT_TIMESTAMP');
 
+            // eslint-disable-next-line no-restricted-syntax
             for (const settingKey of newSettingKeys) {
                 const existingSetting = await connection('settings').where('key', settingKey).first();
 

--- a/core/server/data/migrations/versions/4.9/05-fix-missed-mobiledoc-url-transforms.js
+++ b/core/server/data/migrations/versions/4.9/05-fix-missed-mobiledoc-url-transforms.js
@@ -33,6 +33,7 @@ module.exports = createTransactionalMigration(
                 .forUpdate()
                 .select('id');
 
+            // eslint-disable-next-line no-restricted-syntax
             for (const postIdRow of postIdRows) {
                 const {id} = postIdRow;
                 const [post] = await knex('posts')

--- a/core/server/data/migrations/versions/4.9/06-add-comped-status.js
+++ b/core/server/data/migrations/versions/4.9/06-add-comped-status.js
@@ -3,6 +3,7 @@ const {createTransactionalMigration} = require('../../utils.js');
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
+        // eslint-disable-next-line no-restricted-syntax
         const compedMemberIds = (await knex('members')
             .select('members.id')
             .innerJoin(

--- a/core/server/data/migrations/versions/4.9/07-update-comped-members-status-events.js
+++ b/core/server/data/migrations/versions/4.9/07-update-comped-members-status-events.js
@@ -15,6 +15,7 @@ module.exports = createTransactionalMigration(
             logging.info(`Found ${compedMembers.length} comped members - checking members_status_events`);
         }
 
+        // eslint-disable-next-line no-restricted-syntax
         for (const member of compedMembers) {
             const mostRecentStatusEvent = await knex('members_status_events')
                 .select('*')

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "coffeescript": "2.6.1",
     "cssnano": "5.0.11",
     "eslint": "7.32.0",
-    "eslint-plugin-ghost": "2.8.0",
+    "eslint-plugin-ghost": "2.9.0",
     "grunt": "1.4.1",
     "grunt-bg-shell": "2.3.3",
     "grunt-contrib-clean": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,6 +891,11 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
+"@kapouer/eslint-plugin-no-return-in-loop@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@kapouer/eslint-plugin-no-return-in-loop/-/eslint-plugin-no-return-in-loop-1.0.0.tgz#9fdbe83deca12156c0b5fcbfae1f387e9f2baff5"
+  integrity sha512-IXQp8N68L2fkk7p7RckBBhT/KwAX04GooIGjwzmY5THQanQvsmJpYgwC7A1Io2XDXBJzlGelQkP/C1SRM/aq8w==
+
 "@lodder/grunt-postcss@3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@lodder/grunt-postcss/-/grunt-postcss-3.1.1.tgz#68d658c25fc97f2ad1306a4f33c02dd622c9733b"
@@ -4286,11 +4291,12 @@ eslint-plugin-filenames@1.3.2:
     lodash.snakecase "4.1.1"
     lodash.upperfirst "4.3.1"
 
-eslint-plugin-ghost@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ghost/-/eslint-plugin-ghost-2.8.0.tgz#aaa45539fb5603b8d0b9ee7f6495c05c05c82e37"
-  integrity sha512-fPi3qePZqEY/aeToPNsQ4/an44SWr8s8lEEWObey5+JAsfUvB9ttr7DX/iyJEDNbMjSPEHh3U/P0p4DD04q4mQ==
+eslint-plugin-ghost@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ghost/-/eslint-plugin-ghost-2.9.0.tgz#96992d2a240f0c41011c63107ed7686a33495401"
+  integrity sha512-pc/nFdYjnPmAF9Cs4BhscrE0MhWBUxQlX3gZ5XqkJOP3MqNsuYeecz85QTG6IvjarKLhr6EklVNGoQ42BaJnjA==
   dependencies:
+    "@kapouer/eslint-plugin-no-return-in-loop" "1.0.0"
     eslint-plugin-ember "10.5.7"
     eslint-plugin-filenames "1.3.2"
     eslint-plugin-mocha "7.0.1"


### PR DESCRIPTION
refs: https://github.com/TryGhost/Toolbox/issues/105

The lint rules prevent:

* Invalid naming conventions for new migrations
* Loop constructs in migrations - these should be used with caution and are therefore a warning rule, use `// eslint-disable-next-line no-restricted-syntax` to prevent this rule from firing where a loop is required
* Returing within a loop - this is usually meant to be a continue/break
* Multiple joins - these can be badly performing migrations, so should be treated with caution, disable the rule for the line if the risk is understood / the migration cannot be written without it

Added `// eslint-disable-next-line no-restricted-syntax` in existing migrations to make linting pass, and also as an example for how to use it in future where these constructs are necessary.

For reviewers:
* Are the `2021-11-29-11-45-slugified-name.js` format and the `01-slugified-name.js` formats enough? I've used `(?:-[a-zA-Z]+)+` for the name segments, but if we also need numerical bits in the slugified name I will add those to the regex.
* Is the approach of disabling a rule for a single-line good for removing warnings for the developer around performance?