### PR TITLE
🐛 Fixed an error when updating a user

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -557,7 +557,7 @@ User = ghostBookshelf.Model.extend({
                                 message: tpl(messages.methodDoesNotSupportOwnerRole)
                             })
                         );
-                    } else {
+                    } else if (roleToAssign) {
                         // assign all other roles
                         return user.roles().updatePivot({role_id: roleToAssign.id});
                     }


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1655
refs https://github.com/TryGhost/Ghost/commit/4bc14d2c4

- The API should always accept the input it returns. In this case it did not accept the input when it contained an unchanged roles property
- The problem here came from the referenced commit where we can now end up in the situation when the `roleToAssign` is just empty. It was an optimization to prevent a need to do ANY DB operation when none was needed.
