### PR TITLE
Use newsletter design settings

### DIFF
--- a/core/server/api/canary/utils/serializers/output/mappers/pages.js
+++ b/core/server/api/canary/utils/serializers/output/mappers/pages.js
@@ -6,6 +6,7 @@ module.exports = async (model, frame, options) => {
     delete jsonModel.email_subject;
     delete jsonModel.email_recipient_filter;
     delete jsonModel.email_only;
+    delete jsonModel.newsletter_id;
 
     return jsonModel;
 };

--- a/core/server/api/canary/utils/serializers/output/mappers/posts.js
+++ b/core/server/api/canary/utils/serializers/output/mappers/posts.js
@@ -57,6 +57,8 @@ module.exports = async (model, frame, options = {}) => {
         }
         date.forPost(jsonModel);
         gating.forPost(jsonModel, frame);
+
+        delete jsonModel.newsletter_id;
     }
 
     // Transforms post/page metadata to flat structure

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -48,6 +48,8 @@ const mapPost = (model, frame) => {
         }
         date.forPost(jsonModel);
         gating.forPost(jsonModel, frame);
+
+        delete jsonModel.newsletter_id;
     }
 
     // Transforms post/page metadata to flat structure

--- a/core/server/api/v3/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v3/utils/serializers/output/utils/mapper.js
@@ -45,6 +45,8 @@ const mapPost = (model, frame) => {
         }
         date.forPost(jsonModel);
         gating.forPost(jsonModel, frame);
+
+        delete jsonModel.newsletter_id;
     }
 
     if (typeof jsonModel.email_recipient_filter === 'undefined') {
@@ -100,6 +102,7 @@ const mapPage = (model, frame) => {
     delete jsonModel.email_subject;
     delete jsonModel.send_email_when_published;
     delete jsonModel.email_recipient_filter;
+    delete jsonModel.newsletter_id;
 
     return jsonModel;
 };

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -887,9 +887,6 @@ Post = ghostBookshelf.Model.extend({
         // CASE: never expose the revisions
         delete attrs.mobiledoc_revisions;
 
-        // CASE: hide the newsletter_id for now
-        delete attrs.newsletter_id;
-
         // If the current column settings allow it...
         if (!options.columns || (options.columns && options.columns.indexOf('primary_tag') > -1)) {
             // ... attach a computed property of primary_tag which is the first tag if it is public, else null

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -171,40 +171,33 @@ const parseReplacements = (email) => {
 };
 
 const getTemplateSettings = async (newsletterId = null) => {
+    let newsletter;
+    if (newsletterId) {
+        newsletter = await models.Newsletter.findOne({id: newsletterId, status: 'active'});
+    } else {
+        const newsletters = await models.Newsletter.findPage({status: 'active', limit: 1});
+        newsletter = newsletters.data[0];
+    }
+
     const accentColor = settingsCache.get('accent_color');
     const adjustedAccentColor = accentColor && darkenToContrastThreshold(accentColor, '#ffffff', 2).hex();
     const adjustedAccentContrastColor = accentColor && textColorForBackgroundColor(adjustedAccentColor).hex();
 
     const templateSettings = {
-        headerImage: settingsCache.get('newsletter_header_image'),
-        showHeaderIcon: settingsCache.get('newsletter_show_header_icon') && settingsCache.get('icon'),
-        showHeaderTitle: settingsCache.get('newsletter_show_header_title'),
-        showFeatureImage: settingsCache.get('newsletter_show_feature_image'),
-        titleFontCategory: settingsCache.get('newsletter_title_font_category'),
-        titleAlignment: settingsCache.get('newsletter_title_alignment'),
-        bodyFontCategory: settingsCache.get('newsletter_body_font_category'),
-        showBadge: settingsCache.get('newsletter_show_badge'),
-        footerContent: settingsCache.get('newsletter_footer_content'),
+        headerImage: newsletter.get('header_image'),
+        showHeaderIcon: newsletter.get('show_header_icon') && settingsCache.get('icon'),
+        showHeaderTitle: newsletter.get('show_header_title'),
+        showFeatureImage: newsletter.get('show_feature_image'),
+        titleFontCategory: newsletter.get('title_font_category'),
+        titleAlignment: newsletter.get('title_alignment'),
+        bodyFontCategory: newsletter.get('body_font_category'),
+        showBadge: newsletter.get('show_badge'),
+        footerContent: newsletter.get('footer_content'),
+        showHeaderName: newsletter.get('show_header_name'),
         accentColor,
         adjustedAccentColor,
         adjustedAccentContrastColor
     };
-
-    if (newsletterId) {
-        const newsletter = await models.Newsletter.findOne({id: newsletterId, status: 'active'}, {require: false});
-        if (newsletter) {
-            templateSettings.headerImage = newsletter.get('header_image');
-            templateSettings.showHeaderIcon = newsletter.get('show_header_icon') && settingsCache.get('icon');
-            templateSettings.showHeaderTitle = newsletter.get('show_header_title');
-            templateSettings.showFeatureImage = newsletter.get('show_feature_image');
-            templateSettings.titleFontCategory = newsletter.get('title_font_category');
-            templateSettings.titleAlignment = newsletter.get('title_alignment');
-            templateSettings.bodyFontCategory = newsletter.get('body_font_category');
-            templateSettings.showBadge = newsletter.get('show_badge');
-            templateSettings.footerContent = newsletter.get('footer_content');
-            templateSettings.showHeaderName = newsletter.get('show_header_name');
-        }
-    }
 
     if (templateSettings.headerImage) {
         if (isUnsplashImage(templateSettings.headerImage)) {

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -175,7 +175,7 @@ const getTemplateSettings = async (newsletterId = null) => {
     if (newsletterId) {
         newsletter = await models.Newsletter.findOne({id: newsletterId, filter: 'status:active'});
     } else {
-        const newsletters = await models.Newsletter.findPage({status: 'active', limit: 1});
+        const newsletters = await models.Newsletter.findPage({filter: 'status:active', limit: 1});
         newsletter = newsletters.data[0];
     }
 

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -173,7 +173,7 @@ const parseReplacements = (email) => {
 const getTemplateSettings = async (newsletterId = null) => {
     let newsletter;
     if (newsletterId) {
-        newsletter = await models.Newsletter.findOne({id: newsletterId, status: 'active'});
+        newsletter = await models.Newsletter.findOne({id: newsletterId, filter: 'status:active'});
     } else {
         const newsletters = await models.Newsletter.findPage({status: 'active', limit: 1});
         newsletter = newsletters.data[0];

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -194,7 +194,7 @@ const getTemplateSettings = async (newsletterId = null) => {
         const newsletter = await models.Newsletter.findOne({id: newsletterId, status: 'active'}, {require: false});
         if (newsletter) {
             templateSettings.headerImage = newsletter.get('header_image');
-            templateSettings.showHeaderIcon = newsletter.get('show_header_icon');
+            templateSettings.showHeaderIcon = newsletter.get('show_header_icon') && settingsCache.get('icon');
             templateSettings.showHeaderTitle = newsletter.get('show_header_title');
             templateSettings.showFeatureImage = newsletter.get('show_feature_image');
             templateSettings.titleFontCategory = newsletter.get('title_font_category');
@@ -356,5 +356,7 @@ module.exports = {
     serialize,
     createUnsubscribeUrl,
     renderEmailForSegment,
-    parseReplacements
+    parseReplacements,
+    // Export for tests
+    _getTemplateSettings: getTemplateSettings
 };

--- a/test/e2e-api/admin/utils.js
+++ b/test/e2e-api/admin/utils.js
@@ -71,7 +71,8 @@ const expectedProperties = {
         'email_subject',
         'frontmatter',
         'email_only',
-        'tiers'
+        'tiers',
+        'newsletter_id'
     ],
 
     page: [

--- a/test/regression/api/admin/utils.js
+++ b/test/regression/api/admin/utils.js
@@ -65,7 +65,8 @@ const expectedProperties = {
         'email_subject',
         'frontmatter',
         'email_only',
-        'tiers'
+        'tiers',
+        'newsletter_id'
     ],
     user: [
         'id',

--- a/test/unit/server/services/mega/post-email-serializer.test.js
+++ b/test/unit/server/services/mega/post-email-serializer.test.js
@@ -1,6 +1,9 @@
 const should = require('should');
+const sinon = require('sinon');
+const settingsCache = require('../../../../../core/shared/settings-cache');
+const models = require('../../../../../core/server/models');
 
-const {parseReplacements, renderEmailForSegment} = require('../../../../../core/server/services/mega/post-email-serializer');
+const {parseReplacements, renderEmailForSegment, _getTemplateSettings} = require('../../../../../core/server/services/mega/post-email-serializer');
 
 describe('Post Email Serializer', function () {
     it('creates replacement pattern for valid format and value', function () {
@@ -80,5 +83,88 @@ describe('Post Email Serializer', function () {
             output.html.should.equal('hello');
             output.plaintext.should.equal('hello');
         });
+    });
+
+    describe.only('getTemplateSettings', function () {
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('uses the gloal settings when no newsletter_id is defined', async function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    icon: 'icon',
+                    accent_color: '#990000',
+                    newsletter_header_image: 'image',
+                    newsletter_show_header_icon: true,
+                    newsletter_show_header_title: true,
+                    newsletter_show_feature_image: true,
+                    newsletter_title_font_category: 'sans-serif',
+                    newsletter_title_alignment: 'center',
+                    newsletter_body_font_category: 'serif',
+                    newsletter_show_badge: true,
+                    newsletter_footer_content: 'footer'
+                }[key];
+            });
+
+            const res = await _getTemplateSettings();
+            should(res).eql({
+                headerImage: 'image',
+                showHeaderIcon: 'icon',
+                showHeaderTitle: true,
+                showFeatureImage: true,
+                titleFontCategory: 'sans-serif',
+                titleAlignment: 'center',
+                bodyFontCategory: 'serif',
+                showBadge: true,
+                footerContent: 'footer',
+                accentColor: '#990000',
+                adjustedAccentColor: '#990000',
+                adjustedAccentContrastColor: '#FFFFFF'
+            });
+        });
+
+        // it('uses the newsletter settings when a newsletter_id is defined', async function () {
+        //     sinon.stub(settingsCache, 'get').callsFake(function (key) {
+        //         return {
+        //             icon: 'icon2',
+        //             accent_color: '#000099'
+        //         }[key];
+        //     });
+        //     sinon.stub(models.Newsletter, 'findOne').returns(
+        //         Promise.resolve({
+        //             get: function (key) {
+        //                 return {
+        //                     header_image: 'image',
+        //                     show_header_icon: true,
+        //                     show_header_title: true,
+        //                     show_feature_image: true,
+        //                     title_font_category: 'sans-serif',
+        //                     title_alignment: 'center',
+        //                     body_font_category: 'serif',
+        //                     show_badge: true,
+        //                     footer_content: 'footer',
+        //                     show_header_name: true
+        //                 }[key];
+        //             }
+        //         })
+        //     );
+        //     const res = await _getTemplateSettings('123');
+        //     should(res).eql({
+        //         headerImage: 'image',
+        //         showHeaderIcon: 'icon2',
+        //         showHeaderTitle: true,
+        //         showFeatureImage: true,
+        //         titleFontCategory: 'sans-serif',
+        //         titleAlignment: 'center',
+        //         bodyFontCategory: 'serif',
+        //         showBadge: true,
+        //         footerContent: 'footer',
+        //         accentColor: '#990000',
+        //         adjustedAccentColor: '#990000',
+        //         adjustedAccentContrastColor: '#FFFFFF',
+        //         showHeaderName: true
+        //     });
+        // });
     });
 });

--- a/test/unit/server/services/mega/post-email-serializer.test.js
+++ b/test/unit/server/services/mega/post-email-serializer.test.js
@@ -94,34 +94,46 @@ describe('Post Email Serializer', function () {
             sinon.restore();
         });
 
-        it('uses the gloal settings when no newsletter_id is defined', async function () {
+        it('uses the default newsletter settings when no newsletter_id is defined', async function () {
             sinon.stub(settingsCache, 'get').callsFake(function (key) {
                 return {
                     icon: 'icon',
-                    accent_color: '#990000',
-                    newsletter_header_image: 'image',
-                    newsletter_show_header_icon: true,
-                    newsletter_show_header_title: true,
-                    newsletter_show_feature_image: true,
-                    newsletter_title_font_category: 'sans-serif',
-                    newsletter_title_alignment: 'center',
-                    newsletter_body_font_category: 'serif',
-                    newsletter_show_badge: true,
-                    newsletter_footer_content: 'footer'
+                    accent_color: '#990000'
                 }[key];
             });
+            sinon.stub(models.Newsletter, 'findPage').returns(
+                Promise.resolve({
+                    data: [{
+                        get: function (key) {
+                            return {
+                                header_image: 'image',
+                                show_header_icon: true,
+                                show_header_title: true,
+                                show_feature_image: true,
+                                title_font_category: 'sans_serif',
+                                title_alignment: 'center',
+                                body_font_category: 'serif',
+                                show_badge: true,
+                                footer_content: '',
+                                show_header_name: true
+                            }[key];
+                        }
+                    }]
+                })
+            );
 
             const res = await _getTemplateSettings();
             should(res).eql({
                 headerImage: 'image',
                 showHeaderIcon: 'icon',
                 showHeaderTitle: true,
+                showHeaderName: true,
                 showFeatureImage: true,
-                titleFontCategory: 'sans-serif',
+                titleFontCategory: 'sans_serif',
                 titleAlignment: 'center',
                 bodyFontCategory: 'serif',
                 showBadge: true,
-                footerContent: 'footer',
+                footerContent: '',
                 accentColor: '#990000',
                 adjustedAccentColor: '#990000',
                 adjustedAccentContrastColor: '#FFFFFF'

--- a/test/unit/server/services/mega/post-email-serializer.test.js
+++ b/test/unit/server/services/mega/post-email-serializer.test.js
@@ -86,6 +86,10 @@ describe('Post Email Serializer', function () {
     });
 
     describe.only('getTemplateSettings', function () {
+        before(function () {
+            models.init();
+        });
+
         afterEach(function () {
             sinon.restore();
         });
@@ -124,47 +128,47 @@ describe('Post Email Serializer', function () {
             });
         });
 
-        // it('uses the newsletter settings when a newsletter_id is defined', async function () {
-        //     sinon.stub(settingsCache, 'get').callsFake(function (key) {
-        //         return {
-        //             icon: 'icon2',
-        //             accent_color: '#000099'
-        //         }[key];
-        //     });
-        //     sinon.stub(models.Newsletter, 'findOne').returns(
-        //         Promise.resolve({
-        //             get: function (key) {
-        //                 return {
-        //                     header_image: 'image',
-        //                     show_header_icon: true,
-        //                     show_header_title: true,
-        //                     show_feature_image: true,
-        //                     title_font_category: 'sans-serif',
-        //                     title_alignment: 'center',
-        //                     body_font_category: 'serif',
-        //                     show_badge: true,
-        //                     footer_content: 'footer',
-        //                     show_header_name: true
-        //                 }[key];
-        //             }
-        //         })
-        //     );
-        //     const res = await _getTemplateSettings('123');
-        //     should(res).eql({
-        //         headerImage: 'image',
-        //         showHeaderIcon: 'icon2',
-        //         showHeaderTitle: true,
-        //         showFeatureImage: true,
-        //         titleFontCategory: 'sans-serif',
-        //         titleAlignment: 'center',
-        //         bodyFontCategory: 'serif',
-        //         showBadge: true,
-        //         footerContent: 'footer',
-        //         accentColor: '#990000',
-        //         adjustedAccentColor: '#990000',
-        //         adjustedAccentContrastColor: '#FFFFFF',
-        //         showHeaderName: true
-        //     });
-        // });
+        it('uses the newsletter settings when a newsletter_id is defined', async function () {
+            sinon.stub(settingsCache, 'get').callsFake(function (key) {
+                return {
+                    icon: 'icon2',
+                    accent_color: '#000099'
+                }[key];
+            });
+            sinon.stub(models.Newsletter, 'findOne').returns(
+                Promise.resolve({
+                    get: function (key) {
+                        return {
+                            header_image: 'image',
+                            show_header_icon: true,
+                            show_header_title: true,
+                            show_feature_image: true,
+                            title_font_category: 'sans-serif',
+                            title_alignment: 'center',
+                            body_font_category: 'serif',
+                            show_badge: true,
+                            footer_content: 'footer',
+                            show_header_name: true
+                        }[key];
+                    }
+                })
+            );
+            const res = await _getTemplateSettings('123');
+            should(res).eql({
+                headerImage: 'image',
+                showHeaderIcon: 'icon2',
+                showHeaderTitle: true,
+                showFeatureImage: true,
+                titleFontCategory: 'sans-serif',
+                titleAlignment: 'center',
+                bodyFontCategory: 'serif',
+                showBadge: true,
+                footerContent: 'footer',
+                accentColor: '#000099',
+                adjustedAccentColor: '#000099',
+                adjustedAccentContrastColor: '#FFFFFF',
+                showHeaderName: true
+            });
+        });
     });
 });

--- a/test/unit/server/services/mega/post-email-serializer.test.js
+++ b/test/unit/server/services/mega/post-email-serializer.test.js
@@ -85,7 +85,7 @@ describe('Post Email Serializer', function () {
         });
     });
 
-    describe.only('getTemplateSettings', function () {
+    describe('getTemplateSettings', function () {
         before(function () {
             models.init();
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1550

- Switched to using the newsletter design settings over the global settings
- Only switch if the post is associated with a unarchived newsletter
- Made the `newsletter_id` property available in the Admin API Post resource
- Added the `showHeaderName` variable that can be used in the post html template