### PR TITLE
Added internal frontend integration

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-06-13-22-add-frontend-integration.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-06-13-22-add-frontend-integration.js
@@ -1,0 +1,68 @@
+const logging = require('@tryghost/logging');
+const ObjectID = require('bson-objectid');
+const security = require('@tryghost/security');
+const {createTransactionalMigration} = require('../../utils');
+
+const frontendIntegration = {
+    slug: 'ghost-internal-frontend',
+    name: 'Ghost Internal Frontend',
+    description: 'Internal frontend integration',
+    type: 'internal'
+};
+
+const addInternalIntegrationAndKey = async (knex, integration) => {
+    const message = `Adding ${integration.name} integration`;
+
+    const existing = await knex('integrations').select('id').where('slug', integration.slug).first();
+
+    if (existing && existing.id) {
+        logging.warn(`Skipping ${message}`);
+        return;
+    }
+
+    const now = knex.raw('CURRENT_TIMESTAMP');
+    integration.id = ObjectID().toHexString();
+    integration.created_at = now;
+    integration.created_by = 1;
+
+    await knex('integrations').insert(integration);
+
+    const contentKey = {
+        id: ObjectID().toHexString(),
+        type: 'content',
+        secret: security.secret.create('content'),
+        role_id: null,
+        integration_id: integration.id,
+        created_at: now,
+        created_by: 1
+    };
+
+    logging.info(message);
+
+    await knex('api_keys').insert(contentKey);
+};
+
+const removeInternalIntegrationAndKey = async (knex, integration) => {
+    const message = `Removing ${integration.name} integration`;
+
+    const existing = await knex('integrations').select('id').where('slug', integration.slug).first();
+
+    if (!existing) {
+        logging.warn(`Skipping ${message}`);
+        return;
+    }
+
+    logging.info(message);
+
+    await knex('api_keys').where('integration_id', existing.id).delete();
+    await knex('integrations').where('id', existing.id).delete();
+};
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        await addInternalIntegrationAndKey(knex, frontendIntegration);
+    },
+    async function down(knex) {
+        await removeInternalIntegrationAndKey(knex, frontendIntegration);
+    }
+);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -627,6 +627,13 @@
                     "description": "Internal Scheduler integration",
                     "type": "internal",
                     "api_keys": [{"type": "admin", "role": "Scheduler Integration"}]
+                },
+                {
+                    "slug": "ghost-internal-frontend",
+                    "name": "Ghost Internal Frontend",
+                    "description": "Internal frontend integration",
+                    "type": "internal",
+                    "api_keys": [{"type": "content"}]
                 }
             ]
         }

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '77b49a87395930231fd47ab54d1e558e';
-    const currentFixturesHash = 'e840343b816a5f9c6b1849c5220bacf8';
+    const currentFixturesHash = 'f4795020369ec3a770b538be8d8b2536';
     const currentSettingsHash = 'ffd899a82b0ad2886e92d8244bcbca6a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
refs: https://github.com/TryGhost/Team/issues/1599

- add an internal integration for Ghost's frontend to talk to the content API
- this is so that portal and future features can access our APIs through the correct mechanism of an API key
