### PR TITLE
Removed archived Tiers from theme data

### DIFF
--- a/core/frontend/services/theme-engine/middleware/update-global-template-options.js
+++ b/core/frontend/services/theme-engine/middleware/update-global-template-options.js
@@ -49,7 +49,8 @@ async function getProductAndPricesData() {
     try {
         const page = await api.canary.productsPublic.browse({
             include: ['monthly_price', 'yearly_price'],
-            limit: 'all'
+            limit: 'all',
+            filter: 'active:true'
         });
 
         return page.products;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1252

In order to allow existing subscribe pages to continue working without
an extra flag, we're going to filter out the archived tiers.
