### PR TITLE
Implemented admin auth origin check

### DIFF
--- a/ghost/core/core/frontend/services/admin-auth-assets/service.js
+++ b/ghost/core/core/frontend/services/admin-auth-assets/service.js
@@ -44,7 +44,7 @@ class AdminAuthAssetsService {
      */
     async minify(globs, replacements) {
         try {
-            await this.minifier.minify(globs, replacements);
+            await this.minifier.minify(globs, {replacements});
         } catch (error) {
             if (error.code === 'EACCES') {
                 logging.error('Ghost was not able to write admin-auth asset files due to permissions.');

--- a/ghost/core/core/frontend/services/admin-auth-assets/service.js
+++ b/ghost/core/core/frontend/services/admin-auth-assets/service.js
@@ -42,9 +42,9 @@ class AdminAuthAssetsService {
      * @private
      * @returns {Promise<void>}
      */
-    async minify(globs, replacements) {
+    async minify(globs, options) {
         try {
-            await this.minifier.minify(globs, {replacements});
+            await this.minifier.minify(globs, options);
         } catch (error) {
             if (error.code === 'EACCES') {
                 logging.error('Ghost was not able to write admin-auth asset files due to permissions.');
@@ -100,7 +100,7 @@ class AdminAuthAssetsService {
         const globs = this.generateGlobs();
         const replacements = this.generateReplacements();
         await this.clearFiles();
-        await this.minify(globs, replacements);
+        await this.minify(globs, {replacements});
         await this.copyStatic();
     }
 }

--- a/ghost/core/core/frontend/services/admin-auth-assets/service.js
+++ b/ghost/core/core/frontend/services/admin-auth-assets/service.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs').promises;
 const logging = require('@tryghost/logging');
 const config = require('../../../shared/config');
+const urlUtils = require('../../../shared/url-utils');
 
 class AdminAuthAssetsService {
     constructor(options = {}) {
@@ -29,7 +30,7 @@ class AdminAuthAssetsService {
      */
     generateReplacements() {
         // Clean the URL, only keep schema, host and port (without trailing slashes or subdirectory)
-        const url = new URL(config.get('url'));
+        const url = new URL(urlUtils.getSiteUrl());
         const origin = url.origin;
 
         return {

--- a/ghost/core/core/frontend/services/admin-auth-assets/service.js
+++ b/ghost/core/core/frontend/services/admin-auth-assets/service.js
@@ -26,11 +26,25 @@ class AdminAuthAssetsService {
 
     /**
      * @private
+     */
+    generateReplacements() {
+        // Clean the URL, only keep schema, host and port (without trailing slashes or subdirectory)
+        const url = new URL(config.get('url'));
+        const origin = url.origin;
+
+        return {
+            // Properly encode the origin
+            '\'{{SITE_ORIGIN}}\'': JSON.stringify(origin)
+        };
+    }
+
+    /**
+     * @private
      * @returns {Promise<void>}
      */
-    async minify(globs) {
+    async minify(globs, replacements) {
         try {
-            await this.minifier.minify(globs);
+            await this.minifier.minify(globs, replacements);
         } catch (error) {
             if (error.code === 'EACCES') {
                 logging.error('Ghost was not able to write admin-auth asset files due to permissions.');
@@ -84,8 +98,9 @@ class AdminAuthAssetsService {
      */
     async load() {
         const globs = this.generateGlobs();
+        const replacements = this.generateReplacements();
         await this.clearFiles();
-        await this.minify(globs);
+        await this.minify(globs, replacements);
         await this.copyStatic();
     }
 }

--- a/ghost/core/core/frontend/src/admin-auth/message-handler.js
+++ b/ghost/core/core/frontend/src/admin-auth/message-handler.js
@@ -1,8 +1,12 @@
 const adminUrl = window.location.href.replace('auth-frame/', '');
 
+// At compile time, we'll replace the value with the actual origin.
+const siteOrigin = '{{SITE_ORIGIN}}';
+
 window.addEventListener('message', async function (event) {
-    if (event.origin !== '*') {
-        // return;
+    if (event.origin !== siteOrigin) {
+        console.warn('Ignored message to admin auth iframe because of mismatch in origin', 'expected', siteOrigin, 'got', event.origin, 'with data', event.data);
+        return;
     }
     let data = null;
     try {

--- a/ghost/core/core/frontend/src/admin-auth/message-handler.js
+++ b/ghost/core/core/frontend/src/admin-auth/message-handler.js
@@ -20,7 +20,7 @@ window.addEventListener('message', async function (event) {
             uid: data.uid,
             error: error,
             result: result
-        }), '*');
+        }), siteOrigin);
     }
 
     if (data.action === 'getUser') {

--- a/ghost/minifier/lib/minifier.js
+++ b/ghost/minifier/lib/minifier.js
@@ -109,14 +109,20 @@ class Minifier {
         }
     }
 
-    async minify(options) {
+    async minify(options, replacements) {
         debug('Begin', options);
         const destinations = Object.keys(options);
         const minifiedFiles = [];
 
         for (const dest of destinations) {
             const src = options[dest];
-            const contents = await this.getSrcFileContents(src);
+            let contents = await this.getSrcFileContents(src);
+
+            if (replacements) {
+                for (const key of Object.keys(replacements)) {
+                    contents = contents.replace(key, replacements[key]);
+                }
+            }
             let minifiedContents;
 
             if (dest.endsWith('.css')) {

--- a/ghost/minifier/lib/minifier.js
+++ b/ghost/minifier/lib/minifier.js
@@ -109,13 +109,26 @@ class Minifier {
         }
     }
 
-    async minify(options, replacements) {
-        debug('Begin', options);
-        const destinations = Object.keys(options);
+    /**
+     * Minify files
+     * 
+     * @param {Object} globs An object in the form of 
+     * ```js
+     * {
+     *     'destination1.js': 'glob/*.js',
+     *     'destination2.js': 'glob2/*.js'
+     * }
+     * ```
+     * @param {Object} [replacements] Key value pairs that should get replaced in the content before minifying
+     * @returns {Promise<string[]>} List of minified files (keys of globs)
+     */
+    async minify(globs, replacements) {
+        debug('Begin', globs);
+        const destinations = Object.keys(globs);
         const minifiedFiles = [];
 
         for (const dest of destinations) {
-            const src = options[dest];
+            const src = globs[dest];
             let contents = await this.getSrcFileContents(src);
 
             if (replacements) {

--- a/ghost/minifier/lib/minifier.js
+++ b/ghost/minifier/lib/minifier.js
@@ -119,10 +119,11 @@ class Minifier {
      *     'destination2.js': 'glob2/*.js'
      * }
      * ```
-     * @param {Object} [replacements] Key value pairs that should get replaced in the content before minifying
+     * @param {Object} [options]
+     * @param {Object} [options.replacements] Key value pairs that should get replaced in the content before minifying
      * @returns {Promise<string[]>} List of minified files (keys of globs)
      */
-    async minify(globs, replacements) {
+    async minify(globs, options) {
         debug('Begin', globs);
         const destinations = Object.keys(globs);
         const minifiedFiles = [];
@@ -131,9 +132,9 @@ class Minifier {
             const src = globs[dest];
             let contents = await this.getSrcFileContents(src);
 
-            if (replacements) {
-                for (const key of Object.keys(replacements)) {
-                    contents = contents.replace(key, replacements[key]);
+            if (options?.replacements) {
+                for (const key of Object.keys(options.replacements)) {
+                    contents = contents.replace(key, options.replacements[key]);
                 }
             }
             let minifiedContents;

--- a/ghost/minifier/test/minifier.test.js
+++ b/ghost/minifier/test/minifier.test.js
@@ -71,6 +71,21 @@ describe('Minifier', function () {
 
             result.should.be.an.Array().with.lengthOf(2);
         });
+
+        it('can replace the content', async function () {
+            let result = await minifier.minify({
+                'card.min.js': 'js/*.js'
+            }, {
+                replacements: {
+                    '.kg-gallery-image': 'randomword'
+                }
+            });
+            result.should.be.an.Array().with.lengthOf(1);
+
+            const outputPath = minifier.getFullDest(result[0]);
+            const content = await fs.readFile(outputPath, {encoding: 'utf8'});
+            content.should.match(/randomword/);
+        });
     });
 
     describe('Bad inputs', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1694

- Added replacements option to `@tryghost/minifier` + updated documentation and name of 'options' param which was a bit confusing. 
- At compile time, we'll replace `'{{SITE_ORIGIN}}'` with the actual and JS encoded origin string.
- Block requests to the auth frame with the wrong origin, but log a warning for now to make debugging easier.

**Question:**
- Are we 100% sure that the Ghost site is always hosted on the url which is configured in the site config? Because locally, it also doesn't redirect to the configured site. Technically, it is possible to host it on a different domain, no?