### PR TITLE
Supported restricting limit="all" in get helper

### DIFF
--- a/core/frontend/helpers/get.js
+++ b/core/frontend/helpers/get.js
@@ -109,6 +109,10 @@ function parseOptions(globals, data, options) {
         options.filter = resolvePaths(globals, data, options.filter);
     }
 
+    if (options.limit === 'all' && config.get('getHelperLimitAllMax')) {
+        options.limit = config.get('getHelperLimitAllMax');
+    }
+
     return options;
 }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1251

With sites that have a huge number of resources, using limit="all" can
cause OOM errors at the Node level. Administrators now have the ability
to cap limit="all" requests via config. This only affects the get helper
used in themes, not the API, this is by design as themes have less
visibility of issues.