### PR TITLE
Fixed 404 error handling in Ghost Admin

### DIFF
--- a/core/frontend/web/middleware/error-handler.js
+++ b/core/frontend/web/middleware/error-handler.js
@@ -7,7 +7,7 @@ const config = require('../../../shared/config');
 const helpers = require('../../services/routing/helpers');
 
 // @TODO: make this properly shared code
-const {prepareError} = require('@tryghost/mw-error-handler');
+const {prepareError, prepareStack} = require('@tryghost/mw-error-handler');
 
 const messages = {
     oopsErrorTemplateHasError: 'Oops, seems there is an error in the error template.',
@@ -84,10 +84,12 @@ const themeErrorRenderer = (err, req, res, next) => {
 };
 
 module.exports.handleThemeResponse = [
-    // Handle the error in Sentry
-    sentry.errorHandler,
     // Make sure the error can be served
     prepareError,
+    // Handle the error in Sentry
+    sentry.errorHandler,
+    // Format the stack for the user
+    prepareStack,
     // Render the error using theme template
     themeErrorRenderer
 ];

--- a/core/server/web/admin/app.js
+++ b/core/server/web/admin/app.js
@@ -46,6 +46,14 @@ module.exports = function setupAdminApp() {
     // Finally, routing
     adminApp.get('*', require('./controller'));
 
+    adminApp.use((err, req, res, next) => {
+        if (err.statusCode && err.statusCode === 404) {
+            // Remove 404 errors for next middleware to inject
+            next();
+        } else {
+            next(err);
+        }
+    });
     adminApp.use(errorHandler.pageNotFound);
     adminApp.use(errorHandler.handleHTMLResponse(sentry));
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@tryghost/members-stripe-service": "0.9.1",
     "@tryghost/metrics": "1.0.6",
     "@tryghost/minifier": "0.1.11",
-    "@tryghost/mw-error-handler": "0.1.4",
+    "@tryghost/mw-error-handler": "0.1.5",
     "@tryghost/mw-session-from-token": "0.1.28",
     "@tryghost/nodemailer": "0.3.14",
     "@tryghost/nql": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,10 +2242,10 @@
   dependencies:
     lodash "^4.17.11"
 
-"@tryghost/mw-error-handler@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@tryghost/mw-error-handler/-/mw-error-handler-0.1.4.tgz#d2a0cd308cdcf034ea6920434b7b8376dd93946d"
-  integrity sha512-hST8JPvYwIsx+YkspuC98B7mpwJ/JxF+RYuMMpLQBAX5cUaTsACy/qAz8iMBokqNAUaeNXMWQwEl4KTkvtj8Fg==
+"@tryghost/mw-error-handler@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@tryghost/mw-error-handler/-/mw-error-handler-0.1.5.tgz#e7791c44ba954b19cc91e9ca2f66ef4bc37a6972"
+  integrity sha512-HF0ubWNgOmz47o5+7yuzde40upYf0b/ZveHFO6P0UkLsTdkYhPp5Sj7TCr2TYR2JwuZLt2mTVCBxHRuI4SzlTA==
   dependencies:
     "@tryghost/debug" "^0.1.9"
     "@tryghost/errors" "1.2.5"
@@ -2330,7 +2330,7 @@
     got "9.6.0"
     lodash "^4.17.21"
 
-"@tryghost/root-utils@0.3.11", "@tryghost/root-utils@^0.3.10", "@tryghost/root-utils@^0.3.11", "@tryghost/root-utils@^0.3.8":
+"@tryghost/root-utils@0.3.11", "@tryghost/root-utils@^0.3.11", "@tryghost/root-utils@^0.3.8":
   version "0.3.11"
   resolved "https://registry.yarnpkg.com/@tryghost/root-utils/-/root-utils-0.3.11.tgz#4c3a045c89c75301435b1d1db1946072b3ee3adf"
   integrity sha512-1q01HsaqQSpFPVcq7tqkIUXa/L1P7yXNGbGJCeZ/IyfrSd/OdgQTluwz0BYzJc1mBP+5lIumqARr+XdbE/ZbAQ==
@@ -4613,7 +4613,7 @@ dicer@0.2.5:
     readable-stream "1.1.x"
     streamsearch "0.1.2"
 
-diff-sequences@^27.5.0, diff-sequences@^27.5.1:
+diff-sequences@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
   integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
@@ -8714,11 +8714,6 @@ microsoft-capitalize@~1.0.5:
   resolved "https://registry.yarnpkg.com/microsoft-capitalize/-/microsoft-capitalize-1.0.5.tgz#bcaf915039f14224c8cfd74c31cea42fecacbb31"
   integrity sha512-iqDMU9J643BHg8Zp7EMZNLTp6Pgs2f1S2SMnCW2VlUqMs17xCZ5vwVjalBJEGVcUfG+/1ePqeEGcMW3VfzHK5A==
 
-mime-db@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
-  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
-
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -9048,7 +9043,7 @@ nanoclone@^0.2.1:
   resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
   integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
-nanoid@3.3.1, nanoid@^3.2.0, nanoid@^3.3.1:
+nanoid@3.3.1, nanoid@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==


### PR DESCRIPTION
no issue

Prevents errors from being uploaded to Sentry when a 404 happens in Ghost Admin. At the moment, 404s in Ghost Admin create an ENOENT error in express' static library. Our generic 404 handler at the end will only intercept requests that don't have any errors in the context, so a simple middleware can strip out 404 errors just before we add in our own.

The Ghost-specific error that we attach to requests does not get uploaded to Sentry :) 

---

Edit (additional context for changes other than the 404 fix):

Issue is that we were sending various errors to sentry that shouldn't have been, including some validation errors and 404s under /ghost/assets/.

The changes:

* Separated out prepareError and prepareStack
  * Prepare error still need to run before sending errors to sentry, since errors can be stored in an array (as is the case with validation errors), or can still be converted into a Ghost error at that stage
  * Prepare stack returns a new cloned error to avoid mutating the stack for the error which has already been sent to Sentry
* Prevent 404s in Ghost Admin from being sent to Sentry
  * Strips out the default error generated in Express so that Ghost can inject its own NotFoundError, which isn't sent to Sentry by default