### PR TITLE
Added report API for comments

### DIFF
--- a/ghost/core/core/server/api/endpoints/comments-comments.js
+++ b/ghost/core/core/server/api/endpoints/comments-comments.js
@@ -3,6 +3,7 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 const db = require('../../data/db');
+const service = require('../../services/comments');
 const ALLOWED_INCLUDES = ['post', 'member', 'likes', 'replies'];
 const UNSAFE_ATTRS = ['status'];
 
@@ -242,6 +243,24 @@ module.exports = {
                     message: tpl(messages.memberNotFound)
                 }));
             }
+        }
+    },
+
+    report: {
+        statusCode: 204,
+        options: [
+            'id'
+        ],
+        validation: {},
+        permissions: true,
+        async query(frame) {
+            if (!frame.options?.context?.member?.id) {
+                return Promise.reject(new errors.UnauthorizedError({
+                    message: tpl(messages.memberNotFound)
+                }));
+            }
+
+            await service.api.reportComment(frame.options.id, frame.options?.context?.member);
         }
     }
 };

--- a/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-29-add-comment-reporting-permissions.js
+++ b/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-29-add-comment-reporting-permissions.js
@@ -1,0 +1,10 @@
+const {addPermissionWithRoles} = require('../../utils');
+
+module.exports = addPermissionWithRoles({
+    name: 'Report comments',
+    action: 'report',
+    object: 'comment'
+}, [
+    'Administrator',
+    'Admin Integration'
+]);

--- a/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-31-drop-reports-reason.js
+++ b/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-31-drop-reports-reason.js
@@ -1,0 +1,3 @@
+const {createDropColumnMigration} = require('../../utils');
+
+module.exports = createDropColumnMigration('comment_reports', 'reason', {});

--- a/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-31-drop-reports-reason.js
+++ b/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-31-drop-reports-reason.js
@@ -1,3 +1,3 @@
 const {createDropColumnMigration} = require('../../utils');
 
-module.exports = createDropColumnMigration('comment_reports', 'reason', {});
+module.exports = createDropColumnMigration('comment_reports', 'reason', {type: 'text', maxlength: 65535, nullable: false});

--- a/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-32-drop-nullable-member-id-from-likes.js
+++ b/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-32-drop-nullable-member-id-from-likes.js
@@ -1,0 +1,4 @@
+const {createDropNullableMigration} = require('../../utils');
+
+// We need to disable foreign key checks because if MySQL is missing the STRICT_TRANS_TABLES mode, we cannot drop nullable from a foreign key
+module.exports = createDropNullableMigration('comment_likes', 'member_id', {disableForeignKeyChecks: true});

--- a/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-33-fix-comments-on-delete-foreign-keys.js
+++ b/ghost/core/core/server/data/migrations/versions/5.5/2022-07-18-14-33-fix-comments-on-delete-foreign-keys.js
@@ -1,0 +1,119 @@
+const {addForeign, dropForeign} = require('../../../schema/commands');
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Adding on delete SET NULL for comments');
+    
+        await dropForeign({
+            fromTable: 'comments',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            transaction: knex
+        });
+    
+        await addForeign({
+            fromTable: 'comments',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            setNullDelete: true,
+            transaction: knex
+        });
+    
+        logging.info('Adding on delete CASCADE for comment_likes');
+    
+        await dropForeign({
+            fromTable: 'comment_likes',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            transaction: knex
+        });
+    
+        await addForeign({
+            fromTable: 'comment_likes',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            cascadeDelete: true,
+            transaction: knex
+        });
+    
+        logging.info('Adding on delete SET NULL for comment_reports');
+    
+        await dropForeign({
+            fromTable: 'comment_reports',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            transaction: knex
+        });
+    
+        await addForeign({
+            fromTable: 'comment_reports',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            setNullDelete: true,
+            transaction: knex
+        });
+    }, 
+    async function down(knex) {
+        logging.info('Restoring foreign key for comments');
+    
+        await dropForeign({
+            fromTable: 'comments',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            transaction: knex
+        });
+    
+        await addForeign({
+            fromTable: 'comments',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            transaction: knex
+        });
+    
+        logging.info('Restoring foreign key for comment_likes');
+    
+        await dropForeign({
+            fromTable: 'comment_likes',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            transaction: knex
+        });
+    
+        await addForeign({
+            fromTable: 'comment_likes',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            transaction: knex
+        });
+    
+        logging.info('Restoring foreign key for comment_reports');
+    
+        await dropForeign({
+            fromTable: 'comment_reports',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            transaction: knex
+        });
+    
+        await addForeign({
+            fromTable: 'comment_reports',
+            fromColumn: 'member_id',
+            toTable: 'members',
+            toColumn: 'id',
+            transaction: knex
+        });
+    }
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -610,6 +610,11 @@
                     "name": "Unlike comments",
                     "action_type": "unlike",
                     "object_type": "comment"
+                },
+                {
+                    "name": "Report comments",
+                    "action_type": "report",
+                    "object_type": "comment"
                 }
             ]
         },

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -750,7 +750,7 @@ module.exports = {
     comments: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         post_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'posts.id', cascadeDelete: true},
-        member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id'},
+        member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id', setNullDelete: true},
         parent_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'comments.id'},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'published', validations: {isIn: [['published', 'hidden', 'deleted']]}},
         html: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
@@ -761,15 +761,14 @@ module.exports = {
     comment_likes: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         comment_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'comments.id', cascadeDelete: true},
-        member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id'},
+        member_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'members.id', cascadeDelete: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false}
     },
     comment_reports: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         comment_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'comments.id', cascadeDelete: true},
-        member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id'},
-        reason: {type: 'text', maxlength: 65535, nullable: false},
+        member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id', setNullDelete: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false}
     }

--- a/ghost/core/core/server/models/comment-report.js
+++ b/ghost/core/core/server/models/comment-report.js
@@ -1,0 +1,34 @@
+const ghostBookshelf = require('./base');
+
+const CommentReport = ghostBookshelf.Model.extend({
+    tableName: 'comment_reports',
+
+    defaults: function defaults() {
+        return {};
+    },
+
+    comment() {
+        return this.belongsTo('Comment', 'comment_id');
+    },
+
+    member() {
+        return this.belongsTo('Member', 'member_id');
+    },
+
+    emitChange: function emitChange(event, options) {
+        const eventToTrigger = 'comment_report' + '.' + event;
+        ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
+    },
+
+    onCreated: function onCreated(model, options) {
+        ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
+
+        model.emitChange('added', options);
+    }
+}, {
+
+});
+
+module.exports = {
+    CommentReport: ghostBookshelf.model('CommentReport', CommentReport)
+};

--- a/ghost/core/core/server/services/comments/email-templates/new-comment-reply.hbs
+++ b/ghost/core/core/server/services/comments/email-templates/new-comment-reply.hbs
@@ -116,7 +116,7 @@
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: bold; line-height: 25px; margin: 0; margin-bottom: 15px;">Hey there,</p>
-                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">Someone just replied to your comment on <a href="https://ghost.org">{{postTitle}}</a>.</p>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">Someone just replied to your comment on <a href="{{postUrl}}" target="_blank">{{postTitle}}</a>.</p>
 
                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box; background: #F9F9FA; border-radius: 7px;">
                         <tbody>

--- a/ghost/core/core/server/services/comments/email-templates/new-comment-reply.txt.js
+++ b/ghost/core/core/server/services/comments/email-templates/new-comment-reply.txt.js
@@ -1,14 +1,13 @@
 module.exports = function (data) {
-    return `
-        Hey there,
+    // Be careful when you indent the email, because whitespaces are visible in emails!
+    return `Hey there,
 
-        Someone just replied to your comment on "${data.postTitle}"
+Someone just replied to your comment on "${data.postTitle}"
 
-        ${data.postUrl}#comments-area
+${data.postUrl}#ghost-comments-root
 
-        ---
+---
 
-        Sent to ${data.toEmail} from ${data.siteDomain}.
-        You can manage your notification preferences at ${data.profileUrl}.
-    `;
+Sent to ${data.toEmail} from ${data.siteDomain}.
+You can manage your notification preferences at ${data.profileUrl}.`;
 };

--- a/ghost/core/core/server/services/comments/email-templates/new-comment.txt.js
+++ b/ghost/core/core/server/services/comments/email-templates/new-comment.txt.js
@@ -1,14 +1,15 @@
 module.exports = function (data) {
+    // Be careful when you indent the email, because whitespaces are visible in emails!
     return `
-        Hey there,
+Hey there,
 
-        Someone just posted a comment on your post "${data.postTitle}"
+Someone just posted a comment on your post "${data.postTitle}"
 
-        ${data.postUrl}#comments-area
+${data.postUrl}#ghost-comments-root
 
-        ---
+---
 
-        Sent to ${data.toEmail} from ${data.siteDomain}.
-        You can manage your notification preferences at ${data.staffUrl}.
+Sent to ${data.toEmail} from ${data.siteDomain}.
+You can manage your notification preferences at ${data.staffUrl}.
     `;
 };

--- a/ghost/core/core/server/services/comments/email-templates/report.hbs
+++ b/ghost/core/core/server/services/comments/email-templates/report.hbs
@@ -1,9 +1,9 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta name="viewport" content="width=device-width">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>💬 New comment on {{postTitle}}</title>
+    <title>🚩 A comment has been reported on {{postTitle}}</title>
     <style>
     /* -------------------------------------
         RESPONSIVE AND MOBILE FRIENDLY STYLES
@@ -106,7 +106,7 @@
           <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
 
             <!-- START CENTERED CONTAINER -->
-            <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">Someone left a comment on your post</span>
+            <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">{{reporterName}} ({{reporterEmail}}) reported a comment on your post</span>
             <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
 
               <!-- START MAIN CONTENT AREA -->
@@ -116,7 +116,7 @@
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: bold; line-height: 25px; margin: 0; margin-bottom: 15px;">Hey there,</p>
-                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">Someone just left a comment on your post <a href="{{postUrl}}" target="_blank">{{postTitle}}</a>.</p>
+                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">{{reporter}} has reported the comment below on <a href="{{postUrl}}" target="_blank">{{postTitle}}</a>. This comment will remain visible until you choose to remove it, which can be done directly on the post.</p>
 
                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box; background: #F9F9FA; border-radius: 7px;">
                         <tbody>
@@ -154,7 +154,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}#ghost-comments-root" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View comments</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{postUrl}}#ghost-comments-root" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View comment</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>

--- a/ghost/core/core/server/services/comments/email-templates/report.txt.js
+++ b/ghost/core/core/server/services/comments/email-templates/report.txt.js
@@ -1,0 +1,16 @@
+module.exports = function (data) {
+    // Be careful when you indent the email, because whitespaces are visible in emails!
+    return `Hey there,
+
+${data.reporter} has reported the comment below on ${data.postTitle}. This comment will remain visible until you choose to remove it, which can be done directly on the post.
+
+${data.memberName} (${data.memberEmail}):
+${data.commentText}
+
+${data.postUrl}#ghost-comments-root
+
+---
+
+Sent to ${data.toEmail} from ${data.siteDomain}.
+You can manage your notification preferences at ${data.staffUrl}.`;
+};

--- a/ghost/core/core/server/services/comments/service.js
+++ b/ghost/core/core/server/services/comments/service.js
@@ -19,6 +19,29 @@ class CommentsService {
             this.emails.notifyParentCommentAuthor(comment);
         }
     }
+
+    async reportComment(commentId, reporter) {
+        const comment = await this.models.Comment.findOne({id: commentId}, {require: true});
+
+        // Check if this reporter already reported this comment (then don't send an email)?
+        const existing = await this.models.CommentReport.findOne({
+            comment_id: comment.id,
+            member_id: reporter.id
+        });
+
+        if (existing) {
+            // Ignore silently for now
+            return;
+        }
+
+        // Save report model
+        await this.models.CommentReport.add({
+            comment_id: comment.id,
+            member_id: reporter.id
+        });
+
+        await this.emails.notifiyReport(comment, reporter);
+    }
 }
 
 module.exports = CommentsService;

--- a/ghost/core/core/server/web/comments/routes.js
+++ b/ghost/core/core/server/web/comments/routes.js
@@ -24,5 +24,7 @@ module.exports = function apiRoutes() {
     router.post('/:id/like', http(api.commentsComments.like));
     router.delete('/:id/like', http(api.commentsComments.unlike));
 
+    router.post('/:id/report', http(api.commentsComments.report));
+
     return router;
 };

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -378,6 +378,15 @@ Object {
 }
 `;
 
+exports[`Comments API when authenticated Can report a comment 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when authenticated Cannot like a comment multiple times 1: [body] 1`] = `
 Object {
   "errors": Array [
@@ -410,6 +419,126 @@ Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "218",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when authenticated Cannot report a comment twice 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when not authenticated Can browse all comments of a post 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "<p>First.</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "likes_count": Any<Number>,
+      "member": Object {
+        "avatar_image": null,
+        "bio": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": "Mr Egg",
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [
+        Object {
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "edited_at": null,
+          "html": "<p>Really original</p>",
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "liked": Any<Boolean>,
+          "likes_count": Any<Number>,
+          "member": Object {
+            "avatar_image": null,
+            "bio": null,
+            "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+            "name": null,
+            "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+          },
+          "status": "published",
+        },
+      ],
+      "status": "published",
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 15,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
+}
+`;
+
+exports[`Comments API when not authenticated Can browse all comments of a post 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "721",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when not authenticated Can report a comment 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when not authenticated cannot report a comment 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": null,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Unable to find member",
+      "property": null,
+      "type": "UnauthorizedError",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when not authenticated cannot report a comment 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when not authenticated cannot report a comment 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "211",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -45,7 +45,7 @@ describe('Database Migration (special functions)', function () {
             const permissions = this.obj;
 
             // If you have to change this number, please add the relevant `havePermission` checks below
-            permissions.length.should.eql(105);
+            permissions.length.should.eql(106);
 
             permissions.should.havePermission('Export database', ['Administrator', 'DB Backup Integration']);
             permissions.should.havePermission('Import database', ['Administrator', 'DB Backup Integration']);
@@ -178,6 +178,7 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Moderate comments', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Like comments', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Unlike comments', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Report comments', ['Administrator', 'Admin Integration']);
         });
 
         describe('Populate', function () {
@@ -236,7 +237,6 @@ describe('Database Migration (special functions)', function () {
                     result.roles.at(8).get('name').should.eql('Scheduler Integration');
 
                     // Permissions
-                    result.permissions.length.should.eql(105);
                     result.permissions.toJSON().should.be.CompletePermissions();
                 });
             });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,8 +35,8 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c85378b0bbd7d5eeb1fff39796c30886';
-    const currentFixturesHash = 'ec7487f1ffbe64ede499cc053b915bac';
+    const currentSchemaHash = '6ca68654d9dcb05cf054b0a74f0de2c7';
+    const currentFixturesHash = 'a42105cc0d47dd978dd52ee271340013';
     const currentSettingsHash = 'd54210758b7054e2174fd34aa2320ad7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -610,6 +610,11 @@
                     "name": "Unlike comments",
                     "action_type": "unlike",
                     "object_type": "comment"
+                },
+                {
+                    "name": "Report comments",
+                    "action_type": "report",
+                    "object_type": "comment"
                 }
             ]
         },


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1684

**Migrations:**
- Added report permissions (fixtures + migrations)
- Dropped reason field in reports (no textarea in reports in V1)
- Dropped nullable from comment_likes.member_id (can't be null)
- Added SET NULL/CASCADE foreign keys for comments related tables(*)

(*):
fixes https://github.com/TryGhost/Team/issues/1687
refs https://ghost.slack.com/archives/C02G9E68C/p1658217288591369

This commit adds support for `SET NULL` foreign keys in schema and migration helpers + also fixes the foreign keys for the comment_reports, comment_likes and comments tables.

- When a member is deleted, we **do** want to keep their reports (SET NULL)
- When a member is deleted, we **do not** want to keep their likes (CASCADE)
- When a member is deleted, we **do** want to keep the comments (SET NULL)

**Changes:**
- Added report API: `POST /members/api/comments/{id}}/report/`
- Sends an email to the owner when a comment is reported
- Saves a report to the database (not used for now, but might be useful later)

