### PR TITLE
Added comments table creation migration

### DIFF
--- a/core/server/data/exporter/table-lists.js
+++ b/core/server/data/exporter/table-lists.js
@@ -31,8 +31,8 @@ const BACKUP_TABLES = [
     'members_paid_subscription_events',
     'members_subscribe_events',
     'members_product_events',
-    'members_newsletters'
-
+    'members_newsletters',
+    'comments'
 ];
 
 // NOTE: exposing only tables which are going to be included in a "default" export file

--- a/core/server/data/migrations/versions/5.3/2022-07-04-13-49-add-comments-table.js
+++ b/core/server/data/migrations/versions/5.3/2022-07-04-13-49-add-comments-table.js
@@ -1,0 +1,13 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('comments', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    post_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'posts.id', cascadeDelete: true},
+    member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id'},
+    parent_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'comments.id'},
+    status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'published', validations: {isIn: [['published', 'hidden', 'deleted']]}},
+    html: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+    edited_at: {type: 'dateTime', nullable: true},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: false}
+});

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -742,5 +742,16 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
         newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true}
+    },
+    comments: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        post_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'posts.id', cascadeDelete: true},
+        member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id'},
+        parent_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'comments.id'},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'published', validations: {isIn: [['published', 'hidden', 'deleted']]}},
+        html: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+        edited_at: {type: 'dateTime', nullable: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: false}
     }
 };

--- a/test/integration/exporter/exporter.test.js
+++ b/test/integration/exporter/exporter.test.js
@@ -25,6 +25,7 @@ describe('Exporter', function () {
                 'actions',
                 'api_keys',
                 'brute',
+                'comments',
                 'custom_theme_settings',
                 'email_batches',
                 'email_recipients',

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '2f4266e6e5087ad92dd30f3e721d46e5';
+    const currentSchemaHash = 'b582244f25b7e33b7cdda20427f79702';
     const currentFixturesHash = '2509ff2c1f6e0293a3c3d84f08593b2f';
     const currentSettingsHash = '0b138cdd40e48b5b7dc4ebac2a7819a7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1664

Field notes:

- `parent_id` - used for nested comments but will be limited to 1 level in app-level validation
- `member_id` - when a member is deleted for now the member id is kept but in the future may be removed, hence `nullable: true`
- `status` - "hidden" status will be used when a staff user hides a comment, "deleted" is used when a comment author deletes
- `html` - will store pre-sanitised html
- `edited_at` - used to show an "X edited at Y" note when displaying comments, separate to `updated_at` because changing the status would also change `updated_at` but shouldn't show the "edited at" UI