### PR TITLE
Fixed database environment variables leaking across matrix runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,6 @@ jobs:
             DB_CLIENT: mysql
     env:
       database__client: ${{ matrix.env.DB_CLIENT }}
-      database__connection__filename: /dev/shm/ghost-test.db
-      database__connection__host: 127.0.0.1
-      database__connection__user: root
-      database__connection__password: root
-      database__connection__database: ghost_testing
     name: Migrations (${{ matrix.env.DB }})
     steps:
       - uses: actions/checkout@v2
@@ -86,6 +81,18 @@ jobs:
           mysql version: '8.0'
           mysql database: 'ghost_testing'
           mysql root password: 'root'
+
+      - name: Set env vars (SQLite)
+        if: contains(matrix.env.DB, 'sqlite')
+        run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
+
+      - name: Set env vars (MySQL)
+        if: contains(matrix.env.DB, 'mysql')
+        run: |
+          echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
+          echo "database__connection__user=root" >> $GITHUB_ENV
+          echo "database__connection__password=root" >> $GITHUB_ENV
+          echo "database__connection__database=ghost_testing" >> $GITHUB_ENV
 
       - run: yarn
       - run: |
@@ -148,7 +155,6 @@ jobs:
     env:
       DB: ${{ matrix.env.DB }}
       NODE_ENV: ${{ matrix.env.NODE_ENV }}
-      database__connection__password: root
     name: Database Tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
     steps:
       - uses: actions/checkout@v2
@@ -182,10 +188,16 @@ jobs:
 
       - run: date +%s > ${{ runner.temp }}/startTime # Get start time for test suite
 
+      - name: Set env vars (SQLite)
+        if: contains(matrix.env.DB, 'sqlite')
+        run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
+
+      - name: Set env vars (MySQL)
+        if: contains(matrix.env.DB, 'mysql')
+        run: echo "database__connection__password=root" >> $GITHUB_ENV
+
       - name: Run tests
         run: yarn test:ci
-        env:
-          database__connection__filename: /dev/shm/ghost-test.db
 
       # Get runtime in seconds for test suite
       - run: |


### PR DESCRIPTION
- due to the way we currently set the env vars, they get applied across
  all matrix variations
- this means we're leaking the variables for SQLite to the MySQL test
  runs and this shows a warning because of how strict `mysql2` is
- this commit switches to optionally setting the env variables
- this is a partial workaround for https://github.com/TryGhost/Ghost/blob/fbcdacbd8311c5842a7653813ea33fddc34acd77/core/shared/config/utils.js#L55-L76 not seeming to work