### PR TITLE
Updated e2e framework

### DIFF
--- a/test/utils/e2e-framework.js
+++ b/test/utils/e2e-framework.js
@@ -149,10 +149,36 @@ const getAdminAPIAgent = async (options = {}) => {
     }
 };
 
+/**
+ * Creates a TestAgent which is a drop-in substitution for supertest
+ * It is automatically hooked up to the Members API so you can make requests to e.g.
+ * agent.get('/webhooks/stripe/') without having to worry about URL paths
+ *
+ * @returns {Promise<TestAgent>} agent
+ */
+const getMembersAPIAgent = async () => {
+    const bootOptions = {
+        frontend: true
+    };
+    try {
+        const app = await startGhost(bootOptions);
+        const originURL = configUtils.config.get('url');
+
+        return new TestAgent(app, {
+            apiURL: '/members/',
+            originURL
+        });
+    } catch (error) {
+        error.message = `Unable to create test agent. ${error.message}`;
+        throw error;
+    }
+};
+
 module.exports = {
     // request agent
     agentProvider: {
-        getAdminAPIAgent
+        getAdminAPIAgent,
+        getMembersAPIAgent
     },
 
     // Mocks and Stubs

--- a/test/utils/e2e-framework.js
+++ b/test/utils/e2e-framework.js
@@ -23,6 +23,7 @@ const uuid = require('uuid');
 const fixtureUtils = require('./fixture-utils');
 const redirectsUtils = require('./redirects');
 const configUtils = require('./configUtils');
+const urlServiceUtils = require('./url-service-utils');
 const mockManager = require('./e2e-framework-mock-manager');
 
 const boot = require('../../core/boot');
@@ -34,7 +35,7 @@ const db = require('./db-utils');
  * @param {Boolean} [options.backend] Boot the backend
  * @param {Boolean} [options.frontend] Boot the frontend
  * @param {Boolean} [options.server] Start a server
- * @returns {Express.Application} ghost
+ * @returns {Promise<Express.Application>} ghost
  */
 const startGhost = async (options = {}) => {
     /**
@@ -56,7 +57,15 @@ const startGhost = async (options = {}) => {
     // Ensure the DB state
     await resetDb();
 
-    return boot(Object.assign({}, defaults, options));
+    const bootOptions = Object.assign({}, defaults, options);
+
+    const ghostServer = await boot(bootOptions);
+
+    if (bootOptions.frontend) {
+        await urlServiceUtils.isFinished();
+    }
+
+    return ghostServer;
 };
 
 /**


### PR DESCRIPTION
- [Added getMembersAPIAgent to e2e-framework](https://github.com/TryGhost/Ghost/commit/1e5672496f314322fa75f2a67bf80d9b09179e47)

The Members API is served on a different endpoint to the Admin API, and
also requires that the frontend is booted. This agent is to be used when
testing the Members API, e.g. Stripe webhooks or Members config.

- [Fixed e2e-framework not waiting for Ghost to start](https://github.com/TryGhost/Ghost/commit/9e9533263555805f0945bd46d53e939860af5746)

Because we were returning the call to `boot`, rather than awaiting it,
it meant that once a test was provided with an API Agent the Ghost
application hadn't necessarily started. This was noticed whilst working
on the Members API which requires the frontend to be loaded.

When the frontend is loaded we must also wait for the url service to
have finished initialising, so that we do not run into 503 maintenance
errors when hitting the frontend.