### PR TITLE
Added subscription_id to MRR events

### DIFF
--- a/core/server/data/migrations/versions/4.43/2022-04-08-10-45-add-subscription-id-to-mrr-events.js
+++ b/core/server/data/migrations/versions/4.43/2022-04-08-10-45-add-subscription-id-to-mrr-events.js
@@ -3,7 +3,5 @@ const {createAddColumnMigration} = require('../../utils');
 module.exports = createAddColumnMigration('members_paid_subscription_events', 'subscription_id', {
     type: 'string',
     maxlength: 24,
-    nullable: true,
-    references: 'members_stripe_customers_subscriptions.id',
-    cascadeDelete: true
+    nullable: true
 });

--- a/core/server/data/migrations/versions/4.43/2022-04-08-10-45-add-subscription-id-to-mrr-events.js
+++ b/core/server/data/migrations/versions/4.43/2022-04-08-10-45-add-subscription-id-to-mrr-events.js
@@ -1,0 +1,9 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members_paid_subscription_events', 'subscription_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true,
+    references: 'members_stripe_customers_subscriptions.id',
+    cascadeDelete: true
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -512,7 +512,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         type: {type: 'string', maxlength: 50, nullable: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-        subscription_id: {type: 'string', maxlength: 24, nullable: true, references: 'members_stripe_customers_subscriptions.id', cascadeDelete: true},
+        subscription_id: {type: 'string', maxlength: 24, nullable: true},
         from_plan: {type: 'string', maxlength: 255, nullable: true},
         to_plan: {type: 'string', maxlength: 255, nullable: true},
         currency: {type: 'string', maxLength: 3, nullable: false},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -512,6 +512,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         type: {type: 'string', maxlength: 50, nullable: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+        subscription_id: {type: 'string', maxlength: 24, nullable: true, references: 'members_stripe_customers_subscriptions.id', cascadeDelete: true},
         from_plan: {type: 'string', maxlength: 255, nullable: true},
         to_plan: {type: 'string', maxlength: 255, nullable: true},
         currency: {type: 'string', maxLength: 3, nullable: false},

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '376437023dad73f58fec648a27c4a791';
+    const currentSchemaHash = '7c170051156704992591fe096dffdbed';
     const currentFixturesHash = 'f4dd2a454e1999b6d149cc26ae52ced4';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '136f5ea5350c26ddc5f802b2dece8ce8';
+    const currentSchemaHash = '376437023dad73f58fec648a27c4a791';
     const currentFixturesHash = 'f4dd2a454e1999b6d149cc26ae52ced4';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1453

As part of 5.0 we want to have cancelled evetns affect MRR. We are going
to backfill and begin populating cancelled events _before_ 5.0 however,
adding a migration to set the MRR deltas as part of 5.0

This migration will need to associate the cancelled events with a
subscription, so we are adding the subscription_id now. This will allow
us to guarantee that all cancelled events will have a subscription_id.