### PR TITLE
Various changes needed for MySQL2

### DIFF
--- a/core/server/data/db/connection.js
+++ b/core/server/data/db/connection.js
@@ -33,7 +33,7 @@ function configure(dbConfig) {
     }
 
     if (client === 'mysql') {
-        dbConfig.connection.timezone = 'UTC';
+        dbConfig.connection.timezone = 'Z';
         dbConfig.connection.charset = 'utf8mb4';
 
         // NOTE: disabled so that worker processes can use the db without

--- a/core/server/data/schema/clients/index.js
+++ b/core/server/data/schema/clients/index.js
@@ -3,5 +3,6 @@ const mysql = require('./mysql');
 
 module.exports = {
     sqlite3: sqlite3,
-    mysql: mysql
+    mysql: mysql, //TODO: remove this once we switch to `mysql2`
+    mysql2: mysql
 };


### PR DESCRIPTION
- whilst `UTC` was working, it's technically not supported as per the
  docs for `mysql`: https://www.npmjs.com/package/mysql#connection-options
- `mysql2`, however, is a bit more strict and throws a warning for
  unsupported values, so it was flagging up when I was looking at
  switching to that library
- this commit switches over to `Z` AKA Zulu -
  https://en.wikipedia.org/wiki/Coordinated_Universal_Time so both
  libraries are happy