### PR TITLE
Updated migration to always set a value

### DIFF
--- a/core/server/data/migrations/versions/4.47/2022-05-03-15-30-update-newsletter-sending-options.js
+++ b/core/server/data/migrations/versions/4.47/2022-05-03-15-30-update-newsletter-sending-options.js
@@ -22,7 +22,7 @@ module.exports = createTransactionalMigration(
         await knex('newsletters')
             .update({
                 // CASE: members_from_address is 'noreply' - we leave it as null to maintain fallback behaviour
-                sender_email: !fromAddress || fromAddress.value === 'noreply' ? undefined : fromAddress.value,
+                sender_email: !fromAddress || fromAddress.value === 'noreply' ? null : fromAddress.value,
                 sender_reply_to: replyTo ? replyTo.value : undefined
             })
             .whereNull('sender_email')


### PR DESCRIPTION
- When both parameters passed to `update` resolve to `undefined` we throw an `Empty .update() call detected` error
- This change always updates the `sender_email` to null rather than skipping the field
- `sender_reply_to` should still be `undefined` so we don't override an existing non-null value