### PR TITLE
Fixed newsletter schema column validation

### DIFF
--- a/core/server/data/migrations/versions/4.43/2022-03-28-19-26-recreate-newsletter-table.js
+++ b/core/server/data/migrations/versions/4.43/2022-03-28-19-26-recreate-newsletter-table.js
@@ -7,7 +7,7 @@ module.exports = recreateTable('newsletters', {
     slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
     sender_name: {type: 'string', maxlength: 191, nullable: false},
     sender_email: {type: 'string', maxlength: 191, nullable: true},
-    sender_reply_to: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'newsletter', validations: {isIn: ['newsletter', 'support']}},
+    sender_reply_to: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'newsletter', validations: {isIn: [['newsletter', 'support']]}},
     status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},
     visibility: {
         type: 'string',
@@ -20,10 +20,10 @@ module.exports = recreateTable('newsletters', {
     header_image: {type: 'string', maxlength: 2000, nullable: true},
     show_header_icon: {type: 'bool', nullable: false, defaultTo: true},
     show_header_title: {type: 'bool', nullable: false, defaultTo: true},
-    title_font_category: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'sans_serif', validations: {isIn: ['serif', 'sans_serif']}},
-    title_alignment: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'center', validations: {isIn: ['center', 'left']}},
+    title_font_category: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'sans_serif', validations: {isIn: [['serif', 'sans_serif']]}},
+    title_alignment: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'center', validations: {isIn: [['center', 'left']]}},
     show_feature_image: {type: 'bool', nullable: false, defaultTo: true},
-    body_font_category: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'sans_serif', validations: {isIn: ['serif', 'sans_serif']}},
+    body_font_category: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'sans_serif', validations: {isIn: [['serif', 'sans_serif']]}},
     footer_content: {type: 'text', maxlength: 1000000000, nullable: true},
     show_badge: {type: 'bool', nullable: false, defaultTo: true}
 });

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -15,7 +15,7 @@ module.exports = {
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
         sender_name: {type: 'string', maxlength: 191, nullable: false},
         sender_email: {type: 'string', maxlength: 191, nullable: true},
-        sender_reply_to: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'newsletter', validations: {isIn: ['newsletter', 'support']}},
+        sender_reply_to: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'newsletter', validations: {isIn: [['newsletter', 'support']]}},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},
         visibility: {
             type: 'string',
@@ -28,10 +28,10 @@ module.exports = {
         header_image: {type: 'string', maxlength: 2000, nullable: true},
         show_header_icon: {type: 'bool', nullable: false, defaultTo: true},
         show_header_title: {type: 'bool', nullable: false, defaultTo: true},
-        title_font_category: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'sans_serif', validations: {isIn: ['serif', 'sans_serif']}},
-        title_alignment: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'center', validations: {isIn: ['center', 'left']}},
+        title_font_category: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'sans_serif', validations: {isIn: [['serif', 'sans_serif']]}},
+        title_alignment: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'center', validations: {isIn: [['center', 'left']]}},
         show_feature_image: {type: 'bool', nullable: false, defaultTo: true},
-        body_font_category: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'sans_serif', validations: {isIn: ['serif', 'sans_serif']}},
+        body_font_category: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'sans_serif', validations: {isIn: [['serif', 'sans_serif']]}},
         footer_content: {type: 'text', maxlength: 1000000000, nullable: true},
         show_badge: {type: 'bool', nullable: false, defaultTo: true}
     },

--- a/test/unit/server/data/schema/schema.test.js
+++ b/test/unit/server/data/schema/schema.test.js
@@ -1,0 +1,21 @@
+const should = require('should');
+const _ = require('lodash');
+
+const schema = require('../../../../../core/server/data/schema/schema');
+
+describe('schema validations', function () {
+    it('has correct isIn validation structure', async function () {
+        const tablesOnlyValidation = _.cloneDeep(schema);
+
+        _.each(tablesOnlyValidation, function (table) {
+            _.each(table, function (column) {
+                const columnIsInValidation = _.get(column, 'validations.isIn');
+                // Check column's isIn validation is in correct format
+                if (columnIsInValidation) {
+                    should(columnIsInValidation).be.Array().with.length(1);
+                    should(columnIsInValidation[0]).be.Array();
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1500

- newsletter schema columns were using incorrect syntax for `isIn` validations
- adds schema test to make sure schema `isIn` validations are in correct format

Note: This doesn't affect newsletter schema migration as validations are ignored as part of schema migration