### PR TITLE
Added comment events to activity feed

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/activity-feed-events.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/activity-feed-events.js
@@ -1,0 +1,17 @@
+const mapComment = require('./comments');
+
+const commentEventMapper = (json, frame) => {
+    return {
+        ...json,
+        data: mapComment(json.data, frame)
+    };
+};
+
+const activityFeedMapper = (event, frame) => {
+    if (event.type === 'comment_event') {
+        return commentEventMapper(event, frame);
+    }
+    return event;
+};
+
+module.exports = activityFeedMapper;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const url = require('../utils/url');
 
 const commentFields = [
     'id',
@@ -14,6 +15,13 @@ const memberFields = [
     'name',
     'bio',
     'avatar_image'
+];
+
+const postFields = [
+    'id',
+    'uuid',
+    'title',
+    'url'
 ];
 
 const commentMapper = (model, frame) => {
@@ -35,6 +43,16 @@ const commentMapper = (model, frame) => {
 
     if (jsonModel.replies) {
         response.replies = jsonModel.replies.map(reply => commentMapper(reply, frame));
+    }
+
+    if (jsonModel.parent) {
+        response.parent = commentMapper(jsonModel.parent, frame);
+    }
+
+    if (jsonModel.post) {
+        // We could use the post mapper here, but we need less field + don't need al the async behaviour support
+        url.forPost(jsonModel.post.id, jsonModel.post, frame);
+        response.post = _.pick(jsonModel.post, postFields);
     }
 
     // todo

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     actions: require('./actions'),
+    activityFeedEvents: require('./activity-feed-events'),
     authors: require('./authors'),
     comments: require('./comments'),
     emails: require('./emails'),

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
@@ -1,6 +1,7 @@
 //@ts-check
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:output:members');
 const {unparse} = require('@tryghost/members-csv');
+const mappers = require('./mappers');
 
 module.exports = {
     browse: createSerializer('browse', paginatedMembers),
@@ -18,7 +19,7 @@ module.exports = {
     importCSV: createSerializer('importCSV', passthrough),
     memberStats: createSerializer('memberStats', passthrough),
     mrrStats: createSerializer('mrrStats', passthrough),
-    activityFeed: createSerializer('activityFeed', passthrough)
+    activityFeed: createSerializer('activityFeed', activityFeed)
 };
 
 /**
@@ -70,6 +71,16 @@ function bulkAction(bulkActionResult, _apiConfig, frame) {
                 unsuccessfulData: bulkActionResult.unsuccessfulData
             }
         }
+    };
+}
+
+/**
+ *
+ * @returns {{events: any[]}}
+ */
+function activityFeed(data, _apiConfig, frame) {
+    return {
+        events: data.events.map(e => mappers.activityFeedEvents(e, frame))
     };
 }
 

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -77,7 +77,11 @@ const Comment = ghostBookshelf.Model.extend({
         model.emitChange('added', options);
     },
 
-    enforcedFilters: function enforcedFilters() {
+    enforcedFilters: function enforcedFilters(options) {
+        if (options.context && options.context.user) {
+            return null;
+        }
+
         return 'parent_id:null';
     }
 
@@ -151,7 +155,9 @@ const Comment = ghostBookshelf.Model.extend({
     defaultRelations: function defaultRelations(methodName, options) {
         // @todo: the default relations are not working for 'add' when we add it below
         if (['findAll', 'findPage', 'edit', 'findOne'].indexOf(methodName) !== -1) {
-            options.withRelated = _.union(['member', 'likes', 'replies', 'replies.member', 'replies.likes'], options.withRelated || []);
+            if (!options.withRelated || options.withRelated.length === 0) {
+                options.withRelated = ['member', 'likes', 'replies', 'replies.member', 'replies.likes'];
+            }
         }
 
         return options;

--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -189,7 +189,8 @@ function createApiInstance(config) {
             StripeProduct: models.StripeProduct,
             StripePrice: models.StripePrice,
             Product: models.Product,
-            Settings: models.Settings
+            Settings: models.Settings,
+            Comment: models.Comment
         },
         stripeAPIService: stripeService.api,
         offersAPI: offersService.api,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -3278,6 +3278,45 @@ Object {
 }
 `;
 
+exports[`Members API Returns comments in activity feed 1: [body] 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+  ],
+}
+`;
+
+exports[`Members API Returns comments in activity feed 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "3484",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Members API Search by case-insensitive email MEMBER2 receives member with email member2@test.com 1: [body] 1`] = `
 Object {
   "members": Array [

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -316,6 +316,7 @@ module.exports = {
         anyBoolean: any(Boolean),
         anyString: any(String),
         anyArray: any(Array),
+        anyObject: any(Object),
         anyNumber: any(Number),
         anyStringNumber: stringMatching(/\d+/),
         anyISODateTime: stringMatching(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.000Z/),

--- a/ghost/members-api/lib/MembersAPI.js
+++ b/ghost/members-api/lib/MembersAPI.js
@@ -53,7 +53,8 @@ module.exports = function MembersAPI({
         StripeProduct,
         StripePrice,
         Product,
-        Settings
+        Settings,
+        Comment
     },
     stripeAPIService,
     offersAPI,
@@ -103,6 +104,7 @@ module.exports = function MembersAPI({
         MemberPaymentEvent,
         MemberStatusEvent,
         MemberLoginEvent,
+        Comment,
         labsService
     });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1709

- New event type `comment_event` (comments and replies of a member in the activity feed)
- Includes member, post and parent relation by default
- Added new output mapper for ActivityFeed events

**Changes to `Comment` model:**
* **Only limit comment fetched to root comments when not authenticated as a user:** 
`enforcedFilters` is applied to all queries, which is a problem because for the activity feed we also need to fetch comments which have a parent_id that is not null (`Member x replied to a comment`). The current filter in the model is specifically for the members API, not the admin API (so checking the user should fix that, not sure if that is a good pattern but couldn’t find a better alternative).
* **Only set default relations for comments when withRelated is empty or not set:**
`defaultRelations`: Right now, for every fetch it would force all these relations. But we don’t need all those relations for the activity feed; So I updated the pattern to only set the default relations when it is empty (which we also do on a couple of other places and seems like a good pattern). I also updated the comments-ui frontend to not send ?include 