### PR TITLE
Assigned existing email records and related posts to the default newsletter

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-04-15-24-map-existing-emails-to-default-newsletter.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-04-15-24-map-existing-emails-to-default-newsletter.js
@@ -9,7 +9,7 @@ module.exports = createTransactionalMigration(
         // Note we intentionally use the default newsletter slug instead of the usual orderBy logic
         let newsletter = await knex('newsletters')
             .where('slug', 'default-newsletter')
-            .first('id');
+            .first('id', 'slug');
 
         if (!newsletter) {
             // Fall back to orderBy - just in case
@@ -19,13 +19,15 @@ module.exports = createTransactionalMigration(
                 .orderBy('sort_order', 'asc')
                 .orderBy('created_at', 'asc')
                 .orderBy('id', 'asc')
-                .first('id');
+                .first('id', 'slug');
         }
 
         if (!newsletter) {
             logging.error(`Newsletter not found - skipping`);
             return;
         }
+
+        logging.info(`Assigning existing emails to newsletter ID ${newsletter.id} (${newsletter.slug})`);
 
         // Set newsletter ID only on posts with related email records without a newsletter assigned
         await knex('posts')

--- a/core/server/data/migrations/versions/5.0/2022-05-04-15-24-map-existing-emails-to-default-newsletter.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-04-15-24-map-existing-emails-to-default-newsletter.js
@@ -1,0 +1,33 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Linking existing emails and related posts to the default newsletter');
+
+        // Get the default newsletter
+        const newsletter = await knex('newsletters')
+            .where('status', 'active')
+            .orderBy('sort_order', 'asc')
+            .orderBy('created_at', 'asc')
+            .orderBy('id', 'asc')
+            .first('id');
+
+        if (!newsletter) {
+            logging.error(`Default newsletter not found - skipping`);
+            return;
+        }
+
+        // Set newsletter ID on email and related post records
+        await knex('emails')
+            .join('posts', 'emails.post_id', '=', 'posts.id')
+            .update({
+                ['emails.newsletter_id']: newsletter.id,
+                ['posts.newsletter_id']: newsletter.id
+            })
+            .where('emails.newsletter_id', null);
+    },
+    async function down() {
+        // Not required
+    }
+);

--- a/core/server/data/migrations/versions/5.0/2022-05-04-15-24-map-existing-emails-to-default-newsletter.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-04-15-24-map-existing-emails-to-default-newsletter.js
@@ -18,14 +18,14 @@ module.exports = createTransactionalMigration(
             return;
         }
 
-        // Set newsletter ID on email and related post records
+        // Set newsletter ID only on posts with related email records without a newsletter assigned
+        await knex('posts')
+            .update('newsletter_id', newsletter.id)
+            .whereIn('id', knex.raw('SELECT post_id FROM emails WHERE emails.newsletter_id IS NULL'));
+
         await knex('emails')
-            .join('posts', 'emails.post_id', '=', 'posts.id')
-            .update({
-                ['emails.newsletter_id']: newsletter.id,
-                ['posts.newsletter_id']: newsletter.id
-            })
-            .where('emails.newsletter_id', null);
+            .update('newsletter_id', newsletter.id)
+            .whereNull('newsletter_id');
     },
     async function down() {
         // Not required


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1571

- With the addition of multiple newsletters, all emails sent previously should be assigned to the default newsletter
- This will make sure that the sent count for the default newsletter displays correctly
