### PR TITLE
Migrated mock-express-style tests to standardized syntax

### DIFF
--- a/test/regression/api/canary/admin/authentication.test.js
+++ b/test/regression/api/canary/admin/authentication.test.js
@@ -28,16 +28,16 @@ describe('Authentication API canary', function () {
             framework.restoreMocks();
         });
 
-        it('is setup? no', async function () {
+        it.only('is setup? no', async function () {
             const res = await request
-                .get('authentication/setup')
-                .expect(200);
+                .get('authentication/setup');
 
             expect(res.body).to.matchSnapshot();
             expect(res.headers).to.matchSnapshot({
                 date: any(String),
                 etag: any(String)
             });
+            expect(res.statusCode).to.equal(200);
         });
 
         it('complete setup', async function () {

--- a/test/regression/mock-express-style/api-vs-frontend/canary-e2e-framework.test.js
+++ b/test/regression/mock-express-style/api-vs-frontend/canary-e2e-framework.test.js
@@ -1,0 +1,111 @@
+const sinon = require('sinon');
+const testUtils = require('../../../utils');
+const localUtils = require('../utils');
+const configUtils = require('../../../utils/configUtils');
+
+const themeEngine = require('../../../../core/frontend/services/theme-engine');
+const {expect} = require('chai');
+
+describe('Integration - Web - Site canary', function () {
+    let app;
+    let request;
+
+    before(testUtils.teardownDb);
+    before(testUtils.setup('users:roles', 'posts'));
+
+    describe('default routes.yaml', function () {
+        before(async function () {
+            localUtils.overrideGhostConfig(configUtils);
+
+            request = await localUtils.getAgent(app);
+        });
+
+        beforeEach(function () {
+            sinon.stub(themeEngine.getActive(), 'engine').withArgs('ghost-api').returns('canary');
+            sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(2);
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        after(function () {
+            configUtils.restore();
+        });
+
+        describe('behavior: default cases', function () {
+            it('serves a post page', async function () {
+                const res = await request.get('/html-ipsum/');
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.match(/class="post-template/, 'should render using a post template');
+                expect(res.body).to.match(/<h1>HTML Ipsum Presents<\/h1>/, 'should render lorem ipsum post fixture content');
+            });
+
+            it('serves an amp page', async function () {
+                const res = await request.get('/html-ipsum/amp/');
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.match(/class="amp-template/, 'should render using a amp template');
+                expect(res.body).to.match(/<h1>HTML Ipsum Presents<\/h1>/, 'should render lorem ipsum post fixture content');
+            });
+
+            it('serves a not found page', async function () {
+                const res = await request.get('/i-am-lost/');
+
+                expect(res.statusCode).to.equal(404);
+                expect(res.body).to.match(/class="error-template/, 'should render a 404 error template');
+            });
+
+            it('serves a static page', async function () {
+                const res = await request.get('/static-page-test/');
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.match(/class="page-template/, 'should render a page template');
+            });
+
+            it('serves an author page', async function () {
+                const res = await request.get('/author/joe-bloggs/');
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.match(/class="author-template/, 'should render an author template');
+            });
+
+            it('serves a tag page', async function () {
+                const res = await request.get('/tag/bacon/');
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.match(/class="tag-template/, 'should render a tag template');
+            });
+
+            it('serves a tag rss', async function () {
+                const res = await request.get('/tag/bacon/rss/');
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.match(/<rss/, 'should render a tag rss feed');
+            });
+
+            it('serves a collection', async function () {
+                const res = await request.get('/');
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.match(/class="home-template/, 'should render a home collection template');
+                expect(res.body).to.match(/.post-card/, 'should render post cards');
+            });
+
+            it('serve collection: page 2', async function () {
+                const res = await request.get('/page/2/');
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.body).to.match(/class="paged/, 'should render a paged collection template');
+                expect(res.body).to.match(/.post-card/, 'should render post cards');
+            });
+
+            it('serve theme asset', async function () {
+                const res = await request.get('/assets/css/screen.css');
+
+                expect(res.statusCode).to.equal(200);
+            });
+        });
+    });
+});

--- a/test/regression/mock-express-style/utils/index.js
+++ b/test/regression/mock-express-style/utils/index.js
@@ -1,2 +1,9 @@
-module.exports = require('./setup');
+const MockExpressAgent = require('./mock-express-agent');
+const setup = require('./setup');
+
+module.exports = setup;
 module.exports.mockExpress = require('./mock-express');
+module.exports.getAgent = async (app, host) => {
+    app = await setup.initGhost();
+    return new MockExpressAgent({app, host});
+};

--- a/test/regression/mock-express-style/utils/index.js
+++ b/test/regression/mock-express-style/utils/index.js
@@ -1,4 +1,4 @@
-const MockExpressAgent = require('./mock-express-agent');
+const MockExpressAgent = require('../../../utils/mock-express-agent');
 const setup = require('./setup');
 
 module.exports = setup;

--- a/test/regression/mock-express-style/utils/mock-express-agent.js
+++ b/test/regression/mock-express-style/utils/mock-express-agent.js
@@ -1,0 +1,74 @@
+const http = require('http');
+
+class MockExpressAgent {
+    constructor({app, host}) {
+        this.app = app;
+        this.host = host || 'localhost';
+    }
+
+    buildRequestResponse({url, host, method = 'GET', secure = true}) {
+        let req = new http.IncomingMessage();
+        let res = new http.ServerResponse({
+            method: method
+        });
+
+        res.end = function () {
+            this.emit('finish');
+        };
+
+        req.connection = {
+            encrypted: secure
+        };
+
+        req.method = 'GET';
+        req.url = url;
+        req.headers = {
+            host: this.host
+        };
+
+        res.connection = {
+            _httpMessage: res,
+            writable: true,
+            destroyed: false,
+            cork: function () {},
+            uncork: function () {},
+            write: function () {},
+            on: function () {}
+        };
+
+        return {req, res};
+    }
+
+    get(url) {
+        const {req, res} = this.buildRequestResponse({
+            url
+        });
+        const app = this.app;
+
+        return new Promise(function (resolve) {
+            res.end = function (body) {
+                resolve({
+                    err: res.req.err,
+                    body: body,
+                    statusCode: res.statusCode,
+                    req: req,
+                    res: res
+                });
+            };
+
+            res.send = function (body) {
+                resolve({
+                    err: res.req.err,
+                    body: body,
+                    statusCode: res.statusCode,
+                    req: req,
+                    res: res
+                });
+            };
+
+            app(req, res);
+        });
+    }
+}
+
+module.exports = MockExpressAgent;

--- a/test/utils/e2e-framework.js
+++ b/test/utils/e2e-framework.js
@@ -18,6 +18,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const os = require('os');
 const uuid = require('uuid');
+const url = require('url');
 
 const fixtures = require('./fixture-utils');
 const redirectsUtils = require('./redirects');
@@ -26,6 +27,7 @@ const mockUtils = require('./e2e-framework-mock-utils');
 
 const boot = require('../../core/boot');
 const TestAgent = require('./test-agent');
+const MockExpressAgent = require('./mock-express-agent');
 const db = require('./db-utils');
 
 const startGhost = async () => {
@@ -117,6 +119,11 @@ const getAgent = async (apiURL) => {
     const app = await startGhost();
     const originURL = configUtils.config.get('url');
 
+    // return new MockExpressAgent({
+    //     app,
+    //     host: url.parse(originURL).host,
+    //     urlPrefix: apiURL
+    // });
     return new TestAgent({
         apiURL,
         app,

--- a/test/utils/mock-express-agent.js
+++ b/test/utils/mock-express-agent.js
@@ -46,21 +46,12 @@ class MockExpressAgent {
         const app = this.app;
 
         return new Promise(function (resolve) {
-            res.end = function (body) {
+            res.send = res.end = function (body) {
                 resolve({
                     err: res.req.err,
                     body: body,
                     statusCode: res.statusCode,
-                    req: req,
-                    res: res
-                });
-            };
-
-            res.send = function (body) {
-                resolve({
-                    err: res.req.err,
-                    body: body,
-                    statusCode: res.statusCode,
+                    headers: res._headers,
                     req: req,
                     res: res
                 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/129#issuecomment-983442329
refs https://github.com/TryGhost/Ghost/commit/743b7a16e0c5560ba89f43c5f10eab7499a50877

- This is a "reference refactor" with test structure/syntax to aim for when writing new or rewriting existing mock-express style tests
- The syntax is much more similar to the new one used in e2e-tests (like this one https://github.com/TryGhost/Ghost/commit/743b7a16e0c5560ba89f43c5f10eab7499a50877)
