### PR TITLE
Allowed configurable urls for frontend apps

### DIFF
--- a/ghost/core/core/frontend/utils/frontend-apps.js
+++ b/ghost/core/core/frontend/utils/frontend-apps.js
@@ -1,0 +1,33 @@
+const {config} = require('../services/proxy');
+
+function getFrontendAppConfig(app) {
+    const appVersion = config.get(`${app}:version`);
+    let scriptUrl = config.get(`${app}:url`);
+    let stylesUrl = config.get(`${app}:styles`);
+    if (scriptUrl.includes('{version}')) {
+        scriptUrl = scriptUrl.replace('{version}', appVersion);
+    }
+    if (stylesUrl?.includes('{version}')) {
+        stylesUrl = stylesUrl.replace('{version}', appVersion);
+    }
+    return {
+        scriptUrl,
+        stylesUrl,
+        appVersion
+    };
+}
+
+function getDataAttributes(data) {
+    let dataAttributes = '';
+
+    if (!data) {
+        return dataAttributes;
+    }
+    Object.entries(data).forEach(([key, value]) => {
+        dataAttributes += `data-${key}="${value}" `;
+    });
+
+    return dataAttributes.trim();
+}
+
+module.exports = {getFrontendAppConfig, getDataAttributes};

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -133,12 +133,18 @@
         "emailAnalytics": true
     },
     "portal": {
-        "url": "https://unpkg.com/@tryghost/portal@~2.3.0/umd/portal.min.js",
+        "url": "https://cdn.jsdelivr.net/npm/@tryghost/portal@~{version}/umd/portal.min.js",
         "version": "2.3"
     },
     "sodoSearch": {
-        "url": "https://unpkg.com/@tryghost/sodo-search@~1.0.0/umd/sodo-search.min.js",
-        "version": "1.0.0"
+        "url": "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/sodo-search.min.js",
+        "styles": "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/main.css",
+        "version": "1.0"
+    },
+    "comments": {
+        "url": "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/comments-ui.min.js",
+        "styles": "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/main.css",
+        "version": "0.1"
     },
     "editor": {
         "url": ""
@@ -155,9 +161,5 @@
     },
     "gravatar": {
         "url": "https://www.gravatar.com/avatar/{hash}?s={size}&r={rating}&d={_default}"
-    },
-    "comments": {
-        "url": "https://unpkg.com/@tryghost/comments-ui@~0.1.0/umd/comments-ui.min.js",
-        "version": "0.1.0"
     }
 }

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -139,12 +139,12 @@
     "sodoSearch": {
         "url": "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/sodo-search.min.js",
         "styles": "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/main.css",
-        "version": "1.0"
+        "version": "1.1"
     },
     "comments": {
         "url": "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/comments-ui.min.js",
         "styles": "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/main.css",
-        "version": "0.1"
+        "version": "0.2"
     },
     "editor": {
         "url": ""

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -56,7 +56,8 @@
         "urlCache": "test/utils/fixtures/urls"
     },
     "sodoSearch": {
-        "url": "https://unpkg.com/@tryghost/sodo-search@~0.1.0/umd/sodo-search.min.js",
-        "version": "0.1.0"
+        "url": "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/sodo-search.min.js",
+        "styles": "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/main.css",
+        "version": "1.0"
     }
 }

--- a/ghost/core/test/unit/frontend/helpers/comments.test.js
+++ b/ghost/core/test/unit/frontend/helpers/comments.test.js
@@ -56,8 +56,8 @@ describe('{{comments}} helper', function () {
             }
         });
         should.exist(rendered);
-        rendered.string.should.containEql('<script defer src="https://unpkg.com/@tryghost/comments-ui');
-        rendered.string.should.containEql('data-ghost-comments="http://127.0.0.1:2369/" data-api="http://127.0.0.1:2369/ghost/api/content/" data-admin="http://127.0.0.1:2369/ghost/" data-key="xyz" data-post-id="post_id_123" data-sentry-dsn="" data-color-scheme="auto" data-avatar-saturation="50" data-accent-color="" data-app-version="test.version" data-comments-enabled="all"');
+        rendered.string.should.containEql('<script defer src="https://cdn.jsdelivr.net/npm/@tryghost/comments-ui');
+        rendered.string.should.containEql('data-ghost-comments="http://127.0.0.1:2369/" data-api="http://127.0.0.1:2369/ghost/api/content/" data-admin="http://127.0.0.1:2369/ghost/" data-key="xyz" data-styles="https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~test.version/umd/main.css" data-post-id="post_id_123" data-sentry-dsn="" data-color-scheme="auto" data-avatar-saturation="50" data-accent-color="" data-app-version="test.version" data-comments-enabled="all"');
     });
 
     it('returns a script tag for paid only commenting', async function () {
@@ -75,8 +75,8 @@ describe('{{comments}} helper', function () {
             }
         });
         should.exist(rendered);
-        rendered.string.should.containEql('<script defer src="https://unpkg.com/@tryghost/comments-ui');
-        rendered.string.should.containEql('data-ghost-comments="http://127.0.0.1:2369/" data-api="http://127.0.0.1:2369/ghost/api/content/" data-admin="http://127.0.0.1:2369/ghost/" data-key="xyz" data-post-id="post_id_123" data-sentry-dsn="" data-color-scheme="auto" data-avatar-saturation="50" data-accent-color="" data-app-version="test.version" data-comments-enabled="paid"');
+        rendered.string.should.containEql('<script defer src="https://cdn.jsdelivr.net/npm/@tryghost/comments-ui');
+        rendered.string.should.containEql('data-ghost-comments="http://127.0.0.1:2369/" data-api="http://127.0.0.1:2369/ghost/api/content/" data-admin="http://127.0.0.1:2369/ghost/" data-key="xyz" data-styles="https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~test.version/umd/main.css" data-post-id="post_id_123" data-sentry-dsn="" data-color-scheme="auto" data-avatar-saturation="50" data-accent-color="" data-app-version="test.version" data-comments-enabled="paid"');
     });
 
     it('returns undefined when comments are disabled', async function () {
@@ -113,4 +113,3 @@ describe('{{comments}} helper', function () {
         should.not.exist(rendered);
     });
 });
-

--- a/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost_head.test.js
@@ -1669,7 +1669,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             })).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.containEql('<script defer src="https://unpkg.com/@tryghost/portal');
+                rendered.string.should.containEql('<script defer src="https://cdn.jsdelivr.net/npm/@tryghost/portal');
                 rendered.string.should.containEql('data-ghost="http://127.0.0.1:2369/" data-key="xyz" data-api="http://127.0.0.1:2369/ghost/api/content/"');
                 rendered.string.should.containEql('<style id="gh-members-styles">');
                 done();
@@ -1688,7 +1688,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             })).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.containEql('<script defer src="https://unpkg.com/@tryghost/portal');
+                rendered.string.should.containEql('<script defer src="https://cdn.jsdelivr.net/npm/@tryghost/portal');
                 rendered.string.should.containEql('data-ghost="http://127.0.0.1:2369/" data-key="xyz" data-api="http://127.0.0.1:2369/ghost/api/content/"');
                 rendered.string.should.containEql('<style id="gh-members-styles">');
                 rendered.string.should.containEql('<script async src="https://js.stripe.com');
@@ -1708,7 +1708,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             })).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.not.containEql('<script defer src="https://unpkg.com/@tryghost/portal');
+                rendered.string.should.not.containEql('<script defer src="https://cdn.jsdelivr.net/npm/@tryghost/portal');
                 rendered.string.should.not.containEql('data-ghost="http://127.0.0.1:2369/" data-key="xyz" data-api="http://127.0.0.1:2369/ghost/api/content/"');
                 rendered.string.should.not.containEql('<style id="gh-members-styles">');
                 rendered.string.should.not.containEql('<script async src="https://js.stripe.com');
@@ -1728,7 +1728,7 @@ describe('{{ghost_head}} helper', function () {
                 }
             })).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.containEql('<script defer src="https://unpkg.com/@tryghost/portal');
+                rendered.string.should.containEql('<script defer src="https://cdn.jsdelivr.net/npm/@tryghost/portal');
                 rendered.string.should.containEql('data-ghost="http://127.0.0.1:2369/" data-key="xyz" data-api="http://127.0.0.1:2369/ghost/api/content/"');
                 rendered.string.should.containEql('<style id="gh-members-styles">');
                 rendered.string.should.not.containEql('<script async src="https://js.stripe.com');
@@ -1749,8 +1749,8 @@ describe('{{ghost_head}} helper', function () {
                 }
             })).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.containEql('<script defer src="https://unpkg.com/@tryghost/sodo-search');
-                rendered.string.should.containEql('data-sodo-search="http://127.0.0.1:2369/" data-version="0.1.0" data-key="xyz"');
+                rendered.string.should.containEql('<script defer src="https://cdn.jsdelivr.net/npm/@tryghost/sodo-search');
+                rendered.string.should.containEql('data-key="xyz" data-styles="https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~1.0/umd/main.css" data-sodo-search="http://127.0.0.1:2369/"');
 
                 done();
             }).catch(done);

--- a/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
+++ b/ghost/core/test/unit/frontend/utils/frontend-apps.test.js
@@ -1,0 +1,41 @@
+const should = require('should');
+const {getFrontendAppConfig, getDataAttributes} = require('../../../../core/frontend/utils/frontend-apps');
+const configUtils = require('../../../utils/configUtils');
+
+describe('Frontend apps:', function () {
+    describe('getFrontendAppConfig', function () {
+        before(function () {
+            configUtils.set({'portal:url': 'https://cdn.example.com/~{version}/portal.min.js'});
+            configUtils.set({'portal:version': '1.0'});
+            configUtils.set({'portal:styles': 'https://cdn.example.com/~{version}/main.css'});
+        });
+
+        after(function () {
+            configUtils.restore();
+        });
+
+        it('should return app urls and version from config', async function () {
+            const {stylesUrl, scriptUrl, appVersion} = getFrontendAppConfig('portal');
+            should.equal(appVersion, '1.0');
+            should.equal(stylesUrl, 'https://cdn.example.com/~1.0/main.css');
+            should.equal(scriptUrl, 'https://cdn.example.com/~1.0/portal.min.js');
+        });
+    });
+
+    describe('getDataAttributes', function () {
+        it('should generate data attributes string from object', async function () {
+            const dataAttributes = getDataAttributes({
+                admin: 'test',
+                'example-version': '1.0'
+            });
+
+            should.equal(dataAttributes, 'data-admin="test" data-example-version="1.0"');
+        });
+
+        it('should generate empty string for missing data object', async function () {
+            const dataAttributes = getDataAttributes();
+
+            should.equal(dataAttributes, '');
+        });
+    });
+});


### PR DESCRIPTION
- current config for frontend apps doesn't allow easy switching of CDN for urls used to load them
- this change allows pro to switch out the CDN easily, and also avoids double use of version value
- also extends config to include url needed for loading CSS for frontend app