### PR TITLE
Fixed AMP style compliance

### DIFF
--- a/core/frontend/apps/amp/lib/views/amp.hbs
+++ b/core/frontend/apps/amp/lib/views/amp.hbs
@@ -777,11 +777,11 @@
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
         font-size: 0.95em;
         font-weight: 600;
-        text-decoration: none !important;
+        text-decoration: none;
         border-radius: 5px;
         transition: opacity 0.2s ease-in-out;
         background-color: var(--ghost-accent-color);
-        color: #ffffff !important;
+        color: #ffffff;
         margin: 1.75em 0 0;
     }
 
@@ -800,12 +800,12 @@
     .kg-header-card.kg-style-image a.kg-header-card-button,
     .kg-header-card.kg-style-dark a.kg-header-card-button {
         background: #ffffff;
-        color: #15171a !important;
+        color: #15171a;
     }
 
     .kg-header-card.kg-style-accent a.kg-header-card-button {
         background: #ffffff;
-        color: var(--ghost-accent-color) !important;
+        color: var(--ghost-accent-color);
     }
 
     .kg-audio-card {


### PR DESCRIPTION
no issue

- `!important` qualifier is not allowed in AMP styles as it's disallowed by the framework's spec https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/#disallowed-styles

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
