### PR TITLE
Added access-control-max-age to preflight requests

### DIFF
--- a/core/frontend/web/middleware/cors.js
+++ b/core/frontend/web/middleware/cors.js
@@ -13,7 +13,8 @@ function corsOptionsDelegate(req, callback) {
     const origin = req.header('Origin');
     const corsOptions = {
         origin: false, // disallow cross-origin requests by default
-        credentials: true // required to allow admin-client to login to private sites
+        credentials: true, // required to allow admin-client to login to private sites
+        maxAge: config.get('caching:cors:maxAge')
     };
 
     if (!origin || origin === 'null') {

--- a/core/server/web/api/endpoints/content/routes.js
+++ b/core/server/web/api/endpoints/content/routes.js
@@ -3,11 +3,12 @@ const cors = require('cors');
 const api = require('../../../../api').endpoints;
 const http = require('../../../../api').shared.http;
 const mw = require('./middleware');
+const config = require('../../../../../shared/config');
 
 module.exports = function apiRoutes() {
     const router = express.Router('content api');
 
-    router.use(cors());
+    router.use(cors({maxAge: config.get('caching:cors:maxAge')}));
 
     // ## Posts
     router.get('/posts', mw.authenticatePublic, http(api.postsPublic.browse));

--- a/core/server/web/api/middleware/cors.js
+++ b/core/server/web/api/middleware/cors.js
@@ -2,9 +2,10 @@ const cors = require('cors');
 const url = require('url');
 const os = require('os');
 const urlUtils = require('../../../../shared/url-utils');
+const config = require('../../../../shared/config');
 
 let allowlist = [];
-const ENABLE_CORS = {origin: true, maxAge: 86400};
+const ENABLE_CORS = {origin: true, maxAge: config.get('caching:cors:maxAge')};
 const DISABLE_CORS = {origin: false};
 
 /**

--- a/core/server/web/members/app.js
+++ b/core/server/web/members/app.js
@@ -1,9 +1,7 @@
 const debug = require('@tryghost/debug')('members');
-const {URL} = require('url');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 const express = require('../../../shared/express');
-const urlUtils = require('../../../shared/url-utils');
 const sentry = require('../../../shared/sentry');
 const membersService = require('../../services/members');
 const stripeService = require('../../services/stripe');
@@ -11,6 +9,7 @@ const middleware = membersService.middleware;
 const shared = require('../shared');
 const labs = require('../../../shared/labs');
 const errorHandler = require('@tryghost/mw-error-handler');
+const config = require('../../../shared/config');
 
 const commentRouter = require('../comments');
 
@@ -22,8 +21,7 @@ module.exports = function setupMembersApp() {
     membersApp.use(shared.middleware.cacheControl('private'));
 
     // Support CORS for requests from the frontend
-    const siteUrl = new URL(urlUtils.getSiteUrl());
-    membersApp.use(cors(siteUrl.origin));
+    membersApp.use(cors({maxAge: config.get('caching:cors:maxAge')}));
 
     // Currently global handling for signing in with ?token= magiclinks
     membersApp.use(middleware.createSessionFromMagicLink);

--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -113,6 +113,9 @@
         },
         "robotstxt": {
             "maxAge": 3600000
+        },
+        "cors": {
+            "maxAge": 86400
         }
     },
     "imageOptimization": {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1676

- Added maxAge option to content API
- Added maxAge to members API
- Added maxAge to frontend site preflights (probably not used, but it was configured, so added to be sure)
- Added config option to change default maxAge of preflight requests