### PR TITLE
🐛 Fixed missing published Admin assets when running in development

### DIFF
--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -22,7 +22,7 @@ module.exports = {
         const fs = this.project.require('fs-extra');
         const walkSync = this.project.require('walk-sync');
 
-        const assetsOut = `../core/core/built/admin/${this.env}`;
+        const assetsOut = `../core/core/built/admin`;
         fs.ensureDirSync(assetsOut);
 
         // the dist folder contains more than just index.html and /assets, especially

--- a/ghost/core/core/server/web/admin/app.js
+++ b/ghost/core/core/server/web/admin/app.js
@@ -17,9 +17,8 @@ module.exports = function setupAdminApp() {
     // Admin assets
     // @TODO ensure this gets a local 404 error handler
     const configMaxAge = config.get('caching:admin:maxAge');
-    const envDir = config.get('env') === 'production' ? 'production' : 'development';
     adminApp.use('/assets', serveStatic(
-        path.join(config.get('paths').adminAssets, envDir, 'assets'),
+        path.join(config.get('paths').adminAssets, 'assets'),
         {maxAge: (configMaxAge || configMaxAge === 0) ? configMaxAge : constants.ONE_YEAR_MS, fallthrough: false}
     ));
 

--- a/ghost/core/core/server/web/admin/controller.js
+++ b/ghost/core/core/server/web/admin/controller.js
@@ -29,8 +29,7 @@ module.exports = function adminController(req, res) {
     // CASE: trigger update check unit and let it run in background, don't block the admin rendering
     updateCheck();
 
-    const envDir = config.get('env') === 'production' ? 'production' : 'development';
-    const templatePath = path.resolve(config.get('paths').adminAssets, envDir, 'index.html');
+    const templatePath = path.resolve(config.get('paths').adminAssets, 'index.html');
     const headers = {};
 
     try {

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -94,10 +94,10 @@ describe('Admin Routing', function () {
             configUtils.restore();
         });
 
-        it('serves prod assets in production', async function () {
+        it('serves assets in production', async function () {
             configUtils.set('env', 'production');
 
-            const prodTemplate = fs.readFileSync(path.resolve('test/utils/fixtures/admin-build/production/index.html')).toString();
+            const prodTemplate = fs.readFileSync(path.resolve('test/utils/fixtures/admin-build/index.html')).toString();
 
             const res = await request.get('/ghost/')
                 .set('X-Forwarded-Proto', 'https')
@@ -106,8 +106,8 @@ describe('Admin Routing', function () {
             res.text.should.equal(prodTemplate);
         });
 
-        it('serves dev assets when not in production', async function () {
-            const devTemplate = fs.readFileSync(path.resolve('test/utils/fixtures/admin-build/development/index.html')).toString();
+        it('serves assets when not in production', async function () {
+            const devTemplate = fs.readFileSync(path.resolve('test/utils/fixtures/admin-build/index.html')).toString();
 
             const res = await request.get('/ghost/')
                 .set('X-Forwarded-Proto', 'https')
@@ -122,7 +122,7 @@ describe('Admin Routing', function () {
                 .expect(200);
 
             should.exist(res.headers.etag);
-            res.headers.etag.should.equal('b448e5380dbfc46bc7c6da6045bf3043');
+            res.headers.etag.should.equal('8793333e8e91cde411b1336c58ec6ef3');
         });
     });
 });

--- a/ghost/core/test/utils/admin-utils.js
+++ b/ghost/core/test/utils/admin-utils.js
@@ -2,11 +2,11 @@ const fs = require('fs-extra');
 const path = require('path');
 
 const adminFiles = [
-    'built/admin/development/index.html',
-    'built/admin/development/assets/ghost.js',
-    'built/admin/development/assets/ghost.css',
-    'built/admin/development/assets/vendor.js',
-    'built/admin/development/assets/vendor.css'
+    'built/admin/index.html',
+    'built/admin/assets/ghost.js',
+    'built/admin/assets/ghost.css',
+    'built/admin/assets/vendor.js',
+    'built/admin/assets/vendor.css'
 ];
 
 module.exports.stubAdminFiles = () => {

--- a/ghost/core/test/utils/fixtures/admin-build/development/index.html
+++ b/ghost/core/test/utils/fixtures/admin-build/development/index.html
@@ -1,4 +1,0 @@
-<html>
-    <head><title>Dev template</title></head>
-    <body>Dev template</body>
-</html>

--- a/ghost/core/test/utils/fixtures/admin-build/index.html
+++ b/ghost/core/test/utils/fixtures/admin-build/index.html
@@ -1,0 +1,4 @@
+<html>
+    <head><title>Admin HTML</title></head>
+    <body>Admin HTML</body>
+</html>

--- a/ghost/core/test/utils/fixtures/admin-build/production/index.html
+++ b/ghost/core/test/utils/fixtures/admin-build/production/index.html
@@ -1,4 +1,0 @@
-<html>
-    <head><title>Prod template</title></head>
-    <body>Prod template</body>
-</html>


### PR DESCRIPTION
refs https://forum.ghost.org/t/admin-template-issues-default-install/31750

- we recently switched to using different folders within `core/built`, to
  indicate the assets that are applicable for development/production
  environments
- unfortunately, this came with the side effect of the "development" assets
  missing in the published tarball, which meant Admin wouldn't load when
  running in development mode
- this was a regression from how it previously worked because we used to
  just copy the production HTML file to the development HTML name, and
  use the same assets
- after thinking about it, I think we can get rid of the split folders
  for assets, because I don't think the use-case is there for having
  them:
  - if you run Ghost from source, you're 99% only using the
    development-built assets
  - if you want production ones, you can run with a flag, but the
    development ones get wiped anyway
  - those running Ghost from a published package are using the same
    assets and HTML file
- therefore, I think we can make our lives simpler by removing the env
  folders and using assets under `core/built/admin/...`
- this commit implements that across Ghost and Admin
