### PR TITLE
Fixed missing product name in API response when editing creating/editing subscriptions

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -197,9 +197,7 @@ module.exports = {
                     }
                 });
             }
-            let model = await membersService.api.members.get({id: frame.options.id}, {
-                withRelated: ['labels', 'products', 'stripeSubscriptions', 'stripeSubscriptions.customer', 'stripeSubscriptions.stripePrice', 'stripeSubscriptions.stripePrice.stripeProduct']
-            });
+            let model = await membersService.api.memberBREADService.read({id: frame.options.id});
             if (!model) {
                 throw new errors.NotFoundError({
                     message: tpl(messages.memberNotFound)
@@ -241,9 +239,7 @@ module.exports = {
                     stripe_price_id: frame.data.stripe_price_id
                 }
             });
-            let model = await membersService.api.members.get({id: frame.options.id}, {
-                withRelated: ['labels', 'products', 'stripeSubscriptions', 'stripeSubscriptions.customer', 'stripeSubscriptions.stripePrice', 'stripeSubscriptions.stripePrice.stripeProduct']
-            });
+            let model = await membersService.api.memberBREADService.read({id: frame.options.id});
             if (!model) {
                 throw new errors.NotFoundError({
                     message: tpl(messages.memberNotFound)

--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -205,6 +205,7 @@ Object {
           },
           "default_payment_card_last4": null,
           "id": "sub_123",
+          "offer": null,
           "plan": Object {
             "amount": 5000,
             "currency": "USD",
@@ -221,6 +222,7 @@ Object {
             "price_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
             "product": Object {
               "id": "109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d",
+              "name": "Default Product",
               "product_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
             },
             "type": "recurring",
@@ -240,7 +242,7 @@ exports[`Members API Can add a subscription 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1353",
+  "content-length": "1391",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1141

- switched to the same member fetch method as used in `GET /member/:id/` so there's consistent data available when rendering the API responses
