### PR TITLE
Fixed email preview using wrong newsletter

### DIFF
--- a/core/server/services/mega/email-preview.js
+++ b/core/server/services/mega/email-preview.js
@@ -8,7 +8,10 @@ class EmailPreview {
      * @returns {Promise<Object>}
      */
     async generateEmailContent(post, memberSegment) {
-        const newsletter = await models.Newsletter.getDefaultNewsletter();
+        let newsletter = await post.related('newsletter').fetch();
+        if (!newsletter) {
+            newsletter = await models.Newsletter.getDefaultNewsletter();
+        }
 
         let emailContent = await postEmailSerializer.serialize(post, newsletter, {
             isBrowserPreview: true


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1603

When previewing a scheduled/published post via Post editor menu > E-mail newsletter > Preview in browser. The e-mail template from the default newsletter was used instead of the newsletter that was selected when scheduling the post.