### PR TITLE
Added table to store newsletters for a member

### DIFF
--- a/core/server/data/exporter/table-lists.js
+++ b/core/server/data/exporter/table-lists.js
@@ -40,6 +40,7 @@ const BACKUP_TABLES = [
     'members_paid_subscription_events',
     'members_subscribe_events',
     'members_product_events',
+    'members_newsletters',
     'offers',
     'offer_redemptions'
 ];

--- a/core/server/data/migrations/versions/4.43/2022-03-29-14-45-add-members-newsletters-table.js
+++ b/core/server/data/migrations/versions/4.43/2022-03-29-14-45-add-members-newsletters-table.js
@@ -3,6 +3,5 @@ const {addTable} = require('../../utils');
 module.exports = addTable('members_newsletters', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-    newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true},
-    sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
+    newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true}
 });

--- a/core/server/data/migrations/versions/4.43/2022-03-29-14-45-add-members-newsletters-table.js
+++ b/core/server/data/migrations/versions/4.43/2022-03-29-14-45-add-members-newsletters-table.js
@@ -1,0 +1,8 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('members_newsletters', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+    newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true},
+    sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -733,7 +733,6 @@ module.exports = {
     members_newsletters: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-        newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true},
-        sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
+        newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true}
     }
 };

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -729,5 +729,11 @@ module.exports = {
         },
         subscribe_on_signup: {type: 'bool', nullable: false, defaultTo: false},
         sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
+    },
+    members_newsletters: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+        newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true},
+        sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
     }
 };

--- a/test/integration/exporter/exporter.test.js
+++ b/test/integration/exporter/exporter.test.js
@@ -37,6 +37,7 @@ describe('Exporter', function () {
                 'members_email_change_events',
                 'members_labels',
                 'members_login_events',
+                'members_newsletters',
                 'members_paid_subscription_events',
                 'members_payment_events',
                 'members_products',

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'adaab19330ba19ed2d0cba49458c8f21';
+    const currentSchemaHash = 'e37f1d00ed20f71d83d4d4d1819838f6';
     const currentFixturesHash = 'f4dd2a454e1999b6d149cc26ae52ced4';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'e37f1d00ed20f71d83d4d4d1819838f6';
+    const currentSchemaHash = '8bf6c2996ddd0238d41a9d3e1cb07bd9';
     const currentFixturesHash = 'f4dd2a454e1999b6d149cc26ae52ced4';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1469

With multiple newsletters, members can have access to one or more newsletters on the site. Right now, the subscription to default newsletter for a member is controlled via a single boolean `subscribed` column on the member table.
We want to extend the relation between a newsletter and a member so that multiple newsletters can be attached to a member for different flows via new pivot table.

- adds new `members_newsletters` pivot table
- updates tests
