### PR TITLE
Added mapping from member subscribed to newsletters on edit/create

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@tryghost/logging": "2.1.8",
     "@tryghost/magic-link": "1.0.21",
     "@tryghost/member-events": "0.4.1",
-    "@tryghost/members-api": "6.0.0",
+    "@tryghost/members-api": "6.1.0",
     "@tryghost/members-events-service": "0.3.3",
     "@tryghost/members-importer": "0.5.8",
     "@tryghost/members-offers": "0.11.1",

--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -446,6 +446,7 @@ Object {
           "title_alignment": "center",
           "title_font_category": "sans_serif",
           "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
           "visibility": "members",
         },
         Object {
@@ -471,6 +472,7 @@ Object {
           "title_alignment": "center",
           "title_font_category": "serif",
           "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
           "visibility": "members",
         },
       ],
@@ -490,7 +492,7 @@ exports[`Members API Can add and send a signup confirmation email (old) 2: [head
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1697",
+  "content-length": "1789",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": Any<String>,
@@ -2433,6 +2435,7 @@ Object {
           "title_alignment": "center",
           "title_font_category": "sans_serif",
           "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
           "visibility": "members",
         },
         Object {
@@ -2458,6 +2461,7 @@ Object {
           "title_alignment": "center",
           "title_font_category": "serif",
           "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
           "visibility": "members",
         },
       ],
@@ -2477,7 +2481,7 @@ exports[`Members API Can subscribe by setting (old) subscribed property to true 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1681",
+  "content-length": "1773",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2710,148 +2714,6 @@ Object {
 }
 `;
 
-exports[`Members API Can subscribe to a newsletter 5: [body] 1`] = `
-Object {
-  "events": Array [
-    Object {
-      "data": Object {
-        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "member": Object {
-          "avatar_image": null,
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "email": "member3change@test.com",
-          "email_count": 0,
-          "email_open_rate": null,
-          "email_opened_count": 0,
-          "geolocation": null,
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "last_seen_at": null,
-          "name": "change me",
-          "note": null,
-          "status": "free",
-          "subscribed": true,
-          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "uuid": "afd6010c-53ab-4e33-a1f0-600d942fa1ae",
-        },
-        "member_id": "6267babe96506b05ae3a6285",
-        "newsletter_id": "6267babd96506b05ae3a6050",
-        "source": "admin",
-        "subscribed": true,
-      },
-      "type": Any<String>,
-    },
-    Object {
-      "data": Object {
-        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "member": Object {
-          "avatar_image": null,
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "email": "member3change@test.com",
-          "email_count": 0,
-          "email_open_rate": null,
-          "email_opened_count": 0,
-          "geolocation": null,
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "last_seen_at": null,
-          "name": "change me",
-          "note": null,
-          "status": "free",
-          "subscribed": true,
-          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "uuid": "afd6010c-53ab-4e33-a1f0-600d942fa1ae",
-        },
-        "member_id": "6267babe96506b05ae3a6285",
-        "newsletter_id": "6267baba96506b05ae3a5db9",
-        "source": "admin",
-        "subscribed": true,
-      },
-      "type": Any<String>,
-    },
-    Object {
-      "data": Object {
-        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "member": Object {
-          "avatar_image": null,
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "email": "member3change@test.com",
-          "email_count": 0,
-          "email_open_rate": null,
-          "email_opened_count": 0,
-          "geolocation": null,
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "last_seen_at": null,
-          "name": "change me",
-          "note": null,
-          "status": "free",
-          "subscribed": true,
-          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "uuid": "afd6010c-53ab-4e33-a1f0-600d942fa1ae",
-        },
-        "member_id": "6267babe96506b05ae3a6285",
-        "newsletter_id": "6267babd96506b05ae3a6050",
-        "source": "admin",
-        "subscribed": false,
-      },
-      "type": Any<String>,
-    },
-    Object {
-      "data": Object {
-        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-        "from_status": null,
-        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-        "member": Object {
-          "avatar_image": null,
-          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "email": "member3change@test.com",
-          "email_count": 0,
-          "email_open_rate": null,
-          "email_opened_count": 0,
-          "geolocation": null,
-          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "last_seen_at": null,
-          "name": "change me",
-          "note": null,
-          "status": "free",
-          "subscribed": true,
-          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-          "uuid": "afd6010c-53ab-4e33-a1f0-600d942fa1ae",
-        },
-        "member_id": "6267babe96506b05ae3a6285",
-        "to_status": "free",
-      },
-      "type": Any<String>,
-    },
-  ],
-}
-`;
-
-exports[`Members API Can subscribe to a newsletter 5: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4260",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
-exports[`Members API Can subscribe to a newsletter 6: [headers] 1`] = `
-Object {
-  "access-control-allow-origin": "http://127.0.0.1:2369",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2425",
-  "content-type": "application/json; charset=utf-8",
-  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Origin, Accept-Encoding",
-  "x-powered-by": "Express",
-}
-`;
-
 exports[`Members API Can unsubscribe by setting (old) subscribed property to false 1: [body] 1`] = `
 Object {
   "members": Array [
@@ -2892,6 +2754,7 @@ Object {
           "title_alignment": "center",
           "title_font_category": "sans_serif",
           "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
           "visibility": "members",
         },
       ],
@@ -2911,7 +2774,7 @@ exports[`Members API Can unsubscribe by setting (old) subscribed property to fal
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1083",
+  "content-length": "1129",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,

--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -71,6 +71,48 @@ Object {
 }
 `;
 
+exports[`Members API Can add a member that is not subscribed (old) 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "member_getting_confirmation_old_2@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Array [],
+      "last_seen_at": null,
+      "name": "Send Me Confirmation",
+      "newsletters": Array [],
+      "note": null,
+      "products": Array [],
+      "status": "free",
+      "subscribed": false,
+      "subscriptions": Array [],
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can add a member that is not subscribed (old) 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "501",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": Any<String>,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API Can add a subscription 1: [body] 1`] = `
 Object {
   "members": Array [
@@ -360,6 +402,109 @@ Object {
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can add and send a signup confirmation email (old) 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "member_getting_confirmation_old@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Array [],
+      "last_seen_at": null,
+      "name": "Send Me Confirmation",
+      "newsletters": Array [
+        Object {
+          "body_font_category": "sans_serif",
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "description": null,
+          "footer_content": null,
+          "header_image": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Newsletter",
+          "sender_email": null,
+          "sender_name": null,
+          "sender_reply_to": "newsletter",
+          "show_badge": true,
+          "show_feature_image": true,
+          "show_header_icon": true,
+          "show_header_name": true,
+          "show_header_title": true,
+          "slug": "default-newsletter",
+          "sort_order": 0,
+          "status": "active",
+          "subscribe_on_signup": true,
+          "title_alignment": "center",
+          "title_font_category": "sans_serif",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "members",
+        },
+        Object {
+          "body_font_category": "serif",
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "description": null,
+          "footer_content": null,
+          "header_image": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Weekly newsletter",
+          "sender_email": "jamie@example.com",
+          "sender_name": "Jamie",
+          "sender_reply_to": "newsletter",
+          "show_badge": true,
+          "show_feature_image": true,
+          "show_header_icon": true,
+          "show_header_name": true,
+          "show_header_title": true,
+          "slug": "weekly-newsletter",
+          "sort_order": 2,
+          "status": "active",
+          "subscribe_on_signup": true,
+          "title_alignment": "center",
+          "title_font_category": "serif",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "members",
+        },
+      ],
+      "note": null,
+      "products": Array [],
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Array [],
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can add and send a signup confirmation email (old) 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1697",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": Any<String>,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can add and send a signup confirmation email (old) 3: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin",
   "x-powered-by": "Express",
 }
 `;
@@ -2206,6 +2351,140 @@ Object {
 }
 `;
 
+exports[`Members API Can subscribe by setting (old) subscribed property to true 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "member2subscribe@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "change me",
+      "newsletters": Array [],
+      "note": "initial note",
+      "products": Array [],
+      "status": "free",
+      "subscribed": false,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can subscribe by setting (old) subscribed property to true 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "483",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can subscribe by setting (old) subscribed property to true 3: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "member2subscribe@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "change me",
+      "newsletters": Array [
+        Object {
+          "body_font_category": "sans_serif",
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "description": null,
+          "footer_content": null,
+          "header_image": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Newsletter",
+          "sender_email": null,
+          "sender_name": null,
+          "sender_reply_to": "newsletter",
+          "show_badge": true,
+          "show_feature_image": true,
+          "show_header_icon": true,
+          "show_header_name": true,
+          "show_header_title": true,
+          "slug": "default-newsletter",
+          "sort_order": 0,
+          "status": "active",
+          "subscribe_on_signup": true,
+          "title_alignment": "center",
+          "title_font_category": "sans_serif",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "members",
+        },
+        Object {
+          "body_font_category": "serif",
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "description": null,
+          "footer_content": null,
+          "header_image": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Weekly newsletter",
+          "sender_email": "jamie@example.com",
+          "sender_name": "Jamie",
+          "sender_reply_to": "newsletter",
+          "show_badge": true,
+          "show_feature_image": true,
+          "show_header_icon": true,
+          "show_header_name": true,
+          "show_header_title": true,
+          "slug": "weekly-newsletter",
+          "sort_order": 2,
+          "status": "active",
+          "subscribe_on_signup": true,
+          "title_alignment": "center",
+          "title_font_category": "serif",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "members",
+        },
+      ],
+      "note": "initial note",
+      "products": Array [],
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can subscribe by setting (old) subscribed property to true 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1681",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API Can subscribe to a newsletter 1: [body] 1`] = `
 Object {
   "members": Array [
@@ -2424,6 +2703,257 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "2425",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can subscribe to a newsletter 5: [body] 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "data": Object {
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "member": Object {
+          "avatar_image": null,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "email": "member3change@test.com",
+          "email_count": 0,
+          "email_open_rate": null,
+          "email_opened_count": 0,
+          "geolocation": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "last_seen_at": null,
+          "name": "change me",
+          "note": null,
+          "status": "free",
+          "subscribed": true,
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "uuid": "afd6010c-53ab-4e33-a1f0-600d942fa1ae",
+        },
+        "member_id": "6267babe96506b05ae3a6285",
+        "newsletter_id": "6267babd96506b05ae3a6050",
+        "source": "admin",
+        "subscribed": true,
+      },
+      "type": Any<String>,
+    },
+    Object {
+      "data": Object {
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "member": Object {
+          "avatar_image": null,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "email": "member3change@test.com",
+          "email_count": 0,
+          "email_open_rate": null,
+          "email_opened_count": 0,
+          "geolocation": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "last_seen_at": null,
+          "name": "change me",
+          "note": null,
+          "status": "free",
+          "subscribed": true,
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "uuid": "afd6010c-53ab-4e33-a1f0-600d942fa1ae",
+        },
+        "member_id": "6267babe96506b05ae3a6285",
+        "newsletter_id": "6267baba96506b05ae3a5db9",
+        "source": "admin",
+        "subscribed": true,
+      },
+      "type": Any<String>,
+    },
+    Object {
+      "data": Object {
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "member": Object {
+          "avatar_image": null,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "email": "member3change@test.com",
+          "email_count": 0,
+          "email_open_rate": null,
+          "email_opened_count": 0,
+          "geolocation": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "last_seen_at": null,
+          "name": "change me",
+          "note": null,
+          "status": "free",
+          "subscribed": true,
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "uuid": "afd6010c-53ab-4e33-a1f0-600d942fa1ae",
+        },
+        "member_id": "6267babe96506b05ae3a6285",
+        "newsletter_id": "6267babd96506b05ae3a6050",
+        "source": "admin",
+        "subscribed": false,
+      },
+      "type": Any<String>,
+    },
+    Object {
+      "data": Object {
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "from_status": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "member": Object {
+          "avatar_image": null,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "email": "member3change@test.com",
+          "email_count": 0,
+          "email_open_rate": null,
+          "email_opened_count": 0,
+          "geolocation": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "last_seen_at": null,
+          "name": "change me",
+          "note": null,
+          "status": "free",
+          "subscribed": true,
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "uuid": "afd6010c-53ab-4e33-a1f0-600d942fa1ae",
+        },
+        "member_id": "6267babe96506b05ae3a6285",
+        "to_status": "free",
+      },
+      "type": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can subscribe to a newsletter 5: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "4260",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can subscribe to a newsletter 6: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "2425",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can unsubscribe by setting (old) subscribed property to false 1: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "member2unsusbcribeold@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "change me",
+      "newsletters": Array [
+        Object {
+          "body_font_category": "sans_serif",
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "description": null,
+          "footer_content": null,
+          "header_image": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "name": "Default Newsletter",
+          "sender_email": null,
+          "sender_name": null,
+          "sender_reply_to": "newsletter",
+          "show_badge": true,
+          "show_feature_image": true,
+          "show_header_icon": true,
+          "show_header_name": true,
+          "show_header_title": true,
+          "slug": "default-newsletter",
+          "sort_order": 0,
+          "status": "active",
+          "subscribe_on_signup": true,
+          "title_alignment": "center",
+          "title_font_category": "sans_serif",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "members",
+        },
+      ],
+      "note": "initial note",
+      "products": Array [],
+      "status": "free",
+      "subscribed": true,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can unsubscribe by setting (old) subscribed property to false 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1083",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/members\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Members API Can unsubscribe by setting (old) subscribed property to false 3: [body] 1`] = `
+Object {
+  "members": Array [
+    Object {
+      "avatar_image": null,
+      "comped": false,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "email": "member2unsusbcribeold@test.com",
+      "email_count": 0,
+      "email_open_rate": null,
+      "email_opened_count": 0,
+      "geolocation": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "labels": Any<Array>,
+      "last_seen_at": null,
+      "name": "change me",
+      "newsletters": Array [],
+      "note": "initial note",
+      "products": Array [],
+      "status": "free",
+      "subscribed": false,
+      "subscriptions": Any<Array>,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+    },
+  ],
+}
+`;
+
+exports[`Members API Can unsubscribe by setting (old) subscribed property to false 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "488",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/e2e-api/admin/members.test.js
+++ b/test/e2e-api/admin/members.test.js
@@ -1694,7 +1694,7 @@ describe('Members API', function () {
         await assertMemberEvents({
             eventType: 'MemberSubscribeEvent',
             memberId: newMember.id,
-            asserts: filteredNewsletters.map(n => {
+            asserts: filteredNewsletters.map((n) => {
                 return {
                     subscribed: true,
                     newsletter_id: n.id,
@@ -1770,7 +1770,6 @@ describe('Members API', function () {
             asserts: []
         });
     });
-
 
     it('Can unsubscribe by setting (old) subscribed property to false', async function () {
         const memberToChange = {
@@ -1917,7 +1916,7 @@ describe('Members API', function () {
         await assertMemberEvents({
             eventType: 'MemberSubscribeEvent',
             memberId: newMember.id,
-            asserts: filteredNewsletters.map(n => {
+            asserts: filteredNewsletters.map((n) => {
                 return {
                     subscribed: true,
                     source: 'admin',

--- a/test/e2e-api/admin/members.test.js
+++ b/test/e2e-api/admin/members.test.js
@@ -12,7 +12,12 @@ const models = require('../../../core/server/models');
 
 async function assertMemberEvents({eventType, memberId, asserts}) {
     const events = await models[eventType].where('member_id', memberId).fetchAll();
-    events.map(e => e.toJSON()).should.match(asserts);
+    const eventsJSON = events.map(e => e.toJSON());
+    
+    // Order shouldn't matter here
+    for (const a of asserts) {
+        eventsJSON.should.matchAny(a);
+    }
     assert.equal(events.length, asserts.length, `Only ${asserts.length} ${eventType} should have been added.`);
 }
 
@@ -46,6 +51,18 @@ function buildMemberWithoutIncludesSnapshot(options) {
         created_at: anyISODateTime,
         updated_at: anyISODateTime,
         newsletters: new Array(options.newsletters).fill(newsletterSnapshot)
+    };
+}
+
+function buildMemberWithIncludesSnapshot(options) {
+    return {
+        id: anyObjectId,
+        uuid: anyUuid,
+        created_at: anyISODateTime,
+        updated_at: anyISODateTime,
+        newsletters: new Array(options.newsletters).fill(newsletterSnapshot),
+        subscriptions: anyArray,
+        labels: anyArray
     };
 }
 
@@ -347,71 +364,6 @@ describe('Members API', function () {
         });
     });
 
-    /*it('Can add and send a signup confirmation email (old)', async function () {
-        const member = {
-            name: 'Send Me Confirmation',
-            email: 'member_getting_confirmation@test.com',
-            subscribed: true
-        };
-
-        const queryParams = {
-            send_email: true,
-            email_type: 'signup'
-        };
-
-        const {body} = await agent
-            .post('/members/?send_email=true&email_type=signup')
-            .body({members: [member]})
-            .expectStatus(201)
-            .matchBodySnapshot({
-                members: [news]
-            })
-            .matchHeaderSnapshot({
-                etag: anyEtag,
-                location: anyString
-            });
-
-        const newMember = body.members[0];
-
-        mockManager.assert.sentEmail({
-            subject: '🙌 Complete your sign up to Ghost!',
-            to: 'member_getting_confirmation@test.com'
-        });
-
-        await assertMemberEvents({
-            eventType: 'MemberStatusEvent',
-            memberId: newMember.id,
-            asserts: [
-                {
-                    from_status: null,
-                    to_status: 'free'
-                }
-            ]
-        });
-
-        await assertMemberEvents({
-            eventType: 'MemberSubscribeEvent',
-            memberId: newMember.id,
-            asserts: [
-                {
-                    subscribed: true,
-                    source: 'admin'
-                }
-            ]
-        });
-
-        // @TODO: do we really need to delete this member here?
-        await agent
-            .delete(`members/${body.members[0].id}/`)
-            .matchHeaderSnapshot({
-                etag: anyEtag
-            })
-            .expectStatus(204);
-
-        const events = await models.MemberSubscribeEvent.findAll();
-        assert.equal(events.models.length, 0, 'There should be no MemberSubscribeEvent remaining.');
-    });*/
-
     it('Can add and send a signup confirmation email', async function () {
         const member = {
             name: 'Send Me Confirmation',
@@ -420,11 +372,6 @@ describe('Members API', function () {
                 newsletters[0],
                 newsletters[1]
             ]
-        };
-
-        const queryParams = {
-            send_email: true,
-            email_type: 'signup'
         };
 
         const {body} = await agent
@@ -486,8 +433,12 @@ describe('Members API', function () {
             })
             .expectStatus(204);
 
-        const events = await models.MemberSubscribeEvent.findAll();
-        assert.equal(events.models.length, 0, 'There should be no MemberSubscribeEvent remaining.');
+        // There should be no MemberSubscribeEvent remaining.
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: []
+        });
     });
 
     it('Add should fail when passing incorrect email_type query parameter', async function () {
@@ -495,6 +446,8 @@ describe('Members API', function () {
             name: 'test',
             email: 'memberTestAdd@test.com'
         };
+
+        const statusEventsBefore = await models.MemberStatusEvent.findAll();
 
         await agent
             .post(`members/?send_email=true&email_type=lel`)
@@ -510,7 +463,7 @@ describe('Members API', function () {
             });
 
         const statusEvents = await models.MemberStatusEvent.findAll();
-        assert.equal(statusEvents.models.length, 1, 'No MemberStatusEvent should have been added after failing to create a subscription.');
+        assert.equal(statusEvents.models.length, statusEventsBefore.models.length, 'No MemberStatusEvent should have been added after failing to create a subscription.');
     });
 
     // Edit a member
@@ -1691,5 +1644,286 @@ describe('Members API', function () {
             .post(`/members/`)
             .body({members: [member]})
             .expectStatus(422);
+    });
+
+    it('Can add and send a signup confirmation email (old)', async function () {
+        const filteredNewsletters = newsletters.filter(n => n.get('subscribe_on_signup'));
+        filteredNewsletters.length.should.be.greaterThan(0, 'For this test to work, we need at least one newsletter fixture with subscribe_on_signup = true');
+
+        const member = {
+            name: 'Send Me Confirmation',
+            email: 'member_getting_confirmation_old@test.com',
+            // Mapped to subscribe_on_signup newsletters
+            subscribed: true
+        };
+
+        const {body} = await agent
+            .post('/members/?send_email=true&email_type=signup')
+            .body({members: [member]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: [
+                    buildMemberWithoutIncludesSnapshot({
+                        newsletters: filteredNewsletters.length
+                    })
+                ]
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag,
+                location: anyString
+            });
+
+        const newMember = body.members[0];
+
+        mockManager.assert.sentEmail({
+            subject: '🙌 Complete your sign up to Ghost!',
+            to: 'member_getting_confirmation_old@test.com'
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    from_status: null,
+                    to_status: 'free'
+                }
+            ]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: filteredNewsletters.map(n => {
+                return {
+                    subscribed: true,
+                    newsletter_id: n.id,
+                    source: 'admin'
+                };
+            })
+        });
+
+        // @TODO: do we really need to delete this member here?
+        await agent
+            .delete(`members/${body.members[0].id}/`)
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            })
+            .expectStatus(204);
+
+        // There should be no MemberSubscribeEvent remaining.
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: []
+        });
+    });
+
+    it('Can add a member that is not subscribed (old)', async function () {
+        const filteredNewsletters = newsletters.filter(n => n.get('subscribe_on_signup'));
+        filteredNewsletters.length.should.be.greaterThan(0, 'For this test to work, we need at least one newsletter fixture with subscribe_on_signup = true');
+
+        const member = {
+            name: 'Send Me Confirmation',
+            email: 'member_getting_confirmation_old_2@test.com',
+            // Mapped to empty newsletters
+            subscribed: false
+        };
+
+        const {body} = await agent
+            .post('/members/?send_email=true&email_type=signup')
+            .body({members: [member]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: [
+                    buildMemberWithoutIncludesSnapshot({
+                        newsletters: 0
+                    })
+                ]
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag,
+                location: anyString
+            });
+
+        const newMember = body.members[0];
+
+        mockManager.assert.sentEmail({
+            subject: '🙌 Complete your sign up to Ghost!',
+            to: 'member_getting_confirmation_old_2@test.com'
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    from_status: null,
+                    to_status: 'free'
+                }
+            ]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: []
+        });
+    });
+
+
+    it('Can unsubscribe by setting (old) subscribed property to false', async function () {
+        const memberToChange = {
+            name: 'change me',
+            email: 'member2unsusbcribeold@test.com',
+            note: 'initial note',
+            newsletters: [
+                newsletters[0]
+            ]
+        };
+
+        const memberChanged = {
+            subscribed: false
+        };
+
+        const {body} = await agent
+            .post(`/members/`)
+            .body({members: [memberToChange]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: [
+                    buildMemberWithIncludesSnapshot({
+                        newsletters: 1
+                    })
+                ]
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag,
+                location: anyLocationFor('members')
+            });
+        const newMember = body.members[0];
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: [{
+                subscribed: true,
+                source: 'admin',
+                newsletter_id: newsletters[0].id
+            }]
+        });
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [{
+                from_status: null,
+                to_status: 'free'
+            }]
+        });
+
+        await agent
+            .put(`/members/${newMember.id}/`)
+            .body({members: [memberChanged]})
+            .expectStatus(200)
+            .matchBodySnapshot({
+                members: [
+                    buildMemberWithIncludesSnapshot({
+                        newsletters: 0
+                    })
+                ]
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    subscribed: true,
+                    source: 'admin',
+                    newsletter_id: newsletters[0].id
+                }, {
+                    subscribed: false,
+                    source: 'admin',
+                    newsletter_id: newsletters[0].id
+                }
+            ]
+        });
+    });
+
+    it('Can subscribe by setting (old) subscribed property to true', async function () {
+        const filteredNewsletters = newsletters.filter(n => n.get('subscribe_on_signup'));
+        filteredNewsletters.length.should.be.greaterThan(0, 'For this test to work, we need at least one newsletter fixture with subscribe_on_signup = true');
+
+        const memberToChange = {
+            name: 'change me',
+            email: 'member2subscribe@test.com',
+            note: 'initial note',
+            newsletters: []
+        };
+
+        const memberChanged = {
+            subscribed: true
+        };
+
+        const {body} = await agent
+            .post(`/members/`)
+            .body({members: [memberToChange]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: [
+                    buildMemberWithIncludesSnapshot({
+                        newsletters: 0
+                    })
+                ]
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag,
+                location: anyLocationFor('members')
+            });
+        const newMember = body.members[0];
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: []
+        });
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [{
+                from_status: null,
+                to_status: 'free'
+            }]
+        });
+
+        await agent
+            .put(`/members/${newMember.id}/`)
+            .body({members: [memberChanged]})
+            .expectStatus(200)
+            .matchBodySnapshot({
+                members: [
+                    buildMemberWithIncludesSnapshot({
+                        newsletters: filteredNewsletters.length
+                    })
+                ]
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: filteredNewsletters.map(n => {
+                return {
+                    subscribed: true,
+                    source: 'admin',
+                    newsletter_id: n.id
+                };
+            })
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,10 +2150,10 @@
     "@tryghost/domain-events" "^0.1.9"
     "@tryghost/member-events" "^0.4.1"
 
-"@tryghost/members-api@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-6.0.0.tgz#935aee6298154176424c0574d73e290006d67221"
-  integrity sha512-fMsqb5Tuegw8DBhu9Hdwl/mldzIpZJgor63ub3P4TtRWlF5uNQIAaUi/w8AOQDmTSbkMm3YSXNkescPWBocdkw==
+"@tryghost/members-api@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-6.1.0.tgz#60ee22f62ea0def89815a3563243d9e1840e8a09"
+  integrity sha512-XnfO59JrtN4PySwlfdygnXg6o7+4nVwwSHvhCXBlUEgrszQhT3mQXMSyGvRM4gHg3zOhKOVvzYWPh5Nboos/nA==
   dependencies:
     "@nexes/nql" "^0.6.0"
     "@tryghost/debug" "^0.1.2"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1545

**Changes (`members-api`)**
- Compare via https://github.com/TryGhost/Members/compare/%40tryghost/members-api%406.0.0...%40tryghost/members-api%406.1.0
- Added mapping from member subscribed to newsletters on edit/create
- When editing or creating a member with the subscribed property, it is mapped to the corresponding newletters value
- Defaults to all active newsletters with visibility = members and subscribe_on_signup = true

**Tests**
- Adds test that adds a member with subscribed = true
- Adds test that adds a member with subscribed = false
- Adds test that edits a member with subscribed = true
- Adds test that edits a member with subscribed = false

https://github.com/TryGhost/Ghost/pull/14585 should get merged before this one