### PR TITLE
Added new free tier as proper tier

### DIFF
--- a/core/frontend/services/theme-engine/middleware/update-global-template-options.js
+++ b/core/frontend/services/theme-engine/middleware/update-global-template-options.js
@@ -28,7 +28,9 @@ function calculateLegacyPriceData(products) {
         };
     }
 
-    const defaultProduct = products[0] || {};
+    const defaultProduct = products.find((product) => {
+        return product.type === 'paid';
+    }) || {};
 
     const monthlyPrice = makePriceObject(defaultProduct.monthly_price || defaultPrice);
 

--- a/core/server/api/canary/utils/serializers/output/products.js
+++ b/core/server/api/canary/utils/serializers/output/products.js
@@ -73,6 +73,7 @@ function serializeProduct(product, options, apiType) {
         name: json.name,
         description: json.description,
         slug: json.slug,
+        type: json.type,
         created_at: json.created_at,
         updated_at: json.updated_at,
         stripe_prices: json.stripePrices ? json.stripePrices.map(price => serializeStripePrice(price, hideStripeData)) : null,

--- a/core/server/data/migrations/versions/4.33/2022-01-14-11-50-add-type-column-to-products.js
+++ b/core/server/data/migrations/versions/4.33/2022-01-14-11-50-add-type-column-to-products.js
@@ -1,0 +1,12 @@
+const utils = require('../../utils');
+
+module.exports = utils.createAddColumnMigration(
+    'products',
+    'type',
+    {
+        type: 'string',
+        maxlength: 50,
+        nullable: false,
+        defaultTo: 'paid'
+    }
+);

--- a/core/server/data/migrations/versions/4.33/2022-01-14-11-51-add-default-free-tier.js
+++ b/core/server/data/migrations/versions/4.33/2022-01-14-11-51-add-default-free-tier.js
@@ -1,0 +1,37 @@
+const {createTransactionalMigration} = require('../../utils');
+const ObjectID = require('bson-objectid');
+const {slugify} = require('@tryghost/string');
+const logging = require('@tryghost/logging');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const [result] = await knex
+            .count('id', {as: 'total'})
+            .from('products')
+            .where('type', 'free');
+
+        if (result.total !== 0) {
+            logging.warn(`Not adding default free tier, a free tier already exists`);
+            return;
+        }
+
+        const name = 'Free';
+        const id = ObjectID().toHexString();
+
+        logging.info(`Adding tier "${name}"`);
+        await knex('products')
+            .insert({
+                id: id,
+                name: name,
+                type: 'free',
+                slug: slugify(id),
+                created_at: knex.raw(`CURRENT_TIMESTAMP`)
+            });
+    },
+    async function down(knex) {
+        logging.info('Removing free tier');
+        await knex('products')
+            .where('type', 'free')
+            .del();
+    }
+);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -4,8 +4,14 @@
             "name": "Product",
             "entries": [
                 {
+                    "name":             "Free",
+                    "slug":             "free",
+                    "type":             "free"
+                },
+                {
                     "name":             "Default Product",
-                    "slug":             "default-product"
+                    "slug":             "default-product",
+                    "type":             "paid"
                 }
             ]
         },

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -381,6 +381,7 @@ module.exports = {
         monthly_price_id: {type: 'string', maxlength: 24, nullable: true},
         yearly_price_id: {type: 'string', maxlength: 24, nullable: true},
         description: {type: 'string', maxlength: 191, nullable: true},
+        type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'paid', validations: {isIn: [['paid', 'free']]}},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}
     },

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -113,7 +113,9 @@ const getPortalProductPrices = async function () {
             prices: productPrices
         };
     });
-    const defaultProduct = products[0];
+    const defaultProduct = products.find((product) => {
+        return product.type === 'paid';
+    });
     const defaultPrices = defaultProduct ? defaultProduct.prices : [];
     let portalProducts = defaultProduct ? [defaultProduct] : [];
     if (labsService.isSet('multipleProducts')) {

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -109,6 +109,7 @@ const getPortalProductPrices = async function () {
             monthlyPrice: product.monthlyPrice,
             yearlyPrice: product.yearlyPrice,
             benefits: product.benefits,
+            type: product.type,
             prices: productPrices
         };
     });

--- a/test/regression/models/model_member_stripe_customer.test.js
+++ b/test/regression/models/model_member_stripe_customer.test.js
@@ -24,7 +24,8 @@ describe('MemberStripeCustomer Model', function run() {
 
             const product = await Product.add({
                 name: 'Ghost Product',
-                slug: 'ghost-product'
+                slug: 'ghost-product',
+                type: 'paid'
             }, context);
 
             await StripeProduct.add({
@@ -126,7 +127,8 @@ describe('MemberStripeCustomer Model', function run() {
 
             const product = await Product.add({
                 name: 'Ghost Product',
-                slug: 'ghost-product'
+                slug: 'ghost-product',
+                type: 'paid'
             }, context);
 
             await StripeProduct.add({

--- a/test/regression/models/model_members.test.js
+++ b/test/regression/models/model_members.test.js
@@ -30,7 +30,8 @@ describe('Member Model', function run() {
 
             const product = await Product.add({
                 name: 'Ghost Product',
-                slug: 'ghost-product'
+                slug: 'ghost-product',
+                type: 'paid'
             }, context);
 
             await StripeProduct.add({
@@ -188,7 +189,8 @@ describe('Member Model', function run() {
 
             const product = await Product.add({
                 name: 'Ghost Product',
-                slug: 'ghost-product'
+                slug: 'ghost-product',
+                type: 'paid'
             }, context);
 
             await StripeProduct.add({
@@ -271,14 +273,16 @@ describe('Member Model', function run() {
         it('Products can be created & added to members by the product array', async function () {
             const context = testUtils.context.admin;
             const product = await Product.add({
-                name: 'Product-Add-Test'
+                name: 'Product-Add-Test',
+                type: 'paid'
             });
             const member = await Member.add({
                 email: 'testing-products@test.member',
                 products: [{
                     id: product.id
                 }, {
-                    name: 'Product-Create-Test'
+                    name: 'Product-Create-Test',
+                    type: 'paid'
                 }]
             }, {
                 ...context,
@@ -311,7 +315,8 @@ describe('Member Model', function run() {
                 email: 'filter-test@test.member',
                 products: [{
                     name: 'VIP',
-                    slug: 'vip'
+                    slug: 'vip',
+                    type: 'paid'
                 }]
             }, context);
 
@@ -355,7 +360,8 @@ describe('Member Model', function run() {
                 email: 'name-filter-test@test.member',
                 products: [{
                     name: 'VIP',
-                    slug: 'vip'
+                    slug: 'vip',
+                    type: 'paid'
                 }]
             }, context);
 
@@ -378,7 +384,8 @@ describe('Member Model', function run() {
                 email: 'email-filter-test@test.member',
                 products: [{
                     name: 'VIP',
-                    slug: 'vip'
+                    slug: 'vip',
+                    type: 'paid'
                 }]
             }, context);
 
@@ -404,7 +411,8 @@ describe('Member Model', function run() {
 
             const product = await Product.add({
                 name: 'Ghost Product',
-                slug: 'ghost-product'
+                slug: 'ghost-product',
+                type: 'paid'
             }, context);
 
             await StripeProduct.add({

--- a/test/regression/models/model_stripe_customer_subscription.test.js
+++ b/test/regression/models/model_stripe_customer_subscription.test.js
@@ -26,7 +26,8 @@ describe('StripeCustomerSubscription Model', function run() {
 
             const product = await Product.add({
                 name: 'Ghost Product',
-                slug: 'ghost-product'
+                slug: 'ghost-product',
+                type: 'paid'
             }, context);
 
             await StripeProduct.add({

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,8 +35,8 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'e649797a5de92d417744f6f2623c79cf';
-    const currentFixturesHash = '07d4b0c4cf159b34344a6b5e88c74e9f';
+    const currentSchemaHash = '56769494697fb27c189c63e3e8a228e9';
+    const currentFixturesHash = 'e1d5e5d493aa1b01498505e75ce73e56';
     const currentSettingsHash = 'd73b63e33153c9256bca42ebfd376779';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -368,8 +368,15 @@ DataGenerator.Content = {
     products: [
         {
             id: ObjectId().toHexString(),
+            name: 'Free',
+            slug: 'free',
+            type: 'free'
+        },
+        {
+            id: ObjectId().toHexString(),
             name: 'Ghost Product',
-            slug: 'ghost-product'
+            slug: 'ghost-product',
+            type: 'paid'
         }
     ],
 

--- a/test/utils/fixtures/fixtures.json
+++ b/test/utils/fixtures/fixtures.json
@@ -5,7 +5,13 @@
             "entries": [
                 {
                     "name":             "Default Product",
-                    "slug":             "default-product"
+                    "slug":             "default-product",
+                    "type":             "paid"
+                },
+                {
+                    "name":             "Free",
+                    "slug":             "free",
+                    "type":             "free"
                 }
             ]
         },


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1037

Migrations at - 
- https://github.com/TryGhost/Ghost/pull/13970/files#diff-549e3032ba241e39d0a645d7ec58a652bee03ff53ba36de6d3ef384843404724
- https://github.com/TryGhost/Ghost/pull/13970/files#diff-0fa91bff0d1a019a087be2fa1995abe98a092936741d712358768c904f9f5dc9

-----

At the moment, free tier is not actually structured/stored as a proper "tier", and has the description hard-coded. This doesn't allow the flexibility to attach benefits/description to a free tier like rest of the tiers to publishers. This change adds the free tier as a proper "tier" in database. It also introduces a new `type` column to differentiate between free and paid tiers, allowing free tier to have same first class support for description/benefits as other tiers.