### PR TITLE
Remove unnecessary references to ghostVersion

### DIFF
--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -16,14 +16,11 @@ class MembersConfigProvider {
      * @param {{get: (key: string) => any}} options.settingsCache
      * @param {{get: (key: string) => any}} options.config
      * @param {any} options.urlUtils
-     * @param {any} options.logging
-     * @param {{original: string}} options.ghostVersion
      */
     constructor(options) {
         this._settingsCache = options.settingsCache;
         this._config = options.config;
         this._urlUtils = options.urlUtils;
-        this._ghostVersion = options.ghostVersion;
     }
 
     /**

--- a/core/server/services/members/service.js
+++ b/core/server/services/members/service.js
@@ -13,7 +13,6 @@ const labsService = require('../../../shared/labs');
 const settingsCache = require('../../../shared/settings-cache');
 const config = require('../../../shared/config');
 const models = require('../../models');
-const ghostVersion = require('@tryghost/version');
 const _ = require('lodash');
 const {GhostMailer} = require('../mail');
 const jobsService = require('../jobs');
@@ -35,8 +34,7 @@ const ghostMailer = new GhostMailer();
 const membersConfig = new MembersConfigProvider({
     config,
     settingsCache,
-    urlUtils,
-    ghostVersion
+    urlUtils
 });
 
 let membersApi;

--- a/core/server/services/notifications/index.js
+++ b/core/server/services/notifications/index.js
@@ -1,10 +1,8 @@
 const settingsCache = require('../../../shared/settings-cache');
-const ghostVersion = require('@tryghost/version');
 const Notifications = require('./notifications');
 const models = require('../../models');
 
 module.exports.notifications = new Notifications({
     settingsCache,
-    ghostVersion: ghostVersion.full,
     SettingsModel: models.Settings
 });

--- a/core/server/services/notifications/notifications.js
+++ b/core/server/services/notifications/notifications.js
@@ -3,6 +3,7 @@ const semver = require('semver');
 const Promise = require('bluebird');
 const _ = require('lodash');
 const errors = require('@tryghost/errors');
+const ghostVersion = require('@tryghost/version');
 const tpl = require('@tryghost/tpl');
 const ObjectId = require('bson-objectid');
 
@@ -16,12 +17,10 @@ class Notifications {
      *
      * @param {Object} options
      * @param {Object} options.settingsCache - settings cache instance
-     * @param {String} options.ghostVersion - Ghost instance version in "full" format - major.minor.patch
      * @param {Object} options.SettingsModel - Ghost's Setting model instance
      */
-    constructor({settingsCache, ghostVersion, SettingsModel}) {
+    constructor({settingsCache, SettingsModel}) {
         this.settingsCache = settingsCache;
-        this.ghostVersion = ghostVersion;
         this.SettingsModel = SettingsModel;
     }
 
@@ -74,7 +73,7 @@ class Notifications {
     browse({user}) {
         let allNotifications = this.fetchAllNotifications();
         allNotifications = _.orderBy(allNotifications, 'addedAt', 'desc');
-        const blogVersion = this.ghostVersion.match(/^(\d+\.)(\d+\.)(\d+)/);
+        const blogVersion = ghostVersion.full.match(/^(\d+\.)(\d+\.)(\d+)/);
 
         allNotifications = allNotifications.filter((notification) => {
             if (notification.createdAtVersion && !this.wasSeen(notification, user)) {
@@ -128,7 +127,7 @@ class Notifications {
             location: 'bottom',
             status: 'alert',
             id: ObjectId().toHexString(),
-            createdAtVersion: this.ghostVersion
+            createdAtVersion: ghostVersion.full
         };
 
         const overrides = {

--- a/test/unit/server/services/notifications/notifications.test.js
+++ b/test/unit/server/services/notifications/notifications.test.js
@@ -1,6 +1,7 @@
 const should = require('should');
 const sinon = require('sinon');
 
+const ghostVersion = require('@tryghost/version');
 const moment = require('moment');
 const Notifications = require('../../../../../core/server/services/notifications/notifications');
 const {owner} = require('../../../../utils/fixtures/context');
@@ -13,9 +14,9 @@ describe('Notifications Service', function () {
                 get: sinon.fake.returns(existingNotifications)
             };
 
+            sinon.stub(ghostVersion, 'full').value('4.1.0');
             const notificationsSvc = new Notifications({
-                settingsCache,
-                ghostVersion: '4.1.0'
+                settingsCache
             });
 
             const {allNotifications, notificationsToAdd} = notificationsSvc.add({
@@ -60,9 +61,9 @@ describe('Notifications Service', function () {
                 }])
             };
 
+            sinon.stub(ghostVersion, 'full').value('4.1.0');
             const notificationSvc = new Notifications({
-                settingsCache,
-                ghostVersion: '4.1.0'
+                settingsCache
             });
 
             const notifications = notificationSvc.browse({user: owner});
@@ -89,9 +90,9 @@ describe('Notifications Service', function () {
                 }])
             };
 
+            sinon.stub(ghostVersion, 'full').value('4.0.0');
             const notificationSvc = new Notifications({
-                settingsCache,
-                ghostVersion: '4.0.0'
+                settingsCache
             });
 
             const notifications = notificationSvc.browse({user: owner});
@@ -118,9 +119,9 @@ describe('Notifications Service', function () {
                 }])
             };
 
+            sinon.stub(ghostVersion, 'full').value('3.0.0');
             const notificationSvc = new Notifications({
-                settingsCache,
-                ghostVersion: '3.0.0'
+                settingsCache
             });
 
             const notifications = notificationSvc.browse({user: owner});
@@ -147,9 +148,9 @@ describe('Notifications Service', function () {
                 }])
             };
 
+            sinon.stub(ghostVersion, 'full').value('4.0.0');
             const notificationSvc = new Notifications({
-                settingsCache,
-                ghostVersion: '4.0.0'
+                settingsCache
             });
 
             const notifications = notificationSvc.browse({user: owner});
@@ -176,9 +177,9 @@ describe('Notifications Service', function () {
                 }])
             };
 
+            sinon.stub(ghostVersion, 'full').value('5.0.0');
             const notificationSvc = new Notifications({
-                settingsCache,
-                ghostVersion: '5.0.0'
+                settingsCache
             });
 
             const notifications = notificationSvc.browse({user: owner});
@@ -218,9 +219,9 @@ describe('Notifications Service', function () {
                 }])
             };
 
+            sinon.stub(ghostVersion, 'full').value('4.1.0');
             const notificationSvc = new Notifications({
-                settingsCache,
-                ghostVersion: '4.1.0'
+                settingsCache
             });
 
             const notifications = notificationSvc.browse({user: owner});
@@ -243,7 +244,6 @@ describe('Notifications Service', function () {
 
             const notificationSvc = new Notifications({
                 settingsCache,
-                ghostVersion: '5.0.0',
                 SettingsModel: {
                     edit: settingsModelStub
                 }
@@ -269,9 +269,9 @@ describe('Notifications Service', function () {
             };
             const settingsModelStub = sinon.stub().resolves();
 
+            sinon.stub(ghostVersion, 'full').value('5.0.0');
             const notificationSvc = new Notifications({
                 settingsCache,
-                ghostVersion: '5.0.0',
                 SettingsModel: {
                     edit: settingsModelStub
                 }


### PR DESCRIPTION
refs: TryGhost/Toolbox#146
GhostVersion was passed in here but not used at all. This just removes those unnecessary usages.