### PR TITLE
Fixed the newsletter_id assignement in the post API

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -676,6 +676,7 @@ Post = ghostBookshelf.Model.extend({
 
         // newsletter_id is read-only and should only be set using a query param when publishing/scheduling
         if (options.newsletter_id
+            && !this.get('newsletter_id')
             && this.hasChanged('status')
             && (newStatus === 'published' || newStatus === 'scheduled')) {
             this.set('newsletter_id', options.newsletter_id);
@@ -695,6 +696,7 @@ Post = ghostBookshelf.Model.extend({
                 return self.related('email').fetch({transacting: options.transacting}).then((email) => {
                     if (!email) {
                         self.set('email_recipient_filter', 'none');
+                        self.set('newsletter_id', null);
                     }
                 });
             });

--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -298,11 +298,14 @@ async function pendingEmailHandler(emailModel, options) {
     const emailAnalyticsJobs = require('../email-analytics/jobs');
     emailAnalyticsJobs.scheduleRecurringJobs();
 
-    return jobsService.addJob({
-        job: sendEmailJob,
-        data: {emailModel},
-        offloaded: false
-    });
+    // @TODO move this into the jobService
+    if (!process.env.NODE_ENV.startsWith('test')) {
+        return jobsService.addJob({
+            job: sendEmailJob,
+            data: {emailModel},
+            offloaded: false
+        });
+    }
 }
 
 async function sendEmailJob({emailModel, options}) {

--- a/core/server/services/posts/posts-service.js
+++ b/core/server/services/posts/posts-service.js
@@ -28,6 +28,12 @@ class PostsService {
                     message: messages.invalidNewsletterId
                 });
             }
+        } else {
+            // Set the newsletter_id if it isn't passed to the API
+            const newsletters = await this.models.Newsletter.findPage({status: 'active', limit: 1, columns: ['id']}, {transacting: frame.options.transacting});
+            if (newsletters.data.length > 0) {
+                frame.options.newsletter_id = newsletters.data[0].id;
+            }
         }
 
         if (!frame.options.email_recipient_filter && frame.options.send_email_when_published) {
@@ -76,14 +82,6 @@ class PostsService {
             const sendEmail = model.wasChanged() && this.shouldSendEmail(model.get('status'), model.previous('status'));
 
             if (sendEmail) {
-                // Set the newsletter_id if it isn't passed to the API
-                if (!frame.options.newsletter_id) {
-                    const newsletters = await this.models.Newsletter.findPage({status: 'active', limit: 1, columns: ['id']}, {transacting: frame.options.transacting});
-                    if (newsletters.data.length > 0) {
-                        frame.options.newsletter_id = newsletters.data[0].id;
-                    }
-                }
-
                 let postEmail = model.relations.email;
 
                 if (!postEmail) {

--- a/test/e2e-api/admin/posts.test.js
+++ b/test/e2e-api/admin/posts.test.js
@@ -17,7 +17,11 @@ describe('Posts API', function () {
     before(async function () {
         await localUtils.startGhost();
         request = supertest.agent(config.get('url'));
-        await localUtils.doAuth(request, 'users:extra', 'posts', 'emails', 'newsletters');
+        /**
+         * Members are needed to enable mega to create an email record so that we can test that newsletter_id
+         * can't be overwritten after an email record is created.
+         */
+        await localUtils.doAuth(request, 'users:extra', 'posts', 'emails', 'newsletters', 'members');
     });
 
     afterEach(function () {
@@ -487,6 +491,131 @@ describe('Posts API', function () {
             id
         }, testUtils.context.internal);
 
+        should(model.get('newsletter_id')).eql(newsletterId);
+    });
+
+    it('Defaults to the default newsletter when publishing without a newsletter_id', async function () {
+        const post = {
+            title: 'My post without newsletter_id',
+            status: 'draft',
+            feature_image_alt: 'Testing newsletter_id',
+            feature_image_caption: 'Testing <b>feature image caption</b>',
+            mobiledoc: testUtils.DataGenerator.markdownToMobiledoc('my post'),
+            created_at: moment().subtract(2, 'days').toDate(),
+            updated_at: moment().subtract(2, 'days').toDate(),
+            created_by: ObjectId().toHexString(),
+            updated_by: ObjectId().toHexString()
+        };
+
+        const res = await request.post(localUtils.API.getApiQuery('posts'))
+            .set('Origin', config.get('url'))
+            .send({posts: [post]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201);
+
+        const id = res.body.posts[0].id;
+
+        const updatedPost = {
+            status: 'published',
+            updated_at: res.body.posts[0].updated_at
+        };
+
+        await request
+            .put(localUtils.API.getApiQuery('posts/' + id + '/?email_recipient_filter=all'))
+            .set('Origin', config.get('url'))
+            .send({posts: [updatedPost]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200);
+
+        const model = await models.Post.findOne({
+            id
+        }, testUtils.context.internal);
+
+        should(model.get('newsletter_id')).not.eql(null);
+    });
+
+    it('Can\'t change the newsletter_id once it has been set', async function () {
+        let model;
+        const post = {
+            title: 'My post without newsletter_id',
+            status: 'draft',
+            feature_image_alt: 'Testing newsletter_id',
+            feature_image_caption: 'Testing <b>feature image caption</b>',
+            mobiledoc: testUtils.DataGenerator.markdownToMobiledoc('my post'),
+            created_at: moment().subtract(2, 'days').toDate(),
+            updated_at: moment().subtract(2, 'days').toDate(),
+            created_by: ObjectId().toHexString(),
+            updated_by: ObjectId().toHexString()
+        };
+
+        const res = await request.post(localUtils.API.getApiQuery('posts'))
+            .set('Origin', config.get('url'))
+            .send({posts: [post]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201);
+
+        const id = res.body.posts[0].id;
+        const newsletterId = testUtils.DataGenerator.Content.newsletters[0].id;
+        const newsletterId2 = testUtils.DataGenerator.Content.newsletters[1].id;
+
+        const updatedPost = {
+            status: 'published',
+            updated_at: res.body.posts[0].updated_at
+        };
+
+        const res2 = await request
+            .put(localUtils.API.getApiQuery('posts/' + id + '/?email_recipient_filter=all&send_email_when_published=true&newsletter_id=' + newsletterId))
+            .set('Origin', config.get('url'))
+            .send({posts: [updatedPost]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200);
+
+        model = await models.Post.findOne({
+            id: id,
+            status: 'published'
+        }, testUtils.context.internal);
+        should(model.get('newsletter_id')).eql(newsletterId);
+
+        const unpublished = {
+            status: 'draft',
+            updated_at: res2.body.posts[0].updated_at
+        };
+
+        const res3 = await request
+            .put(localUtils.API.getApiQuery('posts/' + id + '/'))
+            .set('Origin', config.get('url'))
+            .send({posts: [unpublished]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200);
+
+        model = await models.Post.findOne({
+            id: id,
+            status: 'draft'
+        }, testUtils.context.internal);
+        should(model.get('newsletter_id')).eql(newsletterId);
+
+        const republished = {
+            status: 'published',
+            updated_at: res3.body.posts[0].updated_at
+        };
+
+        await request
+            .put(localUtils.API.getApiQuery('posts/' + id + '/?email_recipient_filter=all&newsletter_id=' + newsletterId2))
+            .set('Origin', config.get('url'))
+            .send({posts: [republished]})
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200);
+
+        model = await models.Post.findOne({
+            id: id,
+            status: 'published'
+        }, testUtils.context.internal);
         should(model.get('newsletter_id')).eql(newsletterId);
     });
 

--- a/test/e2e-api/admin/posts.test.js
+++ b/test/e2e-api/admin/posts.test.js
@@ -533,7 +533,11 @@ describe('Posts API', function () {
             id
         }, testUtils.context.internal);
 
-        should(model.get('newsletter_id')).not.eql(null);
+        const defaultNewsletter = await models.Newsletter.findOne({
+            sort_order: 0
+        }, testUtils.context.internal);
+
+        should(model.get('newsletter_id')).eql(defaultNewsletter.get('id'));
     });
 
     it('Can\'t change the newsletter_id once it has been set', async function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1502

- Added two tests to make sure we assign a default `newsletter_id` when needed and to make sure `newsletter_id` can't be changed once an email is sent.
- Fixed the model so that we don't change `newsletter_id` if it's already defined when publishing, and so that we clear `newsletter_id` when a post is changed to draft without an email being sent.
- Fixed the post service so that a `newsletter_id` is always defined when editing a post. The alternative would have been to do an extra post fetch and write complex logic to only fetch the `newsletter_id` when we are about to send an email. The chosen solution has less code and uses an extra newsletter fetch instead of an extra post fetch, which is more performant given there could be ten of thousands of posts and it would be surprising to have more than thousands of newsletters (a more realistic figure would be less than a hundred newsletters).
