### PR TITLE
Added `accentColor` and `description` parameters to `/authentication/setup` route

### DIFF
--- a/core/server/api/canary/authentication.js
+++ b/core/server/api/canary/authentication.js
@@ -42,6 +42,8 @@ module.exports = {
                         password: frame.data.setup[0].password,
                         blogTitle: frame.data.setup[0].blogTitle,
                         theme: frame.data.setup[0].theme,
+                        accentColor: frame.data.setup[0].accentColor,
+                        description: frame.data.setup[0].description,
                         status: 'active'
                     };
 

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -77,7 +77,7 @@ async function doSettings(data, settingsAPI) {
     const context = {context: {user: data.user.id}};
     const user = data.user;
     const blogTitle = data.userData.blogTitle;
-    const description = data.userData.description;
+    const description = data.userData.description ? data.userData.description.trim() : null;
 
     let userSettings;
 
@@ -85,13 +85,9 @@ async function doSettings(data, settingsAPI) {
         return user;
     }
 
-    if (!description || typeof description !== 'string') {
-        return user;
-    }
-
     userSettings = [
         {key: 'title', value: blogTitle.trim()},
-        {key: 'description', value: description.trim() || tpl(messages.sampleBlogDescription)}
+        {key: 'description', value: description || tpl(messages.sampleBlogDescription)}
     ];
 
     if (data.userData.accentColor) {

--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -77,6 +77,7 @@ async function doSettings(data, settingsAPI) {
     const context = {context: {user: data.user.id}};
     const user = data.user;
     const blogTitle = data.userData.blogTitle;
+    const description = data.userData.description;
 
     let userSettings;
 
@@ -84,10 +85,20 @@ async function doSettings(data, settingsAPI) {
         return user;
     }
 
+    if (!description || typeof description !== 'string') {
+        return user;
+    }
+
     userSettings = [
         {key: 'title', value: blogTitle.trim()},
-        {key: 'description', value: tpl(messages.sampleBlogDescription)}
+        {key: 'description', value: description.trim() || tpl(messages.sampleBlogDescription)}
     ];
+
+    if (data.userData.accentColor) {
+        userSettings.push({
+            key: 'accent_color', value: data.userData.accentColor
+        });
+    }
 
     await settingsAPI.edit({settings: userSettings}, context);
 

--- a/test/regression/api/admin/authentication.test.js
+++ b/test/regression/api/admin/authentication.test.js
@@ -48,7 +48,9 @@ describe('Authentication API', function () {
                         email: 'test@example.com',
                         password: 'thisissupersafe',
                         blogTitle: 'a test blog',
-                        theme: 'TryGhost/Dawn'
+                        theme: 'TryGhost/Dawn',
+                        accentColor: '#85FF00',
+                        description: 'Custom Site Description on Setup &mdash; great for everyone'
                     }]
                 })
                 .expectStatus(201)
@@ -70,7 +72,11 @@ describe('Authentication API', function () {
             assert.equal(requestMock.isDone(), true, 'The dawn github URL should have been used');
 
             const activeTheme = await settingsCache.get('active_theme');
+            const accentColor = await settingsCache.get('accent_color');
+            const description = await settingsCache.get('description');
             assert.equal(activeTheme, 'dawn', 'The theme dawn should have been installed');
+            assert.equal(accentColor, '#85FF00', 'The accent color should have been set');
+            assert.equal(description, 'Custom Site Description on Setup &mdash; great for everyone', 'The site description should have been set');
         });
 
         it('is setup? yes', async function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1382

- Added two possible new setup values: `accentColor` and `description` to define the brand colour and site description on initial setup
- Updated tests to reflect those changes
- Only the params when passed and fall back to default site description
