### PR TITLE
Bumped Ghost-CLI test Node version to v14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '12.22.1'
+          node-version: '14.17.0'
           cache: yarn
       - run: npm install -g ghost-cli@latest
       - run: npm --no-git-tag-version version minor # We need to artificially bump the minor version to get migrations to run


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/267

- we're about to remove support for Node 12 so this needs bumping to
  keep things chugging along
