### PR TITLE
Allow custom helpers

### DIFF
--- a/core/frontend/services/helpers/index.js
+++ b/core/frontend/services/helpers/index.js
@@ -1,12 +1,24 @@
 const registry = require('./registry');
-
 const path = require('path');
+const config = require('../../../shared/config');
+const settingsCache = require('../../../shared/settings-cache');
 
-// Initialise Ghost's own helpers
 // This is a weird place for this to live!
-const init = async () => {
+const init = () => {
+    // Initialize Ghost's own helpers
     const helperPath = path.join(__dirname, '../../', 'helpers');
-    return await registry.registerDir(helperPath);
+    registry.registerDir(helperPath);
+
+    // Initialize custom helpers in /content/helpers
+    const customHelperPath = config.getContentPath('helpers');
+    registry.registerDir(customHelperPath);
+    
+    // Initialize helpers of current theme (/content/themes/xy/helpers)
+    const themeName = settingsCache.get('active_theme');
+    if (themeName) {
+      const themeHelperPath = path.join(config.getContentPath('themes'), themeName, 'helpers');
+      registry.registerDir(themeHelperPath);
+    }
 };
 
 // Oh look! A framework for helpers :D

--- a/core/shared/config/helpers.js
+++ b/core/shared/config/helpers.js
@@ -86,6 +86,8 @@ const getContentPath = function getContentPath(type) {
         return path.join(this.get('paths:contentPath'), 'settings/');
     case 'public':
         return path.join(this.get('paths:contentPath'), 'public/');
+    case 'helpers':
+        return path.join(this.get('paths:contentPath'), 'helpers/');
     default:
         // new Error is allowed here, as we do not want config to depend on @tryghost/error
         // @TODO: revisit this decision when @tryghost/error is no longer dependent on all of ghost-ignition


### PR DESCRIPTION
# Allow custom helpers

This pull request makes it possible to use custom helpers with Ghost.

Custom helpers can be placed in `/content/helpers`, or inside a theme folder: `/content/themes/casper/helpers`.

### Example
Place the following code into `/content/helpers/stringify.js`:
```js
module.exports = function stringify(object) {
    return JSON.stringify(parseJson);
 }
```

Now you can use it like after restarting ghost:
```hbs
{{#get "posts" limit="all"}}
{{#stringify posts}}
```