### PR TITLE
Added new default content visibility tiers setting

### DIFF
--- a/core/server/data/migrations/versions/4.35/2022-02-02-10-38-add-default-content-visibility-tiers-setting.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-02-10-38-add-default-content-visibility-tiers-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils.js');
+
+module.exports = addSetting({
+    key: 'default_content_visibility_tiers',
+    value: '[]',
+    type: 'array',
+    group: 'members'
+});

--- a/core/server/data/migrations/versions/4.35/2022-02-02-13-10-transform-specific-tiers-default-content-visibility.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-02-13-10-transform-specific-tiers-default-content-visibility.js
@@ -1,0 +1,147 @@
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Checking default_content_visibility for specific tiers');
+
+        const settings = await knex('settings')
+            .select()
+            .whereIn('key', ['default_content_visibility', 'default_content_visibility_tiers']);
+        const contentVisibilitySetting = settings.find(d => d.key === 'default_content_visibility');
+        const visibilityTiersSetting = settings.find(d => d.key === 'default_content_visibility_tiers');
+        if (!contentVisibilitySetting) {
+            logging.warn('No default_content_visibility setting found.');
+            return;
+        }
+
+        if (!visibilityTiersSetting) {
+            logging.warn('No default_content_visibility_tiers setting found.');
+            return;
+        }
+
+        const contentVisibility = contentVisibilitySetting.value;
+
+        if (['public', 'members', 'paid'].includes(contentVisibility)) {
+            logging.info(`Ignoring default_content_visibility change as already set to ${contentVisibility}.`);
+            return;
+        }
+        // Transform visibility to tiers when stored as nql string
+        const isValidProductNqlFilter = /^(?:product:[\w-]+,?)+$/.test(contentVisibility);
+        const now = knex.raw('CURRENT_TIMESTAMP');
+        // Reset visibility value to paid if invalid string/filter
+        if (!isValidProductNqlFilter) {
+            logging.warn(`Found invalid default_content_visibility value - ${contentVisibility}, resetting to paid`);
+            await knex('settings')
+                .where({
+                    key: 'default_content_visibility'
+                })
+                .update({
+                    value: 'paid',
+                    updated_at: now
+                });
+
+            logging.info(`Resetting default_content_visibility_tiers to []`);
+            await knex('settings')
+                .where({
+                    key: 'default_content_visibility_tiers'
+                })
+                .update({
+                    value: JSON.stringify([]),
+                    updated_at: now
+                });
+            return;
+        }
+
+        // fetch product slugs from nql filter
+        const productSlugs = contentVisibility.split(',').map((segment) => {
+            return segment.replace('product:', '');
+        });
+
+        // get product ids for slugs
+        const products = await knex('products')
+            .select('id')
+            .whereIn('slug', productSlugs);
+        const productList = products.map((product) => {
+            return product.id;
+        });
+
+        logging.info(`Updating default_content_visibility to tiers`);
+        await knex('settings')
+            .where({
+                key: 'default_content_visibility'
+            })
+            .update({
+                value: 'tiers',
+                updated_at: now
+            });
+
+        logging.info(`Updating default_content_visibility_tiers to ${productList}`);
+        await knex('settings')
+            .where({
+                key: 'default_content_visibility_tiers'
+            })
+            .update({
+                value: JSON.stringify(productList),
+                updated_at: now
+            });
+    },
+    async function down(knex) {
+        logging.info('Reverting default_content_visibility for specific tiers');
+
+        const settings = await knex('settings')
+            .select()
+            .whereIn('key', ['default_content_visibility', 'default_content_visibility_tiers']);
+        const contentVisibilitySetting = settings.find(d => d.key === 'default_content_visibility');
+        const visibilityTiersSetting = settings.find(d => d.key === 'default_content_visibility_tiers');
+
+        const visibilityValue = contentVisibilitySetting && contentVisibilitySetting.value;
+        const visibilityTiersValue = visibilityTiersSetting && visibilityTiersSetting.value;
+
+        if (visibilityValue !== 'tiers') {
+            logging.info(`Ignoring default_content_visibility as is set to ${visibilityValue}.`);
+            return;
+        }
+
+        if (!visibilityTiersValue) {
+            logging.warn(`Ignoring, found empty default_content_visibility_tiers value`);
+            return;
+        }
+
+        try {
+            const parsedTiersValue = JSON.parse(visibilityTiersValue);
+            const products = await knex('products')
+                .select('slug')
+                .whereIn('id', parsedTiersValue);
+            const productSlugs = products.map((product) => {
+                return `product:${product.slug}`;
+            }).join(',');
+            const now = knex.raw('CURRENT_TIMESTAMP');
+
+            logging.info(`Setting default_content_visibility to ${productSlugs}`);
+            await knex('settings')
+                .where({
+                    key: 'default_content_visibility'
+                })
+                .update({
+                    value: productSlugs,
+                    updated_at: now
+                });
+
+            logging.info(`Setting default_content_visibility_tiers to []`);
+            await knex('settings')
+                .where({
+                    key: 'default_content_visibility_tiers'
+                })
+                .update({
+                    value: JSON.stringify([]),
+                    updated_at: now
+                });
+        } catch (e) {
+            logging.warn(`Invalid default_content_visibility_tiers value - ${visibilityTiersValue}`);
+            logging.warn(e);
+            return;
+        }
+    }
+);

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -235,6 +235,10 @@
             "defaultValue": "public",
             "type": "string"
         },
+        "default_content_visibility_tiers": {
+            "defaultValue": "[]",
+            "type": "array"
+        },
         "members_signup_access": {
             "defaultValue": "all",
             "validations": {

--- a/test/regression/api/canary/admin/settings.test.js
+++ b/test/regression/api/canary/admin/settings.test.js
@@ -145,6 +145,11 @@ const defaultSettingsKeyTypes = [
         group: 'members'
     },
     {
+        key: 'default_content_visibility_tiers',
+        type: 'array',
+        group: 'members'
+    },
+    {
         key: 'members_signup_access',
         type: 'string',
         group: 'members'

--- a/test/regression/models/model_settings.test.js
+++ b/test/regression/models/model_settings.test.js
@@ -42,7 +42,7 @@ describe('Settings Model', function () {
             await models.Settings.populateDefaults();
 
             const settingsPopulated = await models.Settings.findAll();
-            settingsPopulated.length.should.equal(94);
+            settingsPopulated.length.should.equal(95);
 
             const titleSetting = settingsPopulated.models.find(s => s.get('key') === 'title');
             titleSetting.get('value').should.equal('Testing Defaults');

--- a/test/regression/models/model_settings.test.js
+++ b/test/regression/models/model_settings.test.js
@@ -17,7 +17,7 @@ describe('Settings Model', function () {
             await models.Settings.populateDefaults();
 
             const settingsPopulated = await models.Settings.findAll();
-            settingsPopulated.length.should.equal(94);
+            settingsPopulated.length.should.equal(95);
         });
 
         it('doesn\'t overwrite any existing settings', async function () {

--- a/test/unit/server/data/exporter/index.test.js
+++ b/test/unit/server/data/exporter/index.test.js
@@ -199,7 +199,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 84;
+            const allowedKeysLength = 85;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '9e4eeb5c260047fe21d1f93c523bd771';
     const currentFixturesHash = 'beb040c0376a492c2a44767fdd825a3e';
-    const currentSettingsHash = 'd73b63e33153c9256bca42ebfd376779';
+    const currentSettingsHash = '437d4c6da8759f5c35f11f811b86e5bc';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1071

Default content visibility for a post can be one of `public|members|paid|tiers`, where `tiers` denotes visibility restricted to specific tiers. This change adds a new setting to store the tier ids when default content visibility is set to `tiers`. This closely matches how the visibility is stored on `posts` table as well, with `visibility` stored as `tiers` and tiers data is stored on tiers pivot table.