### PR TITLE
Renamed `/email_preview` API endpoint to `/email_previews`

### DIFF
--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -287,9 +287,8 @@ module.exports = function apiRoutes() {
     router.get('/actions', mw.authAdminApi, http(api.actions.browse));
 
     // ## Email Preview
-    // @TODO: rename to email_previews in 5.0
-    router.get('/email_preview/posts/:id', mw.authAdminApi, http(api.email_preview.read));
-    router.post('/email_preview/posts/:id', mw.authAdminApi, http(api.email_preview.sendTestEmail));
+    router.get('/email_previews/posts/:id', mw.authAdminApi, http(api.email_preview.read));
+    router.post('/email_previews/posts/:id', mw.authAdminApi, http(api.email_preview.sendTestEmail));
 
     // ## Emails
     router.get('/emails', mw.authAdminApi, http(api.emails.browse));

--- a/test/e2e-api/admin/email-preview.test.js
+++ b/test/e2e-api/admin/email-preview.test.js
@@ -42,7 +42,7 @@ describe('Email Preview API', function () {
 
         it('can read post email preview with fields', async function () {
             const res = await request
-                .get(localUtils.API.getApiQuery(`email_preview/posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
+                .get(localUtils.API.getApiQuery(`email_previews/posts/${testUtils.DataGenerator.Content.posts[0].id}/`))
                 .set('Origin', config.get('url'))
                 .set('Accept', 'application/json')
                 .expect('Content-Type', /json/)
@@ -71,7 +71,7 @@ describe('Email Preview API', function () {
 
             await models.Post.add(post, {context: {internal: true}});
             const res = await request
-                .get(localUtils.API.getApiQuery(`email_preview/posts/${post.id}/`))
+                .get(localUtils.API.getApiQuery(`email_previews/posts/${post.id}/`))
                 .set('Origin', config.get('url'))
                 .set('Accept', 'application/json')
                 .expect('Content-Type', /json/)
@@ -109,7 +109,7 @@ describe('Email Preview API', function () {
             await models.Post.add(post, {context: {internal: true}});
 
             const res = await request
-                .get(localUtils.API.getApiQuery(`email_preview/posts/${post.id}/`))
+                .get(localUtils.API.getApiQuery(`email_previews/posts/${post.id}/`))
                 .set('Origin', config.get('url'))
                 .set('Accept', 'application/json')
                 .expect('Content-Type', /json/)
@@ -132,7 +132,7 @@ describe('Email Preview API', function () {
 
     describe('As Owner', function () {
         it('can send test email', async function () {
-            const url = localUtils.API.getApiQuery(`email_preview/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
+            const url = localUtils.API.getApiQuery(`email_previews/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
             await request
                 .post(url)
                 .set('Origin', config.get('url'))
@@ -161,7 +161,7 @@ describe('Email Preview API', function () {
         });
 
         it('can send test email', async function () {
-            const url = localUtils.API.getApiQuery(`email_preview/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
+            const url = localUtils.API.getApiQuery(`email_previews/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
             await request
                 .post(url)
                 .set('Origin', config.get('url'))
@@ -192,7 +192,7 @@ describe('Email Preview API', function () {
         });
 
         it('can send test email', async function () {
-            const url = localUtils.API.getApiQuery(`email_preview/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
+            const url = localUtils.API.getApiQuery(`email_previews/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
             await request
                 .post(url)
                 .set('Origin', config.get('url'))
@@ -223,7 +223,7 @@ describe('Email Preview API', function () {
         });
 
         it('cannot send test email', async function () {
-            const url = localUtils.API.getApiQuery(`email_preview/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
+            const url = localUtils.API.getApiQuery(`email_previews/posts/${testUtils.DataGenerator.Content.posts[0].id}/`);
             await request
                 .post(url)
                 .set('Origin', config.get('url'))


### PR DESCRIPTION
🚧 