### PR TITLE
Migrated email filter columns from VARCHAR to TEXT

### DIFF
--- a/core/server/data/migrations/versions/4.35/2022-02-01-11-48-update-email-recipient-filter-column-type.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-01-11-48-update-email-recipient-filter-column-type.js
@@ -1,0 +1,25 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        if (knex.client.config.client === 'sqlite3') {
+            logging.warn('Skipping migration for SQLite3');
+            return;
+        }
+        logging.info('Changing posts.email_recipient_filter column from VARCHAR(50) to TEXT');
+        await knex.schema.alterTable('posts', function (table) {
+            table.text('email_recipient_filter').alter();
+        });
+    },
+    async function down(knex) {
+        if (knex.client.config.client === 'sqlite3') {
+            logging.warn('Skipping migration for SQLite3');
+            return;
+        }
+        logging.info('Changing posts.email_recipient_filter column from TEXT to VARCHAR(50)');
+        knex.schema.alterTable('posts', function (table) {
+            table.string('email_recipient_filter', 50).alter();
+        });
+    }
+);

--- a/core/server/data/migrations/versions/4.35/2022-02-01-11-48-update-email-recipient-filter-column-type.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-01-11-48-update-email-recipient-filter-column-type.js
@@ -12,14 +12,7 @@ module.exports = createNonTransactionalMigration(
             table.text('email_recipient_filter').alter();
         });
     },
-    async function down(knex) {
-        if (knex.client.config.client === 'sqlite3') {
-            logging.warn('Skipping migration for SQLite3');
-            return;
-        }
-        logging.info('Changing posts.email_recipient_filter column from TEXT to VARCHAR(50)');
-        knex.schema.alterTable('posts', function (table) {
-            table.string('email_recipient_filter', 50).alter();
-        });
+    async function down() {
+        logging.warn('Not changing posts.email_recipient_filter column');
     }
 );

--- a/core/server/data/migrations/versions/4.35/2022-02-01-12-03-update-recipient-filter-column-type.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-01-12-03-update-recipient-filter-column-type.js
@@ -12,14 +12,7 @@ module.exports = createNonTransactionalMigration(
             table.text('recipient_filter').alter();
         });
     },
-    async function down(knex) {
-        if (knex.client.config.client === 'sqlite3') {
-            logging.warn('Skipping migration for SQLite3');
-            return;
-        }
-        logging.info('Changing emails.recipient_filter column from TEXT to VARCHAR(50)');
-        knex.schema.alterTable('emails', function (table) {
-            table.string('recipient_filter', 50).alter();
-        });
+    async function down() {
+        logging.warn('Not changing emails.recipient_filter column');
     }
 );

--- a/core/server/data/migrations/versions/4.35/2022-02-01-12-03-update-recipient-filter-column-type.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-01-12-03-update-recipient-filter-column-type.js
@@ -1,0 +1,25 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        if (knex.client.config.client === 'sqlite3') {
+            logging.warn('Skipping migration for SQLite3');
+            return;
+        }
+        logging.info('Changing emails.recipient_filter column from VARCHAR(50) to TEXT');
+        await knex.schema.alterTable('emails', function (table) {
+            table.text('recipient_filter').alter();
+        });
+    },
+    async function down(knex) {
+        if (knex.client.config.client === 'sqlite3') {
+            logging.warn('Skipping migration for SQLite3');
+            return;
+        }
+        logging.info('Changing emails.recipient_filter column from TEXT to VARCHAR(50)');
+        knex.schema.alterTable('emails', function (table) {
+            table.string('recipient_filter', 50).alter();
+        });
+    }
+);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -30,8 +30,8 @@ module.exports = {
             defaultTo: 'public'
         },
         email_recipient_filter: {
-            type: 'string',
-            maxlength: 50,
+            type: 'text',
+            maxlength: 1000000000,
             nullable: false,
             defaultTo: 'none'
         },
@@ -598,8 +598,8 @@ module.exports = {
             validations: {isIn: [['pending', 'submitting', 'submitted', 'failed']]}
         },
         recipient_filter: {
-            type: 'string',
-            maxlength: 50,
+            type: 'text',
+            maxlength: 1000000000,
             nullable: false,
             defaultTo: 'status:-free'
         },

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '95bef616ba2bf7b91a99c627bbc591a3';
+    const currentSchemaHash = '9e4eeb5c260047fe21d1f93c523bd771';
     const currentFixturesHash = 'beb040c0376a492c2a44767fdd825a3e';
     const currentSettingsHash = 'd73b63e33153c9256bca42ebfd376779';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs TryGhost/Team#1287

Currently we have a hard limit of how large an email filter can be,
which is very restrictive once a site starts using Tiers - by moving
toward a TEXT column, we essentially give the filters unlimited size.

This currently doesn't handle SQLite as I'm waiting on feedback from
Matt on whether or not the development database needs this migration.