### PR TITLE
Fixed admin auth asset loading

### DIFF
--- a/core/frontend/services/admin-auth-assets/service.js
+++ b/core/frontend/services/admin-auth-assets/service.js
@@ -7,20 +7,30 @@ const config = require('../../../shared/config');
 
 class AdminAuthAssetsService {
     constructor(options = {}) {
+        /** @private */
         this.src = options.src || path.join(config.get('paths').assetSrc, 'admin-auth');
+        /** @private */
         this.dest = options.dest || path.join(config.getContentPath('public'), 'admin-auth');
+        /** @private */
         this.minifier = new Minifier({src: this.src, dest: this.dest});
     }
 
+    /**
+     * @private
+     */
     generateGlobs() {
         return {
             'admin-auth.min.js': '*.js'
         };
     }
 
+    /**
+     * @private
+     * @returns {Promise<void>}
+     */
     async minify(globs) {
         try {
-            return await this.minifier.minify(globs);
+            await this.minifier.minify(globs);
         } catch (error) {
             if (error.code === 'EACCES') {
                 logging.error('Ghost was not able to write admin-auth asset files due to permissions.');
@@ -31,9 +41,13 @@ class AdminAuthAssetsService {
         }
     }
 
+    /**
+     * @private
+     * @returns {Promise<void>}
+     */
     async copyStatic() {
         try {
-            return await fs.copyFile(path.join(this.src, 'index.html'), path.join(this.dest, 'index.html'));
+            await fs.copyFile(path.join(this.src, 'index.html'), path.join(this.dest, 'index.html'));
         } catch (error) {
             if (error.code === 'EACCES') {
                 logging.error('Ghost was not able to write admin-auth asset files due to permissions.');
@@ -44,6 +58,10 @@ class AdminAuthAssetsService {
         }
     }
 
+    /**
+     * @private
+     * @returns {Promise<void>}
+     */
     async clearFiles() {
         const rmFile = async (name) => {
             await fs.unlink(path.join(this.dest, name));
@@ -56,14 +74,19 @@ class AdminAuthAssetsService {
         ];
 
         // We don't care if removing these files fails as it's valid for them to not exist
-        return Promise.allSettled(promises);
+        await Promise.allSettled(promises);
     }
 
+    /**
+     * Minify, move into the destination directory, and clear existing asset files.
+     *
+     * @returns {Promise<void>}
+     */
     async load() {
-        await this.clearFiles();
-        this.copyStatic();
         const globs = this.generateGlobs();
+        await this.clearFiles();
         await this.minify(globs);
+        await this.copyStatic();
     }
 }
 


### PR DESCRIPTION
The copyStatic method relies on the directory beign created, which is
done by the minify method. We've reordered the calls which fixes the
issue, but we're still left with the copyStatic method being dependent
on the minify method. Adding the `@private` jsdoc tag removes these
from the public interface, so that the dependency is encapsulated in
this module via the `load` method.

We've also awaited the result of the copyStatic method to avoid
dangling promises.