### PR TITLE
Updated github release action to use new main branch of ghost-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
       - run: grunt release --skip-tests
       - run: npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
       - run: npm publish
-      - uses: tryghost/action-ghost-release@master
+      - uses: tryghost/action-ghost-release@main


### PR DESCRIPTION
no issue

- We have switched over to using the new git standard of using the main branch rather than master.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
