### PR TITLE
Added validation to posts status column

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-10-14-57-cleanup-invalid-posts-status.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-10-14-57-cleanup-invalid-posts-status.js
@@ -1,0 +1,15 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const affectedRows = await knex('posts')
+            .update('status', 'draft')
+            .whereNotIn('status', ['published', 'draft', 'scheduled', 'sent']);
+
+        logging.info(`Updated ${affectedRows} posts with invalid statuses to 'draft'`);
+    },
+    async function down() {
+        // no-op: we don't want to set posts back to invalid statuses
+    }
+);

--- a/core/server/data/migrations/versions/5.0/2022-05-10-14-57-cleanup-invalid-posts-status.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-10-14-57-cleanup-invalid-posts-status.js
@@ -3,6 +3,8 @@ const {createTransactionalMigration} = require('../../utils');
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
+        logging.info(`Updating posts with invalid statuses to 'draft'`);
+
         const affectedRows = await knex('posts')
             .update('status', 'draft')
             .whereNotIn('status', ['published', 'draft', 'scheduled', 'sent']);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -51,8 +51,7 @@ module.exports = {
         feature_image: {type: 'string', maxlength: 2000, nullable: true},
         featured: {type: 'bool', nullable: false, defaultTo: false},
         type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'post', validations: {isIn: [['post', 'page']]}},
-        // @TODO: add isIn validation here to control for all possible status values (published, draft, scheduled, sent)
-        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'draft'},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'draft', validations: {isIn: [['published', 'draft', 'scheduled', 'sent']]}},
         // NOTE: unused at the moment and reserved for future features
         locale: {type: 'string', maxlength: 6, nullable: true},
         visibility: {


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/309

- this commit adds `isIn` validation to the `status` column on the
  `posts` table, with values pulled from the model: https://github.com/TryGhost/Ghost/blob/c0d82122b0324f5f4b6bae078174d966b29c92fd/core/server/models/post.js#L28
- this also adds a migration to update any posts with invalid statuses
  to `draft`