### PR TITLE
🐛 Fixed square brackets being % encoded in URLs

### DIFF
--- a/ghost/core/core/frontend/helpers/url.js
+++ b/ghost/core/core/frontend/helpers/url.js
@@ -17,7 +17,7 @@ module.exports = function url(options) {
     let outputUrl = getMetaDataUrl(this, absolute);
 
     try {
-        outputUrl = encodeURI(decodeURI(outputUrl));
+        outputUrl = encodeURI(decodeURI(outputUrl)).replace(/%5B/g, '[').replace(/%5D/g, ']');
     } catch (err) {
         // Happens when the outputURL contains an invalid URI character like "%%" or "%80"
 

--- a/ghost/core/test/unit/frontend/helpers/url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/url.test.js
@@ -225,6 +225,14 @@ describe('{{url}} helper', function () {
             should.exist(rendered);
             rendered.string.should.equal('');
         });
+
+        it('should not encode square brackets (as in valid IPV6 addresses)', function () {
+            rendered = url.call(
+                {url: 'http://[ffff::]:2368/baz', label: 'Baz', slug: 'baz', current: true},
+                {hash: {absolute: 'true'}});
+            should.exist(rendered);
+            rendered.string.should.equal('http://[ffff::]:2368/baz');
+        });
     });
 
     describe('with subdir', function () {


### PR DESCRIPTION
Resolves #14863 

`encodeURI(decodeURI(outputUrl))` in `core/frontend/helpers/url.js` was encoding square brackets as in valid IPV6 addresses, like `http://[ffff::]:2368`.

At first I thought it would be good to use `new URL()` for absolute URLS ([see doc for URL](https://nodejs.org/api/url.html#new-urlinput-base)), so I tried this:
```
outputUrl = absolute ? (new URL(outputUrl)).toString() : encodeURI(decodeURI(outputUrl));
```
But it made some tests fail in `test/unit/frontend/helpers/url.test.js`, so I guess there are some cases where we do not want this behavior.

Instead, as [MDN docs suggests](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI#encoding_for_ipv6), I added a simple Regex replace for the percent-encoded square brackets to get them back to non-encoded.

Added one test in `test/unit/frontend/helpers/url.test.js`, and tested myself by locally changing `core/shared/config/env/config.development.json` with `"url": "http://[ffff::]:2368"`.

Tell me what you think, thanks!