### PR TITLE
Added paid_subscribed and paid_canceled deltas to aggregateStatusCoun…

### DIFF
--- a/core/server/models/member-status-event.js
+++ b/core/server/models/member-status-event.js
@@ -18,11 +18,22 @@ const MemberStatusEvent = ghostBookshelf.Model.extend({
             const knex = ghostBookshelf.knex;
             return qb.clear('select')
                 .select(knex.raw('DATE(created_at) as date'))
+                // @todo: we don't need the paid_delta in the future as we'll be able to calculate it by 
+                // paid_delta = paid_subscribed - paid_canceled
+                // It is here because we have a circular dependency with the members-api package (which we can only update when this code got merged into main)
                 .select(knex.raw(`SUM(
                     CASE WHEN to_status='paid' THEN 1
                     WHEN from_status='paid' THEN -1
                     ELSE 0 END
                 ) as paid_delta`))
+                .select(knex.raw(`SUM(
+                    CASE WHEN to_status='paid' THEN 1
+                    ELSE 0 END
+                ) as paid_subscribed`))
+                .select(knex.raw(`SUM(
+                    CASE WHEN from_status='paid' THEN 1
+                    ELSE 0 END
+                ) as paid_canceled`))
                 .select(knex.raw(`SUM(
                     CASE WHEN to_status='comped' THEN 1
                     WHEN from_status='comped' THEN -1


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1458

Required for https://github.com/TryGhost/Members/pull/381

These changes are required by the members-api package to know the canceled and subscribed deltas (used in this PR: https://github.com/TryGhost/Members/pull/381). After those changes and version bump of the members api package, I'll be able to add the paid_subscribed and paid_canceled values to the members stats endpoint (and will remove the paid_delta in the SQL-query).

- Added calculated sum of paid_subscribed and paid_canceled to the aggregateStatusCounts of member status events
- Added a aggregateStatusCounts option for the Member object (the event repostory will use this as a starting point for the status counts)