### PR TITLE
Added cache control headers to members api

### DIFF
--- a/core/server/web/members/app.js
+++ b/core/server/web/members/app.js
@@ -18,6 +18,9 @@ module.exports = function setupMembersApp() {
     // Entire app is behind labs flag
     membersApp.use(shared.middlewares.labs.members);
 
+    // Members API shouldn't be cached
+    membersApp.use(shared.middlewares.cacheControl('private'));
+
     // Support CORS for requests from the frontend
     const siteUrl = new URL(urlUtils.getSiteUrl());
     membersApp.use(cors(siteUrl.origin));


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/846

- members api was missing cacheControl middleware to declare its cache control headers

this was never backported to 3.x