### PR TITLE
Added `newsletter_id` column to subscribe events

### DIFF
--- a/core/server/data/migrations/versions/4.46/2022-04-22-07-43-add-newsletter-id-to-subscribe-events.js
+++ b/core/server/data/migrations/versions/4.46/2022-04-22-07-43-add-newsletter-id-to-subscribe-events.js
@@ -1,0 +1,9 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members_subscribe_events', 'newsletter_id', {
+    type: 'string', 
+    maxlength: 24,
+    nullable: true,
+    references: 'newsletters.id', 
+    cascadeDelete: false
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -597,7 +597,8 @@ module.exports = {
         member_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'members.id', cascadeDelete: true},
         subscribed: {type: 'bool', nullable: false, defaultTo: true},
         created_at: {type: 'dateTime', nullable: false},
-        source: {type: 'string', maxlength: 50, nullable: true}
+        source: {type: 'string', maxlength: 50, nullable: true},
+        newsletter_id: {type: 'string', maxlength: 24, nullable: true, references: 'newsletters.id', cascadeDelete: false}
     },
     stripe_products: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'd5f7d8ad423391e56da160e54358963b';
+    const currentSchemaHash = '0e37d7b946574478382c7506a9f5e588';
     const currentFixturesHash = '4924616fbc51dd0ccef62ae04b4708f9';
     const currentSettingsHash = 'ffd899a82b0ad2886e92d8244bcbca6a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1478

The `newsletter_id` is nullable for now to remain compatible until we have a proper data migration + updated code to set it on inserts.