### PR TITLE
✨ Non-blocking bulk image downloader (API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ projectFilesBackup
 /content/media/**/*
 /content/files/**/*
 /content/public/*
+/content/backups/*
 /content/adapters/storage/**/*
 /content/adapters/scheduling/**/*
 !/content/themes/casper

--- a/config.development.json
+++ b/config.development.json
@@ -1,3 +1,0 @@
-{
-    "enableDeveloperExperiments": true
-}

--- a/content/logs/README.md
+++ b/content/logs/README.md
@@ -1,3 +1,0 @@
-# Content / Logs
-
-This is the default log file location when Ghost runs in Production.

--- a/core/server/api/canary/backups.js
+++ b/core/server/api/canary/backups.js
@@ -1,10 +1,11 @@
+const backupsServices = require('../../services/backups');
+
 module.exports = {
     docName: 'backups',
     download: {
-        statusCode: 200,
         permissions: false,
-        query(frame) {
-            return 
+        query() {
+            return backupsServices.api.exporter();
         }
     }
 };

--- a/core/server/api/canary/backups.js
+++ b/core/server/api/canary/backups.js
@@ -1,4 +1,3 @@
-
 module.exports = {
     docName: 'backups',
     download: {

--- a/core/server/api/canary/backups.js
+++ b/core/server/api/canary/backups.js
@@ -1,11 +1,42 @@
 const backupsServices = require('../../services/backups');
+const models = require('../../models');
+const tpl = require('@tryghost/tpl');
+const errors = require('@tryghost/errors');
+
+const messages = {
+    backupsNotFound: 'No Backups Found',
+};
 
 module.exports = {
     docName: 'backups',
-    download: {
+    downloadBackup: {
         permissions: false,
         query() {
             return backupsServices.api.exporter();
         }
+    },
+    initialize: {
+        permissions: false,
+        query() {
+            return backupsServices.api.initializeImageZipping();
+        }
+    },
+    zippingStatus: {
+        permissions: false,
+        async query() {
+            console.log('status')
+            return models.ImageBackups.query((model)=> {
+                console.log(model);
+                if (!model) {
+                    throw new errors.NotFoundError({
+                        message: tpl(messages.emailNotFound)
+                    });
+                }
+
+                return model;
+
+            // return backupsServices.api.getZippingStatus();
+        });
     }
+}
 };

--- a/core/server/api/canary/backups.js
+++ b/core/server/api/canary/backups.js
@@ -24,19 +24,13 @@ module.exports = {
     zippingStatus: {
         permissions: false,
         async query() {
-            console.log('status')
-            return models.ImageBackups.query((model)=> {
-                console.log(model);
-                if (!model) {
-                    throw new errors.NotFoundError({
-                        message: tpl(messages.emailNotFound)
-                    });
-                }
-
-                return model;
-
-            // return backupsServices.api.getZippingStatus();
-        });
+            const backupInstance = await models.ImageBackups.forge().orderBy('created_at', 'DESC').fetch();
+            if (!backupInstance) {
+                throw new errors.NotFoundError({
+                    message: tpl(messages.backupsNotFound)
+                });
+            }
+            return backupInstance;
+        }
     }
-}
 };

--- a/core/server/api/canary/backups.js
+++ b/core/server/api/canary/backups.js
@@ -1,0 +1,11 @@
+
+module.exports = {
+    docName: 'backups',
+    download: {
+        statusCode: 200,
+        permissions: false,
+        query(frame) {
+            return 
+        }
+    }
+};

--- a/core/server/api/canary/backups.js
+++ b/core/server/api/canary/backups.js
@@ -4,7 +4,7 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 
 const messages = {
-    backupsNotFound: 'No Backups Found',
+    backupsNotFound: 'No Backups Found'
 };
 
 module.exports = {

--- a/core/server/api/canary/index.js
+++ b/core/server/api/canary/index.js
@@ -20,6 +20,10 @@ module.exports = {
         return shared.pipeline(require('./identities'), localUtils);
     },
 
+    get backups() {
+        return shared.pipeline(require('./backups'), localUtils);
+    },
+
     get integrations() {
         return shared.pipeline(require('./integrations'), localUtils);
     },

--- a/core/server/api/canary/utils/serializers/output/backups.js
+++ b/core/server/api/canary/utils/serializers/output/backups.js
@@ -1,0 +1,9 @@
+const debug = require('@tryghost/debug')('api:canary:utils:serializers:output:backups');
+
+module.exports = {
+    all(data, apiConfig, frame) {
+        debug('all');
+
+        frame.response = data;
+    }
+};

--- a/core/server/api/canary/utils/serializers/output/backups.js
+++ b/core/server/api/canary/utils/serializers/output/backups.js
@@ -1,4 +1,4 @@
-const debug = require('@tryghost/debug')('api:canary:utils:serializers:output:backups');
+const debug = require('@tryghost/debug');
 
 module.exports = {
     all(data, apiConfig, frame) {

--- a/core/server/api/canary/utils/serializers/output/backups.js
+++ b/core/server/api/canary/utils/serializers/output/backups.js
@@ -1,9 +1,12 @@
 const debug = require('@tryghost/debug');
 
 module.exports = {
-    all(data, apiConfig, frame) {
-        debug('all');
-
+    downloadBackup(data, apiConfig, frame){
+        debug('downloadBackup');
+        frame.response = data;
+    },
+    initialize(data, apiConfig, frame){
+        debug('initialize');
         frame.response = data;
     }
 };

--- a/core/server/api/canary/utils/serializers/output/index.js
+++ b/core/server/api/canary/utils/serializers/output/index.js
@@ -13,6 +13,10 @@ module.exports = {
         return require('./default');
     },
 
+    get backups() {
+        return require('./backups');
+    },
+
     get authentication() {
         return require('./authentication');
     },

--- a/core/server/data/exporter/table-lists.js
+++ b/core/server/data/exporter/table-lists.js
@@ -4,6 +4,7 @@ const BACKUP_TABLES = [
     'api_keys',
     'brute',
     'emails',
+    'image_backups',
     'integrations',
     'invites',
     'labels',

--- a/core/server/data/migrations/versions/5.0/2022-05-07-16-22-add-image-backup-table.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-07-16-22-add-image-backup-table.js
@@ -1,0 +1,7 @@
+const utils = require('../../utils');
+
+module.exports = utils.addTable('image_backups', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    created_at: {type: 'dateTime', nullable: false},
+    backup_completed: { type: 'bool', nullable: false, defaultTo: false},
+});

--- a/core/server/data/migrations/versions/5.0/2022-05-07-16-22-add-image-backup-table.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-07-16-22-add-image-backup-table.js
@@ -3,5 +3,5 @@ const utils = require('../../utils');
 module.exports = utils.addTable('image_backups',{
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     created_at: {type: 'dateTime', nullable: false},
-    backup_completed: { type: 'bool', nullable: false, defaultTo: false}
+    backup_completed: {type: 'bool', nullable: false, defaultTo: false}
 });

--- a/core/server/data/migrations/versions/5.0/2022-05-07-16-22-add-image-backup-table.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-07-16-22-add-image-backup-table.js
@@ -1,7 +1,7 @@
 const utils = require('../../utils');
 
-module.exports = utils.addTable('image_backups', {
+module.exports = utils.addTable('image_backups',{
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     created_at: {type: 'dateTime', nullable: false},
-    backup_completed: { type: 'bool', nullable: false, defaultTo: false},
+    backup_completed: { type: 'bool', nullable: false, defaultTo: false}
 });

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -763,5 +763,11 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
         newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true}
+    },
+    // Experimental
+    image_backups: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        backup_completed: {type: 'bool', nullable: false, defaultTo: false}
     }
 };

--- a/core/server/models/image-backups.js
+++ b/core/server/models/image-backups.js
@@ -1,0 +1,9 @@
+const ghostBookshelf = require('./base');
+
+const ImageBackups = ghostBookshelf.Model.extend({
+    tableName: 'image_backups'
+});
+
+module.exports = {
+    ImageBackups: ghostBookshelf.model('ImageBackups', ImageBackups)
+};

--- a/core/server/services/backups/BackupsExporter.js
+++ b/core/server/services/backups/BackupsExporter.js
@@ -25,7 +25,8 @@ class BackupsExporter {
 
     serve() {
         const self = this;
-        return function downloadbackups(req, res, next) {
+        return function downloadBackup(req, res, next) {
+            console.log('running dlbk')
             const backupsPath = self.getDirectories().backups;
             const imagesPath = self.getDirectories().images;
             const zipPath = path.join(backupsPath, 'images.zip');

--- a/core/server/services/backups/BackupsExporter.js
+++ b/core/server/services/backups/BackupsExporter.js
@@ -46,7 +46,7 @@ class BackupsExporter {
                 throw err;
             });
     }
-
+    // Initialises the zipping process
     startBackupProcess() {
         const self = this;
         self.getModel().ImageBackupsModel.add({created_at: new Date(), backup_completed: false}).then((entry) => {
@@ -54,7 +54,8 @@ class BackupsExporter {
         });
         return {backupStarted: true};
     }
-        
+    
+    // Serves the zip file to the client
     serve() {
         const self = this;
         return function downloadBackup(req, res, next) {

--- a/core/server/services/backups/BackupsExporter.js
+++ b/core/server/services/backups/BackupsExporter.js
@@ -8,25 +8,20 @@ const fs = require('fs-extra');
  */
 
 class BackupsExporter {
-
-
     getDirectories() {
         return {
             images: config.getContentPath('images'),
             backups: config.getContentPath('backups')
         };
     }
-
     /**
      * 
      * @TODO: Perhaps let it multithread to avoid http timeouts and memory issues on big requests?
      * Maybe add cases later for other types for backups?
      */
-
     serve() {
         const self = this;
         return function downloadBackup(req, res, next) {
-            console.log('running dlbk')
             const backupsPath = self.getDirectories().backups;
             const imagesPath = self.getDirectories().images;
             const zipPath = path.join(backupsPath, 'images.zip');

--- a/core/server/services/backups/BackupsExporter.js
+++ b/core/server/services/backups/BackupsExporter.js
@@ -18,7 +18,7 @@ class BackupsExporter {
     getModel() {
         return {
             ImageBackupsModel: models.ImageBackups
-        }
+        };
     }
     // create backup in a new thread
     async createBackupWorker(id) {
@@ -26,26 +26,25 @@ class BackupsExporter {
         const imagesPath = self.getDirectories().images;
         const backupsPath = self.getDirectories().backups;
         const zipPath = path.join(backupsPath, 'images.zip');
+        const backupInstance = await self.getModel().ImageBackupsModel.findOne({id: id});
 
         fs.ensureDir(backupsPath)
-            .then(async function(){
+            .then(async function () {
                 return await compress(imagesPath, zipPath);
-            }).then(async function(result){
-                if(result.size > 0){
-                   const backupInstance = await self.getModel().ImageBackupsModel.findOne({id: id});
-                    if(backupInstance){
+            }).then(async function (result) {
+                if (result.size > 0){
+                    if (backupInstance){
                         backupInstance.set('backup_completed', true);
                         backupInstance.save();
-                       return
+                        return;
                     }
                 }  
-            }).catch(function(err){
+            }).catch(function (err){
                 //  Just destroying the db instance if an error occured, so it can be retried again. 
                 //  Will find a better way to handle errors.
-                const backupInstance = await self.getModel().ImageBackupsModel.findOne({id: id});
                 backupInstance.destroy();
                 throw err;
-            }
+            });
     }
 
     startBackupProcess() {
@@ -53,7 +52,7 @@ class BackupsExporter {
         self.getModel().ImageBackupsModel.add({created_at: new Date(), backup_completed: false}).then((entry) => {
             self.createBackupWorker(entry.attributes.id);
         });
-        return {'backupStarted': true};
+        return {backupStarted: true};
     }
         
     serve() {
@@ -66,7 +65,7 @@ class BackupsExporter {
                 .then(function () {
                     res.set({
                         'Content-disposition': 'attachment; filename={backups}.zip'.replace('{backups}', 'images'),
-                        'Content-Type': 'application/zip',
+                        'Content-Type': 'application/zip'
                     });
                     stream = fs.createReadStream(zipPath);
                     stream.pipe(res);

--- a/core/server/services/backups/BackupsExporter.js
+++ b/core/server/services/backups/BackupsExporter.js
@@ -1,0 +1,57 @@
+const {compress} = require('@tryghost/zip');
+const path = require('path');
+const config = require('../../../shared/config');
+const fs = require('fs-extra');
+
+/**
+ * Prototype for exporting images in bulk
+ */
+
+class BackupsExporter {
+
+
+    getDirectories() {
+        return {
+            images: config.getContentPath('images'),
+            backups: config.getContentPath('backups')
+        };
+    }
+
+    /**
+     * 
+     * @TODO: Perhaps let it multithread to avoid http timeouts and memory issues on big requests?
+     * Maybe add cases later for other types for backups?
+     */
+
+    serve() {
+        const self = this;
+        return function downloadbackups(req, res, next) {
+            const backupsPath = self.getDirectories().backups;
+            const imagesPath = self.getDirectories().images;
+            const zipPath = path.join(backupsPath, 'images.zip');
+            let stream;
+            fs.ensureDir(backupsPath)
+                .then(async function () {
+                    return await compress(imagesPath, zipPath);
+                })
+                .then(function (result) {
+                    res.set({
+                        'Content-disposition': 'attachment; filename={backups}.zip'.replace('{backups}', 'images'),
+                        'Content-Type': 'application/zip',
+                        'Content-Length': result.size
+                    });
+                    stream = fs.createReadStream(zipPath);
+                    stream.pipe(res);
+                })
+                .catch(function (err) {
+                    next(err);
+                })
+                .finally(function () {
+                    return;
+                });
+        };
+    }
+}
+
+module.exports = BackupsExporter;
+

--- a/core/server/services/backups/BackupsExporter.js
+++ b/core/server/services/backups/BackupsExporter.js
@@ -39,7 +39,13 @@ class BackupsExporter {
                        return
                     }
                 }  
-            })
+            }).catch(function(err){
+                //  Just destroying the db instance if an error occured, so it can be retried again. 
+                //  Will find a better way to handle errors.
+                const backupInstance = await self.getModel().ImageBackupsModel.findOne({id: id});
+                backupInstance.destroy();
+                throw err;
+            }
     }
 
     startBackupProcess() {

--- a/core/server/services/backups/backups.js
+++ b/core/server/services/backups/backups.js
@@ -1,0 +1,14 @@
+const BackupsExporter = require('./BackupsExporter');
+
+let backupsExporter;
+
+const getStorage = () => {
+    backupsExporter = backupsExporter || new BackupsExporter();
+    return backupsExporter;
+};
+
+module.exports = {
+    getZip: async () => {
+        return await getStorage().serve();
+    }
+};

--- a/core/server/services/backups/backups.js
+++ b/core/server/services/backups/backups.js
@@ -10,5 +10,8 @@ const getStorage = () => {
 module.exports = {
     getZip: async () => {
         return await getStorage().serve();
+    },
+    initialize: () => {
+        return getStorage().startBackupProcess();
     }
 };

--- a/core/server/services/backups/index.js
+++ b/core/server/services/backups/index.js
@@ -1,0 +1,10 @@
+const {getZip} = require('./backups');
+
+module.exports = {
+    /**
+     * Methods used in the API
+     */
+    api: {
+        exporter: getZip
+    }
+};

--- a/core/server/services/backups/index.js
+++ b/core/server/services/backups/index.js
@@ -1,10 +1,11 @@
-const {getZip} = require('./backups');
+const {getZip, initialize} = require('./backups');
 
 module.exports = {
     /**
      * Methods used in the API
      */
     api: {
-        exporter: getZip
+        exporter: getZip,
+        initializeImageZipping: initialize
     }
 };

--- a/core/server/services/public-config/config.js
+++ b/core/server/services/public-config/config.js
@@ -5,6 +5,7 @@ const databaseInfo = require('../../data/db/info');
 const ghostVersion = require('@tryghost/version');
 
 module.exports = function getConfigProperties() {
+    console.log(config)
     const configProperties = {
         version: ghostVersion.full,
         environment: config.get('env'),

--- a/core/server/services/public-config/config.js
+++ b/core/server/services/public-config/config.js
@@ -5,7 +5,6 @@ const databaseInfo = require('../../data/db/info');
 const ghostVersion = require('@tryghost/version');
 
 module.exports = function getConfigProperties() {
-    console.log(config)
     const configProperties = {
         version: ghostVersion.full,
         environment: config.get('env'),

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -261,7 +261,10 @@ module.exports = function apiRoutes() {
 
     // ## backups
     // @TODO make images dynamic to allow multiple use cases in future
-    router.get('/backups/images/download', mw.authAdminApi, http(api.backups.download));
+    router.get('/backups/images/download', mw.authAdminApi, http(api.backups.downloadBackup));
+    router.get('/backups/images/init', mw.authAdminApi, http(api.backups.initialize));
+    router.get('/backups/images/status', mw.authAdminApi, http(api.backups.zippingStatus));
+
     
     // ## Invites
     router.get('/invites', mw.authAdminApi, http(api.invites.browse));

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -259,13 +259,12 @@ module.exports = function apiRoutes() {
         http(api.files.upload)
     );
 
-    // ## backups
+    // ## image backups
     // @TODO make images dynamic to allow multiple use cases in future
     router.get('/backups/images/download', mw.authAdminApi, http(api.backups.downloadBackup));
     router.get('/backups/images/init', mw.authAdminApi, http(api.backups.initialize));
     router.get('/backups/images/status', mw.authAdminApi, http(api.backups.zippingStatus));
 
-    
     // ## Invites
     router.get('/invites', mw.authAdminApi, http(api.invites.browse));
     router.get('/invites/:id', mw.authAdminApi, http(api.invites.read));

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -261,6 +261,10 @@ module.exports = function apiRoutes() {
         http(api.files.upload)
     );
 
+    // ## backups
+    // @TODO make images dynamic to allow multiple use cases in futurex
+    router.get('/backups/images/download', mw.authAdminApi, http(api.backups.download));
+    
     // ## Invites
     router.get('/invites', mw.authAdminApi, http(api.invites.browse));
     router.get('/invites/:id', mw.authAdminApi, http(api.invites.read));

--- a/core/server/web/api/canary/admin/routes.js
+++ b/core/server/web/api/canary/admin/routes.js
@@ -262,7 +262,7 @@ module.exports = function apiRoutes() {
     );
 
     // ## backups
-    // @TODO make images dynamic to allow multiple use cases in futurex
+    // @TODO make images dynamic to allow multiple use cases in future
     router.get('/backups/images/download', mw.authAdminApi, http(api.backups.download));
     
     // ## Invites

--- a/core/shared/config/helpers.js
+++ b/core/shared/config/helpers.js
@@ -86,6 +86,8 @@ const getContentPath = function getContentPath(type) {
         return path.join(this.get('paths:contentPath'), 'settings/');
     case 'public':
         return path.join(this.get('paths:contentPath'), 'public/');
+    case 'backups':
+        return path.join(this.get('paths:contentPath'), 'backups/');
     default:
         // new Error is allowed here, as we do not want config to depend on @tryghost/error
         // @TODO: revisit this decision when @tryghost/error is no longer dependent on all of ghost-ignition

--- a/test/integration/exporter/exporter.test.js
+++ b/test/integration/exporter/exporter.test.js
@@ -29,6 +29,7 @@ describe('Exporter', function () {
                 'email_batches',
                 'email_recipients',
                 'emails',
+                'image_backups',
                 'integrations',
                 'invites',
                 'labels',

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'cad4a9890ab928de593e4c682a2cd326';
+    const currentSchemaHash = 'c3067e187bef340d642cfbce9e00d5e8';
     const currentFixturesHash = '4924616fbc51dd0ccef62ae04b4708f9';
     const currentSettingsHash = 'ffd899a82b0ad2886e92d8244bcbca6a';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
👋 Hi!

This is my second PR with the same concept, but an improvement, based on @ErisDS 's feedback https://github.com/TryGhost/Ghost/pull/14659

My curiosity couldn't stop me from not attempting another version of it.

This time, it happens in the background in a non-blocking way. 

How it works:
It's added the very bottom Alpha Features in the Labs settings on Ghost Admin.

User initiates an export by clicking the "Create new export" button.
<img width="1310" alt="Screenshot 2022-05-11 at 08 07 12" src="https://user-images.githubusercontent.com/19263291/167780467-f896fca5-4e20-4df2-8861-fa290fe01a92.png">

It would then trigger the background task and user is asked to check back later.

<img width="1263" alt="Screenshot 2022-05-11 at 08 04 44" src="https://user-images.githubusercontent.com/19263291/167780835-b5952a60-3a1b-4f25-be68-b1777a0469d6.png">

Since it's a background task and non-blocking the user can carry on doing other tasks on the platform, or even close the browser.  It interacts with a new table in the database to track the status. 

Once it's done, the download button will be visible.
<img width="1254" alt="Screenshot 2022-05-11 at 08 04 34" src="https://user-images.githubusercontent.com/19263291/167780974-ab688681-45d2-45ac-8bcf-9e7d752804fa.png">

The images.zip inside the backups folder inside content gets overwritten every time as it's not something where "rollbacks" would be appropriate, so it doesn't make sense to need to have more than one export file stored.

The main goal of this is to compliment the existing JSON exporter, particularly when migrating self-hosted environments and perhaps when creating a custom theme for an existing publication, to be able to easily populate posts / pages with images locally. 

Since the posts/pages reference images directly something like `__GHOST_URL__/content/images/2022/05/2022-05-03-14.54.51.jpg`, the images.zip file just need to be extracted inside the content/images folder.

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)


I tested it locally with about 50gb images from my external hard disk dumped into the content/images folder and it zipped without issues.

Wrote some basic frontend for the prototype, under this PR: https://github.com/TryGhost/Admin/pull/2375