### PR TITLE
:bug: Fixed no alt for AMP images

### DIFF
--- a/core/frontend/apps/amp/lib/views/amp.hbs
+++ b/core/frontend/apps/amp/lib/views/amp.hbs
@@ -987,7 +987,7 @@
     <header class="page-header">
         <a href="{{@site.url}}">
             {{#if @site.icon}}
-                <amp-img class="site-icon" src="{{img_url @site.icon absolute="true"}}" width="50" height="50" layout="fixed"></amp-img>
+                <amp-img class="site-icon" src="{{img_url @site.icon absolute="true"}}" width="50" height="50" layout="fixed" alt="{{@site.title}}"></amp-img>
             {{else}}
                 {{@site.title}}
             {{/if}}
@@ -1006,7 +1006,9 @@
             </header>
             {{#if feature_image}}
             <figure class="post-image">
-                <amp-img src="{{img_url feature_image absolute="true"}}" width="600" height="340" layout="responsive"></amp-img>
+                <amp-img src="{{img_url feature_image absolute="true"}}" width="600" height="340" layout="responsive" 
+                alt="{{#if feature_image_alt}}{{feature_image_alt}}{{else}}{{title}}{{/if}}"
+                ></amp-img>
             </figure>
             {{/if}}
             <section class="post-content">
@@ -1020,7 +1022,7 @@
     {{/post}}
     <footer class="page-footer">
         {{#if @site.icon}}
-            <amp-img class="site-icon" src="{{img_url @site.icon absolute="true"}}" width="50" height="50" layout="fixed"></amp-img>
+            <amp-img class="site-icon" src="{{img_url @site.icon absolute="true"}}" width="50" height="50" layout="fixed" alt="{{@site.title}}"></amp-img>
         {{/if}}
         <h3>{{@site.title}}</h3>
         {{#if @site.description}}


### PR DESCRIPTION

refs/closes #14440
It just adds the missing alt attribute in amp.hbs

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution! 

Also, if you'd be interested in writing code like this for us more regularly, we're hiring:
https://careers.ghost.org/product-engineer-node-js
