### PR TITLE
🐛 Fixed email analytics crashing when processing unsubscribe/complaint events

### DIFF
--- a/core/server/services/email-analytics/lib/event-processor.js
+++ b/core/server/services/email-analytics/lib/event-processor.js
@@ -131,42 +131,14 @@ class GhostEventProcessor extends EventProcessor {
     }
 
     async handleUnsubscribed(event) {
-        const memberId = await this.getMemberId(event);
-
-        if (!memberId) {
-            return false;
-        }
-
-        const subscribedNewsletterIds = await this.db.knex('members_newsletters')
-            .where('member_id', '=', memberId)
-            .pluck('newsletter_id');
-
-        await this.db.knex('members_newsletters')
-            .where('member_id', '=', memberId)
-            .del();
-
-        const nowUTC = moment.utc().toDate();
-        for (const newsletterId of subscribedNewsletterIds) {
-            await this.db.knex('members_subscribe_events').insert({
-                id: ObjectID().toHexString(),
-                member_id: memberId,
-                newsletter_id: newsletterId,
-                subscribed: false,
-                created_at: nowUTC,
-                source: 'member'
-            });
-        }
-
-        const updateResult = await this.db.knex('members')
-            .where('id', '=', memberId)
-            .update({
-                updated_at: moment.utc().toDate()
-            });
-
-        return updateResult > 0;
+        return this._unsubscribeFromNewsletters(event);
     }
 
     async handleComplained(event) {
+        return this._unsubscribeFromNewsletters(event);
+    }
+
+    async _unsubscribeFromNewsletters(event) {
         const memberId = await this.getMemberId(event);
 
         if (!memberId) {
@@ -181,12 +153,6 @@ class GhostEventProcessor extends EventProcessor {
             .where('member_id', '=', memberId)
             .del();
 
-        const updateResult = await this.db.knex('members')
-            .where('id', '=', memberId)
-            .update({
-                updated_at: moment.utc().toDate()
-            });
-
         const nowUTC = moment.utc().toDate();
         for (const newsletterId of subscribedNewsletterIds) {
             await this.db.knex('members_subscribe_events').insert({
@@ -198,6 +164,12 @@ class GhostEventProcessor extends EventProcessor {
                 source: 'member'
             });
         }
+
+        const updateResult = await this.db.knex('members')
+            .where('id', '=', memberId)
+            .update({
+                updated_at: moment.utc().toDate()
+            });
 
         return updateResult > 0;
     }

--- a/core/server/services/email-analytics/lib/event-processor.js
+++ b/core/server/services/email-analytics/lib/event-processor.js
@@ -136,10 +136,13 @@ class GhostEventProcessor extends EventProcessor {
             return false;
         }
 
+        await this.db.knex('members_newsletters')
+            .where('member_id', '=', memberId)
+            .del();
+
         const updateResult = await this.db.knex('members')
             .where('id', '=', memberId)
             .update({
-                subscribed: false,
                 updated_at: moment.utc().toDate()
             });
 
@@ -153,10 +156,13 @@ class GhostEventProcessor extends EventProcessor {
             return false;
         }
 
+        await this.db.knex('members_newsletters')
+            .where('member_id', '=', memberId)
+            .del();
+
         const updateResult = await this.db.knex('members')
             .where('id', '=', memberId)
             .update({
-                subscribed: false,
                 updated_at: moment.utc().toDate()
             });
 

--- a/core/server/services/email-analytics/lib/event-processor.js
+++ b/core/server/services/email-analytics/lib/event-processor.js
@@ -154,7 +154,7 @@ class GhostEventProcessor extends EventProcessor {
                 newsletter_id: newsletterId,
                 subscribed: false,
                 created_at: moment.utc().toDate(),
-                source: 'system'
+                source: 'member'
             });
         }
 
@@ -197,7 +197,7 @@ class GhostEventProcessor extends EventProcessor {
                 newsletter_id: newsletterId,
                 subscribed: false,
                 created_at: moment.utc().toDate(),
-                source: 'system'
+                source: 'member'
             });
         }
 

--- a/core/server/services/email-analytics/lib/event-processor.js
+++ b/core/server/services/email-analytics/lib/event-processor.js
@@ -137,9 +137,11 @@ class GhostEventProcessor extends EventProcessor {
             return false;
         }
 
-        const subscribedNewsletterIds = this.db.knex('members_newsletters')
-            .where('member_id', '=', memberId)
-            .select('id');
+        const subscribedNewsletterIds = (
+            await this.db.knex('members_newsletters')
+                .where('member_id', '=', memberId)
+                .select('newsletter_id')
+        ).map(mn => mn.newsletter_id);
 
         await this.db.knex('members_newsletters')
             .where('member_id', '=', memberId)
@@ -172,9 +174,11 @@ class GhostEventProcessor extends EventProcessor {
             return false;
         }
 
-        const subscribedNewsletterIds = this.db.knex('members_newsletters')
-            .where('member_id', '=', memberId)
-            .select('id');
+        const subscribedNewsletterIds = (
+            await this.db.knex('members_newsletters')
+                .where('member_id', '=', memberId)
+                .select('newsletter_id')
+        ).map(mn => mn.newsletter_id);
 
         await this.db.knex('members_newsletters')
             .where('member_id', '=', memberId)

--- a/core/server/services/email-analytics/lib/event-processor.js
+++ b/core/server/services/email-analytics/lib/event-processor.js
@@ -137,23 +137,22 @@ class GhostEventProcessor extends EventProcessor {
             return false;
         }
 
-        const subscribedNewsletterIds = (
-            await this.db.knex('members_newsletters')
-                .where('member_id', '=', memberId)
-                .select('newsletter_id')
-        ).map(mn => mn.newsletter_id);
+        const subscribedNewsletterIds = await this.db.knex('members_newsletters')
+            .where('member_id', '=', memberId)
+            .pluck('newsletter_id');
 
         await this.db.knex('members_newsletters')
             .where('member_id', '=', memberId)
             .del();
 
+        const nowUTC = moment.utc().toDate();
         for (const newsletterId of subscribedNewsletterIds) {
             await this.db.knex('members_subscribe_events').insert({
                 id: ObjectID().toHexString(),
                 member_id: memberId,
                 newsletter_id: newsletterId,
                 subscribed: false,
-                created_at: moment.utc().toDate(),
+                created_at: nowUTC,
                 source: 'member'
             });
         }
@@ -174,11 +173,9 @@ class GhostEventProcessor extends EventProcessor {
             return false;
         }
 
-        const subscribedNewsletterIds = (
-            await this.db.knex('members_newsletters')
-                .where('member_id', '=', memberId)
-                .select('newsletter_id')
-        ).map(mn => mn.newsletter_id);
+        const subscribedNewsletterIds = await this.db.knex('members_newsletters')
+            .where('member_id', '=', memberId)
+            .pluck('newsletter_id');
 
         await this.db.knex('members_newsletters')
             .where('member_id', '=', memberId)
@@ -190,13 +187,14 @@ class GhostEventProcessor extends EventProcessor {
                 updated_at: moment.utc().toDate()
             });
 
+        const nowUTC = moment.utc().toDate();
         for (const newsletterId of subscribedNewsletterIds) {
             await this.db.knex('members_subscribe_events').insert({
                 id: ObjectID().toHexString(),
                 member_id: memberId,
                 newsletter_id: newsletterId,
                 subscribed: false,
-                created_at: moment.utc().toDate(),
+                created_at: nowUTC,
                 source: 'member'
             });
         }


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1649

- updated unsubscribe/complaint event processing methods
  - `member.subscribed` no longer exists, replaced that part of the query with a delete of member<->newsletter association rows from the `members_newsletters` pivot table
  - kept the member `updated_at` bump so we have some timestamp record of an update
  - added creation of `member_subscribe_event` records for the newsletter unsubscribes to keep stats and history in check

TODO:
- [x] create unsubscribe events
- [ ] tests