### PR TITLE
Aliased canary endpoints to point to non-versioned URLs

### DIFF
--- a/core/server/web/api/app.js
+++ b/core/server/web/api/app.js
@@ -25,9 +25,6 @@ module.exports = function setupApiApp() {
     apiApp.lazyUse(urlUtils.getVersionPath({version: 'canary', type: 'content'}), require('./canary/content/app'));
     apiApp.lazyUse(urlUtils.getVersionPath({version: 'canary', type: 'admin'}), require('./canary/admin/app'));
 
-    apiApp.lazyUse('/content/', require('./canary/content/app'));
-    apiApp.lazyUse('/admin/', require('./canary/admin/app'));
-
     // Error handling for requests to non-existent API versions
     apiApp.use(errorHandler.resourceNotFound);
     apiApp.use(errorHandler.handleJSONResponse(sentry));

--- a/core/shared/config/overrides.json
+++ b/core/shared/config/overrides.json
@@ -79,11 +79,15 @@
     },
     "api": {
         "versions": {
-            "all": ["v2", "v3", "v4", "canary"],
+            "all": ["v2", "v3", "v4", "v5", "canary"],
             "default": "v4",
             "canary": {
-                "admin": "canary/admin",
-                "content": "canary/content"
+                "admin": "admin",
+                "content": "content"
+            },
+            "v5": {
+                "admin": "admin",
+                "content": "content"
             },
             "v4": {
                 "admin": "v4/admin",

--- a/test/e2e-api/admin/actions.test.js
+++ b/test/e2e-api/admin/actions.test.js
@@ -98,7 +98,7 @@ describe('Actions API', function () {
         await integrationRequest
             .put(localUtils.API.getApiQuery(`posts/${postId}/`))
             .set('Origin', config.get('url'))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/')}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/')}`)
             .send({
                 posts: [{
                     featured: true,

--- a/test/e2e-api/admin/key_authentication.test.js
+++ b/test/e2e-api/admin/key_authentication.test.js
@@ -32,7 +32,7 @@ describe('Admin API key authentication', function () {
 
     it('Can access browse endpoint with correct token', async function () {
         await request.get(localUtils.API.getApiQuery('posts/'))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/')}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/')}`)
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
@@ -46,7 +46,7 @@ describe('Admin API key authentication', function () {
         const res = await request
             .post(localUtils.API.getApiQuery('posts/?include=authors'))
             .set('Origin', config.get('url'))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/')}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/')}`)
             .send({
                 posts: [post]
             })
@@ -62,7 +62,7 @@ describe('Admin API key authentication', function () {
         const res = await request
             .get(localUtils.API.getApiQuery('users/'))
             .set('Origin', config.get('url'))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/')}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/')}`)
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
@@ -88,7 +88,7 @@ describe('Admin API key authentication', function () {
             await testUtils.initFixtures('api_keys');
 
             const response = await request.get(localUtils.API.getApiQuery('posts/'))
-                .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/')}`)
+                .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/')}`)
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(403);

--- a/test/regression/api/admin/db.test.js
+++ b/test/regression/api/admin/db.test.js
@@ -129,7 +129,7 @@ describe('DB API (canary)', function () {
         const fsStub = sinon.stub(fs, 'writeFile').resolves();
 
         return request.post(localUtils.API.getApiQuery(`db/backup${backupQuery}`))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', backupKey)}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/', backupKey)}`)
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .expect(200)
@@ -144,7 +144,7 @@ describe('DB API (canary)', function () {
         const fsStub = sinon.stub(fs, 'writeFile').resolves();
 
         return request.post(localUtils.API.getApiQuery(`db/backup`))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', schedulerKey)}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/', schedulerKey)}`)
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .expect(403)

--- a/test/regression/api/admin/schedules.test.js
+++ b/test/regression/api/admin/schedules.test.js
@@ -89,7 +89,7 @@ describe('Canary Schedules API', function () {
         before(function () {
             const schedulerKey = _.find(testUtils.getExistingData().apiKeys, {integration: {slug: 'ghost-scheduler'}});
 
-            token = localUtils.getValidAdminToken('/canary/admin/', schedulerKey);
+            token = localUtils.getValidAdminToken('/admin/', schedulerKey);
         });
 
         it('publishes posts', async function () {
@@ -123,7 +123,7 @@ describe('Canary Schedules API', function () {
 
         it('no access', function () {
             const zapierKey = _.find(testUtils.getExistingData().apiKeys, {integration: {slug: 'ghost-backup'}});
-            const zapierToken = localUtils.getValidAdminToken('/canary/admin/', zapierKey);
+            const zapierToken = localUtils.getValidAdminToken('/admin/', zapierKey);
 
             return request
                 .put(localUtils.API.getApiQuery(`schedules/posts/${resources[0].id}/?token=${zapierToken}`))

--- a/test/regression/api/admin/utils.js
+++ b/test/regression/api/admin/utils.js
@@ -1,7 +1,7 @@
 const url = require('url');
 const testUtils = require('../../../utils');
 
-const API_URL = '/ghost/api/canary/admin/';
+const API_URL = '/ghost/api/admin/';
 
 const expectedProperties = {
     posts: ['posts', 'meta'],

--- a/test/regression/api/admin/webhooks.test.js
+++ b/test/regression/api/admin/webhooks.test.js
@@ -27,7 +27,7 @@ describe('Webhooks API (canary)', function () {
         };
 
         return request.post(localUtils.API.getApiQuery('webhooks/'))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
             .send({webhooks: [webhookData]})
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
@@ -134,7 +134,7 @@ describe('Webhooks API (canary)', function () {
                 [createdWebhook] = body.webhooks;
 
                 return request.put(localUtils.API.getApiQuery(`webhooks/${createdWebhook.id}/`))
-                    .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
+                    .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
                     .send({
                         webhooks: [{
                             name: 'Edit Test',
@@ -146,14 +146,14 @@ describe('Webhooks API (canary)', function () {
             })
             .then(() => {
                 return request.del(localUtils.API.getApiQuery(`webhooks/${createdWebhook.id}/`))
-                    .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
+                    .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
                     .expect(403);
             });
     });
 
     it('Integration editing non-existing webhook returns 404', function () {
         return request.put(localUtils.API.getApiQuery(`webhooks/5f27d0287c75da744d8615da/`))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
             .send({
                 webhooks: [{
                     name: 'Edit Test'
@@ -164,7 +164,7 @@ describe('Webhooks API (canary)', function () {
 
     it('Integration deleting non-existing webhook returns 404', function () {
         return request.delete(localUtils.API.getApiQuery(`webhooks/5f27d0287c75da744d8615db/`))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/', testUtils.DataGenerator.Content.api_keys[0])}`)
             .expect(404);
     });
 
@@ -175,7 +175,7 @@ describe('Webhooks API (canary)', function () {
         };
 
         return request.post(localUtils.API.getApiQuery('webhooks/'))
-            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/canary/admin/', testUtils.DataGenerator.Content.api_keys[1])}`)
+            .set('Authorization', `Ghost ${localUtils.getValidAdminToken('/admin/', testUtils.DataGenerator.Content.api_keys[1])}`)
             .send({webhooks: [webhookData]})
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)

--- a/test/regression/api/content/posts.test.js
+++ b/test/regression/api/content/posts.test.js
@@ -220,7 +220,7 @@ describe('api/canary/content/posts', function () {
                 }
 
                 res.headers.vary.should.eql('Accept, Accept-Encoding');
-                res.headers.location.should.eql(`http://localhost:9999/ghost/api/canary/content/posts/?key=${validKey}`);
+                res.headers.location.should.eql(`http://localhost:9999/ghost/api/content/posts/?key=${validKey}`);
                 should.exist(res.headers['access-control-allow-origin']);
                 should.not.exist(res.headers['x-cache-invalidate']);
                 done();

--- a/test/regression/api/content/utils.js
+++ b/test/regression/api/content/utils.js
@@ -2,7 +2,7 @@ const url = require('url');
 const _ = require('lodash');
 const testUtils = require('../../../utils');
 const schema = require('../../../../core/server/data/schema').tables;
-const API_URL = '/ghost/api/canary/content/';
+const API_URL = '/ghost/api/content/';
 
 const expectedProperties = {
     // API top level

--- a/test/regression/mock-express-style/parent-app-vhosts.test.js
+++ b/test/regression/mock-express-style/parent-app-vhosts.test.js
@@ -9,7 +9,7 @@ const themeEngine = require('../../../core/frontend/services/theme-engine');
 describe('Integration - Web - vhosts', function () {
     let app;
 
-    const ADMIN_API_URL = '/ghost/api/canary/admin';
+    const ADMIN_API_URL = '/ghost/api/admin';
 
     before(testUtils.teardownDb);
 

--- a/test/unit/frontend/services/theme-engine/engines/create.test.js
+++ b/test/unit/frontend/services/theme-engine/engines/create.test.js
@@ -56,7 +56,7 @@ describe('Themes: engines', function () {
         it('not supported upcoming version falls back to default version', function () {
             const engines = themeEngines.create({
                 engines: {
-                    'ghost-api': 'v5'
+                    'ghost-api': 'v6'
                 }
             });
 

--- a/test/unit/server/services/auth/api-key/admin.test.js
+++ b/test/unit/server/services/auth/api-key/admin.test.js
@@ -6,7 +6,7 @@ const apiKeyAuth = require('../../../../../../core/server/services/auth/api-key'
 const models = require('../../../../../../core/server/models');
 
 describe('Admin API Key Auth', function () {
-    const ADMIN_API_URL = '/ghost/api/v4/admin/';
+    const ADMIN_API_URL_VERSIONED = '/ghost/api/v4/admin/';
     const ADMIN_API_URL_NON_VERSIONED = '/ghost/api/admin/';
 
     before(models.init);
@@ -43,7 +43,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: ADMIN_API_URL,
+            originalUrl: ADMIN_API_URL_VERSIONED,
             headers: {
                 authorization: `Ghost ${token}`
             }
@@ -118,7 +118,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: `${ADMIN_API_URL}session/`,
+            originalUrl: `${ADMIN_API_URL_VERSIONED}session/`,
             headers: {
                 authorization: `Ghost ${token}`
             }
@@ -181,7 +181,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: ADMIN_API_URL,
+            originalUrl: ADMIN_API_URL_VERSIONED,
             headers: {
                 authorization: `Ghost ${token}`
             }
@@ -210,7 +210,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: ADMIN_API_URL,
+            originalUrl: ADMIN_API_URL_VERSIONED,
             headers: {
                 authorization: `Ghost ${token}`
             }
@@ -240,7 +240,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: ADMIN_API_URL,
+            originalUrl: ADMIN_API_URL_VERSIONED,
             headers: {
                 authorization: `Ghost ${token}`
             }
@@ -268,7 +268,7 @@ describe('Admin API Key Auth', function () {
         });
 
         const req = {
-            originalUrl: ADMIN_API_URL,
+            originalUrl: ADMIN_API_URL_VERSIONED,
             headers: {
                 authorization: `Ghost ${token}`
             }

--- a/test/unit/server/services/auth/api-key/admin.test.js
+++ b/test/unit/server/services/auth/api-key/admin.test.js
@@ -6,7 +6,7 @@ const apiKeyAuth = require('../../../../../../core/server/services/auth/api-key'
 const models = require('../../../../../../core/server/models');
 
 describe('Admin API Key Auth', function () {
-    const ADMIN_API_URL = '/ghost/api/canary/admin/';
+    const ADMIN_API_URL = '/ghost/api/v4/admin/';
     const ADMIN_API_URL_NON_VERSIONED = '/ghost/api/admin/';
 
     before(models.init);
@@ -32,13 +32,13 @@ describe('Admin API Key Auth', function () {
         sinon.restore();
     });
 
-    it('should authenticate known+valid canary API key', function (done) {
+    it('should authenticate known+valid v4 API key', function (done) {
         const token = jwt.sign({
         }, this.secret, {
             keyid: this.fakeApiKey.id,
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: '/canary/admin/',
+            audience: '/v4/admin/',
             issuer: this.fakeApiKey.id
         });
 
@@ -153,7 +153,7 @@ describe('Admin API Key Auth', function () {
             keyid: this.fakeApiKey.id,
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: '/canary/admin/',
+            audience: '/v4/admin/',
             issuer: this.fakeApiKey.id
         });
 
@@ -183,7 +183,7 @@ describe('Admin API Key Auth', function () {
             keyid: this.fakeApiKey.id,
             algorithm: 'HS256',
             expiresIn: '10m',
-            audience: '/canary/admin/',
+            audience: '/v4/admin/',
             issuer: this.fakeApiKey.id
         });
 
@@ -211,7 +211,7 @@ describe('Admin API Key Auth', function () {
             keyid: this.fakeApiKey.id,
             algorithm: 'HS256',
             expiresIn: '5m',
-            audience: '/canary/admin/',
+            audience: 'v4/admin/',
             issuer: this.fakeApiKey.id
         });
 

--- a/test/unit/server/services/members/config.test.js
+++ b/test/unit/server/services/members/config.test.js
@@ -49,8 +49,8 @@ function createUrlUtilsMock() {
         apiVersions: {
             all: ['canary'],
             canary: {
-                admin: 'canary/admin',
-                content: 'canary/content'
+                admin: 'admin',
+                content: 'content'
             }
         },
         defaultApiVersion: 'canary',

--- a/test/unit/server/services/stripe/config.test.js
+++ b/test/unit/server/services/stripe/config.test.js
@@ -50,8 +50,8 @@ function createUrlUtilsMock() {
         apiVersions: {
             all: ['canary'],
             canary: {
-                admin: 'canary/admin',
-                content: 'canary/content'
+                admin: 'admin',
+                content: 'content'
             }
         },
         defaultApiVersion: 'canary',

--- a/test/utils/e2e-framework.js
+++ b/test/utils/e2e-framework.js
@@ -155,7 +155,7 @@ const getContentAPIAgent = async () => {
         const originURL = configUtils.config.get('url');
 
         return new ContentAPITestAgent(app, {
-            apiURL: '/ghost/api/canary/content/',
+            apiURL: '/ghost/api/content/',
             originURL
         });
     } catch (error) {
@@ -185,7 +185,7 @@ const getAdminAPIAgent = async (options = {}) => {
         const originURL = configUtils.config.get('url');
 
         return new AdminAPITestAgent(app, {
-            apiURL: '/ghost/api/canary/admin/',
+            apiURL: '/ghost/api/admin/',
             originURL
         });
     } catch (error) {
@@ -240,7 +240,7 @@ const getAgentsForMembers = async () => {
             originURL
         });
         adminAgent = new AdminAPITestAgent(app, {
-            apiURL: '/ghost/api/canary/admin/',
+            apiURL: '/ghost/api/admin/',
             originURL
         });
     } catch (error) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/169

- Before releasing Ghost v5 we would like to move all canary-related URLs to a non-versioned format, which will become a default in v5.
- 'canary' is by definition unstable, so breaking any unprepared client explicitly using the canary is expected
- Removed the aliased /content/ and /admin/ apps from app.js because with updated configuration they become duplicates of 'canary' endpoints
