### PR TITLE
Fixed failing checkout session creation for offers

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@tryghost/logging": "2.1.8",
     "@tryghost/magic-link": "1.0.26",
     "@tryghost/member-events": "0.4.6",
-    "@tryghost/members-api": "8.0.0",
+    "@tryghost/members-api": "8.0.1",
     "@tryghost/members-events-service": "0.4.3",
     "@tryghost/members-importer": "0.5.14",
     "@tryghost/members-offers": "0.11.6",

--- a/test/e2e-frontend/members.test.js
+++ b/test/e2e-frontend/members.test.js
@@ -104,6 +104,22 @@ describe('Front-end members behaviour', function () {
                 .expect(400);
         });
 
+        it('should not throw 400 for using offer id on members create checkout session endpoint', async function () {
+            await request.post('/members/api/create-stripe-checkout-session')
+                .send({
+                    offerId: '62826b1b6dccb3e3e997ebd4',
+                    identity: null,
+                    metadata: {
+                        name: 'Jamie Larsen'
+                    },
+                    cancelUrl: 'https://example.com/blog/?stripe=cancel',
+                    customerEmail: 'jamie@example.com',
+                    tierId: null,
+                    cadence: null
+                })
+                .expect(500);
+        });
+
         it('should error for invalid data on members create update session endpoint', async function () {
             await request.post('/members/api/create-stripe-update-session')
                 .expect(400);

--- a/test/e2e-frontend/members.test.js
+++ b/test/e2e-frontend/members.test.js
@@ -104,6 +104,7 @@ describe('Front-end members behaviour', function () {
                 .expect(400);
         });
 
+        //TODO: Remove 500 expect once tests are wired up with Stripe
         it('should not throw 400 for using offer id on members create checkout session endpoint', async function () {
             await request.post('/members/api/create-stripe-checkout-session')
                 .send({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,10 +1861,10 @@
     "@tryghost/domain-events" "^0.1.14"
     "@tryghost/member-events" "^0.4.6"
 
-"@tryghost/members-api@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-8.0.0.tgz#490e357cf338ae262c7294cfeb318b1fa22b4de3"
-  integrity sha512-Cv9uzkbmtwaZk7YOTgzTybTVzfZT2z2b+E7F5Mm0UwsVMAAbNbG1iOOAIso0E/QrDfcsENe28QVL+Xk8YW/Ssw==
+"@tryghost/members-api@8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-8.0.1.tgz#f4aa3c74701a6689c816d63437545872f9d949b9"
+  integrity sha512-9/IGfDSF/ZDFfRJH6t/bjb2ldQ+V4JG3OrT64npZsDx1JFaEWDijbN6Hn6dC2aMqCvirQuPAMQYjC6QAqHNq9g==
   dependencies:
     "@nexes/nql" "^0.6.0"
     "@tryghost/debug" "^0.1.2"


### PR DESCRIPTION
- checkout session creation was failing when setup with `offerId` instead of `tierId` and `cadence`
- updates `members-api` to ignore `cadence` value if its `null`, allowing checkout session creation with offer id
