### PR TITLE
Updated calculation of MRR history to use mrr column

### DIFF
--- a/core/server/services/stats/lib/mrr-stats-service.js
+++ b/core/server/services/stats/lib/mrr-stats-service.js
@@ -13,15 +13,7 @@ class MrrStatsService {
         const knex = this.db.knex;
         const rows = await knex('members_stripe_customers_subscriptions')
             .select(knex.raw(`plan_currency as currency`))
-            .select(knex.raw(`SUM(
-                CASE WHEN plan_interval = 'year' THEN
-                    FLOOR(plan_amount / 12)
-                ELSE 
-                    plan_amount
-                END
-            ) AS mrr`))
-            .whereIn('status', ['active', 'unpaid', 'past_due'])
-            .where('cancel_at_period_end', 0)
+            .select(knex.raw(`SUM(mrr) AS mrr`))
             .groupBy('plan_currency')
             .orderBy('currency');
 

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -506,7 +506,7 @@ DataGenerator.Content = {
             plan_interval: 'month',
             plan_amount: '1000',
             plan_currency: 'usd',
-            mrr: 1000
+            mrr: 0
         },
         {
             id: ObjectId().toHexString(),


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1518

- Uses mrr column now
- Doesn't account for `cancel_at_period_end` until a migration fixes the MRR values: https://github.com/TryGhost/Ghost/pull/14480