### PR TITLE
Added member's tier name on Portal account home

### DIFF
--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -128,8 +128,8 @@
         "emailAnalytics": true
     },
     "portal": {
-        "url": "https://unpkg.com/@tryghost/portal@~1.14.0/umd/portal.min.js",
-        "version": "1.14"
+        "url": "https://unpkg.com/@tryghost/portal@~1.15.0/umd/portal.min.js",
+        "version": "1.15"
     },
     "tenor": {
         "publicReadOnlyApiKey": null,


### PR DESCRIPTION
refs https://github.com/TryGhost/Portal/commit/e8b9d8a8c16bebfea97cbb5a95fbc33934a646bc

Adds name of the tier on account home page for a logged-in member in Portal, as with multiple tiers the price/plan info is not sufficient.

- bumps Portal to 1.15
