### PR TITLE
Dropped nullable from members_subscribe_events.newsletter_id

### DIFF
--- a/core/server/data/migrations/utils.js
+++ b/core/server/data/migrations/utils.js
@@ -3,6 +3,7 @@ const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const commands = require('../schema').commands;
+const DatabaseInfo = require('@tryghost/database-info');
 
 const MIGRATION_USER = 1;
 
@@ -454,6 +455,9 @@ function createSetNullableMigration(table, column, options = {}) {
             await commands.setNullable(table, column, knex);
         },
         async function down(knex) {
+            if (DatabaseInfo.isSQLite(knex)) {
+                options.disableForeignKeyChecks = false;
+            }
             logging.info(`Dropping nullable:  ${table}.${column}${options.disableForeignKeyChecks ? ' with foreign keys disabled' : ''}`);
 
             if (options.disableForeignKeyChecks) {
@@ -479,6 +483,9 @@ function createSetNullableMigration(table, column, options = {}) {
 function createDropNullableMigration(table, column, options = {}) {
     return createTransactionalMigration(
         async function up(knex) {
+            if (DatabaseInfo.isSQLite(knex)) {
+                options.disableForeignKeyChecks = false;
+            }
             logging.info(`Dropping nullable: ${table}.${column}${options.disableForeignKeyChecks ? ' with foreign keys disabled' : ''}`);
 
             if (options.disableForeignKeyChecks) {

--- a/core/server/data/migrations/utils.js
+++ b/core/server/data/migrations/utils.js
@@ -459,16 +459,17 @@ function createSetNullableMigration(table, column, options = {}) {
                 options.disableForeignKeyChecks = false;
             }
             logging.info(`Dropping nullable:  ${table}.${column}${options.disableForeignKeyChecks ? ' with foreign keys disabled' : ''}`);
-
             if (options.disableForeignKeyChecks) {
                 await knex.raw('SET FOREIGN_KEY_CHECKS=0;').transacting(knex);
             }
 
-            await commands.dropNullable(table, column, knex);
-
-            if (options.disableForeignKeyChecks) {
-                await knex.raw('SET FOREIGN_KEY_CHECKS=1;').transacting(knex);
-            }
+            try {
+                await commands.dropNullable(table, column, knex);
+            } finally {
+                if (options.disableForeignKeyChecks) {
+                    await knex.raw('SET FOREIGN_KEY_CHECKS=1;').transacting(knex);
+                }
+            }            
         }
     );
 }
@@ -492,10 +493,12 @@ function createDropNullableMigration(table, column, options = {}) {
                 await knex.raw('SET FOREIGN_KEY_CHECKS=0;').transacting(knex);
             }
 
-            await commands.dropNullable(table, column, knex);
-            
-            if (options.disableForeignKeyChecks) {
-                await knex.raw('SET FOREIGN_KEY_CHECKS=1;').transacting(knex);
+            try {
+                await commands.dropNullable(table, column, knex);
+            } finally {
+                if (options.disableForeignKeyChecks) {
+                    await knex.raw('SET FOREIGN_KEY_CHECKS=1;').transacting(knex);
+                }
             }
         },
         async function down(knex) {

--- a/core/server/data/migrations/versions/5.0/2022-05-03-09-39-drop-nullable-subscribe-event-newsletter-id.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-03-09-39-drop-nullable-subscribe-event-newsletter-id.js
@@ -1,0 +1,4 @@
+const {createDropNullableMigration} = require('../../utils');
+
+// We need to disable foreign key checks because if MySQL is missing the STRICT_TRANS_TABLES mode, we cannot drop nullable from a foreign key
+module.exports = createDropNullableMigration('members_subscribe_events', 'newsletter_id', {disableForeignKeyChecks: true});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1570

- Includes utils to disable foreign key checks when dropping nullable from columns
- Migration to drop nullable from members_subscribe_events.newsletter_id