### PR TITLE
Removed notification on theme install failure during setup step

### DIFF
--- a/core/server/services/auth/setup.js
+++ b/core/server/services/auth/setup.js
@@ -185,14 +185,6 @@ async function installTheme(data, api) {
     } catch (error) {
         //Fallback to Casper by doing nothing as the theme setting update is the last step
         logging.warn(tpl(messages.failedThemeInstall, {themeName, error: error.message}));
-
-        await api.notifications.add({
-            notifications: [{
-                custom: true, //avoids update-check from deleting the notification
-                type: 'warn',
-                message: 'The installation of the theme you have selected wasn\'t successful.'
-            }]
-        }, {context: {internal: true}});
     }
 
     return data;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1417

- we no longer want to display a notification if theme install fails
- the notification has been removed so we fail silently, but log the warning
