### PR TITLE
Added the newsletters table

### DIFF
--- a/core/server/data/exporter/table-lists.js
+++ b/core/server/data/exporter/table-lists.js
@@ -15,6 +15,7 @@ const BACKUP_TABLES = [
     'members_stripe_customers_subscriptions',
     'migrations',
     'migrations_lock',
+    'newsletters',
     'oauth',
     'permissions',
     'permissions_roles',

--- a/core/server/data/migrations/versions/4.42/2022-03-21-17-17-add.js
+++ b/core/server/data/migrations/versions/4.42/2022-03-21-17-17-add.js
@@ -1,0 +1,20 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('newsletters', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    name: {type: 'string', maxlength: 191, nullable: false},
+    description: {type: 'string', maxlength: 2000, nullable: true},
+    sender_name: {type: 'string', maxlength: 191, nullable: false},
+    sender_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
+    sender_reply_to: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
+    default: {type: 'bool', nullable: false, defaultTo: false},
+    status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},
+    recipient_filter: {
+        type: 'text',
+        maxlength: 1000000000,
+        nullable: false,
+        defaultTo: ''
+    },
+    subscribe_on_signup: {type: 'bool', nullable: false, defaultTo: false},
+    sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -711,5 +711,23 @@ module.exports = {
             }
         },
         value: {type: 'text', maxlength: 65535, nullable: true}
+    },
+    newsletters: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        name: {type: 'string', maxlength: 191, nullable: false},
+        description: {type: 'string', maxlength: 2000, nullable: true},
+        sender_name: {type: 'string', maxlength: 191, nullable: false},
+        sender_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
+        sender_reply_to: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
+        default: {type: 'bool', nullable: false, defaultTo: false},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},
+        recipient_filter: {
+            type: 'text',
+            maxlength: 1000000000,
+            nullable: false,
+            defaultTo: ''
+        },
+        subscribe_on_signup: {type: 'bool', nullable: false, defaultTo: false},
+        sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
     }
 };

--- a/test/integration/exporter/exporter.test.js
+++ b/test/integration/exporter/exporter.test.js
@@ -49,6 +49,7 @@ describe('Exporter', function () {
                 'migrations',
                 'migrations_lock',
                 'mobiledoc_revisions',
+                'newsletters',
                 'oauth',
                 'offers',
                 'offer_redemptions',

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'b7867be4de694b4592d748c0367064b5';
+    const currentSchemaHash = 'adaab19330ba19ed2d0cba49458c8f21';
     const currentFixturesHash = 'f4dd2a454e1999b6d149cc26ae52ced4';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1433

- The `default` property stores whether a newsletter is set as default by the admin (the one `default` newsletter is the one selected by default when admins publish a new article)
- The `status` property stores whether a newsletter is archived or not
- The `recipient_filter` property is only storing whether a newsletter is "paid-only" or not for now, although it can be expanded to more specific filters in the future
- The `subscribe_on_signup` property stores whether a new member should be automatically signed up to the newsletter
- The `sort_order` property enables displaying the newsletter list in an order chosen by the admins
