### PR TITLE
Readded notEnoughPermission message in post model

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -21,7 +21,8 @@ const messages = {
     isAlreadyPublished: 'Your post is already published, please reload your page.',
     valueCannotBeBlank: 'Value in {key} cannot be blank.',
     expectedPublishedAtInFuture: 'Date must be at least {cannotScheduleAPostBeforeInMinutes} minutes in the future.',
-    untitled: '(Untitled)'
+    untitled: '(Untitled)',
+    notEnoughPermission: 'You do not have permission to perform this action'
 };
 
 const MOBILEDOC_REVISIONS_COUNT = 10;


### PR DESCRIPTION
no issue

The message was removed somewhere, but the git history seems to be modified so I couldn't find the reference to when and why it was removed (the message seems to be added and removed in the same commit).

It is still used: https://github.com/TryGhost/Ghost/blob/c6b26ba7421da68591d758b10a172908b6b01945/core/server/models/post.js#L1262-L1264

Added in: https://github.com/tryghost/Ghost/commit/e84916747248720a5726b627412f9a8ac5e56935
No reference to where it was removed. But after the same commit above, it wasn't present any longer.