### PR TITLE
🐛 Fixed page vs post context calculation

### DIFF
--- a/core/frontend/services/rendering/context.js
+++ b/core/frontend/services/rendering/context.js
@@ -60,17 +60,13 @@ function setResponseContext(req, res, data) {
     // @TODO: remove first if condition when only page key is returned
     //        ref.: https://github.com/TryGhost/Ghost/issues/10042
     // The first if is now used by the preview route
-    if (data && data.post && data.post.page) {
+    if (data && data.page) {
         if (!res.locals.context.includes('page')) {
             res.locals.context.push('page');
         }
     } else if (data && data.post) {
         if (!res.locals.context.includes('post')) {
             res.locals.context.push('post');
-        }
-    } else if (data && data.page) {
-        if (!res.locals.context.includes('page')) {
-            res.locals.context.push('page');
         }
     } else if (data && data.tag) {
         if (!res.locals.context.includes('tag')) {

--- a/core/frontend/services/rendering/templates.js
+++ b/core/frontend/services/rendering/templates.js
@@ -190,7 +190,7 @@ module.exports.setTemplate = function setTemplate(req, res, data) {
     } else if (res.routerOptions.type === 'custom') {
         res._template = _private.pickTemplate(res.routerOptions.templates, res.routerOptions.defaultTemplate);
     } else if (res.routerOptions.type === 'entry') {
-        if (res.routerOptions?.context?.includes('page')) {
+        if (res.routerOptions?.context?.includes('page') || (res.routerOptions?.context?.includes('preview') && data.page)) {
             res._template = _private.getTemplateForEntry(data.page, 'page');
         } else {
             res._template = _private.getTemplateForEntry(data.post, 'post');


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/14886
refs https://github.com/naz/Ghost/commit/0c097f653289e197576381078cac56e8a6327b1d

- The context calculation after referenced change was adding a stray "post" entry into the context, causing the `{{#is "post"}}` helper to fail.