### PR TITLE
🐛 Added fallback for meta_description to custom_excerpt

### DIFF
--- a/core/frontend/meta/description.js
+++ b/core/frontend/meta/description.js
@@ -51,7 +51,7 @@ function getDescription(data, root, options = {}) {
                 || settingsCache.get('description')
                 || '';
         } else {
-            description = data.post.meta_description || '';
+            description = data.post.meta_description || data.post.custom_excerpt || '';
         }
     } else if (_.includes(context, 'page') && data.post) {
         // Page description dependent on legacy object formatting (https://github.com/TryGhost/Ghost/issues/10042)
@@ -63,7 +63,7 @@ function getDescription(data, root, options = {}) {
                 || settingsCache.get('description')
                 || '';
         } else {
-            description = data.post.meta_description || '';
+            description = data.post.meta_description || data.post.custom_excerpt || '';
         }
     } else if (_.includes(context, 'page') && data.page) {
         if (options.property) {
@@ -74,7 +74,7 @@ function getDescription(data, root, options = {}) {
                 || settingsCache.get('description')
                 || '';
         } else {
-            description = data.page.meta_description || '';
+            description = data.page.meta_description || data.page.custom_excerpt || '';
         }
     }
 

--- a/test/unit/frontend/meta/description.test.js
+++ b/test/unit/frontend/meta/description.test.js
@@ -68,6 +68,12 @@ describe('getMetaDescription', function () {
             should(
                 getMetaDescription({post}, {context: 'post'})
             ).equal(null);
+
+            post.custom_excerpt = 'Custom excerpt';
+
+            should(
+                getMetaDescription({post}, {context: 'post'})
+            ).equal('Custom excerpt');
         });
 
         it('has correct fallbacks for context: page', function () {
@@ -83,6 +89,12 @@ describe('getMetaDescription', function () {
             should(
                 getMetaDescription({page}, {context: 'page'})
             ).equal(null);
+
+            page.custom_excerpt = 'Custom excerpt';
+
+            should(
+                getMetaDescription({page}, {context: 'page'})
+            ).equal('Custom excerpt');
         });
 
         // NOTE: this is a legacy format and should be resolved with https://github.com/TryGhost/Ghost/issues/10042


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/13920

- Custom excerpt should be used as a fallback for meta_description in line with the behaviour of OG and Twitter metadata
- We specifically don't want to use the full fallback to the auto-generated preview text when a custom excerpt isn't defined, because we trust search engines to be able to summarise content better than we can
