### PR TITLE
Added inviting user's email address as the reply-to address for staff invites

### DIFF
--- a/core/server/services/invites/invites.js
+++ b/core/server/services/invites/invites.js
@@ -52,6 +52,7 @@ class Invites {
                     mail: [{
                         message: {
                             to: invite.get('email'),
+                            replyTo: emailData.invitedByEmail,
                             subject: tpl(messages.invitedByName, {
                                 invitedByName: emailData.invitedByName,
                                 blogName: emailData.blogName


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1501

- Staff invites previously came from the default site from-address, which is often a no-reply