### PR TITLE
Fixed missing products in members export

### DIFF
--- a/core/server/api/canary/members.js
+++ b/core/server/api/canary/members.js
@@ -5,7 +5,6 @@ const moment = require('moment-timezone');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 const membersService = require('../../services/members');
-const labsService = require('../../../shared/labs');
 
 const settingsCache = require('../../../shared/settings-cache');
 const tpl = require('@tryghost/tpl');
@@ -350,13 +349,7 @@ module.exports = {
         },
         validation: {},
         async query(frame) {
-            frame.options.withRelated = ['labels', 'stripeSubscriptions', 'stripeSubscriptions.customer'];
-            if (labsService.isSet('multipleProducts')) {
-                frame.options.withRelated.push('products');
-            }
-            if (labsService.isSet('multipleNewsletters')) {
-                frame.options.withRelated.push('newsletters');
-            }
+            frame.options.withRelated = ['labels', 'stripeSubscriptions', 'stripeSubscriptions.customer', 'products', 'newsletters'];
             const page = await membersService.api.members.list(frame.options);
 
             return page;

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@tryghost/member-events": "0.4.6",
     "@tryghost/members-api": "8.0.1",
     "@tryghost/members-events-service": "0.4.3",
-    "@tryghost/members-importer": "0.5.14",
+    "@tryghost/members-importer": "0.5.15",
     "@tryghost/members-offers": "0.11.6",
     "@tryghost/members-ssr": "1.0.28",
     "@tryghost/members-stripe-service": "0.10.5",

--- a/test/e2e-api/admin/members.test.js
+++ b/test/e2e-api/admin/members.test.js
@@ -1562,13 +1562,15 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        res.text.should.match(/id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at/);
+        res.text.should.match(/id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,products/);
 
         const csv = Papa.parse(res.text, {header: true});
         should.exist(csv.data.find(row => row.name === 'Mr Egg'));
         should.exist(csv.data.find(row => row.name === 'Winston Zeddemore'));
         should.exist(csv.data.find(row => row.name === 'Ray Stantz'));
         should.exist(csv.data.find(row => row.email === 'member2@test.com'));
+        should.exist(csv.data.find(row => row.products.length > 0));
+        should.exist(csv.data.find(row => row.labels.length > 0));
     });
 
     it('Can export a filtered CSV', async function () {
@@ -1581,13 +1583,15 @@ describe('Members API', function () {
                 'content-disposition': anyString
             });
 
-        res.text.should.match(/id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at/);
+        res.text.should.match(/id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,products/);
 
         const csv = Papa.parse(res.text, {header: true});
         should.exist(csv.data.find(row => row.name === 'Mr Egg'));
         should.not.exist(csv.data.find(row => row.name === 'Egon Spengler'));
         should.not.exist(csv.data.find(row => row.name === 'Ray Stantz'));
         should.not.exist(csv.data.find(row => row.email === 'member2@test.com'));
+        // note that this member doesn't have products
+        should.exist(csv.data.find(row => row.labels.length > 0));
     });
 
     // Get stats

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,10 +1889,10 @@
     lodash "^4.17.11"
     node-jose "^2.0.0"
 
-"@tryghost/members-csv@^1.2.15":
-  version "1.2.15"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-csv/-/members-csv-1.2.15.tgz#0462a2dfebeb9c6820a65d17051f4af30665128c"
-  integrity sha512-D9AfAa2T01WGxTA8P5i87CP6iTS6HI0pAN/fgB16H+TOvCaG7LGDOwte7aD4Odw95RamxgsuX7faAQY1SlxzdQ==
+"@tryghost/members-csv@^1.2.16":
+  version "1.2.16"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-csv/-/members-csv-1.2.16.tgz#7c5faad34e9f42f1db3b8667335331d5a3b1f371"
+  integrity sha512-fwOnC7edOdJS4eA3o+5DIh9umIv3YmK5LxLo/bm84qMM720Gt6Czxek6Z+zvTiRiaLXp54nTHhegi4k1EHpquw==
   dependencies:
     bluebird "^3.7.2"
     fs-extra "^10.0.0"
@@ -1909,13 +1909,13 @@
     "@tryghost/member-events" "^0.4.6"
     moment-timezone "^0.5.34"
 
-"@tryghost/members-importer@0.5.14":
-  version "0.5.14"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-importer/-/members-importer-0.5.14.tgz#01ffb27f3e5d7cd094ab1943c6aa4063f56f1957"
-  integrity sha512-6Wbv25I9U3TszgC2AIPj3RcL5P0sROumz3CpcCWp0R/GiRfqG1zU7R4pcHhXa0mlACGSfaKQbR8eJlLYZ3xo/g==
+"@tryghost/members-importer@0.5.15":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-importer/-/members-importer-0.5.15.tgz#a28d4c14d0f43608b9363892faf442b4afb49e5f"
+  integrity sha512-rHig0CUBRAtInn/iXHaiR4QTGvnOMvRh6UmZ9oGn4oxUMuYo8wRhA1xyKOhgxOx/rFFIT2i27d21/m0QzXX1zQ==
   dependencies:
     "@tryghost/errors" "^1.0.0"
-    "@tryghost/members-csv" "^1.2.15"
+    "@tryghost/members-csv" "^1.2.16"
     "@tryghost/tpl" "^0.1.3"
     moment-timezone "^0.5.23"
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1642

- Updated `members-csv` (dependency via `members-importer`, shouldn't this be a separate dependency too?)  package to use the `tiers` field instead of the (removed) products field.
- Added basic test to see if products and labels are returned in the csv.