### PR TITLE
Increased body parser limit to 50mb

### DIFF
--- a/core/server/web/api/canary/admin/app.js
+++ b/core/server/web/api/canary/admin/app.js
@@ -16,8 +16,8 @@ module.exports = function setupApiApp() {
     // API middleware
 
     // Body parsing
-    apiApp.use(bodyParser.json({limit: '1mb'}));
-    apiApp.use(bodyParser.urlencoded({extended: true, limit: '1mb'}));
+    apiApp.use(bodyParser.json({limit: '50mb'}));
+    apiApp.use(bodyParser.urlencoded({extended: true, limit: '50mb'}));
 
     // Query parsing
     apiApp.use(boolParser());

--- a/core/server/web/api/canary/content/app.js
+++ b/core/server/web/api/canary/content/app.js
@@ -15,7 +15,7 @@ module.exports = function setupApiApp() {
     // API middleware
 
     // @NOTE: req.body is undefined if we don't use this parser, this can trouble if components rely on req.body being present
-    apiApp.use(bodyParser.json({limit: '1mb'}));
+    apiApp.use(bodyParser.json({limit: '50mb'}));
 
     // Query parsing
     apiApp.use(boolParser());

--- a/core/server/web/members/app.js
+++ b/core/server/web/members/app.js
@@ -36,12 +36,12 @@ module.exports = function setupMembersApp() {
 
     // Manage newsletter subscription via unsubscribe link
     membersApp.get('/api/member/newsletters', middleware.getMemberNewsletters);
-    membersApp.put('/api/member/newsletters', bodyParser.json({limit: '1mb'}), middleware.updateMemberNewsletters);
+    membersApp.put('/api/member/newsletters', bodyParser.json({limit: '50mb'}), middleware.updateMemberNewsletters);
 
     // Get and update member data
     membersApp.get('/api/member', middleware.getMemberData);
-    membersApp.put('/api/member', bodyParser.json({limit: '1mb'}), middleware.updateMemberData);
-    membersApp.post('/api/member/email', bodyParser.json({limit: '1mb'}), (req, res) => membersService.api.middleware.updateEmailAddress(req, res));
+    membersApp.put('/api/member', bodyParser.json({limit: '50mb'}), middleware.updateMemberData);
+    membersApp.post('/api/member/email', bodyParser.json({limit: '50mb'}), (req, res) => membersService.api.middleware.updateEmailAddress(req, res));
 
     // Manage session
     membersApp.get('/api/session', middleware.getIdentityToken);


### PR DESCRIPTION
refs: https://github.com/TryGhost/Ghost/issues/5998#issuecomment-928981043

- Starting to see more people using long form content and otherwise exceeding the 1mb internal limit
- Setting it to 50mb matches Ghost-CLI's max body for nginx
- It might be ideal at some point to make this configurable, but I think increasing the limit solves the problem very simply for the foreseeable future

