### PR TITLE
Enabled Admin integration for newsletters API

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-05-13-29-add-newsletters-admin-integration-permission-roles.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-05-13-29-add-newsletters-admin-integration-permission-roles.js
@@ -1,0 +1,20 @@
+const {combineTransactionalMigrations, addPermissionToRole} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionToRole({
+        permission: 'Browse newsletters',
+        role: 'Admin Integration'
+    }),
+    addPermissionToRole({
+        permission: 'Read newsletters',
+        role: 'Admin Integration'
+    }),
+    addPermissionToRole({
+        permission: 'Edit newsletters',
+        role: 'Admin Integration'
+    }),
+    addPermissionToRole({
+        permission: 'Add newsletters',
+        role: 'Admin Integration'
+    })
+);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -699,7 +699,8 @@
                     "email": "all",
                     "snippet": "all",
                     "product": ["browse", "read", "add", "edit"],
-                    "offer": ["browse", "read", "add", "edit"]
+                    "offer": ["browse", "read", "add", "edit"],
+                    "newsletter": ["browse", "read", "add", "edit"]
                 },
                 "Editor": {
                     "notification": "all",

--- a/test/integration/migrations/migration.test.js
+++ b/test/integration/migrations/migration.test.js
@@ -152,10 +152,10 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Edit offers', ['Administrator']);
             permissions.should.havePermission('Add offers', ['Administrator']);
 
-            permissions.should.havePermission('Browse Products', ['Administrator', 'Editor', 'Author']);
-            permissions.should.havePermission('Read Products', ['Administrator', 'Editor', 'Author']);
-            permissions.should.havePermission('Edit Products', ['Administrator']);
-            permissions.should.havePermission('Add Products', ['Administrator']);
+            permissions.should.havePermission('Browse Products', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
+            permissions.should.havePermission('Read Products', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
+            permissions.should.havePermission('Edit Products', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Add Products', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Delete Products', ['Administrator']);
 
             permissions.should.havePermission('Reset all passwords', ['Administrator']);
@@ -163,10 +163,15 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Browse custom theme settings', ['Administrator']);
             permissions.should.havePermission('Edit custom theme settings', ['Administrator']);
 
-            permissions.should.havePermission('Browse newsletters', ['Administrator']);
-            permissions.should.havePermission('Read newsletters', ['Administrator']);
-            permissions.should.havePermission('Edit newsletters', ['Administrator']);
-            permissions.should.havePermission('Add newsletters', ['Administrator']);
+            permissions.should.havePermission('Browse offers', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Read offers', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Edit offers', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Add offers', ['Administrator', 'Admin Integration']);
+
+            permissions.should.havePermission('Browse newsletters', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Read newsletters', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Edit newsletters', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Add newsletters', ['Administrator', 'Admin Integration']);
         });
 
         describe('Populate', function () {

--- a/test/integration/migrations/migration.test.js
+++ b/test/integration/migrations/migration.test.js
@@ -147,10 +147,10 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Add Members');
             permissions.should.havePermission('Delete Members');
 
-            permissions.should.havePermission('Browse offers', ['Administrator']);
-            permissions.should.havePermission('Read offers', ['Administrator']);
-            permissions.should.havePermission('Edit offers', ['Administrator']);
-            permissions.should.havePermission('Add offers', ['Administrator']);
+            permissions.should.havePermission('Browse offers', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Read offers', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Edit offers', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Add offers', ['Administrator', 'Admin Integration']);
 
             permissions.should.havePermission('Browse Products', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
             permissions.should.havePermission('Read Products', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
@@ -162,11 +162,6 @@ describe('Database Migration (special functions)', function () {
 
             permissions.should.havePermission('Browse custom theme settings', ['Administrator']);
             permissions.should.havePermission('Edit custom theme settings', ['Administrator']);
-
-            permissions.should.havePermission('Browse offers', ['Administrator', 'Admin Integration']);
-            permissions.should.havePermission('Read offers', ['Administrator', 'Admin Integration']);
-            permissions.should.havePermission('Edit offers', ['Administrator', 'Admin Integration']);
-            permissions.should.havePermission('Add offers', ['Administrator', 'Admin Integration']);
 
             permissions.should.havePermission('Browse newsletters', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Read newsletters', ['Administrator', 'Admin Integration']);

--- a/test/integration/migrations/migration.test.js
+++ b/test/integration/migrations/migration.test.js
@@ -147,10 +147,10 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Add Members');
             permissions.should.havePermission('Delete Members');
 
-            permissions.should.havePermission('Browse offers', ['Administrator', 'Admin Integration']);
-            permissions.should.havePermission('Read offers', ['Administrator', 'Admin Integration']);
-            permissions.should.havePermission('Edit offers', ['Administrator', 'Admin Integration']);
-            permissions.should.havePermission('Add offers', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Browse offers');
+            permissions.should.havePermission('Read offers');
+            permissions.should.havePermission('Edit offers');
+            permissions.should.havePermission('Add offers');
 
             permissions.should.havePermission('Browse Products', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
             permissions.should.havePermission('Read Products', ['Administrator', 'Editor', 'Author', 'Admin Integration']);

--- a/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -201,18 +201,18 @@ describe('Migration Fixture Utils', function () {
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
-                result.should.have.property('expected', 83);
-                result.should.have.property('done', 83);
+                result.should.have.property('expected', 86);
+                result.should.have.property('done', 86);
 
                 // Permissions & Roles
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(83);
+                dataMethodStub.filter.callCount.should.eql(86);
                 dataMethodStub.find.callCount.should.eql(7);
-                baseUtilAttachStub.callCount.should.eql(83);
+                baseUtilAttachStub.callCount.should.eql(86);
 
-                fromItem.related.callCount.should.eql(83);
-                fromItem.find.callCount.should.eql(83);
+                fromItem.related.callCount.should.eql(86);
+                fromItem.find.callCount.should.eql(86);
 
                 done();
             }).catch(done);

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'e913ad0d62d2e8e64c28aa41cb443076';
-    const currentFixturesHash = 'ab89cbc5cfb7b977c34b2de00e1bea40';
+    const currentFixturesHash = 'e840343b816a5f9c6b1849c5220bacf8';
     const currentSettingsHash = 'ffd899a82b0ad2886e92d8244bcbca6a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/test/utils/fixtures/fixtures.json
+++ b/test/utils/fixtures/fixtures.json
@@ -870,7 +870,10 @@
                     "label": "all",
                     "email_preview": "all",
                     "email": "all",
-                    "snippet": "all"
+                    "snippet": "all",
+                    "product": ["browse", "read", "add", "edit"],
+                    "offer": ["browse", "read", "add", "edit"],
+                    "newsletter": ["browse", "read", "add", "edit"]
                 },
                 "Editor": {
                     "notification": "all",


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1546

- allows newsletters API to work with Admin API keys
- updates fixtures to add permissions to admin integration role for new sites
- adds migration to update existing sites to have correct permissions for role
- whitelists add/edit/read/browse on newsletters API for integrations