### PR TITLE
    Migrated redirect settings to welcome_page_urls

### DIFF
--- a/core/server/data/migrations/versions/4.35/2022-01-30-15-17-set-welcome-page-url-from-settings.js
+++ b/core/server/data/migrations/versions/4.35/2022-01-30-15-17-set-welcome-page-url-from-settings.js
@@ -1,0 +1,39 @@
+const logging = require('@tryghost/logging');
+
+// For DML - data changes
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Setting welcome_page_url from settings');
+
+        const paidSignupRedirect = await knex()
+            .select('value')
+            .from('settings')
+            .where('key', 'members_paid_signup_redirect')
+            .first();
+
+        const freeSignupRedirect = await knex()
+            .select('value')
+            .from('settings')
+            .where('key', 'members_free_signup_redirect')
+            .first();
+
+        logging.info(`Setting paid Tiers welcome_page_url to ${paidSignupRedirect.value}`);
+
+        await knex('products')
+            .update('welcome_page_url', paidSignupRedirect.value)
+            .where('type', 'paid');
+
+        logging.info(`Setting free Tiers welcome_page_url to ${freeSignupRedirect.value}`);
+
+        await knex('products')
+            .update('welcome_page_url', freeSignupRedirect.value)
+            .where('type', 'free');
+    },
+    async function down(knex) {
+        logging.info('Setting welcome_page_url to NULL');
+        await knex('products')
+            .update('welcome_page_url', null);
+    }
+);

--- a/core/server/data/migrations/versions/4.35/2022-01-30-15-17-set-welcome-page-url-from-settings.js
+++ b/core/server/data/migrations/versions/4.35/2022-01-30-15-17-set-welcome-page-url-from-settings.js
@@ -7,29 +7,35 @@ module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Setting welcome_page_url from settings');
 
-        const paidSignupRedirect = await knex()
+        const paidSignupRedirect = await knex('settings')
             .select('value')
-            .from('settings')
             .where('key', 'members_paid_signup_redirect')
             .first();
 
-        const freeSignupRedirect = await knex()
+        const freeSignupRedirect = await knex('settings')
             .select('value')
-            .from('settings')
             .where('key', 'members_free_signup_redirect')
             .first();
 
-        logging.info(`Setting paid Tiers welcome_page_url to ${paidSignupRedirect.value}`);
+        if (paidSignupRedirect) {
+            logging.info(`Setting paid Tiers welcome_page_url to ${paidSignupRedirect.value}`);
 
-        await knex('products')
-            .update('welcome_page_url', paidSignupRedirect.value)
-            .where('type', 'paid');
+            await knex('products')
+                .update('welcome_page_url', paidSignupRedirect.value)
+                .where('type', 'paid');
+        } else {
+            logging.info(`No members_paid_signup_redirect setting found`);
+        }
 
-        logging.info(`Setting free Tiers welcome_page_url to ${freeSignupRedirect.value}`);
+        if (freeSignupRedirect) {
+            logging.info(`Setting free Tiers welcome_page_url to ${freeSignupRedirect.value}`);
 
-        await knex('products')
-            .update('welcome_page_url', freeSignupRedirect.value)
-            .where('type', 'free');
+            await knex('products')
+                .update('welcome_page_url', freeSignupRedirect.value)
+                .where('type', 'free');
+        } else {
+            logging.info(`No members_paid_signup_redirect setting found`);
+        }
     },
     async function down(knex) {
         logging.info('Setting welcome_page_url to NULL');


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1168

This migrates the existing settings onto the Tier objects, so that users
with Tiers enabled can seamless move from global settings to Tier level
settings - without losing/modifying data/functionality.