### PR TITLE
Fix MIME type for public/cards.min.js

### DIFF
--- a/core/frontend/web/site.js
+++ b/core/frontend/web/site.js
@@ -112,7 +112,7 @@ module.exports = function setupSiteApp(options = {}) {
 
     // Card assets
     siteApp.use(mw.servePublicFile('built', 'public/cards.min.css', 'text/css', constants.ONE_YEAR_S));
-    siteApp.use(mw.servePublicFile('built', 'public/cards.min.js', 'text/js', constants.ONE_YEAR_S));
+    siteApp.use(mw.servePublicFile('built', 'public/cards.min.js', 'text/javascript', constants.ONE_YEAR_S));
 
     // Serve blog images using the storage adapter
     siteApp.use(STATIC_IMAGE_URL_PREFIX, mw.handleImageSizes, storage.getStorage('images').serve());


### PR DESCRIPTION
This script does not load if `x-content-type-options: nosniff` is enforced due to wrong MIME type

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
