### PR TITLE
Added three email delivery events to the `member/event` endpoint

### DIFF
--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -173,6 +173,7 @@ function createApiInstance(config) {
             stripe: config.getStripePaymentConfig()
         },
         models: {
+            EmailRecipient: models.EmailRecipient,
             StripeCustomer: models.MemberStripeCustomer,
             StripeCustomerSubscription: models.StripeCustomerSubscription,
             Member: models.Member,

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@tryghost/limit-service": "1.0.8",
     "@tryghost/logging": "2.0.1",
     "@tryghost/magic-link": "1.0.15",
-    "@tryghost/members-api": "4.0.1",
+    "@tryghost/members-api": "4.1.3",
     "@tryghost/members-csv": "1.2.2",
     "@tryghost/members-importer": "0.4.0",
     "@tryghost/members-offers": "0.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,10 +1600,10 @@
     "@tryghost/domain-events" "^0.1.4"
     "@tryghost/member-events" "^0.3.2"
 
-"@tryghost/members-api@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-4.0.1.tgz#d272537874b4372df8dd1fc126bc7d0a768c3949"
-  integrity sha512-/wpozXUw2xJLIbG/GcZF62jkGY3oGjxuy1ORGmkH4Vuy/1+NV68Fxz99VnqfKPCNU/q63g7BMTG9iR63IM4sUQ==
+"@tryghost/members-api@4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-4.1.3.tgz#23e4a14a82e310ee5d44425e39f366b08dd45133"
+  integrity sha512-dWAwR/iQQKW8DKKPytXWN6R9FvV0mrI80JAffxpAGmHCuiBszEC+OV3TWEQC3ltgzeuIYaHaF2HWb+S+PSs4fw==
   dependencies:
     "@tryghost/debug" "^0.1.2"
     "@tryghost/domain-events" "^0.1.4"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1277

- The new events types are: `email_delivered_event`, `email_opened_event` and `email_failed_event`.
- This makes existing data accessible to the admin dashboard