### PR TITLE
Updated to always invalidating cache for tier edit

### DIFF
--- a/core/server/api/canary/products.js
+++ b/core/server/api/canary/products.js
@@ -93,7 +93,9 @@ module.exports = {
         options: [
             'id'
         ],
-        headers: {},
+        headers: {
+            cacheInvalidate: true
+        },
         validation: {
             options: {
                 id: {
@@ -108,11 +110,6 @@ module.exports = {
                 frame.options
             );
 
-            if (model.wasChanged()) {
-                this.headers.cacheInvalidate = true;
-            } else {
-                this.headers.cacheInvalidate = false;
-            }
             return model;
         }
     }

--- a/core/server/api/canary/tiers.js
+++ b/core/server/api/canary/tiers.js
@@ -95,7 +95,9 @@ module.exports = {
         options: [
             'id'
         ],
-        headers: {},
+        headers: {
+            cacheInvalidate: true
+        },
         validation: {
             options: {
                 id: {
@@ -112,11 +114,6 @@ module.exports = {
                 frame.options
             );
 
-            if (model.wasChanged()) {
-                this.headers.cacheInvalidate = true;
-            } else {
-                this.headers.cacheInvalidate = false;
-            }
             return model;
         }
     }


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1240

We were selectively invalidating cache on tier/product edit which was consistent with pattern for other APIs, but in case of tier/product, the model changed method always returns false due to how its setup. This change updates the edit to always invalidate cache, similar to tier add, to ensure sites don't see old tier values.
