### PR TITLE
Updated SingleUseToken grace period to 10 minutes

### DIFF
--- a/core/server/models/single-use-token.js
+++ b/core/server/models/single-use-token.js
@@ -33,7 +33,7 @@ const SingleUseToken = ghostBookshelf.Model.extend({
                 } catch (err) {
                     logging.error(err);
                 }
-            }, 10000);
+            }, 10 * 60 * 1000);
         }
 
         return model;

--- a/test/unit/server/models/single-use-token.test.js
+++ b/test/unit/server/models/single-use-token.test.js
@@ -34,7 +34,11 @@ describe('Unit: models/single-use-token', function () {
 
             clock.tick(10000);
 
-            should.ok(destroyStub.called, 'destroy was called after 10 seconds');
+            should.ok(!destroyStub.called, 'destroy was not called after 10 seconds');
+
+            clock.tick(10 * 60 * 1000 - 10000);
+
+            should.ok(destroyStub.called, 'destroy was not called after 10 seconds');
         });
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1216

Some email security clients are scanning links at delivery, rather than
at the point the user clicks on them. This is causing magic links to
expire. To get around this we're increasing the grace period in which a
link can be used multiple times to 10 minutes.
