### PR TITLE
Added migration that backfills newsletter_id on all subscribe events

### DIFF
--- a/core/server/data/migrations/versions/4.46/2022-04-27-07-59-set-newsletter-id-subscribe-events.js
+++ b/core/server/data/migrations/versions/4.46/2022-04-27-07-59-set-newsletter-id-subscribe-events.js
@@ -16,7 +16,7 @@ module.exports = createTransactionalMigration(
             return;
         }
 
-        // Set susbcribe events
+        // Set subscribe events
         const updatedRows = await knex('members_subscribe_events')
             .update({
                 newsletter_id: newsletter.id

--- a/core/server/data/migrations/versions/4.46/2022-04-27-07-59-set-newsletter-id-subscribe-events.js
+++ b/core/server/data/migrations/versions/4.46/2022-04-27-07-59-set-newsletter-id-subscribe-events.js
@@ -23,7 +23,7 @@ module.exports = createTransactionalMigration(
             })
             .where('newsletter_id', null);
 
-        logging.log(`Updated ${updatedRows} members_subscribe_events with default newsletter id`);
+        logging.info(`Updated ${updatedRows} members_subscribe_events with default newsletter id`);
     },
     async function down() {
         // Not required

--- a/core/server/data/migrations/versions/4.46/2022-04-27-07-59-set-newsletter-id-subscribe-events.js
+++ b/core/server/data/migrations/versions/4.46/2022-04-27-07-59-set-newsletter-id-subscribe-events.js
@@ -1,0 +1,31 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        // Get the default newsletter
+        const newsletter = await knex('newsletters')
+            .where('status', 'active')
+            .orderBy('sort_order', 'asc')
+            .orderBy('created_at', 'asc')
+            .orderBy('id', 'asc')
+            .first('id');
+
+        if (!newsletter) {
+            logging.error(`Default newsletter not found - skipping`);
+            return;
+        }
+
+        // Set susbcribe events
+        const updatedRows = await knex('members_subscribe_events')
+            .update({
+                newsletter_id: newsletter.id
+            })
+            .where('newsletter_id', null);
+
+        logging.log(`Updated ${updatedRows} members_subscribe_events with default newsletter id`);
+    },
+    async function down() {
+        // Not required
+    }
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1478

Sets the newsletter_id to the id of the default newsletter.