### PR TITLE
Added subscription stats API

### DIFF
--- a/core/server/api/canary/stats.js
+++ b/core/server/api/canary/stats.js
@@ -19,5 +19,14 @@ module.exports = {
         async query() {
             return await statsService.mrr.getHistory();
         }
+    },
+    subscriptions: {
+        permissions: {
+            docName: 'members',
+            method: 'browse'
+        },
+        async query() {
+            return await statsService.members.getSubscriptionHistory();
+        }
     }
 };

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -41,7 +41,7 @@ class MembersStatsService {
 
         for (let index = subscriptionDeltaEntries.length - 1; index >= 0; index -= 1) {
             const entry = subscriptionDeltaEntries[index];
-            entry.count = countData[entry.tier][entry.cadence]
+            entry.count = countData[entry.tier][entry.cadence];
             countData[entry.tier][entry.cadence] += entry.negative_delta;
             countData[entry.tier][entry.cadence] -= entry.positive_delta;
         }
@@ -56,7 +56,7 @@ class MembersStatsService {
         const rows = await knex('members_paid_subscription_events')
             .join('stripe_prices AS price', function () {
                 this.on('price.stripe_price_id', '=', 'members_paid_subscription_events.from_plan')
-                    .orOn('price.stripe_price_id', '=', 'members_paid_subscription_events.to_plan')
+                    .orOn('price.stripe_price_id', '=', 'members_paid_subscription_events.to_plan');
             })
             .join('stripe_products AS product', 'product.stripe_product_id', '=', 'price.stripe_product_id')
             .join('products AS tier', 'tier.id', '=', 'product.product_id')

--- a/core/server/services/stats/lib/members-stats-service.js
+++ b/core/server/services/stats/lib/members-stats-service.js
@@ -27,6 +27,92 @@ class MembersStatsService {
         };
     }
 
+    async getSubscriptionHistory() {
+        const subscriptionDeltaEntries = await this.fetchAllSubscriptionDeltas();
+        const counts = await this.fetchSubscriptionCounts();
+
+        const countData = {};
+        counts.forEach((count) => {
+            if (!countData[count.tier]) {
+                countData[count.tier] = {};
+            }
+            countData[count.tier][count.cadence] = count.count;
+        });
+
+        for (let index = subscriptionDeltaEntries.length - 1; index >= 0; index -= 1) {
+            const entry = subscriptionDeltaEntries[index];
+            entry.count = countData[entry.tier][entry.cadence]
+            countData[entry.tier][entry.cadence] += entry.negative_delta;
+            countData[entry.tier][entry.cadence] -= entry.positive_delta;
+        }
+
+        return {
+            data: subscriptionDeltaEntries
+        };
+    }
+
+    async fetchAllSubscriptionDeltas() {
+        const knex = this.db.knex;
+        const rows = await knex('members_paid_subscription_events')
+            .join('stripe_prices AS price', function () {
+                this.on('price.stripe_price_id', '=', 'members_paid_subscription_events.from_plan')
+                    .orOn('price.stripe_price_id', '=', 'members_paid_subscription_events.to_plan')
+            })
+            .join('stripe_products AS product', 'product.stripe_product_id', '=', 'price.stripe_product_id')
+            .join('products AS tier', 'tier.id', '=', 'product.product_id')
+            .leftJoin('stripe_prices AS from_price', 'from_price.stripe_price_id', '=', 'members_paid_subscription_events.from_plan')
+            .leftJoin('stripe_prices AS to_price', 'to_price.stripe_price_id', '=', 'members_paid_subscription_events.to_plan')
+            .select(knex.raw(`
+                DATE(members_paid_subscription_events.created_at) as date
+            `))
+            .select(knex.raw(`
+                tier.id as tier
+            `))
+            .select(knex.raw(`
+                price.interval as cadence
+            `))
+            .select(knex.raw(`SUM(
+                CASE
+                    WHEN members_paid_subscription_events.type='created' AND members_paid_subscription_events.mrr_delta != 0 THEN 1
+                    WHEN members_paid_subscription_events.type='updated' AND price.id = to_price.id THEN 1
+                    ELSE 0
+                END
+            ) as positive_delta`))
+            .select(knex.raw(`SUM(
+                CASE
+                    WHEN members_paid_subscription_events.type IN ('canceled', 'expired') AND members_paid_subscription_events.mrr_delta != 0 THEN 1
+                    WHEN members_paid_subscription_events.type='updated' AND price.id = from_price.id THEN 1
+                    ELSE 0
+                END
+            ) as negative_delta`))
+            .groupBy('date', 'tier', 'cadence')
+            .orderBy('date');
+
+        return rows;
+    }
+
+    /**
+      * Get the current total subscriptions grouped by Cadence and Tier
+      * @returns {Promise<TotalSubscriptionStats>}
+      **/
+    async fetchSubscriptionCounts() {
+        const knex = this.db.knex;
+
+        const data = await knex('members_stripe_customers_subscriptions')
+            .select(knex.raw(`
+                  COUNT(members_stripe_customers_subscriptions.id) AS count,
+                  products.id AS tier,
+                  stripe_prices.interval AS cadence
+             `))
+            .join('stripe_prices', 'stripe_prices.stripe_price_id', '=', 'members_stripe_customers_subscriptions.stripe_price_id')
+            .join('stripe_products', 'stripe_products.stripe_product_id', '=', 'stripe_prices.stripe_product_id')
+            .join('products', 'products.id', '=', 'stripe_products.product_id')
+            .whereNot('members_stripe_customers_subscriptions.mrr', 0)
+            .groupBy('tier', 'cadence');
+
+        return data;
+    }
+
     /**
      * Get the member deltas by status for all days, sorted ascending
      * @returns {Promise<MemberStatusDelta[]>} The deltas of paid, free and comped users per day, sorted ascending

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -140,6 +140,7 @@ module.exports = function apiRoutes() {
     // ## Stats
     router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
     router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
+    router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
 
     // ## Labels
     router.get('/labels', mw.authAdminApi, http(api.labels.browse));

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -32,6 +32,42 @@ Object {
 }
 `;
 
+exports[`Stats API Can fetch Subscription deltas 1: [body] 1`] = `
+Object {
+  "stats": Array [],
+}
+`;
+
+exports[`Stats API Can fetch Subscription deltas 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "12",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Stats API Can fetch Subscription stats 1: [body] 1`] = `
+Object {
+  "stats": Array [],
+}
+`;
+
+exports[`Stats API Can fetch Subscription stats 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "12",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Stats API Can fetch member count history 1: [body] 1`] = `
 Object {
   "meta": Object {

--- a/test/e2e-api/admin/stats.test.js
+++ b/test/e2e-api/admin/stats.test.js
@@ -37,4 +37,16 @@ describe('Stats API', function () {
                 etag: anyEtag
             });
     });
+
+    it('Can fetch Subscription stats', async function () {
+        await agent
+            .get(`/stats/subscriptions`)
+            .expectStatus(200)
+            .matchBodySnapshot({
+                stats: []
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            });
+    });
 });

--- a/test/unit/server/services/stats/members-stats-service.test.js
+++ b/test/unit/server/services/stats/members-stats-service.test.js
@@ -14,7 +14,7 @@ describe('MembersStatsService', function () {
             }
         });
 
-        beforeEach(async function() {
+        beforeEach(async function () {
             await knex.schema.dropTableIfExists('products');
             await knex.schema.dropTableIfExists('stripe_products');
             await knex.schema.dropTableIfExists('stripe_prices');


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1505
refs https://github.com/TryGhost/Team/issues/1466

This adds a subscription stats api which returns the total count as well as the negative and positive deltas for subscriptions broken down by Tier and Cadence.

We use the same strategy as with MRR where we count backwards from the known totals.