### PR TITLE
Fixed incorrect usage of limit config causing Ghost not to boot

### DIFF
--- a/test/unit/server/services/limits.test.js
+++ b/test/unit/server/services/limits.test.js
@@ -1,0 +1,55 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const rewire = require('rewire');
+
+const limits = rewire('../../../../core/server/services/limits');
+const configUtils = require('../../../utils/configUtils');
+const logging = require('@tryghost/logging');
+
+const errors = require('@tryghost/errors');
+
+describe('Limit Service Init', function () {
+    let loggerStub;
+    let limitServiceStub;
+
+    beforeEach(function () {
+        loggerStub = sinon.spy(logging);
+        limitServiceStub = sinon.stub();
+
+        limits.__set__('limitService.loadLimits', limitServiceStub);
+
+        configUtils.set({
+            hostSettings: {}
+        });
+    });
+
+    afterEach(function () {
+        configUtils.restore();
+        sinon.restore();
+    });
+
+    it('initiates and loads limits - minimal setup', async function () {
+        limitServiceStub.returns(Promise.resolve());
+        await limits.init();
+
+        sinon.assert.notCalled(loggerStub.warn);
+    });
+    it('handles limit-service incorrect usage errors gracefully with a warning', async function () {
+        limitServiceStub.throws(new errors.IncorrectUsageError('Incorrect limits'));
+
+        await limits.init();
+
+        sinon.assert.called(loggerStub.warn);
+    });
+    it('handles limit-service other errors with exit', async function () {
+        const thrownError = new errors.InternalServerError('Something went wrong');
+        limitServiceStub.throws(thrownError);
+
+        try {
+            await limits.init();
+        } catch (error) {
+            sinon.assert.notCalled(loggerStub.warn);
+            assert.deepEqual(error, thrownError);
+        }
+    });
+});


### PR DESCRIPTION
no issue

- When applying an incorrect limits config, or missing expected values, Ghost would not boot as the errors would interrupt this process, which should not happen
- This commit catches the error thrown by the limit-service on boot sequence and transforms it into a warning if it's an `IncorrectUsageError`. Other errors are handled as before
- Added a test for the limit-service service