### PR TITLE
Added /tiers endpoint to Content API

### DIFF
--- a/core/frontend/helpers/get.js
+++ b/core/frontend/helpers/get.js
@@ -31,6 +31,9 @@ const RESOURCES = {
     },
     authors: {
         alias: 'authorsPublic'
+    },
+    tiers: {
+        alias: 'tiersPublic'
     }
 };
 

--- a/core/server/api/canary/index.js
+++ b/core/server/api/canary/index.js
@@ -207,5 +207,9 @@ module.exports = {
 
     get productsPublic() {
         return shared.pipeline(require('./products-public'), localUtils, 'content');
+    },
+
+    get tiersPublic() {
+        return shared.pipeline(require('./tiers-public'), localUtils, 'content');
     }
 };

--- a/core/server/api/canary/tiers-public.js
+++ b/core/server/api/canary/tiers-public.js
@@ -1,0 +1,34 @@
+// NOTE: We must not cache references to membersService.api
+// as it is a getter and may change during runtime.
+const membersService = require('../../services/members');
+
+const allowedIncludes = ['monthly_price', 'yearly_price', 'benefits'];
+
+module.exports = {
+    docName: 'tiers',
+
+    browse: {
+        options: [
+            'limit',
+            'fields',
+            'include',
+            'filter',
+            'order',
+            'debug',
+            'page'
+        ],
+        permissions: true,
+        validation: {
+            options: {
+                include: {
+                    values: allowedIncludes
+                }
+            }
+        },
+        async query(frame) {
+            const page = await membersService.api.productRepository.list(frame.options);
+
+            return page;
+        }
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/products.js
+++ b/core/server/api/canary/utils/serializers/output/products.js
@@ -74,6 +74,7 @@ function serializeProduct(product, options, apiType) {
         description: json.description,
         slug: json.slug,
         active: json.active,
+        visible: json.visible,
         type: json.type,
         welcome_page_url: json.welcome_page_url,
         created_at: json.created_at,

--- a/core/server/api/canary/utils/serializers/output/tiers.js
+++ b/core/server/api/canary/utils/serializers/output/tiers.js
@@ -81,7 +81,8 @@ function serializeTier(tier, options, apiType) {
         stripe_prices: json.stripePrices ? json.stripePrices.map(price => serializeStripePrice(price, hideStripeData)) : null,
         monthly_price: serializeStripePrice(json.monthlyPrice, hideStripeData),
         yearly_price: serializeStripePrice(json.yearlyPrice, hideStripeData),
-        benefits: json.benefits || null
+        benefits: json.benefits || null,
+        visible: json.visible
     };
 
     return serialized;

--- a/core/server/web/api/canary/content/routes.js
+++ b/core/server/web/api/canary/content/routes.js
@@ -34,6 +34,7 @@ module.exports = function apiRoutes() {
     router.get('/settings', mw.authenticatePublic, http(api.publicSettings.browse));
 
     router.get('/products', mw.authenticatePublic, http(api.productsPublic.browse));
+    router.get('/tiers', mw.authenticatePublic, http(api.tiersPublic.browse));
 
     return router;
 };

--- a/test/e2e-api/admin/__snapshots__/tiers.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/tiers.test.js.snap
@@ -24,6 +24,7 @@ Object {
       "stripe_prices": null,
       "type": "free",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "visible": false,
       "welcome_page_url": "/welcome-free",
     },
     Object {
@@ -37,6 +38,7 @@ Object {
       "stripe_prices": null,
       "type": "paid",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "visible": false,
       "welcome_page_url": "/welcome-paid",
     },
   ],

--- a/test/e2e-api/content/__snapshots__/tiers.test.js.snap
+++ b/test/e2e-api/content/__snapshots__/tiers.test.js.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tiers Content API Can request tiers 1: [body] 1`] = `
+Object {
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 2,
+    },
+  },
+  "tiers": Array [
+    Object {
+      "active": true,
+      "benefits": null,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "description": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "name": "Free",
+      "slug": "free",
+      "stripe_prices": null,
+      "type": "free",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "visible": false,
+      "welcome_page_url": "/welcome-free",
+    },
+    Object {
+      "active": true,
+      "benefits": null,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "description": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "name": "Default Product",
+      "slug": "default-product",
+      "stripe_prices": null,
+      "type": "paid",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "visible": false,
+      "welcome_page_url": "/welcome-paid",
+    },
+  ],
+}
+`;
+
+exports[`Tiers Content API Can request tiers 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "643",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Tiers Content API Can request tiers 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "675",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/test/e2e-api/content/tiers.test.js
+++ b/test/e2e-api/content/tiers.test.js
@@ -1,0 +1,26 @@
+const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+
+describe('Tiers Content API', function () {
+    let agent;
+
+    before(async function () {
+        agent = await agentProvider.getContentAPIAgent();
+        await fixtureManager.init('members', 'api_keys');
+        agent.authenticate();
+    });
+
+    it('Can request tiers', async function () {
+        await agent.get('/tiers/')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                etag: matchers.anyEtag
+            })
+            .matchBodySnapshot({
+                tiers: Array(2).fill({
+                    id: matchers.anyObjectId,
+                    created_at: matchers.anyISODate,
+                    updated_at: matchers.anyISODate
+                })
+            });
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1313

When adding the tiers endpoint the Content API was missed, this is
needed so that themes can access Tiers via the `{{#get}}` helper.