### PR TITLE
Fixed detection of Windows environment when connecting to SQLite temp DB

### DIFF
--- a/core/server/data/db/connection.js
+++ b/core/server/data/db/connection.js
@@ -1,4 +1,8 @@
+const _ = require('lodash');
 const knex = require('knex');
+const os = require('os');
+
+const logging = require('@tryghost/logging');
 const config = require('../../../shared/config');
 let knexInstance;
 
@@ -30,6 +34,15 @@ function configure(dbConfig) {
         // Force bthreads to use child_process backend until a worker_thread-compatible version of sqlite3 is published
         // https://github.com/mapbox/node-sqlite3/issues/1386
         process.env.BTHREADS_BACKEND = 'child_process';
+
+        // In the default SQLite test config we set the path to /tmp/ghost-test.db,
+        // but this won't work on Windows, so we need to replace the /tmp bit with
+        // the Windows temp folder
+        const filename = dbConfig.connection.filename;
+        if (process.platform === 'win32' && _.isString(filename) && filename.match(/^\/tmp/)) {
+            dbConfig.connection.filename = filename.replace(/^\/tmp/, os.tmpdir());
+            logging.info(`Ghost DB path: ${dbConfig.connection.filename}`);
+        }
     }
 
     if (client === 'mysql2') {

--- a/core/shared/config/utils.js
+++ b/core/shared/config/utils.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const fs = require('fs-extra');
-const os = require('os');
 const _ = require('lodash');
 
 /**
@@ -73,14 +72,6 @@ const sanitizeDatabaseProperties = function sanitizeDatabaseProperties(nconf) {
 
     if (nconf.get('database:client') === 'sqlite3') {
         makePathsAbsolute(nconf, nconf.get('database:connection'), 'database:connection');
-
-        // In the default SQLite test config we set the path to /tmp/ghost-test.db,
-        // but this won't work on Windows, so we need to replace the /tmp bit with
-        // the Windows temp folder
-        const filename = nconf.get('database:connection:filename');
-        if (_.isString(filename) && filename.match(/^\/tmp/)) {
-            nconf.set('database:connection:filename', filename.replace(/^\/tmp/, os.tmpdir()));
-        }
     }
 };
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Toolbox/issues/284

- this section of code rewrites `/tmp` in the SQlite filename to the
  temp dir
- the fix was only intended for Windows environments, because they
  typically don't have a `/tmp` dir
- this commit adds a `process.platform` check for Windows
- it also moves the code into the DB connection file instead of the
  config lib