### PR TITLE
Added new express-test framework to our ref tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
   "devDependencies": {
     "@ethanresnick/chai-jest-snapshot": "3.0.0",
     "@lodder/grunt-postcss": "3.1.1",
+    "@tryghost/express-test": "0.1.1",
     "c8": "7.11.0",
     "chai": "4.3.6",
     "coffeescript": "2.6.1",

--- a/test/regression/api/canary/admin/authentication.test.js
+++ b/test/regression/api/canary/admin/authentication.test.js
@@ -31,7 +31,7 @@ describe('Authentication API canary', function () {
         it('is setup? no', async function () {
             const res = await agent
                 .get('authentication/setup')
-                .expect(200);
+                .expectStatus(200);
 
             expect(res.body).to.matchSnapshot();
             expect(res.headers).to.matchSnapshot({
@@ -43,7 +43,7 @@ describe('Authentication API canary', function () {
         it('complete setup', async function () {
             const res = await agent
                 .post('authentication/setup')
-                .send({
+                .body({
                     setup: [{
                         name: 'test user',
                         email: 'test@example.com',
@@ -51,8 +51,8 @@ describe('Authentication API canary', function () {
                         blogTitle: 'a test blog'
                     }]
                 })
-                .expect('Content-Type', /json/)
-                .expect(201);
+                .expectHeader('Content-Type', 'application/json; charset=utf-8')
+                .expectStatus(201);
 
             expect(res.body).to.matchSnapshot({
                 users: [{
@@ -82,7 +82,7 @@ describe('Authentication API canary', function () {
         it('complete setup again', function () {
             return agent
                 .post('authentication/setup')
-                .send({
+                .body({
                     setup: [{
                         name: 'test user',
                         email: 'test-leo@example.com',
@@ -90,8 +90,8 @@ describe('Authentication API canary', function () {
                         blogTitle: 'a test blog'
                     }]
                 })
-                .expect('Content-Type', /json/)
-                .expect(403);
+                .expectHeader('Content-Type', 'application/json; charset=utf-8')
+                .expectStatus(403);
         });
 
         it('update setup', async function () {
@@ -100,7 +100,7 @@ describe('Authentication API canary', function () {
 
             const res = await agent
                 .put('authentication/setup')
-                .send({
+                .body({
                     setup: [{
                         name: 'test user edit',
                         email: 'test-edit@example.com',
@@ -108,8 +108,8 @@ describe('Authentication API canary', function () {
                         blogTitle: 'a test blog'
                     }]
                 })
-                .expect('Content-Type', /json/)
-                .expect(200);
+                .expectHeader('Content-Type', 'application/json; charset=utf-8')
+                .expectStatus(200);
 
             expect(res.body).to.matchSnapshot({
                 users: [{
@@ -140,15 +140,15 @@ describe('Authentication API canary', function () {
         it('check invite with invalid email', function () {
             return agent
                 .get('authentication/invitation?email=invalidemail')
-                .expect('Content-Type', /json/)
-                .expect(400);
+                .expectHeader('Content-Type', 'application/json; charset=utf-8')
+                .expectStatus(400);
         });
 
         it('check valid invite', async function () {
             const res = await agent
                 .get(`authentication/invitation?email=${testUtils.DataGenerator.forKnex.invites[0].email}`)
-                .expect('Content-Type', /json/)
-                .expect(200);
+                .expectHeader('Content-Type', 'application/json; charset=utf-8')
+                .expectStatus(200);
 
             expect(res.body).to.matchSnapshot();
         });
@@ -156,8 +156,8 @@ describe('Authentication API canary', function () {
         it('check invalid invite', async function () {
             const res = await agent
                 .get(`authentication/invitation?email=notinvited@example.org`)
-                .expect('Content-Type', /json/)
-                .expect(200);
+                .expectHeader('Content-Type', 'application/json; charset=utf-8')
+                .expectStatus(200);
 
             expect(res.body).to.matchSnapshot();
         });
@@ -165,7 +165,7 @@ describe('Authentication API canary', function () {
         it('try to accept without invite', function () {
             return agent
                 .post('authentication/invitation')
-                .send({
+                .body({
                     invitation: [{
                         token: 'lul11111',
                         password: 'lel123456',
@@ -173,14 +173,14 @@ describe('Authentication API canary', function () {
                         name: 'not invited'
                     }]
                 })
-                .expect('Content-Type', /json/)
-                .expect(404);
+                .expectHeader('Content-Type', 'application/json; charset=utf-8')
+                .expectStatus(404);
         });
 
         it('try to accept with invite and existing email address', function () {
             return agent
                 .post('authentication/invitation')
-                .send({
+                .body({
                     invitation: [{
                         token: testUtils.DataGenerator.forKnex.invites[0].token,
                         password: '12345678910',
@@ -188,14 +188,14 @@ describe('Authentication API canary', function () {
                         name: 'invited'
                     }]
                 })
-                .expect('Content-Type', /json/)
-                .expect(422);
+                .expectHeader('Content-Type', 'application/json; charset=utf-8')
+                .expectStatus(422);
         });
 
         it('try to accept with invite', async function () {
             const res = await agent
                 .post('authentication/invitation')
-                .send({
+                .body({
                     invitation: [{
                         token: testUtils.DataGenerator.forKnex.invites[0].token,
                         password: '12345678910',
@@ -203,8 +203,8 @@ describe('Authentication API canary', function () {
                         name: 'invited'
                     }]
                 })
-                .expect('Content-Type', /json/)
-                .expect(200);
+                .expectHeader('Content-Type', 'application/json; charset=utf-8')
+                .expectStatus(200);
 
             expect(res.body).to.matchSnapshot();
         });
@@ -243,15 +243,15 @@ describe('Authentication API canary', function () {
             });
 
             const res = await agent.put('authentication/passwordreset')
-                .set('Accept', 'application/json')
-                .send({
+                .header('Accept', 'application/json')
+                .body({
                     passwordreset: [{
                         token: token,
                         newPassword: 'thisissupersafe',
                         ne2Password: 'thisissupersafe'
                     }]
                 })
-                .expect(200);
+                .expectStatus(200);
 
             expect(res.body).to.matchSnapshot();
             expect(res.headers).to.matchSnapshot({
@@ -263,15 +263,15 @@ describe('Authentication API canary', function () {
         it('reset password: invalid token', async function () {
             const res = await agent
                 .put('authentication/passwordreset')
-                .set('Accept', 'application/json')
-                .send({
+                .header('Accept', 'application/json')
+                .body({
                     passwordreset: [{
                         token: 'invalid',
                         newPassword: 'thisissupersafe',
                         ne2Password: 'thisissupersafe'
                     }]
                 })
-                .expect(401);
+                .expectStatus(401);
 
             expect(res.body).to.matchSnapshot({
                 errors: [{
@@ -297,15 +297,15 @@ describe('Authentication API canary', function () {
 
             const res = await agent
                 .put('authentication/passwordreset')
-                .set('Accept', 'application/json')
-                .send({
+                .header('Accept', 'application/json')
+                .body({
                     passwordreset: [{
                         token: token,
                         newPassword: 'thisissupersafe',
                         ne2Password: 'thisissupersafe'
                     }]
                 })
-                .expect(400);
+                .expectStatus(400);
 
             expect(res.body).to.matchSnapshot({
                 errors: [{
@@ -328,15 +328,15 @@ describe('Authentication API canary', function () {
 
             const res = await agent
                 .put('authentication/passwordreset')
-                .set('Accept', 'application/json')
-                .send({
+                .header('Accept', 'application/json')
+                .body({
                     passwordreset: [{
                         token: token,
                         newPassword: 'thisissupersafe',
                         ne2Password: 'thisissupersafe'
                     }]
                 })
-                .expect(400);
+                .expectStatus(400);
 
             expect(res.body).to.matchSnapshot({
                 errors: [{
@@ -352,13 +352,13 @@ describe('Authentication API canary', function () {
         it('reset password: generate reset token', async function () {
             const res = await agent
                 .post('authentication/passwordreset')
-                .set('Accept', 'application/json')
-                .send({
+                .header('Accept', 'application/json')
+                .body({
                     passwordreset: [{
                         email: user.email
                     }]
                 })
-                .expect(200);
+                .expectStatus(200);
 
             expect(res.body).to.matchSnapshot();
             expect(res.headers).to.matchSnapshot({
@@ -391,9 +391,9 @@ describe('Authentication API canary', function () {
 
         it('reset all passwords returns 200', async function () {
             const res = await agent.post('authentication/reset_all_passwords')
-                .set('Accept', 'application/json')
-                .send({})
-                .expect(200);
+                .header('Accept', 'application/json')
+                .body({})
+                .expectStatus(200);
 
             expect(res.body).to.matchSnapshot();
             expect(res.headers).to.matchSnapshot({

--- a/test/regression/api/canary/admin/authentication.test.js.snap
+++ b/test/regression/api/canary/admin/authentication.test.js.snap
@@ -15,7 +15,6 @@ exports[`Authentication API canary Blog setup complete setup 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "434",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,
@@ -40,7 +39,6 @@ exports[`Authentication API canary Blog setup is setup? no 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "28",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,
@@ -64,7 +62,6 @@ exports[`Authentication API canary Blog setup is setup? yes 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "27",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,
@@ -90,7 +87,6 @@ exports[`Authentication API canary Blog setup update setup 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "506",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,
@@ -145,7 +141,6 @@ exports[`Authentication API canary Password reset reset password 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "64",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,
@@ -169,7 +164,6 @@ exports[`Authentication API canary Password reset reset password: expired token 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "260",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,
@@ -193,7 +187,6 @@ exports[`Authentication API canary Password reset reset password: generate reset
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "76",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,
@@ -217,7 +210,6 @@ exports[`Authentication API canary Password reset reset password: invalid token 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "314",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,
@@ -241,7 +233,6 @@ exports[`Authentication API canary Password reset reset password: unmatched toke
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "274",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,
@@ -257,7 +248,6 @@ exports[`Authentication API canary Reset all passwords reset all passwords retur
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "2",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,

--- a/test/regression/api/canary/admin/site.test.js.snap
+++ b/test/regression/api/canary/admin/site.test.js.snap
@@ -16,7 +16,6 @@ exports[`Config API can retrieve config and all expected properties 2`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "connection": "close",
   "content-length": "167",
   "content-type": "application/json; charset=utf-8",
   "date": Any<String>,

--- a/test/utils/e2e-framework.js
+++ b/test/utils/e2e-framework.js
@@ -27,7 +27,6 @@ const mockUtils = require('./e2e-framework-mock-utils');
 const boot = require('../../core/boot');
 const TestAgent = require('./test-agent');
 const db = require('./db-utils');
-const DataGenerator = require('./fixtures/data-generator');
 
 const startGhost = async () => {
     /**
@@ -115,19 +114,17 @@ const resetDb = async () => {
  * @returns {TestAgent}
  */
 const getAgent = async (apiURL) => {
-    const app = await startGhost();
-    const originURL = configUtils.config.get('url');
-    const ownerUser = {
-        email: DataGenerator.Content.users[0].email,
-        password: DataGenerator.Content.users[0].password
-    };
+    try {
+        const app = await startGhost();
+        const originURL = configUtils.config.get('url');
 
-    return new TestAgent({
-        apiURL,
-        app,
-        originURL,
-        ownerUser
-    });
+        return new TestAgent(app, {
+            apiURL,
+            originURL
+        });
+    } catch (error) {
+        throw new Error('Unable to create test agent');
+    }
 };
 
 // request agent

--- a/test/utils/test-agent.js
+++ b/test/utils/test-agent.js
@@ -1,60 +1,32 @@
-const supertest = require('supertest');
+const Agent = require('@tryghost/express-test');
 const errors = require('@tryghost/errors');
+const DataGenerator = require('./fixtures/data-generator');
 
-class TestAgent {
-    /**
-     * @constructor
-     * @param {Object} options
-     * @param {String} options.apiURL
-     * @param {String} options.originURL
-     * @param {Object} options.app  Ghost express app instance
-     * @param {Object} options.ownerUser owner used for login
-     * @param {String} options.ownerUser.email
-     * @param {String} options.ownerUser.password
-     */
-    constructor({apiURL, app, originURL, ownerUser}) {
-        this.API_URL = apiURL;
-        this.app = app;
-        this.originURL = originURL;
-        this.ownerUser = ownerUser;
-        this.request = supertest.agent(app);
-    }
+const ownerUser = {
+    email: DataGenerator.Content.users[0].email,
+    password: DataGenerator.Content.users[0].password
+};
 
-    /**
-     * Helper method to concatenate urls
-     * @NOTE: this is essentially a duplicate of our internal urljoin tool that is stuck in the too-big url-utils package atm
-     * @param {string} url
-     * @returns
-     */
-    makeUrl(url) {
-        // Join the base URL and the main url and remove any duplicate slashes
-        return `${this.API_URL}/${url}`.replace(/(^|[^:])\/\/+/g, '$1/');
-    }
-
-    // Forward get(), post(), put(), and delete() straight to the request agent & handle the URL
-    get(url) {
-        return this.request.get(this.makeUrl(url))
-            .set('Origin', this.originURL);
-    }
-
-    post(url) {
-        return this.request.post(this.makeUrl(url))
-            .set('Origin', this.originURL);
-    }
-
-    put(url) {
-        return this.request.put(this.makeUrl(url))
-            .set('Origin', this.originURL);
-    }
-
-    delete(url) {
-        return this.request.delete(this.makeUrl(url))
-            .set('Origin', this.originURL);
+/**
+ * @constructor
+ * @param {Object} app  Ghost express app instance
+ * @param {Object} options
+ * @param {String} options.apiURL
+ * @param {String} options.originURL
+ */
+class TestAgent extends Agent {
+    constructor(app, options) {
+        super(app, {
+            baseUrl: options.apiURL,
+            headers: {
+                origin: options.originURL
+            }
+        });
     }
 
     async loginAs(email, password) {
         await this.post('/session/')
-            .send({
+            .body({
                 grant_type: 'password',
                 username: email,
                 password: password
@@ -76,7 +48,7 @@ class TestAgent {
     }
 
     async loginAsOwner() {
-        await this.loginAs(this.ownerUser.email, this.ownerUser.password);
+        await this.loginAs(ownerUser.email, ownerUser.password);
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,6 +1399,14 @@
   resolved "https://registry.yarnpkg.com/@tryghost/express-dynamic-redirects/-/express-dynamic-redirects-0.2.4.tgz#ae11560e16ca9438778a8e9e8034e4c6e7507f6d"
   integrity sha512-i1/6SAgfdLRoJX6OCAh7mNm50TzKbWM6hf5W6yGUSAz1M99y+7VypnTkGoy+0XPefS3OgjBTEThYWnz4aimcbQ==
 
+"@tryghost/express-test@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/express-test/-/express-test-0.1.1.tgz#c94fec1009f88319a37ee6ae80ad11c94e0707bd"
+  integrity sha512-I7OFfCskpOXQjBmLYi+m044WSGYGNA9OCeGZVc0w+PcHf/8J19If6uqmqAbZtyEaNK4FaLzW12QoselFO5xd7g==
+  dependencies:
+    cookiejar "^2.1.3"
+    reqresnext "^1.6.6"
+
 "@tryghost/helpers@1.1.56":
   version "1.1.56"
   resolved "https://registry.yarnpkg.com/@tryghost/helpers/-/helpers-1.1.56.tgz#9599dd0d9a435077ee1053bf5c1877ff7c043040"
@@ -4852,7 +4860,7 @@ express-unless@^1.0.0:
   resolved "https://registry.yarnpkg.com/express-unless/-/express-unless-1.0.0.tgz#ecd1c354c5ccf7709a8a17ece617934e037cccd8"
   integrity sha512-zXSSClWBPfcSYjg0hcQNompkFN/MxQQ53eyrzm9BYgik2ut2I7PxAf2foVqBRMYCwWaZx/aWodi+uk76npdSAw==
 
-express@4.17.2, express@^4.16.4:
+express@4.17.2, express@^4.16.4, express@^4.17.2:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.2.tgz#c18369f265297319beed4e5558753cc8c1364cb3"
   integrity sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==
@@ -10008,6 +10016,15 @@ repeat-string@^1.5.4, repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
+reqresnext@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/reqresnext/-/reqresnext-1.6.6.tgz#ac35485e5910823b33ccd5153c298ce9558eb65f"
+  integrity sha512-gP3U2ZbjmICAAEPA923eeRgsFh1M1WLioa9Sqsphyu4wA2vcmoKzRC8olM7XfABxnt4guCMdujhm0aXJdDKlPg==
+  dependencies:
+    express "^4.17.2"
+    lodash "^4.17.21"
+    setprototypeof "^1.2.0"
+
 request-promise-core@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
@@ -10370,7 +10387,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setprototypeof@1.2.0:
+setprototypeof@1.2.0, setprototypeof@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==


### PR DESCRIPTION
refs: https://github.com/TryGhost/Toolbox/issues/158

- Authentication and Site are our two reference test suites where we're trying to set up a
  perfect example of what our e2e tests should look like
- This comit adds the new @tryghost/express-test package and wires it up to work in these tests
- The new package is similar to supertest but does not make http calls & therefore should be faster
- It has a similar chained API, with some modifications I propose make the tests more readable

