### PR TITLE
Removed unused getNewsletterRelations method

### DIFF
--- a/core/server/models/member.js
+++ b/core/server/models/member.js
@@ -377,18 +377,6 @@ const Member = ghostBookshelf.Model.extend({
         return query;
     },
 
-    getNewsletterRelations(data, unfilteredOptions = {}) {
-        const query = ghostBookshelf.knex('members_newsletters')
-            .select('id')
-            .whereIn('member_id', data.memberIds);
-
-        if (unfilteredOptions.transacting) {
-            query.transacting(unfilteredOptions.transacting);
-        }
-
-        return query;
-    },
-
     fetchAllSubscribed(unfilteredOptions = {}) {
         // we use raw queries instead of model relationships because model hydration is expensive
         const query = ghostBookshelf.knex('members_newsletters')


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/14870
refs https://github.com/TryGhost/Members/pull/400

- Since the ref'd PRs, this method is no longer used
