### PR TITLE
Added filtering for members api on newsletter subscription

### DIFF
--- a/core/server/models/member.js
+++ b/core/server/models/member.js
@@ -30,6 +30,9 @@ const Member = ghostBookshelf.Model.extend({
         }, {
             key: 'products',
             replacement: 'products.slug'
+        }, {
+            key: 'newsletters',
+            replacement: 'newsletters.slug'
         }];
     },
 

--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -2655,6 +2655,56 @@ Object {
 }
 `;
 
+exports[`Members API: with multiple newsletters Can filter on newsletter slug 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "memberTestNewsletterAdd@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "test",
+      "newsletters": Any<Array>,
+      "note": "test note",
+      "status": "free",
+      "subscribed": false,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Members API: with multiple newsletters Can filter on newsletter slug 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1704",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API: with multiple newsletters Can read 1: [body] 1`] = `
 Object {
   "members": Array [

--- a/test/e2e-api/admin/members.test.js
+++ b/test/e2e-api/admin/members.test.js
@@ -1317,6 +1317,7 @@ describe('Members API: with multiple newsletters', function () {
                 etag: anyEtag
             });
     });
+
     // Read a member
 
     it('Can read', async function () {
@@ -1361,6 +1362,18 @@ describe('Members API: with multiple newsletters', function () {
             .matchHeaderSnapshot({
                 etag: anyEtag,
                 location: anyLocationFor('members')
+            });
+    });
+
+    it('Can filter on newsletter slug', async function () {
+        await agent
+            .get('/members/?filter=newsletters:daily-newsletter')
+            .expectStatus(200)
+            .matchBodySnapshot({
+                members: new Array(1).fill(memberMatcherShallowIncludesForNewsletters)
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag
             });
     });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1484

While sending a post to a specific newsletter, we'll need to get list/count of members eligible to receive the post. This change enables members admin API to filter list of members on specific newsletter by their slug.
