### PR TITLE
Dropped `oauth` table

### DIFF
--- a/core/server/data/exporter/table-lists.js
+++ b/core/server/data/exporter/table-lists.js
@@ -16,7 +16,6 @@ const BACKUP_TABLES = [
     'migrations',
     'migrations_lock',
     'newsletters',
-    'oauth',
     'permissions',
     'permissions_roles',
     'permissions_users',

--- a/core/server/data/migrations/versions/5.0/2022-05-05-15-17-drop-oauth-table.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-05-15-17-drop-oauth-table.js
@@ -1,0 +1,3 @@
+const {dropTables} = require('../../utils');
+
+module.exports = dropTables(['oauth']);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -142,17 +142,6 @@ module.exports = {
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true}
     },
-    // @deprecated: oauth prototype needs to be removed so we can reimplement
-    oauth: {
-        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        provider: {type: 'string', maxlength: 50, nullable: false},
-        provider_id: {type: 'string', maxlength: 191, nullable: false},
-        access_token: {type: 'text', maxlength: 65535, nullable: true},
-        refresh_token: {type: 'text', maxlength: 2000, nullable: true},
-        created_at: {type: 'dateTime', nullable: false},
-        updated_at: {type: 'dateTime', nullable: true},
-        user_id: {type: 'string', maxlength: 24, nullable: false, references: 'users.id'}
-    },
     posts_authors: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id'},

--- a/test/integration/exporter/exporter.test.js
+++ b/test/integration/exporter/exporter.test.js
@@ -51,7 +51,6 @@ describe('Exporter', function () {
                 'migrations_lock',
                 'mobiledoc_revisions',
                 'newsletters',
-                'oauth',
                 'offers',
                 'offer_redemptions',
                 'permissions',

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c38b892b9d0667c57c21e850c0fb1998';
+    const currentSchemaHash = 'eb4e97aa5f59cb0b53b0cb5a6a833e94';
     const currentFixturesHash = 'ab89cbc5cfb7b977c34b2de00e1bea40';
     const currentSettingsHash = 'ffd899a82b0ad2886e92d8244bcbca6a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/309

- we're removing the OAuth prototype and the table was never used, so we
  should be good to drop it
- this commit adds a migration to drop the table