### PR TITLE
Removed `client` and `subscriber` permissions

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-06-08-16-cleanup-client-subscriber-permissions.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-06-08-16-cleanup-client-subscriber-permissions.js
@@ -1,0 +1,68 @@
+const {combineTransactionalMigrations, createRemovePermissionMigration} = require('../../utils');
+
+const ROLES = [
+    'Admin Integration',
+    'Administrator',
+    'Author',
+    'Editor',
+    'Contributor'
+];
+
+const PERMISSIONS = [
+    {
+        name: 'Browse clients',
+        object: 'client',
+        action: 'browse'
+    },
+    {
+        name: 'Read clients',
+        object: 'client',
+        action: 'read'
+    },
+    {
+        name: 'Edit clients',
+        object: 'client',
+        action: 'edit'
+    },
+    {
+        name: 'Add clients',
+        object: 'client',
+        action: 'add'
+    },
+    {
+        name: 'Delete clients',
+        object: 'client',
+        action: 'delete'
+    },
+    {
+        name: 'Browse subscribers',
+        object: 'subscriber',
+        action: 'browse'
+    },
+    {
+        name: 'Read subscribers',
+        object: 'subscriber',
+        action: 'read'
+    },
+    {
+        name: 'Edit subscribers',
+        object: 'subscriber',
+        action: 'edit'
+    },
+    {
+        name: 'Add subscribers',
+        object: 'subscriber',
+        action: 'add'
+    },
+    {
+        name: 'Delete subscribers',
+        object: 'subscriber',
+        action: 'delete'
+    }
+];
+
+module.exports = combineTransactionalMigrations(...PERMISSIONS.map(p => createRemovePermissionMigration(p, ROLES)));
+
+module.exports.down = async function () {
+    // no-op: we don't want to re-add the permissions
+};


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/309

- these stopped being added to the DB in v3 but there was never a
  migration to clean up existing permissions and the role link in the DB
- we now have the utils to do this cleanly, so we can drop all the
  permissions in this migration