### PR TITLE
Added stats endpoint for subscription deltas

### DIFF
--- a/core/server/api/canary/stats.js
+++ b/core/server/api/canary/stats.js
@@ -19,5 +19,14 @@ module.exports = {
         async query() {
             return await statsService.mrr.getHistory();
         }
+    },
+    subscriptionDeltas: {
+        permissions: {
+            docName: 'members',
+            method: 'browse'
+        },
+        async query() {
+            return await statsService.members.getSubscriptionDeltas();
+        }
     }
 };

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -140,6 +140,7 @@ module.exports = function apiRoutes() {
     // ## Stats
     router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
     router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
+    router.get('/stats/subscription_deltas', mw.authAdminApi, http(api.stats.subscriptionDeltas));
 
     // ## Labels
     router.get('/labels', mw.authAdminApi, http(api.labels.browse));

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -32,6 +32,24 @@ Object {
 }
 `;
 
+exports[`Stats API Can fetch Subscription deltas 1: [body] 1`] = `
+Object {
+  "stats": Array [],
+}
+`;
+
+exports[`Stats API Can fetch Subscription deltas 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "12",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Stats API Can fetch member count history 1: [body] 1`] = `
 Object {
   "meta": Object {

--- a/test/e2e-api/admin/stats.test.js
+++ b/test/e2e-api/admin/stats.test.js
@@ -37,4 +37,16 @@ describe('Stats API', function () {
                 etag: anyEtag
             });
     });
+
+    it('Can fetch Subscription deltas', async function () {
+        await agent
+            .get(`/stats/subscription_deltas`)
+            .expectStatus(200)
+            .matchBodySnapshot({
+                stats: []
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            });
+    });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1505

This calculates the new and cancelled subscriptions as/when they affect MRR.
We need to count both canceled and expired events because sometimes a subscription will expire without cancelation.
All events must affect MRR, as this chart is designed to show the changes in income generating subscriptions.

This won't include subscriptions which are started with a trial period. However Ghost/Members expects that trial periods are managed by Offers (e.g. 100% for the first month) - which will work correctly.
