### PR TITLE
Removed de-duplication of events in `/members/events`

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@tryghost/limit-service": "1.0.9",
     "@tryghost/logging": "2.0.1",
     "@tryghost/magic-link": "1.0.17",
-    "@tryghost/members-api": "4.8.0",
+    "@tryghost/members-api": "4.8.1",
     "@tryghost/members-importer": "0.4.1",
     "@tryghost/members-offers": "0.10.6",
     "@tryghost/members-ssr": "1.0.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,10 +1513,10 @@
     "@tryghost/domain-events" "^0.1.6"
     "@tryghost/member-events" "^0.3.3"
 
-"@tryghost/members-api@4.8.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-4.8.0.tgz#46d7bedb1089cddda4c0e470849b67bde45b5c8a"
-  integrity sha512-RSz2hSW+BF2pQ1LecNi71MGYF1C/RPDJo7zLPNFf6K58FihP4mQtjtqPBY68xbAKOcBo1MLxBsqBkGoz3nVAaw==
+"@tryghost/members-api@4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-4.8.1.tgz#f3f6e4b5373407bc9c73275edf7aeb3007d4b446"
+  integrity sha512-tAmdwrtFwB8DbezSySIL1GhumVpfCi4b2FIfQo4eTtfyEGiUdoD5JRR+ToNbxor1/h+HN0gETnteflmQ97mOEw==
   dependencies:
     "@nexes/nql" "^0.6.0"
     "@tryghost/debug" "^0.1.2"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1277

- When a user signs-up, two events are created, the api route was only returning one of these events.
- This was introduce in commit https://github.com/TryGhost/Members/commit/120116e8a279e15718e2d7b78e4fd587ed7fddb4 when the only usage of the api route was to extract the 5 most recent events. Any duplication was creating too much noise.
- This was creating issues now that we introduced event filtering. Some `newsletter_event` events would appear from nowhere we we were filtering-out `signup_event` events.
- We removed the deduplication when the `membersActivityFeed` flag is enabled.
