### PR TITLE
Migrated old recipient filters to NQL string format

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-05-13-13-migrate-legacy-recipient-filters.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-05-13-13-migrate-legacy-recipient-filters.js
@@ -1,0 +1,30 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(transaction) {
+        const postsFreeCount = await transaction('posts')
+            .where('email_recipient_filter', 'free')
+            .update('email_recipient_filter', 'status:free');
+        logging.info(`Migrated ${postsFreeCount} posts with 'email_recipient_filter' = 'free' to 'status:free'`);
+
+        const postsPaidCount = await transaction('posts')
+            .where('email_recipient_filter', 'paid')
+            .update('email_recipient_filter', 'status:-free');
+        logging.info(`Migrated ${postsPaidCount} posts with 'email_recipient_filter' = 'paid' to 'status:-free'`);
+
+        const emailsFreeCount = await transaction('emails')
+            .where('recipient_filter', 'free')
+            .update('recipient_filter', 'status:free');
+        logging.info(`Migrated ${emailsFreeCount} emails with 'recipient_filter' = 'free' to 'status:free'`);
+
+        const emailsPaidCount = await transaction('emails')
+            .where('recipient_filter', 'paid')
+            .update('recipient_filter', 'status:-free');
+        logging.info(`Migrated ${emailsPaidCount} emails with 'recipient_filter' = 'paid' to 'status:-free'`);
+    },
+    async function down() {
+        // no-op: we don't want to migrate values back to the old-style
+        // when they are supported anyway
+    }
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/309

- we started off with "free" and "paid" in these columns but since moved
  to NQL strings
- there is code in Ghost to rewrite these values to NQL strings, but we
  still have posts/emails in the DB with these old values so they need
  to be updated
- once this migration is merged, we can probably clean a lot of that
  aliasing up
- this commit migrates values in `posts.email_recipient_filter` and
  `emails.recipient_filter` from `free` to `status:free` and `paid` to
  `status:-free`
- I've left the down as a no-op because we don't want to translate
  values back, and we don't know which ones we originally migrated in
  the first place
