### PR TITLE
:bug: Added test case for bug #13971

### DIFF
--- a/test/unit/frontend/meta/asset-url.test.js
+++ b/test/unit/frontend/meta/asset-url.test.js
@@ -34,6 +34,11 @@ describe('getAssetUrl', function () {
         testUrl.should.equal('/public/myfile.js?v=' + config.get('assetHash'));
     });
 
+    it('should return asset url with ?v= before # if asset has #', function() {
+      const testUrl = getAssetUrl('myfile.svg#minus');
+      testUrl.should.equal('/assets/myfile.svg?v=' + config.get('assetHash') + '#minus');
+    });
+
     describe('favicon', function () {
         it('should not add asset to url if favicon.ico', function () {
             const testUrl = getAssetUrl('favicon.ico');


### PR DESCRIPTION
- Added test case to check the url of svg assets with hash so it appears after ?v=

- refs #13971
- The test case was added to check that the svg hash is added at the end instead of the middle so the asset helper can work properly with svg files with hashes at the end

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)