### PR TITLE
Added secret handling for webhooks

### DIFF
--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -954,3 +954,4 @@ add|ember-template-lint|no-passed-in-event-handlers|176|44|176|44|dcb4785647a508
 add|ember-template-lint|no-passed-in-event-handlers|186|44|186|44|70487c008d7dda453fef82f0140699ee93c0055c|1660521600000|1670893200000|1676077200000|app/components/modal-tier.hbs
 add|ember-template-lint|style-concatenation|303|54|303|54|23293f0c3838b23432d2b2daaf04b34504896d91|1660608000000|1670979600000|1676163600000|app/components/modal-tier.hbs
 remove|ember-template-lint|no-nested-interactive|23|28|23|28|5cf783a5684dda036706ff7438472e99c60a88e7|1658102400000|1668474000000|1673658000000|app/templates/whatsnew.hbs
+add|ember-template-lint|no-passed-in-event-handlers|72|20|72|20|e639a281bd34eefbe403ddf46501154b89a1f477|1661212800000|1671584400000|1676768400000|app/components/modal-webhook-form.hbs

--- a/ghost/admin/app/components/modal-webhook-form.hbs
+++ b/ghost/admin/app/components/modal-webhook-form.hbs
@@ -69,7 +69,7 @@
                 <label for="webhook-secret" class="fw6">Secret</label>
                 <GhTextInput
                     @value={{readonly this.webhook.secret}}
-                    @oninput={{action (mut this.webhook.secret) value="target.value"}}
+                    @input={{action (mut this.webhook.secret) value="target.value"}}
                     @focus-out={{action "validate" "secret" target=this.webhook}}
                     @id="webhook-secret"
                     @name="secret"

--- a/ghost/admin/app/validators/webhook.js
+++ b/ghost/admin/app/validators/webhook.js
@@ -3,7 +3,7 @@ import validator from 'validator';
 import {isBlank} from '@ember/utils';
 
 export default BaseValidator.create({
-    properties: ['name', 'event', 'targetUrl'],
+    properties: ['name', 'event', 'targetUrl', 'secret'],
 
     name(model) {
         if (isBlank(model.name)) {
@@ -37,6 +37,14 @@ export default BaseValidator.create({
         model.hasValidated.pushObject('targetUrl');
 
         if (model.errors.has('targetUrl')) {
+            this.invalidate();
+        }
+    },
+
+    secret(model) {
+        if (!validator.isLength(model.secret, 0, 191)) {
+            model.errors.add('secret', 'Secret is too long, max 191 chars');
+            model.hasValidated.pushObject('secret');
             this.invalidate();
         }
     }

--- a/ghost/admin/app/validators/webhook.js
+++ b/ghost/admin/app/validators/webhook.js
@@ -42,7 +42,7 @@ export default BaseValidator.create({
     },
 
     secret(model) {
-        if (!validator.isLength(model.secret, 0, 191)) {
+        if (!isBlank(model.secret) && !validator.isLength(model.secret, 0, 191)) {
             model.errors.add('secret', 'Secret is too long, max 191 chars');
             model.hasValidated.pushObject('secret');
             this.invalidate();

--- a/ghost/core/core/server/services/webhooks/trigger.js
+++ b/ghost/core/core/server/services/webhooks/trigger.js
@@ -1,7 +1,7 @@
 const debug = require('@tryghost/debug')('services:webhooks:trigger');
 const logging = require('@tryghost/logging');
 const ghostVersion = require('@tryghost/version');
-const crypto = require('crypto')
+const crypto = require('crypto');
 
 class WebhookTrigger {
     /**
@@ -88,22 +88,19 @@ class WebhookTrigger {
             const url = webhook.get('target_url');
             const secret = webhook.get('secret') || '';
 
-            let tmpHeaders = {
+            const headers = {
                 'Content-Length': Buffer.byteLength(reqPayload),
                 'Content-Type': 'application/json',
-                'Content-Version': `v${ghostVersion.safe}`,
-            }
+                'Content-Version': `v${ghostVersion.safe}`
+            };
 
-            if (secret != '') {
-                tmpHeaders = {
-                    ...tmpHeaders,
-                    'X-Ghost-Signature': `sha256=${crypto.createHmac('sha256', secret).update(reqPayload).digest('hex')}, t=${Date.now()}`
-                }
+            if (secret !== '') {
+                headers['X-Ghost-Signature'] = `sha256=${crypto.createHmac('sha256', secret).update(reqPayload).digest('hex')}, t=${Date.now()}`;
             }
 
             const opts = {
                 body: reqPayload,
-                headers: tmpHeaders,
+                headers,
                 timeout: 2 * 1000,
                 retry: 5
             };

--- a/ghost/core/core/server/services/webhooks/trigger.js
+++ b/ghost/core/core/server/services/webhooks/trigger.js
@@ -1,6 +1,7 @@
 const debug = require('@tryghost/debug')('services:webhooks:trigger');
 const logging = require('@tryghost/logging');
 const ghostVersion = require('@tryghost/version');
+const crypto = require('crypto')
 
 class WebhookTrigger {
     /**
@@ -85,13 +86,24 @@ class WebhookTrigger {
 
             const reqPayload = JSON.stringify(hookPayload);
             const url = webhook.get('target_url');
+            const secret = webhook.get('secret') || '';
+
+            let tmpHeaders = {
+                'Content-Length': Buffer.byteLength(reqPayload),
+                'Content-Type': 'application/json',
+                'Content-Version': `v${ghostVersion.safe}`,
+            }
+
+            if (secret != '') {
+                tmpHeaders = {
+                    ...tmpHeaders,
+                    'X-Ghost-Signature': `sha256=${crypto.createHmac('sha256', secret).update(reqPayload).digest('hex')}, t=${Date.now()}`
+                }
+            }
+
             const opts = {
                 body: reqPayload,
-                headers: {
-                    'Content-Length': Buffer.byteLength(reqPayload),
-                    'Content-Type': 'application/json',
-                    'Content-Version': `v${ghostVersion.safe}`
-                },
+                headers: tmpHeaders,
                 timeout: 2 * 1000,
                 retry: 5
             };


### PR DESCRIPTION
This change will allow to verify the source of the POST request.
The idea is to have the same functionality as in githubs
guide on securing webhooks.

https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks

With this change there is an additional header that will be sent to the
webhooks targetUrl and that can then verify the authenticity of
the source.

This will require another change in the admin client. That is already prepared and I will submit a
pull request there to.

The idea was already discussed in issue #9942 but the implementation seemed to be left behind.

If there is need for any other changes please let me know.

Regards
Georg