### PR TITLE
🐛 Fixed importing posts with a newsletter assigned

### DIFF
--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -6,6 +6,7 @@ const mobiledocLib = require('../../../../lib/mobiledoc');
 const validator = require('@tryghost/validator');
 const postsMetaSchema = require('../../../schema').tables.posts_meta;
 const metaAttrs = _.keys(_.omit(postsMetaSchema, ['id']));
+const ignoredColumns = ['newsletter_id'];
 
 class PostsImporter extends BaseImporter {
     constructor(allDataFromFile) {
@@ -42,6 +43,10 @@ class PostsImporter extends BaseImporter {
                 }
                 delete obj.send_email_when_published;
             }
+
+            ignoredColumns.forEach((column) => {
+                delete obj[column];
+            });
         });
     }
 

--- a/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/test/unit/server/data/importer/importers/data/posts.test.js
@@ -87,5 +87,20 @@ describe('PostsImporter', function () {
             should.exist(pageTrueTypePost);
             pageTrueTypePost.type.should.equal('post', 'pageTrueTypePost.type');
         });
+
+        it('Removes the newsletter_id column', function () {
+            const fakePosts = [{
+                slug: 'post-with-newsletter',
+                newsletter_id: 'bananas'
+            }];
+
+            const importer = new PostsImporter({posts: fakePosts});
+
+            importer.beforeImport();
+
+            const postWithoutNewsletter = find(importer.dataToImport, {slug: 'post-with-newsletter'});
+            should.exist(postWithoutNewsletter);
+            should.not.exist(postWithoutNewsletter.newsletter_id);
+        });
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1595

- Since adding multiple newsletters, posts may be linked to a related newsletter
- We don't export newsletters, so the related newsletter_id doesn't exist and fails the FK check on import
