### PR TITLE
Filter member email recipients based on the newsletter subscriptions

### DIFF
--- a/core/server/models/email.js
+++ b/core/server/models/email.js
@@ -54,6 +54,10 @@ const Email = ghostBookshelf.Model.extend({
         return this.hasMany('EmailRecipient', 'email_id');
     },
 
+    newsletter() {
+        return this.belongsTo('Newsletter', 'newsletter_id');
+    },
+
     emitChange: function emitChange(event, options) {
         const eventToTrigger = 'email' + '.' + event;
         ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -828,6 +828,10 @@ Post = ghostBookshelf.Model.extend({
         return this.hasOne('Email', 'post_id');
     },
 
+    newsletter: function newsletter() {
+        return this.belongsTo('Newsletter', 'newsletter_id');
+    },
+
     /**
      * @NOTE:
      * If you are requesting models with `columns`, you try to only receive some fields of the model/s.

--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -134,6 +134,8 @@ const transformEmailRecipientFilter = (emailRecipientFilter, {errorProperty = 'e
 
     if (!newsletter) {
         filter.push(`subscribed:true`);
+    } else {
+        filter.push(`newsletters.id:${newsletter.id}`);
     }
 
     switch (emailRecipientFilter) {
@@ -215,7 +217,7 @@ const addEmail = async (postModel, options) => {
 
     const startRetrieve = Date.now();
     debug('addEmail: retrieving members count');
-    const {meta: {pagination: {total: membersCount}}} = await membersService.api.members.list(Object.assign({}, knexOptions, filterOptions));
+    const {meta: {pagination: {total: membersCount}}} = await membersService.api.members.list({...knexOptions, ...filterOptions});
     debug(`addEmail: retrieved members count - ${membersCount} members (${Date.now() - startRetrieve}ms)`);
 
     // NOTE: don't create email object when there's nobody to send the email to
@@ -418,7 +420,7 @@ async function getEmailMemberRows({emailModel, memberSegment, options}) {
     const knexOptions = _.pick(options, ['transacting', 'forUpdate']);
     const filterOptions = Object.assign({}, knexOptions);
 
-    let newsletter;
+    let newsletter = null;
     if (labsService.isSet('multipleNewsletters')) {
         newsletter = await emailModel.related('newsletter').fetch(Object.assign({}, {require: false}, _.pick(options, ['transacting'])));
     }

--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -17,6 +17,7 @@ const models = require('../../models');
 const postEmailSerializer = require('./post-email-serializer');
 const labs = require('../../../shared/labs');
 const {getSegmentsFromHtml} = require('./segment-parser');
+const labsService = require('../../../shared/labs');
 
 // Used to listen to email.added and email.edited model events originally, I think to offload this - ideally would just use jobs now if possible
 const events = require('../../lib/common/events');
@@ -390,6 +391,11 @@ async function getEmailMemberRows({emailModel, memberSegment, options}) {
 
     if (memberSegment) {
         filterOptions.filter = `${filterOptions.filter}+${memberSegment}`;
+    }
+
+    if (labsService.isSet('multipleNewsletters') && emailModel.get('newsletter_id')) {
+        const newsletter = await emailModel.related('newsletter').fetch();
+        filterOptions.filter = `${filterOptions.filter}+newsletters:${newsletter.slug}`;
     }
 
     const startRetrieve = Date.now();

--- a/core/server/services/posts/posts-service.js
+++ b/core/server/services/posts/posts-service.js
@@ -30,7 +30,7 @@ class PostsService {
             }
         } else {
             // Set the newsletter_id if it isn't passed to the API
-            const newsletters = await this.models.Newsletter.findPage({filter: 'status:active', limit: 10, columns: ['id', 'status', 'sort_order', 'name']}, {transacting: frame.options.transacting});
+            const newsletters = await this.models.Newsletter.findPage({filter: 'status:active', limit: 1, columns: ['id']}, {transacting: frame.options.transacting});
             if (newsletters.data.length > 0) {
                 frame.options.newsletter_id = newsletters.data[0].id;
             }

--- a/core/server/services/posts/posts-service.js
+++ b/core/server/services/posts/posts-service.js
@@ -22,7 +22,7 @@ class PostsService {
 
         // Make sure the newsletter_id is matching an active newsletter
         if (frame.options.newsletter_id) {
-            const newsletter = await this.models.Newsletter.findOne({id: frame.options.newsletter_id, status: 'active'}, {transacting: frame.options.transacting});
+            const newsletter = await this.models.Newsletter.findOne({id: frame.options.newsletter_id, filter: 'status:active'}, {transacting: frame.options.transacting});
             if (!newsletter) {
                 throw new BadRequestError({
                     message: messages.invalidNewsletterId
@@ -30,7 +30,7 @@ class PostsService {
             }
         } else {
             // Set the newsletter_id if it isn't passed to the API
-            const newsletters = await this.models.Newsletter.findPage({status: 'active', limit: 1, columns: ['id']}, {transacting: frame.options.transacting});
+            const newsletters = await this.models.Newsletter.findPage({filter: 'status:active', limit: 10, columns: ['id', 'status', 'sort_order', 'name']}, {transacting: frame.options.transacting});
             if (newsletters.data.length > 0) {
                 frame.options.newsletter_id = newsletters.data[0].id;
             }

--- a/test/regression/api/admin/posts.test.js
+++ b/test/regression/api/admin/posts.test.js
@@ -8,13 +8,16 @@ const config = require('../../../../core/shared/config');
 const models = require('../../../../core/server/models');
 const localUtils = require('./utils');
 
+const default_newsletter_id = testUtils.DataGenerator.Content.newsletters[0].id;
+const second_newsletter_id = testUtils.DataGenerator.Content.newsletters[1].id;
+
 describe('Posts API (canary)', function () {
     let request;
 
     before(async function () {
         await localUtils.startGhost();
         request = supertest.agent(config.get('url'));
-        await localUtils.doAuth(request, 'users:extra', 'posts', 'emails', 'members');
+        await localUtils.doAuth(request, 'users:extra', 'posts', 'emails', 'newsletters', 'members:newsletters');
     });
 
     describe('Browse', function () {
@@ -563,7 +566,7 @@ describe('Posts API (canary)', function () {
                 });
         });
 
-        it('publishes a post with email_only and sends email', async function () {
+        it('publishes a post with email_only and sends email to all without specifying the default newsletter_id', async function () {
             const res = await request
                 .post(localUtils.API.getApiQuery('posts/'))
                 .set('Origin', config.get('url'))
@@ -604,10 +607,10 @@ describe('Posts API (canary)', function () {
             publishedRes.body.posts[0].status.should.equal('sent');
 
             should.exist(publishedRes.body.posts[0].email);
-            publishedRes.body.posts[0].email.email_count.should.equal(6);
+            publishedRes.body.posts[0].email.email_count.should.equal(4);
         });
 
-        it('publishes a post while setting email_only flag sends an email', async function () {
+        it('publishes a post while setting email_only flag sends an email to paid without specifying the default newsletter_id', async function () {
             const res = await request
                 .post(localUtils.API.getApiQuery('posts/'))
                 .set('Origin', config.get('url'))
@@ -647,7 +650,137 @@ describe('Posts API (canary)', function () {
             publishedRes.body.posts[0].status.should.equal('sent');
 
             should.exist(publishedRes.body.posts[0].email);
-            publishedRes.body.posts[0].email.email_count.should.equal(3);
+            publishedRes.body.posts[0].email.email_count.should.equal(2);
+        });
+
+        it('publishes a post with email_only and sends email to all', async function () {
+            const res = await request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Email me',
+                        email_only: true
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+
+            should.exist(res.body.posts);
+            should.exist(res.body.posts[0].title);
+            res.body.posts[0].title.should.equal('Email me');
+            res.body.posts[0].email_only.should.be.true();
+            res.body.posts[0].status.should.equal('draft');
+
+            should.exist(res.headers.location);
+            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
+
+            const publishedRes = await request
+                .put(localUtils.API.getApiQuery(`posts/${res.body.posts[0].id}/?email_recipient_filter=all&newsletter_id=${default_newsletter_id}`))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        status: 'published',
+                        updated_at: res.body.posts[0].updated_at
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+
+            should.exist(publishedRes.body.posts);
+            res.body.posts[0].email_only.should.be.true();
+            publishedRes.body.posts[0].status.should.equal('sent');
+
+            should.exist(publishedRes.body.posts[0].email);
+            publishedRes.body.posts[0].email.email_count.should.equal(4);
+        });
+
+        it('publishes a post while setting email_only flag sends an email to paid', async function () {
+            const res = await request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Email me'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+
+            should.exist(res.body.posts);
+            should.exist(res.body.posts[0].title);
+            res.body.posts[0].title.should.equal('Email me');
+            res.body.posts[0].email_only.should.be.false();
+            res.body.posts[0].status.should.equal('draft');
+
+            should.exist(res.headers.location);
+            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
+
+            const publishedRes = await request
+                .put(localUtils.API.getApiQuery(`posts/${res.body.posts[0].id}/?email_recipient_filter=paid&newsletter_id=${default_newsletter_id}`))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        status: 'published',
+                        email_only: true,
+                        updated_at: res.body.posts[0].updated_at
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+
+            should.exist(publishedRes.body.posts);
+            publishedRes.body.posts[0].status.should.equal('sent');
+
+            should.exist(publishedRes.body.posts[0].email);
+            publishedRes.body.posts[0].email.email_count.should.equal(2);
+        });
+
+        it('only send an email to paid subscribed members of the selected newsletter', async function () {
+            const res = await request
+                .post(localUtils.API.getApiQuery('posts/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        title: 'Email me'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(201);
+
+            should.exist(res.body.posts);
+            should.exist(res.body.posts[0].title);
+            res.body.posts[0].title.should.equal('Email me');
+            res.body.posts[0].email_only.should.be.false();
+            res.body.posts[0].status.should.equal('draft');
+
+            should.exist(res.headers.location);
+            res.headers.location.should.equal(`http://127.0.0.1:2369${localUtils.API.getApiQuery('posts/')}${res.body.posts[0].id}/`);
+
+            const publishedRes = await request
+                .put(localUtils.API.getApiQuery(`posts/${res.body.posts[0].id}/?email_recipient_filter=paid&newsletter_id=${second_newsletter_id}`))
+                .set('Origin', config.get('url'))
+                .send({
+                    posts: [{
+                        status: 'published',
+                        email_only: true,
+                        updated_at: res.body.posts[0].updated_at
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+
+            should.exist(publishedRes.body.posts);
+            publishedRes.body.posts[0].status.should.equal('sent');
+
+            should.exist(publishedRes.body.posts[0].email);
+            publishedRes.body.posts[0].email.email_count.should.equal(2);
         });
 
         it('read-only value do not cause errors when edited', function () {

--- a/test/regression/api/admin/posts.test.js
+++ b/test/regression/api/admin/posts.test.js
@@ -17,6 +17,11 @@ describe('Posts API (canary)', function () {
     before(async function () {
         await localUtils.startGhost();
         request = supertest.agent(config.get('url'));
+
+        // Archive the default newsletter fixture
+        const defaultNewsletter = await models.Newsletter.findOne({status: 'active'});
+        await models.Newsletter.edit({status: 'archived'}, {id: defaultNewsletter.id});
+
         await localUtils.doAuth(request, 'users:extra', 'posts', 'emails', 'newsletters', 'members:newsletters');
     });
 

--- a/test/unit/server/services/mega/mega.test.js
+++ b/test/unit/server/services/mega/mega.test.js
@@ -44,7 +44,7 @@ describe('MEGA', function () {
         });
 
         // via transformEmailRecipientFilter
-        it('throws when "none" is used as a email_recipient_filter', async function () {
+        it('throws when "public" is used as newsletter.visibility', async function () {
             const postModel = {
                 get: sinon.stub().returns('status:free'),
                 fetch: sinon.stub().returns(Promise.resolve({
@@ -73,6 +73,11 @@ describe('MEGA', function () {
         it('doesn\'t enforce subscribed:true when sending an email to a newsletter', function () {
             const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {visibility: 'members'});
             transformedFilter.should.equal('(status:free,status:-free)');
+        });
+
+        it('combines successfully with the newsletter paid-only visibility', function () {
+            const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {visibility: 'paid'});
+            transformedFilter.should.equal('(status:free,status:-free)+status:-free');
         });
     });
 

--- a/test/unit/server/services/mega/mega.test.js
+++ b/test/unit/server/services/mega/mega.test.js
@@ -70,13 +70,13 @@ describe('MEGA', function () {
         });
 
         it('doesn\'t enforce subscribed:true when sending an email to a newsletter', function () {
-            const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {get: () => 'members'});
-            transformedFilter.should.equal('(status:free,status:-free)');
+            const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {id: 'test', get: () => 'members'});
+            transformedFilter.should.equal('newsletters.id:test+(status:free,status:-free)');
         });
 
         it('combines successfully with the newsletter paid-only visibility', function () {
-            const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {get: () => 'paid'});
-            transformedFilter.should.equal('(status:free,status:-free)+status:-free');
+            const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {id: 'test', get: () => 'paid'});
+            transformedFilter.should.equal('newsletters.id:test+(status:free,status:-free)+status:-free');
         });
     });
 
@@ -121,7 +121,12 @@ describe('MEGA', function () {
     describe('getEmailMemberRows', function () {
         it('addEmail throws when "free" or "paid" strings are used as a recipient_filter', async function () {
             const emailModel = {
-                get: sinon.stub().returns('paid')
+                get: sinon.stub().returns('paid'),
+                related: sinon.stub().returns({
+                    fetch: sinon.stub().returns({
+                        id: 'test'
+                    })
+                })
             };
 
             try {
@@ -135,7 +140,12 @@ describe('MEGA', function () {
 
         it('addEmail throws when "none" is used as a recipient_filter', async function () {
             const emailModel = {
-                get: sinon.stub().returns('none')
+                get: sinon.stub().returns('none'),
+                related: sinon.stub().returns({
+                    fetch: sinon.stub().returns({
+                        id: 'test'
+                    })
+                })
             };
 
             try {

--- a/test/unit/server/services/mega/mega.test.js
+++ b/test/unit/server/services/mega/mega.test.js
@@ -48,7 +48,7 @@ describe('MEGA', function () {
             const postModel = {
                 get: sinon.stub().returns('status:free'),
                 fetch: sinon.stub().returns(Promise.resolve({
-                    visibility: 'public'
+                    get: () => 'public'
                 }))
             };
             postModel.related = sinon.stub().returns(postModel);
@@ -71,12 +71,12 @@ describe('MEGA', function () {
         });
 
         it('doesn\'t enforce subscribed:true when sending an email to a newsletter', function () {
-            const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {visibility: 'members'});
+            const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {get: () => 'members'});
             transformedFilter.should.equal('(status:free,status:-free)');
         });
 
         it('combines successfully with the newsletter paid-only visibility', function () {
-            const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {visibility: 'paid'});
+            const transformedFilter = _transformEmailRecipientFilter('status:free,status:-free', {}, {get: () => 'paid'});
             transformedFilter.should.equal('(status:free,status:-free)+status:-free');
         });
     });

--- a/test/unit/server/services/mega/mega.test.js
+++ b/test/unit/server/services/mega/mega.test.js
@@ -5,7 +5,6 @@ const labs = require('../../../../../core/shared/labs');
 
 const {addEmail, _partitionMembersBySegment, _getEmailMemberRows, _transformEmailRecipientFilter, handleUnsubscribeRequest} = require('../../../../../core/server/services/mega/mega');
 const membersService = require('../../../../../core/server/services/members');
-const labs = require('../../../../../core/shared/labs');
 
 describe('MEGA', function () {
     describe('addEmail', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1524

- We need to fetch the post newsletter to grab the slug as it's needed for the member NQL filter.
- We can then use the newsletter slug and append it in the existing member NQL filter.

This is the backend implementation only, there is still the need for an admin PR to update the members counts that are displayed in the Publish flow.