### PR TITLE
Added active flag to products API

### DIFF
--- a/core/server/api/canary/utils/serializers/output/products.js
+++ b/core/server/api/canary/utils/serializers/output/products.js
@@ -73,6 +73,7 @@ function serializeProduct(product, options, apiType) {
         name: json.name,
         description: json.description,
         slug: json.slug,
+        active: json.active,
         type: json.type,
         created_at: json.created_at,
         updated_at: json.updated_at,
@@ -161,6 +162,8 @@ function createSerializer(debugString, serialize) {
  * @prop {string} name
  * @prop {string} slug
  * @prop {string} description
+ * @prop {boolean} active
+ * @prop {string} type
  * @prop {Date} created_at
  * @prop {Date} updated_at
  * @prop {StripePrice[]} [stripe_prices]


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1252

This flag is used to determine whether a Tier (currently product) as
active or archived
