### PR TITLE
Extended tests for member events

### DIFF
--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -1132,6 +1132,34 @@ Object {
 }
 `;
 
+exports[`Members API Can edit by id 2: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "member2Change@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "change me",
+      "note": "initial note",
+      "products": Array [],
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
 exports[`Members API Can edit by id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -1173,7 +1201,60 @@ Object {
 }
 `;
 
+exports[`Members API Can edit by id 3: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "462",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can edit by id 4: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "cantChangeMe@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "changed",
+      "note": "edited note",
+      "products": Array [],
+      "status": "free",
+      "subscribed": false,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
 exports[`Members API Can edit by id 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "459",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can edit by id 5: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",

--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -17,35 +17,6 @@ Object {
 }
 `;
 
-exports[`Members API Add should fail when passing incorrect email_type query parameter 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "249",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Members API Add should fail when passing incorrect email_type query parameter 2: [body] 1`] = `
-Object {
-  "errors": Array [
-    Object {
-      "code": null,
-      "context": "Validation (AllowedValues) failed for email_type",
-      "details": null,
-      "help": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      "message": "Validation error, cannot save member.",
-      "property": null,
-      "type": "ValidationError",
-    },
-  ],
-}
-`;
-
 exports[`Members API Add should fail when passing incorrect email_type query parameter 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -94,80 +65,6 @@ Object {
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Members API Can add a subcription 1: [body] 1`] = `
-Object {
-  "members": Array [
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "member1@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Mr Egg",
-      "note": null,
-      "products": Array [],
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Array [
-        Object {
-          "cancel_at_period_end": false,
-          "cancellation_reason": null,
-          "current_period_end": Any<String>,
-          "customer": Object {
-            "email": "member1@test.com",
-            "id": "cus_123",
-            "name": null,
-          },
-          "default_payment_card_last4": null,
-          "id": "sub_123",
-          "plan": Object {
-            "amount": 5000,
-            "currency": "USD",
-            "id": "173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730b12",
-            "interval": "month",
-            "nickname": "month",
-          },
-          "price": Object {
-            "amount": 5000,
-            "currency": "USD",
-            "id": "173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730b12",
-            "interval": "month",
-            "nickname": "Monthly",
-            "price_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            "product": Object {
-              "id": "109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d",
-              "product_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-            },
-            "type": "recurring",
-          },
-          "start_date": Any<String>,
-          "status": "active",
-        },
-      ],
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-  ],
-}
-`;
-
-exports[`Members API Can add a subcription 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1333",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
   "x-powered-by": "Express",
 }
@@ -378,7 +275,7 @@ Object {
 }
 `;
 
-exports[`Members API Can add complimentary subscription 1: [body] 1`] = `
+exports[`Members API Can add complimentary subscription (out of date) 1: [body] 1`] = `
 Object {
   "members": Array [
     Object {
@@ -406,7 +303,7 @@ Object {
 }
 `;
 
-exports[`Members API Can add complimentary subscription 2: [headers] 1`] = `
+exports[`Members API Can add complimentary subscription (out of date) 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -419,7 +316,7 @@ Object {
 }
 `;
 
-exports[`Members API Can add complimentary subscription 3: [body] 1`] = `
+exports[`Members API Can add complimentary subscription (out of date) 3: [body] 1`] = `
 Object {
   "members": Array [
     Object {
@@ -447,11 +344,203 @@ Object {
 }
 `;
 
-exports[`Members API Can add complimentary subscription 4: [headers] 1`] = `
+exports[`Members API Can add complimentary subscription (out of date) 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "444",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can add complimentary subscription by assigning a product to a member 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "compedtest2@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "Name",
+      "note": null,
+      "products": Array [],
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can add complimentary subscription by assigning a product to a member 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "445",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can add complimentary subscription by assigning a product to a member 3: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": true,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "compedtest2@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "Name",
+      "note": null,
+      "products": Array [
+        Object {
+          "active": true,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "monthly_price_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Product",
+          "slug": "default-product",
+          "type": "paid",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "public",
+          "welcome_page_url": "/welcome-paid",
+          "yearly_price_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        },
+      ],
+      "status": "comped",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can add complimentary subscription by assigning a product to a member 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1730",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can add complimentary subscription in the new way 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "compedtest2@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "Name",
+      "note": null,
+      "products": Array [],
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can add complimentary subscription in the new way 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "445",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can add complimentary subscription in the new way 3: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": true,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "compedtest2@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "Name",
+      "note": null,
+      "products": Array [
+        Object {
+          "active": true,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "monthly_price_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Product",
+          "slug": "default-product",
+          "type": "paid",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "public",
+          "welcome_page_url": "/welcome-paid",
+          "yearly_price_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        },
+      ],
+      "status": "comped",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can add complimentary subscription in the new way 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1730",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -746,6 +835,146 @@ Object {
 }
 `;
 
+exports[`Members API Can create a member with an existing complimentary subscription 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": true,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "create-member-comped-test@email.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "Test Member",
+      "note": null,
+      "products": Any<Array>,
+      "status": "comped",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can create a member with an existing complimentary subscription 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1774",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can create a member with an existing paid subscription 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "create-member-paid-test@email.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "Test Member",
+      "note": null,
+      "products": Any<Array>,
+      "status": "paid",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can create a member with an existing paid subscription 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1769",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can create a new member with a product (complementary) 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": true,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "compedtest4@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "Name",
+      "note": null,
+      "products": Array [
+        Object {
+          "active": true,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "monthly_price_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Product",
+          "slug": "default-product",
+          "type": "paid",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "public",
+          "welcome_page_url": "/welcome-paid",
+          "yearly_price_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        },
+      ],
+      "status": "comped",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can create a new member with a product (complementary) 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1730",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can delete a member without cancelling Stripe Subscription 1: [body] 1`] = `Object {}`;
+
 exports[`Members API Can delete a member without cancelling Stripe Subscription 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -834,7 +1063,36 @@ Object {
 }
 `;
 
+exports[`Members API Can destroy 5: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Member not found.",
+      "details": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Resource not found error, cannot read member.",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
 exports[`Members API Can destroy 5: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "224",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can destroy 6: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -927,6 +1185,8 @@ Object {
 }
 `;
 
+exports[`Members API Can export CSV 1: [body] 1`] = `Object {}`;
+
 exports[`Members API Can export CSV 1: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -940,7 +1200,35 @@ Object {
 }
 `;
 
+exports[`Members API Can export CSV 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-length": Any<String>,
+  "content-type": "text/csv; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can export a filtered CSV 1: [body] 1`] = `Object {}`;
+
 exports[`Members API Can export a filtered CSV 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-disposition": Any<String>,
+  "content-length": "215",
+  "content-type": "text/csv; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can export a filtered CSV 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -957,14 +1245,14 @@ exports[`Members API Can fetch member counts stats 1: [body] 1`] = `
 Object {
   "data": Array [
     Object {
-      "comped": 0,
+      "comped": 3,
       "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
-      "free": 2,
-      "paid": 1,
+      "free": 3,
+      "paid": 2,
     },
   ],
   "resource": "members",
-  "total": 3,
+  "total": 8,
 }
 `;
 
@@ -1464,187 +1752,6 @@ Object {
 }
 `;
 
-exports[`Members API Can order by email_open_rate 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": Any<String>,
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Members API Can order by email_open_rate 2: [body] 1`] = `
-Object {
-  "members": Array [
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "paid@test.com",
-      "email_count": 0,
-      "email_open_rate": 80,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Egon Spengler",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "member2@test.com",
-      "email_count": 0,
-      "email_open_rate": 50,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": null,
-      "note": null,
-      "status": "free",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "member1@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Mr Egg",
-      "note": null,
-      "status": "free",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "trialing@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Ray Stantz",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "comped@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Vinz Clortho",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "vip@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Winston Zeddemore",
-      "note": null,
-      "status": "free",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "vip-paid@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Peter Venkman",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "with-product@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Dana Barrett",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 8,
-    },
-  },
-}
-`;
-
 exports[`Members API Can order by email_open_rate 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -1834,187 +1941,6 @@ Object {
 }
 `;
 
-exports[`Members API Can order by email_open_rate 3: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": Any<String>,
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Members API Can order by email_open_rate 4: [body] 1`] = `
-Object {
-  "members": Array [
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "member2@test.com",
-      "email_count": 0,
-      "email_open_rate": 50,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": null,
-      "note": null,
-      "status": "free",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "paid@test.com",
-      "email_count": 0,
-      "email_open_rate": 80,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Egon Spengler",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "member1@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Mr Egg",
-      "note": null,
-      "status": "free",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "trialing@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Ray Stantz",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "comped@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Vinz Clortho",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "vip@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Winston Zeddemore",
-      "note": null,
-      "status": "free",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "vip-paid@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Peter Venkman",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "with-product@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Dana Barrett",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 8,
-    },
-  },
-}
-`;
-
 exports[`Members API Can order by email_open_rate 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
@@ -2125,136 +2051,11 @@ Object {
 }
 `;
 
-exports[`Members API Errors when fetching stats with unknown days param value 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "248",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Members API Errors when fetching stats with unknown days param value 2: [body] 1`] = `
-Object {
-  "errors": Array [
-    Object {
-      "code": null,
-      "context": "Validation (matches) failed for id undefined.id",
-      "details": null,
-      "help": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-      "message": "Validation error, cannot read member.",
-      "property": null,
-      "type": "ValidationError",
-    },
-  ],
-}
-`;
-
 exports[`Members API Errors when fetching stats with unknown days param value 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "248",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Members API Sarch by case-insensitive name egg receives member with name Mr Egg 1: [body] 1`] = `
-Object {
-  "members": Array [
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "member1@test.com",
-      "email_count": 0,
-      "email_open_rate": null,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Mr Egg",
-      "note": null,
-      "status": "free",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 1,
-    },
-  },
-}
-`;
-
-exports[`Members API Sarch by case-insensitive name egg receives member with name Mr Egg 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "644",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Members API Sarch for paid members retrieves member with email paid@test.com 1: [body] 1`] = `
-Object {
-  "members": Array [
-    Object {
-      "avatar_image": null,
-      "comped": false,
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "email": "paid@test.com",
-      "email_count": 0,
-      "email_open_rate": 80,
-      "email_opened_count": 0,
-      "geolocation": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "labels": Any<Array>,
-      "name": "Egon Spengler",
-      "note": null,
-      "status": "paid",
-      "subscribed": true,
-      "subscriptions": Any<Array>,
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
-    },
-  ],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 1,
-    },
-  },
-}
-`;
-
-exports[`Members API Sarch for paid members retrieves member with email paid@test.com 2: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1296",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2361,34 +2162,6 @@ Object {
 `;
 
 exports[`Members API Search for non existing member returns empty result set 1: [body] 1`] = `
-Object {
-  "members": Array [],
-  "meta": Object {
-    "pagination": Object {
-      "limit": 15,
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 0,
-    },
-  },
-}
-`;
-
-exports[`Members API Search for non existing member returns empty result set 1: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "102",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Members API Search for non existing member returns empty result set 2: [body] 1`] = `
 Object {
   "members": Array [],
   "meta": Object {

--- a/test/e2e-api/admin/members.test.js
+++ b/test/e2e-api/admin/members.test.js
@@ -806,8 +806,8 @@ describe('Members API', function () {
                     created_at: anyISODateTime,
                     updated_at: anyISODateTime,
                     labels: anyArray,
-                    products: anyArray,
-                    subscriptions: anyArray
+                    subscriptions: anyArray,
+                    products: anyArray
                 })
             })
             .matchHeaderSnapshot({
@@ -929,8 +929,8 @@ describe('Members API', function () {
                     created_at: anyISODateTime,
                     updated_at: anyISODateTime,
                     labels: anyArray,
-                    products: anyArray,
-                    subscriptions: anyArray
+                    subscriptions: anyArray,
+                    products: anyArray
                 })
             })
             .matchHeaderSnapshot({

--- a/test/e2e-api/admin/members.test.js
+++ b/test/e2e-api/admin/members.test.js
@@ -9,7 +9,17 @@ const testUtils = require('../../utils');
 const Papa = require('papaparse');
 
 const models = require('../../../core/server/models');
+const {Product} = require('../../../core/server/models/product');
 
+async function assertMemberEvents({eventType, memberId, asserts}) {
+    const events = await models[eventType].where('member_id', memberId).fetchAll();
+    events.map(e => e.toJSON()).should.match(asserts);
+    assert.equal(events.length, asserts.length, `Only ${asserts.length} ${eventType} should have been added.`);
+}
+
+/**
+ * @deprecated
+ */
 async function assertEvents({eventType, eventName, quantity, asserts}) {
     const events = await models[eventType].findAll();
     assert.equal(events.models.length, quantity, `Only one ${eventType} should have been added after ${eventName}.`);
@@ -19,6 +29,10 @@ async function assertEvents({eventType, eventName, quantity, asserts}) {
         const value = asserts[attribute];
         assert.equal(event[attribute], value, `The ${attribute} attribute of ${eventType} should have been ${value}`);
     }
+}
+
+async function getPaidProduct() {
+    return await Product.findOne({type: 'paid'});
 }
 
 const memberMatcherNoIncludes = {
@@ -299,7 +313,7 @@ describe('Members API', function () {
             labels: ['test-label']
         };
 
-        await agent
+        const {body} = await agent
             .post(`/members/`)
             .body({members: [member]})
             .expectStatus(201)
@@ -310,17 +324,22 @@ describe('Members API', function () {
                 etag: anyEtag,
                 location: anyLocationFor('members')
             });
+        const newMember = body.members[0];
 
         await agent
             .post(`/members/`)
             .body({members: [member]})
             .expectStatus(422);
 
-        await assertEvents({
-            eventName: 'creating a subscription',
+        await assertMemberEvents({
             eventType: 'MemberStatusEvent',
-            quantity: 1,
-            asserts: {from_status: null, to_status: 'free'}
+            memberId: newMember.id,
+            asserts: [
+                {
+                    from_status: null, 
+                    to_status: 'free'
+                }
+            ]
         });
     });
 
@@ -348,29 +367,33 @@ describe('Members API', function () {
                 location: anyString
             });
 
+        const newMember = body.members[0];
+
         mockManager.assert.sentEmail({
             subject: '🙌 Complete your sign up to Ghost!',
             to: 'member_getting_confirmation@test.com'
         });
 
-        await assertEvents({
-            eventName: 'creating a subscription',
+        await assertMemberEvents({
             eventType: 'MemberStatusEvent',
-            quantity: 2,
-            asserts: {
-                from_status: null,
-                to_status: 'free'
-            }
+            memberId: newMember.id,
+            asserts: [
+                {
+                    from_status: null,
+                    to_status: 'free'
+                }
+            ]
         });
 
-        await assertEvents({
-            eventName: 'creating a subscription',
+        await assertMemberEvents({
             eventType: 'MemberSubscribeEvent',
-            quantity: 1,
-            asserts: {
-                subscribed: true,
-                source: 'admin'
-            }
+            memberId: newMember.id,
+            asserts: [
+                {
+                    subscribed: true,
+                    source: 'admin'
+                }
+            ]
         });
 
         // @TODO: do we really need to delete this member here?
@@ -410,7 +433,7 @@ describe('Members API', function () {
 
     // Edit a member
 
-    it('Can add complimentary subscription', async function () {
+    it('Can add complimentary subscription (out of date)', async function () {
         const stripeService = require('../../../core/server/services/stripe');
         const fakePrice = {
             id: 'price_1',
@@ -483,24 +506,472 @@ describe('Members API', function () {
                 etag: anyEtag
             });
 
-        await assertEvents({
-            eventName: 'creating a subscription',
+        await assertMemberEvents({
             eventType: 'MemberStatusEvent',
-            quantity: 2,
-            asserts: {
+            memberId: newMember.id,
+            asserts: [{
                 from_status: null,
                 to_status: 'free'
-            }
+            }]
         });
 
-        await assertEvents({
-            eventName: 'creating a subscription',
+        await assertMemberEvents({
             eventType: 'MemberSubscribeEvent',
-            quantity: 1,
-            asserts: {
+            memberId: newMember.id,
+            asserts: [{
                 subscribed: true,
                 source: 'admin'
+            }]
+        });
+    });
+
+    it('Can add complimentary subscription by assigning a product to a member', async function () {
+        const initialMember = {
+            name: 'Name',
+            email: 'compedtest2@test.com',
+            subscribed: true
+        };
+
+        const {body} = await agent
+            .post(`/members/`)
+            .body({members: [initialMember]})
+            .expectStatus(201);
+
+        const newMember = body.members[0];
+        assert.equal(newMember.status, 'free', 'A new member should have the free status');
+
+        const product = await getPaidProduct();
+
+        const compedPayload = {
+            id: newMember.id,
+            email: newMember.email,
+            products: [
+                {
+                    id: product.id
+                }
+            ]
+        };
+
+        const {body: body2} = await agent
+            .put(`/members/${newMember.id}/`)
+            .body({members: [compedPayload]})
+            .expectStatus(200);
+
+        const updatedMember = body2.members[0];
+        assert.equal(updatedMember.status, 'comped', 'A comped member should have the comped status');
+        assert.equal(updatedMember.products.length, 1, 'The member should have one product');
+
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    from_status: null,
+                    to_status: 'free'
+                },
+                {
+                    from_status: 'free',
+                    to_status: 'comped'
+                }
+            ]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: [{
+                subscribed: true,
+                source: 'admin'
+            }]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberPaidSubscriptionEvent',
+            memberId: newMember.id,
+            asserts: []
+        });
+    });
+
+    it('Can end a complimentary subscription by removing a product from a member', async function () {
+        const product = await getPaidProduct();
+        const initialMember = {
+            name: 'Name',
+            email: 'compedtest3@test.com',
+            subscribed: true,
+            products: [
+                {
+                    id: product.id
+                }
+            ]
+        };
+        
+        const {body} = await agent
+            .post(`/members/`)
+            .body({members: [initialMember]})
+            .expectStatus(201);
+
+        const newMember = body.members[0];
+        assert.equal(newMember.status, 'comped', 'The new member should have the comped status');
+        assert.equal(newMember.products.length, 1, 'The member should have 1 product');
+
+        // Remove it
+        const removePayload = {
+            id: newMember.id,
+            email: newMember.email,
+            products: []
+        };
+
+        const {body: body2} = await agent
+            .put(`/members/${newMember.id}/`)
+            .body({members: [removePayload]})
+            .expectStatus(200);
+
+        const updatedMember = body2.members[0];
+        assert.equal(updatedMember.status, 'free', 'The member should have the free status');
+        assert.equal(updatedMember.products.length, 0, 'The member should have 0 products');
+
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    from_status: null,
+                    to_status: 'comped'
+                },
+                {
+                    from_status: 'comped',
+                    to_status: 'free'
+                }
+            ]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    subscribed: true,
+                    source: 'admin'
+                }
+            ]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberPaidSubscriptionEvent',
+            memberId: newMember.id,
+            asserts: []
+        });
+    });
+
+    it('Can create a new member with a product (complementary)', async function () {
+        const product = await getPaidProduct();
+        const initialMember = {
+            name: 'Name',
+            email: 'compedtest4@test.com',
+            subscribed: true,
+            products: [
+                {
+                    id: product.id
+                }
+            ]
+        };
+
+        const {body} = await agent
+            .post(`/members/`)
+            .body({members: [initialMember]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: new Array(1).fill({
+                    id: anyObjectId,
+                    uuid: anyUuid,
+                    created_at: anyISODateTime,
+                    updated_at: anyISODateTime,
+                    labels: anyArray,
+                    subscriptions: anyArray,
+                    products: new Array(1).fill({
+                        id: anyObjectId,
+                        monthly_price_id: anyObjectId,
+                        yearly_price_id: anyObjectId,
+                        created_at: anyISODateTime,
+                        updated_at: anyISODateTime
+                    })
+                })
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag,
+                location: anyLocationFor('members')
+            });
+
+        const newMember = body.members[0];
+        assert.equal(newMember.status, 'comped', 'The newly imported member should have the comped status');
+
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [{
+                from_status: null,
+                to_status: 'comped'
+            }]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: [{
+                subscribed: true,
+                source: 'admin'
+            }]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberPaidSubscriptionEvent',
+            memberId: newMember.id,
+            asserts: []
+        });
+    });
+
+    it('Can create a member with an existing complimentary subscription', async function () {
+        const fakePrice = {
+            id: 'price_1',
+            product: '',
+            active: true,
+            nickname: 'Complimentary',
+            unit_amount: 0,
+            currency: 'USD',
+            type: 'recurring',
+            recurring: {
+                interval: 'year'
             }
+        };
+
+        const fakeSubscription = {
+            id: 'sub_1',
+            customer: 'cus_1234',
+            status: 'active',
+            cancel_at_period_end: false,
+            metadata: {},
+            current_period_end: Date.now() / 1000 + 1000,
+            start_date: Date.now() / 1000,
+            plan: fakePrice,
+            items: {
+                data: [{
+                    price: fakePrice
+                }]
+            }
+        };
+
+        const fakeCustomer = {
+            id: 'cus_1234',
+            name: 'Test Member',
+            email: 'create-member-comped-test@email.com',
+            subscriptions: {
+                type: 'list',
+                data: [fakeSubscription]
+            }
+        };
+        nock('https://api.stripe.com')
+            .persist()
+            .get(/v1\/.*/)
+            .reply((uri, body) => {
+                const [match, resource, id] = uri.match(/\/?v1\/(\w+)\/?(\w+)/) || [null];
+
+                if (!match) {
+                    return [500];
+                }
+
+                if (resource === 'customers') {
+                    return [200, fakeCustomer];
+                }
+
+                if (resource === 'subscriptions') {
+                    return [200, fakeSubscription];
+                }
+            });
+        
+        const initialMember = {
+            name: fakeCustomer.name,
+            email: fakeCustomer.email,
+            subscribed: true,
+            stripe_customer_id: fakeCustomer.id
+        };
+
+        const {body} = await agent
+            .post(`/members/`)
+            .body({members: [initialMember]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: new Array(1).fill({
+                    id: anyObjectId,
+                    uuid: anyUuid,
+                    created_at: anyISODateTime,
+                    updated_at: anyISODateTime,
+                    labels: anyArray,
+                    products: anyArray,
+                    subscriptions: anyArray
+                })
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag,
+                location: anyLocationFor('members')
+            });
+
+        const newMember = body.members[0];
+        assert.equal(newMember.status, 'comped', 'The created member should have the comped status');
+
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    from_status: null,
+                    to_status: 'free'
+                },
+                {
+                    from_status: 'free',
+                    to_status: 'comped'
+                }
+            ]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    subscribed: true,
+                    source: 'admin'
+                }
+            ]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberPaidSubscriptionEvent',
+            memberId: newMember.id,
+            asserts: [{
+                mrr_delta: 0
+            }]
+        });
+    });
+
+    it('Can create a member with an existing paid subscription', async function () {
+        const fakePrice = {
+            id: 'price_1',
+            product: '',
+            active: true,
+            nickname: 'Paid',
+            unit_amount: 1200,
+            currency: 'USD',
+            type: 'recurring',
+            recurring: {
+                interval: 'year'
+            }
+        };
+
+        const fakeSubscription = {
+            id: 'sub_987623',
+            customer: 'cus_12345',
+            status: 'active',
+            cancel_at_period_end: false,
+            metadata: {},
+            current_period_end: Date.now() / 1000 + 1000,
+            start_date: Date.now() / 1000,
+            plan: fakePrice,
+            items: {
+                data: [{
+                    price: fakePrice
+                }]
+            }
+        };
+
+        const fakeCustomer = {
+            id: 'cus_12345',
+            name: 'Test Member',
+            email: 'create-member-paid-test@email.com',
+            subscriptions: {
+                type: 'list',
+                data: [fakeSubscription]
+            }
+        };
+        nock('https://api.stripe.com')
+            .persist()
+            .get(/v1\/.*/)
+            .reply((uri, body) => {
+                const [match, resource, id] = uri.match(/\/?v1\/(\w+)\/?(\w+)/) || [null];
+
+                if (!match) {
+                    return [500];
+                }
+
+                if (resource === 'customers') {
+                    return [200, fakeCustomer];
+                }
+
+                if (resource === 'subscriptions') {
+                    return [200, fakeSubscription];
+                }
+            });
+        
+        const initialMember = {
+            name: fakeCustomer.name,
+            email: fakeCustomer.email,
+            subscribed: true,
+            stripe_customer_id: fakeCustomer.id
+        };
+
+        const {body} = await agent
+            .post(`/members/`)
+            .body({members: [initialMember]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: new Array(1).fill({
+                    id: anyObjectId,
+                    uuid: anyUuid,
+                    created_at: anyISODateTime,
+                    updated_at: anyISODateTime,
+                    labels: anyArray,
+                    products: anyArray,
+                    subscriptions: anyArray
+                })
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag,
+                location: anyLocationFor('members')
+            });
+
+        const newMember = body.members[0];
+        assert.equal(newMember.status, 'paid', 'The created member should have the paid status');
+
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    from_status: null,
+                    to_status: 'free'
+                }, {
+                    from_status: 'free',
+                    to_status: 'paid'
+                }
+            ]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: [{
+                subscribed: true,
+                source: 'admin'
+            }]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberPaidSubscriptionEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    mrr_delta: 100
+                }
+            ]
         });
     });
 
@@ -530,27 +1001,24 @@ describe('Members API', function () {
                 etag: anyEtag,
                 location: anyLocationFor('members')
             });
+        const newMember = body.members[0];
 
-        await assertEvents({
-            eventName: 'creating a subscription',
+        await assertMemberEvents({
             eventType: 'MemberSubscribeEvent',
-            quantity: 2,
-            asserts: {
+            memberId: newMember.id,
+            asserts: [{
                 subscribed: true,
                 source: 'admin'
-            }
+            }]
         });
-        await assertEvents({
-            eventName: 'updating a memer',
+        await assertMemberEvents({
             eventType: 'MemberStatusEvent',
-            quantity: 3,
-            asserts: {
+            memberId: newMember.id,
+            asserts: [{
                 from_status: null,
                 to_status: 'free'
-            }
+            }]
         });
-
-        const newMember = body.members[0];
 
         await agent
             .put(`/members/${newMember.id}/`)
@@ -563,23 +1031,26 @@ describe('Members API', function () {
                 etag: anyEtag
             });
 
-        await assertEvents({
-            eventName: 'updating a member email',
+        await assertMemberEvents({
             eventType: 'MemberEmailChangeEvent',
-            quantity: 1,
-            asserts: {
+            memberId: newMember.id,
+            asserts: [{
                 from_email: memberToChange.email,
                 to_email: memberChanged.email
-            }
+            }]
         });
-        await assertEvents({
-            eventName: 'removing a subscription',
+        await assertMemberEvents({
             eventType: 'MemberSubscribeEvent',
-            quantity: 3,
-            asserts: {
-                subscribed: false,
-                source: 'admin'
-            }
+            memberId: newMember.id,
+            asserts: [
+                {
+                    subscribed: true,
+                    source: 'admin'
+                }, {
+                    subscribed: false,
+                    source: 'admin'
+                }
+            ]
         });
     });
 

--- a/test/e2e-api/members/webhooks.test.js
+++ b/test/e2e-api/members/webhooks.test.js
@@ -1,10 +1,20 @@
 const assert = require('assert');
 const nock = require('nock');
+const should = require('should');
 const stripe = require('stripe');
+const {MemberStatusEvent} = require('../../../core/server/models/member-status-event');
+const {Product} = require('../../../core/server/models/product');
 const {agentProvider, mockManager, fixtureManager} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
 
 let membersAgent;
 let adminAgent;
+
+async function assertMemberEvents({eventType, memberId, asserts}) {
+    const events = await models[eventType].where('member_id', memberId).fetchAll();
+    events.map(e => e.toJSON()).should.match(asserts);
+    assert.equal(events.length, asserts.length, `Only ${asserts.length} ${eventType} should have been added.`);
+}
 
 describe('Members API', function () {
     before(async function () {
@@ -31,7 +41,104 @@ describe('Members API', function () {
             .expectStatus(200);
     });
 
+    // @todo: Test what happens when a complementary subscription ends (should create comped -> free event)
+    // @todo: Test what happens when a complementary subscription starts a paid subscription
+
     describe('/webhooks/stripe/', function () {
+        // We create some shared stripe resources, so we don't have to have nocks in every test case
+        const subscription = {};
+        const customer = {};
+        const paymentMethod = {};
+        const setupIntent = {};
+
+        beforeEach(function () {
+            nock('https://api.stripe.com')
+                .persist()
+                .get(/v1\/.*/)
+                .reply((uri, body) => {
+                    const [match, resource, id] = uri.match(/\/?v1\/(\w+)\/?(\w+)/) || [null];
+
+                    if (!match) {
+                        return [500];
+                    }
+
+                    if (resource === 'setup_intents') {
+                        return [200, setupIntent];
+                    }
+
+                    if (resource === 'customers') {
+                        if (customer.id !== id) {
+                            return [404];
+                        }
+                        return [200, customer];
+                    }
+
+                    if (resource === 'subscriptions') {
+                        if (subscription.id !== id) {
+                            return [404];
+                        }
+                        return [200, subscription];
+                    }
+                });
+
+            nock('https://api.stripe.com')
+                .persist()
+                .post(/v1\/.*/)
+                .reply((uri, body) => {
+                    const [match, resource, id, action] = uri.match(/\/?v1\/(\w+)(?:\/?(\w+)){0,2}/) || [null];
+
+                    if (!match) {
+                        return [500];
+                    }
+
+                    if (resource === 'payment_methods') {
+                        return [200, paymentMethod];
+                    }
+
+                    if (resource === 'subscriptions') {
+                        return [200, subscription];
+                    }
+
+                    if (resource === 'customers') {
+                        return [200, customer];
+                    }
+
+                    return [500];
+                });
+        });
+
+        afterEach(function () {
+            nock.cleanAll();
+        });
+
+        // Helper methods to update the customer and subscription
+        function set(object, newValues) {
+            for (const key of Object.keys(object)) {
+                delete object[key];
+            }
+            Object.assign(object, newValues);
+        }
+
+        /**
+         * Helper method to create an existing member based on a customer in stripe (= current customer)
+         */
+        async function createMemberFromStripe() {
+            const initialMember = {
+                name: customer.name,
+                email: customer.email,
+                subscribed: true,
+                stripe_customer_id: customer.id
+            };
+
+            const {body} = await adminAgent
+                .post(`/members/`)
+                .body({members: [initialMember]})
+                .expectStatus(201);
+            assert.equal(body.members.length, 1, 'The member was not created');
+            const member = body.members[0];
+            return member;
+        }
+  
         it('Responds with a 401 when the signature is invalid', async function () {
             await membersAgent.post('/webhooks/stripe/')
                 .body({
@@ -59,28 +166,15 @@ describe('Members API', function () {
                 .expectStatus(200);
         });
 
-        describe('checkout.session.completed', function () {
-            it('Will create a member if one does not exist', async function () {
-                const webhookPayload = JSON.stringify({
-                    type: 'checkout.session.completed',
-                    data: {
-                        object: {
-                            mode: 'subscription',
-                            customer: 'cus_123',
-                            subscription: 'sub_123',
-                            metadata: {}
-                        }
-                    }
-                });
+        describe('Handling the end of subscriptions', function () {
+            it('Handles cancellation of paid subscriptions correctly', async function () {
+                const customer_id = 'cust_3432';
+                const subscription_id = 'sub_3432';
 
-                const webhookSignature = stripe.webhooks.generateTestHeaderString({
-                    payload: webhookPayload,
-                    secret: process.env.WEBHOOK_SECRET
-                });
-
-                const subscription = {
-                    id: 'sub_123',
-                    customer: 'cus_123',
+                // Create a new subscription in Stripe
+                set(subscription, {
+                    id: subscription_id,
+                    customer: customer_id,
                     status: 'active',
                     items: {
                         type: 'list',
@@ -103,9 +197,229 @@ describe('Members API', function () {
                     start_date: Date.now() / 1000,
                     current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
                     cancel_at_period_end: false
+                });
+
+                // Create a new customer in Stripe
+                set(customer, {
+                    id: customer_id,
+                    name: 'Test Member',
+                    email: 'cancel-paid-test@email.com',
+                    subscriptions: {
+                        type: 'list',
+                        data: [subscription]
+                    }
+                });
+
+                // Make sure this customer has a corresponding member in the database
+                // And all the subscriptions are setup correctly
+                const initialMember = await createMemberFromStripe();
+                assert.equal(initialMember.status, 'paid', 'The member initial status should be paid');
+
+                // Cancel the previously created subscription in Stripe
+                set(subscription, {
+                    ...subscription, 
+                    status: 'canceled'
+                });
+
+                // Send the webhook call to anounce the cancelation
+                const webhookPayload = JSON.stringify({
+                    type: 'customer.subscription.updated',
+                    data: {
+                        object: subscription
+                    }
+                });
+                const webhookSignature = stripe.webhooks.generateTestHeaderString({
+                    payload: webhookPayload,
+                    secret: process.env.WEBHOOK_SECRET
+                });
+
+                await membersAgent.post('/webhooks/stripe/')
+                    .body(webhookPayload)
+                    .header('stripe-signature', webhookSignature)
+                    .expectStatus(200);
+
+                // Check status has been updated to 'free' after cancelling
+                const {body: body2} = await adminAgent.get('/members/?search=' + encodeURIComponent(customer.email));
+                assert.equal(body2.members.length, 1, 'The member does not exist');
+                const updatedMember = body2.members[0];
+                assert.equal(updatedMember.status, 'free');
+
+                // Check the status events for this newly created member (should be NULL -> paid only)
+                assertMemberEvents({
+                    eventType: 'MemberStatusEvent',
+                    memberId: updatedMember.id,
+                    asserts: [
+                        {
+                            from_status: null,
+                            to_status: 'free'
+                        },
+                        {
+                            from_status: 'free',
+                            to_status: 'paid'
+                        },
+                        {
+                            from_status: 'paid',
+                            to_status: 'free'
+                        }
+                    ]
+                });
+
+                assertMemberEvents({
+                    eventType: 'MemberPaidSubscriptionEvent',
+                    memberId: updatedMember.id,
+                    asserts: [
+                        {
+                            mrr_delta: 500
+                        },
+                        {
+                            mrr_delta: -500
+                        }
+                    ]
+                });
+            });
+
+            it('Handles cancellation of old fashioned comped subscriptions correctly', async function () {
+                const customer_id = 'cust_3433';
+                const subscription_id = 'sub_3433';
+
+                const price = {
+                    id: 'price_123',
+                    product: 'product_123',
+                    active: true,
+                    nickname: 'Complimentary',
+                    currency: 'USD',
+                    recurring: {
+                        interval: 'month'
+                    },
+                    unit_amount: 0,
+                    type: 'recurring'
                 };
 
-                const customer = {
+                // Create a new subscription in Stripe
+                set(subscription, {
+                    id: subscription_id,
+                    customer: customer_id,
+                    status: 'active',
+                    items: {
+                        type: 'list',
+                        data: [{
+                            id: 'item_123',
+                            price
+                        }]
+                    },
+                    plan: price, // Old stripe thing
+                    start_date: Date.now() / 1000,
+                    current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                    cancel_at_period_end: false
+                });
+
+                // Create a new customer in Stripe
+                set(customer, {
+                    id: customer_id,
+                    name: 'Test Member',
+                    email: 'cancel-complementary-test@email.com',
+                    subscriptions: {
+                        type: 'list',
+                        data: [subscription]
+                    }
+                });
+
+                // Make sure this customer has a corresponding member in the database
+                // And all the subscriptions are setup correctly
+                const initialMember = await createMemberFromStripe();
+                assert.equal(initialMember.status, 'comped', 'The member initial status should be comped');
+
+                // Cancel the previously created subscription in Stripe
+                set(subscription, {
+                    ...subscription, 
+                    status: 'canceled'
+                });
+
+                // Send the webhook call to anounce the cancelation
+                const webhookPayload = JSON.stringify({
+                    type: 'customer.subscription.updated',
+                    data: {
+                        object: subscription
+                    }
+                });
+                const webhookSignature = stripe.webhooks.generateTestHeaderString({
+                    payload: webhookPayload,
+                    secret: process.env.WEBHOOK_SECRET
+                });
+
+                await membersAgent.post('/webhooks/stripe/')
+                    .body(webhookPayload)
+                    .header('stripe-signature', webhookSignature)
+                    .expectStatus(200);
+
+                // Check status has been updated to 'free' after cancelling
+                const {body: body2} = await adminAgent.get('/members/?search=' + encodeURIComponent(customer.email));
+                assert.equal(body2.members.length, 1, 'The member does not exist');
+                const updatedMember = body2.members[0];
+                assert.equal(updatedMember.status, 'free');
+
+                // Check the status events for this newly created member (should be NULL -> paid only)
+                assertMemberEvents({
+                    eventType: 'MemberStatusEvent',
+                    memberId: updatedMember.id,
+                    asserts: [
+                        {
+                            from_status: null,
+                            to_status: 'free'
+                        },
+                        {
+                            from_status: 'free',
+                            to_status: 'comped'
+                        },
+                        {
+                            from_status: 'comped',
+                            to_status: 'free'
+                        }
+                    ]
+                });
+
+                assertMemberEvents({
+                    eventType: 'MemberPaidSubscriptionEvent',
+                    memberId: updatedMember.id,
+                    asserts: []
+                });
+            });
+        });
+
+        describe('checkout.session.completed', function () {
+            // The subscription that we got from Stripe was created 2 seconds earlier (used for testing events)
+            const beforeNow = Math.floor((Date.now() - 2000) / 1000) * 1000;
+            before(function () {
+                set(subscription, {
+                    id: 'sub_123',
+                    customer: 'cus_123',
+                    status: 'active',
+                    items: {
+                        type: 'list',
+                        data: [{
+                            id: 'item_123',
+                            price: {
+                                id: 'price_123',
+                                product: 'product_123',
+                                active: true,
+                                nickname: 'Monthly',
+                                currency: 'USD',
+                                recurring: {
+                                    interval: 'month'
+                                },
+                                unit_amount: 500,
+                                type: 'recurring'
+                            }
+                        }]
+                    },
+                    start_date: beforeNow / 1000,
+                    current_period_end: beforeNow / 1000 + (60 * 60 * 24 * 31),
+                    cancel_at_period_end: false
+                });
+            });
+
+            it('Will create a member if one does not exist', async function () {                
+                set(customer, {
                     id: 'cus_123',
                     name: 'Test Member',
                     email: 'checkout-webhook-test@email.com',
@@ -113,31 +427,29 @@ describe('Members API', function () {
                         type: 'list',
                         data: [subscription]
                     }
-                };
-
-                nock('https://api.stripe.com')
-                    .persist()
-                    .get(/v1\/.*/)
-                    .reply((uri, body) => {
-                        const [match, resource, id] = uri.match(/\/?v1\/(\w+)\/?(\w+)/) || [null];
-
-                        if (!match) {
-                            return [500];
-                        }
-
-                        if (resource === 'customers') {
-                            return [200, customer];
-                        }
-
-                        if (resource === 'subscriptions') {
-                            return [200, subscription];
-                        }
-                    });
+                });
 
                 { // ensure member didn't already exist
                     const {body} = await adminAgent.get('/members/?search=checkout-webhook-test@email.com');
                     assert.equal(body.members.length, 0, 'A member already existed');
                 }
+
+                const webhookPayload = JSON.stringify({
+                    type: 'checkout.session.completed',
+                    data: {
+                        object: {
+                            mode: 'subscription',
+                            customer: customer.id,
+                            subscription: subscription.id,
+                            metadata: {}
+                        }
+                    }
+                });
+                
+                const webhookSignature = stripe.webhooks.generateTestHeaderString({
+                    payload: webhookPayload,
+                    secret: process.env.WEBHOOK_SECRET
+                });
 
                 await membersAgent.post('/webhooks/stripe/')
                     .body(webhookPayload)
@@ -154,39 +466,42 @@ describe('Members API', function () {
                     subject: '🙌 Thank you for signing up to Ghost!',
                     to: 'checkout-webhook-test@email.com'
                 });
+
+                // Check the status events for this newly created member (should be NULL -> paid only)
+                assertMemberEvents({
+                    eventType: 'MemberStatusEvent',
+                    memberId: member.id,
+                    asserts: [
+                        {
+                            from_status: null,
+                            to_status: 'free',
+                            created_at: new Date(member.created_at)
+                        },
+                        {
+                            from_status: 'free',
+                            to_status: 'paid',
+                            created_at: new Date(beforeNow)
+                        }
+                    ]
+                });
+
+                assertMemberEvents({
+                    eventType: 'MemberPaidSubscriptionEvent',
+                    memberId: member.id,
+                    asserts: [
+                        {
+                            mrr_delta: 500
+                        }
+                    ]
+                });
             });
 
             it('Does not 500 if the member is unknown', async function () {
-                const setupIntent = {
-                    id: 'setup_intent_456',
-                    payment_method: 'card_456',
-                    metadata: {
-                        customer_id: 'cus_456',
-                        subscription_id: 'sub_456'
-                    }
-                };
-
-                const paymentMethod = {
+                set(paymentMethod, {
                     id: 'card_456'
-                };
-
-                const webhookPayload = JSON.stringify({
-                    type: 'checkout.session.completed',
-                    data: {
-                        object: {
-                            mode: 'setup',
-                            customer: 'cus_456',
-                            setup_intent: 'setup_intent_456'
-                        }
-                    }
                 });
 
-                const webhookSignature = stripe.webhooks.generateTestHeaderString({
-                    payload: webhookPayload,
-                    secret: process.env.WEBHOOK_SECRET
-                });
-
-                const subscription = {
+                set(subscription, {
                     id: 'sub_456',
                     customer: 'cus_456',
                     status: 'active',
@@ -211,47 +526,32 @@ describe('Members API', function () {
                     start_date: Date.now() / 1000,
                     current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
                     cancel_at_period_end: false
-                };
+                });
 
-                nock('https://api.stripe.com')
-                    .persist()
-                    .get(/v1\/.*/)
-                    .reply((uri, body) => {
-                        const [match, resource, id] = uri.match(/\/?v1\/(\w+)\/?(\w+)/) || [null];
+                set(setupIntent, {
+                    id: 'setup_intent_456',
+                    payment_method: paymentMethod.id,
+                    metadata: {
+                        customer_id: 'cus_456', // invalid customer id
+                        subscription_id: subscription.id
+                    }
+                });
 
-                        if (!match) {
-                            return [500];
+                const webhookPayload = JSON.stringify({
+                    type: 'checkout.session.completed',
+                    data: {
+                        object: {
+                            mode: 'setup',
+                            customer: 'cus_456',
+                            setup_intent: setupIntent.id
                         }
+                    }
+                });
 
-                        if (resource === 'setup_intents') {
-                            return [200, setupIntent];
-                        }
-
-                        if (resource === 'subscriptions') {
-                            return [200, subscription];
-                        }
-                    });
-
-                nock('https://api.stripe.com')
-                    .persist()
-                    .post(/v1\/.*/)
-                    .reply((uri, body) => {
-                        const [match, resource, id, action] = uri.match(/\/?v1\/(\w+)(?:\/?(\w+)){0,2}/) || [null];
-
-                        if (!match) {
-                            return [500];
-                        }
-
-                        if (resource === 'payment_methods') {
-                            return [200, paymentMethod];
-                        }
-
-                        if (resource === 'subscriptions') {
-                            return [200, subscription];
-                        }
-
-                        return [500];
-                    });
+                const webhookSignature = stripe.webhooks.generateTestHeaderString({
+                    payload: webhookPayload,
+                    secret: process.env.WEBHOOK_SECRET
+                });
 
                 await membersAgent.post('/webhooks/stripe/')
                     .body(webhookPayload)


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1372

- Added tests for Stripe webhooks that cancel a subscription (paid and complimentary)
- Tests for manually adding a complimentary member, and removing it again (the 'new' way)
- Added tests for creating new members (paid, complimentary)
- Includes tests for the `stripe_customer_id` property when creating new members (this is broken, fixed by https://github.com/TryGhost/Members/pull/378#issuecomment-1070835800)
- Deduplicated some nock code for Stripe
- Improved event assertions and interference between multiple tests in the giant members test file (by asserting only for the affected member id instead of all events).