### PR TITLE
Added editor.url config

### DIFF
--- a/core/server/api/endpoints/utils/serializers/output/config.js
+++ b/core/server/api/endpoints/utils/serializers/output/config.js
@@ -18,7 +18,8 @@ module.exports = {
             'mailgunIsConfigured',
             'emailAnalytics',
             'hostSettings',
-            'tenor'
+            'tenor',
+            'editor'
         ];
 
         frame.response = {

--- a/core/server/services/public-config/config.js
+++ b/core/server/services/public-config/config.js
@@ -18,7 +18,8 @@ module.exports = function getConfigProperties() {
         mailgunIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').mailgun),
         emailAnalytics: config.get('emailAnalytics'),
         hostSettings: config.get('hostSettings'),
-        tenor: config.get('tenor')
+        tenor: config.get('tenor'),
+        editor: config.get('editor')
     };
 
     const billingUrl = config.get('hostSettings:billing:enabled') ? config.get('hostSettings:billing:url') : '';

--- a/core/shared/config/defaults.json
+++ b/core/shared/config/defaults.json
@@ -140,6 +140,9 @@
         "url": "https://unpkg.com/@tryghost/sodo-search@~1.0.0/umd/sodo-search.min.js",
         "version": "1.0.0"
     },
+    "editor": {
+        "url": ""
+    },
     "tenor": {
         "publicReadOnlyApiKey": null,
         "contentFilter": "off"

--- a/test/e2e-api/admin/utils.js
+++ b/test/e2e-api/admin/utils.js
@@ -28,7 +28,21 @@ const expectedProperties = {
 
     action: ['id', 'resource_type', 'actor_type', 'event', 'created_at', 'actor'],
 
-    config: ['version', 'environment', 'database', 'mail', 'labs', 'clientExtensions', 'enableDeveloperExperiments', 'useGravatar', 'stripeDirect', 'emailAnalytics', 'tenor', 'mailgunIsConfigured'],
+    config: [
+        'version',
+        'environment',
+        'database',
+        'mail',
+        'labs',
+        'clientExtensions',
+        'enableDeveloperExperiments',
+        'useGravatar',
+        'stripeDirect',
+        'emailAnalytics',
+        'tenor',
+        'mailgunIsConfigured',
+        'editor'
+    ],
 
     post: [
         'id',


### PR DESCRIPTION
no issue

- used for an ongoing react based editor experiment
- by exposing `editor.url` in public config it lets Admin dynamically fetch the external module and allows for independent releases of the editor without needing to have a full Ghost release
- follows the same pattern as portal and comments
