### PR TITLE
Removed the `default` column from the `newsletters` table

### DIFF
--- a/core/server/data/migrations/versions/4.43/2022-04-04-15-41-remove-newsletters-default-column.js
+++ b/core/server/data/migrations/versions/4.43/2022-04-04-15-41-remove-newsletters-default-column.js
@@ -1,0 +1,7 @@
+const {createDropColumnMigration} = require('../../utils');
+
+module.exports = createDropColumnMigration('newsletters', 'default', {
+    type: 'bool',
+    nullable: false,
+    defaultTo: false
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -15,7 +15,6 @@ module.exports = {
         sender_name: {type: 'string', maxlength: 191, nullable: false},
         sender_email: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
         sender_reply_to: {type: 'string', maxlength: 191, nullable: false, validations: {isEmail: true}},
-        default: {type: 'bool', nullable: false, defaultTo: false},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},
         recipient_filter: {
             type: 'text',

--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -2260,7 +2260,6 @@ Object {
       "name": "test",
       "newsletters": Array [
         Object {
-          "default": false,
           "description": null,
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "name": "Daily newsletter",
@@ -2273,7 +2272,6 @@ Object {
           "subscribe_on_signup": true,
         },
         Object {
-          "default": false,
           "description": null,
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "name": "Weekly newsletter",
@@ -2302,7 +2300,7 @@ exports[`Members API: with multiple newsletters Can add with default newsletters
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1179",
+  "content-length": "1147",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -2329,7 +2327,6 @@ Object {
       "name": "test newsletter",
       "newsletters": Array [
         Object {
-          "default": false,
           "description": null,
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "name": "Weekly newsletter",
@@ -2358,7 +2355,7 @@ exports[`Members API: with multiple newsletters Can and and edit with custom new
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "919",
+  "content-length": "903",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -2385,7 +2382,6 @@ Object {
       "name": "test newsletter",
       "newsletters": Array [
         Object {
-          "default": false,
           "description": null,
           "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "name": "Daily newsletter",
@@ -2414,7 +2410,7 @@ exports[`Members API: with multiple newsletters Can and and edit with custom new
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "918",
+  "content-length": "902",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
@@ -4,7 +4,6 @@ exports[`Newsletters API Can add a newsletter 1: [body] 1`] = `
 Object {
   "newsletters": Array [
     Object {
-      "default": false,
       "description": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "name": "My test newsletter",
@@ -24,7 +23,7 @@ exports[`Newsletters API Can add a newsletter 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "288",
+  "content-length": "272",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": Any<String>,
@@ -47,7 +46,6 @@ Object {
   },
   "newsletters": Array [
     Object {
-      "default": false,
       "description": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "name": "My test newsletter",
@@ -67,7 +65,7 @@ exports[`Newsletters API Can add a newsletter 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "376",
+  "content-length": "360",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -89,7 +87,6 @@ Object {
   },
   "newsletters": Array [
     Object {
-      "default": false,
       "description": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "name": "My test newsletter",
@@ -109,7 +106,7 @@ exports[`Newsletters API Can browse newsletters 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "376",
+  "content-length": "360",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -131,7 +128,6 @@ Object {
   },
   "newsletters": Array [
     Object {
-      "default": false,
       "description": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "name": "My test newsletter",
@@ -151,7 +147,7 @@ exports[`Newsletters API Can edit newsletters 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "375",
+  "content-length": "359",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -163,7 +159,6 @@ exports[`Newsletters API Can edit newsletters 3: [body] 1`] = `
 Object {
   "newsletters": Array [
     Object {
-      "default": false,
       "description": null,
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "name": "Updated newsletter name",
@@ -183,7 +178,7 @@ exports[`Newsletters API Can edit newsletters 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "293",
+  "content-length": "277",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'cbfa94566ed4af324defe7a2b561519c';
+    const currentSchemaHash = '2611cd9a3249e2dbb3d3b02218bf06bc';
     const currentFixturesHash = 'f4dd2a454e1999b6d149cc26ae52ced4';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1474

- The `default` concept will be replaced by the first newsletter based on the `sort_order`
- This simplifies the design to make it more maintainable
- This removes the `default` value from the newsletter API