### PR TITLE
Added members.last_commented_at and last_seen_at update when commenting

### DIFF
--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -2,7 +2,6 @@ const ghostBookshelf = require('./base');
 const _ = require('lodash');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
-const commentsService = require('../services/comments');
 
 const messages = {
     commentNotFound: 'Comment could not be found',
@@ -69,10 +68,6 @@ const Comment = ghostBookshelf.Model.extend({
 
     onCreated: function onCreated(model, options) {
         ghostBookshelf.Model.prototype.onCreated.apply(this, arguments);
-
-        if (!options.context.internal) {
-            commentsService.api.sendNewCommentNotifications(model);
-        }
 
         model.emitChange('added', options);
     },

--- a/ghost/core/core/server/services/comments/emails.js
+++ b/ghost/core/core/server/services/comments/emails.js
@@ -48,7 +48,7 @@ class CommentsServiceEmails {
 
             const {html, text} = await this.renderEmailTemplate('new-comment', templateData);
 
-            this.sendMail({
+            await this.sendMail({
                 to,
                 subject,
                 html,
@@ -147,7 +147,7 @@ class CommentsServiceEmails {
 
         const {html, text} = await this.renderEmailTemplate('report', templateData);
 
-        this.sendMail({
+        await this.sendMail({
             to,
             subject,
             html,

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -3,6 +3,8 @@ const {agentProvider, mockManager, fixtureManager, matchers} = require('../../ut
 const {anyEtag, anyObjectId, anyLocationFor, anyISODateTime, anyUuid, anyNumber, anyBoolean} = matchers;
 const should = require('should');
 const models = require('../../../core/server/models');
+const moment = require('moment-timezone');
+const settingsCache = require('../../../core/shared/settings-cache');
 
 let membersAgent, membersAgent2, member, postId, commentId;
 
@@ -97,6 +99,8 @@ describe('Comments API', function () {
         });
 
         it('Can comment on a post', async function () {
+            await models.Member.edit({last_seen_at: null, last_commented_at: null}, {id: member.get('id')});
+
             const {body} = await membersAgent
                 .post(`/api/comments/`)
                 .body({comments: [{
@@ -114,15 +118,22 @@ describe('Comments API', function () {
             // Save for other tests
             commentId = body.comments[0].id;
 
-            // Wait for the emails (because this happens async)
-            await sleep(100);
-
             // Check if author got an email
             mockManager.assert.sentEmailCount(1);
             mockManager.assert.sentEmail({
                 subject: '💬 You have a new comment on one of your posts',
                 to: fixtureManager.get('users', 0).email
             });
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+
+            // Check last_updated_at changed?
+            member = await models.Member.findOne({id: member.id});
+            should.notEqual(member.get('last_seen_at'), null, 'The member should have a `last_seen_at` property after posting a comment.');
+
+            // Check last_commented_at changed?
+            should.notEqual(member.get('last_commented_at'), null, 'The member should have a `last_commented_at` property after posting a comment.');
         });
 
         it('Can browse all comments of a post', async function () {
@@ -138,6 +149,11 @@ describe('Comments API', function () {
         });
 
         it('Can reply to your own comment', async function () {
+            // Should not update last_seen_at or last_commented_at when both are already set to a value on the same day
+            const timezone = settingsCache.get('timezone');
+            const date = moment.utc(new Date()).tz(timezone).startOf('day').toDate();
+            await models.Member.edit({last_seen_at: date, last_commented_at: date}, {id: member.get('id')});
+
             const {body} = await membersAgent
                 .post(`/api/comments/`)
                 .body({comments: [{
@@ -154,18 +170,28 @@ describe('Comments API', function () {
                     comments: [commentMatcherNoMember]
                 });
 
-            // Wait for the emails (because this happens async)
-            await sleep(100);
-
             // Check only the author got an email (because we are the author of this parent comment)
             mockManager.assert.sentEmailCount(1);
             mockManager.assert.sentEmail({
                 subject: '💬 You have a new comment on one of your posts',
                 to: fixtureManager.get('users', 0).email
             });
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+
+            // Check last updated_at is not changed?
+            member = await models.Member.findOne({id: member.id});
+            should.equal(member.get('last_seen_at').getTime(), date.getTime(), 'The member should not update `last_seen_at` if last seen at is same day');
+
+            // Check last_commented_at changed?
+            should.equal(member.get('last_commented_at').getTime(), date.getTime(), 'The member should not update `last_commented_at` f last seen at is same day');
         });
 
         it('Can reply to a comment', async function () {
+            const date = new Date(0);
+            await models.Member.edit({last_seen_at: date, last_commented_at: date}, {id: member.get('id')});
+
             const {body} = await membersAgent
                 .post(`/api/comments/`)
                 .body({comments: [{
@@ -182,8 +208,6 @@ describe('Comments API', function () {
                     comments: [commentMatcherNoMember]
                 });
 
-            // Wait for the emails (because this happens async)
-            await sleep(100);
             mockManager.assert.sentEmailCount(2);
             mockManager.assert.sentEmail({
                 subject: '💬 You have a new comment on one of your posts',
@@ -194,6 +218,16 @@ describe('Comments API', function () {
                 subject: '💬 You have a new reply on one of your comments',
                 to: fixtureManager.get('members', 0).email
             });
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+
+            // Check last_updated_at changed?
+            member = await models.Member.findOne({id: member.id});
+            should.notEqual(member.get('last_seen_at').getTime(), date.getTime(), 'Should update `last_seen_at` property after posting a comment.');
+ 
+            // Check last_commented_at changed?
+            should.notEqual(member.get('last_commented_at').getTime(), date.getTime(), 'Should update `last_commented_at` property after posting a comment.');
         });
 
         it('Can like a comment', async function () {

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -126,7 +126,7 @@ describe('Comments API', function () {
             });
 
             // Wait for the dispatched events (because this happens async)
-            await sleep(250);
+            await sleep(200);
 
             // Check last_updated_at changed?
             member = await models.Member.findOne({id: member.id});
@@ -178,7 +178,7 @@ describe('Comments API', function () {
             });
 
             // Wait for the dispatched events (because this happens async)
-            await sleep(250);
+            await sleep(200);
 
             // Check last updated_at is not changed?
             member = await models.Member.findOne({id: member.id});

--- a/ghost/member-events/index.js
+++ b/ghost/member-events/index.js
@@ -6,5 +6,6 @@ module.exports = {
     MemberPaidConverstionEvent: require('./lib/MemberPaidConversionEvent'),
     MemberPaidCancellationEvent: require('./lib/MemberPaidCancellationEvent'),
     MemberPageViewEvent: require('./lib/MemberPageViewEvent'),
-    SubscriptionCreatedEvent: require('./lib/SubscriptionCreatedEvent')
+    SubscriptionCreatedEvent: require('./lib/SubscriptionCreatedEvent'),
+    MemberCommentEvent: require('./lib/MemberCommentEvent')
 };

--- a/ghost/member-events/lib/MemberCommentEvent.js
+++ b/ghost/member-events/lib/MemberCommentEvent.js
@@ -1,8 +1,8 @@
 /**
  * @typedef {object} MemberCommentEventData
  * @prop {string} memberId
- * @prop {string} memberLastSeenAt
- * @prop {string} memberLastCommentedAt
+ * @prop {string} commentId
+ * @prop {string} postId
  */
 
 /**

--- a/ghost/member-events/lib/MemberCommentEvent.js
+++ b/ghost/member-events/lib/MemberCommentEvent.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {object} MemberCommentEventData
+ * @prop {string} memberId
+ * @prop {string} memberLastSeenAt
+ * @prop {string} memberLastCommentedAt
+ */
+
+/**
+ * Server-side event firing on page views (page, post, tags...)
+ */
+module.exports = class MemberCommentEvent {
+    /**
+     * @param {MemberCommentEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {MemberCommentEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new MemberCommentEvent(data, timestamp || new Date);
+    }
+};

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -318,7 +318,8 @@ module.exports = class MemberRepository {
             'products',
             'newsletters',
             'enable_comment_notifications',
-            'last_seen_at'
+            'last_seen_at',
+            'last_commented_at'
         ]);
 
         // Determine if we need to fetch the initial member with relations

--- a/ghost/members-events-service/lib/last-seen-at-updater.js
+++ b/ghost/members-events-service/lib/last-seen-at-updater.js
@@ -1,4 +1,4 @@
-const {MemberPageViewEvent} = require('@tryghost/member-events');
+const {MemberPageViewEvent, MemberCommentEvent} = require('@tryghost/member-events');
 const moment = require('moment-timezone');
 const {IncorrectUsageError} = require('@tryghost/errors');
 
@@ -32,6 +32,10 @@ class LastSeenAtUpdater {
         this._domainEventsService.subscribe(MemberPageViewEvent, async (event) => {
             await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
         });
+
+        this._domainEventsService.subscribe(MemberCommentEvent, async (event) => {
+            await this.updateLastCommentedAt(event.data.memberId, event.data.memberLastSeenAt, event.data.memberLastCommentedAt, event.timestamp);
+        });
     }
 
     /**
@@ -49,6 +53,29 @@ class LastSeenAtUpdater {
             const membersApi = await this._getMembersApi();
             await membersApi.members.update({
                 last_seen_at: moment.utc(timestamp).format('YYYY-MM-DD HH:mm:ss')
+            }, {
+                id: memberId
+            });
+        }
+    }
+
+    /**
+     * Updates the member.last_seen_at field if it wasn't updated in the current day yet (in the publication timezone)
+     * Example: current time is 2022-02-28 18:00:00
+     * - memberLastSeenAt is 2022-02-27 23:00:00, timestamp is current time, then `last_seen_at` is set to the current time
+     * - memberLastSeenAt is 2022-02-28 01:00:00, timestamp is current time, then `last_seen_at` isn't changed
+     * @param {string} memberId The id of the member to be udpated
+     * @param {string} memberLastSeenAt The previous last_seen_at property value for the current member
+     * @param {string} memberLastCommentedAt The previous last_commented_at property value for the current member
+     * @param {Date} timestamp The event timestamp
+     */
+    async updateLastCommentedAt(memberId, memberLastSeenAt, memberLastCommentedAt, timestamp) {
+        const timezone = this._settingsCacheService.get('timezone');
+        if (memberLastSeenAt === null || moment(moment.utc(timestamp).tz(timezone).startOf('day')).isAfter(memberLastSeenAt) || memberLastCommentedAt === null || moment(moment.utc(timestamp).tz(timezone).startOf('day')).isAfter(memberLastCommentedAt)) {
+            const membersApi = await this._getMembersApi();
+            await membersApi.members.update({
+                last_seen_at: moment.utc(timestamp).format('YYYY-MM-DD HH:mm:ss'),
+                last_commented_at: moment.utc(timestamp).format('YYYY-MM-DD HH:mm:ss')
             }, {
                 id: memberId
             });

--- a/ghost/members-events-service/test/last-seen-at-updater.test.js
+++ b/ghost/members-events-service/test/last-seen-at-updater.test.js
@@ -37,7 +37,6 @@ describe('LastSeenAtUpdater', function () {
 
     it('Calls updateLastCommentedAt on MemberCommentEvents', async function () {
         const now = moment('2022-02-28T18:00:00Z').utc();
-        const previousLastSeen = moment('2022-02-27T23:00:00Z').toISOString();
         const stub = sinon.stub().resolves();
         const settingsCache = sinon.stub().returns('Etc/UTC');
         const updater = new LastSeenAtUpdater({
@@ -56,8 +55,8 @@ describe('LastSeenAtUpdater', function () {
             }
         });
         sinon.stub(updater, 'updateLastCommentedAt');
-        DomainEvents.dispatch(MemberCommentEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, memberLastCommentedAt: previousLastSeen, url: '/'}, now.toDate()));
-        assert(updater.updateLastCommentedAt.calledOnceWithExactly('1', previousLastSeen, previousLastSeen, now.toDate()));
+        DomainEvents.dispatch(MemberCommentEvent.create({memberId: '1'}, now.toDate()));
+        assert(updater.updateLastCommentedAt.calledOnceWithExactly('1', now.toDate()));
     });
 
     it('works correctly on another timezone (not updating last_seen_at)', async function () {
@@ -99,12 +98,20 @@ describe('LastSeenAtUpdater', function () {
             async getMembersApi() {
                 return {
                     members: {
-                        update: stub
+                        update: stub,
+                        get: () => {
+                            return {
+                                id: '1',
+                                get: () => {
+                                    return previousLastSeen;
+                                }
+                            };
+                        }
                     }
                 };
             }
         });
-        await updater.updateLastCommentedAt('1', previousLastSeen, previousLastSeen, now.toDate());
+        await updater.updateLastCommentedAt('1', now.toDate());
         assert(stub.notCalled, 'The LastSeenAtUpdater should attempt a member update when the new timestamp is within the same day in the publication timezone.');
     });
 
@@ -175,12 +182,20 @@ describe('LastSeenAtUpdater', function () {
             async getMembersApi() {
                 return {
                     members: {
-                        update: stub
+                        update: stub,
+                        get: () => {
+                            return {
+                                id: '1',
+                                get: () => {
+                                    return previousLastSeen;
+                                }
+                            };
+                        }
                     }
                 };
             }
         });
-        await updater.updateLastCommentedAt('1', previousLastSeen, previousLastSeen, now.toDate());
+        await updater.updateLastCommentedAt('1', now.toDate());
         assert(stub.notCalled, 'The LastSeenAtUpdater should\'t update a member when the previous last_seen_at is close to the event timestamp.');
     });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1717

- Updates last_commented_at and last_seen_at (only once a day)
- Used the LastSeenAtUpdater, so we can combine updating last_commented_at and last_seen_at in one query + used same pattern
- Updated comments service to await emails in order to make E2E tests more stable (as we don't have any method to await emails and test emails otherwise). This removed the email sending logic from the `onCreated` hook of the model (having it in the service is also cleaner I think?).