### PR TITLE
Added `version_notifications` key to settings table

### DIFF
--- a/core/server/data/migrations/versions/4.45/2022-04-21-02-55-add-notifications-key-entry-to-settings-table.js
+++ b/core/server/data/migrations/versions/4.45/2022-04-21-02-55-add-notifications-key-entry-to-settings-table.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils.js');
+
+module.exports = addSetting({
+    key: 'version_notifications',
+    value: '[]',
+    type: 'array',
+    group: 'core'
+});

--- a/core/server/data/schema/default-settings/default-settings.json
+++ b/core/server/data/schema/default-settings/default-settings.json
@@ -16,6 +16,10 @@
             "defaultValue": "[]",
             "type": "array"
         },
+        "version_notifications": {
+            "defaultValue": "[]",
+            "type": "array"
+        },
         "session_secret": {
             "defaultValue": null,
             "type": "string"

--- a/test/integration/settings/settings.test.js
+++ b/test/integration/settings/settings.test.js
@@ -19,6 +19,7 @@ describe('Settings', function () {
         'routes_hash',
         'next_update_check',
         'notifications',
+        'version_notifications',
         'session_secret',
         'theme_session_secret',
         'ghost_public_key',

--- a/test/regression/models/model_settings.test.js
+++ b/test/regression/models/model_settings.test.js
@@ -17,7 +17,7 @@ describe('Settings Model', function () {
             await models.Settings.populateDefaults();
 
             const settingsPopulated = await models.Settings.findAll();
-            settingsPopulated.length.should.equal(95);
+            settingsPopulated.length.should.equal(96);
         });
 
         it('doesn\'t overwrite any existing settings', async function () {
@@ -42,7 +42,7 @@ describe('Settings Model', function () {
             await models.Settings.populateDefaults();
 
             const settingsPopulated = await models.Settings.findAll();
-            settingsPopulated.length.should.equal(95);
+            settingsPopulated.length.should.equal(96);
 
             const titleSetting = settingsPopulated.models.find(s => s.get('key') === 'title');
             titleSetting.get('value').should.equal('Testing Defaults');

--- a/test/unit/server/data/exporter/index.test.js
+++ b/test/unit/server/data/exporter/index.test.js
@@ -198,7 +198,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 85;
+            const allowedKeysLength = 86;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'ae71340a8c89f6580b2eb06101f003b4';
     const currentFixturesHash = '2fe576bcde3428c3063c05b2f2c37367';
-    const currentSettingsHash = '71fa38d0c805c18ceebe0fda80886230';
+    const currentSettingsHash = 'ffd899a82b0ad2886e92d8244bcbca6a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/test/utils/fixtures/default-settings.json
+++ b/test/utils/fixtures/default-settings.json
@@ -16,6 +16,10 @@
             "defaultValue": "[]",
             "type": "array"
         },
+        "version_notifications": {
+            "defaultValue": "[]",
+            "type": "array"
+        },
         "session_secret": {
             "defaultValue": null,
             "type": "string"


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/292

- When version missmatch handling is done in Ghost we need to store the 'Accept-Version' header values that have been already processed in the past (to avoid sending notifications about the same mismatch multiple times)
- The `version_notifications` will be storing an array with handled versions like so: `['v3.44', 'v4.23', 'v4.39']`.
- The emailing logic and processing is slightly similar to how "notification" key is handled, that's why I've placed the definition of this new key close by.

@ErisDS added you as a reviewer as you are the most context loaded on the feature :)