### PR TITLE
Supported 'FOR UPDATE' lock for `findOne`

### DIFF
--- a/core/server/models/base/plugins/crud.js
+++ b/core/server/models/base/plugins/crud.js
@@ -183,6 +183,8 @@ module.exports = function (Bookshelf) {
                 model.hasTimestamps = false;
             }
 
+            options.lock = 'forUpdate';
+
             const object = await model.fetch(options);
             if (object) {
                 options.method = 'update';

--- a/core/server/models/base/plugins/crud.js
+++ b/core/server/models/base/plugins/crud.js
@@ -137,7 +137,7 @@ module.exports = function (Bookshelf) {
                 options.columns = _.intersection(options.columns, this.prototype.permittedAttributes());
             }
 
-            if (options.forUpdate) {
+            if (options.transacting && options.forUpdate) {
                 options.lock = 'forUpdate';
             }
 
@@ -183,7 +183,9 @@ module.exports = function (Bookshelf) {
                 model.hasTimestamps = false;
             }
 
-            options.lock = 'forUpdate';
+            if (options.transacting) {
+                options.lock = 'forUpdate';
+            }
 
             const object = await model.fetch(options);
             if (object) {

--- a/core/server/models/base/plugins/crud.js
+++ b/core/server/models/base/plugins/crud.js
@@ -137,6 +137,10 @@ module.exports = function (Bookshelf) {
                 options.columns = _.intersection(options.columns, this.prototype.permittedAttributes());
             }
 
+            if (options.forUpdate) {
+                options.lock = 'forUpdate';
+            }
+
             return model.fetch(options)
                 .catch((err) => {
                     // CASE: SQL syntax is incorrect

--- a/test/unit/server/models/base/crud.test.js
+++ b/test/unit/server/models/base/crud.test.js
@@ -105,13 +105,14 @@ describe('Models: crud', function () {
             });
         });
 
-        it('Sets the `lock` option to "forUpdate" when the `forUpdate` option is passed', function () {
+        it('Sets the `lock` option to "forUpdate" when the `forUpdate` and `transacting` options are passed', function () {
             const data = {
                 id: 670
             };
             const unfilteredOptions = {
                 donny: 'donson',
-                forUpdate: true
+                forUpdate: true,
+                transacting: {}
             };
             const model = models.Base.Model.forge({});
             const fetchedModel = models.Base.Model.forge({});
@@ -161,12 +162,31 @@ describe('Models: crud', function () {
                 should.deepEqual(forgeStub.args[0][0], {id: filteredOptions.id});
 
                 should.equal(fetchStub.args[0][0], filteredOptions);
-                should.equal(fetchStub.args[0][0].lock, 'forUpdate');
+                should.equal(fetchStub.args[0][0].lock, undefined);
 
                 const filteredData = filterDataSpy.returnValues[0];
                 should.equal(saveStub.args[0][0], filteredData);
                 should.equal(saveStub.args[0][1].method, 'update');
                 should.deepEqual(saveStub.args[0][1], filteredOptions);
+            });
+        });
+
+        it('sets options.lock to "forUpdate" if options.transacting is present', function () {
+            const data = {
+                base: 'cannon'
+            };
+            const unfilteredOptions = {
+                transacting: {}
+            };
+
+            const model = models.Base.Model.forge({});
+            sinon.stub(models.Base.Model, 'forge')
+                .returns(model);
+            const fetchStub = sinon.stub(model, 'fetch')
+                .resolves();
+
+            return models.Base.Model.findOne(data, unfilteredOptions).then(() => {
+                should.equal(fetchStub.args[0][0].lock, undefined);
             });
         });
 

--- a/test/unit/server/models/base/crud.test.js
+++ b/test/unit/server/models/base/crud.test.js
@@ -104,6 +104,30 @@ describe('Models: crud', function () {
                 should.equal(fetchStub.args[0][0], filteredOptions);
             });
         });
+
+        it('Sets the `lock` option to "forUpdate" when the `forUpdate` option is passed', function () {
+            const data = {
+                id: 670
+            };
+            const unfilteredOptions = {
+                donny: 'donson',
+                forUpdate: true
+            };
+            const model = models.Base.Model.forge({});
+            const fetchedModel = models.Base.Model.forge({});
+            sinon.spy(models.Base.Model, 'filterOptions');
+            sinon.spy(models.Base.Model, 'filterData');
+            sinon.stub(models.Base.Model, 'forge')
+                .returns(model);
+            const fetchStub = sinon.stub(model, 'fetch')
+                .resolves(fetchedModel);
+
+            const findOneReturnValue = models.Base.Model.findOne(data, unfilteredOptions);
+
+            return findOneReturnValue.then((result) => {
+                should.equal(fetchStub.args[0][0].lock, 'forUpdate');
+            });
+        });
     });
 
     describe('edit', function () {
@@ -137,6 +161,7 @@ describe('Models: crud', function () {
                 should.deepEqual(forgeStub.args[0][0], {id: filteredOptions.id});
 
                 should.equal(fetchStub.args[0][0], filteredOptions);
+                should.equal(fetchStub.args[0][0].lock, 'forUpdate');
 
                 const filteredData = filterDataSpy.returnValues[0];
                 should.equal(saveStub.args[0][0], filteredData);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1248

This is the underlying cause of the problems we've seen whilst handling
Stripe webhooks. A transaction ensures that the operations are atomic,
but not that they can run concurrently.

If you have some code which does this, concurrently:
1. Starts a transaction
2. Reads a value
3. Changes the values
4. Ends the transaction

Without applying the `FOR UPDATE` lock - you will have both sequences
read the same value at step 2.

With the `FOR UPDATE` lock - one of the sequences will hang at step 2,
waiting for the other transaction to end, at which point it will resume
and read the _changed_ value.