### PR TITLE
Added /stats/subscriptions API

### DIFF
--- a/core/server/api/canary/stats.js
+++ b/core/server/api/canary/stats.js
@@ -19,5 +19,14 @@ module.exports = {
         async query() {
             return await statsService.getMRRHistory();
         }
+    },
+    subscriptions: {
+        permissions: {
+            docName: 'members',
+            method: 'browse'
+        },
+        async query() {
+            return await statsService.getSubscriptionCountHistory();
+        }
     }
 };

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -140,6 +140,7 @@ module.exports = function apiRoutes() {
     // ## Stats
     router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
     router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
+    router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
 
     // ## Labels
     router.get('/labels', mw.authAdminApi, http(api.labels.browse));

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@tryghost/session-service": "0.1.38",
     "@tryghost/settings-path-manager": "0.1.4",
     "@tryghost/social-urls": "0.1.29",
-    "@tryghost/stats-service": "0.1.0",
+    "@tryghost/stats-service": "0.2.0",
     "@tryghost/string": "0.1.23",
     "@tryghost/tpl": "0.1.14",
     "@tryghost/update-check-service": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@tryghost/session-service": "0.1.38",
     "@tryghost/settings-path-manager": "0.1.4",
     "@tryghost/social-urls": "0.1.29",
-    "@tryghost/stats-service": "0.2.0",
+    "@tryghost/stats-service": "0.2.1",
     "@tryghost/string": "0.1.23",
     "@tryghost/tpl": "0.1.14",
     "@tryghost/update-check-service": "0.3.2",

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -14,6 +14,11 @@ Object {
     Object {
       "currency": "usd",
       "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "mrr": 0,
+    },
+    Object {
+      "currency": "usd",
+      "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "mrr": 1000,
     },
   ],
@@ -24,7 +29,7 @@ exports[`Stats API Can fetch MRR history 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "111",
+  "content-length": "158",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -68,7 +73,40 @@ Object {
 
 exports[`Stats API Can fetch subscriptions history 1: [body] 1`] = `
 Object {
-  "stats": Array [],
+  "meta": Object {
+    "cadences": Array [
+      "year",
+      "month",
+    ],
+    "tiers": Array [
+      StringMatching /\\[a-f0-9\\]\\{24\\}/,
+    ],
+    "totals": Array [
+      Object {
+        "cadence": "month",
+        "count": 1,
+        "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      },
+    ],
+  },
+  "stats": Array [
+    Object {
+      "cadence": "month",
+      "count": 1,
+      "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "negative_delta": 0,
+      "positive_delta": 1,
+      "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+    },
+    Object {
+      "cadence": "year",
+      "count": 0,
+      "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "negative_delta": 0,
+      "positive_delta": 0,
+      "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+    },
+  ],
 }
 `;
 
@@ -76,7 +114,7 @@ exports[`Stats API Can fetch subscriptions history 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "12",
+  "content-length": "403",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -65,3 +65,21 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Stats API Can fetch subscriptions history 1: [body] 1`] = `
+Object {
+  "stats": Array [],
+}
+`;
+
+exports[`Stats API Can fetch subscriptions history 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "12",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/test/e2e-api/admin/stats.test.js
+++ b/test/e2e-api/admin/stats.test.js
@@ -37,4 +37,16 @@ describe('Stats API', function () {
                 etag: anyEtag
             });
     });
+
+    it('Can fetch subscriptions history', async function () {
+        await agent
+            .get(`/stats/subscriptions`)
+            .expectStatus(200)
+            .matchBodySnapshot({
+                stats: []
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            });
+    });
 });

--- a/test/e2e-api/admin/stats.test.js
+++ b/test/e2e-api/admin/stats.test.js
@@ -1,5 +1,5 @@
 const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
-const {anyEtag, anyISODate} = matchers;
+const {anyEtag, anyISODate, anyObjectId} = matchers;
 
 let agent;
 
@@ -31,6 +31,8 @@ describe('Stats API', function () {
             .matchBodySnapshot({
                 stats: [{
                     date: anyISODate
+                }, {
+                    date: anyISODate
                 }]
             })
             .matchHeaderSnapshot({
@@ -43,7 +45,19 @@ describe('Stats API', function () {
             .get(`/stats/subscriptions`)
             .expectStatus(200)
             .matchBodySnapshot({
-                stats: []
+                stats: [{
+                    date: anyISODate,
+                    tier: anyObjectId
+                }, {
+                    date: anyISODate,
+                    tier: anyObjectId
+                }],
+                meta: {
+                    tiers: [anyObjectId],
+                    totals: [{
+                        tier: anyObjectId
+                    }]
+                }
             })
             .matchHeaderSnapshot({
                 etag: anyEtag

--- a/test/utils/fixture-utils.js
+++ b/test/utils/fixture-utils.js
@@ -562,6 +562,10 @@ const fixtures = {
                     })}, {id: member.id});
                 }
             }
+        }).then(async function () {
+            for (const event of DataGenerator.forKnex.members_paid_subscription_events) {
+                await models.MemberPaidSubscriptionEvent.add(event);
+            }
         });
     },
 

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -492,6 +492,42 @@ DataGenerator.Content = {
         }
     ],
 
+    members_paid_subscription_events: [
+        {
+            id: ObjectId().toHexString(),
+            type: 'created',
+            mrr_delta: 1000,
+            currency: 'usd',
+            source: 'stripe',
+            created_at: null,
+            subscription_id: null,
+            member_id: null,
+            from_plan: null,
+            to_plan: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb8'
+        }, {
+            id: ObjectId().toHexString(),
+            type: 'created',
+            mrr_delta: 0,
+            currency: 'usd',
+            source: 'stripe',
+            created_at: null,
+            subscription_id: null,
+            member_id: null,
+            from_plan: null,
+            to_plan: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb9'
+        }, {
+            id: ObjectId().toHexString(),
+            type: 'created',
+            mrr_delta: 0,
+            currency: 'usd',
+            source: 'stripe',
+            created_at: null,
+            subscription_id: null,
+            member_id: null,
+            from_plan: null,
+            to_plan: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730ba0'
+        }
+    ],
     members_stripe_customers_subscriptions: [
         {
             id: ObjectId().toHexString(),
@@ -780,6 +816,9 @@ DataGenerator.Content.members_stripe_customers[1].member_id = DataGenerator.Cont
 DataGenerator.Content.members_stripe_customers[2].member_id = DataGenerator.Content.members[4].id;
 DataGenerator.Content.members_stripe_customers[3].member_id = DataGenerator.Content.members[6].id;
 DataGenerator.Content.members_stripe_customers[4].member_id = DataGenerator.Content.members[7].id;
+DataGenerator.Content.members_paid_subscription_events[0].member_id = DataGenerator.Content.members[2].id;
+DataGenerator.Content.members_paid_subscription_events[1].member_id = DataGenerator.Content.members[3].id;
+DataGenerator.Content.members_paid_subscription_events[2].member_id = DataGenerator.Content.members[4].id;
 
 DataGenerator.forKnex = (function () {
     function createBasic(overrides) {
@@ -1472,6 +1511,12 @@ DataGenerator.forKnex = (function () {
         createBasic(DataGenerator.Content.members_stripe_customers_subscriptions[2])
     ];
 
+    const members_paid_subscription_events = [
+        createBasic(DataGenerator.Content.members_paid_subscription_events[0]),
+        createBasic(DataGenerator.Content.members_paid_subscription_events[1]),
+        createBasic(DataGenerator.Content.members_paid_subscription_events[2])
+    ];
+
     const snippets = [
         createBasic(DataGenerator.Content.snippets[0])
     ];
@@ -1536,7 +1581,9 @@ DataGenerator.forKnex = (function () {
         stripe_prices,
         stripe_products,
         snippets,
-        custom_theme_settings
+        custom_theme_settings,
+
+        members_paid_subscription_events
     };
 }());
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,10 +2352,10 @@
   resolved "https://registry.yarnpkg.com/@tryghost/social-urls/-/social-urls-0.1.29.tgz#09177858959e9521244d0192bf219237f0fb6094"
   integrity sha512-PUgSQj/Y8x4Sbp0/Lq/Pq6ZN8ICSoAIHpVouJwblW3LvY/C0eeDrDLQMrUmR2SSBx59mS+Blavwy5mFlt23lwg==
 
-"@tryghost/stats-service@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/stats-service/-/stats-service-0.1.0.tgz#5638ac07b6de6de40ea4f7a9963e832530eef2e2"
-  integrity sha512-YJRdomtJ8y3f0UDvYjSnK4/RMu5xvZoMvtFAZfxiDC1d0yKA4YostxFQHAKh32t2y0FNO6IJzO7yJ5HnUXjueg==
+"@tryghost/stats-service@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/stats-service/-/stats-service-0.2.0.tgz#7867212861f05a944efe3f6f7ac578d3ca762926"
+  integrity sha512-kkOXkWFM51MxaphhDjvrUpbst26nsHkWAOVoBJF3w3n6MPaSZn34CqUmdR3ly15qSQZxaMze2YJDyRbrQA7lUw==
   dependencies:
     moment "^2.29.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,10 +2352,10 @@
   resolved "https://registry.yarnpkg.com/@tryghost/social-urls/-/social-urls-0.1.29.tgz#09177858959e9521244d0192bf219237f0fb6094"
   integrity sha512-PUgSQj/Y8x4Sbp0/Lq/Pq6ZN8ICSoAIHpVouJwblW3LvY/C0eeDrDLQMrUmR2SSBx59mS+Blavwy5mFlt23lwg==
 
-"@tryghost/stats-service@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/stats-service/-/stats-service-0.2.0.tgz#7867212861f05a944efe3f6f7ac578d3ca762926"
-  integrity sha512-kkOXkWFM51MxaphhDjvrUpbst26nsHkWAOVoBJF3w3n6MPaSZn34CqUmdR3ly15qSQZxaMze2YJDyRbrQA7lUw==
+"@tryghost/stats-service@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/stats-service/-/stats-service-0.2.1.tgz#d9b0488d705b9a697dc9ebff9ec8e64b33902649"
+  integrity sha512-2w2C8f9BR7QjcyvgPLQmzNW+cDHT6eceCMa8Ihp3PoQtcikE8TKAOx1cwlEDxs+0Blf5BQ8HILA2bJYsfsylAg==
   dependencies:
     moment "^2.29.3"
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1505
refs https://github.com/TryGhost/Team/issues/1466

Exposes an API for historical counts broken down by tier and cadence.

Counts backwards from the current stats like MRR to minimize inaccruate
data due to missing/superfluous events.


Changes to the stats service: https://github.com/TryGhost/Analytics/commit/2d91318e9dccb754d24453f5fbbd50b435211f47
