### PR TITLE
Removed unused defaults from `text` columns in schema

### DIFF
--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -64,8 +64,7 @@ module.exports = {
         email_recipient_filter: {
             type: 'text',
             maxlength: 1000000000,
-            nullable: false,
-            defaultTo: 'none'
+            nullable: false
         },
         created_at: {type: 'dateTime', nullable: false},
         /**
@@ -643,8 +642,7 @@ module.exports = {
         recipient_filter: {
             type: 'text',
             maxlength: 1000000000,
-            nullable: false,
-            defaultTo: 'status:-free'
+            nullable: false
         },
         error: {type: 'string', maxlength: 2000, nullable: true},
         error_data: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'eb4e97aa5f59cb0b53b0cb5a6a833e94';
+    const currentSchemaHash = 'e913ad0d62d2e8e64c28aa41cb443076';
     const currentFixturesHash = 'ab89cbc5cfb7b977c34b2de00e1bea40';
     const currentSettingsHash = 'ffd899a82b0ad2886e92d8244bcbca6a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/309

- I originally started looking at this because I wanted to change the default of
  `emails.recipient_filter` for old DBs to `status:-free`
- we changed these columns to a `text` type, which doesn't support
  defaults
- the tables already have defaults set in the model, so the only change
  needed here is to delete the `defaultTo` in the schema to avoid
  confusion
- on the way, I ended up fixing https://github.com/TryGhost/Ghost/commit/51498abb5cb9cd0a07ed34aecab955fffd1be9b2 too
