### PR TITLE
Populated mrr_delta for cancelled subscriptions

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-04-08-11-46-update-mrr-for-cancelled-events.js
+++ b/core/server/data/migrations/versions/5.0/2022-04-08-11-46-update-mrr-for-cancelled-events.js
@@ -9,7 +9,7 @@ module.exports = createTransactionalMigration(
                 'members_stripe_customers_subscriptions.id',
                 'members_stripe_customers_subscriptions.plan_currency',
                 'members_stripe_customers_subscriptions.plan_interval',
-                'members_stripe_customers_subscriptions.plan_amount',
+                'members_stripe_customers_subscriptions.plan_amount'
             )
             .from('members_stripe_customers_subscriptions')
             .join('members_stripe_customers', 'members_stripe_customers.customer_id', '=', 'members_stripe_customers_subscriptions.customer_id')

--- a/core/server/data/migrations/versions/5.0/2022-04-08-11-46-update-mrr-for-cancelled-events.js
+++ b/core/server/data/migrations/versions/5.0/2022-04-08-11-46-update-mrr-for-cancelled-events.js
@@ -40,7 +40,7 @@ module.exports = createTransactionalMigration(
 
             logging.info(`Updating cancelled events for ${subscription.id} to include mrr_delta`);
             await knex('members_paid_subscription_events').update({mrr_delta: mrrDelta}).where({
-                type: 'cancelled',
+                type: 'canceled',
                 subscription_id: subscription.id
             });
             logging.info(`Updating reactivated events for ${subscription.id} to include mrr_delta`);
@@ -51,6 +51,6 @@ module.exports = createTransactionalMigration(
         }
     },
     async function down(knex) {
-        await knex('members_paid_subscription_events').update({mrr_delta: 0}).whereIn('type', ['cancelled', 'reactivated']);
+        await knex('members_paid_subscription_events').update({mrr_delta: 0}).whereIn('type', ['canceled', 'reactivated']);
     }
 );

--- a/core/server/data/migrations/versions/5.0/2022-04-08-11-46-update-mrr-for-cancelled-events.js
+++ b/core/server/data/migrations/versions/5.0/2022-04-08-11-46-update-mrr-for-cancelled-events.js
@@ -1,0 +1,56 @@
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const cancelledSubscriptions = await knex
+            .select(
+                'members_stripe_customers_subscriptions.id',
+                'members_stripe_customers_subscriptions.plan_currency',
+                'members_stripe_customers_subscriptions.plan_interval',
+                'members_stripe_customers_subscriptions.plan_amount',
+            )
+            .from('members_stripe_customers_subscriptions')
+            .join('members_stripe_customers', 'members_stripe_customers.customer_id', '=', 'members_stripe_customers_subscriptions.customer_id')
+            .join('members', 'members_stripe_customers.member_id', '=', 'members.id')
+            .where('members_stripe_customers_subscriptions.cancel_at_period_end', true)
+            .whereNot('members_stripe_customers_subscriptions.status', 'canceled');
+
+        if (cancelledSubscriptions.length === 0) {
+            logging.info('No cancelled subscriptions - skipping migration');
+            return;
+        }
+
+        logging.info(`Found ${cancelledSubscriptions.length} subscriptions to update events for`);
+        for (const subscription of cancelledSubscriptions) {
+            let mrrDelta;
+            if (subscription.plan_interval === 'year') {
+                mrrDelta = -1 * Math.floor(subscription.plan_amount / 12);
+            }
+            if (subscription.plan_interval === 'month') {
+                mrrDelta = -1 * subscription.plan_amount;
+            }
+            if (subscription.plan_interval === 'week') {
+                mrrDelta = -1 * subscription.plan_amount * 4;
+            }
+            if (subscription.plan_interval === 'day') {
+                mrrDelta = -1 * subscription.plan_amount * 30;
+            }
+
+            logging.info(`Updating cancelled events for ${subscription.id} to include mrr_delta`);
+            await knex('members_paid_subscription_events').update({mrr_delta: mrrDelta}).where({
+                type: 'cancelled',
+                subscription_id: subscription.id
+            });
+            logging.info(`Updating reactivated events for ${subscription.id} to include mrr_delta`);
+            await knex('members_paid_subscription_events').update({mrr_delta: -1 * mrrDelta}).where({
+                type: 'reactivated',
+                subscription_id: subscription.id
+            });
+        }
+    },
+    async function down(knex) {
+        await knex('members_paid_subscription_events').update({mrr_delta: 0}).whereIn('type', ['cancelled', 'reactivated']);
+    }
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1455

We have to consider that a cancelled subscription may have been
cancelled and reactivated in the past, one option would be to only
update the most recent cancelled event, but this requires more
computation than updated all cancelled events, and then balancing out
any reactivated events with the inverse MRR.

This doesn't give us perfectly accurate historical data, but the current
data will be.
