### PR TITLE
Deleted `membersActivity` flag

### DIFF
--- a/core/shared/labs.js
+++ b/core/shared/labs.js
@@ -34,7 +34,6 @@ const BETA_FEATURES = [
 
 const ALPHA_FEATURES = [
     'oauthLogin',
-    'membersActivity',
     'urlCache',
     'beforeAfterCard',
     'tweetGridCard',

--- a/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -873,7 +873,7 @@ Object {
       "key": "labs",
       "type": "object",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "value": "{\\"multipleNewslettersUI\\":true,\\"activitypub\\":true,\\"oauthLogin\\":true,\\"membersActivity\\":true,\\"urlCache\\":true,\\"beforeAfterCard\\":true,\\"tweetGridCard\\":true,\\"dashboardV5\\":true,\\"publishingFlow\\":true,\\"multipleProducts\\":true,\\"tierWelcomePages\\":true,\\"tierName\\":true,\\"selectablePortalLinks\\":true,\\"membersTableStatus\\":true,\\"improvedOnboarding\\":true,\\"multipleNewsletters\\":true,\\"membersActivityFeed\\":true,\\"members\\":true}",
+      "value": "{\\"multipleNewslettersUI\\":true,\\"activitypub\\":true,\\"oauthLogin\\":true,\\"urlCache\\":true,\\"beforeAfterCard\\":true,\\"tweetGridCard\\":true,\\"dashboardV5\\":true,\\"publishingFlow\\":true,\\"multipleProducts\\":true,\\"tierWelcomePages\\":true,\\"tierName\\":true,\\"selectablePortalLinks\\":true,\\"membersTableStatus\\":true,\\"improvedOnboarding\\":true,\\"multipleNewsletters\\":true,\\"membersActivityFeed\\":true,\\"members\\":true}",
     },
     Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -1115,7 +1115,7 @@ exports[`Settings API Can request all settings 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "18324",
+  "content-length": "18299",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/325

- this was used for an alpha proof-of-concept for member activity data
  collection but we're rethinking the strategy so this is the easiest
  way to ensure it can't be enabled when the database table has been deleted