### PR TITLE
Added migrations to change Ghost Explore integration type

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-17-add-ghost-explore-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-17-add-ghost-explore-integration.js
@@ -29,6 +29,7 @@ module.exports = createTransactionalMigration(
         logging.info('Deleting Ghost Explore Integration');
 
         await knex('integrations').where({
+            type: 'internal',
             name: 'Ghost Explore',
             slug: 'ghost-explore'
         }).del();

--- a/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-17-add-ghost-explore-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-17-add-ghost-explore-integration.js
@@ -6,7 +6,6 @@ module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Creating Ghost Explore Integration');
         const existingIntegration = await knex('integrations').where({
-            type: 'internal',
             name: 'Ghost Explore',
             slug: 'ghost-explore'
         }).first();
@@ -30,7 +29,6 @@ module.exports = createTransactionalMigration(
         logging.info('Deleting Ghost Explore Integration');
 
         await knex('integrations').where({
-            type: 'internal',
             name: 'Ghost Explore',
             slug: 'ghost-explore'
         }).del();

--- a/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-26-add-ghost-explore-integration-api-key.js
+++ b/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-26-add-ghost-explore-integration-api-key.js
@@ -10,7 +10,6 @@ module.exports = createTransactionalMigration(
 
         const integration = await knex('integrations').where({
             slug: 'ghost-explore',
-            type: 'internal',
             name: 'Ghost Explore'
         }).first();
 

--- a/ghost/core/core/server/data/migrations/versions/5.6/2022-07-27-13-40-change-explore-type.js
+++ b/ghost/core/core/server/data/migrations/versions/5.6/2022-07-27-13-40-change-explore-type.js
@@ -6,19 +6,16 @@ module.exports = createTransactionalMigration(
         logging.info('Changing Ghost Explore Integration to type "builtin"');
         await knex('integrations')
             .where({
-                type: 'internal',
                 name: 'Ghost Explore',
                 slug: 'ghost-explore'
             })
             .update('type', 'builtin');
-        return;
     },
     async function down(knex) {
-        logging.info('Deleting Ghost Explore Integration to type "internal"');
+        logging.info('Changing Ghost Explore Integration to type "internal"');
 
         await knex('integrations')
             .where({
-                type: 'builtin',
                 name: 'Ghost Explore',
                 slug: 'ghost-explore'
             })

--- a/ghost/core/core/server/data/migrations/versions/5.6/2022-07-27-13-40-change-explore-type.js
+++ b/ghost/core/core/server/data/migrations/versions/5.6/2022-07-27-13-40-change-explore-type.js
@@ -5,7 +5,11 @@ module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Changing Ghost Explore Integration to type "builtin"');
         await knex('integrations')
-            .where('slug', 'ghost-explore')
+            .where({
+                type: 'internal',
+                name: 'Ghost Explore',
+                slug: 'ghost-explore'
+            })
             .update('type', 'builtin');
         return;
     },
@@ -13,7 +17,11 @@ module.exports = createTransactionalMigration(
         logging.info('Deleting Ghost Explore Integration to type "internal"');
 
         await knex('integrations')
-            .where('slug', 'ghost-explore')
+            .where({
+                type: 'builtin',
+                name: 'Ghost Explore',
+                slug: 'ghost-explore'
+            })
             .update('type', 'internal');
     }
 );

--- a/ghost/core/core/server/data/migrations/versions/5.6/2022-07-27-13-40-change-explore-type.js
+++ b/ghost/core/core/server/data/migrations/versions/5.6/2022-07-27-13-40-change-explore-type.js
@@ -1,0 +1,19 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Changing Ghost Explore Integration to type "builtin"');
+        await knex('integrations')
+            .where('slug', 'ghost-explore')
+            .update('type', 'builtin');
+        return;
+    },
+    async function down(knex) {
+        logging.info('Deleting Ghost Explore Integration to type "internal"');
+
+        await knex('integrations')
+            .where('slug', 'ghost-explore')
+            .update('type', 'internal');
+    }
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -672,7 +672,7 @@
                     "slug": "ghost-explore",
                     "name": "Ghost Explore",
                     "description": "Built-in Ghost Explore integration",
-                    "type": "internal",
+                    "type": "builtin",
                     "api_keys": [{"type": "admin", "role": "Ghost Explore Integration"}]
                 },
                 {

--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -23,7 +23,7 @@ describe('Integrations API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.equal(res.body.integrations.length, 2);
+        should.equal(res.body.integrations.length, 3);
 
         // there is no enforced order for integrations which makes order different on SQLite and MySQL
         const zapierIntegration = _.find(res.body.integrations, {name: 'Zapier'}); // from migrations

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '71daf7814834fffd40abba86a92f4347';
-    const currentFixturesHash = 'a42105cc0d47dd978dd52ee271340013';
+    const currentFixturesHash = 'a75211a41f515202280be7cb287e101f';
     const currentSettingsHash = 'd54210758b7054e2174fd34aa2320ad7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -845,7 +845,7 @@
                     "slug": "ghost-explore",
                     "name": "Ghost Explore",
                     "description": "Built-in Ghost Explore integration",
-                    "type": "internal",
+                    "type": "builtin",
                     "api_keys": [{"type": "admin", "role": "Ghost Explore Integration"}]
                 },
                 {


### PR DESCRIPTION
no issue

Added migrations to change the current Ghost Explore integration type from `internal` to `builtin`.