### PR TITLE
Ignore casper install on setup

### DIFF
--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -164,6 +164,11 @@ async function installTheme(data, api) {
         return data;
     }
 
+    if (themeName.toLowerCase() === 'tryghost/casper') {
+        logging.warn('Skipping theme install as Casper is the default theme.');
+        return data;
+    }
+
     // Use the api instead of the services as the api performs extra logic
     try {
         const installResults = await api.themes.install({

--- a/test/regression/api/admin/__snapshots__/authentication.test.js.snap
+++ b/test/regression/api/admin/__snapshots__/authentication.test.js.snap
@@ -71,6 +71,48 @@ Object {
 }
 `;
 
+exports[`Authentication API Blog setup complete setup with default theme 1: [body] 1`] = `
+Object {
+  "users": Array [
+    Object {
+      "accessibility": null,
+      "bio": null,
+      "cover_image": null,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "test@example.com",
+      "facebook": null,
+      "id": "1",
+      "last_seen": null,
+      "location": null,
+      "meta_description": null,
+      "meta_title": null,
+      "name": "test user",
+      "profile_image": null,
+      "slug": "test",
+      "status": "active",
+      "tour": null,
+      "twitter": null,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+      "website": null,
+    },
+  ],
+}
+`;
+
+exports[`Authentication API Blog setup complete setup with default theme 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "434",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Authentication API Blog setup is setup? no 1: [body] 1`] = `
 Object {
   "setup": Array [

--- a/test/regression/api/admin/authentication.test.js
+++ b/test/regression/api/admin/authentication.test.js
@@ -35,8 +35,8 @@ describe('Authentication API', function () {
         });
 
         it('complete setup', async function () {
-            const email = 'test@example.com'
-            const password = 'thisissupersafe'
+            const email = 'test@example.com';
+            const password = 'thisissupersafe';
 
             const requestMock = nock('https://api.github.com')
                 .get('/repos/tryghost/dawn/zipball')
@@ -82,12 +82,12 @@ describe('Authentication API', function () {
             assert.equal(description, 'Custom Site Description on Setup &mdash; great for everyone', 'The site description should have been set');
 
             // Test that we would not show any notifications (errors) to the user
-            await agent.loginAs(email, password)
+            await agent.loginAs(email, password);
             await agent
                 .get('notifications/')
                 .expectStatus(200)
                 .expect(({body}) => {
-                    assert.deepEqual(body.notifications, [], "The setup should not create notifications");
+                    assert.deepEqual(body.notifications, [], 'The setup should not create notifications');
                 });
         });
 
@@ -150,17 +150,17 @@ describe('Authentication API', function () {
         });
 
         it('complete setup with default theme', async function () {
-            const agent = await agentProvider.getAdminAPIAgent()
+            const cleanAgent = await agentProvider.getAdminAPIAgent();
 
-            const email = 'test@example.com'
-            const password = 'thisissupersafe'
+            const email = 'test@example.com';
+            const password = 'thisissupersafe';
 
             const requestMock = nock('https://api.github.com')
                 .get('/repos/tryghost/casper/zipball')
                 .query(true)
                 .replyWithFile(200, __dirname + '/../../../utils/fixtures/themes/valid.zip');
 
-            await agent
+            await cleanAgent
                 .post('authentication/setup')
                 .body({
                     setup: [{
@@ -199,12 +199,12 @@ describe('Authentication API', function () {
             assert.equal(description, 'Custom Site Description on Setup &mdash; great for everyone', 'The site description should have been set');
 
             // Test that we would not show any notifications (errors) to the user
-            await agent.loginAs(email, password)
-            await agent
+            await cleanAgent.loginAs(email, password);
+            await cleanAgent
                 .get('notifications/')
                 .expectStatus(200)
                 .expect(({body}) => {
-                    assert.deepEqual(body.notifications, [], "The setup should not create notifications");
+                    assert.deepEqual(body.notifications, [], 'The setup should not create notifications');
                 });
         });
     });

--- a/test/regression/api/admin/authentication.test.js
+++ b/test/regression/api/admin/authentication.test.js
@@ -35,6 +35,9 @@ describe('Authentication API', function () {
         });
 
         it('complete setup', async function () {
+            const email = 'test@example.com'
+            const password = 'thisissupersafe'
+
             const requestMock = nock('https://api.github.com')
                 .get('/repos/tryghost/dawn/zipball')
                 .query(true)
@@ -45,8 +48,8 @@ describe('Authentication API', function () {
                 .body({
                     setup: [{
                         name: 'test user',
-                        email: 'test@example.com',
-                        password: 'thisissupersafe',
+                        email,
+                        password,
                         blogTitle: 'a test blog',
                         theme: 'TryGhost/Dawn',
                         accentColor: '#85FF00',
@@ -67,7 +70,7 @@ describe('Authentication API', function () {
             // Test our side effects
             mockManager.assert.sentEmail({
                 subject: 'Your New Ghost Site',
-                to: 'test@example.com'
+                to: email
             });
             assert.equal(requestMock.isDone(), true, 'The dawn github URL should have been used');
 
@@ -77,6 +80,15 @@ describe('Authentication API', function () {
             assert.equal(activeTheme, 'dawn', 'The theme dawn should have been installed');
             assert.equal(accentColor, '#85FF00', 'The accent color should have been set');
             assert.equal(description, 'Custom Site Description on Setup &mdash; great for everyone', 'The site description should have been set');
+
+            // Test that we would not show any notifications (errors) to the user
+            await agent.loginAs(email, password)
+            await agent
+                .get('notifications/')
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.deepEqual(body.notifications, [], "The setup should not create notifications");
+                });
         });
 
         it('is setup? yes', async function () {
@@ -134,6 +146,65 @@ describe('Authentication API', function () {
                 })
                 .matchHeaderSnapshot({
                     etag: anyEtag
+                });
+        });
+
+        it('complete setup with default theme', async function () {
+            const agent = await agentProvider.getAdminAPIAgent()
+
+            const email = 'test@example.com'
+            const password = 'thisissupersafe'
+
+            const requestMock = nock('https://api.github.com')
+                .get('/repos/tryghost/casper/zipball')
+                .query(true)
+                .replyWithFile(200, __dirname + '/../../../utils/fixtures/themes/valid.zip');
+
+            await agent
+                .post('authentication/setup')
+                .body({
+                    setup: [{
+                        name: 'test user',
+                        email,
+                        password,
+                        blogTitle: 'a test blog',
+                        theme: 'TryGhost/Casper',
+                        accentColor: '#85FF00',
+                        description: 'Custom Site Description on Setup &mdash; great for everyone'
+                    }]
+                })
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    users: [{
+                        created_at: anyDate,
+                        updated_at: anyDate
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    etag: anyEtag
+                });
+
+            // Test our side effects
+            mockManager.assert.sentEmail({
+                subject: 'Your New Ghost Site',
+                to: email
+            });
+            assert.equal(requestMock.isDone(), false, 'The ghost github URL should not have been used');
+
+            const activeTheme = await settingsCache.get('active_theme');
+            const accentColor = await settingsCache.get('accent_color');
+            const description = await settingsCache.get('description');
+            assert.equal(activeTheme, 'casper', 'The theme casper should have been installed');
+            assert.equal(accentColor, '#85FF00', 'The accent color should have been set');
+            assert.equal(description, 'Custom Site Description on Setup &mdash; great for everyone', 'The site description should have been set');
+
+            // Test that we would not show any notifications (errors) to the user
+            await agent.loginAs(email, password)
+            await agent
+                .get('notifications/')
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.deepEqual(body.notifications, [], "The setup should not create notifications");
                 });
         });
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1362

- Casper is already installed, so the installation from github always fail.
- There is no need to display an error message in that case.
