### PR TITLE
Added member endpoints for managing newsletter subscriptions

### DIFF
--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -85,7 +85,7 @@ const getMemberNewsletters = async function (req, res) {
         });
         if (!memberData) {
             res.writeHead(400);
-            res.end('Email address not found.');
+            return res.end('Email address not found.');
         } else {
             const data = _.pick(memberData.toJSON(), 'uuid', 'email', 'name', 'newsletters', 'status');
             return res.json(data);
@@ -109,7 +109,7 @@ const updateMemberNewsletters = async function (req, res) {
         });
         if (!memberData) {
             res.writeHead(400);
-            res.end('Email address not found.');
+            return res.end('Email address not found.');
         }
         const options = {
             id: memberData.get('id'),

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -69,6 +69,57 @@ const getOfferData = async function (req, res) {
     });
 };
 
+const getMemberNewsletters = async function (req, res) {
+    try {
+        const memberUuid = req.query.uuid;
+
+        const memberData = await membersService.api.members.get({
+            uuid: memberUuid
+        }, {
+            withRelated: ['newsletters']
+        });
+        if (!memberData) {
+            res.writeHead(400);
+            res.end('Email address not found.');
+        } else {
+            const data = _.pick(memberData.toJSON(), 'uuid', 'email', 'name', 'newsletters', 'status');
+            return res.json(data);
+        }
+    } catch (err) {
+        res.writeHead(400);
+        res.end('Failed to unsubscribe this email address');
+    }
+};
+
+const updateMemberNewsletters = async function (req, res) {
+    try {
+        const memberUuid = req.query.uuid;
+        if (!memberUuid) {
+            res.writeHead(400);
+            return res.end('Missing member uuid');
+        }
+        const data = _.pick(req.body, 'newsletters');
+        const memberData = await membersService.api.members.get({
+            uuid: memberUuid
+        });
+        if (!memberData) {
+            res.writeHead(400);
+            return res.end('Member not found');
+        }
+        const options = {
+            id: memberData.get('id'),
+            withRelated: ['newsletters']
+        };
+
+        const updatedMember = await membersService.api.members.update(data, options);
+        const updatedMemberData = _.pick(updatedMember.toJSON(), ['uuid', 'email', 'name', 'newsletters', 'status']);
+        res.json(updatedMemberData);
+    } catch (err) {
+        res.writeHead(400);
+        res.end('Failed to update newsletters');
+    }
+};
+
 const updateMemberData = async function (req, res) {
     try {
         const data = _.pick(req.body, 'name', 'subscribed', 'newsletters');
@@ -270,9 +321,11 @@ module.exports = {
     loadMemberSession,
     createSessionFromMagicLink,
     getIdentityToken,
+    getMemberNewsletters,
     getMemberData,
     getOfferData,
     updateMemberData,
+    updateMemberNewsletters,
     getMemberSiteData,
     deleteSession
 };

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -83,13 +83,14 @@ const getMemberNewsletters = async function (req, res) {
         }, {
             withRelated: ['newsletters']
         });
+
         if (!memberData) {
             res.writeHead(404);
             return res.end('Email address not found.');
-        } else {
-            const data = _.pick(memberData.toJSON(), 'uuid', 'email', 'name', 'newsletters', 'status');
-            return res.json(data);
         }
+
+        const data = _.pick(memberData.toJSON(), 'uuid', 'email', 'name', 'newsletters', 'status');
+        return res.json(data);
     } catch (err) {
         res.writeHead(400);
         res.end('Failed to unsubscribe this email address');
@@ -103,6 +104,7 @@ const updateMemberNewsletters = async function (req, res) {
             res.writeHead(400);
             return res.end('Invalid member uuid');
         }
+
         const data = _.pick(req.body, 'newsletters');
         const memberData = await membersService.api.members.get({
             uuid: memberUuid
@@ -111,6 +113,7 @@ const updateMemberNewsletters = async function (req, res) {
             res.writeHead(404);
             return res.end('Email address not found.');
         }
+
         const options = {
             id: memberData.get('id'),
             withRelated: ['newsletters']

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -73,6 +73,11 @@ const getMemberNewsletters = async function (req, res) {
     try {
         const memberUuid = req.query.uuid;
 
+        if (!memberUuid) {
+            res.writeHead(400);
+            return res.end('Invalid member uuid');
+        }
+
         const memberData = await membersService.api.members.get({
             uuid: memberUuid
         }, {
@@ -96,7 +101,7 @@ const updateMemberNewsletters = async function (req, res) {
         const memberUuid = req.query.uuid;
         if (!memberUuid) {
             res.writeHead(400);
-            return res.end('Missing member uuid');
+            return res.end('Invalid member uuid');
         }
         const data = _.pick(req.body, 'newsletters');
         const memberData = await membersService.api.members.get({
@@ -104,7 +109,7 @@ const updateMemberNewsletters = async function (req, res) {
         });
         if (!memberData) {
             res.writeHead(400);
-            return res.end('Member not found');
+            res.end('Email address not found.');
         }
         const options = {
             id: memberData.get('id'),

--- a/core/server/services/members/middleware.js
+++ b/core/server/services/members/middleware.js
@@ -84,7 +84,7 @@ const getMemberNewsletters = async function (req, res) {
             withRelated: ['newsletters']
         });
         if (!memberData) {
-            res.writeHead(400);
+            res.writeHead(404);
             return res.end('Email address not found.');
         } else {
             const data = _.pick(memberData.toJSON(), 'uuid', 'email', 'name', 'newsletters', 'status');
@@ -108,7 +108,7 @@ const updateMemberNewsletters = async function (req, res) {
             uuid: memberUuid
         });
         if (!memberData) {
-            res.writeHead(400);
+            res.writeHead(404);
             return res.end('Email address not found.');
         }
         const options = {

--- a/core/server/web/members/app.js
+++ b/core/server/web/members/app.js
@@ -33,6 +33,11 @@ module.exports = function setupMembersApp() {
 
     // Initializes members specific routes as well as assigns members specific data to the req/res objects
     // We don't want to add global bodyParser middleware as that interfers with stripe webhook requests on - `/webhooks`.
+
+    // Manage newsletter subscription via unsubscribe link
+    membersApp.get('/api/member/newsletters', middleware.getMemberNewsletters);
+    membersApp.put('/api/member/newsletters', bodyParser.json({limit: '1mb'}), middleware.updateMemberNewsletters);
+
     membersApp.get('/api/member', middleware.getMemberData);
     membersApp.put('/api/member', bodyParser.json({limit: '1mb'}), middleware.updateMemberData);
     membersApp.post('/api/member/email', bodyParser.json({limit: '1mb'}), (req, res) => membersService.api.middleware.updateEmailAddress(req, res));

--- a/test/e2e-frontend/members.test.js
+++ b/test/e2e-frontend/members.test.js
@@ -117,6 +117,26 @@ describe('Front-end members behaviour', function () {
                 .expect(400);
         });
 
+        it('should error for fetching member newsletters with missing uuid', async function () {
+            await request.get('/members/api/member/newsletters')
+                .expect(400);
+        });
+
+        it('should error for fetching member newsletters with invalid uuid', async function () {
+            await request.get('/members/api/member/newsletters?uuid=abc')
+                .expect(400);
+        });
+
+        it('should error for updating member newsletters with missing uuid', async function () {
+            await request.put('/members/api/member/newsletters')
+                .expect(400);
+        });
+
+        it('should error for updating member newsletters with invalid uuid', async function () {
+            await request.put('/members/api/member/newsletters?uuid=abc')
+                .expect(400);
+        });
+
         it('should serve theme 404 on members endpoint', async function () {
             await request.get('/members/')
                 .expect(404)

--- a/test/e2e-frontend/members.test.js
+++ b/test/e2e-frontend/members.test.js
@@ -10,6 +10,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const {MemberPageViewEvent} = require('@tryghost/member-events');
 const models = require('../../core/server/models');
 const {mockManager} = require('../utils/e2e-framework');
+const DataGenerator = require('../utils/fixtures/data-generator');
 
 function assertContentIsPresent(res) {
     res.text.should.containEql('<h2 id="markdown">markdown</h2>');
@@ -57,7 +58,8 @@ describe('Front-end members behaviour', function () {
             return originalSettingsCacheGetFn(key, options);
         });
         await testUtils.startGhost();
-        await testUtils.initFixtures('members');
+        await testUtils.initFixtures('newsletters', 'members:newsletters');
+
         request = supertest.agent(configUtils.config.get('url'));
     });
 
@@ -135,6 +137,33 @@ describe('Front-end members behaviour', function () {
         it('should error for updating member newsletters with invalid uuid', async function () {
             await request.put('/members/api/member/newsletters?uuid=abc')
                 .expect(400);
+        });
+
+        it('should fetch and update member newsletters with valid uuid', async function () {
+            const memberUUID = DataGenerator.Content.members[0].uuid;
+
+            // Can fetch newsletter subscriptions
+            const getRes = await request.get(`/members/api/member/newsletters?uuid=${memberUUID}`)
+                .expect(200);
+            const getJsonResponse = getRes.body;
+
+            should.exist(getJsonResponse);
+            getJsonResponse.should.have.properties(['email', 'uuid', 'status', 'name', 'newsletters']);
+            getJsonResponse.should.not.have.property('id');
+            getJsonResponse.newsletters.should.have.length(1);
+
+            // Can update newsletter subscription
+            const res = await request.put(`/members/api/member/newsletters?uuid=${memberUUID}`)
+                .send({
+                    newsletters: []
+                })
+                .expect(200);
+            const jsonResponse = res.body;
+
+            should.exist(jsonResponse);
+            jsonResponse.should.have.properties(['email', 'uuid', 'status', 'name', 'newsletters']);
+            jsonResponse.should.not.have.property('id');
+            jsonResponse.newsletters.should.have.length(0);
         });
 
         it('should serve theme 404 on members endpoint', async function () {

--- a/test/e2e-frontend/members.test.js
+++ b/test/e2e-frontend/members.test.js
@@ -126,7 +126,7 @@ describe('Front-end members behaviour', function () {
 
         it('should error for fetching member newsletters with invalid uuid', async function () {
             await request.get('/members/api/member/newsletters?uuid=abc')
-                .expect(400);
+                .expect(404);
         });
 
         it('should error for updating member newsletters with missing uuid', async function () {
@@ -136,7 +136,7 @@ describe('Front-end members behaviour', function () {
 
         it('should error for updating member newsletters with invalid uuid', async function () {
             await request.put('/members/api/member/newsletters?uuid=abc')
-                .expect(400);
+                .expect(404);
         });
 
         it('should fetch and update member newsletters with valid uuid', async function () {


### PR DESCRIPTION
refs TryGhost/Team#1495

With multiple newsletters, members are allowed to manage their newsletter pref via email unsubscribe link with member uuid. Since Portal needs to manage member's newsletter pref via their UUID, we need new endpoints on members that allow fetch/update of newsletter subscriptions via only uuid. The endpoints return only limited data for a member that are needed for the UI.

- adds endpoint to fetch newsletter subscriptions for member via uuid
- adds endpoint to update newsletter subscriptions for member via uuid
