### PR TITLE
:bug: Fixed Multiple accounts for members

### DIFF
--- a/ghost/core/core/server/web/shared/middleware/brute.js
+++ b/ghost/core/core/server/web/shared/middleware/brute.js
@@ -103,6 +103,8 @@ module.exports = {
             ignoreIP: false,
             key(_req, _res, _next) {
                 if (_req.body.email) {
+                    // Change the email to lower case to prevent multi accounts creations
+                    req.body.email = req.body.email.toLowerCase();
                     return _next(`${_req.body.email}login`);
                 }
 


### PR DESCRIPTION
Resolves #14840

- It's allowed to create multi accounts with the same email
- The emails are equal but have different characters cases
- e.g example@domain.com & Example@domain.com are both saved to the DB
- I fixed the issue by changing the email to lower case before saving it to the DB