### PR TITLE
Switched to util for retrieving DB info in migrations

### DIFF
--- a/core/server/data/migrations/versions/3.29/01-remove-duplicate-subscriptions.js
+++ b/core/server/data/migrations/versions/3.29/01-remove-duplicate-subscriptions.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = {
     config: {
@@ -6,7 +7,7 @@ module.exports = {
     },
 
     async up({transacting: knex}) {
-        if (knex.client.config.client !== 'mysql') {
+        if (!DatabaseInfo.isMySQL(knex)) {
             logging.warn('Skipping cleanup of duplicate subscriptions - database is not MySQL');
             return;
         }

--- a/core/server/data/migrations/versions/3.29/02-remove-duplicate-customers.js
+++ b/core/server/data/migrations/versions/3.29/02-remove-duplicate-customers.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = {
     config: {
@@ -6,7 +7,7 @@ module.exports = {
     },
 
     async up({transacting: knex}) {
-        if (knex.client.config.client !== 'mysql') {
+        if (!DatabaseInfo.isMySQL(knex)) {
             logging.warn('Skipping cleanup of duplicate customers - database is not MySQL');
             return;
         }

--- a/core/server/data/migrations/versions/3.29/03-remove-orphaned-customers.js
+++ b/core/server/data/migrations/versions/3.29/03-remove-orphaned-customers.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = {
     config: {
@@ -6,7 +7,7 @@ module.exports = {
     },
 
     async up({transacting: knex}) {
-        if (knex.client.config.client !== 'mysql') {
+        if (!DatabaseInfo.isMySQL(knex)) {
             logging.warn('Skipping cleanup of orphaned customers - database is not MySQL');
             return;
         }

--- a/core/server/data/migrations/versions/3.29/04-remove-orphaned-subscriptions.js
+++ b/core/server/data/migrations/versions/3.29/04-remove-orphaned-subscriptions.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = {
     config: {
@@ -6,7 +7,7 @@ module.exports = {
     },
 
     async up({transacting: knex}) {
-        if (knex.client.config.client !== 'mysql') {
+        if (!DatabaseInfo.isMySQL(knex)) {
             logging.warn('Skipping cleanup of orphaned subscriptions - database is not MySQL');
             return;
         }

--- a/core/server/data/migrations/versions/3.29/05-add-member-constraints.js
+++ b/core/server/data/migrations/versions/3.29/05-add-member-constraints.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = {
     config: {
@@ -6,7 +7,7 @@ module.exports = {
     },
 
     async up({transacting: knex}) {
-        if (knex.client.config.client !== 'mysql') {
+        if (!DatabaseInfo.isMySQL(knex)) {
             return logging.warn('Skipping member tables index creation - database is not MySQL');
         }
 
@@ -91,7 +92,7 @@ module.exports = {
     },
 
     async down({transacting: knex}) {
-        if (knex.client.config.client !== 'mysql') {
+        if (!DatabaseInfo.isMySQL(knex)) {
             return logging.warn('Skipping member tables index removal - database is not MySQL');
         }
 

--- a/core/server/data/migrations/versions/4.0/14-remove-orphaned-stripe-records.js
+++ b/core/server/data/migrations/versions/4.0/14-remove-orphaned-stripe-records.js
@@ -1,8 +1,9 @@
 const {createIrreversibleMigration} = require('../../utils');
 const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createIrreversibleMigration(async function up(connection) {
-    if (connection.client.config.client === 'mysql') {
+    if (DatabaseInfo.isMySQL(connection)) {
         logging.info('Skipping removal of orphaned stripe records for MySQL');
         return;
     }

--- a/core/server/data/migrations/versions/4.0/26-add-cascade-on-delete.js
+++ b/core/server/data/migrations/versions/4.0/26-add-cascade-on-delete.js
@@ -1,9 +1,10 @@
 const logging = require('@tryghost/logging');
 const {createIrreversibleMigration} = require('../../utils');
 const {addForeign, dropForeign} = require('../../../schema/commands');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createIrreversibleMigration(async (knex) => {
-    if (knex.client.config.client !== 'sqlite3') {
+    if (!DatabaseInfo.isSQLite(knex)) {
         return logging.warn('Skipping adding "on delete cascade" - database is not SQLite3');
     }
 

--- a/core/server/data/migrations/versions/4.0/29-fix-foreign-key-for-members-stripe-customers-subscriptions.js
+++ b/core/server/data/migrations/versions/4.0/29-fix-foreign-key-for-members-stripe-customers-subscriptions.js
@@ -1,9 +1,10 @@
 const logging = require('@tryghost/logging');
 const {createIrreversibleMigration} = require('../../utils');
 const {addForeign, dropForeign} = require('../../../schema/commands');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createIrreversibleMigration(async (knex) => {
-    if (knex.client.config.client !== 'sqlite3') {
+    if (!DatabaseInfo.isSQLite(knex)) {
         return logging.warn('Skipping fixing foreign key for members_stripe_customers_subscriptions - database is not SQLite3');
     }
 

--- a/core/server/data/migrations/versions/4.1/02-add-unique-constraint-for-member-stripe-tables.js
+++ b/core/server/data/migrations/versions/4.1/02-add-unique-constraint-for-member-stripe-tables.js
@@ -1,10 +1,11 @@
 const logging = require('@tryghost/logging');
 const {createTransactionalMigration} = require('../../utils');
 const {addUnique} = require('../../../schema/commands');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createTransactionalMigration(
     async function up(connection) {
-        if (connection.client.config.client !== 'sqlite3') {
+        if (!DatabaseInfo.isSQLite(connection)) {
             return logging.warn('Skipping adding unique constraint for members_stripe_customers_subscriptions and members_stripe_customers - database is not SQLite3');
         }
 

--- a/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
+++ b/core/server/data/migrations/versions/4.20/05-remove-not-null-constraint-from-portal-title.js
@@ -1,6 +1,7 @@
 const logging = require('@tryghost/logging');
 const {createNonTransactionalMigration} = require('../../utils');
 const {addUnique} = require('../../../schema/commands');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createNonTransactionalMigration(
     async function up(knex) {
@@ -14,7 +15,7 @@ module.exports = createNonTransactionalMigration(
             table.string('portal_title', 191).nullable();
         });
 
-        if (knex.client.config.client === 'sqlite3') {
+        if (DatabaseInfo.isSQLite(knex)) {
             // eslint-disable-next-line no-restricted-syntax
             for (const column of ['name', 'code', 'stripe_coupon_id']) {
                 await addUnique('offers', column, knex);
@@ -32,7 +33,7 @@ module.exports = createNonTransactionalMigration(
             table.string('portal_title', 191).notNullable();
         });
 
-        if (knex.client.config.client === 'sqlite3') {
+        if (DatabaseInfo.isSQLite(knex)) {
             // eslint-disable-next-line no-restricted-syntax
             for (const column of ['name', 'code', 'stripe_coupon_id']) {
                 await addUnique('offers', column, knex);

--- a/core/server/data/migrations/versions/4.33/2022-01-18-09-07-remove-duplicate-offer-redemptions.js
+++ b/core/server/data/migrations/versions/4.33/2022-01-18-09-07-remove-duplicate-offer-redemptions.js
@@ -1,10 +1,10 @@
 const logging = require('@tryghost/logging');
-
 const {createTransactionalMigration} = require('../../utils');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
-        if (knex.client.config.client !== 'mysql') {
+        if (!DatabaseInfo.isMySQL(knex)) {
             logging.warn('Skipping cleanup of duplicate offer redemptions - database is not MySQL');
             return;
         }

--- a/core/server/data/migrations/versions/4.35/2022-02-01-11-48-update-email-recipient-filter-column-type.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-01-11-48-update-email-recipient-filter-column-type.js
@@ -1,9 +1,10 @@
 const logging = require('@tryghost/logging');
 const {createNonTransactionalMigration} = require('../../utils');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createNonTransactionalMigration(
     async function up(knex) {
-        if (knex.client.config.client === 'sqlite3') {
+        if (DatabaseInfo.isSQLite(knex)) {
             logging.warn('Skipping migration for SQLite3');
             return;
         }

--- a/core/server/data/migrations/versions/4.35/2022-02-01-12-03-update-recipient-filter-column-type.js
+++ b/core/server/data/migrations/versions/4.35/2022-02-01-12-03-update-recipient-filter-column-type.js
@@ -1,9 +1,10 @@
 const logging = require('@tryghost/logging');
 const {createNonTransactionalMigration} = require('../../utils');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createNonTransactionalMigration(
     async function up(knex) {
-        if (knex.client.config.client === 'sqlite3') {
+        if (DatabaseInfo.isSQLite(knex)) {
             logging.warn('Skipping migration for SQLite3');
             return;
         }

--- a/core/server/data/migrations/versions/4.37/2022-02-21-09-53-backfill-members-last-seen-at-column.js
+++ b/core/server/data/migrations/versions/4.37/2022-02-21-09-53-backfill-members-last-seen-at-column.js
@@ -1,9 +1,10 @@
 const logging = require('@tryghost/logging');
 const {createTransactionalMigration} = require('../../utils');
+const DatabaseInfo = require('@tryghost/database-info');
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
-        if (knex.client.config.client === 'sqlite3') {
+        if (DatabaseInfo.isSQLite(knex)) {
             logging.warn('Skipping migration for SQLite3');
             return;
         }
@@ -21,7 +22,7 @@ module.exports = createTransactionalMigration(
         `);
     },
     async function down(knex) {
-        if (knex.client.config.client === 'sqlite3') {
+        if (DatabaseInfo.isSQLite(knex)) {
             logging.warn('Skipping migration for SQLite3');
             return;
         }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@tryghost/config-url-helpers": "0.1.4",
     "@tryghost/constants": "1.0.1",
     "@tryghost/custom-theme-settings-service": "0.3.1",
-    "@tryghost/database-info": "0.1.0",
+    "@tryghost/database-info": "0.2.4",
     "@tryghost/debug": "0.1.13",
     "@tryghost/email-analytics-provider-mailgun": "1.0.7",
     "@tryghost/email-analytics-service": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1891,10 +1891,10 @@
     "@tryghost/tpl" "^0.1.4"
     lodash "^4.17.21"
 
-"@tryghost/database-info@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/database-info/-/database-info-0.1.0.tgz#881e47e802fc2ae321d8c42d17a2a1cb8e4da143"
-  integrity sha512-3Nwo6pGR8yXrhSky2Uikz8oEKJsBLuaG68rcwIsMB6kFoWR3q7uAMWPvw3jIzVNnkZE1FQPb36w4z1t/v7dujw==
+"@tryghost/database-info@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@tryghost/database-info/-/database-info-0.2.4.tgz#83ca8976878f5a8eb8b1b3b229294252932bcbe0"
+  integrity sha512-zIV0IPpHXvH8ThuMpO9JhbUy8tntBnlF+UIon5KtryZq6F91n0lf/ZGpvvm+7X4kduTQQsIk26/S3UzrI88LeA==
 
 "@tryghost/debug@0.1.10":
   version "0.1.10"


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/174

- right now, our migrations manually check the client of the knex
  instance to see whether we're running on MySQL or SQLite
- that's been working fine, but the problem is that we're due to switch
  to the mysql2 driver soon, so all these checks will be faulty
- i've altered the functionality of `@tryghost/database-info` to accept
  a knex instance, and it'll return if the DB is MySQL or SQLite in some
  helper functions
- this commit bumps the package and switches to that format
- originally I used a shared instance of the class within
  `@tryghost/database-info` but there's a chance that the knex instance
  inside migrations actually comes from knex-migrator, and not Ghost, so
  that wouldn't work