### PR TITLE
Added newsletters table to default export

### DIFF
--- a/core/server/data/exporter/table-lists.js
+++ b/core/server/data/exporter/table-lists.js
@@ -15,7 +15,6 @@ const BACKUP_TABLES = [
     'members_stripe_customers_subscriptions',
     'migrations',
     'migrations_lock',
-    'newsletters',
     'permissions',
     'permissions_roles',
     'permissions_users',
@@ -57,7 +56,8 @@ const TABLES_ALLOWLIST = [
     'settings',
     'custom_theme_settings',
     'tags',
-    'users'
+    'users',
+    'newsletters'
 ];
 
 // NOTE: these are settings keys which should never end up in the export file

--- a/test/regression/api/admin/db.test.js
+++ b/test/regression/api/admin/db.test.js
@@ -52,8 +52,8 @@ describe('DB API (canary)', function () {
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
 
-                // NOTE: 10 default tables + 1 from include parameters
-                Object.keys(jsonResponse.db[0].data).length.should.eql(11);
+                // NOTE: 11 default tables + 1 from include parameters
+                Object.keys(jsonResponse.db[0].data).length.should.eql(12);
             });
     });
 
@@ -95,7 +95,7 @@ describe('DB API (canary)', function () {
                     .expect(200);
             })
             .then((res) => {
-                res.body.problems.length.should.eql(3);
+                res.body.problems.length.should.eql(4);
                 fs.removeSync(exportFolder);
             });
     });

--- a/test/unit/server/data/exporter/index.test.js
+++ b/test/unit/server/data/exporter/index.test.js
@@ -39,8 +39,8 @@ describe('Exporter', function () {
 
         it('should try to export all the correct tables (without excluded)', function (done) {
             exporter.doExport().then(function (exportData) {
-                // NOTE: 10 default tables
-                const expectedCallCount = 10;
+                // NOTE: 11 default tables
+                const expectedCallCount = 11;
 
                 should.exist(exportData);
 
@@ -52,16 +52,17 @@ describe('Exporter', function () {
                 knexMock.callCount.should.eql(expectedCallCount);
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
 
-                knexMock.getCall(0).args[0].should.eql('posts');
-                knexMock.getCall(1).args[0].should.eql('posts_meta');
-                knexMock.getCall(2).args[0].should.eql('users');
-                knexMock.getCall(3).args[0].should.eql('posts_authors');
-                knexMock.getCall(4).args[0].should.eql('roles');
-                knexMock.getCall(5).args[0].should.eql('roles_users');
-                knexMock.getCall(6).args[0].should.eql('settings');
-                knexMock.getCall(7).args[0].should.eql('tags');
-                knexMock.getCall(8).args[0].should.eql('posts_tags');
-                knexMock.getCall(9).args[0].should.eql('custom_theme_settings');
+                knexMock.getCall(0).args[0].should.eql('newsletters');
+                knexMock.getCall(1).args[0].should.eql('posts');
+                knexMock.getCall(2).args[0].should.eql('posts_meta');
+                knexMock.getCall(3).args[0].should.eql('users');
+                knexMock.getCall(4).args[0].should.eql('posts_authors');
+                knexMock.getCall(5).args[0].should.eql('roles');
+                knexMock.getCall(6).args[0].should.eql('roles_users');
+                knexMock.getCall(7).args[0].should.eql('settings');
+                knexMock.getCall(8).args[0].should.eql('tags');
+                knexMock.getCall(9).args[0].should.eql('posts_tags');
+                knexMock.getCall(10).args[0].should.eql('custom_theme_settings');
 
                 done();
             }).catch(done);
@@ -71,8 +72,8 @@ describe('Exporter', function () {
             const include = ['mobiledoc_revisions', 'email_recipients'];
 
             exporter.doExport({include}).then(function (exportData) {
-                // NOTE: 10 default tables + 2 includes
-                const expectedCallCount = 12;
+                // NOTE: 11 default tables + 2 includes
+                const expectedCallCount = 13;
 
                 should.exist(exportData);
 
@@ -85,18 +86,19 @@ describe('Exporter', function () {
                 knexMock.callCount.should.eql(expectedCallCount);
                 queryMock.select.callCount.should.have.eql(expectedCallCount);
 
-                knexMock.getCall(0).args[0].should.eql('posts');
-                knexMock.getCall(1).args[0].should.eql('posts_meta');
-                knexMock.getCall(2).args[0].should.eql('users');
-                knexMock.getCall(3).args[0].should.eql('posts_authors');
-                knexMock.getCall(4).args[0].should.eql('roles');
-                knexMock.getCall(5).args[0].should.eql('roles_users');
-                knexMock.getCall(6).args[0].should.eql('settings');
-                knexMock.getCall(7).args[0].should.eql('tags');
-                knexMock.getCall(8).args[0].should.eql('posts_tags');
-                knexMock.getCall(9).args[0].should.eql('mobiledoc_revisions');
-                knexMock.getCall(10).args[0].should.eql('email_recipients');
-                knexMock.getCall(11).args[0].should.eql('custom_theme_settings');
+                knexMock.getCall(0).args[0].should.eql('newsletters');
+                knexMock.getCall(1).args[0].should.eql('posts');
+                knexMock.getCall(2).args[0].should.eql('posts_meta');
+                knexMock.getCall(3).args[0].should.eql('users');
+                knexMock.getCall(4).args[0].should.eql('posts_authors');
+                knexMock.getCall(5).args[0].should.eql('roles');
+                knexMock.getCall(6).args[0].should.eql('roles_users');
+                knexMock.getCall(7).args[0].should.eql('settings');
+                knexMock.getCall(8).args[0].should.eql('tags');
+                knexMock.getCall(9).args[0].should.eql('posts_tags');
+                knexMock.getCall(10).args[0].should.eql('mobiledoc_revisions');
+                knexMock.getCall(11).args[0].should.eql('email_recipients');
+                knexMock.getCall(12).args[0].should.eql('custom_theme_settings');
 
                 done();
             }).catch(done);

--- a/test/utils/fixtures/export/body-generator.js
+++ b/test/utils/fixtures/export/body-generator.js
@@ -142,6 +142,7 @@ const exportedBodyLatest = () => {
             },
             data: {
                 custom_theme_settings: [],
+                newsletters: [],
                 posts: [],
                 posts_authors: [],
                 posts_meta: [],


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1629

- We want to export the default newsletter so that we don't lose the post<>newsletter relationship when exporting
- The newsletter_id is currently ignored in the post importer (https://github.com/TryGhost/Ghost/pull/14720) so imports won't work right now (the relationship won't exist)
- This change means that exports created in 5.0+ will work later on with no data loss once the importer supports it
- The counts displayed for the newsletters are a count of email records, not post records - and we don't export/import emails so the count will always be 0 after importing a newsletter
