### PR TITLE
[4.x] 🐛 Fixed wrong newsletter used when sending scheduled post

### DIFF
--- a/core/server/services/mega/mega.js
+++ b/core/server/services/mega/mega.js
@@ -214,12 +214,10 @@ const addEmail = async (postModel, options) => {
     }
 
     const knexOptions = _.pick(options, ['transacting', 'forUpdate']);
-    const filterOptions = Object.assign({}, knexOptions, {limit: 1});
+    const filterOptions = {...knexOptions, limit: 1};
 
-    let newsletter;
-    if (labsService.isSet('multipleNewsletters')) {
-        newsletter = await postModel.related('newsletter').fetch(Object.assign({}, {require: false}, _.pick(options, ['transacting'])));
-    }
+    const newsletter = await postModel.related('newsletter').fetch({require: true, ..._.pick(options, ['transacting'])});
+
     const emailRecipientFilter = postModel.get('email_recipient_filter');
     filterOptions.filter = transformEmailRecipientFilter(emailRecipientFilter, {errorProperty: 'email_recipient_filter'}, newsletter);
 
@@ -257,7 +255,7 @@ const addEmail = async (postModel, options) => {
             submitted_at: moment().toDate(),
             track_opens: !!settingsCache.get('email_track_opens'),
             recipient_filter: emailRecipientFilter,
-            newsletter_id: options.newsletter_id
+            newsletter_id: newsletter.id
         }, knexOptions);
     } else {
         return existing;

--- a/core/server/services/posts/posts-service.js
+++ b/core/server/services/posts/posts-service.js
@@ -30,6 +30,8 @@ class PostsService {
             }
         } else {
             // Set the newsletter_id if it isn't passed to the API
+            // NOTE: this option is ignored if the newsletter_id is already set on the post.
+            // Never use frame.options.newsletter_id to do actual logic. Use model.newsletter_id after the edit.
             const newsletters = await this.models.Newsletter.findPage({filter: 'status:active', limit: 1, columns: ['id']}, {transacting: frame.options.transacting});
             if (newsletters.data.length > 0) {
                 frame.options.newsletter_id = newsletters.data[0].id;
@@ -85,7 +87,7 @@ class PostsService {
                 let postEmail = model.relations.email;
 
                 if (!postEmail) {
-                    const email = await this.mega.addEmail(model, Object.assign({}, frame.options, {apiVersion: this.apiVersion}));
+                    const email = await this.mega.addEmail(model, {...frame.options, apiVersion: this.apiVersion});
                     model.set('email', email);
                 } else if (postEmail && postEmail.get('status') === 'failed') {
                     const email = await this.mega.retryFailedEmail(postEmail);


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1651939076681719

Cause:
- When a scheduled post was published via the post scheduler, no `newsletter_id` option is passed when editing the post.
- When editing a post via the posts service, without the `newsletter_id` option, the `newsletter_id` option is automatically set to the default newsletter's id.
- Inside the post model, this new `newsletter_id` was not saved, because it was already set, and changing it is prevented.
- The `mega` service wasn't using the (unchanged) post's newsletter_id, but used the option instead, which contained the default newsletter's id.

Fix:
- Always using the newsletter_id from the post and requiring the newsletter associated with a post to exist.
- This behaviour can be/is tested by publishing a scheduled post without any option.