### PR TITLE
✨ Bumped new built-in search to GA

### DIFF
--- a/core/frontend/helpers/ghost_head.js
+++ b/core/frontend/helpers/ghost_head.js
@@ -58,10 +58,6 @@ function getMembersHelper(data, frontendKey) {
 }
 
 function getSearchHelper(frontendKey) {
-    if (!labs.isSet('sodoSearch')) {
-        return '';
-    }
-
     const adminUrl = urlUtils.getAdminUrl() || urlUtils.getSiteUrl();
 
     let helper = `<script defer src="${config.get('sodoSearch:url')}" data-sodo-search="${adminUrl}" data-version="${config.get('sodoSearch:version')}" data-key="${frontendKey}" crossorigin="anonymous"></script>`;

--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -132,8 +132,8 @@
         "version": "2.2"
     },
     "sodoSearch": {
-        "url": "https://unpkg.com/@tryghost/sodo-search@~0.1.0/umd/sodo-search.min.js",
-        "version": "0.1.0"
+        "url": "https://unpkg.com/@tryghost/sodo-search@~1.0.0/umd/sodo-search.min.js",
+        "version": "1.0.0"
     },
     "tenor": {
         "publicReadOnlyApiKey": null,

--- a/core/shared/labs.js
+++ b/core/shared/labs.js
@@ -25,7 +25,6 @@ const BETA_FEATURES = [
 const ALPHA_FEATURES = [
     'urlCache',
     'beforeAfterCard',
-    'sodoSearch',
     'comments'
 ];
 

--- a/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -230,7 +230,7 @@ Object {
     },
     Object {
       "key": "labs",
-      "value": "{\\"activitypub\\":true,\\"urlCache\\":true,\\"beforeAfterCard\\":true,\\"sodoSearch\\":true,\\"comments\\":true,\\"members\\":true}",
+      "value": "{\\"activitypub\\":true,\\"urlCache\\":true,\\"beforeAfterCard\\":true,\\"comments\\":true,\\"members\\":true}",
     },
     Object {
       "key": "slack_url",
@@ -280,7 +280,7 @@ exports[`Settings API Browse Can request all settings 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3399",
+  "content-length": "3379",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1665

- bumps new search feature to GA from alpha
- allows sites to trigger new built-in search feature via `data-ghost-search` attribute or navigation link ( `#/search` )