### PR TITLE
Cleaned up mention of `subscribers` in test folder

### DIFF
--- a/test/e2e-api/admin/utils.js
+++ b/test/e2e-api/admin/utils.js
@@ -16,7 +16,6 @@ const expectedProperties = {
     tags: ['tags', 'meta'],
     users: ['users', 'meta'],
     settings: ['settings', 'meta'],
-    subscribers: ['subscribers', 'meta'],
     roles: ['roles'],
     pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
     slugs: ['slugs'],
@@ -126,9 +125,6 @@ const expectedProperties = {
         .without('parent_id')
     ,
     setting: _(schema.settings)
-        .keys()
-    ,
-    subscriber: _(schema.subscribers)
         .keys()
     ,
     member: [

--- a/test/regression/api/admin/utils.js
+++ b/test/regression/api/admin/utils.js
@@ -8,7 +8,6 @@ const expectedProperties = {
     tags: ['tags', 'meta'],
     users: ['users', 'meta'],
     settings: ['settings', 'meta'],
-    subscribers: ['subscribers', 'meta'],
     roles: ['roles'],
     pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
     slugs: ['slugs'],

--- a/test/utils/fixtures/data-generator.js
+++ b/test/utils/fixtures/data-generator.js
@@ -294,17 +294,6 @@ DataGenerator.Content = {
         }
     ],
 
-    subscribers: [
-        {
-            id: ObjectId().toHexString(),
-            email: 'subscriber1@test.com'
-        },
-        {
-            id: ObjectId().toHexString(),
-            email: 'subscriber2@test.com'
-        }
-    ],
-
     members: [
         {
             id: ObjectId().toHexString(),
@@ -736,7 +725,6 @@ DataGenerator.Content = {
 };
 
 // set up belongs_to relationships
-DataGenerator.Content.subscribers[0].post_id = DataGenerator.Content.posts[0].id;
 DataGenerator.Content.api_keys[0].integration_id = DataGenerator.Content.integrations[0].id;
 DataGenerator.Content.api_keys[1].integration_id = DataGenerator.Content.integrations[0].id;
 DataGenerator.Content.webhooks[0].integration_id = DataGenerator.Content.integrations[0].id;


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/308

- we had a few mentions of `subscribers` in the test suite data generator
  but this shouldn't be used any more because it's an ancienttttt concept
- removing this for v5 as it helps to clean the codebase