### PR TITLE
Added visible column to products table

### DIFF
--- a/core/server/data/migrations/versions/4.38/2022-03-01-08-46-add-visibility-to-tiers.js
+++ b/core/server/data/migrations/versions/4.38/2022-03-01-08-46-add-visibility-to-tiers.js
@@ -3,5 +3,5 @@ const {createAddColumnMigration} = require('../../utils');
 module.exports = createAddColumnMigration('products', 'visible', {
     type: 'boolean',
     nullable: false,
-    defaultTo: true
+    defaultTo: false
 });

--- a/core/server/data/migrations/versions/4.38/2022-03-01-08-46-add-visibility-to-tiers.js
+++ b/core/server/data/migrations/versions/4.38/2022-03-01-08-46-add-visibility-to-tiers.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('products', 'visible', {
+    type: 'boolean',
+    nullable: false,
+    defaultTo: true
+});

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -7,13 +7,15 @@
                     "name":             "Free",
                     "slug":             "free",
                     "type":             "free",
-                    "active":           true
+                    "active":           true,
+                    "visible":          true
                 },
                 {
                     "name":             "Default Product",
                     "slug":             "default-product",
                     "type":             "paid",
-                    "active":           true
+                    "active":           true,
+                    "visible":          true
                 }
             ]
         },

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -381,7 +381,7 @@ module.exports = {
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
         active: {type: 'boolean', nullable: false, defaultTo: true},
         welcome_page_url: {type: 'string', maxlength: 2000, nullable: true},
-        visible: {type: 'boolean', nullable: false, defaultTo: true},
+        visible: {type: 'boolean', nullable: false, defaultTo: false},
         monthly_price_id: {type: 'string', maxlength: 24, nullable: true},
         yearly_price_id: {type: 'string', maxlength: 24, nullable: true},
         description: {type: 'string', maxlength: 191, nullable: true},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -381,6 +381,7 @@ module.exports = {
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
         active: {type: 'boolean', nullable: false, defaultTo: true},
         welcome_page_url: {type: 'string', maxlength: 2000, nullable: true},
+        visible: {type: 'boolean', nullable: false, defaultTo: true},
         monthly_price_id: {type: 'string', maxlength: 24, nullable: true},
         yearly_price_id: {type: 'string', maxlength: 24, nullable: true},
         description: {type: 'string', maxlength: 191, nullable: true},

--- a/core/server/models/product.js
+++ b/core/server/models/product.js
@@ -5,7 +5,8 @@ const Product = ghostBookshelf.Model.extend({
     tableName: 'products',
 
     defaults: {
-        active: true
+        active: true,
+        visible: false
     },
 
     relationships: ['benefits'],

--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -561,7 +561,7 @@ exports[`Members API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8211",
+  "content-length": "8275",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1032,7 +1032,7 @@ exports[`Members API Can filter by paid status 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "6676",
+  "content-length": "6740",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2210,7 +2210,7 @@ exports[`Members API Search for paid members retrieves member with email paid@te
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1660",
+  "content-length": "1676",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,8 +35,8 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c8442427463a0bf25ecca871b01016dc';
-    const currentFixturesHash = 'beb040c0376a492c2a44767fdd825a3e';
+    const currentSchemaHash = '0bbdeb5993fc2b84fac68acb419d41b9';
+    const currentFixturesHash = '72eb92cf78dd7c3fe12ba5c3d59498ba';
     const currentSettingsHash = '437d4c6da8759f5c35f11f811b86e5bc';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1387

We are moving away from the portal_products setting to instead store
each tiers visiblity on the Tier itself. This column will be used for
that data.

Both of the default Tiers should be visible, but newly created tiers
should not be.