### PR TITLE
Add timezone and locale to the options of the date helper

### DIFF
--- a/core/frontend/helpers/date.js
+++ b/core/frontend/helpers/date.js
@@ -25,12 +25,11 @@ module.exports = function (...attrs) {
     // ensure that date is undefined, not null, as that can cause errors
     date = date === null ? undefined : date;
 
-    const timezone = options.data.site.timezone;
-    const locale = options.data.site.locale;
-
     const {
         format = 'll',
-        timeago
+        timeago,
+        timezone = options.data.site.timezone,
+        locale = options.data.site.locale
     } = options.hash;
 
     const timeNow = moment().tz(timezone);

--- a/test/unit/frontend/helpers/date.test.js
+++ b/test/unit/frontend/helpers/date.test.js
@@ -168,4 +168,34 @@ describe('{{date}} helper', function () {
         should.exist(rendered);
         String(rendered).should.equal('a few seconds ago');
     });
+
+    it('allows user to override the site\'s locale and timezone', function () {
+        const context = {
+            hash: {
+                format: 'ddd, DD MMM YYYY HH:mm:ss ZZ' // RFC 822
+            },
+            data: {
+                site: {
+                    timezone: 'Asia/Tokyo',
+                    locale: 'ja-jp'
+                }
+            }
+        };
+
+        // Using the site locale by default, none specified in hash
+        const published_at = '2013-12-31T23:58:58.593+02:00';
+        String(date.call({published_at}, context)).should.equal('水, 01 1月 2014 06:58:58 +0900');
+        
+        // Overriding the site locale and timezone in hash
+        context.hash.timezone = 'Europe/Paris';
+        context.hash.locale = 'fr-fr';
+        String(date.call({published_at}, context)).should.equal('mar., 31 déc. 2013 22:58:58 +0100');
+        
+        context.hash.timezone = 'Europe/Moscow';
+        context.hash.locale = 'ru-ru';
+        String(date.call({published_at}, context)).should.equal('ср, 01 янв. 2014 01:58:58 +0400');
+        
+        context.hash.locale = 'en-us';
+        String(date.call({published_at}, context)).should.equal('Wed, 01 Jan 2014 01:58:58 +0400');
+    });
 });


### PR DESCRIPTION
The `date` handlebars helper has only one option currently — `format`. It assumes the locale and timezone from the `options.data.site` object which is not always desired behavior.

The helper sometimes is used, for example, in custom RSS template where we always need the `en-US` locale, not the one that we have configured for the website globally. This change makes the two options configurable. The default values come from the `options.data.site` object values if omitted, and therefore this change is backwards compatible.

This pull request fixes the issue #13832.