### PR TITLE
Removed archived tiers from content api

### DIFF
--- a/core/server/api/canary/utils/serializers/input/tiers.js
+++ b/core/server/api/canary/utils/serializers/input/tiers.js
@@ -1,3 +1,13 @@
+const localUtils = require('../../index');
+
+const forceActiveFilter = (frame) => {
+    if (frame.options.filter) {
+        frame.options.filter = `(${frame.options.filter})+active:true`;
+    } else {
+        frame.options.filter = 'active:true';
+    }
+};
+
 module.exports = {
     all(_apiConfig, frame) {
         if (!frame.options.withRelated) {
@@ -16,6 +26,13 @@ module.exports = {
             }
             return relation;
         });
+    },
+
+    browse(_apiConfig, frame) {
+        if (localUtils.isContentAPI(frame)) {
+            // CASE: content api can only has active tiers
+            forceActiveFilter(frame);
+        }
     },
 
     add(_apiConfig, frame) {

--- a/test/e2e-api/content/tiers.test.js
+++ b/test/e2e-api/content/tiers.test.js
@@ -5,11 +5,11 @@ describe('Tiers Content API', function () {
 
     before(async function () {
         agent = await agentProvider.getContentAPIAgent();
-        await fixtureManager.init('members', 'api_keys');
+        await fixtureManager.init('members', 'api_keys', 'tiers:archived');
         agent.authenticate();
     });
 
-    it('Can request tiers', async function () {
+    it('Can request only active tiers', async function () {
         await agent.get('/tiers/')
             .expectStatus(200)
             .matchHeaderSnapshot({

--- a/test/utils/fixture-utils.js
+++ b/test/utils/fixture-utils.js
@@ -457,6 +457,14 @@ const fixtures = {
         });
     },
 
+    insertArchivedTiers: function insertArchivedTiers() {
+        let archivedProduct = DataGenerator.forKnex.createProduct({
+            active: false
+        });
+
+        return models.Product.add(archivedProduct, context.internal);
+    },
+
     insertMembersAndLabelsAndProducts: function insertMembersAndLabelsAndProducts() {
         return Promise.map(DataGenerator.forKnex.labels, function (label) {
             return models.Label.add(label, context.internal);
@@ -693,6 +701,9 @@ const toDoList = {
     },
     custom_theme_settings: function insertCustomThemeSettings() {
         return fixtures.insertCustomThemeSettings();
+    },
+    'tiers:archived': function insertArchivedTiers() {
+        return fixtures.insertArchivedTiers();
     }
 };
 

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -911,6 +911,24 @@ DataGenerator.forKnex = (function () {
         });
     }
 
+    function createProduct(overrides) {
+        const newObj = _.cloneDeep(overrides);
+
+        return _.defaults(newObj, {
+            id: ObjectId().toHexString(),
+            name: 'product',
+            slug: 'gold',
+            active: true,
+            type: 'paid',
+            visibility: 'public',
+            benefits: [],
+            created_by: DataGenerator.Content.users[0].id,
+            created_at: new Date(),
+            updated_by: DataGenerator.Content.users[0].id,
+            updated_at: new Date()
+        });
+    }
+
     function createMembersLabels(member_id, label_id, sort_order = 0) {
         return {
             id: ObjectId().toHexString(),
@@ -1337,6 +1355,7 @@ DataGenerator.forKnex = (function () {
         createIntegration,
         createEmail,
         createCustomThemeSetting: createBasic,
+        createProduct,
 
         invites,
         posts,


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1426

When fetching tiers using the content API, we incorrectly returned all tiers including archived ones unless the active:true filter is passed. Correct behaviour is to always hide archived tiers, so this filter should not be required.

- forces `active:true` filter for tiers content api browse
- updates test to check for archived test removal in tiers content api
