### PR TITLE
Added permissions for Authors to read labels

### DIFF
--- a/core/server/data/migrations/versions/5.0/2022-05-12-13-51-add-label-permissions-for-authors.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-12-13-51-add-label-permissions-for-authors.js
@@ -1,0 +1,12 @@
+const {combineTransactionalMigrations, addPermissionToRole} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionToRole({
+        permission: 'Browse labels',
+        role: 'Author'
+    }),
+    addPermissionToRole({
+        permission: 'Read labels',
+        role: 'Author'
+    })
+);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -737,6 +737,7 @@
                     "email_preview": "read",
                     "email": "read",
                     "snippet": ["browse", "read"],
+                    "label": ["browse", "read"],
                     "product": ["browse", "read"],
                     "newsletter": ["browse", "read"]
                 },

--- a/test/integration/migrations/migration.test.js
+++ b/test/integration/migrations/migration.test.js
@@ -131,8 +131,8 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Add snippets', ['Administrator', 'Editor', 'Admin Integration']);
             permissions.should.havePermission('Delete snippets', ['Administrator', 'Editor', 'Admin Integration']);
 
-            permissions.should.havePermission('Browse labels', ['Administrator', 'Editor', 'Admin Integration']);
-            permissions.should.havePermission('Read labels', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Browse labels', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
+            permissions.should.havePermission('Read labels', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
             permissions.should.havePermission('Edit labels', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Add labels', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Delete labels', ['Administrator', 'Admin Integration']);

--- a/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -201,18 +201,18 @@ describe('Migration Fixture Utils', function () {
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
-                result.should.have.property('expected', 88);
-                result.should.have.property('done', 88);
+                result.should.have.property('expected', 89);
+                result.should.have.property('done', 89);
 
                 // Permissions & Roles
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
-                dataMethodStub.filter.callCount.should.eql(88);
+                dataMethodStub.filter.callCount.should.eql(89);
                 dataMethodStub.find.callCount.should.eql(7);
-                baseUtilAttachStub.callCount.should.eql(88);
+                baseUtilAttachStub.callCount.should.eql(89);
 
-                fromItem.related.callCount.should.eql(88);
-                fromItem.find.callCount.should.eql(88);
+                fromItem.related.callCount.should.eql(89);
+                fromItem.find.callCount.should.eql(89);
 
                 done();
             }).catch(done);

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '2f4266e6e5087ad92dd30f3e721d46e5';
-    const currentFixturesHash = '2219972fb91a30f8d740e05afd3a033c';
+    const currentFixturesHash = '2509ff2c1f6e0293a3c3d84f08593b2f';
     const currentSettingsHash = '53606d11dafcd3f4ab1acb3962122082';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/test/utils/fixtures/fixtures.json
+++ b/test/utils/fixtures/fixtures.json
@@ -910,6 +910,7 @@
                     "email_preview": "read",
                     "email": "read",
                     "snippet": ["browse", "read"],
+                    "label": ["browse", "read"],
                     "product": ["browse", "read"],
                     "newsletter": ["browse", "read"]
                 },


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1618

- Authors require access to labels as part of the publish + send workflow
