### PR TITLE
Fixed created_at newsletter migration

### DIFF
--- a/core/server/data/migrations/utils.js
+++ b/core/server/data/migrations/utils.js
@@ -441,6 +441,44 @@ function createDropColumnMigration(table, column, columnDefinition) {
 }
 
 /**
+ * @param {string} table
+ * @param {string} column
+ *
+ * @returns {Migration}
+ */
+function createSetNullableMigration(table, column) {
+    return createNonTransactionalMigration(
+        async function up(knex) {
+            logging.info(`Setting nullable: ${table}.${column}`);
+            await commands.setNullable(table, column, knex);
+        },
+        async function down(knex) {
+            logging.info(`Dropping nullable:  ${table}.${column}`);
+            await commands.dropNullable(table, column, knex);
+        }
+    );
+}
+
+/**
+ * @param {string} table
+ * @param {string} column
+ *
+ * @returns {Migration}
+ */
+function createDropNullableMigration(table, column) {
+    return createNonTransactionalMigration(
+        async function up(knex) {
+            logging.info(`Dropping nullable: ${table}.${column}`);
+            await commands.dropNullable(table, column, knex);
+        },
+        async function down(knex) {
+            logging.info(`Setting nullable: ${table}.${column}`);
+            await commands.setNullable(table, column, knex);
+        }
+    );
+}
+
+/**
  * Creates a migration which will insert a new setting in settings table
  * @param {object} settingSpec - setting key, value, group and type
  *
@@ -505,6 +543,8 @@ module.exports = {
     combineNonTransactionalMigrations,
     createAddColumnMigration,
     createDropColumnMigration,
+    createSetNullableMigration,
+    createDropNullableMigration,
     meta: {
         MIGRATION_USER
     }

--- a/core/server/data/migrations/versions/4.46/2022-04-13-12-00-add-created-at-newsletters.js
+++ b/core/server/data/migrations/versions/4.46/2022-04-13-12-00-add-created-at-newsletters.js
@@ -2,5 +2,5 @@ const {createAddColumnMigration} = require('../../utils');
 
 module.exports = createAddColumnMigration('newsletters', 'created_at', {
     type: 'dateTime',
-    nullable: false
+    nullable: true
 });

--- a/core/server/data/migrations/versions/4.46/2022-04-13-12-02-fill-created-at-newsletters.js
+++ b/core/server/data/migrations/versions/4.46/2022-04-13-12-02-fill-created-at-newsletters.js
@@ -1,0 +1,18 @@
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Setting missing created_at values for existing newsletters');
+
+        const updatedRows = await knex('newsletters')
+            .where('created_at', null)
+            .update('created_at', new Date());
+
+        logging.info(`Updated ${updatedRows} newsletters with created_at = now`);
+    },
+    async function down() {
+        // Not required: we would lose information here.
+    }
+);

--- a/core/server/data/migrations/versions/4.46/2022-04-13-12-02-fill-created-at-newsletters.js
+++ b/core/server/data/migrations/versions/4.46/2022-04-13-12-02-fill-created-at-newsletters.js
@@ -6,9 +6,10 @@ module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Setting missing created_at values for existing newsletters');
 
+        const now = knex.raw('CURRENT_TIMESTAMP');
         const updatedRows = await knex('newsletters')
             .where('created_at', null)
-            .update('created_at', new Date());
+            .update('created_at', now);
 
         logging.info(`Updated ${updatedRows} newsletters with created_at = now`);
     },

--- a/core/server/data/migrations/versions/4.46/2022-04-13-12-03-drop-nullable-created-at-newsletters.js
+++ b/core/server/data/migrations/versions/4.46/2022-04-13-12-03-drop-nullable-created-at-newsletters.js
@@ -1,0 +1,3 @@
+const {createDropNullableMigration} = require('../../utils');
+
+module.exports = createDropNullableMigration('newsletters', 'created_at');

--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -59,6 +59,18 @@ function addTableColumn(tableName, table, columnName, columnSpec = schema[tableN
     }
 }
 
+function setNullable(tableName, column, transaction = db.knex) {
+    return transaction.schema.table(tableName, function (table) {
+        table.setNullable(column);
+    });
+}
+
+function dropNullable(tableName, column, transaction = db.knex) {
+    return transaction.schema.table(tableName, function (table) {
+        table.dropNullable(column);
+    });
+}
+
 function addColumn(tableName, column, transaction = db.knex, columnSpec) {
     return transaction.schema.table(tableName, function (table) {
         addTableColumn(tableName, table, column, columnSpec);
@@ -412,6 +424,8 @@ module.exports = {
     dropForeign: dropForeign,
     addColumn: addColumn,
     dropColumn: dropColumn,
+    setNullable: setNullable,
+    dropNullable: dropNullable,
     getColumns: getColumns,
     createColumnMigration,
     // NOTE: below are exposed for testing purposes only


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1551

One of the existing migrations has changed. This should be allowed because that one isn't merged in `main`. The end result and new migrations are also compatible with users that already ran the previous version of that migration (so don't have a nullable created_at, I've tested this). The end result for everyone is the same, so no rollback is required.

- Updated existing migration to insert a nullable created_at column
- Added a migration to update all the created_at values to now
- Added a migration to drop nullable
- Also includes new helper methods to set and drop nullable