### PR TITLE
🐛 Fixed config API not returning boolean

### DIFF
--- a/core/server/api/canary/config.js
+++ b/core/server/api/canary/config.js
@@ -22,7 +22,7 @@ module.exports = {
                 clientExtensions: config.get('clientExtensions') || {},
                 enableDeveloperExperiments: config.get('enableDeveloperExperiments') || false,
                 stripeDirect: config.get('stripeDirect'),
-                mailgunIsConfigured: config.get('bulkEmail') && config.get('bulkEmail').mailgun,
+                mailgunIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').mailgun),
                 emailAnalytics: config.get('emailAnalytics'),
                 forceUpgrade: config.get('host_settings:forceUpgrade') || false
             };

--- a/test/api-acceptance/admin/utils.js
+++ b/test/api-acceptance/admin/utils.js
@@ -24,7 +24,7 @@ const expectedProperties = {
 
     action: ['id', 'resource_type', 'actor_type', 'event', 'created_at', 'actor'],
 
-    config: ['version', 'environment', 'database', 'mail', 'labs', 'clientExtensions', 'enableDeveloperExperiments', 'useGravatar', 'stripeDirect', 'emailAnalytics', 'forceUpgrade'],
+    config: ['version', 'environment', 'database', 'mail', 'labs', 'clientExtensions', 'enableDeveloperExperiments', 'useGravatar', 'stripeDirect', 'emailAnalytics', 'forceUpgrade', 'mailgunIsConfigured'],
 
     post: _(schema.posts)
         .keys()


### PR DESCRIPTION
no-issue

The mailgunIsConfigured config should be a boolean, rather than a string/undefined/null.