### PR TITLE
Fixed error when editing user with empty roles data

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -510,7 +510,7 @@ User = ghostBookshelf.Model.extend({
             return ghostBookshelf.Model.edit.call(self, data, options).then((user) => {
                 let roleId;
 
-                if (!data.roles) {
+                if (!data.roles || !data.roles.length) {
                     return user;
                 }
 

--- a/test/e2e-api/admin/users.test.js
+++ b/test/e2e-api/admin/users.test.js
@@ -185,6 +185,17 @@ describe('User API', function () {
         }
     });
 
+    it('Can edit user with empty roles data', async function () {
+        await request.put(localUtils.API.getApiQuery('users/me'))
+            .set('Origin', config.get('url'))
+            .send({
+                users: [{
+                    roles: []
+                }]
+            })
+            .expect(200);
+    });
+
     it('Can destroy an active user', async function () {
         const userId = testUtils.getExistingData().users[1].id;
 


### PR DESCRIPTION
- we send the roles data array in when we're changing the role of the
  user
- if we send an empty array, we don't want to edit the user's role
- the code _thought_ that's what it was doing, but we only check the
  falsiness of the array, which is truthy for `[]`
- it also needs to check the length of the array
- this commit includes a test which would fail with a 500 error without
  the fix