### PR TITLE
Port 4.47 changes to main

### DIFF
--- a/core/server/data/migrations/versions/4.47/2022-05-03-15-30-update-newsletter-sending-options.js
+++ b/core/server/data/migrations/versions/4.47/2022-05-03-15-30-update-newsletter-sending-options.js
@@ -1,0 +1,34 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+const find = require('lodash/find');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Migrating sender settings to default newsletter');
+
+        // Get all settings in one query
+        const settings = await knex('settings')
+            .whereIn('key', [
+                'members_from_address',
+                'members_reply_address'
+            ])
+            .select(['key', 'value']);
+
+        // sender_reply_to and members_reply_address are both enums ['newsletter', 'support']
+        const replyTo = find(settings, {key: 'members_reply_address'});
+        const fromAddress = find(settings, {key: 'members_from_address'});
+
+        // Update all newsletters that haven't been (re)configured already
+        await knex('newsletters')
+            .update({
+                // CASE: members_from_address is 'noreply' - we leave it as null to maintain fallback behaviour
+                sender_email: !fromAddress || fromAddress.value === 'noreply' ? undefined : fromAddress.value,
+                sender_reply_to: replyTo ? replyTo.value : undefined
+            })
+            .whereNull('sender_email')
+            .where('sender_reply_to', 'newsletter');
+    },
+    async function down() {
+        // no-op
+    }
+);

--- a/core/server/data/migrations/versions/4.47/2022-05-04-10-03-transform-newsletter-header-image.js
+++ b/core/server/data/migrations/versions/4.47/2022-05-04-10-03-transform-newsletter-header-image.js
@@ -1,0 +1,26 @@
+const logging = require('@tryghost/logging');
+const urlUtils = require('../../../../../shared/url-utils');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const newsletters = await knex.select('id', 'header_image').from('newsletters').whereNotNull('header_image');
+
+        logging.info(`Transforming header_image to transformReady format for ${newsletters.length} newsletters.`);
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const newsletter of newsletters) {
+            await knex('newsletters').update('header_image', urlUtils.toTransformReady(newsletter.header_image)).where('id', newsletter.id);
+        }
+    },
+    async function down(knex) {
+        const newsletters = await knex.select('id', 'header_image').from('newsletters').whereNotNull('header_image');
+
+        logging.info(`Transforming header_image to absolute format for ${newsletters.length} newsletters.`);
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const newsletter of newsletters) {
+            await knex('newsletters').update('header_image', urlUtils.transformReadyToAbsolute(newsletter.header_image)).where('id', newsletter.id);
+        }
+    }
+);

--- a/core/server/models/newsletter.js
+++ b/core/server/models/newsletter.js
@@ -1,6 +1,7 @@
 const ghostBookshelf = require('./base');
 const ObjectID = require('bson-objectid');
 const uuid = require('uuid');
+const urlUtils = require('../../shared/url-utils');
 
 const Newsletter = ghostBookshelf.Model.extend({
     tableName: 'newsletters',
@@ -74,6 +75,28 @@ const Newsletter = ghostBookshelf.Model.extend({
         }
 
         return query;
+    },
+
+    formatOnWrite(attrs) {
+        ['header_image'].forEach((attr) => {
+            if (attrs[attr]) {
+                attrs[attr] = urlUtils.toTransformReady(attrs[attr]);
+            }
+        });
+
+        return attrs;
+    },
+
+    parse() {
+        const attrs = ghostBookshelf.Model.prototype.parse.apply(this, arguments);
+
+        ['header_image'].forEach((attr) => {
+            if (attrs[attr]) {
+                attrs[attr] = urlUtils.transformReadyToAbsolute(attrs[attr]);
+            }
+        });
+
+        return attrs;
     }
 }, {
     orderDefaultRaw: function () {

--- a/core/server/services/members/config.js
+++ b/core/server/services/members/config.js
@@ -35,13 +35,8 @@ class MembersConfigProvider {
     }
 
     getEmailFromAddress() {
-        const fromAddress = this._settingsCache.get('members_from_address') || 'noreply';
-
-        // Any fromAddress without domain uses site domain, like default setting `noreply`
-        if (fromAddress.indexOf('@') < 0) {
-            return `${fromAddress}@${this._getDomain()}`;
-        }
-        return fromAddress;
+        // Individual from addresses are set per newsletter - this is the fallback address
+        return `noreply@${this._getDomain()}`;
     }
 
     getEmailSupportAddress() {

--- a/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
@@ -215,7 +215,7 @@ Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "description": null,
       "footer_content": null,
-      "header_image": null,
+      "header_image": "http://127.0.0.1:2369/content/images/2022/05/cover-image.jpg",
       "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
       "name": "My test newsletter",
       "sender_email": null,
@@ -244,7 +244,7 @@ exports[`Newsletters API Can add a newsletter 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "652",
+  "content-length": "710",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/newsletters\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1581
closes https://github.com/TryGhost/Team/issues/1579

4.47 includes migrations added after the split of the main branch to 5.x.

These migrations and associated changes need to be ported to the 5.x branch to prevent a mismatch of migrations when upgrading from 4.47 to 5.0.
