### PR TITLE
Updated mapping for stripe_products when product import is skipped

### DIFF
--- a/test/regression/api/admin/db.test.js
+++ b/test/regression/api/admin/db.test.js
@@ -379,20 +379,9 @@ describe('DB API (canary)', function () {
     });
 
     it('Can import a JSON database with products for an existing product', async function () {
-        await request.delete(localUtils.API.getApiQuery('db/'))
-            .set('Origin', config.get('url'))
-            .set('Accept', 'application/json')
-            .expect(204);
-
-        // Create a product with existing slug
-        const existingProduct = await models.Product.forge({
-            slug: 'ghost-inc',
-            name: 'Ghost Inc.',
-            description: 'Our daily newsletter',
-            type: 'paid',
-            active: 1,
-            visibility: 'public'
-        }).save();
+        const existingProduct = await models.Product.findOne({slug: 'ghost-inc'});
+        should.exist(existingProduct);
+        existingProduct.get('name').should.equal('Ghost Inc.');
 
         const res = await request.post(localUtils.API.getApiQuery('db/'))
             .set('Origin', config.get('url'))
@@ -409,7 +398,7 @@ describe('DB API (canary)', function () {
         const product = await models.Product.findOne({slug: 'ghost-inc'});
         should.exist(product);
         product.id.should.equal(existingProduct.id);
-        product.slug.should.equal('ghost-inc');
+        product.get('slug').should.equal('ghost-inc');
 
         product.get('name').should.equal('Ghost Inc.');
         product.get('description').should.equal('Our daily newsletter');


### PR DESCRIPTION
refs d63e9256eafc8dcd338fc68898557ff517d47a5d

- Following the ref'd commit, when migrating a site the default and free tiers would be skipped because they exist by default in the new site
- As the product is skipped, we don't have the ID available in the imported data to map the stripe_product to
- If the stripe_product isn't mapped, imported members won't be mapped to the correct tier
- This commit adds a lookup for the product by name and slug to restore the correct stripe_product mapping
