### PR TITLE
🐛 Fixed Stripe Checkout for Members w/ existing subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@tryghost/logging": "2.1.8",
     "@tryghost/magic-link": "1.0.26",
     "@tryghost/member-events": "0.4.6",
-    "@tryghost/members-api": "8.1.2",
+    "@tryghost/members-api": "8.1.3",
     "@tryghost/members-events-service": "0.4.3",
     "@tryghost/members-importer": "0.5.16",
     "@tryghost/members-offers": "0.11.6",

--- a/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
+++ b/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
@@ -1,6 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Create Stripe Checkout Session Will not set a cookie if the token is invalid 1: [body] 1`] = `
+exports[`Create Stripe Checkout Session Does allow to create a checkout session if the customerEmail is not associated with a paid member 1: [body] 1`] = `
+Object {
+  "publicKey": "pk_test_for_stripe",
+  "sessionId": "cs_123",
+}
+`;
+
+exports[`Create Stripe Checkout Session Does allow to create a checkout session if the customerEmail is not associated with a paid member 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-type": "application/json",
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Create Stripe Checkout Session Does not allow to create a checkout session if the customerEmail is associated with a paid member 1: [body] 1`] = `
 Object {
   "errors": Array [
     Object {
@@ -15,5 +32,17 @@ Object {
       "type": "NoPermissionError",
     },
   ],
+}
+`;
+
+exports[`Create Stripe Checkout Session Does not allow to create a checkout session if the customerEmail is associated with a paid member 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "268",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
 }
 `;

--- a/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
+++ b/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Create Stripe Checkout Session Will not set a cookie if the token is invalid 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": "CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION",
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "A subscription exists for this Member.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;

--- a/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -29,17 +29,17 @@ describe('Create Stripe Checkout Session', function () {
         const paidTier = tiers.find(tier => tier.type === 'paid');
 
         await membersAgent.post('/api/create-stripe-checkout-session/')
-              .body({
-                  customerEmail: 'paid@test.com',
-                  tierId: paidTier.id,
-                  cadence: 'month'
-              })
-              .expectStatus(403)
-              .matchBodySnapshot({
-                  errors: [{
-                      id: matchers.anyUuid,
-                      code: 'CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION'
-                  }]
-              });
+            .body({
+                customerEmail: 'paid@test.com',
+                tierId: paidTier.id,
+                cadence: 'month'
+            })
+            .expectStatus(403)
+            .matchBodySnapshot({
+                errors: [{
+                    id: matchers.anyUuid,
+                    code: 'CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION'
+                }]
+            });
     });
 });

--- a/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -1,0 +1,45 @@
+const {agentProvider, mockManager, fixtureManager, matchers} = require('../../utils/e2e-framework');
+
+let membersAgent, adminAgent, membersService;
+
+describe('Create Stripe Checkout Session', function () {
+    before(async function () {
+        const agents = await agentProvider.getAgentsForMembers();
+        membersAgent = agents.membersAgent;
+        adminAgent = agents.adminAgent;
+
+        membersService = require('../../../core/server/services/members');
+
+        await fixtureManager.init('members');
+        await adminAgent.loginAsOwner();
+    });
+
+    beforeEach(function () {
+        mockManager.mockMail();
+        mockManager.mockStripe();
+    });
+
+    afterEach(function () {
+        mockManager.restore();
+    });
+
+    it('Will not set a cookie if the token is invalid', async function () {
+        const {body: {tiers}} = await adminAgent.get('/tiers/?include=monthly_price&yearly_price');
+
+        const paidTier = tiers.find(tier => tier.type === 'paid');
+
+        await membersAgent.post('/api/create-stripe-checkout-session/')
+              .body({
+                  customerEmail: 'paid@test.com',
+                  tierId: paidTier.id,
+                  cadence: 'month'
+              })
+              .expectStatus(403)
+              .matchBodySnapshot({
+                  errors: [{
+                      id: matchers.anyUuid,
+                      code: 'CANNOT_CHECKOUT_WITH_EXISTING_SUBSCRIPTION'
+                  }]
+              });
+    });
+});

--- a/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -23,7 +23,7 @@ describe('Create Stripe Checkout Session', function () {
         mockManager.restore();
     });
 
-    it('Will not set a cookie if the token is invalid', async function () {
+    it('Does not allow to create a checkout session if the custoemrEmail is associated with a paid member', async function () {
         const {body: {tiers}} = await adminAgent.get('/tiers/?include=monthly_price&yearly_price');
 
         const paidTier = tiers.find(tier => tier.type === 'paid');

--- a/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -23,7 +23,7 @@ describe('Create Stripe Checkout Session', function () {
         mockManager.restore();
     });
 
-    it('Does not allow to create a checkout session if the custoemrEmail is associated with a paid member', async function () {
+    it('Does not allow to create a checkout session if the customerEmail is associated with a paid member', async function () {
         const {body: {tiers}} = await adminAgent.get('/tiers/?include=monthly_price&yearly_price');
 
         const paidTier = tiers.find(tier => tier.type === 'paid');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,10 +1871,10 @@
     "@tryghost/domain-events" "^0.1.14"
     "@tryghost/member-events" "^0.4.6"
 
-"@tryghost/members-api@8.1.2":
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-8.1.2.tgz#dd4191ad7cbf0e6687c69153b06b8b5f9ef4709e"
-  integrity sha512-cD1NrGgPJQfaZBkW0GfTJRq5pcOABu13Tf/BFa4koFi03JUbK3QM92mZPmboks2cpDzkku6EzwFS4D7nbgcS5Q==
+"@tryghost/members-api@8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/members-api/-/members-api-8.1.3.tgz#8ddcf3d12e31639969a9678b3eb87fb6e49a7c5c"
+  integrity sha512-XJLXfwSd4EGbk5D9XJ0qOIF/9QBroT51/MN89Vtufw8MLHMx5OxlbIWfCXezrZHADg9GHWyao0xej3MQjGJqAA==
   dependencies:
     "@nexes/nql" "^0.6.0"
     "@tryghost/debug" "^0.1.2"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1526

This adds a check for existing subscriptions for a member associated with the
email addressed used for Stripe Checkout, if any are found the Checkout Session
creation fails and responds with a 403.

We've also updated the error handling for the create-stripe-checkout-session
endpoint so that it follows the existing Ghost API patterns.