### PR TITLE
core: refactor bulk email service to allow non-mailgun senders.

### DIFF
--- a/core/server/services/bulk-email/mailgun.js
+++ b/core/server/services/bulk-email/mailgun.js
@@ -111,6 +111,7 @@ function send(message, recipientData, replacements) {
             });
         });
     } catch (error) {
+        // REF: possible mailgun errors https://documentation.mailgun.com/en/latest/api-intro.html#errors
         return Promise.reject({error, messageData});
     }
 }

--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -143,5 +143,8 @@
     },
     "gravatar": {
         "url": "https://www.gravatar.com/avatar/{hash}?s={size}&r={rating}&d={_default}"
+    },
+    "bulkEmail": {
+        "module": "./mailgun"
     }
 }


### PR DESCRIPTION
## Use Case

Ghost documentation says "More bulk mailers besides  Mailgun are planned". This PR helps along that goal with some foundational work.

Also, I signed up with Mailgun today, and there is no indication there is a free tier. The lowest
publish tier is the $35/month "Foundation" plan. I contact support today to clarify.

## Design Goal

This refactor is designed so that the Ghost does not need to support an alternate bulk email sender in the core. Alternate providers could be implemented as unsupported, third-party NPM modules.

Retrieving analytics back from the bulk email provider could be handled in the same way.

## Implementation

 - Removes references to mailgun in bulk-email-processor.js
 - Defines a bulk emailer module in configuration, defaulting to Mailgun
 - Loads the bulk mailer module based on the config

Now a new bulk email service can be defined by:

 1. Creating a bulk email module that exports `BATCH_SIZE`,
    `getInstance` and `send` compatible with Ghost's `mailgun.js`.
 2. Upload that module to NPM.
 3. Reference that module in config at `buklEmail:module`

The alternate module will likely require its own API key, which can
also be defined in the config system or setting system.
