### PR TITLE
Added mrr column to subscriptions

### DIFF
--- a/core/server/data/migrations/versions/4.44/2022-04-11-10-54-add-mrr-to-subscriptions.js
+++ b/core/server/data/migrations/versions/4.44/2022-04-11-10-54-add-mrr-to-subscriptions.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members_stripe_customers_subscriptions', 'mrr', {
+    type: 'integer',
+    unsigned: true,
+    nullable: false,
+    defaultTo: 0
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -575,6 +575,7 @@ module.exports = {
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true},
+        mrr: {type: 'integer', unsigned: true, nullable: false, defaultTo: 0},
         /* Below fields are now redundant as we link prie_id to stripe_prices table */
         plan_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
         plan_nickname: {type: 'string', maxlength: 50, nullable: false},

--- a/core/server/models/stripe-customer-subscription.js
+++ b/core/server/models/stripe-customer-subscription.js
@@ -4,6 +4,10 @@ const _ = require('lodash');
 const StripeCustomerSubscription = ghostBookshelf.Model.extend({
     tableName: 'members_stripe_customers_subscriptions',
 
+    defaults: {
+        mrr: 0
+    },
+
     customer() {
         return this.belongsTo('MemberStripeCustomer', 'customer_id', 'customer_id');
     },

--- a/test/e2e-api/admin/legacy-members.test.js
+++ b/test/e2e-api/admin/legacy-members.test.js
@@ -260,10 +260,9 @@ describe('Legacy Members API', function () {
             .put(localUtils.API.getApiQuery(`members/${newMember.id}/`))
             .send({members: [compedPayload]})
             .set('Origin', config.get('url'))
-            .expect((res) => {
-                should.exist(res.body);
-                res.body.should.have.property('members');
-                res.body.members.should.have.length(1);
+            .expect(({body}) => {
+                body.should.have.property('members');
+                body.members.should.have.length(1);
             })
             .expect(200);
 

--- a/test/e2e-api/admin/legacy-members.test.js
+++ b/test/e2e-api/admin/legacy-members.test.js
@@ -260,15 +260,16 @@ describe('Legacy Members API', function () {
             .put(localUtils.API.getApiQuery(`members/${newMember.id}/`))
             .send({members: [compedPayload]})
             .set('Origin', config.get('url'))
+            .expect((res) => {
+                should.exist(res.body);
+                should.exist(res.body.members);
+                res.body.members.should.have.length(1);
+            })
             .expect(200);
 
         should.not.exist(res2.headers['x-cache-invalidate']);
 
         const jsonResponse2 = res2.body;
-
-        should.exist(jsonResponse2);
-        should.exist(jsonResponse2.members);
-        jsonResponse2.members.should.have.length(1);
         localUtils.API.checkResponse(jsonResponse2.members[0], 'member', ['subscriptions', 'products']);
 
         const member = jsonResponse2.members[0];

--- a/test/e2e-api/admin/legacy-members.test.js
+++ b/test/e2e-api/admin/legacy-members.test.js
@@ -262,7 +262,7 @@ describe('Legacy Members API', function () {
             .set('Origin', config.get('url'))
             .expect((res) => {
                 should.exist(res.body);
-                should.exist(res.body.members);
+                res.body.should.have.property('members');
                 res.body.members.should.have.length(1);
             })
             .expect(200);

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '782afa7e2a808fc79fcb797ae9bfa601';
+    const currentSchemaHash = 'ff2c43dc264d712397a912e9709a0410';
     const currentFixturesHash = 'f4dd2a454e1999b6d149cc26ae52ced4';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -488,7 +488,8 @@ DataGenerator.Content = {
             plan_nickname: 'Monthly',
             plan_interval: 'month',
             plan_amount: '1000',
-            plan_currency: 'usd'
+            plan_currency: 'usd',
+            mrr: 1000
         },
         {
             id: ObjectId().toHexString(),
@@ -504,7 +505,8 @@ DataGenerator.Content = {
             plan_nickname: 'Monthly',
             plan_interval: 'month',
             plan_amount: '1000',
-            plan_currency: 'usd'
+            plan_currency: 'usd',
+            mrr: 1000
         },
         {
             id: ObjectId().toHexString(),
@@ -520,7 +522,8 @@ DataGenerator.Content = {
             plan_nickname: 'Complimentary',
             plan_interval: 'year',
             plan_amount: '0',
-            plan_currency: 'usd'
+            plan_currency: 'usd',
+            mrr: 0
         }
     ],
     stripe_prices: [


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1457

We want to save the MRR with a subscription to simplify the calculation of the total MRR once, in 5.0, we also take 'forever' offers into account into the MRR (so we can just SUM the MRR of all subscriptions).

- Sets the MRR to 0 for now.
- A migration (in a different PR) will fill in all the values in a data migration, but this needs to get merged first because we need this new column in order to update the members-api package (so we already save the MRR before doing the data migration).