### PR TITLE
Removed pagination from members stats endpoint and added extra day to…

### DIFF
--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -3,14 +3,6 @@
 exports[`Stats API Can fetch member count history 1: [body] 1`] = `
 Object {
   "meta": Object {
-    "pagination": Object {
-      "limit": "all",
-      "next": null,
-      "page": 1,
-      "pages": 1,
-      "prev": null,
-      "total": 1,
-    },
     "totals": Object {
       "comped": 0,
       "free": 3,
@@ -34,7 +26,7 @@ exports[`Stats API Can fetch member count history 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "231",
+  "content-length": "149",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/unit/server/services/stats/members-stats-service.test.js
+++ b/test/unit/server/services/stats/members-stats-service.test.js
@@ -16,19 +16,28 @@ describe('MembersStatsService', function () {
         /**
          * @type {MembersStatsService.MemberStatusDelta[]}
          */
-        const events = [];
+        let events = [];
         const today = '2000-01-10';
         const tomorrow = '2000-01-11';
         const yesterday = '2000-01-09';
+        const dayBeforeYesterday = '2000-01-08';
+        const twoDaysBeforeYesterday = '2000-01-07';
         const todayDate = DateTime.fromISO(today).toJSDate();
         const tomorrowDate = DateTime.fromISO(tomorrow).toJSDate();
         const yesterdayDate = DateTime.fromISO(yesterday).toJSDate();
+        const dayBeforeYesterdayDate = DateTime.fromISO(dayBeforeYesterday).toJSDate();
 
         before(function () {
             sinon.useFakeTimers(todayDate.getTime());
             membersStatsService = new MembersStatsService({db: null});
             fakeTotal = sinon.stub(membersStatsService, 'getCount').resolves(currentCounts);
-            fakeStatuses = sinon.stub(membersStatsService, 'fetchAllStatusDeltas').resolves(events);
+            fakeStatuses = sinon.stub(membersStatsService, 'fetchAllStatusDeltas').callsFake(() => {
+                // Sort here ascending to mimic same ordering
+                events.sort((a, b) => {
+                    return a.date < b.date ? -1 : 1;
+                });
+                return Promise.resolve(events);
+            });
         });
 
         afterEach(function () {
@@ -38,7 +47,7 @@ describe('MembersStatsService', function () {
 
         it('Always returns at least one value', async function () {
             // No status events
-            events.splice(0, events.length);
+            events = [];
             currentCounts.paid = 1;
             currentCounts.free = 2;
             currentCounts.comped = 3;
@@ -61,13 +70,15 @@ describe('MembersStatsService', function () {
 
         it('Passes paid_subscribers and paid_canceled', async function () {
             // Update faked status events
-            events.splice(0, events.length, {
-                date: todayDate,
-                paid_subscribed: 4,
-                paid_canceled: 3,
-                free_delta: 2,
-                comped_delta: 3
-            });
+            events = [
+                {
+                    date: todayDate,
+                    paid_subscribed: 4,
+                    paid_canceled: 3,
+                    free_delta: 2,
+                    comped_delta: 3
+                }
+            ];
 
             // Update current faked counts
             currentCounts.paid = 1;
@@ -75,39 +86,47 @@ describe('MembersStatsService', function () {
             currentCounts.comped = 3;
 
             const {data: results, meta} = await membersStatsService.getCountHistory();
-            results.length.should.eql(1);
-            results[0].should.eql({
-                date: today,
-                paid: 1,
-                free: 2,
-                comped: 3,
-                paid_subscribed: 4,
-                paid_canceled: 3
-            });
+            results.should.eql([
+                {
+                    date: yesterday,
+                    paid: 0,
+                    free: 0,
+                    comped: 0,
+                    paid_subscribed: 0,
+                    paid_canceled: 0
+                },
+                {
+                    date: today,
+                    paid: 1,
+                    free: 2,
+                    comped: 3,
+                    paid_subscribed: 4,
+                    paid_canceled: 3
+                }
+            ]);
             meta.totals.should.eql(currentCounts);
-
             fakeStatuses.calledOnce.should.eql(true);
             fakeTotal.calledOnce.should.eql(true);
         });
 
         it('Correctly resolves deltas', async function () {
             // Update faked status events
-            events.splice(0, events.length, 
-                {
-                    date: todayDate,
-                    paid_subscribed: 4,
-                    paid_canceled: 3,
-                    free_delta: 2,
-                    comped_delta: 3
-                }, 
+            events = [
                 {
                     date: yesterdayDate,
                     paid_subscribed: 2,
                     paid_canceled: 1,
                     free_delta: 0,
                     comped_delta: 0
+                },
+                {
+                    date: todayDate,
+                    paid_subscribed: 4,
+                    paid_canceled: 3,
+                    free_delta: 2,
+                    comped_delta: 3
                 }
-            );
+            ];
 
             // Update current faked counts
             currentCounts.paid = 2;
@@ -116,6 +135,14 @@ describe('MembersStatsService', function () {
 
             const {data: results, meta} = await membersStatsService.getCountHistory();
             results.should.eql([
+                {
+                    date: dayBeforeYesterday,
+                    paid: 0,
+                    free: 1,
+                    comped: 1,
+                    paid_subscribed: 0,
+                    paid_canceled: 0
+                },
                 {
                     date: yesterday,
                     paid: 1,
@@ -138,16 +165,89 @@ describe('MembersStatsService', function () {
             fakeTotal.calledOnce.should.eql(true);
         });
 
+        it('Correctly handles negative numbers', async function () {
+            // Update faked status events
+            events = [ 
+                {
+                    date: dayBeforeYesterdayDate,
+                    paid_subscribed: 2,
+                    paid_canceled: 1,
+                    free_delta: 2,
+                    comped_delta: 10
+                },
+                {
+                    date: yesterdayDate,
+                    paid_subscribed: 2,
+                    paid_canceled: 1,
+                    free_delta: -100,
+                    comped_delta: 0
+                }, 
+                {
+                    date: todayDate,
+                    paid_subscribed: 4,
+                    paid_canceled: 3,
+                    free_delta: 100,
+                    comped_delta: 3
+                }
+            ];
+
+            // Update current faked counts
+            currentCounts.paid = 2;
+            currentCounts.free = 3;
+            currentCounts.comped = 4;
+
+            const {data: results, meta} = await membersStatsService.getCountHistory();
+            results.should.eql([
+                {
+                    date: twoDaysBeforeYesterday,
+                    paid: 0,
+                    free: 1,
+                    comped: 0,
+                    paid_subscribed: 0,
+                    paid_canceled: 0
+                },
+                {
+                    date: dayBeforeYesterday,
+                    paid: 0,
+                    // note that this shouldn't be 100 (which is also what we test here):
+                    free: 3, 
+                    comped: 1,
+                    paid_subscribed: 2,
+                    paid_canceled: 1
+                }, 
+                {
+                    date: yesterday,
+                    paid: 1,
+                    // never return negative numbers, this is in fact -997:
+                    free: 0,
+                    comped: 1,
+                    paid_subscribed: 2,
+                    paid_canceled: 1
+                }, 
+                {
+                    date: today,
+                    paid: 2,
+                    free: 3,
+                    comped: 4,
+                    paid_subscribed: 4,
+                    paid_canceled: 3
+                }
+            ]);
+            meta.totals.should.eql(currentCounts);
+            fakeStatuses.calledOnce.should.eql(true);
+            fakeTotal.calledOnce.should.eql(true);
+        });
+
         it('Ignores events in the future', async function () {
             // Update faked status events
-            events.splice(0, events.length, 
+            events = [
                 {
-                    date: tomorrowDate,
-                    paid_subscribed: 10,
-                    paid_canceled: 5,
-                    free_delta: 8,
-                    comped_delta: 9
-                }, 
+                    date: yesterdayDate,
+                    paid_subscribed: 1,
+                    paid_canceled: 0,
+                    free_delta: 1,
+                    comped_delta: 0
+                },
                 {
                     date: todayDate,
                     paid_subscribed: 4,
@@ -156,13 +256,13 @@ describe('MembersStatsService', function () {
                     comped_delta: 3
                 }, 
                 {
-                    date: yesterdayDate,
-                    paid_subscribed: 0,
-                    paid_canceled: 0,
-                    free_delta: 0,
-                    comped_delta: 0
+                    date: tomorrowDate,
+                    paid_subscribed: 10,
+                    paid_canceled: 5,
+                    free_delta: 8,
+                    comped_delta: 9
                 }
-            );
+            ];
 
             // Update current faked counts
             currentCounts.paid = 1;
@@ -172,11 +272,19 @@ describe('MembersStatsService', function () {
             const {data: results, meta} = await membersStatsService.getCountHistory();
             results.should.eql([
                 {
-                    date: yesterday,
+                    date: dayBeforeYesterday,
                     paid: 0,
                     free: 0,
                     comped: 0,
                     paid_subscribed: 0,
+                    paid_canceled: 0
+                },
+                {
+                    date: yesterday,
+                    paid: 0,
+                    free: 0,
+                    comped: 0,
+                    paid_subscribed: 1,
                     paid_canceled: 0
                 },
                 {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1458

- Removed pagination from endpoint (refs slack https://ghost.slack.com/archives/C02G9E68C/p1649169172732619?thread_ts=1649157179.904669&cid=C02G9E68C)
- Fixes a special case for negative member counts (test included)
- Always adds an extra day to the output (should be zero for perfect events)
- Changed sort order of (private) fetchAllStatusDeltas method