### PR TITLE
Added library for extracting database information

### DIFF
--- a/core/boot.js
+++ b/core/boot.js
@@ -58,6 +58,9 @@ async function initDatabase({config}) {
     const DatabaseStateManager = require('./server/data/db/state-manager');
     const dbStateManager = new DatabaseStateManager({knexMigratorFilePath: config.get('paths:appRoot')});
     await dbStateManager.makeReady();
+
+    const databaseInfo = require('./server/data/db/info');
+    await databaseInfo.init();
 }
 
 /**

--- a/core/server/data/db/info.js
+++ b/core/server/data/db/info.js
@@ -1,0 +1,4 @@
+const connection = require('./connection');
+const DatabaseInfo = require('@tryghost/database-info');
+
+module.exports = new DatabaseInfo(connection);

--- a/core/server/services/public-config/config.js
+++ b/core/server/services/public-config/config.js
@@ -1,13 +1,14 @@
 const {isPlainObject} = require('lodash');
 const config = require('../../../shared/config');
 const labs = require('../../../shared/labs');
+const databaseInfo = require('../../data/db/info');
 const ghostVersion = require('@tryghost/version');
 
 module.exports = function getConfigProperties() {
     const configProperties = {
         version: ghostVersion.full,
         environment: config.get('env'),
-        database: config.get('database').client,
+        database: databaseInfo.getEngine(),
         mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',
         useGravatar: !config.isPrivacyDisabled('useGravatar'),
         labs: labs.getAll(),

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -4,6 +4,7 @@ const api = require('./api');
 const config = require('../shared/config');
 const urlUtils = require('./../shared/url-utils');
 const jobsService = require('./services/jobs');
+const databaseInfo = require('./data/db/info');
 
 const request = require('@tryghost/request');
 const ghostVersion = require('@tryghost/version');
@@ -44,7 +45,7 @@ module.exports = async () => {
         config: {
             mail: config.get('mail'),
             env: config.get('env'),
-            databaseType: config.get('database').client,
+            databaseType: databaseInfo.getEngine(),
             checkEndpoint: config.get('updateCheck:url'),
             isPrivacyDisabled: config.isPrivacyDisabled('useUpdateCheck'),
             notificationGroups: config.get('notificationGroups'),

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@tryghost/config-url-helpers": "0.1.3",
     "@tryghost/constants": "1.0.0",
     "@tryghost/custom-theme-settings-service": "0.3.1",
+    "@tryghost/database-info": "0.1.0",
     "@tryghost/debug": "0.1.10",
     "@tryghost/email-analytics-provider-mailgun": "1.0.7",
     "@tryghost/email-analytics-service": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,6 +1360,11 @@
     "@tryghost/tpl" "^0.1.4"
     lodash "^4.17.21"
 
+"@tryghost/database-info@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/database-info/-/database-info-0.1.0.tgz#881e47e802fc2ae321d8c42d17a2a1cb8e4da143"
+  integrity sha512-3Nwo6pGR8yXrhSky2Uikz8oEKJsBLuaG68rcwIsMB6kFoWR3q7uAMWPvw3jIzVNnkZE1FQPb36w4z1t/v7dujw==
+
 "@tryghost/debug@0.1.10", "@tryghost/debug@^0.1.10":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@tryghost/debug/-/debug-0.1.10.tgz#26d67921c3edd562c7d2bee136d04faefa99bb3c"


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/175

- we're going to be making some changes in v5 wrt supported databases
- we needed a way of detecting the difference between MySQL 5 + 8,
  MariaDB etc
- I've created `@tryghost/database-info`, which is a small wrapper
  around `knex`, which returns this information
- this commit:
  - adds the library to Ghost
  - initializes the DB info library upon boot
  - updates the Admin API /config/ endpoint and UpdateCheck to return
    the new string - `mysql5`, `mysql8` etc