### PR TITLE
Backfilled the members `last_seen_at` column

### DIFF
--- a/core/server/data/migrations/versions/4.37/2022-02-21-09-53-backfill-members-last-seen-at-column.js
+++ b/core/server/data/migrations/versions/4.37/2022-02-21-09-53-backfill-members-last-seen-at-column.js
@@ -1,0 +1,31 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        if (knex.client.config.client === 'sqlite3') {
+            logging.warn('Skipping migration for SQLite3');
+            return;
+        }
+        logging.info('Backfilling the members.last_seen_at column from members_login_events.');
+        await knex.raw(`
+            UPDATE members
+                INNER JOIN (SELECT member_id as id, MAX(created_at) as last_seen_at
+                    FROM members_login_events
+                    GROUP BY member_id) as logins ON logins.id = members.id
+            SET
+                members.last_seen_at = logins.last_seen_at
+            WHERE
+                members.last_seen_at IS NULL
+                    OR members.last_seen_at < logins.last_seen_at
+        `);
+    },
+    async function down(knex) {
+        if (knex.client.config.client === 'sqlite3') {
+            logging.warn('Skipping migration for SQLite3');
+            return;
+        }
+        logging.info('Rolling back the backfilling of the members.last_seen_at column from members_login_events.');
+        await knex('members').update({last_seen_at: null});
+    }
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1305

- Skipped sqlite3 compatibility due to the lack of join support in update
- Uses a raw migration to improve performance

This PR takes into account the cases where there were a member login or not. And if there is already a `last_seen_at` value or not.
There should never be a `last_seen_at` value but I'm not sure what kind of convoluted migration flows could happen.

I've added a `down` function, which is great to test the migration. However in the future, `last_seen_at` will be changed based on several events (login, email open), so running the down migration could delete data that couldn't be recovered by the backfilling. So I'm ok to delete/empty the `down` function if you think I should.