### PR TITLE
Re-throw error when attempting to create webhooks

### DIFF
--- a/core/server/services/webhooks/webhooks-service.js
+++ b/core/server/services/webhooks/webhooks-service.js
@@ -41,6 +41,8 @@ class WebhooksService {
                     help: messages.nonExistingIntegrationIdProvided.help
                 });
             }
+
+            throw error;
         }
     }
 }

--- a/test/unit/server/services/webhooks/webhook-service.test.js
+++ b/test/unit/server/services/webhooks/webhook-service.test.js
@@ -1,0 +1,37 @@
+const errors = require('@tryghost/errors');
+const should = require('should');
+const sinon = require('sinon');
+
+const createWebhookService = require('../../../../../core/server/services/webhooks/webhooks-service');
+const models = require('../../../../../core/server/models');
+
+describe('Webhook Service', function () {
+    before(models.init);
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('re-throws any unhandled errors', async function () {
+        sinon.stub(models.Webhook, 'getByEventAndTarget').resolves(null);
+        sinon.stub(models.Webhook, 'add').throws('CustomTestError');
+
+        const webhookService = createWebhookService({WebhookModel: models.Webhook});
+
+        const fakeWebhook = {
+            webhooks: [
+                {
+                    event: 'post.published',
+                    target_url: 'http://example.com/webhook'
+                }
+            ]
+        };
+
+        try {
+            await webhookService.add(fakeWebhook, {});
+            should.fail('should have thrown');
+        } catch (err) {
+            err.name.should.equal('CustomTestError');
+        }
+    });
+});


### PR DESCRIPTION
- we catch errors arising from creating webhooks and check for specific codes
- if our error does not match one of those codes, we don't propagate the
  error up
- this becomes a problem if saving a webhook fails for some other reason
  because upstream code assumes we return an error or model
- this commit re-throws the error