### PR TITLE
Fixed issue with creation of multiple newsletters

### DIFF
--- a/core/server/models/newsletter.js
+++ b/core/server/models/newsletter.js
@@ -5,21 +5,23 @@ const uuid = require('uuid');
 const Newsletter = ghostBookshelf.Model.extend({
     tableName: 'newsletters',
 
-    defaults: {
-        uuid: uuid.v4(),
-        sender_reply_to: 'newsletter',
-        status: 'active',
-        visibility: 'members',
-        subscribe_on_signup: true,
-        sort_order: 0,
-        title_font_category: 'sans_serif',
-        title_alignment: 'center',
-        show_feature_image: true,
-        body_font_category: 'sans_serif',
-        show_badge: true,
-        show_header_icon: true,
-        show_header_title: true,
-        show_header_name: true
+    defaults: function defaults() {
+        return {
+            uuid: uuid.v4(),
+            sender_reply_to: 'newsletter',
+            status: 'active',
+            visibility: 'members',
+            subscribe_on_signup: true,
+            sort_order: 0,
+            title_font_category: 'sans_serif',
+            title_alignment: 'center',
+            show_feature_image: true,
+            body_font_category: 'sans_serif',
+            show_badge: true,
+            show_header_icon: true,
+            show_header_title: true,
+            show_header_name: true
+        };
     },
 
     members() {

--- a/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
@@ -23,7 +23,7 @@ Object {
       "show_header_name": true,
       "show_header_title": true,
       "slug": "new-newsletter-with-existing-members-subscribed",
-      "sort_order": 5,
+      "sort_order": 7,
       "status": "active",
       "subscribe_on_signup": true,
       "title_alignment": "center",
@@ -75,7 +75,7 @@ Object {
       "show_header_name": true,
       "show_header_title": true,
       "slug": "my-test-newsletter-with-custom-sender_email",
-      "sort_order": 4,
+      "sort_order": 6,
       "status": "active",
       "subscribe_on_signup": true,
       "title_alignment": "center",
@@ -140,6 +140,100 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "652",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/newsletters\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Newsletters API Can add multiple newsletters 1: [body] 1`] = `
+Object {
+  "newsletters": Array [
+    Object {
+      "body_font_category": "sans_serif",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": null,
+      "footer_content": null,
+      "header_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "name": "My first test newsletter",
+      "sender_email": null,
+      "sender_name": null,
+      "sender_reply_to": "newsletter",
+      "show_badge": true,
+      "show_feature_image": true,
+      "show_header_icon": true,
+      "show_header_name": true,
+      "show_header_title": true,
+      "slug": "my-first-test-newsletter",
+      "sort_order": 4,
+      "status": "active",
+      "subscribe_on_signup": true,
+      "title_alignment": "center",
+      "title_font_category": "sans_serif",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "visibility": "members",
+    },
+  ],
+}
+`;
+
+exports[`Newsletters API Can add multiple newsletters 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "672",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/newsletters\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Newsletters API Can add multiple newsletters 3: [body] 1`] = `
+Object {
+  "newsletters": Array [
+    Object {
+      "body_font_category": "sans_serif",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": null,
+      "footer_content": null,
+      "header_image": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "name": "My second test newsletter",
+      "sender_email": null,
+      "sender_name": null,
+      "sender_reply_to": "newsletter",
+      "show_badge": true,
+      "show_feature_image": true,
+      "show_header_icon": true,
+      "show_header_name": true,
+      "show_header_title": true,
+      "slug": "my-second-test-newsletter",
+      "sort_order": 5,
+      "status": "active",
+      "subscribe_on_signup": true,
+      "title_alignment": "center",
+      "title_font_category": "sans_serif",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "visibility": "members",
+    },
+  ],
+}
+`;
+
+exports[`Newsletters API Can add multiple newsletters 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "674",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/newsletters\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,

--- a/test/e2e-api/admin/newsletters.test.js
+++ b/test/e2e-api/admin/newsletters.test.js
@@ -117,6 +117,40 @@ describe('Newsletters API', function () {
             });
     });
 
+    it('Can add multiple newsletters', async function () {
+        const firstNewsletter = {
+            name: 'My first test newsletter'
+        };
+
+        const secondNewsletter = {
+            name: 'My second test newsletter'
+        };
+
+        await agent
+            .post(`newsletters/`)
+            .body({newsletters: [firstNewsletter]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                newsletters: [newsletterSnapshot]
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag,
+                location: anyLocationFor('newsletters')
+            });
+
+        await agent
+            .post(`newsletters/`)
+            .body({newsletters: [secondNewsletter]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                newsletters: [newsletterSnapshot]
+            })
+            .matchHeaderSnapshot({
+                etag: anyEtag,
+                location: anyLocationFor('newsletters')
+            });
+    });
+
     it('Can add a newsletter - with custom sender_email', async function () {
         const newsletter = {
             uuid: uuid.v4(),


### PR DESCRIPTION
- Newsletter defaults were a static object with the default UUID resolved once
- This caused conflicts on subsequent create requests
- Defaults are now resolved as a function so each call gets a new UUID
