### PR TITLE
Fixed the newsletters api permissions

### DIFF
--- a/core/server/data/migrations/versions/4.44/2022-04-11-08-24-add-newsletter-permissions.js
+++ b/core/server/data/migrations/versions/4.44/2022-04-11-08-24-add-newsletter-permissions.js
@@ -1,0 +1,33 @@
+const {
+    addPermissionWithRoles,
+    combineTransactionalMigrations
+} = require('../../utils');
+
+/**
+ * This is similar to core/server/data/migrations/versions/4.42/2022-03-30-15-44-add-newsletter-permissions.js
+ * as the permissions were not added in the fixture file at the time of the migration.
+ * This means the new Ghost installs do not have the newsletter permission and we need this migration.
+*/
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse newsletters',
+        action: 'browse',
+        object: 'newsletter'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add newsletters',
+        action: 'add',
+        object: 'newsletter'
+    }, [
+        'Administrator'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit newsletters',
+        action: 'edit',
+        object: 'newsletter'
+    }, [
+        'Administrator'
+    ])
+);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -541,6 +541,21 @@
                     "name": "Edit custom theme settings",
                     "action_type": "edit",
                     "object_type": "custom_theme_setting"
+                },
+                {
+                    "name": "Browse newsletters",
+                    "action_type": "browse",
+                    "object_type": "newsletter"
+                },
+                {
+                    "name": "Add newsletters",
+                    "action_type": "add",
+                    "object_type": "newsletter"
+                },
+                {
+                    "name": "Edit newsletters",
+                    "action_type": "edit",
+                    "object_type": "newsletter"
                 }
             ]
         },

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -667,7 +667,8 @@
                     "custom_theme_setting": "all",
                     "offer": "all",
                     "authentication": "resetAllPasswords",
-                    "members_stripe_connect": "auth"
+                    "members_stripe_connect": "auth",
+                    "newsletter": "all"
                 },
                 "DB Backup Integration": {
                     "db": "all"

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'ff2c43dc264d712397a912e9709a0410';
-    const currentFixturesHash = 'dcc81e94da6fb9d96becf208cfa5bc73';
+    const currentFixturesHash = 'ac79691860fb5b4b8bda2ad5ea8d7744';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'ff2c43dc264d712397a912e9709a0410';
-    const currentFixturesHash = 'ac79691860fb5b4b8bda2ad5ea8d7744';
+    const currentFixturesHash = 'a08bedf7a552498ed6f4a0d72c732dd5';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1504

- The permissions were missing in the fixture file
- This caused some Ghost installs to not have the right permissions
- This is fixed by adding the missing permissions to the fixture file and creating a migration to resolve the missing permissions
