### PR TITLE
Added offer_id column to members_stripe_customers_subscriptions

### DIFF
--- a/core/server/data/migrations/versions/4.44/2022-04-15-07-53-add-offer-id-to-subscriptions.js
+++ b/core/server/data/migrations/versions/4.44/2022-04-15-07-53-add-offer-id-to-subscriptions.js
@@ -1,0 +1,9 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members_stripe_customers_subscriptions', 'offer_id', {
+    type: 'string', 
+    maxlength: 24, 
+    nullable: true, 
+    unique: false, 
+    references: 'offers.id'
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -576,6 +576,7 @@ module.exports = {
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true},
         mrr: {type: 'integer', unsigned: true, nullable: false, defaultTo: 0},
+        offer_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'offers.id'},
         /* Below fields are now redundant as we link prie_id to stripe_prices table */
         plan_id: {type: 'string', maxlength: 255, nullable: false, unique: false},
         plan_nickname: {type: 'string', maxlength: 50, nullable: false},

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '026d0bffc2be9420c1d9fccf76656dac';
+    const currentSchemaHash = 'ae71340a8c89f6580b2eb06101f003b4';
     const currentFixturesHash = '2fb171312dfdd1dc3a569dfb845ac6f5';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1519

Migration that adds the (nullable) offer_id column to members_stripe_customers_subscriptions.
- New reliable way to know which offer is active for a given subscription (currently we compare the tier and cadence in offer redemptions)
- We'll create a separate migration to backfill all the offer_ids, but only after we updated the code to also store them correctly for new or updated subscriptions (https://github.com/TryGhost/Team/issues/1520)
- Allows us to backfill the MRR of all subscriptions to account for forever offers

I didn't add the `cascadeDelete` option because that wouldn't be appropriate here. A `ON DELETE SET NULL` option would be better in this situation, but the schema doesn't support that currently. I don't think it matters that much because we cannot and should not delete offers.