### PR TITLE
Add welcome page url

### DIFF
--- a/core/server/data/migrations/versions/4.34/2022-01-25-13-53-add-welcome-page-url-column-to-products.js
+++ b/core/server/data/migrations/versions/4.34/2022-01-25-13-53-add-welcome-page-url-column-to-products.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('products', 'welcome_page_url', {
+    type: 'string',
+    maxlength: 2000,
+    nullable: true
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -379,6 +379,7 @@ module.exports = {
         name: {type: 'string', maxlength: 191, nullable: false},
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
         active: {type: 'boolean', nullable: false, defaultTo: true},
+        welcome_page_url: {type: 'string', maxlength: 2000, nullable: true},
         monthly_price_id: {type: 'string', maxlength: 24, nullable: true},
         yearly_price_id: {type: 'string', maxlength: 24, nullable: true},
         description: {type: 'string', maxlength: 191, nullable: true},

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '92d822bfe44d49f99e7b0ba5efe49143';
+    const currentSchemaHash = '690caeeb4b3b52591a204704aa15dec9';
     const currentFixturesHash = 'beb040c0376a492c2a44767fdd825a3e';
     const currentSettingsHash = 'd73b63e33153c9256bca42ebfd376779';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs TryGhost/Team#1168

Rather than using a single url for paid signup redirects, we want to
support setting a welcome page on a tier by tier basis. This column will
be used to store the URL. A text column of length 2000 is how we have
stored URL's elsewhere in the schema.