### PR TITLE
Updated email unsubscribe links to use site home

### DIFF
--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -75,7 +75,8 @@ const htmlToPlaintext = (html) => {
 const createUnsubscribeUrl = (uuid, newsletterUuid) => {
     const siteUrl = urlUtils.getSiteUrl();
     const unsubscribeUrl = new URL(siteUrl);
-    unsubscribeUrl.pathname = `${unsubscribeUrl.pathname}/unsubscribe/`.replace('//', '/');
+    unsubscribeUrl.pathname = `${unsubscribeUrl.pathname}/`.replace('//', '/');
+    unsubscribeUrl.searchParams.set('action', 'unsubscribe');
     if (uuid) {
         unsubscribeUrl.searchParams.set('uuid', uuid);
     } else {

--- a/test/unit/server/services/mega/post-email-serializer.test.js
+++ b/test/unit/server/services/mega/post-email-serializer.test.js
@@ -98,19 +98,19 @@ describe('Post Email Serializer', function () {
         it('generates unsubscribe url for preview', function () {
             sinon.stub(urlUtils, 'getSiteUrl').returns('https://site.com/blah');
             const unsubscribeUrl = createUnsubscribeUrl(null);
-            unsubscribeUrl.should.eql('https://site.com/blah/unsubscribe/?preview=1');
+            unsubscribeUrl.should.eql('https://site.com/blah/?action=unsubscribe&preview=1');
         });
 
         it('generates unsubscribe url with only post uuid', function () {
             sinon.stub(urlUtils, 'getSiteUrl').returns('https://site.com/blah');
             const unsubscribeUrl = createUnsubscribeUrl('post-abcd');
-            unsubscribeUrl.should.eql('https://site.com/blah/unsubscribe/?uuid=post-abcd');
+            unsubscribeUrl.should.eql('https://site.com/blah/?action=unsubscribe&uuid=post-abcd');
         });
 
         it('generates unsubscribe url with both post and newsletter uuid', function () {
             sinon.stub(urlUtils, 'getSiteUrl').returns('https://site.com/blah');
             const unsubscribeUrl = createUnsubscribeUrl('post-abcd', 'newsletter-abcd');
-            unsubscribeUrl.should.eql('https://site.com/blah/unsubscribe/?uuid=post-abcd&newsletter=newsletter-abcd');
+            unsubscribeUrl.should.eql('https://site.com/blah/?action=unsubscribe&uuid=post-abcd&newsletter=newsletter-abcd');
         });
     });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1495

- unsubscribe urls on emails were using a reserved `/unsubscribe` route with custom handlebars template for UI
- with multiple newsletters, the unsubscribe flow is handled directly by Portal, and current unsubscribe urls are redirected to site home with action params
- updates the newly generated unsubscribe links to use site home with action params directly, moving away from `SITE_URL/unsubscribe?uuid=POST_UUID` to `SITE_URL/?action=unsubscribe&uuid=POST_UUID&newsletter=NEWSLETTER_UUID`
- also allows us to remove the special unsubscribe route going forward