### PR TITLE
Excluded newsletter's sender email value when importing

### DIFF
--- a/core/server/data/importer/importers/data/data-importer.js
+++ b/core/server/data/importer/importers/data/data-importer.js
@@ -9,6 +9,7 @@ const PostsImporter = require('./posts');
 const TagsImporter = require('./tags');
 const SettingsImporter = require('./settings');
 const UsersImporter = require('./users');
+const NewslettersImporter = require('./newsletters');
 const RolesImporter = require('./roles');
 let importers = {};
 let DataImporter;
@@ -26,6 +27,7 @@ DataImporter = {
         importers.roles = new RolesImporter(importData.data);
         importers.tags = new TagsImporter(importData.data);
         importers.posts = new PostsImporter(importData.data);
+        importers.newsletters = new NewslettersImporter(importData.data);
         importers.settings = new SettingsImporter(importData.data);
 
         return importData;

--- a/core/server/data/importer/importers/data/newsletters.js
+++ b/core/server/data/importer/importers/data/newsletters.js
@@ -1,0 +1,37 @@
+const debug = require('@tryghost/debug')('importer:newsletters');
+const _ = require('lodash');
+const BaseImporter = require('./base');
+
+const ignoredColumns = ['sender_email'];
+
+class NewslettersImporter extends BaseImporter {
+    constructor(allDataFromFile) {
+        super(allDataFromFile, {
+            modelName: 'Newsletter',
+            dataKeyToImport: 'newsletters'
+        });
+    }
+
+    /**
+    * Remove ignored columns
+    */
+    sanitizeValues() {
+        _.each(this.dataToImport, (obj) => {
+            _.each(_.pick(obj, ignoredColumns), (value, key) => {
+                delete obj[key];
+            });
+        });
+    }
+
+    beforeImport() {
+        debug('beforeImport');
+        this.sanitizeValues();
+        return super.beforeImport();
+    }
+
+    doImport(options, importOptions) {
+        return super.doImport(options, importOptions);
+    }
+}
+
+module.exports = NewslettersImporter;

--- a/test/unit/server/data/importer/importers/data/newsletters.test.js
+++ b/test/unit/server/data/importer/importers/data/newsletters.test.js
@@ -1,0 +1,56 @@
+const should = require('should');
+const NewslettersImporter = require('../../../../../../../core/server/data/importer/importers/data/newsletters');
+
+const fakeNewsletters = [{
+    id: '1',
+    name: 'Daily newsletter',
+    slug: 'daily-newsletter',
+    description: '',
+    sender_name: 'Jamie',
+    sender_email: 'jamie@example.com',
+    sender_reply_to: 'newsletter',
+    status: 'active',
+    subscribe_on_signup: true,
+    title_font_category: 'serif',
+    body_font_category: 'serif',
+    show_header_icon: true,
+    show_header_title: true,
+    show_badge: true,
+    sort_order: 1
+}, {
+    id: '2',
+    name: 'Weekly roundup',
+    slug: 'weekly-roundup',
+    description: '',
+    sender_name: 'Jamie',
+    sender_email: 'jamie@example.com',
+    sender_reply_to: 'newsletter',
+    status: 'active',
+    subscribe_on_signup: false,
+    title_font_category: 'serif',
+    body_font_category: 'serif',
+    show_header_icon: true,
+    show_header_title: true,
+    show_badge: true,
+    sort_order: 2
+}];
+
+describe('NewslettersImporter', function () {
+    describe('#beforeImport', function () {
+        it('Removes the sender_email column', function () {
+            const importer = new NewslettersImporter({newsletters: fakeNewsletters});
+
+            importer.beforeImport();
+            importer.dataToImport.should.have.length(2);
+
+            const newsletter1 = importer.dataToImport[0];
+            const newsletter2 = importer.dataToImport[1];
+
+            newsletter1.name.should.be.eql('Daily newsletter');
+            should.not.exist(newsletter1.sender_email);
+
+            newsletter2.name.should.be.eql('Weekly roundup');
+            should.not.exist(newsletter2.sender_email);
+        });
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1529

- excludes `sender_email` value for newsletters on import, so it fallbacks to `null`
- the sender email addresses for newsletters require verification to set.
- this ensures there isn't a way around by modifying an export file then importing it.