### PR TITLE
Removed duplicate snapshot initialization code

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:unit": "c8 --reporter text-summary --reporter cobertura mocha --require=./test/utils/overrides.js --exit --trace-warnings --recursive --extension=test.js './test/unit' --timeout=2000",
     "test:integration": "mocha --require=./test/utils/overrides.js --exit --trace-warnings --recursive --extension=test.js  './test/integration' --timeout=5000",
     "test:e2e": "mocha --require=./test/utils/overrides.js --exit --trace-warnings --recursive --extension=test.js './test/e2e-api' './test/e2e-frontend' './test/e2e-server' --timeout=10000",
-    "test:regression": "mocha --require=./test/utils/overrides.js --exit --trace-warnings --recursive --extension=test.js  './test/regression' --timeout=60000",
+    "test:regression": "mocha --require=./test/utils/overrides.js --require=./test/utils/snapshots.js --exit --trace-warnings --recursive --extension=test.js  './test/regression' --timeout=60000",
     "test:unit:slow": "yarn test:unit --reporter=mocha-slow-test-reporter",
     "test:int:slow": "yarn test:integration --reporter=mocha-slow-test-reporter",
     "test:e2e:slow": "yarn test:e2e --reporter=mocha-slow-test-reporter",

--- a/test/regression/api/canary/admin/authentication.test.js
+++ b/test/regression/api/canary/admin/authentication.test.js
@@ -1,12 +1,10 @@
-const chai = require('chai');
 const {expect} = require('chai');
 const {any} = require('expect');
-const chaiJestSnapshot = require('@ethanresnick/chai-jest-snapshot');
+const security = require('@tryghost/security');
 
 const testUtils = require('../../../../utils/index');
 const framework = require('../../../../utils/e2e-framework');
 const models = require('../../../../../core/server/models/index');
-const security = require('@tryghost/security');
 const settingsCache = require('../../../../../core/shared/settings-cache');
 const config = require('../../../../../core/shared/config/index');
 
@@ -16,7 +14,6 @@ describe('Authentication API canary', function () {
 
     describe('Blog setup', function () {
         before(async function () {
-            chaiJestSnapshot.resetSnapshotRegistry();
             request = await framework.getAgent('/ghost/api/canary/admin/');
         });
 
@@ -25,7 +22,6 @@ describe('Authentication API canary', function () {
         });
 
         beforeEach(function () {
-            chaiJestSnapshot.configureUsingMochaContext(this);
             emailStub = framework.stubMail();
         });
 

--- a/test/regression/api/canary/admin/authentication.test.js.snap
+++ b/test/regression/api/canary/admin/authentication.test.js.snap
@@ -101,17 +101,7 @@ Object {
 }
 `;
 
-exports[`Authentication API canary Blog setup update setup 3`] = `
-Object {
-  "invitation": Array [
-    Object {
-      "valid": true,
-    },
-  ],
-}
-`;
-
-exports[`Authentication API canary Blog setup update setup 4`] = `
+exports[`Authentication API canary Invitation check invalid invite 1`] = `
 Object {
   "invitation": Array [
     Object {
@@ -121,7 +111,17 @@ Object {
 }
 `;
 
-exports[`Authentication API canary Blog setup update setup 5`] = `
+exports[`Authentication API canary Invitation check valid invite 1`] = `
+Object {
+  "invitation": Array [
+    Object {
+      "valid": true,
+    },
+  ],
+}
+`;
+
+exports[`Authentication API canary Invitation try to accept with invite 1`] = `
 Object {
   "invitation": Array [
     Object {
@@ -131,7 +131,7 @@ Object {
 }
 `;
 
-exports[`Authentication API canary Blog setup update setup 6`] = `
+exports[`Authentication API canary Password reset reset password 1`] = `
 Object {
   "passwordreset": Array [
     Object {
@@ -141,7 +141,7 @@ Object {
 }
 `;
 
-exports[`Authentication API canary Blog setup update setup 7`] = `
+exports[`Authentication API canary Password reset reset password 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -155,7 +155,7 @@ Object {
 }
 `;
 
-exports[`Authentication API canary Blog setup update setup 8`] = `
+exports[`Authentication API canary Password reset reset password: expired token 1`] = `
 Object {
   "errors": Array [
     Object {
@@ -165,31 +165,7 @@ Object {
 }
 `;
 
-exports[`Authentication API canary Blog setup update setup 9`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
-  "content-length": "314",
-  "content-type": "application/json; charset=utf-8",
-  "date": Any<String>,
-  "etag": Any<String>,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Authentication API canary Blog setup update setup 10`] = `
-Object {
-  "errors": Array [
-    Object {
-      "id": Any<String>,
-    },
-  ],
-}
-`;
-
-exports[`Authentication API canary Blog setup update setup 11`] = `
+exports[`Authentication API canary Password reset reset password: expired token 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -203,31 +179,7 @@ Object {
 }
 `;
 
-exports[`Authentication API canary Blog setup update setup 12`] = `
-Object {
-  "errors": Array [
-    Object {
-      "id": Any<String>,
-    },
-  ],
-}
-`;
-
-exports[`Authentication API canary Blog setup update setup 13`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
-  "content-length": "274",
-  "content-type": "application/json; charset=utf-8",
-  "date": Any<String>,
-  "etag": Any<String>,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Authentication API canary Blog setup update setup 14`] = `
+exports[`Authentication API canary Password reset reset password: generate reset token 1`] = `
 Object {
   "passwordreset": Array [
     Object {
@@ -237,7 +189,7 @@ Object {
 }
 `;
 
-exports[`Authentication API canary Blog setup update setup 15`] = `
+exports[`Authentication API canary Password reset reset password: generate reset token 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -251,9 +203,57 @@ Object {
 }
 `;
 
-exports[`Authentication API canary Blog setup update setup 16`] = `Object {}`;
+exports[`Authentication API canary Password reset reset password: invalid token 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "id": Any<String>,
+    },
+  ],
+}
+`;
 
-exports[`Authentication API canary Blog setup update setup 17`] = `
+exports[`Authentication API canary Password reset reset password: invalid token 2`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "connection": "close",
+  "content-length": "314",
+  "content-type": "application/json; charset=utf-8",
+  "date": Any<String>,
+  "etag": Any<String>,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Authentication API canary Password reset reset password: unmatched token 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "id": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Authentication API canary Password reset reset password: unmatched token 2`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "connection": "close",
+  "content-length": "274",
+  "content-type": "application/json; charset=utf-8",
+  "date": Any<String>,
+  "etag": Any<String>,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Authentication API canary Reset all passwords reset all passwords returns 200 1`] = `Object {}`;
+
+exports[`Authentication API canary Reset all passwords reset all passwords returns 200 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",

--- a/test/regression/api/canary/admin/site.test.js
+++ b/test/regression/api/canary/admin/site.test.js
@@ -1,22 +1,14 @@
-const chai = require('chai');
 const {expect} = require('chai');
 const {any, stringMatching} = require('expect');
-const chaiJestSnapshot = require('@ethanresnick/chai-jest-snapshot');
+
 const framework = require('../../../../utils/e2e-framework');
 const config = require('../../../../../core/shared/config');
-
-chai.use(chaiJestSnapshot);
 
 describe('Config API', function () {
     let request;
 
     before(async function () {
-        chaiJestSnapshot.resetSnapshotRegistry();
         request = await framework.getAgent('/ghost/api/canary/admin/');
-    });
-
-    beforeEach(function () {
-        chaiJestSnapshot.configureUsingMochaContext(this);
     });
 
     it('can retrieve config and all expected properties', async function () {

--- a/test/utils/snapshots.js
+++ b/test/utils/snapshots.js
@@ -1,0 +1,14 @@
+const chai = require('chai');
+const chaiJestSnapshot = require('@ethanresnick/chai-jest-snapshot');
+
+chai.use(chaiJestSnapshot);
+
+exports.mochaHooks = {
+    beforeAll() {
+        chaiJestSnapshot.resetSnapshotRegistry();
+    },
+
+    beforeEach() {
+        chaiJestSnapshot.configureUsingMochaContext(this);
+    }
+};


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/158

- Allows for much smaller amount of code to configure a test to work with chai-jest-snapshots. They now work automatically for all regression tests and could be enabled for other suites by adding the "--require=./test/utils/snapshots.js" parameter in respective test:* package script