### PR TITLE
Removed bluebird from frontend/meta

### DIFF
--- a/ghost/core/core/frontend/meta/get-meta.js
+++ b/ghost/core/core/frontend/meta/get-meta.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const settingsCache = require('../../shared/settings-cache');
 const urlUtils = require('../../shared/url-utils');
 const logging = require('@tryghost/logging');
@@ -81,7 +80,7 @@ function getMetaData(data, root) {
     }
 
     // @TODO: wrap this in a utility function
-    return Promise.props(getImageDimensions(metaData)).then(function () {
+    return getImageDimensions(metaData).then(function () {
         metaData.structuredData = getStructuredData(metaData);
         metaData.schema = getSchema(metaData, data);
 

--- a/ghost/core/core/frontend/meta/image-dimensions.js
+++ b/ghost/core/core/frontend/meta/image-dimensions.js
@@ -1,15 +1,14 @@
-const Promise = require('bluebird');
 const _ = require('lodash');
 const imageSizeCache = require('../../server/lib/image').cachedImageSizeFromUrl;
 
 /**
  * Get Image dimensions
  * @param {object} metaData
- * @returns {object} metaData
+ * @returns {Promise<object>} metaData
  * @description for image properties in meta data (coverImage, authorImage and site.logo), `getCachedImageSizeFromUrl` is
  * called to receive image width and height
  */
-function getImageDimensions(metaData) {
+async function getImageDimensions(metaData) {
     const fetch = {
         coverImage: imageSizeCache.getCachedImageSizeFromUrl(metaData.coverImage.url),
         authorImage: imageSizeCache.getCachedImageSizeFromUrl(metaData.authorImage.url),
@@ -17,45 +16,54 @@ function getImageDimensions(metaData) {
         logo: imageSizeCache.getCachedImageSizeFromUrl(metaData.site.logo.url)
     };
 
-    return Promise
-        .props(fetch)
-        .then(function (imageObj) {
-            _.forEach(imageObj, function (key, value) {
-                if (_.has(key, 'width') && _.has(key, 'height')) {
-                    // We have some restrictions for publisher.logo:
-                    // The image needs to be <=600px wide and <=60px high (ideally exactly 600px x 60px).
-                    // Unless we have proper image-handling (see https://github.com/TryGhost/Ghost/issues/4453),
-                    // we will fake it in some cases or not produce an imageObject at all.
-                    if (value === 'logo') {
-                        if (key.height <= 60 && key.width <= 600) {
-                            _.assign(metaData.site[value], {
-                                dimensions: {
-                                    width: key.width,
-                                    height: key.height
-                                }
-                            });
-                        } else if (key.width === key.height) {
-                            // CASE: the logo is too large, but it is a square. We fake it...
-                            _.assign(metaData.site[value], {
-                                dimensions: {
-                                    width: 60,
-                                    height: 60
-                                }
-                            });
-                        }
-                    } else {
-                        _.assign(metaData[value], {
-                            dimensions: {
-                                width: key.width,
-                                height: key.height
-                            }
-                        });
-                    }
-                }
-            });
+    const [coverImage, authorImage, ogImage, logo] = await Promise.all([
+        fetch.coverImage,
+        fetch.authorImage,
+        fetch.ogImage,
+        fetch.logo
+    ]);
+    const imageObj = {
+        coverImage,
+        authorImage,
+        ogImage,
+        logo
+    };
 
-            return metaData;
-        });
+    _.forEach(imageObj, function (key, value) {
+        if (_.has(key, 'width') && _.has(key, 'height')) {
+            // We have some restrictions for publisher.logo:
+            // The image needs to be <=600px wide and <=60px high (ideally exactly 600px x 60px).
+            // Unless we have proper image-handling (see https://github.com/TryGhost/Ghost/issues/4453),
+            // we will fake it in some cases or not produce an imageObject at all.
+            if (value === 'logo') {
+                if (key.height <= 60 && key.width <= 600) {
+                    _.assign(metaData.site[value], {
+                        dimensions: {
+                            width: key.width,
+                            height: key.height
+                        }
+                    });
+                } else if (key.width === key.height) {
+                    // CASE: the logo is too large, but it is a square. We fake it...
+                    _.assign(metaData.site[value], {
+                        dimensions: {
+                            width: 60,
+                            height: 60
+                        }
+                    });
+                }
+            } else {
+                _.assign(metaData[value], {
+                    dimensions: {
+                        width: key.width,
+                        height: key.height
+                    }
+                });
+            }
+        }
+    });
+
+    return metaData;
 }
 
 module.exports = getImageDimensions;


### PR DESCRIPTION
Issue #14882
- Bluebird promise was being used for getting cached image sizes using .props method. It has been removed to be replaced by native promise using Promise.all