### PR TITLE
Switched products.visible for products.visibility

### DIFF
--- a/core/server/api/canary/utils/serializers/output/products.js
+++ b/core/server/api/canary/utils/serializers/output/products.js
@@ -74,7 +74,7 @@ function serializeProduct(product, options, apiType) {
         description: json.description,
         slug: json.slug,
         active: json.active,
-        visible: json.visible,
+        visibility: json.visibility,
         type: json.type,
         welcome_page_url: json.welcome_page_url,
         created_at: json.created_at,

--- a/core/server/api/canary/utils/serializers/output/tiers.js
+++ b/core/server/api/canary/utils/serializers/output/tiers.js
@@ -82,7 +82,7 @@ function serializeTier(tier, options, apiType) {
         monthly_price: serializeStripePrice(json.monthlyPrice, hideStripeData),
         yearly_price: serializeStripePrice(json.yearlyPrice, hideStripeData),
         benefits: json.benefits || null,
-        visible: json.visible
+        visibility: json.visibility
     };
 
     return serialized;

--- a/core/server/data/migrations/versions/4.38/2022-03-01-08-46-add-visibility-to-tiers.js
+++ b/core/server/data/migrations/versions/4.38/2022-03-01-08-46-add-visibility-to-tiers.js
@@ -5,3 +5,7 @@ module.exports = createAddColumnMigration('products', 'visible', {
     nullable: false,
     defaultTo: false
 });
+
+module.exports.up = () => {
+    // noop - column will be replaced with `visibility` instead
+};

--- a/core/server/data/migrations/versions/4.38/2022-03-01-08-46-add-visibility-to-tiers.js
+++ b/core/server/data/migrations/versions/4.38/2022-03-01-08-46-add-visibility-to-tiers.js
@@ -6,6 +6,6 @@ module.exports = createAddColumnMigration('products', 'visible', {
     defaultTo: false
 });
 
-module.exports.up = () => {
+module.exports.up = async () => {
     // noop - column will be replaced with `visibility` instead
 };

--- a/core/server/data/migrations/versions/4.38/2022-03-03-16-12-add-visibility-to-tiers.js
+++ b/core/server/data/migrations/versions/4.38/2022-03-03-16-12-add-visibility-to-tiers.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('products', 'visibility', {
+    type: 'string',
+    maxlength: 50,
+    nullable: false,
+    defaultTo: 'none'
+});

--- a/core/server/data/migrations/versions/4.38/2022-03-03-16-17-drop-tiers-visible-column.js
+++ b/core/server/data/migrations/versions/4.38/2022-03-03-16-17-drop-tiers-visible-column.js
@@ -1,0 +1,7 @@
+const {createDropColumnMigration} = require('../../utils');
+
+module.exports = createDropColumnMigration('products', 'visible', {});
+
+module.exports.down = () => {
+    // noop - column was replaced by `visibility` instead
+};

--- a/core/server/data/migrations/versions/4.38/2022-03-03-16-17-drop-tiers-visible-column.js
+++ b/core/server/data/migrations/versions/4.38/2022-03-03-16-17-drop-tiers-visible-column.js
@@ -2,6 +2,6 @@ const {createDropColumnMigration} = require('../../utils');
 
 module.exports = createDropColumnMigration('products', 'visible', {});
 
-module.exports.down = () => {
+module.exports.down = async () => {
     // noop - column was replaced by `visibility` instead
 };

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -8,14 +8,14 @@
                     "slug":             "free",
                     "type":             "free",
                     "active":           true,
-                    "visible":          true
+                    "visibility":       "public"
                 },
                 {
                     "name":             "Default Product",
                     "slug":             "default-product",
                     "type":             "paid",
                     "active":           true,
-                    "visible":          true
+                    "visibility":       "public"
                 }
             ]
         },

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -381,7 +381,13 @@ module.exports = {
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
         active: {type: 'boolean', nullable: false, defaultTo: true},
         welcome_page_url: {type: 'string', maxlength: 2000, nullable: true},
-        visible: {type: 'boolean', nullable: false, defaultTo: false},
+        visibility: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'none',
+            validations: {isIn: [['public', 'none']]}
+        },
         monthly_price_id: {type: 'string', maxlength: 24, nullable: true},
         yearly_price_id: {type: 'string', maxlength: 24, nullable: true},
         description: {type: 'string', maxlength: 191, nullable: true},

--- a/core/server/models/product.js
+++ b/core/server/models/product.js
@@ -6,7 +6,7 @@ const Product = ghostBookshelf.Model.extend({
 
     defaults: {
         active: true,
-        visible: false
+        visibility: 'none'
     },
 
     relationships: ['benefits'],

--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -561,7 +561,7 @@ exports[`Members API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8275",
+  "content-length": "8291",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1032,7 +1032,7 @@ exports[`Members API Can filter by paid status 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "6740",
+  "content-length": "6756",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2210,7 +2210,7 @@ exports[`Members API Search for paid members retrieves member with email paid@te
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1676",
+  "content-length": "1680",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/e2e-api/admin/__snapshots__/tiers.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/tiers.test.js.snap
@@ -24,7 +24,7 @@ Object {
       "stripe_prices": null,
       "type": "free",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "visible": false,
+      "visibility": "none",
       "welcome_page_url": "/welcome-free",
     },
     Object {
@@ -38,7 +38,7 @@ Object {
       "stripe_prices": null,
       "type": "paid",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "visible": false,
+      "visibility": "none",
       "welcome_page_url": "/welcome-paid",
     },
   ],

--- a/test/e2e-api/content/__snapshots__/tiers.test.js.snap
+++ b/test/e2e-api/content/__snapshots__/tiers.test.js.snap
@@ -24,7 +24,7 @@ Object {
       "stripe_prices": null,
       "type": "free",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
-      "visible": false,
+      "visibility": "none",
       "welcome_page_url": "/welcome-free",
     },
     Object {
@@ -38,7 +38,7 @@ Object {
       "stripe_prices": null,
       "type": "paid",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
-      "visible": false,
+      "visibility": "none",
       "welcome_page_url": "/welcome-paid",
     },
   ],
@@ -61,7 +61,7 @@ exports[`Tiers Content API Can request tiers 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "675",
+  "content-length": "683",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,8 +35,8 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '0bbdeb5993fc2b84fac68acb419d41b9';
-    const currentFixturesHash = '72eb92cf78dd7c3fe12ba5c3d59498ba';
+    const currentSchemaHash = '821b2327490e3bebdc62cd54d12932e0';
+    const currentFixturesHash = 'c677d4991347eaaf0bb3f676dd077c53';
     const currentSettingsHash = '437d4c6da8759f5c35f11f811b86e5bc';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
- We have an existing pattern for using `visibility: public` instead of `visible: true|false`
- We no-op the existing migration and roll forward so that we don't have to manually revert db changes
