### PR TITLE
Added a `theme` parameter to the `/authentication/setup` route

### DIFF
--- a/core/server/api/canary/authentication.js
+++ b/core/server/api/canary/authentication.js
@@ -13,6 +13,7 @@ const apiSettings = require('./index').settings;
 const UsersService = require('../../services/users');
 const userService = new UsersService({dbBackup, models, auth, apiMail, apiSettings});
 const {deleteAllSessions} = require('../../services/auth/session');
+const labs = require('../../../shared/labs');
 
 const messages = {
     notTheBlogOwner: 'You are not the site owner.'
@@ -41,6 +42,7 @@ module.exports = {
                         email: frame.data.setup[0].email,
                         password: frame.data.setup[0].password,
                         blogTitle: frame.data.setup[0].blogTitle,
+                        theme: frame.data.setup[0].theme,
                         status: 'active'
                     };
 
@@ -52,6 +54,12 @@ module.exports = {
                     } catch (e) {
                         return data;
                     }
+                })
+                .then((data) => {
+                    if (labs.isSet('improvedOnboarding')) {
+                        return auth.setup.installTheme(data, api);
+                    }
+                    return data;
                 })
                 .then((data) => {
                     return auth.setup.doSettings(data, api.settings);

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -149,11 +149,47 @@ function sendWelcomeEmail(email, mailAPI) {
     return Promise.resolve();
 }
 
+async function installTheme(data, api) {
+    const {theme: themeName} = data.userData;
+
+    if (!themeName) {
+        return data;
+    }
+
+    // Use the api instead of the services as the api performs extra logic
+    try {
+        const installResults = await api.themes.install({
+            source: 'github',
+            ref: themeName,
+            context: {internal: true}
+        });
+        const theme = installResults.themes[0];
+
+        await api.themes.activate({
+            name: theme.name,
+            context: {internal: true}
+        });
+    } catch (e) {
+        //Fallback to Casper by doing nothing as the theme setting update is the last step
+
+        await api.notifications.add({
+            notifications: [{
+                custom: true, //avoids update-check from deleting the notification
+                type: 'warn',
+                message: 'The installation of the theme you have selected wasn\'t successful.'
+            }]
+        }, {context: {internal: true}});
+    }
+
+    return data;
+}
+
 module.exports = {
     checkIsSetup: checkIsSetup,
     assertSetupCompleted: assertSetupCompleted,
     setupUser: setupUser,
     doSettings: doSettings,
     doProduct: doProduct,
-    sendWelcomeEmail: sendWelcomeEmail
+    sendWelcomeEmail: sendWelcomeEmail,
+    installTheme: installTheme
 };


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1296

- The `theme` must be a github `org/repo` string
- This uses the internal API instead of the services because the API has extra implementation details not present in the services.
