### PR TITLE
Added subscriber signup and cancellation deltas to stats API

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@tryghost/session-service": "0.1.43",
     "@tryghost/settings-path-manager": "0.1.8",
     "@tryghost/social-urls": "0.1.32",
-    "@tryghost/stats-service": "0.2.2",
+    "@tryghost/stats-service": "0.3.0",
     "@tryghost/string": "0.1.26",
     "@tryghost/tpl": "0.1.17",
     "@tryghost/update-check-service": "0.3.4",

--- a/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -92,18 +92,22 @@ Object {
   "stats": Array [
     Object {
       "cadence": "month",
+      "cancellations": 0,
       "count": 1,
       "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "negative_delta": 0,
       "positive_delta": 1,
+      "signups": 1,
       "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
     },
     Object {
       "cadence": "year",
+      "cancellations": 0,
       "count": 0,
       "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "negative_delta": 0,
       "positive_delta": 0,
+      "signups": 0,
       "tier": StringMatching /\\[a-f0-9\\]\\{24\\}/,
     },
   ],
@@ -114,7 +118,7 @@ exports[`Stats API Can fetch subscriptions history 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "403",
+  "content-length": "463",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,10 +2200,10 @@
   resolved "https://registry.yarnpkg.com/@tryghost/social-urls/-/social-urls-0.1.32.tgz#c8a8a80d758bedff5c594667543fd658ed139301"
   integrity sha512-TU/nbqKRVxRJyVBpha5u9pw9oJTlCJhIislE0kS6IfGfjO6EDGa20gfXHV8AGeTuB1pNpiBUKcpX+IsHjjCM/w==
 
-"@tryghost/stats-service@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@tryghost/stats-service/-/stats-service-0.2.2.tgz#79995fb5b4770284f6312537275965afa5aeb804"
-  integrity sha512-HCq6bPVdhU1AROON/+jGuniM3PrX+bv6d5zfa8fVPo423IMhYfYNzD7GzYCpW9sJBwklrl3XO+x7nQMXaTQtTg==
+"@tryghost/stats-service@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/stats-service/-/stats-service-0.3.0.tgz#72ee35cb3492471ff31356a53c8a9483a00c4123"
+  integrity sha512-8HM/miFOCANVa8TcWUxa1MXU8p748cTMJWy+TfVc0r1BftUvpJXIiGpjcMMzUfBdtOBsJau7rTtkKyvkFBeDwQ==
   dependencies:
     moment "^2.29.3"
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1673

When a user switches plan, the paid subscribers delta chart on the dashboard displays the change as a cancellation plus a new subscription. This display is misleading and confusing - instead, plan changes should be excluded from the paid subscribers delta chart.

To accomplish this, we added new properties to the API (signups and cancellations) that can be used to exclude plan changes in the statistics.

Changes in `@tryghost/stats-service`: https://github.com/TryGhost/Analytics/commit/d0dd218fc7c46f9c2420cc4f12384947c9f842bf

Pending admin changes that will get merged after this PR: https://github.com/TryGhost/Admin/pull/2425