### PR TITLE
Handled default value in post for specific tier content visibility

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -54,9 +54,20 @@ Post = ghostBookshelf.Model.extend({
      */
     defaults: function defaults() {
         let visibility = 'public';
-
-        if (settingsCache.get('default_content_visibility')) {
-            visibility = settingsCache.get('default_content_visibility');
+        let tiers = [];
+        const defaultContentVisibility = settingsCache.get('default_content_visibility');
+        if (defaultContentVisibility) {
+            if (defaultContentVisibility === 'tiers') {
+                const tiersData = settingsCache.get('default_content_visibility_tiers') || [];
+                visibility = 'tiers',
+                tiers = tiersData.map((tierId) => {
+                    return {
+                        id: tierId
+                    };
+                });
+            } else if (defaultContentVisibility !== 'tiers') {
+                visibility = settingsCache.get('default_content_visibility');
+            }
         }
 
         return {
@@ -64,6 +75,7 @@ Post = ghostBookshelf.Model.extend({
             status: 'draft',
             featured: false,
             type: 'post',
+            tiers,
             visibility: visibility,
             email_recipient_filter: 'none'
         };


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1071

Default visibility for a post when set to specific tiers needs special handling as data for specific tiers is stored as an array of tiers on a pivot table. This change handles the default visibility for a new post when set to specific tiers to generate the right default values in model.
