### PR TITLE
🐛 Fixed cookies when running Ghost without SSL

### DIFF
--- a/core/server/services/auth/session/express-session.js
+++ b/core/server/services/auth/session/express-session.js
@@ -23,7 +23,7 @@ function getExpressSessionMiddleware() {
                 maxAge: constants.SIX_MONTH_MS,
                 httpOnly: true,
                 path: urlUtils.getSubdir() + '/ghost',
-                sameSite: 'none',
+                sameSite: urlUtils.isSSL(config.get('url')) ? 'none' : 'lax',
                 secure: urlUtils.isSSL(config.get('url'))
             }
         });


### PR DESCRIPTION
As part of the updates to auth cookies we switched to SameSite=None
which requires an SSL connection. Local development, and some
production sites do not use SSL and so the cookie is invalid and a
session is unable to be created with the browser.