### PR TITLE
Migrated previous email sending settings to newsletters

### DIFF
--- a/core/server/data/migrations/versions/4.47/2022-05-03-15-30-update-newsletter-sending-options.js
+++ b/core/server/data/migrations/versions/4.47/2022-05-03-15-30-update-newsletter-sending-options.js
@@ -1,0 +1,34 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+const find = require('lodash/find');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Migrating sender settings to default newsletter');
+
+        // Get all settings in one query
+        const settings = await knex('settings')
+            .whereIn('key', [
+                'members_from_address',
+                'members_reply_address'
+            ])
+            .select(['key', 'value']);
+
+        // sender_reply_to and members_reply_address are both enums ['newsletter', 'support']
+        const replyTo = find(settings, {key: 'members_reply_address'});
+        const fromAddress = find(settings, {key: 'members_from_address'});
+
+        // Update all newsletters that haven't been (re)configured already
+        await knex('newsletters')
+            .update({
+                // CASE: members_from_address is 'noreply' - we leave it as null to maintain fallback behaviour
+                sender_email: !fromAddress || fromAddress.value === 'noreply' ? undefined : fromAddress.value,
+                sender_reply_to: replyTo ? replyTo.value : undefined
+            })
+            .whereNull('sender_email')
+            .where('sender_reply_to', 'newsletter');
+    },
+    async function down() {
+        // no-op
+    }
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1581

- The original migration to create the default newsletter omitted the from address and reply-to settings
- `sender_reply_to` and `members_reply_address` are both enums with the same values and copy straight across
- `members_from_address` had a default value of 'noreply' as the fallback, which is remapped to NULL in the newsletters table
- We apply the change to all newsletters (there should only be one outside of alpha) which haven't already been reconfigured