### PR TITLE
🐛 Fixed 500 error when creating product benefits without name

### DIFF
--- a/test/e2e-api/admin/products.test.js
+++ b/test/e2e-api/admin/products.test.js
@@ -64,4 +64,34 @@ describe('Tiers API', function () {
             .body({products: [tier]})
             .expectStatus(422);
     });
+
+    it('Errors when a benefit has an empty name', async function () {
+        const tier = {
+            name: 'Blah',
+            monthly_price: {
+                amount: 10
+            },
+            benefits: [{
+                name: ''
+            }]
+        };
+
+        await agent
+            .post('/products/')
+            .body({products: [tier]})
+            .expectStatus(422);
+    });
+
+    it('Errors when a product is edited with a benefit that has an empty name', async function () {
+        const tier = {
+            benefits: [{
+                name: ''
+            }]
+        };
+
+        await agent
+            .put('/products/' + fixtureManager.get('products', 0).id)
+            .body({products: [tier]})
+            .expectStatus(422);
+    });
 });

--- a/test/e2e-api/admin/products.test.js
+++ b/test/e2e-api/admin/products.test.js
@@ -1,4 +1,5 @@
 const should = require('should');
+const sinon = require('sinon');
 
 const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
 
@@ -16,6 +17,21 @@ describe('Tiers API', function () {
         const stripeService = require('../../../core/server/services/stripe');
         stripeService.api._configured = true;
         mockManager.mockStripe();
+
+        sinon
+            .stub(stripeService.api, 'createProduct')
+            .resolves({
+                id: 'prod_LFPlH9BDDwXcZ1'
+            });
+
+        sinon
+            .stub(stripeService.api, 'createPrice')
+            .resolves({
+                id: 'price_1KYpK92eZvKYlo2C86IrYSPM',
+                currency: 'usd',
+                nickname: null,
+                unit_amount: 299
+            });
     });
 
     afterEach(function () {

--- a/test/e2e-api/admin/products.test.js
+++ b/test/e2e-api/admin/products.test.js
@@ -15,6 +15,7 @@ describe('Tiers API', function () {
         mockManager.mockLabsDisabled('multipleProducts');
         const stripeService = require('../../../core/server/services/stripe');
         stripeService.api._configured = true;
+        mockManager.mockStripe();
     });
 
     afterEach(function () {
@@ -63,6 +64,23 @@ describe('Tiers API', function () {
             .post('/products/')
             .body({products: [tier]})
             .expectStatus(422);
+    });
+
+    it('Create a new tier with benefits', async function () {
+        const tier = {
+            name: 'Blah',
+            monthly_price: {
+                amount: 10
+            },
+            benefits: [{
+                name: 'This is a benefit'
+            }]
+        };
+
+        await agent
+            .post('/products/')
+            .body({products: [tier]})
+            .expectStatus(201);
     });
 
     it('Errors when a benefit has an empty name', async function () {

--- a/test/utils/e2e-framework-mock-manager.js
+++ b/test/utils/e2e-framework-mock-manager.js
@@ -11,7 +11,6 @@ let emailCount = 0;
 
 // Mockable services
 const mailService = require('../../core/server/services/mail/index');
-const stripeService = require('../../core/server/services/stripe/index');
 const labs = require('../../core/shared/labs');
 
 const mockMail = () => {
@@ -24,20 +23,6 @@ const mockMail = () => {
 
 const mockStripe = () => {
     nock.disableNetConnect();
-    mocks.stripe = sinon
-        .stub(stripeService.api, 'createProduct')
-        .resolves({
-            id: 'prod_LFPlH9BDDwXcZ1'
-        });
-
-    mocks.stripe = sinon
-        .stub(stripeService.api, 'createPrice')
-        .resolves({
-            id: 'price_1KYpK92eZvKYlo2C86IrYSPM',
-            currency: 'usd',
-            nickname: null,
-            unit_amount: 299
-        });
 };
 
 const mockLabsEnabled = (flag, alpha = true) => {

--- a/test/utils/e2e-framework-mock-manager.js
+++ b/test/utils/e2e-framework-mock-manager.js
@@ -11,6 +11,7 @@ let emailCount = 0;
 
 // Mockable services
 const mailService = require('../../core/server/services/mail/index');
+const stripeService = require('../../core/server/services/stripe/index');
 const labs = require('../../core/shared/labs');
 
 const mockMail = () => {
@@ -23,6 +24,20 @@ const mockMail = () => {
 
 const mockStripe = () => {
     nock.disableNetConnect();
+    mocks.stripe = sinon
+        .stub(stripeService.api, 'createProduct')
+        .resolves({
+            id: 'prod_LFPlH9BDDwXcZ1'
+        });
+
+    mocks.stripe = sinon
+        .stub(stripeService.api, 'createPrice')
+        .resolves({
+            id: 'price_1KYpK92eZvKYlo2C86IrYSPM',
+            currency: 'usd',
+            nickname: null,
+            unit_amount: 299
+        });
 };
 
 const mockLabsEnabled = (flag, alpha = true) => {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1188

The products API currently returns a 500 error when you try to store product benefits with an empty name. This should throw a 422 Validation Error instead.

- Updated bookshelf-relations to 2.4.0, which includes a fix for this issue (validation error was not rethrown correctly)
- Added test when creating a new product with an empty benefit name
- Added test when updating an existing product with new benefits, with an empty name
- Added a test that creates a new product with benefits