### PR TITLE
Remove Editor card settings panel alpha flag

### DIFF
--- a/core/shared/labs.js
+++ b/core/shared/labs.js
@@ -27,7 +27,6 @@ const BETA_FEATURES = [
 const ALPHA_FEATURES = [
     'oauthLogin',
     'membersActivity',
-    'cardSettingsPanel',
     'urlCache',
     'beforeAfterCard',
     'tweetGridCard',


### PR DESCRIPTION
Settings panel should be turned on by default. This PR removes the alpha flag and corresponding conditions for it.