### PR TITLE
Updated newsletter sender name column as nullable

### DIFF
--- a/core/server/data/migrations/versions/4.44/2022-04-13-12-00-remove-newsletter-sender-name-not-null-constraint.js
+++ b/core/server/data/migrations/versions/4.44/2022-04-13-12-00-remove-newsletter-sender-name-not-null-constraint.js
@@ -21,6 +21,7 @@ module.exports = createNonTransactionalMigration(
         });
 
         await knex.schema.table('newsletters', function (table) {
+            // SQLite doesn't allow adding a non nullable column without any default
             table.string('sender_name', 191).notNullable().defaultTo('Ghost');
         });
     }

--- a/core/server/data/migrations/versions/4.44/2022-04-13-12-00-remove-newsletter-sender-name-not-null-constraint.js
+++ b/core/server/data/migrations/versions/4.44/2022-04-13-12-00-remove-newsletter-sender-name-not-null-constraint.js
@@ -21,7 +21,7 @@ module.exports = createNonTransactionalMigration(
         });
 
         await knex.schema.table('newsletters', function (table) {
-            table.string('sender_name', 191).notNullable();
+            table.string('sender_name', 191).notNullable().defaultTo('Ghost');
         });
     }
 );

--- a/core/server/data/migrations/versions/4.44/2022-04-13-12-00-remove-newsletter-sender-name-not-null-constraint.js
+++ b/core/server/data/migrations/versions/4.44/2022-04-13-12-00-remove-newsletter-sender-name-not-null-constraint.js
@@ -1,0 +1,28 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info('Dropping NOT NULL constraint for: sender_name in table: newsletters');
+
+        await knex.schema.table('newsletters', function (table) {
+            table.dropColumn('sender_name');
+        });
+
+        await knex.schema.table('newsletters', function (table) {
+            table.string('sender_name', 191).nullable();
+        });
+    },
+    async function down(knex) {
+        logging.info('Adding NOT NULL constraint for: sender_name in table: newsletters');
+
+        await knex.schema.table('newsletters', function (table) {
+            table.dropColumn('sender_name');
+        });
+
+        await knex.schema.table('newsletters', function (table) {
+            table.string('sender_name', 191).notNullable();
+        });
+    }
+);
+

--- a/core/server/data/migrations/versions/4.44/2022-04-13-12-00-remove-newsletter-sender-name-not-null-constraint.js
+++ b/core/server/data/migrations/versions/4.44/2022-04-13-12-00-remove-newsletter-sender-name-not-null-constraint.js
@@ -1,6 +1,10 @@
 const logging = require('@tryghost/logging');
 const {createNonTransactionalMigration} = require('../../utils');
 
+/**
+ * Note: This doesn't use knex.alterTable as it doesn't work for down migration.
+ * It tries to insert a `null` into non `nullable` column while altering column
+ */
 module.exports = createNonTransactionalMigration(
     async function up(knex) {
         logging.info('Dropping NOT NULL constraint for: sender_name in table: newsletters');

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -13,7 +13,7 @@ module.exports = {
         name: {type: 'string', maxlength: 191, nullable: false, unique: true},
         description: {type: 'string', maxlength: 2000, nullable: true},
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
-        sender_name: {type: 'string', maxlength: 191, nullable: false},
+        sender_name: {type: 'string', maxlength: 191, nullable: true},
         sender_email: {type: 'string', maxlength: 191, nullable: true},
         sender_reply_to: {type: 'string', maxlength: 191, nullable: false, defaultTo: 'newsletter', validations: {isIn: [['newsletter', 'support']]}},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'ff2c43dc264d712397a912e9709a0410';
+    const currentSchemaHash = '026d0bffc2be9420c1d9fccf76656dac';
     const currentFixturesHash = 'a08bedf7a552498ed6f4a0d72c732dd5';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/test/unit/server/models/newsletter.test.js
+++ b/test/unit/server/models/newsletter.test.js
@@ -33,22 +33,6 @@ describe('Unit: models/newsletter', function () {
                         err[0].message.should.match(/newsletters\.name/);
                     });
             });
-
-            it('sender name cannot be blank', function () {
-                return models.Newsletter.add({
-                    name: 'Daily report 2',
-                    sender_email: 'jamie@example.com',
-                    sender_reply_to: 'newsletter',
-                    sort_order: 0
-                })
-                    .then(function () {
-                        throw new Error('expected ValidationError');
-                    })
-                    .catch(function (err) {
-                        (err[0] instanceof errors.ValidationError).should.eql(true);
-                        err[0].message.should.match(/newsletters\.sender_name/);
-                    });
-            });
         });
     });
 });

--- a/test/unit/server/models/newsletter.test.js
+++ b/test/unit/server/models/newsletter.test.js
@@ -17,20 +17,17 @@ describe('Unit: models/newsletter', function () {
 
     describe('validation', function () {
         describe('blank', function () {
-            it('name cannot be blank', function () {
-                return models.Newsletter.add({
-                    sender_name: 'Jamie',
-                    sender_email: 'jamie@example.com',
-                    sender_reply_to: 'newsletter',
-                    visibility: 'members',
-                    sort_order: 0
-                })
+            it('throws validation error for mandatory fields', function () {
+                return models.Newsletter.add({})
                     .then(function () {
                         throw new Error('expected ValidationError');
                     })
                     .catch(function (err) {
-                        should(err[0] instanceof errors.ValidationError).eql(true);
+                        err.length.should.eql(2);
+                        (err[0] instanceof errors.ValidationError).should.eql(true);
+                        (err[1] instanceof errors.ValidationError).should.eql(true);
                         err[0].message.should.match(/newsletters\.name/);
+                        err[1].message.should.match(/newsletters\.slug/);
                     });
             });
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1513

- nullable `sender_name` allows us to use auto fallback of site title for sender name without setting any explicit value