### PR TITLE
Allow managing newsletter prefs on unsubscribe url

### DIFF
--- a/core/frontend/services/routing/controllers/unsubscribe.js
+++ b/core/frontend/services/routing/controllers/unsubscribe.js
@@ -2,14 +2,20 @@ const debug = require('@tryghost/debug')('services:routing:controllers:unsubscri
 const path = require('path');
 const megaService = require('../../../../server/services/mega');
 const renderer = require('../../rendering');
+const {config, labs} = require('../../proxy');
 
 module.exports = async function unsubscribeController(req, res) {
     debug('unsubscribeController');
 
     let data = {};
+    const portalUrl = config.get('portal:url');
 
     try {
-        data.member = await megaService.mega.handleUnsubscribeRequest(req);
+        if (labs.isSet('multipleNewslettersUI')) {
+            data.portalUrl = portalUrl;
+        } else {
+            data.member = await megaService.mega.handleUnsubscribeRequest(req);
+        }
     } catch (err) {
         data.error = err.message;
     }

--- a/core/frontend/views/unsubscribe.hbs
+++ b/core/frontend/views/unsubscribe.hbs
@@ -11,6 +11,9 @@
             Successfully Unsubscribed
         {{/if}}
     </title>
+    {{#if portalUrl}}
+        <script defer src="{{portalUrl}}" data-ghost="{{@site.url}}" crossorigin="anonymous"></script>
+    {{/if}}
     <link rel="stylesheet" href="{{asset "public/ghost.css" hasMinFile="true"}}" />
 </head>
 <body>

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -69,6 +69,50 @@ const getOfferData = async function (req, res) {
     });
 };
 
+const getMemberNewsletters = async function (req, res) {
+    try {
+        const memberUuid = req.query.uuid;
+
+        const memberData = await membersService.api.members.get({
+            uuid: memberUuid
+        }, {
+            withRelated: ['newsletters']
+        });
+        if (!memberData) {
+            res.writeHead(400);
+            res.end('Email address not found.');
+        } else {
+            const data = _.pick(memberData.toJSON(), 'uuid', 'email', 'name', 'newsletters', 'status');
+            return res.json(data);
+        }
+    } catch (err) {
+        res.writeHead(400);
+        res.end('Failed to unsubscribe this email address');
+    }
+};
+
+const updateMemberNewsletters = async function (req, res) {
+    try {
+        const memberUuid = req.query.uuid;
+        const data = _.pick(req.body, 'newsletters');
+        const memberData = await membersService.api.members.get({
+            uuid: memberUuid
+        });
+
+        const options = {
+            id: memberData.get('id'),
+            withRelated: ['newsletters']
+        };
+
+        const updatedMember = await membersService.api.members.update(data, options);
+        const updatedMemberData = _.pick(updatedMember.toJSON(), ['uuid', 'email', 'name', 'newsletters', 'status']);
+        res.json(updatedMemberData);
+    } catch (err) {
+        res.writeHead(err.statusCode);
+        res.end(err.message);
+    }
+};
+
 const updateMemberData = async function (req, res) {
     try {
         const data = _.pick(req.body, 'name', 'subscribed', 'newsletters');
@@ -270,9 +314,11 @@ module.exports = {
     loadMemberSession,
     createSessionFromMagicLink,
     getIdentityToken,
+    getMemberNewsletters,
     getMemberData,
     getOfferData,
     updateMemberData,
+    updateMemberNewsletters,
     getMemberSiteData,
     deleteSession
 };

--- a/core/server/web/members/app.js
+++ b/core/server/web/members/app.js
@@ -33,6 +33,11 @@ module.exports = function setupMembersApp() {
 
     // Initializes members specific routes as well as assigns members specific data to the req/res objects
     // We don't want to add global bodyParser middleware as that interfers with stripe webhook requests on - `/webhooks`.
+
+    // Manage newsletter subscription via unsubscribe link
+    membersApp.get('/api/member/newsletters', middleware.getMemberNewsletters);
+    membersApp.put('/api/member/newsletters', bodyParser.json({limit: '1mb'}), middleware.updateMemberNewsletters);
+
     membersApp.get('/api/member', middleware.getMemberData);
     membersApp.put('/api/member', bodyParser.json({limit: '1mb'}), middleware.updateMemberData);
     membersApp.post('/api/member/email', bodyParser.json({limit: '1mb'}), (req, res) => membersService.api.middleware.updateEmailAddress(req, res));


### PR DESCRIPTION
- Added member endpoints for managing newsletter subscription
- Added portal to unsubscribe page

New endpoints allows Portal to manage member's newsletter preference on the unsubscribe page via just the UUID. The endpoints return and accept only limited data points. Portal is only enabled on the unsubscribe link if the `multipleNewslettersUI` flag is enabled, which allows site owner to add multiple newsletters.