### PR TITLE
♻️ refactored security.password to use native bcrypt promises

### DIFF
--- a/ghost/security/lib/password.js
+++ b/ghost/security/lib/password.js
@@ -1,18 +1,9 @@
-const Promise = require('bluebird');
-
-module.exports.hash = function hash(plainPassword) {
-    const bcrypt = require('bcryptjs');
-    const bcryptGenSalt = Promise.promisify(bcrypt.genSalt);
-    const bcryptHash = Promise.promisify(bcrypt.hash);
-
-    return bcryptGenSalt().then(function (salt) {
-        return bcryptHash(plainPassword, salt);
-    });
+const bcrypt = require('bcryptjs');
+module.exports.hash = async function hash(plainPassword) {
+    const salt = await bcrypt.genSalt();
+    return bcrypt.hash(plainPassword, salt);
 };
 
 module.exports.compare = function compare(plainPassword, hashedPassword) {
-    const bcrypt = require('bcryptjs');
-    const bcryptCompare = Promise.promisify(bcrypt.compare);
-
-    return bcryptCompare(plainPassword, hashedPassword);
+    return bcrypt.compare(plainPassword, hashedPassword);
 };

--- a/ghost/security/lib/string.js
+++ b/ghost/security/lib/string.js
@@ -1,10 +1,8 @@
-const _ = require('lodash');
 const slugify = require('@tryghost/string').slugify;
 
-module.exports.safe = function safe(string, options) {
-    options = options || {};
+module.exports.safe = function safe(string, options = {}) {
     let opts = {requiredChangesOnly: true};
-    if (!_.has(options, 'importing') || !options.importing) {
+    if (!('importing' in options) || !options.importing) {
         opts.requiredChangesOnly = false;
     }
     return slugify(string, opts);

--- a/ghost/security/package.json
+++ b/ghost/security/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@tryghost/string": "0.1.26",
     "bcryptjs": "2.4.3",
-    "bluebird": "3.7.2",
     "lodash": "4.17.21"
   }
 }

--- a/ghost/security/package.json
+++ b/ghost/security/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@tryghost/string": "0.1.26",
-    "bcryptjs": "2.4.3",
-    "lodash": "4.17.21"
+    "bcryptjs": "2.4.3"
   }
 }


### PR DESCRIPTION
same as https://github.com/TryGhost/Utils/pull/147

I was doing some work on bcrypt and noticed that it now supports returning Promises, so we no longer need to use bluebird to promisify the methods 🎉

Also took a minute to clean up string to not need lodash.

Open questions:

Is there anything preventing identifier from using crypto.ramdomBytes? If not, I can do that too 😄
See comment (tbd)