### PR TITLE
Added internal integration for Ghost Explore

### DIFF
--- a/core/server/data/migrations/versions/5.3/2022-07-06-07-58-add-ghost-explore-integration-role.js
+++ b/core/server/data/migrations/versions/5.3/2022-07-06-07-58-add-ghost-explore-integration-role.js
@@ -1,0 +1,31 @@
+const logging = require('@tryghost/logging');
+const {default: ObjectID} = require('bson-objectid');
+const {createTransactionalMigration, meta} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Creating "Ghost Explore Integration" role');
+        const existingRole = await knex('roles').where({
+            name: 'Ghost Explore Integration'
+        }).first();
+
+        if (existingRole) {
+            logging.info('"Ghost Explore Integration" role already exists, skipping');
+            return;
+        }
+
+        await knex('roles').insert({
+            id: (new ObjectID()).toHexString(),
+            name: 'Ghost Explore Integration',
+            description: 'Internal Integration for the Ghost Explore directory',
+            created_by: meta.MIGRATION_USER,
+            created_at: knex.raw('current_timestamp')
+        });
+    },
+    async function down(knex) {
+        logging.info('Deleting role "Ghost Explore Integration"');
+        await knex('roles').where({
+            name: 'Ghost Explore Integration'
+        }).del();
+    }
+);

--- a/core/server/data/migrations/versions/5.3/2022-07-06-09-13-add-ghost-explore-integration-role-permissions.js
+++ b/core/server/data/migrations/versions/5.3/2022-07-06-09-13-add-ghost-explore-integration-role-permissions.js
@@ -1,0 +1,20 @@
+const {addPermissionToRole, combineTransactionalMigrations} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionToRole({
+        permission: 'Browse Members',
+        role: 'Ghost Explore Integration'
+    }),
+    addPermissionToRole({
+        permission: 'Browse newsletters',
+        role: 'Ghost Explore Integration'
+    }),
+    addPermissionToRole({
+        permission: 'Browse posts',
+        role: 'Ghost Explore Integration'
+    }),
+    addPermissionToRole({
+        permission: 'Browse settings',
+        role: 'Ghost Explore Integration'
+    })
+);

--- a/core/server/data/migrations/versions/5.3/2022-07-06-09-17-add-ghost-explore-integration.js
+++ b/core/server/data/migrations/versions/5.3/2022-07-06-09-17-add-ghost-explore-integration.js
@@ -1,0 +1,37 @@
+const logging = require('@tryghost/logging');
+const {default: ObjectID} = require('bson-objectid');
+const {createTransactionalMigration, meta} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Creating Ghost Explore Integration');
+        const existingIntegration = await knex('integrations').where({
+            type: 'internal',
+            name: 'Ghost Explore',
+            slug: 'ghost-explore'
+        }).first();
+
+        if (existingIntegration) {
+            logging.info('Integration already exists, skipping');
+            return;
+        }
+
+        await knex('integrations').insert({
+            id: (new ObjectID()).toHexString(),
+            type: 'internal',
+            name: 'Ghost Explore',
+            description: 'Internal Integration for the Ghost Explore directory',
+            slug: 'ghost-explore',
+            created_at: knex.raw('current_timestamp'),
+            created_by: meta.MIGRATION_USER
+        });
+    },
+    async function down(knex) {
+        logging.info('Deleting Ghost Explore Integration');
+        await knex('integrations').where({
+            type: 'internal',
+            name: 'Ghost Explore',
+            slug: 'ghost-explore'
+        }).del();
+    }
+);

--- a/core/server/data/migrations/versions/5.3/2022-07-06-09-26-add-ghost-explore-integration-api-key.js
+++ b/core/server/data/migrations/versions/5.3/2022-07-06-09-26-add-ghost-explore-integration-api-key.js
@@ -1,0 +1,70 @@
+const {InternalServerError} = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+const security = require('@tryghost/security');
+const {default: ObjectID} = require('bson-objectid');
+const {createTransactionalMigration, meta} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Adding an admin api key for Ghost Explore Integration');
+        const integration = await knex('integrations').where({
+            slug: 'ghost-explore',
+            type: 'internal',
+            name: 'Ghost Explore'
+        }).first();
+
+        if (!integration) {
+            throw new InternalServerError('Could not find Ghost Explore Integration');
+        }
+
+        const role = await knex('roles').where({
+            name: 'Ghost Explore Integration'
+        }).first();
+
+        if (!role) {
+            throw new InternalServerError('Could not find Ghost Explore Integration Role');
+        }
+
+        const existingKey = await knex('api_keys').where({
+            integration_id: integration.id,
+            role_id: role.id
+        }).first();
+
+        if (existingKey) {
+            logging.info('Admin API key already exists');
+            return;
+        }
+
+        await knex('api_keys').insert({
+            id: (new ObjectID()).toHexString(),
+            type: 'admin',
+            secret: security.secret.create('admin'),
+            role_id: role.id,
+            integration_id: integration.id,
+            created_at: knex.raw('current_timestamp'),
+            created_by: meta.MIGRATION_USER
+        });
+    },
+    async function down(knex) {
+        const integration = await knex('integrations').where({
+            slug: 'ghost-explore',
+            type: 'internal',
+            name: 'Ghost Explore'
+        }).first();
+
+        const role = await knex('roles').where({
+            name: 'Ghost Explore Integration'
+        }).first();
+
+        if (!role && !integration) {
+            logging.info('Could not delete api key');
+            return;
+        }
+
+        logging.info('Deleting Api Key');
+        await knex('api_keys').where({
+            integration_id: integration.id,
+            role_id: role.id
+        }).del();
+    }
+);

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -70,6 +70,10 @@
                     "description": "External Apps"
                 },
                 {
+                    "name": "Ghost Explore Integration",
+                    "description": "Internal Integration for the Ghost Explore directory"
+                },
+                {
                     "name": "DB Backup Integration",
                     "description": "Internal DB Backup Client"
                 },
@@ -615,6 +619,13 @@
                     "api_keys": [{"type": "admin"}]
                 },
                 {
+                    "slug": "ghost-explore",
+                    "name": "Ghost Explore",
+                    "description": "Built-in Ghost Explore integration",
+                    "type": "internal",
+                    "api_keys": [{"type": "admin", "role": "Ghost Explore Integration"}]
+                },
+                {
                     "slug": "ghost-backup",
                     "name": "Ghost Backup",
                     "description": "Internal DB Backup integration",
@@ -685,6 +696,12 @@
                 },
                 "Scheduler Integration": {
                     "post": "publish"
+                },
+                "Ghost Explore Integration": {
+                    "member": "browse",
+                    "post": "browse",
+                    "newsletter": "browse",
+                    "setting": "browse"
                 },
                 "Admin Integration": {
                     "mail": "all",

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '2f4266e6e5087ad92dd30f3e721d46e5';
-    const currentFixturesHash = '2509ff2c1f6e0293a3c3d84f08593b2f';
+    const currentFixturesHash = '9153385239bf358f5e719d0f33919640';
     const currentSettingsHash = '0b138cdd40e48b5b7dc4ebac2a7819a7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/test/unit/server/data/schema/integrity.test.js
+++ b/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '2f4266e6e5087ad92dd30f3e721d46e5';
-    const currentFixturesHash = '9153385239bf358f5e719d0f33919640';
+    const currentFixturesHash = 'fb9f49c14c192a999934eae21e718669';
     const currentSettingsHash = '0b138cdd40e48b5b7dc4ebac2a7819a7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
The members browse permission is used to fetch mrr stats as well as
the total members count. The site api is permissionless, so nothing
needed on that front.