### PR TITLE
Dropped `subscribed` column in `members` table

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-09-10-00-drop-members-subscribed-column.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-09-10-00-drop-members-subscribed-column.js
@@ -1,0 +1,18 @@
+const {createDropColumnMigration} = require('../../utils');
+
+// Preferably I could use `createIrreversibleMigration` here like
+// `createIrreversibleMigration(createDropColumnMigration(...).up)` but
+// that seems to throw some obscure error that I'm not sure about... something
+// to look into for the future
+module.exports = {
+    ...createDropColumnMigration('members', 'subscribed', {}),
+
+    down: async () => {
+        // no-op: we're setting this migration to irreversible so we won't
+        // execute the `down`
+    },
+
+    config: {
+        irreversible: true
+    }
+};

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -397,8 +397,6 @@ module.exports = {
         name: {type: 'string', maxlength: 191, nullable: true},
         note: {type: 'string', maxlength: 2000, nullable: true},
         geolocation: {type: 'string', maxlength: 2000, nullable: true},
-        // @deprecated: unused in 5.0 use newsletter.status:active or newsletter.status:-active
-        subscribed: {type: 'bool', nullable: true, defaultTo: true},
         email_count: {type: 'integer', unsigned: true, nullable: false, defaultTo: 0},
         email_opened_count: {type: 'integer', unsigned: true, nullable: false, defaultTo: 0},
         email_open_rate: {type: 'integer', unsigned: true, nullable: true, index: true},

--- a/core/server/models/member.js
+++ b/core/server/models/member.js
@@ -10,7 +10,6 @@ const Member = ghostBookshelf.Model.extend({
     defaults() {
         return {
             status: 'free',
-            subscribed: true,
             uuid: uuid.v4(),
             email_count: 0,
             email_opened_count: 0

--- a/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -2696,7 +2696,7 @@ exports[`Members API Can subscribe to a newsletter 5: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4398",
+  "content-length": "4326",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'e913ad0d62d2e8e64c28aa41cb443076';
+    const currentSchemaHash = '48249818d02099371089a8d386abb565';
     const currentFixturesHash = 'e840343b816a5f9c6b1849c5220bacf8';
     const currentSettingsHash = 'ffd899a82b0ad2886e92d8244bcbca6a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/309

- this column is now a calculated value based upon the relation of a
  member to a newsletter
- we should no longer need `subscribed`, so this migrations cleans up
  the column in the DB