### PR TITLE
✨Image Backups API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ projectFilesBackup
 /content/media/**/*
 /content/files/**/*
 /content/public/*
+/content/backups/*
 /content/adapters/storage/**/*
 /content/adapters/scheduling/**/*
 !/content/themes/casper

--- a/config.development.json
+++ b/config.development.json
@@ -1,3 +1,0 @@
-{
-    "enableDeveloperExperiments": true
-}

--- a/content/logs/README.md
+++ b/content/logs/README.md
@@ -1,3 +1,0 @@
-# Content / Logs
-
-This is the default log file location when Ghost runs in Production.

--- a/core/server/api/canary/backups.js
+++ b/core/server/api/canary/backups.js
@@ -1,10 +1,11 @@
+const backupsServices = require('../../services/backups');
+
 module.exports = {
     docName: 'backups',
     download: {
-        statusCode: 200,
         permissions: false,
-        query(frame) {
-            return 
+        query() {
+            return backupsServices.api.exporter();
         }
     }
 };

--- a/core/server/api/canary/backups.js
+++ b/core/server/api/canary/backups.js
@@ -1,4 +1,3 @@
-
 module.exports = {
     docName: 'backups',
     download: {

--- a/core/server/api/canary/backups.js
+++ b/core/server/api/canary/backups.js
@@ -1,0 +1,11 @@
+
+module.exports = {
+    docName: 'backups',
+    download: {
+        statusCode: 200,
+        permissions: false,
+        query(frame) {
+            return 
+        }
+    }
+};

--- a/core/server/api/canary/index.js
+++ b/core/server/api/canary/index.js
@@ -20,6 +20,10 @@ module.exports = {
         return shared.pipeline(require('./identities'), localUtils);
     },
 
+    get backups() {
+        return shared.pipeline(require('./backups'), localUtils);
+    },
+
     get integrations() {
         return shared.pipeline(require('./integrations'), localUtils);
     },

--- a/core/server/api/canary/utils/serializers/output/backups.js
+++ b/core/server/api/canary/utils/serializers/output/backups.js
@@ -1,0 +1,9 @@
+const debug = require('@tryghost/debug')('api:canary:utils:serializers:output:backups');
+
+module.exports = {
+    all(data, apiConfig, frame) {
+        debug('all');
+
+        frame.response = data;
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/backups.js
+++ b/core/server/api/canary/utils/serializers/output/backups.js
@@ -1,4 +1,4 @@
-const debug = require('@tryghost/debug')('api:canary:utils:serializers:output:backups');
+const debug = require('@tryghost/debug');
 
 module.exports = {
     all(data, apiConfig, frame) {

--- a/core/server/api/canary/utils/serializers/output/index.js
+++ b/core/server/api/canary/utils/serializers/output/index.js
@@ -13,6 +13,10 @@ module.exports = {
         return require('./default');
     },
 
+    get backups() {
+        return require('./backups');
+    },
+
     get authentication() {
         return require('./authentication');
     },

--- a/core/server/services/backups/BackupsExporter.js
+++ b/core/server/services/backups/BackupsExporter.js
@@ -25,7 +25,8 @@ class BackupsExporter {
 
     serve() {
         const self = this;
-        return function downloadbackups(req, res, next) {
+        return function downloadBackup(req, res, next) {
+            console.log('running dlbk')
             const backupsPath = self.getDirectories().backups;
             const imagesPath = self.getDirectories().images;
             const zipPath = path.join(backupsPath, 'images.zip');

--- a/core/server/services/backups/BackupsExporter.js
+++ b/core/server/services/backups/BackupsExporter.js
@@ -8,25 +8,20 @@ const fs = require('fs-extra');
  */
 
 class BackupsExporter {
-
-
     getDirectories() {
         return {
             images: config.getContentPath('images'),
             backups: config.getContentPath('backups')
         };
     }
-
     /**
      * 
      * @TODO: Perhaps let it multithread to avoid http timeouts and memory issues on big requests?
      * Maybe add cases later for other types for backups?
      */
-
     serve() {
         const self = this;
         return function downloadBackup(req, res, next) {
-            console.log('running dlbk')
             const backupsPath = self.getDirectories().backups;
             const imagesPath = self.getDirectories().images;
             const zipPath = path.join(backupsPath, 'images.zip');

--- a/core/server/services/backups/BackupsExporter.js
+++ b/core/server/services/backups/BackupsExporter.js
@@ -1,0 +1,57 @@
+const {compress} = require('@tryghost/zip');
+const path = require('path');
+const config = require('../../../shared/config');
+const fs = require('fs-extra');
+
+/**
+ * Prototype for exporting images in bulk
+ */
+
+class BackupsExporter {
+
+
+    getDirectories() {
+        return {
+            images: config.getContentPath('images'),
+            backups: config.getContentPath('backups')
+        };
+    }
+
+    /**
+     * 
+     * @TODO: Perhaps let it multithread to avoid http timeouts and memory issues on big requests?
+     * Maybe add cases later for other types for backups?
+     */
+
+    serve() {
+        const self = this;
+        return function downloadbackups(req, res, next) {
+            const backupsPath = self.getDirectories().backups;
+            const imagesPath = self.getDirectories().images;
+            const zipPath = path.join(backupsPath, 'images.zip');
+            let stream;
+            fs.ensureDir(backupsPath)
+                .then(async function () {
+                    return await compress(imagesPath, zipPath);
+                })
+                .then(function (result) {
+                    res.set({
+                        'Content-disposition': 'attachment; filename={backups}.zip'.replace('{backups}', 'images'),
+                        'Content-Type': 'application/zip',
+                        'Content-Length': result.size
+                    });
+                    stream = fs.createReadStream(zipPath);
+                    stream.pipe(res);
+                })
+                .catch(function (err) {
+                    next(err);
+                })
+                .finally(function () {
+                    return;
+                });
+        };
+    }
+}
+
+module.exports = BackupsExporter;
+

--- a/core/server/services/backups/backups.js
+++ b/core/server/services/backups/backups.js
@@ -1,0 +1,14 @@
+const BackupsExporter = require('./BackupsExporter');
+
+let backupsExporter;
+
+const getStorage = () => {
+    backupsExporter = backupsExporter || new BackupsExporter();
+    return backupsExporter;
+};
+
+module.exports = {
+    getZip: async () => {
+        return await getStorage().serve();
+    }
+};

--- a/core/server/services/backups/index.js
+++ b/core/server/services/backups/index.js
@@ -1,0 +1,10 @@
+const {getZip} = require('./backups');
+
+module.exports = {
+    /**
+     * Methods used in the API
+     */
+    api: {
+        exporter: getZip
+    }
+};

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -261,6 +261,10 @@ module.exports = function apiRoutes() {
         http(api.files.upload)
     );
 
+    // ## backups
+    // @TODO make images dynamic to allow multiple use cases in futurex
+    router.get('/backups/images/download', mw.authAdminApi, http(api.backups.download));
+    
     // ## Invites
     router.get('/invites', mw.authAdminApi, http(api.invites.browse));
     router.get('/invites/:id', mw.authAdminApi, http(api.invites.read));

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -262,7 +262,7 @@ module.exports = function apiRoutes() {
     );
 
     // ## backups
-    // @TODO make images dynamic to allow multiple use cases in futurex
+    // @TODO make images dynamic to allow multiple use cases in future
     router.get('/backups/images/download', mw.authAdminApi, http(api.backups.download));
     
     // ## Invites

--- a/core/shared/config/helpers.js
+++ b/core/shared/config/helpers.js
@@ -86,6 +86,8 @@ const getContentPath = function getContentPath(type) {
         return path.join(this.get('paths:contentPath'), 'settings/');
     case 'public':
         return path.join(this.get('paths:contentPath'), 'public/');
+    case 'backups':
+        return path.join(this.get('paths:contentPath'), 'backups/');
     default:
         // new Error is allowed here, as we do not want config to depend on @tryghost/error
         // @TODO: revisit this decision when @tryghost/error is no longer dependent on all of ghost-ignition


### PR DESCRIPTION
👋 Hi, first time contributor here.

I've been using Ghost for years and one small feature I've always felt was missing, is an image exporter on self-hosted installations, that could potentially compliment the JSON Content exporter. Of course, one could just ssh onto a server and manually zip + download via sftp or something, but it feels like extra steps to achieve something that one would expect to be in the settings.

I challenged myself to build it, as it would be a great way to familiarise myself with the Ghost codebase and as a gateway to perhaps get more involved in open-source.

Last week I dived right in and have a working alpha prototype up and running, that's ready for PR. 


- [X] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues (I hope I did)
- [X] The build will pass (run yarn test:all and yarn lint)


I added an Export button in the Admin client as well under Labs -> Alpha features. 
Added PR for that here https://github.com/TryGhost/Admin/pull/2362

<img width="1800" alt="Screenshot 2022-05-03 at 16 53 50" src="https://user-images.githubusercontent.com/19263291/166482025-1bba0439-7b9a-4f4e-a537-cc699feaaad2.png">


A next iteration of this would be perhaps to make it a multithreaded task, to avoid it timing out when it's a big archive. 
I only tested it with around 50mb worths photo content, on an M1 Pro. Most cloud servers aren't that powerful and production entities will have much more content to compress.
And then finally, perhaps an uploader that does the reverse. 