### PR TITLE
Excerpt Improvements

### DIFF
--- a/core/server/api/canary/utils/serializers/output/utils/post-gating.js
+++ b/core/server/api/canary/utils/serializers/output/utils/post-gating.js
@@ -15,7 +15,7 @@ const forPost = (attrs, frame) => {
 
         if (paywallIndex !== -1) {
             attrs.html = attrs.html.slice(0, paywallIndex);
-            attrs.plaintext = htmlToPlaintext(attrs.html);
+            attrs.plaintext = htmlToPlaintext.excerpt(attrs.html);
 
             if (!attrs.custom_excerpt && attrs.excerpt) {
                 attrs.excerpt = attrs.plaintext.substring(0, 500);

--- a/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
+++ b/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
@@ -1,7 +1,7 @@
 const logging = require('@tryghost/logging');
 const {createIrreversibleMigration} = require('../../utils');
 const mobiledocLib = require('../../../../lib/mobiledoc');
-const htmlToText = require('html-to-text');
+const htmlToPlaintext = require('../../../../../shared/html-to-plaintext');
 
 module.exports = createIrreversibleMigration(async (knex) => {
     logging.info('Starting re-generation of posts html.');
@@ -45,17 +45,8 @@ module.exports = createIrreversibleMigration(async (knex) => {
                 html: html
             };
 
-            // NOTE: block comes straight from the Post model
-            // https://github.com/TryGhost/Ghost/blob/4.0.0-alpha.2/core/server/models/post.js#L484
             if (html !== post.html || !post.plaintext) {
-                const plaintext = htmlToText.fromString(html, {
-                    wordwrap: 80,
-                    ignoreImage: true,
-                    hideLinkHrefIfSameAsText: true,
-                    preserveNewlines: true,
-                    returnDomByDefault: true,
-                    uppercaseHeadings: false
-                });
+                const plaintext = htmlToPlaintext(html);
 
                 if (plaintext !== post.plaintext) {
                     updatedAttrs.plaintext = plaintext;

--- a/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
+++ b/core/server/data/migrations/versions/4.0/23-regenerate-posts-html.js
@@ -46,7 +46,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
             };
 
             if (html !== post.html || !post.plaintext) {
-                const plaintext = htmlToPlaintext(html);
+                const plaintext = htmlToPlaintext.excerpt(html);
 
                 if (plaintext !== post.plaintext) {
                     updatedAttrs.plaintext = plaintext;

--- a/core/server/data/migrations/versions/4.9/05-fix-missed-mobiledoc-url-transforms.js
+++ b/core/server/data/migrations/versions/4.9/05-fix-missed-mobiledoc-url-transforms.js
@@ -65,7 +65,7 @@ module.exports = createTransactionalMigration(
                     continue;
                 }
 
-                const plaintext = htmlToPlaintext(html);
+                const plaintext = htmlToPlaintext.excerpt(html);
 
                 await knex('posts')
                     .transacting(trx)

--- a/core/server/data/migrations/versions/5.0/2022-05-21-00-00-regenerate-posts-html.js
+++ b/core/server/data/migrations/versions/5.0/2022-05-21-00-00-regenerate-posts-html.js
@@ -50,7 +50,7 @@ module.exports = createIrreversibleMigration(async (knex) => {
             };
 
             if (html !== post.html || !post.plaintext) {
-                const plaintext = htmlToPlaintext(html);
+                const plaintext = htmlToPlaintext.excerpt(html);
 
                 if (plaintext !== post.plaintext) {
                     updatedAttrs.plaintext = plaintext;

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -639,7 +639,7 @@ Post = ghostBookshelf.Model.extend({
             if (this.get('html') === null) {
                 plaintext = null;
             } else {
-                plaintext = htmlToPlaintext(this.get('html'));
+                plaintext = htmlToPlaintext.excerpt(this.get('html'));
             }
 
             // CASE: html is e.g. <p></p>

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -7,7 +7,7 @@ const api = require('../../api').endpoints;
 const apiShared = require('../../api').shared;
 const {URL} = require('url');
 const mobiledocLib = require('../../lib/mobiledoc');
-const htmlToText = require('html-to-text');
+const htmlToPlaintext = require('../../../shared/html-to-plaintext');
 const {isUnsplashImage, isLocalContentImage} = require('@tryghost/kg-default-cards/lib/utils');
 const {textColorForBackgroundColor, darkenToContrastThreshold} = require('@tryghost/color-utils');
 const logging = require('@tryghost/logging');
@@ -46,20 +46,6 @@ const getSite = () => {
     return Object.assign({}, publicSettings, {
         url: urlUtils.urlFor('home', true),
         iconUrl: publicSettings.icon ? urlUtils.urlFor('image', {image: publicSettings.icon}, true) : null
-    });
-};
-
-const htmlToPlaintext = (html) => {
-    // same options as used in Post model for generating plaintext but without `wordwrap: 80`
-    // to avoid replacement strings being split across lines and for mail clients to handle
-    // word wrapping based on user preferences
-    return htmlToText.fromString(html, {
-        wordwrap: false,
-        ignoreImage: true,
-        hideLinkHrefIfSameAsText: true,
-        preserveNewlines: true,
-        returnDomByDefault: true,
-        uppercaseHeadings: false
     });
 };
 

--- a/core/server/services/mega/post-email-serializer.js
+++ b/core/server/services/mega/post-email-serializer.js
@@ -248,7 +248,7 @@ const serialize = async (postModel, newsletter, options = {isBrowserPreview: fal
     `).remove();
     post.html = _cheerio('body').html();
 
-    post.plaintext = htmlToPlaintext(post.html);
+    post.plaintext = htmlToPlaintext.email(post.html);
 
     // Outlook will render feature images at full-size breaking the layout.
     // Content images fix this by rendering max 600px images - do the same for feature image here
@@ -321,7 +321,7 @@ function renderEmailForSegment(email, memberSegment) {
     });
 
     result.html = formatHtmlForEmail($.html());
-    result.plaintext = htmlToPlaintext(result.html);
+    result.plaintext = htmlToPlaintext.email(result.html);
 
     return result;
 }

--- a/core/shared/html-to-plaintext.js
+++ b/core/shared/html-to-plaintext.js
@@ -1,12 +1,28 @@
 module.exports = function htmlToPlaintext(html) {
-    const htmlToText = require('html-to-text');
+    const {convert} = require('html-to-text');
 
-    return htmlToText.fromString(html, {
+    return convert(html, {
         wordwrap: false,
-        ignoreImage: true,
-        hideLinkHrefIfSameAsText: true,
         preserveNewlines: true,
-        returnDomByDefault: true,
-        uppercaseHeadings: false
+
+        // equiv returnDomByDefault: true,
+        baseElements: {returnDomByDefault: true},
+        selectors: [
+            // Ignore images, equiv ignoreImage: true
+            {selector: 'img', format: 'skip'} ,
+            // disable uppercase headings, equiv uppercaseHeadings: false
+            {selector: 'h1', options: {uppercase: false}},
+            {selector: 'h2', options: {uppercase: false}},
+            {selector: 'h3', options: {uppercase: false}},
+            {selector: 'h4', options: {uppercase: false}},
+            {selector: 'h5', options: {uppercase: false}},
+            {selector: 'h6', options: {uppercase: false}},
+            {selector: 'table', options: {uppercaseHeaderCells: false}},
+            // equiv hideLinkHrefIfSameAsText: true
+            {selector: 'a', options: {hideLinkHrefIfSameAsText: true}},
+
+            // Backwards compatibility with html-to-text 5.1.1
+            {selector: 'div', format: 'inline'}
+        ]
     });
 };

--- a/core/shared/html-to-plaintext.js
+++ b/core/shared/html-to-plaintext.js
@@ -1,3 +1,13 @@
+const _ = require('lodash');
+
+const mergeSettings = (extraSettings) => {
+    return _.mergeWith({}, baseSettings, extraSettings, function customizer(objValue, srcValue) {
+        if (_.isArray(objValue)) {
+            return objValue.concat(srcValue);
+        }
+    });
+};
+
 const baseSettings = {
     wordwrap: false,
     preserveNewlines: true,
@@ -17,9 +27,6 @@ const baseSettings = {
         {selector: 'h6', options: {uppercase: false}},
         {selector: 'table', options: {uppercaseHeaderCells: false}},
 
-        // equiv hideLinkHrefIfSameAsText: true
-        {selector: 'a', options: {hideLinkHrefIfSameAsText: true}},
-
         // Backwards compatibility with html-to-text 5.1.1
         {selector: 'div', format: 'inline'}
     ]
@@ -35,8 +42,22 @@ const loadConverters = () => {
 
     const {compile} = require('html-to-text');
 
-    excerptConverter = compile(baseSettings);
-    emailConverter = compile(baseSettings);
+    const excerptSettings = mergeSettings({
+        selectors: [
+            {selector: 'a', options: {ignoreHref: true}},
+            {selector: 'figcaption', format: 'skip'}
+        ]
+    });
+
+    const emailSettings = mergeSettings({
+        selectors: [
+            // equiv hideLinkHrefIfSameAsText: true
+            {selector: 'a', options: {hideLinkHrefIfSameAsText: true}}
+        ]
+    });
+
+    excerptConverter = compile(excerptSettings);
+    emailConverter = compile(emailSettings);
 };
 
 module.exports.excerpt = (html) => {

--- a/core/shared/html-to-plaintext.js
+++ b/core/shared/html-to-plaintext.js
@@ -1,28 +1,52 @@
-module.exports = function htmlToPlaintext(html) {
-    const {convert} = require('html-to-text');
+const baseSettings = {
+    wordwrap: false,
+    preserveNewlines: true,
 
-    return convert(html, {
-        wordwrap: false,
-        preserveNewlines: true,
+    // equiv returnDomByDefault: true,
+    baseElements: {returnDomByDefault: true},
+    selectors: [
+        // Ignore images, equiv ignoreImage: true
+        {selector: 'img', format: 'skip'},
 
-        // equiv returnDomByDefault: true,
-        baseElements: {returnDomByDefault: true},
-        selectors: [
-            // Ignore images, equiv ignoreImage: true
-            {selector: 'img', format: 'skip'} ,
-            // disable uppercase headings, equiv uppercaseHeadings: false
-            {selector: 'h1', options: {uppercase: false}},
-            {selector: 'h2', options: {uppercase: false}},
-            {selector: 'h3', options: {uppercase: false}},
-            {selector: 'h4', options: {uppercase: false}},
-            {selector: 'h5', options: {uppercase: false}},
-            {selector: 'h6', options: {uppercase: false}},
-            {selector: 'table', options: {uppercaseHeaderCells: false}},
-            // equiv hideLinkHrefIfSameAsText: true
-            {selector: 'a', options: {hideLinkHrefIfSameAsText: true}},
+        // disable uppercase headings, equiv uppercaseHeadings: false
+        {selector: 'h1', options: {uppercase: false}},
+        {selector: 'h2', options: {uppercase: false}},
+        {selector: 'h3', options: {uppercase: false}},
+        {selector: 'h4', options: {uppercase: false}},
+        {selector: 'h5', options: {uppercase: false}},
+        {selector: 'h6', options: {uppercase: false}},
+        {selector: 'table', options: {uppercaseHeaderCells: false}},
 
-            // Backwards compatibility with html-to-text 5.1.1
-            {selector: 'div', format: 'inline'}
-        ]
-    });
+        // equiv hideLinkHrefIfSameAsText: true
+        {selector: 'a', options: {hideLinkHrefIfSameAsText: true}},
+
+        // Backwards compatibility with html-to-text 5.1.1
+        {selector: 'div', format: 'inline'}
+    ]
+};
+
+let excerptConverter;
+let emailConverter;
+
+const loadConverters = () => {
+    if (excerptConverter && emailConverter) {
+        return;
+    }
+
+    const {compile} = require('html-to-text');
+
+    excerptConverter = compile(baseSettings);
+    emailConverter = compile(baseSettings);
+};
+
+module.exports.excerpt = (html) => {
+    loadConverters();
+
+    return excerptConverter(html);
+};
+
+module.exports.email = (html) => {
+    loadConverters();
+
+    return emailConverter(html);
 };

--- a/core/shared/html-to-plaintext.js
+++ b/core/shared/html-to-plaintext.js
@@ -2,7 +2,7 @@ module.exports = function htmlToPlaintext(html) {
     const htmlToText = require('html-to-text');
 
     return htmlToText.fromString(html, {
-        wordwrap: 80,
+        wordwrap: false,
         ignoreImage: true,
         hideLinkHrefIfSameAsText: true,
         preserveNewlines: true,

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "glob": "8.0.1",
     "got": "9.6.0",
     "gscan": "4.27.0",
-    "html-to-text": "5.1.1",
+    "html-to-text": "8.2.0",
     "image-size": "1.0.1",
     "intl": "1.2.5",
     "intl-messageformat": "5.4.3",

--- a/test/e2e-api/content/__snapshots__/pages.test.js.snap
+++ b/test/e2e-api/content/__snapshots__/pages.test.js.snap
@@ -77,16 +77,11 @@ Object {
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "custom_excerpt": null,
       "custom_template": null,
-      "excerpt": "Unlike posts, pages in Ghost don't appear in the main feed. They're separate,
-individual pages which only show up when you link to them. Great for content
-which is important, but separate from your usual posts.
+      "excerpt": "Unlike posts, pages in Ghost don't appear in the main feed. They're separate, individual pages which only show up when you link to them. Great for content which is important, but separate from your usual posts.
 
-An about page is a great example of one you might want to set up early on so
-people can find out more about you, and what you do. Why should people subscribe
-to your site and become a member? Details help!
+An about page is a great example of one you might want to set up early on so people can find out more about you, and what you do. Why should people subscribe to your site and become a member? Details help!
 
-> Tip: If you're reading any post or page on your site and you notice something
-y",
+> Tip: If you're reading any post or page on your site and you notice something y",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -121,17 +116,14 @@ y",
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "custom_excerpt": null,
       "custom_template": null,
-      "excerpt": "If you want to set up a contact page for people to be able to reach out to you,
-the simplest way is to set up a simple page like this and list the different
-ways people can reach out to you.
+      "excerpt": "If you want to set up a contact page for people to be able to reach out to you, the simplest way is to set up a simple page like this and list the different ways people can reach out to you.
 
 For example, here's how to reach us!
  * @Ghost [https://twitter.com/ghost] on Twitter
  * @Ghost [https://www.facebook.com/ghost] on Facebook
  * @Ghost [https://instagram.com/ghost] on Instagram
 
-If you prefer to use a contact form, almost all of the great embedded form
-services work great with Ghost and are",
+If you prefer to use a contact form, almost all of the great embedded form services work great with Ghost and are",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -166,13 +158,9 @@ services work great with Ghost and are",
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "custom_excerpt": null,
       "custom_template": null,
-      "excerpt": "Oh hey, you clicked every link of our starter content and even clicked this
-small link in the footer! If you like Ghost and you're enjoying the product so
-far, we'd hugely appreciate your support in any way you care to show it.
+      "excerpt": "Oh hey, you clicked every link of our starter content and even clicked this small link in the footer! If you like Ghost and you're enjoying the product so far, we'd hugely appreciate your support in any way you care to show it.
 
-Ghost is a non-profit organization, and we give away all our intellectual
-property as open source software. If you believe in what we do, there are a
-number of ways you can give us a hand, and we hugely appreciate all of them:
+Ghost is a non-profit organization, and we give away all our intellectual property as open source software. If you believe in what we do, there are a number of ways you can give us a hand, and we hugely appreciate all of them:
 
  * Contribute code via GitHub [https://gith",
       "feature_image": null,
@@ -209,12 +197,9 @@ number of ways you can give us a hand, and we hugely appreciate all of them:
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "custom_excerpt": null,
       "custom_template": null,
-      "excerpt": "Wondering how Ghost fares when it comes to privacy and GDPR rules? Good news:
-Ghost does not use any tracking cookies of any kind.
+      "excerpt": "Wondering how Ghost fares when it comes to privacy and GDPR rules? Good news: Ghost does not use any tracking cookies of any kind.
 
-You can integrate any products, services, ads or integrations with Ghost
-yourself if you want to, but it's always a good idea to disclose how subscriber
-data will be used by putting together a privacy page.",
+You can integrate any products, services, ads or integrations with Ghost yourself if you want to, but it's always a good idea to disclose how subscriber data will be used by putting together a privacy page.",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -284,7 +269,7 @@ exports[`Pages Content API Can request pages 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9207",
+  "content-length": "9192",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/test/e2e-api/content/__snapshots__/pages.test.js.snap
+++ b/test/e2e-api/content/__snapshots__/pages.test.js.snap
@@ -122,11 +122,11 @@ An about page is a great example of one you might want to set up early on so peo
 
 For example, here's how to reach us!
 
- * @Ghost [https://twitter.com/ghost] on Twitter
- * @Ghost [https://www.facebook.com/ghost] on Facebook
- * @Ghost [https://instagram.com/ghost] on Instagram
+ * @Ghost on Twitter
+ * @Ghost on Facebook
+ * @Ghost on Instagram
 
-If you prefer to use a contact form, almost all of the great embedded form services work great with Ghost and a",
+If you prefer to use a contact form, almost all of the great embedded form services work great with Ghost and are easy to set up:",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -165,7 +165,8 @@ If you prefer to use a contact form, almost all of the great embedded form servi
 
 Ghost is a non-profit organization, and we give away all our intellectual property as open source software. If you believe in what we do, there are a number of ways you can give us a hand, and we hugely appreciate all of them:
 
- * Contribute code via GitHub [https://gith",
+ * Contribute code via GitHub
+ * Contribute",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -273,7 +274,7 @@ exports[`Pages Content API Can request pages 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9196",
+  "content-length": "9124",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/test/e2e-api/content/__snapshots__/pages.test.js.snap
+++ b/test/e2e-api/content/__snapshots__/pages.test.js.snap
@@ -13,6 +13,7 @@ Object {
       "custom_excerpt": null,
       "custom_template": null,
       "excerpt": "Static page test is what this is for.
+
 Hopefully you don't find it a bore.",
       "feature_image": null,
       "feature_image_alt": null,
@@ -47,7 +48,7 @@ exports[`Pages Content API Can request page 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1076",
+  "content-length": "1078",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -118,12 +119,14 @@ An about page is a great example of one you might want to set up early on so peo
       "custom_template": null,
       "excerpt": "If you want to set up a contact page for people to be able to reach out to you, the simplest way is to set up a simple page like this and list the different ways people can reach out to you.
 
+
 For example, here's how to reach us!
+
  * @Ghost [https://twitter.com/ghost] on Twitter
  * @Ghost [https://www.facebook.com/ghost] on Facebook
  * @Ghost [https://instagram.com/ghost] on Instagram
 
-If you prefer to use a contact form, almost all of the great embedded form services work great with Ghost and are",
+If you prefer to use a contact form, almost all of the great embedded form services work great with Ghost and a",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -235,6 +238,7 @@ You can integrate any products, services, ads or integrations with Ghost yoursel
       "custom_excerpt": null,
       "custom_template": null,
       "excerpt": "Static page test is what this is for.
+
 Hopefully you don't find it a bore.",
       "feature_image": null,
       "feature_image_alt": null,
@@ -269,7 +273,7 @@ exports[`Pages Content API Can request pages 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9192",
+  "content-length": "9196",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/test/e2e-api/content/__snapshots__/posts.test.js.snap
+++ b/test/e2e-api/content/__snapshots__/posts.test.js.snap
@@ -270,11 +270,11 @@ Object {
  * Praesent
  * Pellentesque
 
-
-
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
-1234abcdefghijklDefinition listConsectetur ad",
+1234abcdefghijkl
+
+Definition listConsectetur ad",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -653,7 +653,9 @@ Using subscriptions, you can build an independent media business like Stratecher
 
 The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
 
-[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
+https://thebrowser.comThe Browser has over 10,000 paying subscribers
+
+Most successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "primary_author": Object {
         "bio": "You can delete this user to remove all the welcome posts",
         "cover_image": null,
@@ -847,11 +849,15 @@ The creator economy is just getting started, and Ghost allows you to build somet
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "testing
+
+
 mctesters
+
 
  * test
  * line
- * items",
+ * items
+",
       "feature_image": "http://placekitten.com/500/200",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -927,7 +933,8 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -1043,7 +1050,7 @@ exports[`Posts Content API Can filter posts by authors 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "55235",
+  "content-length": "55246",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1082,11 +1089,11 @@ Object {
  * Praesent
  * Pellentesque
 
-
-
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
-1234abcdefghijklDefinition listConsectetur ad",
+1234abcdefghijkl
+
+Definition listConsectetur ad",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -1125,11 +1132,15 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "testing
+
+
 mctesters
+
 
  * test
  * line
- * items",
+ * items
+",
       "feature_image": "http://placekitten.com/500/200",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -1217,7 +1228,8 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -1416,7 +1428,7 @@ exports[`Posts Content API Can filter posts by tag 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "14028",
+  "content-length": "14037",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1784,7 +1796,9 @@ Using subscriptions, you can build an independent media business like Stratecher
 
 The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
 
-[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
+https://thebrowser.comThe Browser has over 10,000 paying subscribers
+
+Most successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "primary_author": Object {
         "bio": "You can delete this user to remove all the welcome posts",
         "cover_image": null,
@@ -2002,11 +2016,11 @@ The creator economy is just getting started, and Ghost allows you to build somet
  * Praesent
  * Pellentesque
 
-
-
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
-1234abcdefghijklDefinition listConsectetur ad",
+1234abcdefghijkl
+
+Definition listConsectetur ad",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2061,11 +2075,15 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "testing
+
+
 mctesters
+
 
  * test
  * line
- * items",
+ * items
+",
       "feature_image": "http://placekitten.com/500/200",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2147,7 +2165,8 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2291,7 +2310,7 @@ exports[`Posts Content API Can include relations 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "65564",
+  "content-length": "65575",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2623,7 +2642,9 @@ Using subscriptions, you can build an independent media business like Stratecher
 
 The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
 
-[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
+https://thebrowser.comThe Browser has over 10,000 paying subscribers
+
+Most successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "reading_time": 1,
       "slug": "sell",
@@ -2727,11 +2748,11 @@ The creator economy is just getting started, and Ghost allows you to build somet
  * Praesent
  * Pellentesque
 
-
-
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
-1234abcdefghijklDefinition listConsectetur ad",
+1234abcdefghijkl
+
+Definition listConsectetur ad",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2768,11 +2789,15 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "testing
+
+
 mctesters
+
 
  * test
  * line
- * items",
+ * items
+",
       "feature_image": "http://placekitten.com/500/200",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2816,7 +2841,8 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2885,7 +2911,7 @@ exports[`Posts Content API Can request posts 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "46683",
+  "content-length": "46694",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -3100,7 +3126,9 @@ Using subscriptions, you can build an independent media business like Stratecher
 
 The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
 
-[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
+https://thebrowser.comThe Browser has over 10,000 paying subscribers
+
+Most successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "reading_time": 1,
       "slug": "sell",
@@ -3204,11 +3232,11 @@ The creator economy is just getting started, and Ghost allows you to build somet
  * Praesent
  * Pellentesque
 
-
-
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
-1234abcdefghijklDefinition listConsectetur ad",
+1234abcdefghijkl
+
+Definition listConsectetur ad",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -3245,11 +3273,15 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "testing
+
+
 mctesters
+
 
  * test
  * line
- * items",
+ * items
+",
       "feature_image": "http://placekitten.com/500/200",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -3293,7 +3325,8 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum o",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -3362,7 +3395,7 @@ exports[`Posts Content API Can request posts from different origin 2: [headers] 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "46683",
+  "content-length": "46694",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/test/e2e-api/content/__snapshots__/posts.test.js.snap
+++ b/test/e2e-api/content/__snapshots__/posts.test.js.snap
@@ -264,9 +264,9 @@ Object {
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": " * Lorem
- * Aliquam [http://127.0.0.1:2369/about#nowhere]
- * Tortor [//somewhere.com/link#nowhere]
- * Morbi [http://somewhere.com/link#nowhere]
+ * Aliquam
+ * Tortor
+ * Morbi
  * Praesent
  * Pellentesque
 
@@ -274,7 +274,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 
 1234abcdefghijkl
 
-Definition listConsectetur ad",
+Definition listConsectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim venia",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -628,9 +628,11 @@ Definition listConsectetur ad",
       "email_subject": null,
       "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
-Ghost takes 0% payment fees, so everything you make is yours to ",
+Ghost takes 0% payment fees, so everything you make is yours to keep!
+
+Using subscrip",
       "feature_image": "https://static.ghost.org/v4.0.0/images/organizing-your-content.png",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -645,15 +647,13 @@ Ghost takes 0% payment fees, so everything you make is yours to ",
       "og_title": null,
       "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to keep!
 
-Using subscriptions, you can build an independent media business like Stratechery [https://stratechery.com], The Information [https://www.theinformation.com], or The Browser [https://thebrowser.com].
+Using subscriptions, you can build an independent media business like Stratechery, The Information, or The Browser.
 
 The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
-
-https://thebrowser.comThe Browser has over 10,000 paying subscribers
 
 Most successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "primary_author": Object {
@@ -1050,7 +1050,7 @@ exports[`Posts Content API Can filter posts by authors 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "55246",
+  "content-length": "55071",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1083,9 +1083,9 @@ Object {
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": " * Lorem
- * Aliquam [http://127.0.0.1:2369/about#nowhere]
- * Tortor [//somewhere.com/link#nowhere]
- * Morbi [http://somewhere.com/link#nowhere]
+ * Aliquam
+ * Tortor
+ * Morbi
  * Praesent
  * Pellentesque
 
@@ -1093,7 +1093,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 
 1234abcdefghijkl
 
-Definition listConsectetur ad",
+Definition listConsectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim venia",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -1771,9 +1771,11 @@ Object {
       "email_subject": null,
       "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
-Ghost takes 0% payment fees, so everything you make is yours to ",
+Ghost takes 0% payment fees, so everything you make is yours to keep!
+
+Using subscrip",
       "feature_image": "https://static.ghost.org/v4.0.0/images/organizing-your-content.png",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -1788,15 +1790,13 @@ Ghost takes 0% payment fees, so everything you make is yours to ",
       "og_title": null,
       "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to keep!
 
-Using subscriptions, you can build an independent media business like Stratechery [https://stratechery.com], The Information [https://www.theinformation.com], or The Browser [https://thebrowser.com].
+Using subscriptions, you can build an independent media business like Stratechery, The Information, or The Browser.
 
 The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
-
-https://thebrowser.comThe Browser has over 10,000 paying subscribers
 
 Most successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "primary_author": Object {
@@ -2010,9 +2010,9 @@ Most successful subscription businesses publish a mix of free and paid posts to 
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": " * Lorem
- * Aliquam [http://127.0.0.1:2369/about#nowhere]
- * Tortor [//somewhere.com/link#nowhere]
- * Morbi [http://somewhere.com/link#nowhere]
+ * Aliquam
+ * Tortor
+ * Morbi
  * Praesent
  * Pellentesque
 
@@ -2020,7 +2020,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 
 1234abcdefghijkl
 
-Definition listConsectetur ad",
+Definition listConsectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim venia",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2310,7 +2310,7 @@ exports[`Posts Content API Can include relations 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "65575",
+  "content-length": "65400",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2617,9 +2617,11 @@ Object {
       "email_subject": null,
       "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
-Ghost takes 0% payment fees, so everything you make is yours to ",
+Ghost takes 0% payment fees, so everything you make is yours to keep!
+
+Using subscrip",
       "feature_image": "https://static.ghost.org/v4.0.0/images/organizing-your-content.png",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2634,15 +2636,13 @@ Ghost takes 0% payment fees, so everything you make is yours to ",
       "og_title": null,
       "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to keep!
 
-Using subscriptions, you can build an independent media business like Stratechery [https://stratechery.com], The Information [https://www.theinformation.com], or The Browser [https://thebrowser.com].
+Using subscriptions, you can build an independent media business like Stratechery, The Information, or The Browser.
 
 The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
-
-https://thebrowser.comThe Browser has over 10,000 paying subscribers
 
 Most successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
@@ -2742,9 +2742,9 @@ Most successful subscription businesses publish a mix of free and paid posts to 
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": " * Lorem
- * Aliquam [http://127.0.0.1:2369/about#nowhere]
- * Tortor [//somewhere.com/link#nowhere]
- * Morbi [http://somewhere.com/link#nowhere]
+ * Aliquam
+ * Tortor
+ * Morbi
  * Praesent
  * Pellentesque
 
@@ -2752,7 +2752,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 
 1234abcdefghijkl
 
-Definition listConsectetur ad",
+Definition listConsectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim venia",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2911,7 +2911,7 @@ exports[`Posts Content API Can request posts 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "46694",
+  "content-length": "46519",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -3101,9 +3101,11 @@ Object {
       "email_subject": null,
       "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
-Ghost takes 0% payment fees, so everything you make is yours to ",
+Ghost takes 0% payment fees, so everything you make is yours to keep!
+
+Using subscrip",
       "feature_image": "https://static.ghost.org/v4.0.0/images/organizing-your-content.png",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -3118,15 +3120,13 @@ Ghost takes 0% payment fees, so everything you make is yours to ",
       "og_title": null,
       "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to keep!
 
-Using subscriptions, you can build an independent media business like Stratechery [https://stratechery.com], The Information [https://www.theinformation.com], or The Browser [https://thebrowser.com].
+Using subscriptions, you can build an independent media business like Stratechery, The Information, or The Browser.
 
 The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
-
-https://thebrowser.comThe Browser has over 10,000 paying subscribers
 
 Most successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
@@ -3226,9 +3226,9 @@ Most successful subscription businesses publish a mix of free and paid posts to 
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": " * Lorem
- * Aliquam [http://127.0.0.1:2369/about#nowhere]
- * Tortor [//somewhere.com/link#nowhere]
- * Morbi [http://somewhere.com/link#nowhere]
+ * Aliquam
+ * Tortor
+ * Morbi
  * Praesent
  * Pellentesque
 
@@ -3236,7 +3236,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 
 1234abcdefghijkl
 
-Definition listConsectetur ad",
+Definition listConsectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim venia",
       "feature_image": null,
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -3395,7 +3395,7 @@ exports[`Posts Content API Can request posts from different origin 2: [headers] 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "46694",
+  "content-length": "46519",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/test/e2e-api/content/__snapshots__/posts.test.js.snap
+++ b/test/e2e-api/content/__snapshots__/posts.test.js.snap
@@ -272,10 +272,7 @@ Object {
 
 
 
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
 1234abcdefghijklDefinition listConsectetur ad",
       "feature_image": null,
@@ -629,13 +626,9 @@ mi vitae est. Mauris placerat eleifend leo.
       "custom_template": null,
       "email_recipient_filter": "none",
       "email_subject": null,
-      "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable
-recurring revenue stream from their creative work, Ghost has built-in payments
-allowing you to create a subscription commerce business.
+      "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to
-quickly and easily create monthly and yearly premium plans for members to
-subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to ",
       "feature_image": "https://static.ghost.org/v4.0.0/images/organizing-your-content.png",
@@ -650,29 +643,17 @@ Ghost takes 0% payment fees, so everything you make is yours to ",
       "og_description": null,
       "og_image": null,
       "og_title": null,
-      "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable
-recurring revenue stream from their creative work, Ghost has built-in payments
-allowing you to create a subscription commerce business.
+      "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to
-quickly and easily create monthly and yearly premium plans for members to
-subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to keep!
 
-Using subscriptions, you can build an independent media business like 
-Stratechery [https://stratechery.com], The Information
-[https://www.theinformation.com], or The Browser [https://thebrowser.com].
+Using subscriptions, you can build an independent media business like Stratechery [https://stratechery.com], The Information [https://www.theinformation.com], or The Browser [https://thebrowser.com].
 
-The creator economy is just getting started, and Ghost allows you to build
-something based on technology that you own and control.
+The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
 
-[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost
-successful subscription businesses publish a mix of free and paid posts to
-attract a new audience, and upsell the most loyal members to a premium offering.
-You can also mix different access levels within the same post, showing a free
-preview to logged out members and then, right when you're ready for a
-cliffhanger, that's a good time to...",
+[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "primary_author": Object {
         "bio": "You can delete this user to remove all the welcome posts",
         "cover_image": null,
@@ -946,13 +927,7 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
-ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros
-ipsum rutrum or",
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -1068,7 +1043,7 @@ exports[`Posts Content API Can filter posts by authors 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "55261",
+  "content-length": "55235",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1109,10 +1084,7 @@ Object {
 
 
 
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
 1234abcdefghijklDefinition listConsectetur ad",
       "feature_image": null,
@@ -1245,13 +1217,7 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
-ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros
-ipsum rutrum or",
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -1450,7 +1416,7 @@ exports[`Posts Content API Can filter posts by tag 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "14037",
+  "content-length": "14028",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -1791,13 +1757,9 @@ Object {
       "custom_template": null,
       "email_recipient_filter": "none",
       "email_subject": null,
-      "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable
-recurring revenue stream from their creative work, Ghost has built-in payments
-allowing you to create a subscription commerce business.
+      "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to
-quickly and easily create monthly and yearly premium plans for members to
-subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to ",
       "feature_image": "https://static.ghost.org/v4.0.0/images/organizing-your-content.png",
@@ -1812,29 +1774,17 @@ Ghost takes 0% payment fees, so everything you make is yours to ",
       "og_description": null,
       "og_image": null,
       "og_title": null,
-      "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable
-recurring revenue stream from their creative work, Ghost has built-in payments
-allowing you to create a subscription commerce business.
+      "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to
-quickly and easily create monthly and yearly premium plans for members to
-subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to keep!
 
-Using subscriptions, you can build an independent media business like 
-Stratechery [https://stratechery.com], The Information
-[https://www.theinformation.com], or The Browser [https://thebrowser.com].
+Using subscriptions, you can build an independent media business like Stratechery [https://stratechery.com], The Information [https://www.theinformation.com], or The Browser [https://thebrowser.com].
 
-The creator economy is just getting started, and Ghost allows you to build
-something based on technology that you own and control.
+The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
 
-[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost
-successful subscription businesses publish a mix of free and paid posts to
-attract a new audience, and upsell the most loyal members to a premium offering.
-You can also mix different access levels within the same post, showing a free
-preview to logged out members and then, right when you're ready for a
-cliffhanger, that's a good time to...",
+[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "primary_author": Object {
         "bio": "You can delete this user to remove all the welcome posts",
         "cover_image": null,
@@ -2054,10 +2004,7 @@ cliffhanger, that's a good time to...",
 
 
 
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
 1234abcdefghijklDefinition listConsectetur ad",
       "feature_image": null,
@@ -2200,13 +2147,7 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
-ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros
-ipsum rutrum or",
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2350,7 +2291,7 @@ exports[`Posts Content API Can include relations 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "65590",
+  "content-length": "65564",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -2655,13 +2596,9 @@ Object {
       "custom_template": null,
       "email_recipient_filter": "none",
       "email_subject": null,
-      "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable
-recurring revenue stream from their creative work, Ghost has built-in payments
-allowing you to create a subscription commerce business.
+      "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to
-quickly and easily create monthly and yearly premium plans for members to
-subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to ",
       "feature_image": "https://static.ghost.org/v4.0.0/images/organizing-your-content.png",
@@ -2676,29 +2613,17 @@ Ghost takes 0% payment fees, so everything you make is yours to ",
       "og_description": null,
       "og_image": null,
       "og_title": null,
-      "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable
-recurring revenue stream from their creative work, Ghost has built-in payments
-allowing you to create a subscription commerce business.
+      "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to
-quickly and easily create monthly and yearly premium plans for members to
-subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to keep!
 
-Using subscriptions, you can build an independent media business like 
-Stratechery [https://stratechery.com], The Information
-[https://www.theinformation.com], or The Browser [https://thebrowser.com].
+Using subscriptions, you can build an independent media business like Stratechery [https://stratechery.com], The Information [https://www.theinformation.com], or The Browser [https://thebrowser.com].
 
-The creator economy is just getting started, and Ghost allows you to build
-something based on technology that you own and control.
+The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
 
-[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost
-successful subscription businesses publish a mix of free and paid posts to
-attract a new audience, and upsell the most loyal members to a premium offering.
-You can also mix different access levels within the same post, showing a free
-preview to logged out members and then, right when you're ready for a
-cliffhanger, that's a good time to...",
+[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "reading_time": 1,
       "slug": "sell",
@@ -2804,10 +2729,7 @@ cliffhanger, that's a good time to...",
 
 
 
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
 1234abcdefghijklDefinition listConsectetur ad",
       "feature_image": null,
@@ -2894,13 +2816,7 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
-ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros
-ipsum rutrum or",
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -2969,7 +2885,7 @@ exports[`Posts Content API Can request posts 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "46709",
+  "content-length": "46683",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",
@@ -3157,13 +3073,9 @@ Object {
       "custom_template": null,
       "email_recipient_filter": "none",
       "email_subject": null,
-      "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable
-recurring revenue stream from their creative work, Ghost has built-in payments
-allowing you to create a subscription commerce business.
+      "excerpt": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to
-quickly and easily create monthly and yearly premium plans for members to
-subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to ",
       "feature_image": "https://static.ghost.org/v4.0.0/images/organizing-your-content.png",
@@ -3178,29 +3090,17 @@ Ghost takes 0% payment fees, so everything you make is yours to ",
       "og_description": null,
       "og_image": null,
       "og_title": null,
-      "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable
-recurring revenue stream from their creative work, Ghost has built-in payments
-allowing you to create a subscription commerce business.
+      "plaintext": "For creators and aspiring entrepreneurs looking to generate a sustainable recurring revenue stream from their creative work, Ghost has built-in payments allowing you to create a subscription commerce business.
 
-Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to
-quickly and easily create monthly and yearly premium plans for members to
-subscribe to, as well as complimentary plans for friends and family.
+Connect your Stripe [https://stripe.com] account to Ghost, and you'll be able to quickly and easily create monthly and yearly premium plans for members to subscribe to, as well as complimentary plans for friends and family.
 
 Ghost takes 0% payment fees, so everything you make is yours to keep!
 
-Using subscriptions, you can build an independent media business like 
-Stratechery [https://stratechery.com], The Information
-[https://www.theinformation.com], or The Browser [https://thebrowser.com].
+Using subscriptions, you can build an independent media business like Stratechery [https://stratechery.com], The Information [https://www.theinformation.com], or The Browser [https://thebrowser.com].
 
-The creator economy is just getting started, and Ghost allows you to build
-something based on technology that you own and control.
+The creator economy is just getting started, and Ghost allows you to build something based on technology that you own and control.
 
-[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost
-successful subscription businesses publish a mix of free and paid posts to
-attract a new audience, and upsell the most loyal members to a premium offering.
-You can also mix different access levels within the same post, showing a free
-preview to logged out members and then, right when you're ready for a
-cliffhanger, that's a good time to...",
+[https://thebrowser.com]The Browser has over 10,000 paying subscribersMost successful subscription businesses publish a mix of free and paid posts to attract a new audience, and upsell the most loyal members to a premium offering. You can also mix different access levels within the same post, showing a free preview to logged out members and then, right when you're ready for a cliffhanger, that's a good time to...",
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000\\\\\\+\\\\d\\{2\\}:\\\\d\\{2\\}/,
       "reading_time": 1,
       "slug": "sell",
@@ -3306,10 +3206,7 @@ cliffhanger, that's a good time to...",
 
 
 
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo.
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
 
 1234abcdefghijklDefinition listConsectetur ad",
       "feature_image": null,
@@ -3396,13 +3293,7 @@ mctesters
       "email_recipient_filter": "none",
       "email_subject": null,
       "excerpt": "HTML Ipsum Presents
-Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac
-turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor
-sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies
-mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien
-ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae,
-ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros
-ipsum rutrum or",
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum or",
       "feature_image": "http://127.0.0.1:2369/content/images/2018/hey.jpg",
       "feature_image_alt": null,
       "feature_image_caption": null,
@@ -3471,7 +3362,7 @@ exports[`Posts Content API Can request posts from different origin 2: [headers] 
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "46709",
+  "content-length": "46683",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/test/regression/api/content/posts.test.js
+++ b/test/regression/api/content/posts.test.js
@@ -249,7 +249,7 @@ describe('api/canary/content/posts', function () {
                 localUtils.API.checkResponse(res.body.posts[0], 'post', null, null, ['id', 'title', 'slug', 'excerpt', 'plaintext']);
 
                 // excerpt should transform links to absolute URLs
-                res.body.posts[0].excerpt.should.match(/\* Aliquam \[http:\/\/127.0.0.1:2369\/about#nowhere\]/);
+                res.body.posts[0].excerpt.should.match(/\* Aliquam/);
             });
     });
 

--- a/test/regression/models/model_posts.test.js
+++ b/test/regression/models/model_posts.test.js
@@ -1225,7 +1225,7 @@ describe('Post Model', function () {
                 models.Post.add(post, context).then((createdPost) => {
                     createdPost.get('mobiledoc').should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"http://127.0.0.1:2369/content/images/card.jpg"}]],"markups":[["a",["href","http://127.0.0.1:2369/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
                     createdPost.get('html').should.equal('<p><a href="http://127.0.0.1:2369/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="http://127.0.0.1:2369/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
-                    createdPost.get('plaintext').should.containEql('Testing [http://127.0.0.1:2369/test]');
+                    createdPost.get('plaintext').should.containEql('Testing');
                     createdPost.get('custom_excerpt').should.equal('Testing <a href="http://127.0.0.1:2369/internal">links</a> in custom excerpts');
                     createdPost.get('codeinjection_head').should.equal('<script src="http://127.0.0.1:2369/assets/head.js"></script>');
                     createdPost.get('codeinjection_foot').should.equal('<script src="http://127.0.0.1:2369/assets/foot.js"></script>');
@@ -1254,7 +1254,7 @@ describe('Post Model', function () {
                     const [knexPost] = knexResult;
                     knexPost.mobiledoc.should.equal('{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"__GHOST_URL__/content/images/card.jpg"}]],"markups":[["a",["href","__GHOST_URL__/test"]]],"sections":[[1,"p",[[0,[0],1,"Testing"]]],[10,0]]}');
                     knexPost.html.should.equal('<p><a href="__GHOST_URL__/test">Testing</a></p><figure class="kg-card kg-image-card"><img src="__GHOST_URL__/content/images/card.jpg" class="kg-image" alt loading="lazy"></figure>');
-                    knexPost.plaintext.should.containEql('Testing [__GHOST_URL__/test]');
+                    knexPost.plaintext.should.containEql('Testing');
                     knexPost.custom_excerpt.should.equal('Testing <a href="__GHOST_URL__/internal">links</a> in custom excerpts');
                     knexPost.codeinjection_head.should.equal('<script src="__GHOST_URL__/assets/head.js"></script>');
                     knexPost.codeinjection_foot.should.equal('<script src="__GHOST_URL__/assets/foot.js"></script>');

--- a/test/unit/shared/html-to-plaintext.test.js
+++ b/test/unit/shared/html-to-plaintext.test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const htmlToPlaintext = require('../../../core/shared/html-to-plaintext');
+
+describe('Html to Plaintext', function () {
+    function getEmailandExcert(input) {
+        const excerpt = htmlToPlaintext.excerpt(input);
+        const email = htmlToPlaintext.email(input);
+
+        return {email, excerpt};
+    }
+
+    describe('excerpt vs email behaviour', function () {
+        it('example case with img & link', function () {
+            const input = '<p>Some thing <a href="https://google.com">Google</a> once told me.</p><img src="https://hotlink.com" alt="An important image"><p>And <strong>another</strong> thing.</p>';
+
+            const {excerpt, email} = getEmailandExcert(input);
+
+            assert.equal(excerpt, 'Some thing Google [https://google.com] once told me.\n\nAnd another thing.');
+            assert.equal(email, 'Some thing Google [https://google.com] once told me.\n\nAnd another thing.');
+        });
+
+        it('example case with figure + figcaption', function () {
+            const input = '<figcaption>A snippet from a post template</figcaption></figure><p>See? Not that scary! But still completely optional. </p>';
+
+            const {excerpt, email} = getEmailandExcert(input);
+
+            assert.equal(excerpt, 'A snippet from a post template\n\nSee? Not that scary! But still completely optional.');
+            assert.equal(email, 'A snippet from a post template\n\nSee? Not that scary! But still completely optional.');
+        });
+
+        it('example case with figure + figcaption inside a link', function () {
+            const input = '<a href="https://mysite.com"><figcaption>A snippet from a post template</figcaption></figure></a><p>See? Not that scary! But still completely optional. </p>';
+
+            const {excerpt, email} = getEmailandExcert(input);
+
+            assert.equal(excerpt, 'A snippet from a post template [https://mysite.com]\n\nSee? Not that scary! But still completely optional.');
+            assert.equal(email, 'A snippet from a post template [https://mysite.com]\n\nSee? Not that scary! But still completely optional.');
+        });
+    });
+});

--- a/test/unit/shared/html-to-plaintext.test.js
+++ b/test/unit/shared/html-to-plaintext.test.js
@@ -15,7 +15,7 @@ describe('Html to Plaintext', function () {
 
             const {excerpt, email} = getEmailandExcert(input);
 
-            assert.equal(excerpt, 'Some thing Google [https://google.com] once told me.\n\nAnd another thing.');
+            assert.equal(excerpt, 'Some thing Google once told me.\n\nAnd another thing.');
             assert.equal(email, 'Some thing Google [https://google.com] once told me.\n\nAnd another thing.');
         });
 
@@ -24,7 +24,7 @@ describe('Html to Plaintext', function () {
 
             const {excerpt, email} = getEmailandExcert(input);
 
-            assert.equal(excerpt, 'A snippet from a post template\n\nSee? Not that scary! But still completely optional.');
+            assert.equal(excerpt, 'See? Not that scary! But still completely optional.');
             assert.equal(email, 'A snippet from a post template\n\nSee? Not that scary! But still completely optional.');
         });
 
@@ -33,8 +33,24 @@ describe('Html to Plaintext', function () {
 
             const {excerpt, email} = getEmailandExcert(input);
 
-            assert.equal(excerpt, 'A snippet from a post template [https://mysite.com]\n\nSee? Not that scary! But still completely optional.');
+            assert.equal(excerpt, 'See? Not that scary! But still completely optional.');
             assert.equal(email, 'A snippet from a post template [https://mysite.com]\n\nSee? Not that scary! But still completely optional.');
+        });
+
+        it('longer example', function () {
+            const input = '<p>As discussed in the <a href="https://demo.ghost.io/welcome/">introduction</a> post, one of the best things about Ghost is just how much you can customize to turn your site into something unique. Everything about your layout and design can be changed, so you\'re not stuck with yet another clone of a social network profile.</p><p>How far you want to go with customization is completely up to you, there\'s no right or wrong approach! The majority of people use one of Ghost\'s built-in themes to get started, and then progress to something more bespoke later on as their site grows. </p><p>The best way to get started is with Ghost\'s branding settings, where you can set up colors, images and logos to fit with your brand.</p><figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="https://static.ghost.org/v4.0.0/images/brandsettings.png" class="kg-image" alt loading="lazy" width="3456" height="2338"><figcaption>Ghost Admin → Settings → Branding</figcaption></figure><p>Any Ghost theme that\'s up to date and compatible with Ghost 4.0 and higher will reflect your branding settings in the preview window, so you can see what your site will look like as you experiment with different options.</p><p>When selecting an accent color, try to choose something which will contrast well with white text. Many themes will use your accent color as the background for buttons, headers and navigational elements. Vibrant colors with a darker hue tend to work best, as a general rule.</p><h2 id="installing-ghost-themes">Installing Ghost themes</h2><p>By default, new sites are created with Ghost\'s friendly publication theme, called Casper. Everything in Casper is optimized to work for the most common types of blog, newsletter and publication that people create with Ghost — so it\'s a perfect place to start.</p><p>However, there are hundreds of different themes available to install, so you can pick out a look and feel that suits you best.</p><figure class="kg-card kg-image-card kg-width-wide kg-card-hascaption"><img src="https://static.ghost.org/v4.0.0/images/themesettings.png" class="kg-image" alt loading="lazy" width="3208" height="1618"><figcaption>Ghost Admin → Settings → Theme</figcaption></figure><p>Inside Ghost\'s theme settings you\'ll find 4 more official themes that can be directly installed and activated. Each theme is suited to slightly different use-cases.</p><ul><li><strong>Casper</strong> <em>(default)</em> — Made for all sorts of blogs and newsletters</li><li><strong>Edition</strong> — A beautiful minimal template for newsletter authors</li><li><strong>Alto</strong> — A slick news/magazine style design for creators</li><li><strong>London</strong> — A light photography theme with a bold grid</li><li><strong>Ease</strong> — A library theme for organizing large content archives</li></ul><p>And if none of those feel quite right, head on over to the <a href="https://ghost.org/themes/">Ghost Marketplace</a>, where you\'ll find a huge variety of both free and premium themes.</p><h2 id="building-something-custom">Building something custom</h2><p>Finally, if you want something completely bespoke for your site, you can always build a custom theme from scratch and upload it to your site.</p><p>Ghost\'s theming template files are very easy to work with, and can be picked up in the space of a few hours by anyone who has just a little bit of knowledge of HTML and CSS. Templates from other platforms can also be ported to Ghost with relatively little effort.</p><p>If you want to take a quick look at the theme syntax to see what it\'s like, you can <a href="https://github.com/tryghost/casper/">browse through the files of the default Casper theme</a>. We\'ve added tons of inline code comments to make it easy to learn, and the structure is very readable.</p><figure class="kg-card kg-code-card"><pre><code class="language-handlebars">{{#post}}\n&lt;article class="article {{post_class}}"&gt;\n\n &lt;h1&gt;{{title}}&lt;/h1&gt;\n \n {{#if feature_image}}\n \t&lt;img src="{{feature_image}}" alt="Feature image" /&gt;\n {{/if}}\n \n {{content}}\n\n&lt;/article&gt;\n{{/post}}</code></pre><figcaption>A snippet from a post template</figcaption></figure><p>See? Not that scary! But still completely optional. </p><p>If you\'re interested in creating your own Ghost theme, check out our extensive <a href="https://ghost.org/docs/themes/">theme documentation</a> for a full guide to all the different template variables and helpers which are available.</p>';
+
+            const {excerpt, email} = getEmailandExcert(input);
+
+            // No link
+            assert.doesNotMatch(excerpt, /https:\/\/demo\.ghost\.io\/welcome/);
+            // No figcaption
+            assert.doesNotMatch(excerpt, /Ghost Admin → Settings → Theme/);
+
+            // contains link
+            assert.match(email, /https:\/\/demo\.ghost\.io\/welcome/);
+            // contains figcaption
+            assert.match(email, /Ghost Admin → Settings → Theme/);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,6 +1502,14 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
+"@selderee/plugin-htmlparser2@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz#27e994afd1c2cb647ceb5406a185a5574188069d"
+  integrity sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==
+  dependencies:
+    domhandler "^4.2.0"
+    selderee "^0.6.0"
+
 "@sentry/core@6.19.6":
   version "6.19.6"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.19.6.tgz#7d4649d0148b5d0be1358ab02e2f869bf7363e9a"
@@ -4743,6 +4751,11 @@ diff@5.0.0, diff@^5.0.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -6740,7 +6753,19 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-html-to-text@5.1.1, html-to-text@^5.1.1:
+html-to-text@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-8.2.0.tgz#8b35e280ba7fc27710b7aa76d4500aab30731924"
+  integrity sha512-CLXExYn1b++Lgri+ZyVvbUEFwzkLZppjjZOwB7X1qv2jIi8MrMEvxWX5KQ7zATAzTvcqgmtO00M2kCRMtEdOKQ==
+  dependencies:
+    "@selderee/plugin-htmlparser2" "^0.6.0"
+    deepmerge "^4.2.2"
+    he "^1.2.0"
+    htmlparser2 "^6.1.0"
+    minimist "^1.2.6"
+    selderee "^0.6.0"
+
+html-to-text@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-5.1.1.tgz#2d89db7bf34bc7bcb7d546b1b228991a16926e87"
   integrity sha512-Bci6bD/JIfZSvG4s0gW/9mMKwBRoe/1RWLxUME/d6WUSZCdY7T60bssf/jFf7EYXRyqU4P5xdClVqiYU0/ypdA==
@@ -9140,6 +9165,11 @@ moment@2.24.0, moment@2.27.0, "moment@>= 2.9.0", moment@^2.18.1, moment@^2.19.3,
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
+moo@^0.5.0, moo@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
+  integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -9275,6 +9305,16 @@ ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
+
+nearley@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 needle@^2.5.2:
   version "2.9.1"
@@ -9899,6 +9939,14 @@ parse5@6.0.1, parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
+parseley@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/parseley/-/parseley-0.7.0.tgz#9949e3a0ed05c5072adb04f013c2810cf49171a8"
+  integrity sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==
+  dependencies:
+    moo "^0.5.1"
+    nearley "^2.20.1"
 
 parseurl@~1.3.3:
   version "1.3.3"
@@ -10622,10 +10670,23 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
 ramda@^0.27.0:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
   integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 random-bytes@~1.0.0:
   version "1.0.0"
@@ -11155,6 +11216,13 @@ secure-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/secure-keys/-/secure-keys-1.0.0.tgz#f0c82d98a3b139a8776a8808050b824431087fca"
   integrity sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=
+
+selderee@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/selderee/-/selderee-0.6.0.tgz#f3bee66cfebcb6f33df98e4a1df77388b42a96f7"
+  integrity sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==
+  dependencies:
+    parseley "^0.7.0"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
refs: https://github.com/TryGhost/Team/issues/1609

I'm changing the default output that goes into the `plaintext` field here, but I don't think it warrants regeneration.

I also have a further commit that I'm unsure of, which restricts the processing to 15 child nodes: https://github.com/ErisDS/Ghost/commit/335dd36df6385bb71cba9d831156b2b3a6b1028b This would mean the plaintext format is no longer the full document, but the first 15 children, which is quite a lot of it. 

I am not sure that anyone actually has a usecase for the plaintext field beyond the excerpt, so I'm tempted to push it and see if it impacts anyone. If it doesn't, we know we can drop the plaintext field from the API (as long as excerpts still work).