### PR TITLE
Fixed same redirectManager used in offer service between tests

### DIFF
--- a/core/boot.js
+++ b/core/boot.js
@@ -148,6 +148,11 @@ async function initServicesForFrontend() {
     await themeService.init();
     debug('End: Themes');
 
+    debug('Begin: Offers');
+    const offers = require('./server/services/offers');
+    await offers.init();
+    debug('End: Offers');
+
     debug('End: initServicesForFrontend');
 }
 
@@ -239,7 +244,6 @@ async function initServices({config}) {
     debug('Begin: Services');
     const stripe = require('./server/services/stripe');
     const members = require('./server/services/members');
-    const offers = require('./server/services/offers');
     const permissions = require('./server/services/permissions');
     const xmlrpc = require('./server/services/xmlrpc');
     const slack = require('./server/services/slack');
@@ -258,7 +262,6 @@ async function initServices({config}) {
     // NOTE: Members service depends on these
     //       so they are initialized before it.
     await stripe.init();
-    await offers.init();
 
     await Promise.all([
         members.init(),

--- a/core/server/services/offers/service.js
+++ b/core/server/services/offers/service.js
@@ -5,19 +5,20 @@ const config = require('../../../shared/config');
 const urlUtils = require('../../../shared/url-utils');
 const models = require('../../models');
 
-const redirectManager = new DynamicRedirectManager({
-    permanentMaxAge: config.get('caching:customRedirects:maxAge'),
-    getSubdirectoryURL: (pathname) => {
-        return urlUtils.urlJoin(urlUtils.getSubdir(), pathname);
-    }
-});
+let redirectManager;
 
 module.exports = {
     async init() {
+        redirectManager = new DynamicRedirectManager({
+            permanentMaxAge: config.get('caching:customRedirects:maxAge'),
+            getSubdirectoryURL: (pathname) => {
+                return urlUtils.urlJoin(urlUtils.getSubdir(), pathname);
+            }
+        });
         const offersModule = OffersModule.create({
             OfferModel: models.Offer,
             OfferRedemptionModel: models.OfferRedemption,
-            redirectManager: redirectManager
+            redirectManager
         });
 
         this.api = offersModule.api;
@@ -27,5 +28,7 @@ module.exports = {
 
     api: null,
 
-    middleware: redirectManager.handleRequest
+    get middleware() {
+        return redirectManager.handleRequest;
+    }
 };


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1647599592576139
refs https://ghost.slack.com/archives/C02G9E68C/p1647620250625909

Issue: `Cannot destructure property 'fromRegex' of 'this.redirectsredirectId]' as it is undefined.` is being thrown, only when running all tests.
Cause: duplicate redirects are added to a redirectManager, and not cleared correctly in the redirectManager, which throws an error when removing one of the duplicate redirects.

Because the same redirectManager is used, multiple event listeners are connected to the same redirectManager. So when the offer service has been initialised multiple times, multiple listeners are added, which create a redirect for every newly created offer... to the same redirectManager.
So there are three possible fixes for the same problem (would be best to fix them all):
- Create a new redirectManager every time the offer service is initialised **(= this PR)**
- Figure out a way to remove DomainEvents subscribers between tests
- https://github.com/TryGhost/Members/pull/379

This commit contains a fix for the first solution.

It also moved the offers service initialising before the frontend (to `initServicesForFrontend`)