### PR TITLE
Fixed missing portal product data

### DIFF
--- a/core/server/data/migrations/versions/4.35/2022-02-04-04-34-populate-empty-portal-products.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-04-04-34-populate-empty-portal-products.js
@@ -52,6 +52,7 @@ module.exports = createTransactionalMigration(
                 });
         } catch (e) {
             logging.warn(`Ignoring, unable to parse portal_products setting value - ${portalProductsSetting.value}`);
+            logging.warn(e);
         }
     },
     // no-op - we don't want to return to invalid state

--- a/core/server/data/migrations/versions/4.35/2022-02-04-04-34-populate-empty-portal-products.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-04-04-34-populate-empty-portal-products.js
@@ -51,7 +51,7 @@ module.exports = createTransactionalMigration(
                     updated_at: now
                 });
         } catch (e) {
-            logging.warn(`Ignoring, unable to parse portal_products setting value`);
+            logging.warn(`Ignoring, unable to parse portal_products setting value - ${portalProductsSetting.value}`);
         }
     },
     // no-op - we don't want to return to invalid state

--- a/core/server/data/migrations/versions/4.35/2022-02-04-04-34-populate-empty-portal-products.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-04-04-34-populate-empty-portal-products.js
@@ -33,7 +33,7 @@ module.exports = createTransactionalMigration(
         const currPortalProductsValue = JSON.parse(portalProductsSetting.value);
 
         if (currPortalProductsValue.length > 0) {
-            logging.warn(`Ignoring - portal_products setting is not empty, is - ${currPortalProductsValue}`);
+            logging.warn(`Ignoring - portal_products setting is not empty, - ${currPortalProductsValue}`);
             return;
         }
 
@@ -42,9 +42,14 @@ module.exports = createTransactionalMigration(
 
         logging.info(`Setting portal_products setting to have product - ${defaultProduct.id}`);
 
+        const now = knex.raw('CURRENT_TIMESTAMP');
+
         await knex('settings')
             .where('key', 'portal_products')
-            .update({value: JSON.stringify(portalProductsValue)});
+            .update({
+                value: JSON.stringify(portalProductsValue),
+                updated_at: now
+            });
     },
     // no-op - we don't want to return to invalid state
     async function down() {}

--- a/core/server/data/migrations/versions/4.35/2022-02-04-04-34-populate-empty-portal-products.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-04-04-34-populate-empty-portal-products.js
@@ -1,0 +1,51 @@
+const {createTransactionalMigration} = require('../../utils');
+const logging = require('@tryghost/logging');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const products = await knex
+            .select('id')
+            .where({
+                type: 'paid'
+            })
+            .from('products');
+
+        if (products.length === 0) {
+            logging.warn(`Skipping updating portal_products, no product exists`);
+            return;
+        }
+
+        if (products.length > 1) {
+            logging.warn(`Skipping updating portal_products, tiers beta is enabled`);
+            return;
+        }
+
+        const portalProductsSetting = await knex('settings')
+            .where('key', 'portal_products')
+            .select('value')
+            .first();
+
+        if (!portalProductsSetting) {
+            logging.warn(`Missing portal_products setting`);
+            return;
+        }
+
+        const currPortalProductsValue = JSON.parse(portalProductsSetting.value);
+
+        if (currPortalProductsValue.length > 0) {
+            logging.warn(`Ignoring - portal_products setting is not empty, is - ${currPortalProductsValue}`);
+            return;
+        }
+
+        const defaultProduct = products[0];
+        const portalProductsValue = [defaultProduct.id];
+
+        logging.info(`Setting portal_products setting to have product - ${defaultProduct.id}`);
+
+        await knex('settings')
+            .where('key', 'portal_products')
+            .update({value: JSON.stringify(portalProductsValue)});
+    },
+    // no-op - we don't want to return to invalid state
+    async function down() {}
+);


### PR DESCRIPTION
refs  https://github.com/TryGhost/Team/issues/1311

For some sites, the portal_products array was created without any value and due to a possible bug in older version of Ghost, it also didn't get filled on Stripe connect with default product. This causes a side-effect of sites not showing the prices in Portal when tiers beta is enabled or is out as GA. This change populates the missing product data in `portal_product` for sites that have a single tier (haven't enabled tiers beta), as they right now don't have an option to hide the tier.