### PR TITLE
Regenerated HTML for posts containing a product or video card

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-21-00-00-regenerate-posts-html.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-21-00-00-regenerate-posts-html.js
@@ -1,0 +1,70 @@
+const logging = require('@tryghost/logging');
+const {createIrreversibleMigration} = require('../../utils');
+const mobiledocLib = require('../../../../lib/mobiledoc');
+const htmlToPlaintext = require('../../../../../shared/html-to-plaintext');
+
+module.exports = createIrreversibleMigration(async (knex) => {
+    logging.info(`Starting regeneration of posts HTML`);
+
+    await knex.transaction(async (trx) => {
+        // get list of posts ids, use .forUpdate to lock rows until the transaction is finished
+        const postIdRows = await knex('posts')
+            .transacting(trx)
+            .forUpdate()
+            .select('id')
+            .where('mobiledoc', 'like', '%["video%')
+            .orWhere('mobiledoc', 'like', '%["product%');
+
+        logging.info(`Updating HTML for ${postIdRows.length} posts`);
+
+        // transform each post individually to avoid dumping all posts into memory and
+        // pushing all queries into the query builder buffer in parallel
+        // https://stackoverflow.com/questions/54105280/how-to-loop-through-multi-line-sql-query-and-use-them-in-knex-transactions
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const postIdRow of postIdRows) {
+            const {id} = postIdRow;
+            const [post] = await knex('posts')
+                .transacting(trx)
+                .where({id})
+                .select('mobiledoc', 'html', 'plaintext');
+
+            let mobiledoc;
+
+            try {
+                mobiledoc = JSON.parse(post.mobiledoc || null);
+
+                if (!mobiledoc) {
+                    logging.warn(`No mobiledoc for ${id}. Skipping.`);
+                    continue;
+                }
+            } catch (err) {
+                logging.warn(`Invalid JSON structure for ${id}. Skipping`);
+                continue;
+            }
+
+            const html = mobiledocLib.mobiledocHtmlRenderer.render(mobiledoc);
+
+            const updatedAttrs = {
+                html
+            };
+
+            if (html !== post.html || !post.plaintext) {
+                const plaintext = htmlToPlaintext(html);
+
+                if (plaintext !== post.plaintext) {
+                    updatedAttrs.plaintext = plaintext;
+                }
+            }
+
+            await knex('posts')
+                .transacting(trx)
+                .where({id})
+                .update(updatedAttrs);
+        }
+
+        return 'transaction complete';
+    });
+
+    logging.info('Finished regeneration of posts HTML');
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/309
refs https://github.com/TryGhost/Ghost/issues/14344

- this migration will regenerate the HTML for posts that contain a
  product or video card as we experiencing a bug in the card generation
- this migration is mostly ripped from https://github.com/TryGhost/Ghost/blob/c0d82122b0324f5f4b6bae078174d966b29c92fd/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
