### PR TITLE
🐛 Fixed missing authors in webhook payload

### DIFF
--- a/core/server/services/webhooks/serialize.js
+++ b/core/server/services/webhooks/serialize.js
@@ -13,9 +13,14 @@ module.exports = (event, model) => {
         ops.push(() => {
             let frame = {options: {previous: false, context: {user: true}}};
 
+            // NOTE: below options are lost in the during event processing, a more holistic approach would be
+            //       to pass them somehow along with the model
             if (['posts', 'pages'].includes(docName)) {
                 frame.options.formats = ['mobiledoc', 'html', 'plaintext'];
                 frame.options.withRelated = ['tags', 'authors'];
+                model._originalOptions = {
+                    withRelated: ['tags', 'authors']
+                };
             }
 
             return apiShared

--- a/test/e2e-webhooks/__snapshots__/posts.test.js.snap
+++ b/test/e2e-webhooks/__snapshots__/posts.test.js.snap
@@ -4,6 +4,30 @@ exports[`post.* events post.added even is triggered 1: [body] 1`] = `
 Object {
   "post": Object {
     "current": Object {
+      "authors": Array [
+        Object {
+          "accessibility": null,
+          "bio": "bio",
+          "cover_image": null,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "email": "jbloggs@example.com",
+          "facebook": null,
+          "id": "1",
+          "last_seen": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "location": "location",
+          "meta_description": null,
+          "meta_title": null,
+          "name": "Joe Bloggs",
+          "profile_image": "https://example.com/super_photo.jpg",
+          "slug": "joe-bloggs",
+          "status": "active",
+          "tour": null,
+          "twitter": null,
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+          "website": null,
+        },
+      ],
       "canonical_url": null,
       "codeinjection_foot": null,
       "codeinjection_head": null,
@@ -82,6 +106,39 @@ exports[`post.* events post.published even is triggered 1: [body] 1`] = `
 Object {
   "post": Object {
     "current": Object {
+      "authors": Array [
+        Object {
+          "accessibility": null,
+          "bio": "bio",
+          "cover_image": null,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "email": "jbloggs@example.com",
+          "facebook": null,
+          "id": "1",
+          "last_seen": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "location": "location",
+          "meta_description": null,
+          "meta_title": null,
+          "name": "Joe Bloggs",
+          "profile_image": "https://example.com/super_photo.jpg",
+          "roles": Array [
+            Object {
+              "created_at": "2022-06-03T09:31:02.000Z",
+              "description": "Blog Owner",
+              "id": "6299d4d6cf0c0f6aabf10096",
+              "name": "Owner",
+              "updated_at": "2022-06-03T09:31:02.000Z",
+            },
+          ],
+          "slug": "joe-bloggs",
+          "status": "active",
+          "tour": null,
+          "twitter": null,
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+          "website": null,
+        },
+      ],
       "canonical_url": null,
       "codeinjection_foot": null,
       "codeinjection_head": null,

--- a/test/e2e-webhooks/__snapshots__/posts.test.js.snap
+++ b/test/e2e-webhooks/__snapshots__/posts.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`post.* events post.added even is triggered 1: [body] 1`] = `
+exports[`post.* events post.added event is triggered 1: [body] 1`] = `
 Object {
   "post": Object {
     "current": Object {
@@ -8,6 +8,7 @@ Object {
         Object {
           "accessibility": null,
           "bio": "bio",
+          "comment_notifications": true,
           "cover_image": null,
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
           "email": "jbloggs@example.com",
@@ -53,6 +54,29 @@ Object {
       "og_description": null,
       "og_image": null,
       "og_title": null,
+      "primary_author": Object {
+        "accessibility": null,
+        "bio": "bio",
+        "comment_notifications": true,
+        "cover_image": null,
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "email": "jbloggs@example.com",
+        "facebook": null,
+        "id": "1",
+        "last_seen": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "location": "location",
+        "meta_description": null,
+        "meta_title": null,
+        "name": "Joe Bloggs",
+        "profile_image": "https://example.com/super_photo.jpg",
+        "slug": "joe-bloggs",
+        "status": "active",
+        "tour": null,
+        "twitter": null,
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+        "website": null,
+      },
       "primary_tag": null,
       "published_at": null,
       "slug": "testing-post-added-webhook",
@@ -102,7 +126,7 @@ Object {
 }
 `;
 
-exports[`post.* events post.published even is triggered 1: [body] 1`] = `
+exports[`post.* events post.published event is triggered 1: [body] 1`] = `
 Object {
   "post": Object {
     "current": Object {
@@ -110,6 +134,7 @@ Object {
         Object {
           "accessibility": null,
           "bio": "bio",
+          "comment_notifications": true,
           "cover_image": null,
           "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
           "email": "jbloggs@example.com",
@@ -123,11 +148,11 @@ Object {
           "profile_image": "https://example.com/super_photo.jpg",
           "roles": Array [
             Object {
-              "created_at": "2022-06-03T09:31:02.000Z",
+              "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
               "description": "Blog Owner",
-              "id": "6299d4d6cf0c0f6aabf10096",
+              "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
               "name": "Owner",
-              "updated_at": "2022-06-03T09:31:02.000Z",
+              "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
             },
           ],
           "slug": "joe-bloggs",
@@ -163,6 +188,38 @@ Object {
       "og_description": null,
       "og_image": null,
       "og_title": null,
+      "primary_author": Object {
+        "accessibility": null,
+        "bio": "bio",
+        "comment_notifications": true,
+        "cover_image": null,
+        "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "email": "jbloggs@example.com",
+        "facebook": null,
+        "id": "1",
+        "last_seen": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "location": "location",
+        "meta_description": null,
+        "meta_title": null,
+        "name": "Joe Bloggs",
+        "profile_image": "https://example.com/super_photo.jpg",
+        "roles": Array [
+          Object {
+            "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+            "description": "Blog Owner",
+            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+            "name": "Owner",
+            "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          },
+        ],
+        "slug": "joe-bloggs",
+        "status": "active",
+        "tour": null,
+        "twitter": null,
+        "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+        "url": "http://127.0.0.1:2369/author/joe-bloggs/",
+        "website": null,
+      },
       "primary_tag": null,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "slug": "webhookz",

--- a/test/e2e-webhooks/posts.test.js
+++ b/test/e2e-webhooks/posts.test.js
@@ -7,13 +7,27 @@ const tierSnapshot = {
     updated_at: anyISODateTime
 };
 
-const authorSnapshot = {
-    last_seen: anyISODateTime,
-    created_at: anyISODateTime,
-    updated_at: anyISODateTime
+const buildAuthorSnapshot = (roles = false) => {
+    const authorSnapshot = {
+        last_seen: anyISODateTime,
+        created_at: anyISODateTime,
+        updated_at: anyISODateTime
+    };
+
+    // NOTE: this is such a bad hack! for the reasons I did not investigate the "add" event does not include
+    //       the roles but the "published" does! massive inconsistency and needs to be fixed one day
+    if (roles) {
+        authorSnapshot.roles = new Array(1).fill({
+            id: anyObjectId,
+            created_at: anyISODateTime,
+            updated_at: anyISODateTime
+        });
+    }
+
+    return authorSnapshot;
 };
 
-const buildPostSnapshotWithTiers = ({published, tiersCount}) => {
+const buildPostSnapshotWithTiers = ({published, tiersCount, roles = false}) => {
     return {
         id: anyObjectId,
         uuid: anyUuid,
@@ -25,8 +39,8 @@ const buildPostSnapshotWithTiers = ({published, tiersCount}) => {
         //        this matcher should be removed once the issue is solved
         url: stringMatching(/http:\/\/127.0.0.1:2369\/\w+\//),
         tiers: new Array(tiersCount).fill(tierSnapshot),
-        primary_author: authorSnapshot,
-        authors: new Array(1).fill(authorSnapshot)
+        primary_author: buildAuthorSnapshot(roles),
+        authors: new Array(1).fill(buildAuthorSnapshot(roles))
     };
 };
 
@@ -55,7 +69,7 @@ describe('post.* events', function () {
         mockManager.restore();
     });
 
-    it('post.published even is triggered', async function () {
+    it('post.published event is triggered', async function () {
         const webhookURL = 'https://test-webhook-receiver.com/post-published/';
         await webhookMockReceiver.mock(webhookURL);
         await fixtureManager.insertWebhook({
@@ -91,14 +105,17 @@ describe('post.* events', function () {
                 post: {
                     current: buildPostSnapshotWithTiers({
                         published: true,
-                        tiersCount: 2
+                        tiersCount: 2,
+                        roles: true
                     }),
-                    previous: buildPreviousPostSnapshotWithTiers({tiersCount: 2})
+                    previous: buildPreviousPostSnapshotWithTiers({
+                        tiersCount: 2
+                    })
                 }
             });
     });
 
-    it('post.added even is triggered', async function () {
+    it('post.added event is triggered', async function () {
         const webhookURL = 'https://test-webhook-receiver.com/post-added/';
         await webhookMockReceiver.mock(webhookURL);
         await fixtureManager.insertWebhook({

--- a/test/e2e-webhooks/posts.test.js
+++ b/test/e2e-webhooks/posts.test.js
@@ -7,6 +7,12 @@ const tierSnapshot = {
     updated_at: anyISODateTime
 };
 
+const authorSnapshot = {
+    last_seen: anyISODateTime,
+    created_at: anyISODateTime,
+    updated_at: anyISODateTime
+};
+
 const buildPostSnapshotWithTiers = ({published, tiersCount}) => {
     return {
         id: anyObjectId,
@@ -18,7 +24,9 @@ const buildPostSnapshotWithTiers = ({published, tiersCount}) => {
         // @TODO: hack here! it's due to https://github.com/TryGhost/Toolbox/issues/341
         //        this matcher should be removed once the issue is solved
         url: stringMatching(/http:\/\/127.0.0.1:2369\/\w+\//),
-        tiers: new Array(tiersCount).fill(tierSnapshot)
+        tiers: new Array(tiersCount).fill(tierSnapshot),
+        primary_author: authorSnapshot,
+        authors: new Array(1).fill(authorSnapshot)
     };
 };
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Toolbox/issues/340
closes https://github.com/TryGhost/Ghost/issues/13451

- Webhook subscribers were receiving post request payloads without `authors` and `primary_author` properties.
- The behavior was due to missing "originalOptions" property that is needed to correctly serialize the model to json on the model layer.
- A more holistic approach would be to pass the options somehow along with the model with the event. This would require a deeper rework though


This PR still needs love around **_not_** including "roles" with the authors. Might be worked on once we are back from the break.