### PR TITLE
Added newsletter read permission

### DIFF
--- a/core/server/data/migrations/versions/4.45/2022-04-20-11-25-add-newsletter-read-permission.js
+++ b/core/server/data/migrations/versions/4.45/2022-04-20-11-25-add-newsletter-read-permission.js
@@ -1,0 +1,9 @@
+const {addPermissionWithRoles} = require('../../utils');
+
+module.exports = addPermissionWithRoles({
+    name: 'Read newsletters',
+    action: 'read',
+    object: 'newsletter'
+}, [
+    'Administrator'
+]);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -547,6 +547,11 @@
                     "object_type": "newsletter"
                 },
                 {
+                    "name": "Read newsletters",
+                    "action_type": "read",
+                    "object_type": "newsletter"
+                },
+                {
                     "name": "Add newsletters",
                     "action_type": "add",
                     "object_type": "newsletter"

--- a/test/integration/migrations/migration.test.js
+++ b/test/integration/migrations/migration.test.js
@@ -45,7 +45,7 @@ describe('Database Migration (special functions)', function () {
             const permissions = this.obj;
 
             // If you have to change this number, please add the relevant `havePermission` checks below
-            permissions.length.should.eql(95);
+            permissions.length.should.eql(96);
 
             permissions.should.havePermission('Export database', ['Administrator', 'DB Backup Integration']);
             permissions.should.havePermission('Import database', ['Administrator', 'DB Backup Integration']);
@@ -164,6 +164,7 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Edit custom theme settings', ['Administrator']);
 
             permissions.should.havePermission('Browse newsletters', ['Administrator']);
+            permissions.should.havePermission('Read newsletters', ['Administrator']);
             permissions.should.havePermission('Edit newsletters', ['Administrator']);
             permissions.should.havePermission('Add newsletters', ['Administrator']);
         });
@@ -223,7 +224,7 @@ describe('Database Migration (special functions)', function () {
                     result.roles.at(7).get('name').should.eql('Scheduler Integration');
 
                     // Permissions
-                    result.permissions.length.should.eql(95);
+                    result.permissions.length.should.eql(96);
                     result.permissions.toJSON().should.be.CompletePermissions();
                 });
             });

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'ae71340a8c89f6580b2eb06101f003b4';
-    const currentFixturesHash = '2fb171312dfdd1dc3a569dfb845ac6f5';
+    const currentFixturesHash = '2fe576bcde3428c3063c05b2f2c37367';
     const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/test/utils/fixtures/fixtures.json
+++ b/test/utils/fixtures/fixtures.json
@@ -108,6 +108,11 @@
                     "object_type": "notification"
                 },
                 {
+                    "name": "Read newsletters",
+                    "action_type": "read",
+                    "object_type": "newsletter"
+                },
+                {
                     "name": "Add notifications",
                     "action_type": "add",
                     "object_type": "notification"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1533

- Needed to create the read newsletter endpoint to make the newsletter resource more consistent with the other resources
- Read is available to Admins like other newsletter actions
