### PR TITLE
Added bulkDestroy column option

### DIFF
--- a/core/server/models/base/plugins/bulk-operations.js
+++ b/core/server/models/base/plugins/bulk-operations.js
@@ -52,9 +52,9 @@ async function editMultiple(knex, table, chunk, options) {
     await knex(table).whereIn('id', chunk).update(options.data);
 }
 
-async function delSingle(knex, table, id) {
+async function delSingle(knex, table, id, options) {
     try {
-        await knex(table).where('id', id).del();
+        await knex(table).where(options.column ?? 'id', id).del();
     } catch (err) {
         const importError = new errors.DataImportError({
             message: `Failed to remove entry from ${table}`,
@@ -66,8 +66,8 @@ async function delSingle(knex, table, id) {
     }
 }
 
-async function delMultiple(knex, table, chunk) {
-    await knex(table).whereIn('id', chunk).del();
+async function delMultiple(knex, table, chunk, options) {
+    await knex(table).whereIn(options.column ?? 'id', chunk).del();
 }
 
 const insert = createBulkOperation(insertSingle, insertMultiple);
@@ -91,10 +91,18 @@ module.exports = function (Bookshelf) {
             return edit(Bookshelf.knex, tableName, data, options);
         },
 
-        bulkDestroy: function bulkDestroy(data, tableName) {
+        /**
+         * 
+         * @param {string[]} data List of ids to delete
+         * @param {*} tableName 
+         * @param {Object} [options] 
+         * @param {string} [options.column] Delete the rows where this column equals the ids in `data` (defaults to 'id')
+         * @returns 
+         */
+        bulkDestroy: function bulkDestroy(data, tableName, options = {}) {
             tableName = tableName || this.prototype.tableName;
 
-            return del(Bookshelf.knex, tableName, data);
+            return del(Bookshelf.knex, tableName, data, options);
         }
     });
 };


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1652980792270029

- When bulk unsubscribing members, the number of deleted newsletter relations are returned instead of the number of members with newsletters that were cleared
- This adds options to the bulk destroy methods.
- You can pass the column on which you want to delete rows in a bulk destroy operation via the `column` option.

This will get used in https://github.com/TryGhost/Members/pull/400