### PR TITLE
Added the post-newsletter relation

### DIFF
--- a/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
+++ b/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('posts', 'newsletter_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true,
+    references: 'newsletters.id'
+});

--- a/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
+++ b/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
@@ -55,7 +55,7 @@ module.exports = {
 
         await knex.raw('alter table `posts` drop foreign key `posts_newsletter_id_foreign`;');
 
-        await knex.raw('alter table `posts` drop `newsletter_id`;');
+        await knex.raw('alter table `posts` drop `newsletter_id`, algorithm=copy;');
     }
 };
 

--- a/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
+++ b/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
@@ -1,15 +1,8 @@
 const logging = require('@tryghost/logging');
 const DatabaseInfo = require('@tryghost/database-info');
-const commands = require('../../../schema/commands');
 
 const table = 'posts';
 const column = 'newsletter_id';
-const columnDefinition = {
-    type: 'string',
-    maxlength: 24,
-    nullable: true,
-    references: 'newsletters.id'
-};
 
 /**
  * This migration is adding a new column `newsletter_id` to the table posts
@@ -36,6 +29,8 @@ module.exports = {
 
         logging.info(`Adding ${table}.${column} column`);
 
+        // Add the column
+
         let sql = knex.schema.table(table, function (t) {
             t.string(column, 24);
         }).toSQL()[0].sql;
@@ -45,6 +40,8 @@ module.exports = {
         }
 
         await knex.raw(sql);
+
+        // Add the foreign key constraint
 
         await knex.schema.alterTable(table, function (t) {
             t.foreign(column).references('newsletters.id');
@@ -62,9 +59,13 @@ module.exports = {
 
         logging.info(`Removing ${table}.${column} column`);
 
+        // Drop the foreign key constraint
+
         await knex.schema.alterTable(table, function (t) {
             t.dropForeign(column);
         });
+
+        // Drop the column
 
         let sql = knex.schema.table(table, function (t) {
             t.dropColumn(column);

--- a/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
+++ b/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
@@ -3,7 +3,7 @@ const DatabaseInfo = require('@tryghost/database-info');
 const commands = require('../../../schema/commands');
 
 const table = 'posts';
-const column = 'newsletters_id';
+const column = 'newsletter_id';
 const columnDefinition = {
     type: 'string',
     maxlength: 24,

--- a/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
+++ b/core/server/data/migrations/versions/4.43/2022-04-01-10-13-add-post-newsletter-relation.js
@@ -1,8 +1,61 @@
-const {createAddColumnMigration} = require('../../utils');
+const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
+const commands = require('../../../schema/commands');
 
-module.exports = createAddColumnMigration('posts', 'newsletter_id', {
+const table = 'posts';
+const column = 'newsletters_id';
+const columnDefinition = {
     type: 'string',
     maxlength: 24,
     nullable: true,
     references: 'newsletters.id'
-});
+};
+
+module.exports = {
+    config: {
+        transaction: true
+    },
+    async up(config) {
+        const knex = config.transacting;
+
+        const hasColumn = await knex.schema.hasColumn(table, column);
+
+        if (hasColumn) {
+            logging.info(`Adding ${table}.${column} column - skipping as table is correct`);
+            return;
+        }
+
+        logging.info(`Adding ${table}.${column} column`);
+
+        if (DatabaseInfo.isSQLite(knex)) {
+            await commands.addColumn(table, column, knex, columnDefinition);
+            return;
+        }
+
+        await knex.raw('alter table `posts` add column `newsletter_id` varchar(24) null, algorithm=copy;');
+
+        await knex.raw('alter table `posts` add constraint `posts_newsletter_id_foreign` foreign key (`newsletter_id`) references `newsletters` (`id`);');
+    },
+    async down(config) {
+        const knex = config.transacting;
+
+        const hasColumn = await knex.schema.hasColumn(table, column);
+
+        if (!hasColumn) {
+            logging.info(`Removing ${table}.${column} column - skipping as table is correct`);
+            return;
+        }
+
+        logging.info(`Removing ${table}.${column} column`);
+
+        if (DatabaseInfo.isSQLite(knex)) {
+            await commands.dropColumn(table, column, knex, columnDefinition);
+            return;
+        }
+
+        await knex.raw('alter table `posts` drop foreign key `posts_newsletter_id_foreign`;');
+
+        await knex.raw('alter table `posts` drop `newsletter_id`;');
+    }
+};
+

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -8,6 +8,24 @@
  * Long text = length 1,000,000,000
  */
 module.exports = {
+    newsletters: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        name: {type: 'string', maxlength: 191, nullable: false},
+        description: {type: 'string', maxlength: 2000, nullable: true},
+        sender_name: {type: 'string', maxlength: 191, nullable: false},
+        sender_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
+        sender_reply_to: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
+        default: {type: 'bool', nullable: false, defaultTo: false},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},
+        recipient_filter: {
+            type: 'text',
+            maxlength: 1000000000,
+            nullable: false,
+            defaultTo: ''
+        },
+        subscribe_on_signup: {type: 'bool', nullable: false, defaultTo: false},
+        sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
+    },
     posts: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         uuid: {type: 'string', maxlength: 36, nullable: false, validations: {isUUID: true}},
@@ -56,6 +74,7 @@ module.exports = {
         codeinjection_foot: {type: 'text', maxlength: 65535, nullable: true},
         custom_template: {type: 'string', maxlength: 100, nullable: true},
         canonical_url: {type: 'text', maxlength: 2000, nullable: true},
+        newsletter_id: {type: 'string', maxlength: 24, nullable: true, references: 'newsletters.id'},
         '@@UNIQUE_CONSTRAINTS@@': [
             ['slug', 'type']
         ]
@@ -711,24 +730,6 @@ module.exports = {
             }
         },
         value: {type: 'text', maxlength: 65535, nullable: true}
-    },
-    newsletters: {
-        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        name: {type: 'string', maxlength: 191, nullable: false},
-        description: {type: 'string', maxlength: 2000, nullable: true},
-        sender_name: {type: 'string', maxlength: 191, nullable: false},
-        sender_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
-        sender_reply_to: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
-        default: {type: 'bool', nullable: false, defaultTo: false},
-        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},
-        recipient_filter: {
-            type: 'text',
-            maxlength: 1000000000,
-            nullable: false,
-            defaultTo: ''
-        },
-        subscribe_on_signup: {type: 'bool', nullable: false, defaultTo: false},
-        sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
     },
     members_newsletters: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -557,7 +557,7 @@ Post = ghostBookshelf.Model.extend({
                 if (!tag.id && !tag.tag_id && tag.slug) {
                     // Clean up the provided slugs before we do any matching with existing tags
                     tag.slug = await ghostBookshelf.Model.generateSlug(
-                        Tag, 
+                        Tag,
                         tag.slug,
                         {skipDuplicateChecks: true}
                     );
@@ -877,6 +877,9 @@ Post = ghostBookshelf.Model.extend({
 
         // CASE: never expose the revisions
         delete attrs.mobiledoc_revisions;
+
+        // CASE: hide the newsletter_id for now
+        delete attrs.newsletter_id;
 
         // If the current column settings allow it...
         if (!options.columns || (options.columns && options.columns.indexOf('primary_tag') > -1)) {

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '8bf6c2996ddd0238d41a9d3e1cb07bd9';
+    const currentSchemaHash = 'cbfa94566ed4af324defe7a2b561519c';
     const currentFixturesHash = 'f4dd2a454e1999b6d149cc26ae52ced4';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1471

- This is a many-to-one relation so that many posts can be linked to a specific newsletter
- The `newsletters` table had to come first in the schema file so that it's initialized before the `posts` table (because of the foreign key)
- Updated the model to make sure the new field doesn't leak in the API for now
- This migration isn't using the existing utils because of a performance issue. In MySQL, adding a new row without `algorithm=copy` uses the INPLACE algorithm which was too slow on big `posts` tables (~3 minutes for 10k posts). Switching to the COPY algorithm fixed the issue (~3 seconds for 10k posts).

[Slack conversation](https://ghost.slack.com/archives/C02G9E68C/p1649151709623559) for the `algorithm=copy`