### PR TITLE
🐛 Fixed duplicate tags created when slugs contain spaces

### DIFF
--- a/core/server/models/base/plugins/generate-slug.js
+++ b/core/server/models/base/plugins/generate-slug.js
@@ -13,7 +13,7 @@ module.exports = function (Bookshelf) {
          * Create a string to act as the permalink for an object.
          * @param {Bookshelf['Model']} Model Model type to generate a slug for
          * @param {String} base The string for which to generate a slug, usually a title or name
-         * @param {Object} options Options to pass to findOne
+         * @param {GenerateSlugOptions} [options] Options to pass to findOne
          * @return {Promise<String>} Resolves to a unique slug string
          */
         generateSlug: function generateSlug(Model, base, options) {
@@ -98,6 +98,10 @@ module.exports = function (Bookshelf) {
                 slug = baseName;
             }
 
+            if (options && options.skipDuplicateChecks === true) {
+                return slug;
+            }
+
             // Test for duplicate slugs.
             return checkIfSlugExists(slug);
         }
@@ -106,4 +110,12 @@ module.exports = function (Bookshelf) {
 
 /**
  * @type {import('bookshelf')} Bookshelf
+ */
+
+/**
+ * @typedef {object} GenerateSlugOptions
+ * @property {string} [status] Used for posts, to also filter by post status when generating a slug
+ * @property {boolean} [importing] Set to true to don't cut the slug on import
+ * @property {boolean} [shortSlug] If it's a user, let's try to cut it down (unless this is a human request)
+ * @property {boolean} [skipDuplicateChecks] Don't append unique identifiers when the slug is not unique (this prevents any database queries)
  */

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -552,11 +552,10 @@ Post = ghostBookshelf.Model.extend({
         if (!_.isUndefined(this.get('tags')) && !_.isNull(this.get('tags'))) {
             tagsToSave = [];
 
-            // When only the slug is set for a new tag
-            // pretend it to be the name, instead of the slug
-            // This is required to fix any issues when matching with existing ta
+            //  and deduplicate upper/lowercase tags
             for (const tag of this.get('tags')) {
                 if (!tag.id && !tag.tag_id && tag.slug) {
+                    // Clean up the provided slugs before we do any matching with existing tags
                     const slug = await ghostBookshelf.Model.generateSlug(
                         Tag, 
                         tag.slug || tag.name,
@@ -564,18 +563,15 @@ Post = ghostBookshelf.Model.extend({
                     );
                     tag.slug = slug;
                 }
-            }
 
-            //  and deduplicate upper/lowercase tags
-            _.each(this.get('tags'), function each(item) {
                 for (i = 0; i < tagsToSave.length; i = i + 1) {
-                    if (tagsToSave[i].name && item.name && tagsToSave[i].name.toLocaleLowerCase() === item.name.toLocaleLowerCase()) {
+                    if (tagsToSave[i].name && tag.name && tagsToSave[i].name.toLocaleLowerCase() === tag.name.toLocaleLowerCase()) {
                         return;
                     }
                 }
 
-                tagsToSave.push(item);
-            });
+                tagsToSave.push(tag);
+            }
 
             this.set('tags', tagsToSave);
         }

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -557,12 +557,6 @@ Post = ghostBookshelf.Model.extend({
             // This is required to fix any issues when matching with existing ta
             for (const tag of this.get('tags')) {
                 if (!tag.id && !tag.tag_id && tag.slug) {
-                    if (!tag.name) {
-                        // When only the slug is set, we want to keep the original slug as the name if we
-                        // needed to correct it (e.g. when there are spaces in the slug)
-                        tag.name = tag.slug;
-                    }
-
                     const slug = await ghostBookshelf.Model.generateSlug(
                         Tag, 
                         tag.slug || tag.name,

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -15,7 +15,7 @@ const limitService = require('../services/limits');
 const mobiledocLib = require('../lib/mobiledoc');
 const relations = require('./relations');
 const urlUtils = require('../../shared/url-utils');
-const { Tag } = require('./tag');
+const {Tag} = require('./tag');
 
 const messages = {
     isAlreadyPublished: 'Your post is already published, please reload your page.',

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -553,7 +553,7 @@ Post = ghostBookshelf.Model.extend({
             tagsToSave = [];
 
             //  and deduplicate upper/lowercase tags
-            for (const tag of this.get('tags')) {
+            loopTags: for (const tag of this.get('tags')) {
                 if (!tag.id && !tag.tag_id && tag.slug) {
                     // Clean up the provided slugs before we do any matching with existing tags
                     tag.slug = await ghostBookshelf.Model.generateSlug(
@@ -565,7 +565,7 @@ Post = ghostBookshelf.Model.extend({
 
                 for (i = 0; i < tagsToSave.length; i = i + 1) {
                     if (tagsToSave[i].name && tag.name && tagsToSave[i].name.toLocaleLowerCase() === tag.name.toLocaleLowerCase()) {
-                        return;
+                        continue loopTags;
                     }
                 }
 

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -556,12 +556,11 @@ Post = ghostBookshelf.Model.extend({
             for (const tag of this.get('tags')) {
                 if (!tag.id && !tag.tag_id && tag.slug) {
                     // Clean up the provided slugs before we do any matching with existing tags
-                    const slug = await ghostBookshelf.Model.generateSlug(
+                    tag.slug = await ghostBookshelf.Model.generateSlug(
                         Tag, 
-                        tag.slug || tag.name,
+                        tag.slug,
                         {skipDuplicateChecks: true}
                     );
-                    tag.slug = slug;
                 }
 
                 for (i = 0; i < tagsToSave.length; i = i + 1) {

--- a/test/regression/api/admin/posts.test.js
+++ b/test/regression/api/admin/posts.test.js
@@ -416,6 +416,7 @@ describe('Posts API (canary)', function () {
             res.body.posts[0].title.should.equal('Tags test 5');
             res.body.posts[0].tags.length.should.equal(1);
             res.body.posts[0].tags[0].slug.should.equal('five-spaces');
+            res.body.posts[0].tags[0].name.should.equal('five spaces');
 
             // If we create another post again now that the five-spaces tag exists, 
             // we need to make sure it matches correctly and doesn't create a new tag again
@@ -437,7 +438,53 @@ describe('Posts API (canary)', function () {
             should.exist(res2.body.posts[0].title);
             res2.body.posts[0].title.should.equal('Tags test 6');
             res2.body.posts[0].tags.length.should.equal(1);
-            res2.body.posts[0].tags[0].slug.should.equal('five-spaces');
+            res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
+        });
+
+        it('can add with tags - slug with spaces not automated', async function () {
+            // Make sure that the matching still works when using a different name
+            // this is important because it invalidates any solution that would just consider a slug as the name
+            const res = await request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Tags test 7',
+                        tags: [{slug: 'six-spaces', name: 'Not automated name for six spaces'}]
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+            
+            should.exist(res.body.posts);
+            should.exist(res.body.posts[0].title);
+            res.body.posts[0].title.should.equal('Tags test 7');
+            res.body.posts[0].tags.length.should.equal(1);
+            res.body.posts[0].tags[0].slug.should.equal('six-spaces');
+            res.body.posts[0].tags[0].name.should.equal('Not automated name for six spaces');
+
+            // If we create another post again now that the five-spaces tag exists, 
+            // we need to make sure it matches correctly and doesn't create a new tag again
+
+            const res2 = await request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Tags test 8',
+                        tags: [{slug: 'six spaces'}]
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+            
+            should.exist(res2.body.posts);
+            should.exist(res2.body.posts[0].title);
+            res2.body.posts[0].title.should.equal('Tags test 8');
+            res2.body.posts[0].tags.length.should.equal(1);
+            res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
         });
 
         it('can add with tags - too long slug', async function () {
@@ -448,7 +495,7 @@ describe('Posts API (canary)', function () {
                 .set('Origin', config.get('url'))
                 .send({
                     posts: [{
-                        title: 'Tags test 7',
+                        title: 'Tags test 9',
                         tags: [{slug: tooLongSlug}]
                     }]
                 })
@@ -458,7 +505,7 @@ describe('Posts API (canary)', function () {
             
             should.exist(res.body.posts);
             should.exist(res.body.posts[0].title);
-            res.body.posts[0].title.should.equal('Tags test 7');
+            res.body.posts[0].title.should.equal('Tags test 9');
             res.body.posts[0].tags.length.should.equal(1);
             res.body.posts[0].tags[0].slug.should.equal(tooLongSlug.substring(0, 185));
 
@@ -470,7 +517,7 @@ describe('Posts API (canary)', function () {
                 .set('Origin', config.get('url'))
                 .send({
                     posts: [{
-                        title: 'Tags test 8',
+                        title: 'Tags test 10',
                         tags: [{slug: tooLongSlug}]
                     }]
                 })
@@ -480,9 +527,9 @@ describe('Posts API (canary)', function () {
             
             should.exist(res2.body.posts);
             should.exist(res2.body.posts[0].title);
-            res2.body.posts[0].title.should.equal('Tags test 8');
+            res2.body.posts[0].title.should.equal('Tags test 10');
             res2.body.posts[0].tags.length.should.equal(1);
-            res2.body.posts[0].tags[0].slug.should.equal(tooLongSlug.substring(0, 185));
+            res2.body.posts[0].tags[0].id.should.equal(res.body.posts[0].tags[0].id);
         });
     });
 

--- a/test/regression/api/admin/posts.test.js
+++ b/test/regression/api/admin/posts.test.js
@@ -439,6 +439,51 @@ describe('Posts API (canary)', function () {
             res2.body.posts[0].tags.length.should.equal(1);
             res2.body.posts[0].tags[0].slug.should.equal('five-spaces');
         });
+
+        it('can add with tags - too long slug', async function () {
+            const tooLongSlug = 'a'.repeat(190);
+
+            const res = await request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Tags test 7',
+                        tags: [{slug: tooLongSlug}]
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+            
+            should.exist(res.body.posts);
+            should.exist(res.body.posts[0].title);
+            res.body.posts[0].title.should.equal('Tags test 7');
+            res.body.posts[0].tags.length.should.equal(1);
+            res.body.posts[0].tags[0].slug.should.equal(tooLongSlug.substring(0, 185));
+
+            // If we create another post again now that the very long tag exists, 
+            // we need to make sure it matches correctly and doesn't create a new tag again
+
+            const res2 = await request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Tags test 8',
+                        tags: [{slug: tooLongSlug}]
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+            
+            should.exist(res2.body.posts);
+            should.exist(res2.body.posts[0].title);
+            res2.body.posts[0].title.should.equal('Tags test 8');
+            res2.body.posts[0].tags.length.should.equal(1);
+            res2.body.posts[0].tags[0].slug.should.equal(tooLongSlug.substring(0, 185));
+        });
     });
 
     describe('Edit', function () {

--- a/test/regression/api/admin/posts.test.js
+++ b/test/regression/api/admin/posts.test.js
@@ -396,6 +396,49 @@ describe('Posts API (canary)', function () {
                     res.body.posts[0].tags[1].slug.should.equal('four');
                 });
         });
+
+        it('can add with tags - slug with spaces', async function () {
+            const res = await request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Tags test 5',
+                        tags: [{slug: 'five spaces'}]
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+            
+            should.exist(res.body.posts);
+            should.exist(res.body.posts[0].title);
+            res.body.posts[0].title.should.equal('Tags test 5');
+            res.body.posts[0].tags.length.should.equal(1);
+            res.body.posts[0].tags[0].slug.should.equal('five-spaces');
+
+            // If we create another post again now that the five-spaces tag exists, 
+            // we need to make sure it matches correctly and doesn't create a new tag again
+
+            const res2 = await request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Tags test 6',
+                        tags: [{slug: 'five spaces'}]
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+            
+            should.exist(res2.body.posts);
+            should.exist(res2.body.posts[0].title);
+            res2.body.posts[0].title.should.equal('Tags test 6');
+            res2.body.posts[0].tags.length.should.equal(1);
+            res2.body.posts[0].tags[0].slug.should.equal('five-spaces');
+        });
     });
 
     describe('Edit', function () {

--- a/test/regression/api/admin/posts.test.js
+++ b/test/regression/api/admin/posts.test.js
@@ -416,7 +416,9 @@ describe('Posts API (canary)', function () {
             res.body.posts[0].title.should.equal('Tags test 5');
             res.body.posts[0].tags.length.should.equal(1);
             res.body.posts[0].tags[0].slug.should.equal('five-spaces');
-            res.body.posts[0].tags[0].name.should.equal('five spaces');
+
+            // Expected behaviour when creating a slug with spaces:
+            res.body.posts[0].tags[0].name.should.equal('five-spaces');
 
             // If we create another post again now that the five-spaces tag exists, 
             // we need to make sure it matches correctly and doesn't create a new tag again


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1284

- Matching tags by slug has been updated to work for slugs with spaces
- Also added a test to check slugs that are longer than 185 characters (since that will cause the same issue)
- Now, the tag slug gets filtered before doing any matching unless a tag `id` (or foreign key) is set when creating or editing posts.
- Added `skipDuplicateChecks` option to `generateSlug` model plugin.
- Added tests

#### Edge case
Say that we have an existing tag: `{slug: 'my-slug', name: 'This is my slug'}`

When you create a new post like this:
`api.posts.add({title: 'test post', tags: [{slug: 'my slug'}]})`

The current solution is to transform it into the following query in the `onSaving` event of Post:
`api.posts.add({title: 'test post', tags: [{slug: 'my-slug'}]})`

This works! But the only downside is, that when creating a new tag, it creates it with the name 'my-slug' instead of 'my slug'.

To work around this issue there needs to be a way for `bookshelf-relations` to have a different matching logic (to search for existing tags), separate from the insert logic (when creating new tags). Currently you cannot match existing tags on the slug `my-slug` (and not match on name `my slug` at the same time), while setting the name to `my slug` when inserting (but not when updating an existing tag). This gets far too complex for this small issue, since the user can just change the name afterwards.
