### PR TITLE
Removed unnecessary checks during initial DB init

### DIFF
--- a/core/server/data/migrations/init/1-create-tables.js
+++ b/core/server/data/migrations/init/1-create-tables.js
@@ -7,7 +7,10 @@ const schemaTables = Object.keys(schema);
 module.exports.up = async (options) => {
     const connection = options.connection;
 
-    await Promise.mapSeries(schemaTables, async (table) => {
+    const existingTables = await commands.getTables(connection);
+    const missingTables = schemaTables.filter(t => !existingTables.includes(t));
+
+    await Promise.mapSeries(missingTables, async (table) => {
         logging.info('Creating table: ' + table);
         await commands.createTable(table, connection);
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/202

- during DB init, we have to create all the tables
- right now we loop over all tables and call the `createTable` command
  - this command checks if the table exists and if not, creates the table
  - this works fine but it means we query the database for every table
  - in MySQL, we query the information_schema table, which we've seen
    issues with before because it doesn't have indexes
- the smarter thing to do here is to get all the tables that already exist,
  remove them from the list, and just straight up create them without
  further checks
- this entire thing should be protected by the migration lock so we
  shouldn't encounter issues from multiple processes initializing the DB
  and tables existing after the initial check
- this commit also removes the check from `createTable` because this isn't
  really needed. We should be using the migration utils, which do
  check for existing tables. I've added a note to the function and
  audited anywhere we still call the function
- this commit removes (- 49 tables + 1 initial check) 48 queries from
  the initial DB init