### PR TITLE
Validate tier prices

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@tryghost/limit-service": "1.0.9",
     "@tryghost/logging": "2.0.3",
     "@tryghost/magic-link": "1.0.17",
-    "@tryghost/members-api": "4.8.13",
+    "@tryghost/members-api": "4.8.14",
     "@tryghost/members-importer": "0.5.0",
     "@tryghost/members-offers": "0.10.6",
     "@tryghost/members-ssr": "1.0.19",

--- a/test/e2e-api/admin/products.test.js
+++ b/test/e2e-api/admin/products.test.js
@@ -1,0 +1,69 @@
+const should = require('should');
+const sinon = require('sinon');
+const labs = require('../../../core/shared/labs');
+
+const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
+
+describe('Tiers API', function() {
+    let agent;
+
+    before(async function() {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('members');
+        await agent.loginAsOwner();
+    });
+
+    beforeEach(function() {
+        sinon.stub(labs, 'isSet').withArgs('multipleProducts').returns(false);
+        const stripeService = require('../../../core/server/services/stripe');
+        stripeService.api._configured = true;
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        const stripeService = require('../../../core/server/services/stripe');
+        stripeService.api._configured = false;
+    });
+
+    it('Errors when price is non-integer', async function () {
+        const tier = {
+            name: 'Blah',
+            monthly_price: {
+                amount: 99.99
+            }
+        };
+
+        await agent
+            .post('/products/')
+            .body({products: [tier]})
+            .expectStatus(422);
+    });
+
+    it('Errors when price is negative', async function () {
+        const tier = {
+            name: 'Blah',
+            monthly_price: {
+                amount: -100
+            }
+        };
+
+        await agent
+            .post('/products/')
+            .body({products: [tier]})
+            .expectStatus(422);
+    });
+
+    it('Errors when price is too large', async function () {
+        const tier = {
+            name: 'Blah',
+            monthly_price: {
+                amount: Number.MAX_SAFE_INTEGER
+            }
+        };
+
+        await agent
+            .post('/products/')
+            .body({products: [tier]})
+            .expectStatus(422);
+    });
+});

--- a/test/e2e-api/admin/products.test.js
+++ b/test/e2e-api/admin/products.test.js
@@ -4,16 +4,16 @@ const labs = require('../../../core/shared/labs');
 
 const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
 
-describe('Tiers API', function() {
+describe('Tiers API', function () {
     let agent;
 
-    before(async function() {
+    before(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('members');
         await agent.loginAsOwner();
     });
 
-    beforeEach(function() {
+    beforeEach(function () {
         sinon.stub(labs, 'isSet').withArgs('multipleProducts').returns(false);
         const stripeService = require('../../../core/server/services/stripe');
         stripeService.api._configured = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1848,10 +1848,10 @@
     "@tryghost/domain-events" "^0.1.6"
     "@tryghost/member-events" "^0.3.4"
 
-"@tryghost/members-api@4.8.13":
-  version "4.8.13"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-4.8.13.tgz#080a460ad154d7bb4965f4fb577479d4e19018ed"
-  integrity sha512-IIr1O3Yi52bBVV0aO/TxCwGD/JCHv7TT82PuCUt74b6Bq0IvCWz7iQXT80s2Sn8sTofhmIqzYLsSATYlhvJ79Q==
+"@tryghost/members-api@4.8.14":
+  version "4.8.14"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-4.8.14.tgz#45d94467992c609dafa8b19bffc5a658ced475c7"
+  integrity sha512-Ogq4BS8PjRjrEA6QeTnAd+Jq2JnjluePQJaVSLI1pTY7BoTghYwxvcmlFdJE4zx0KXtQoVeZbQg3UQbQhtKF8g==
   dependencies:
     "@nexes/nql" "^0.6.0"
     "@tryghost/debug" "^0.1.2"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1319

This updates the members-api to explicitly validate Tier prices rather
than deferring to Stripe and using whichever errors they throw.