### PR TITLE
🐛 Fixed {{t}} helper not working in combination with concat subexpression

### DIFF
--- a/core/frontend/services/theme-engine/i18n/i18n.js
+++ b/core/frontend/services/theme-engine/i18n/i18n.js
@@ -163,6 +163,7 @@ class I18n {
         const options = merge({log: true}, opts || {});
         let candidateString;
         let matchingString;
+        msgPath = msgPath.toString();
 
         // no path? no string
         if (msgPath.length === 0 || !isString(msgPath)) {


### PR DESCRIPTION
The following Handlebars expression does not work as expected: `{{t (concat label "-en")}}`.
The `concat` helper returns a `SafeString` which does not pass the `isString` in [i18n.js#L169](https://github.com/albogdano/Ghost/blob/1b0a69efdbc8902c14c66b9e3ce7be12ea634daf/core/frontend/services/theme-engine/i18n/i18n.js#L169).

Since we have no easy way of switching to another language from the clientside, the only way to easily add i18n support in a theme is to have a single `locale.json` file with strings for two or more languages like so:
```json
{
    "Home-en": "Home",
    "Home-de": "Anfang",
}
```
Then inside the `.hbs` templates, we can add `{{t (concat key (block "lang"))}}`. This simple change makes it possible to achieve that.

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)
