### PR TITLE
Add Crawl-delay to robots.txt by default

### DIFF
--- a/core/frontend/public/robots.txt
+++ b/core/frontend/public/robots.txt
@@ -3,3 +3,4 @@ Sitemap: {{blog-url}}/sitemap.xml
 Disallow: /ghost/
 Disallow: /p/
 Disallow: /email/
+Crawl-delay: 10

--- a/test/e2e-frontend/default_routes.test.js
+++ b/test/e2e-frontend/default_routes.test.js
@@ -326,7 +326,8 @@ describe('Default Frontend routing', function () {
                 'User-agent: *\n' +
                 'Sitemap: http://127.0.0.1:2369/sitemap.xml\nDisallow: /ghost/\n' +
                 'Disallow: /p/\n' +
-                'Disallow: /email/\n'
+                'Disallow: /email/\n' +
+                'Crawl-delay: 10\n'
             );
         });
 


### PR DESCRIPTION
We have recently faced a DDoS attack on our ghost instance using a search bot amplification mechanism.
This setting is respected by some search engines such as Bing and Yandex and mitigates such attacks.
This should be a default setting, we believe.