### PR TITLE
Updated theme card asset default setting

### DIFF
--- a/core/frontend/services/theme-engine/config/defaults.json
+++ b/core/frontend/services/theme-engine/config/defaults.json
@@ -1,6 +1,4 @@
 {
     "posts_per_page": 5,
-    "card_assets": {
-        "exclude": ["bookmark", "gallery"]
-    }
+    "card_assets": true
 }

--- a/test/unit/frontend/services/card-assets.test.js
+++ b/test/unit/frontend/services/card-assets.test.js
@@ -113,8 +113,8 @@ describe('Card Asset Service', function () {
             });
 
             cardAssets.generateGlobs().should.eql({
-                'cards.min.css': 'css/!(bookmark|gallery).css',
-                'cards.min.js': 'js/!(bookmark|gallery).js'
+                'cards.min.css': 'css/*.css',
+                'cards.min.js': 'js/*.js'
             });
         });
 

--- a/test/unit/frontend/services/theme-engine/config.test.js
+++ b/test/unit/frontend/services/theme-engine/config.test.js
@@ -13,9 +13,7 @@ describe('Themes', function () {
 
             config.should.eql({
                 posts_per_page: 5,
-                card_assets: {
-                    exclude: ['bookmark', 'gallery']
-                }
+                card_assets: true
             });
         });
 
@@ -24,9 +22,7 @@ describe('Themes', function () {
 
             config.should.eql({
                 posts_per_page: 5,
-                card_assets: {
-                    exclude: ['bookmark', 'gallery']
-                }
+                card_assets: true
             });
         });
 
@@ -44,9 +40,7 @@ describe('Themes', function () {
 
             config.should.eql({
                 posts_per_page: 5,
-                card_assets: {
-                    exclude: ['bookmark', 'gallery']
-                }
+                card_assets: true
             });
         });
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1611

- For Ghost 5.0 card assets will be included by default, including bookmark and gallery cards
