### PR TITLE
🐛Fixed urlUtils usage in member config provider 

### DIFF
--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -4,7 +4,6 @@ const tpl = require('@tryghost/tpl');
 const {URL} = require('url');
 const crypto = require('crypto');
 const createKeypair = require('keypair');
-const path = require('path');
 
 const messages = {
     incorrectKeyType: 'type must be one of "direct" or "connect".'
@@ -190,10 +189,7 @@ class MembersConfigProvider {
     }
 
     getTokenConfig() {
-        const {href: membersApiUrl} = new URL(
-            this._urlUtils.getApiPath({version: 'v4', type: 'members'}),
-            this._urlUtils.urlFor('admin', true)
-        );
+        const membersApiUrl = this._urlUtils.urlFor({relativeUrl: '/members/api'}, true);
 
         let privateKey = this._settingsCache.get('members_private_key');
         let publicKey = this._settingsCache.get('members_public_key');
@@ -213,12 +209,11 @@ class MembersConfigProvider {
     }
 
     getSigninURL(token, type) {
-        const siteUrl = this._urlUtils.getSiteUrl();
+        const siteUrl = this._urlUtils.urlFor({relativeUrl: '/members/'}, true);
         const signinURL = new URL(siteUrl);
-        signinURL.pathname = path.join(signinURL.pathname, '/members/');
         signinURL.searchParams.set('token', token);
         signinURL.searchParams.set('action', type);
-        return signinURL.href;
+        return signinURL.toString();
     }
 }
 

--- a/test/unit/server/services/members/config.test.js
+++ b/test/unit/server/services/members/config.test.js
@@ -1,9 +1,10 @@
-const should = require('should');
-const UrlUtils = require('@tryghost/url-utils');
+const assert = require('assert');
+const sinon = require('sinon');
+
 const MembersConfigProvider = require('../../../../../core/server/services/members/config');
 
+const urlUtils = require('../../../../utils/urlUtils');
 const configUtils = require('../../../../utils/configUtils');
-const sinon = require('sinon');
 
 /**
  * @param {object} options
@@ -36,60 +37,52 @@ function createSettingsMock({setDirect, setConnect}) {
     getStub.withArgs('stripe_connect_display_name').returns('Test');
     getStub.withArgs('stripe_connect_account_id').returns('ac_XXXXXXXXXXXXX');
 
+    getStub.withArgs('members_private_key').returns('PRIVATE');
+    getStub.withArgs('members_public_key').returns('PUBLIC');
+
     return {
         get: getStub
     };
 }
 
-function createUrlUtilsMock() {
-    return new UrlUtils({
-        getSubdir: configUtils.config.getSubdir,
-        getSiteUrl: configUtils.config.getSiteUrl,
-        getAdminUrl: configUtils.config.getAdminUrl,
-        apiVersions: {
-            all: ['canary'],
-            canary: {
-                admin: 'admin',
-                content: 'content'
-            }
-        },
-        defaultApiVersion: 'canary',
-        slugs: ['ghost', 'rss', 'amp'],
-        redirectCacheMaxAge: 31536000,
-        baseApiPath: '/ghost/api'
-    });
-}
-
 describe('Members - config', function () {
+    let membersConfig;
+
     beforeEach(function () {
         configUtils.set({
             url: 'http://domain.tld/subdir',
             admin: {url: 'http://sub.domain.tld'}
         });
+
+        membersConfig = new MembersConfigProvider({
+            config: configUtils.config,
+            settingsCache: createSettingsMock({setDirect: true, setConnect: false}),
+            urlUtils: urlUtils.stubUrlUtilsFromConfig()
+        });
     });
 
     afterEach(function () {
         configUtils.restore();
+        urlUtils.restore();
+        sinon.restore();
     });
 
     it('Does not export webhookHandlerUrl', function () {
-        configUtils.set({
-            stripeDirect: false,
-            url: 'http://site.com/subdir'
-        });
-        const settingsCache = createSettingsMock({setDirect: true, setConnect: false});
-        const urlUtils = createUrlUtilsMock();
-
-        const membersConfig = new MembersConfigProvider({
-            config: configUtils.config,
-            settingsCache,
-            urlUtils,
-            ghostVersion: {original: 'v7357'},
-            logging: console
-        });
-
         const paymentConfig = membersConfig.getStripePaymentConfig();
 
-        should.not.exist(paymentConfig.webhookHandlerUrl);
+        assert.equal(paymentConfig.webhookHandlerUrl, undefined, 'webhookHandlerUrl should not exist');
+    });
+
+    it('can get correct tokenConfig', function () {
+        const {issuer, publicKey, privateKey} = membersConfig.getTokenConfig();
+
+        assert.equal(issuer, 'http://domain.tld/subdir/members/api');
+        assert.equal(publicKey, 'PUBLIC');
+        assert.equal(privateKey, 'PRIVATE');
+    });
+
+    it('can get correct signinUrl', function () {
+        const signinUrl = membersConfig.getSigninURL('a', 'b');
+        assert.equal(signinUrl, 'http://domain.tld/subdir/members/?token=a&action=b');
     });
 });


### PR DESCRIPTION
- This is preparation work for getting rid of API versions
- The existing code used api versions for members, but the members API is not versioned
- This caused a bug as issuer was begin set to {{admin_url}}/ghost/api/undefined
- The updated code returns the correct value and is unit tested
- Whilst cleaning up I also swapped the usage of urlUtils to consistently use urlFor, as that is our main helper