### PR TITLE
Added jobs table creation migration

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -34,7 +34,8 @@ const BACKUP_TABLES = [
     'members_newsletters',
     'comments',
     'comment_likes',
-    'comment_reports'
+    'comment_reports',
+    'jobs'
 ];
 
 // NOTE: exposing only tables which are going to be included in a "default" export file

--- a/ghost/core/core/server/data/migrations/versions/5.5/2022-07-21-08-56-add-jobs-table.js
+++ b/ghost/core/core/server/data/migrations/versions/5.5/2022-07-21-08-56-add-jobs-table.js
@@ -1,0 +1,11 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('jobs', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    name: {type: 'string', maxlength: 191, nullable: false, unique: true},
+    status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'queued', validations: {isIn: [['started', 'finished', 'failed', 'queued']]}},
+    started_at: {type: 'dateTime', nullable: true},
+    finished_at: {type: 'dateTime', nullable: true},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: true}
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -771,5 +771,14 @@ module.exports = {
         member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id', setNullDelete: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false}
+    },
+    jobs: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        name: {type: 'string', maxlength: 191, nullable: false, unique: true},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'queued', validations: {isIn: [['started', 'finished', 'failed', 'queued']]}},
+        started_at: {type: 'dateTime', nullable: true},
+        finished_at: {type: 'dateTime', nullable: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: true}
     }
 };

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -34,6 +34,7 @@ describe('Exporter', function () {
                 'emails',
                 'integrations',
                 'invites',
+                'jobs',
                 'labels',
                 'members',
                 'members_cancel_events',

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '6ca68654d9dcb05cf054b0a74f0de2c7';
+    const currentSchemaHash = '71daf7814834fffd40abba86a92f4347';
     const currentFixturesHash = 'a42105cc0d47dd978dd52ee271340013';
     const currentSettingsHash = 'd54210758b7054e2174fd34aa2320ad7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/357

One time jobs need a storage mechanism to be run only ever once.

Field notes:
- `id`, `created_at`, `updated_at` - standard Ghost fields
- `name` - unique name of the job, could also be used with prefixing to identify certain type of job (e.g.: backup-bob-2022-10-16, backup-sam-2023-01-13 identifying backup jobs run by users)
- `status` - 'active' | 'done' | 'failed' | 'queued'  (need to identify when the job is in progress, done, added to the queue, or errored)
- `started_at` -  when the job started execution
- `finished_at` - when the job *successfully?* finished execution

Added `jobs` to the exported tables list as they are not a part of "secret" data and would identify which data transformations have potentially have been already done through one-time jobs (main usecase of this type of jobs).

:heavy_check_mark:  ~The final spec of the table structure is still in the review.~ Having the PR opened for visibility and be ready to tweak&merge in coming days.