### PR TITLE
Added stats endpoint for subscriptions

### DIFF
--- a/core/server/api/canary/stats.js
+++ b/core/server/api/canary/stats.js
@@ -19,5 +19,14 @@ module.exports = {
         async query() {
             return await statsService.mrr.getHistory();
         }
+    },
+    subscriptions: {
+        permissions: {
+            docName: 'members',
+            method: 'browse'
+        },
+        async query() {
+            return await statsService.members.getSubscriptionCount();
+        }
     }
 };

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -23,8 +23,15 @@ class MembersStatsService {
             .join('products', 'products.id', '=', 'stripe_products.product_id')
             .groupBy('tier', 'cadence');
 
+        const date = DateTime.now().toISODate();
+
         return {
-            data: data,
+            data: data.map(row => {
+                return {
+                    ...row,
+                    date
+                };
+            }),
             meta: {
                 tiers: data.reduce((tiers, row) => {
                     if (tiers.includes(row.tier)) {

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+const {DateTime} = require('luxon');
 
 class MembersStatsService {
     constructor({db}) {
@@ -101,7 +101,7 @@ class MembersStatsService {
         let {paid, free, comped} = totals;
 
         // Get today in UTC (default timezone)
-        const today = moment().format('YYYY-MM-DD');
+        const today = DateTime.now().toISODate();
 
         const cumulativeResults = [];
 
@@ -110,7 +110,7 @@ class MembersStatsService {
             const row = rows[i];
 
             // Convert JSDates to YYYY-MM-DD (in UTC)
-            const date = moment(row.date).format('YYYY-MM-DD');
+            const date = DateTime.fromJSDate(row.date).toISODate();
             if (date > today) {
                 // Skip results that are in the future (fix for invalid events)
                 continue;
@@ -133,7 +133,7 @@ class MembersStatsService {
         }
 
         // Now also add the oldest day we have left over (this one will be zero, which is also needed as a data point for graphs)
-        const oldestDate = rows.length > 0 ? moment(rows[0].date).add(-1, 'days').format('YYYY-MM-DD') : today;
+        const oldestDate = rows.length > 0 ? DateTime.fromJSDate(rows[0].date).minus({days: 1}).toISODate() : today;
 
         cumulativeResults.unshift({
             date: oldestDate,

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -26,7 +26,7 @@ class MembersStatsService {
         const date = DateTime.now().toISODate();
 
         return {
-            data: data.map(row => {
+            data: data.map((row) => {
                 return {
                     ...row,
                     date

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -21,9 +21,7 @@ class MembersStatsService {
             .join('stripe_prices', 'stripe_prices.stripe_price_id', '=', 'members_stripe_customers_subscriptions.stripe_price_id')
             .join('stripe_products', 'stripe_products.stripe_product_id', '=', 'stripe_prices.stripe_product_id')
             .join('products', 'products.id', '=', 'stripe_products.product_id')
-            .where('members_stripe_customers_subscriptions.cancel_at_period_end', false)
-            .whereNotIn('members_stripe_customers_subscriptions.status', ['trialing', 'canceled', 'incomplete', 'incomplete_expired'])
-            .whereNot('stripe_prices.amount', 0)
+            .whereNot('members_stripe_customers_subscriptions.mrr', 0)
             .groupBy('tier', 'cadence');
 
         const date = moment().format('YYYY-MM-DD');

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -1,4 +1,4 @@
-const {DateTime} = require('luxon');
+const moment = require('moment');
 
 class MembersStatsService {
     constructor({db}) {
@@ -114,7 +114,7 @@ class MembersStatsService {
         let {paid, free, comped} = totals;
 
         // Get today in UTC (default timezone)
-        const today = DateTime.now().toISODate();
+        const today = moment().format('YYYY-MM-DD');
 
         const cumulativeResults = [];
 
@@ -123,7 +123,7 @@ class MembersStatsService {
             const row = rows[i];
 
             // Convert JSDates to YYYY-MM-DD (in UTC)
-            const date = DateTime.fromJSDate(row.date).toISODate();
+            const date = moment(row.date).format('YYYY-MM-DD');
             if (date > today) {
                 // Skip results that are in the future (fix for invalid events)
                 continue;
@@ -146,7 +146,7 @@ class MembersStatsService {
         }
 
         // Now also add the oldest day we have left over (this one will be zero, which is also needed as a data point for graphs)
-        const oldestDate = rows.length > 0 ? DateTime.fromJSDate(rows[0].date).minus({days: 1}).toISODate() : today;
+        const oldestDate = rows.length > 0 ? moment(rows[0].date).add(-1, 'days').format('YYYY-MM-DD') : today;
 
         cumulativeResults.unshift({
             date: oldestDate,

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -23,7 +23,7 @@ class MembersStatsService {
             .join('products', 'products.id', '=', 'stripe_products.product_id')
             .groupBy('tier', 'cadence');
 
-        const date = DateTime.now().toISODate();
+        const date = moment().format('YYYY-MM-DD');
 
         return {
             data: data.map((row) => {

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -38,6 +38,12 @@ class MembersStatsService {
                         return tiers;
                     }
                     return tiers.concat(row.tier);
+                }, []),
+                cadences: data.reduce((cadences, row) => {
+                    if (cadences.includes(row.cadence)) {
+                        return cadences;
+                    }
+                    return cadences.concat(row.cadence);
                 }, [])
             }
         };

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -21,6 +21,9 @@ class MembersStatsService {
             .join('stripe_prices', 'stripe_prices.stripe_price_id', '=', 'members_stripe_customers_subscriptions.stripe_price_id')
             .join('stripe_products', 'stripe_products.stripe_product_id', '=', 'stripe_prices.stripe_product_id')
             .join('products', 'products.id', '=', 'stripe_products.product_id')
+            .where('members_stripe_customers_subscriptions.cancel_at_period_end', false)
+            .whereNotIn('members_stripe_customers_subscriptions.status', ['trialing', 'canceled', 'incomplete', 'incomplete_expired'])
+            .whereNot('stripe_prices.amount', 0)
             .groupBy('tier', 'cadence');
 
         const date = moment().format('YYYY-MM-DD');

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -140,6 +140,7 @@ module.exports = function apiRoutes() {
     // ## Stats
     router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
     router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
+    router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
 
     // ## Labels
     router.get('/labels', mw.authAdminApi, http(api.labels.browse));

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -70,8 +70,8 @@ exports[`Stats API Can fetch subscriptions count 1: [body] 1`] = `
 Object {
   "meta": Object {
     "cadences": Array [
-      "month",
-      "year",
+      StringMatching /month\\|year/,
+      StringMatching /month\\|year/,
     ],
     "tiers": Array [
       StringMatching /\\[a-f0-9\\]\\{24\\}/,
@@ -80,13 +80,13 @@ Object {
   "stats": Array [
     Object {
       "cadence": StringMatching /month\\|year/,
-      "count": 1,
+      "count": Any<Number>,
       "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
     },
     Object {
       "cadence": StringMatching /month\\|year/,
-      "count": 2,
+      "count": Any<Number>,
       "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
     },

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -77,11 +77,13 @@ Object {
     Object {
       "cadence": StringMatching /month\\|year/,
       "count": 1,
+      "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
     },
     Object {
       "cadence": StringMatching /month\\|year/,
       "count": 2,
+      "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
     },
   ],
@@ -92,7 +94,7 @@ exports[`Stats API Can fetch subscriptions count 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "184",
+  "content-length": "224",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -65,3 +65,37 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Stats API Can fetch subscriptions count 1: [body] 1`] = `
+Object {
+  "meta": Object {
+    "tiers": Array [
+      StringMatching /\\[a-f0-9\\]\\{24\\}/,
+    ],
+  },
+  "stats": Array [
+    Object {
+      "cadence": StringMatching /month\\|year/,
+      "count": 1,
+      "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+    },
+    Object {
+      "cadence": StringMatching /month\\|year/,
+      "count": 2,
+      "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Stats API Can fetch subscriptions count 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "184",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -71,19 +71,12 @@ Object {
   "meta": Object {
     "cadences": Array [
       StringMatching /month\\|year/,
-      StringMatching /month\\|year/,
     ],
     "tiers": Array [
       StringMatching /\\[a-f0-9\\]\\{24\\}/,
     ],
   },
   "stats": Array [
-    Object {
-      "cadence": StringMatching /month\\|year/,
-      "count": Any<Number>,
-      "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
-      "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-    },
     Object {
       "cadence": StringMatching /month\\|year/,
       "count": Any<Number>,
@@ -98,7 +91,7 @@ exports[`Stats API Can fetch subscriptions count 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "252",
+  "content-length": "162",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -71,12 +71,19 @@ Object {
   "meta": Object {
     "cadences": Array [
       StringMatching /month\\|year/,
+      StringMatching /month\\|year/,
     ],
     "tiers": Array [
       StringMatching /\\[a-f0-9\\]\\{24\\}/,
     ],
   },
   "stats": Array [
+    Object {
+      "cadence": StringMatching /month\\|year/,
+      "count": Any<Number>,
+      "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+    },
     Object {
       "cadence": StringMatching /month\\|year/,
       "count": Any<Number>,
@@ -91,7 +98,7 @@ exports[`Stats API Can fetch subscriptions count 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "162",
+  "content-length": "252",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -69,6 +69,10 @@ Object {
 exports[`Stats API Can fetch subscriptions count 1: [body] 1`] = `
 Object {
   "meta": Object {
+    "cadences": Array [
+      "month",
+      "year",
+    ],
     "tiers": Array [
       StringMatching /\\[a-f0-9\\]\\{24\\}/,
     ],
@@ -94,7 +98,7 @@ exports[`Stats API Can fetch subscriptions count 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "224",
+  "content-length": "252",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/e2e-api/admin/stats.test.js
+++ b/test/e2e-api/admin/stats.test.js
@@ -1,5 +1,5 @@
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
-const {anyEtag, anyISODate} = matchers;
+const {anyEtag, anyISODate, anyObjectId, stringMatching} = matchers;
 
 let agent;
 
@@ -32,6 +32,27 @@ describe('Stats API', function () {
                 stats: [{
                     date: anyISODate
                 }]
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            });
+    });
+
+    it('Can fetch subscriptions count', async function () {
+        await agent
+            .get(`/stats/subscriptions`)
+            .expectStatus(200)
+            .matchBodySnapshot({
+                stats: [{
+                    tier: anyObjectId,
+                    cadence: stringMatching(/month|year/)
+                },{
+                    tier: anyObjectId,
+                    cadence: stringMatching(/month|year/)
+                }],
+                meta: {
+                    tiers: [anyObjectId]
+                }
             })
             .matchHeaderSnapshot({
                 etag: anyEtag

--- a/test/e2e-api/admin/stats.test.js
+++ b/test/e2e-api/admin/stats.test.js
@@ -48,15 +48,10 @@ describe('Stats API', function () {
                     tier: anyObjectId,
                     cadence: stringMatching(/month|year/),
                     count: anyNumber
-                },{
-                    date: anyISODate,
-                    tier: anyObjectId,
-                    cadence: stringMatching(/month|year/),
-                    count: anyNumber
                 }],
                 meta: {
                     tiers: [anyObjectId],
-                    cadences: [stringMatching(/month|year/), stringMatching(/month|year/)]
+                    cadences: [stringMatching(/month|year/)]
                 }
             })
             .matchHeaderSnapshot({

--- a/test/e2e-api/admin/stats.test.js
+++ b/test/e2e-api/admin/stats.test.js
@@ -44,9 +44,11 @@ describe('Stats API', function () {
             .expectStatus(200)
             .matchBodySnapshot({
                 stats: [{
+                    date: anyISODate,
                     tier: anyObjectId,
                     cadence: stringMatching(/month|year/)
                 },{
+                    date: anyISODate,
                     tier: anyObjectId,
                     cadence: stringMatching(/month|year/)
                 }],

--- a/test/e2e-api/admin/stats.test.js
+++ b/test/e2e-api/admin/stats.test.js
@@ -1,5 +1,5 @@
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
-const {anyEtag, anyISODate, anyObjectId, stringMatching} = matchers;
+const {anyEtag, anyISODate, anyObjectId, anyNumber, stringMatching} = matchers;
 
 let agent;
 
@@ -46,14 +46,17 @@ describe('Stats API', function () {
                 stats: [{
                     date: anyISODate,
                     tier: anyObjectId,
-                    cadence: stringMatching(/month|year/)
+                    cadence: stringMatching(/month|year/),
+                    count: anyNumber
                 },{
                     date: anyISODate,
                     tier: anyObjectId,
-                    cadence: stringMatching(/month|year/)
+                    cadence: stringMatching(/month|year/),
+                    count: anyNumber
                 }],
                 meta: {
-                    tiers: [anyObjectId]
+                    tiers: [anyObjectId],
+                    cadences: [stringMatching(/month|year/), stringMatching(/month|year/)]
                 }
             })
             .matchHeaderSnapshot({

--- a/test/e2e-api/admin/stats.test.js
+++ b/test/e2e-api/admin/stats.test.js
@@ -48,10 +48,15 @@ describe('Stats API', function () {
                     tier: anyObjectId,
                     cadence: stringMatching(/month|year/),
                     count: anyNumber
+                }, {
+                    date: anyISODate,
+                    tier: anyObjectId,
+                    cadence: stringMatching(/month|year/),
+                    count: anyNumber
                 }],
                 meta: {
                     tiers: [anyObjectId],
-                    cadences: [stringMatching(/month|year/)]
+                    cadences: [stringMatching(/month|year/), stringMatching(/month|year/)]
                 }
             })
             .matchHeaderSnapshot({

--- a/test/utils/e2e-framework.js
+++ b/test/utils/e2e-framework.js
@@ -279,6 +279,7 @@ module.exports = {
     matchers: {
         anyString: any(String),
         anyArray: any(Array),
+        anyNumber: any(Number),
         anyISODateTime: stringMatching(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000Z/),
         anyISODate: stringMatching(/\d{4}-\d{2}-\d{2}/),
         anyISODateTimeWithTZ: stringMatching(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000\+\d{2}:\d{2}/),


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1466

The chart breaking down members by tier/cadence actually needs to break
down subscriptions, this endpoint exports the necessary data.