### PR TITLE
Included monthly_price,yearly_price&benefits defaults for Content API

### DIFF
--- a/core/server/api/canary/utils/serializers/input/tiers.js
+++ b/core/server/api/canary/utils/serializers/input/tiers.js
@@ -45,10 +45,26 @@ function convertTierInput(input) {
 
 module.exports = {
     all(_apiConfig, frame) {
+        if (localUtils.isContentAPI(frame)) {
+            // CASE: content api can only have active tiers
+            forceActiveFilter(frame);
+
+            // CASE: content api includes these by default
+            const defaultRelations = ['monthly_price', 'yearly_price', 'benefits'];
+            if (!frame.options.withRelated) {
+                frame.options.withRelated = defaultRelations;
+            } else {
+                for (const relation of defaultRelations) {
+                    if (!frame.options.withRelated.includes(relation)) {
+                        frame.options.withRelated.push(relation);
+                    }
+                }
+            }
+        }
+
         if (!frame.options.withRelated) {
             return;
         }
-
         frame.options.withRelated = frame.options.withRelated.map((relation) => {
             if (relation === 'stripe_prices') {
                 return 'stripePrices';
@@ -61,13 +77,6 @@ module.exports = {
             }
             return relation;
         });
-    },
-
-    browse(_apiConfig, frame) {
-        if (localUtils.isContentAPI(frame)) {
-            // CASE: content api can only has active tiers
-            forceActiveFilter(frame);
-        }
     },
 
     add(_apiConfig, frame) {

--- a/core/server/api/canary/utils/serializers/output/tiers.js
+++ b/core/server/api/canary/utils/serializers/output/tiers.js
@@ -24,7 +24,7 @@ module.exports = {
 function paginatedTiers(page, _apiConfig, frame) {
     return {
         tiers: page.data.map((model) => {
-            return serializeTier(model, frame.options, frame)
+            return serializeTier(model, frame.options, frame);
         }),
         meta: page.meta
     };

--- a/test/e2e-api/content/tiers.test.js
+++ b/test/e2e-api/content/tiers.test.js
@@ -10,7 +10,7 @@ describe('Tiers Content API', function () {
     });
 
     it('Can request only active tiers', async function () {
-        await agent.get('/tiers/?include=monthly_price,yearly_price,benefits')
+        await agent.get('/tiers/?include=monthly_price')
             .expectStatus(200)
             .matchHeaderSnapshot({
                 etag: matchers.anyEtag


### PR DESCRIPTION
We have to update the output serializer to only clean includes for the
Admin API, so that these includes aren't stripped for not being in the
original include query param.

This also rejigs the other Content API only logic to sit together in
the input serializer.