### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -337,7 +337,7 @@ module.exports = function (grunt) {
                 // A list of files and patterns to include when creating a release zip.
                 // This is read from the `.npmignore` file and all patterns are inverted as we want to define what to include
                 src: fs.readFileSync('.npmignore', 'utf8').split('\n').filter(Boolean).map(function (pattern) {
-                    return pattern[0] === '!' ? pattern.substr(1) : '!' + pattern;
+                    return pattern[0] === '!' ? pattern.slice(1) : '!' + pattern;
                 }),
                 dest: '<%= paths.releaseBuild %>/'
             });

--- a/core/frontend/helpers/get.js
+++ b/core/frontend/helpers/get.js
@@ -80,7 +80,7 @@ function resolvePaths(globals, data, value) {
         path = path.replace(/\.\[/g, '[');
 
         if (path.charAt(0) === '@') {
-            result = jsonpath.query(globals, path.substr(1));
+            result = jsonpath.query(globals, path.slice(1));
         } else {
             // Do the query, which always returns an array of matches
             result = jsonpath.query(data, path);

--- a/core/server/models/base/plugins/generate-slug.js
+++ b/core/server/models/base/plugins/generate-slug.js
@@ -79,7 +79,7 @@ module.exports = function (Bookshelf) {
             // If it's a user, let's try to cut it down (unless this is a human request)
             if (baseName === 'user' && options && options.shortSlug && slugTryCount === 1 && slug !== 'ghost-owner') {
                 longSlug = slug;
-                slug = (slug.indexOf('-') > -1) ? slug.substr(0, slug.indexOf('-')) : slug;
+                slug = (slug.indexOf('-') > -1) ? slug.slice(0, slug.indexOf('-')) : slug;
             }
 
             if (!_.has(options, 'importing') || !options.importing) {


### PR DESCRIPTION
Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
