### PR TITLE
🐛 Fixed avatar overlapping with initials

### DIFF
--- a/ghost/admin/app/components/gh-member-avatar.hbs
+++ b/ghost/admin/app/components/gh-member-avatar.hbs
@@ -1,8 +1,9 @@
 <figure class="gh-member-gravatar {{@containerClass}}">
-    <div class="gh-member-initials flex items-center justify-center br-100 {{@containerClass}}" style={{this.backgroundStyle}}>
-        <span class="gh-member-avatar-label {{or @sizeClass "gh-member-list-avatar"}}">{{this.initials}}</span>
-    </div>
     {{#if this.avatarImage}}
         <img class="gh-member-avatar-image" src="{{this.avatarImage}}" alt="{{or @member.name @member.email}}" />
+    {{else}}
+        <div class="gh-member-initials flex items-center justify-center br-100 {{@containerClass}}" style={{this.backgroundStyle}}>
+            <span class="gh-member-avatar-label {{or @sizeClass "gh-member-list-avatar"}}">{{this.initials}}</span>
+        </div>
     {{/if}}
 </figure>


### PR DESCRIPTION
refs/closes #15165
- either the initials or the avatar will be rendered but not both this avoids overlapping of the avatar with the initials.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution! 

Also, if you'd be interested in writing code like this for us more regularly, we're hiring:
https://careers.ghost.org/product-engineer-node-js
