### PR TITLE
Dropped `temp_member_analytic_events` table

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-10-08-33-drop-members-analytics-table.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-10-08-33-drop-members-analytics-table.js
@@ -1,0 +1,3 @@
+const {dropTables} = require('../../utils');
+
+module.exports = dropTables(['temp_member_analytic_events']);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -721,17 +721,6 @@ module.exports = {
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true}
     },
-    // @TODO: this experiment can be cleaned up and removed
-    temp_member_analytic_events: {
-        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        event_name: {type: 'string', maxlength: 50, nullable: false},
-        created_at: {type: 'dateTime', nullable: false},
-        member_id: {type: 'string', maxlength: 24, nullable: false},
-        member_status: {type: 'string', maxlength: 50, nullable: false},
-        entry_id: {type: 'string', maxlength: 24, nullable: true},
-        source_url: {type: 'string', maxlength: 2000, nullable: true},
-        metadata: {type: 'string', maxlength: 191, nullable: true}
-    },
     custom_theme_settings: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         theme: {type: 'string', maxlength: 191, nullable: false},

--- a/test/integration/exporter/exporter.test.js
+++ b/test/integration/exporter/exporter.test.js
@@ -46,7 +46,6 @@ describe('Exporter', function () {
                 'members_stripe_customers',
                 'members_stripe_customers_subscriptions',
                 'members_subscribe_events',
-                'temp_member_analytic_events',
                 'migrations',
                 'migrations_lock',
                 'mobiledoc_revisions',

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '48249818d02099371089a8d386abb565';
+    const currentSchemaHash = '77b49a87395930231fd47ab54d1e558e';
     const currentFixturesHash = 'e840343b816a5f9c6b1849c5220bacf8';
     const currentSettingsHash = 'ffd899a82b0ad2886e92d8244bcbca6a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/309

- this table was used an an experiment for member analytics
- as we rethink the strategy, we can take the opportunity to clean the table up