### PR TITLE
Backfilled MRR column based on forever Offers

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-04-25-10-32-backfill-mrr-for-discounted-subscriptions.js
+++ b/core/server/data/migrations/versions/5.0/2022-04-25-10-32-backfill-mrr-for-discounted-subscriptions.js
@@ -7,7 +7,7 @@ module.exports = createTransactionalMigration(
         const subscriptionsToUpdate = await knex('members_stripe_customers_subscriptions AS s')
             .join('offers AS o', 's.offer_id', '=', 'o.id')
             .where('o.duration', '=', 'forever')
-            .andWhere('s.mrr', '!=', '0')
+            .andWhere('s.mrr', '!=', 0)
             .select('s.*', 'o.discount_type AS offer_type', 'o.discount_amount AS offer_amount');
 
         if (!subscriptionsToUpdate.length) {

--- a/core/server/data/migrations/versions/5.0/2022-04-25-10-32-backfill-mrr-for-discounted-subscriptions.js
+++ b/core/server/data/migrations/versions/5.0/2022-04-25-10-32-backfill-mrr-for-discounted-subscriptions.js
@@ -1,0 +1,45 @@
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const subscriptionsToUpdate = await knex('members_stripe_customers_subscriptions AS s')
+            .join('offers AS o', 's.offer_id', '=', 'o.id')
+            .where('o.duration', '=', 'forever')
+            .andWhere('s.mrr', '!=', '0')
+            .select('s.*', 'o.discount_type AS offer_type', 'o.discount_amount AS offer_amount');
+
+        if (!subscriptionsToUpdate.length) {
+            logging.info('No subscriptions found needing updating');
+            return;
+        }
+
+        const toInsert = subscriptionsToUpdate.map((subscription) => {
+            let discountedAmount
+            if (subscription.offer_type === 'percent') {
+                discountedAmount = subscription.plan_amount * (100 - subscription.offer_amount) / 100;
+            } else {
+                discountedAmount = subscription.plan_amount - subscription.offer_amount;
+            }
+
+            const newSubscription = {
+                ...subscription,
+                mrr: subscription.plan_interval === 'year' ? discountedAmount / 12 : discountedAmount
+            };
+
+            delete newSubscription.offer_interval;
+            delete newSubscription.offer_type;
+            delete newSubscription.offer_amount;
+
+            return newSubscription;
+        });
+
+        const toDelete = toInsert.map(sub => sub.id);
+
+        logging.info(`Replacing ${toDelete.length} subscriptions with updated MRR based on Offers`);
+        await knex('members_stripe_customers_subscriptions').whereIn('id', toDelete).del();
+        await knex.batchInsert('members_stripe_customers_subscriptions', toInsert);
+    },
+    async function down() {}
+);

--- a/core/server/data/migrations/versions/5.0/2022-04-25-10-32-backfill-mrr-for-discounted-subscriptions.js
+++ b/core/server/data/migrations/versions/5.0/2022-04-25-10-32-backfill-mrr-for-discounted-subscriptions.js
@@ -16,7 +16,7 @@ module.exports = createTransactionalMigration(
         }
 
         const toInsert = subscriptionsToUpdate.map((subscription) => {
-            let discountedAmount
+            let discountedAmount;
             if (subscription.offer_type === 'percent') {
                 discountedAmount = subscription.plan_amount * (100 - subscription.offer_amount) / 100;
             } else {

--- a/core/server/data/migrations/versions/5.0/2022-04-25-10-32-backfill-mrr-for-discounted-subscriptions.js
+++ b/core/server/data/migrations/versions/5.0/2022-04-25-10-32-backfill-mrr-for-discounted-subscriptions.js
@@ -28,7 +28,6 @@ module.exports = createTransactionalMigration(
                 mrr: subscription.plan_interval === 'year' ? discountedAmount / 12 : discountedAmount
             };
 
-            delete newSubscription.offer_interval;
             delete newSubscription.offer_type;
             delete newSubscription.offer_amount;
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1516

We use the offer_id column to determine whether or not an offer is active, as
well as the mrr column not being 0 - the idea being that a canceled or expired
subscription may still have the offer_column set.