### PR TITLE
Added migration to adjust mrr in subscriptions for cancel_at_period_end

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-04-14-12-36-backfill-mrr-for-canceled-subscriptions.js
+++ b/core/server/data/migrations/versions/5.0/2022-04-14-12-36-backfill-mrr-for-canceled-subscriptions.js
@@ -1,0 +1,31 @@
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Setting "mrr" to 0 for all canceled subscriptions in "members_stripe_customers_subscriptions"');
+
+        await knex('members_stripe_customers_subscriptions')
+            .update('mrr', 0)
+            .where('cancel_at_period_end', true);
+    },
+    async function down(knex) {
+        logging.info('Setting "mrr" for all canceled and not yet expired subscriptions in "members_stripe_customers_subscriptions"');
+
+        await knex('members_stripe_customers_subscriptions')
+            .update('mrr', knex.raw(`
+                CASE WHEN plan_interval = 'year' THEN
+                    FLOOR(plan_amount / 12)
+                WHEN plan_interval = 'week' THEN
+                    plan_amount * 4
+                WHEN plan_interval = 'day' THEN
+                    plan_amount * 30
+                ELSE 
+                    plan_amount
+                END
+            `))
+            .where('cancel_at_period_end', true)
+            .whereNotIn('status', ['trialing', 'incomplete', 'incomplete_expired', 'canceled']);
+    }
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1515

- Sets MRR to zero for all subscriptions where `cancel_at_period_end` is true
- Rollbacks to same logic as migration https://github.com/TryGhost/Ghost/pull/14465
- We need to be careful that future backfill adjustments of MRR happen after this one for the rollback to keep working