### PR TITLE
Fixed failing admin preview test email

### DIFF
--- a/ghost/core/core/server/services/mega/mega.js
+++ b/ghost/core/core/server/services/mega/mega.js
@@ -69,6 +69,7 @@ const getEmailData = async (postModel, options) => {
     }
 
     return {
+        post: postModel.toJSON(), // for content paywalling
         subject,
         html,
         plaintext,
@@ -87,9 +88,6 @@ const sendTestEmail = async (postModel, toEmails, memberSegment) => {
     let emailData = await getEmailData(postModel);
     emailData.subject = `[Test] ${emailData.subject}`;
 
-    if (memberSegment) {
-        emailData = postEmailSerializer.renderEmailForSegment(emailData, memberSegment);
-    }
     // fetch any matching members so that replacements use expected values
     const recipients = await Promise.all(toEmails.map(async (email) => {
         const member = await membersService.api.members.get({email});
@@ -109,7 +107,7 @@ const sendTestEmail = async (postModel, toEmails, memberSegment) => {
     // enable tracking for previews to match real-world behaviour
     emailData.track_opens = !!settingsCache.get('email_track_opens');
 
-    const response = await bulkEmailService.send(emailData, recipients);
+    const response = await bulkEmailService.send(emailData, recipients, memberSegment);
 
     if (response instanceof bulkEmailService.FailedBatch) {
         return Promise.reject(response.error);

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -385,7 +385,7 @@ function renderEmailForSegment(email, memberSegment) {
     */
     if (labs.isSet('newsletterPaywall')) {
         const paywallIndex = (result.html || '').indexOf('<!--members-only-->');
-        if (paywallIndex !== -1 && memberSegment) {
+        if (paywallIndex !== -1 && memberSegment && result.post) {
             let statusFilter = memberSegment === 'status:free' ? {status: 'free'} : {status: 'paid'};
             const postVisiblity = result.post.visibility;
 

--- a/ghost/core/test/unit/server/services/mega/post-email-serializer.test.js
+++ b/ghost/core/test/unit/server/services/mega/post-email-serializer.test.js
@@ -206,6 +206,19 @@ describe('Post Email Serializer', function () {
             output.html.should.equal(`<p>Free content</p><!--members-only--><p>Members content</p>`);
             output.plaintext.should.equal(`Free content\n\nMembers content`);
         });
+
+        it('should not crash on missing post for email with paywall', function () {
+            sinon.stub(urlService, 'getUrlByResourceId').returns('https://site.com/blah/');
+            sinon.stub(labs, 'isSet').returns(true);
+            const email = {
+                html: '<p>Free content</p><!--members-only--><p>Members content</p>',
+                plaintext: 'Free content. Members content'
+            };
+
+            let output = renderEmailForSegment(email, 'status:-free');
+            output.html.should.equal(`<p>Free content</p><!--members-only--><p>Members content</p>`);
+            output.plaintext.should.equal(`Free content\n\nMembers content`);
+        });
     });
 
     describe('createUnsubscribeUrl', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1680

- using test emails via email preview in admin were failing due to missing post data attached to them
- adds test to make sure email segment rendering doesn't crash even with missing data