### PR TITLE
Redacted comment html for deleted and hidden comments

### DIFF
--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -226,6 +226,6 @@ module.exports = {
     },
 
     get commentsMembers() {
-        return shared.pipeline(require('./comments-members'), localUtils, 'comments');
+        return shared.pipeline(require('./comments-members'), localUtils, 'members');
     }
 };

--- a/ghost/core/core/server/api/endpoints/utils/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/index.js
@@ -26,6 +26,10 @@ module.exports = {
         return frame.apiType === 'content';
     },
 
+    isMembersAPI: (frame) => {
+        return frame.apiType === 'members';
+    },
+
     isInternal: (frame) => {
         return frame.options.context && frame.options.context.internal;
     }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -63,7 +63,7 @@ const commentMapper = (model, frame) => {
         response.liked = !!jsonModel.likes.find(l => l.member_id === id);
     }
 
-    if (utils.isContentAPI(frame)) {
+    if (utils.isMembersAPI(frame)) {
         if (jsonModel.status !== 'published') {
             delete response.html;
         }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const utils = require('../../..');
 const url = require('../utils/url');
 
 const commentFields = [
@@ -60,6 +61,12 @@ const commentMapper = (model, frame) => {
     if (jsonModel.likes && frame.original.context.member && frame.original.context.member.id) {
         const id = frame.original.context.member.id;
         response.liked = !!jsonModel.likes.find(l => l.member_id === id);
+    }
+
+    if (utils.isContentAPI(frame)) {
+        if (jsonModel.status !== 'published') {
+            delete response.html;
+        }
     }
 
     return response;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -65,7 +65,7 @@ const commentMapper = (model, frame) => {
 
     if (utils.isMembersAPI(frame)) {
         if (jsonModel.status !== 'published') {
-            delete response.html;
+            response.html = null;
         }
     }
 

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -8,7 +8,8 @@ const messages = {
     emptyComment: 'The body of a comment cannot be empty',
     commentNotFound: 'Comment could not be found',
     notYourCommentToEdit: 'You may only edit your own comments',
-    notYourCommentToDestroy: 'You may only delete your own comments'
+    notYourCommentToDestroy: 'You may only delete your own comments',
+    cannotEditDeletedComment: 'You may only edit published comments'
 };
 
 /**
@@ -61,6 +62,12 @@ const Comment = ghostBookshelf.Model.extend({
 
     onSaving() {
         ghostBookshelf.Model.prototype.onSaving.apply(this, arguments);
+
+        if (this.hasChanged('html') && this.get('status') !== 'published') {
+            throw new ValidationError({
+                message: tpl(messages.cannotEditDeletedComment)
+            });
+        }
 
         if (this.hasChanged('html')) {
             const sanitizeHtml = require('sanitize-html');

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -103,17 +103,6 @@ const Comment = ghostBookshelf.Model.extend({
         }
 
         return 'parent_id:null';
-    },
-
-    toJSON(unfilteredOptions) {
-        const options = Comment.filterOptions(unfilteredOptions, 'toJSON');
-        const attrs = ghostBookshelf.Model.prototype.toJSON.call(this, options);
-
-        if (attrs.status !== 'published') {
-            attrs.html = null;
-        }
-
-        return attrs;
     }
 
 }, {

--- a/ghost/core/core/server/models/comment.js
+++ b/ghost/core/core/server/models/comment.js
@@ -103,6 +103,17 @@ const Comment = ghostBookshelf.Model.extend({
         }
 
         return 'parent_id:null';
+    },
+
+    toJSON(unfilteredOptions) {
+        const options = Comment.filterOptions(unfilteredOptions, 'toJSON');
+        const attrs = ghostBookshelf.Model.prototype.toJSON.call(this, options);
+
+        if (attrs.status !== 'published') {
+            attrs.html = null;
+        }
+
+        return attrs;
     }
 
 }, {

--- a/ghost/core/core/server/services/comments/service.js
+++ b/ghost/core/core/server/services/comments/service.js
@@ -10,7 +10,8 @@ const messages = {
     alreadyLiked: 'This comment was liked already',
     replyToReply: 'Can not reply to a reply',
     commentsNotEnabled: 'Comments are not enabled for this site.',
-    cannotCommentOnPost: 'You do not have permission to comment on this post.'
+    cannotCommentOnPost: 'You do not have permission to comment on this post.',
+    cannotEditComment: 'You do not have permission to edit comments'
 };
 
 class CommentsService {
@@ -285,8 +286,7 @@ class CommentsService {
 
         if (existingComment.get('member_id') !== member) {
             throw new errors.NoPermissionError({
-                // todo fix message
-                message: tpl(messages.memberNotFound)
+                message: tpl(messages.cannotEditComment)
             });
         }
 

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -620,7 +620,7 @@ describe('Comments API', function () {
             const {
                 body: {
                     comments: [{
-                        id: commentId
+                        id: commentToDeleteId
                     }]
                 }
             } = await membersAgent
@@ -635,7 +635,7 @@ describe('Comments API', function () {
                     comments: [deletedComment]
                 }
             } = await membersAgent
-                .put(`/api/comments/${commentId}`)
+                .put(`/api/comments/${commentToDeleteId}`)
                 .body({comments: [{
                     status: 'deleted'
                 }]});

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -615,5 +615,32 @@ describe('Comments API', function () {
                 })
                 .matchBodySnapshot();
         });
+
+        it('Can delete a comment, and it is redacted from', async function () {
+            const {
+                body: {
+                    comments: [{
+                        id: commentId
+                    }]
+                }
+            } = await membersAgent
+                .post(`/api/comments/`)
+                .body({comments: [{
+                    post_id: postId,
+                    html: 'Comment to delete'
+                }]});
+
+            const {
+                body: {
+                    comments: [deletedComment]
+                }
+            } = await membersAgent
+                .put(`/api/comments/${commentId}`)
+                .body({comments: [{
+                    status: 'deleted'
+                }]});
+
+            assert(!deletedComment.html);
+        });
     });
 });

--- a/ghost/core/test/unit/server/models/comment.test.js
+++ b/ghost/core/test/unit/server/models/comment.test.js
@@ -1,4 +1,3 @@
-const assert = require('assert');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 const testUtils = require('../../../utils');

--- a/ghost/core/test/unit/server/models/comment.test.js
+++ b/ghost/core/test/unit/server/models/comment.test.js
@@ -12,25 +12,6 @@ describe('Unit: models/comment', function () {
         sinon.restore();
     });
 
-    describe('toJSON', function () {
-        it('Will not return html unless comment is published', function () {
-            const comment = models.Comment.forge({
-                html: `<p>It's gonna be lights out and away we go for Lewis Hamilton only</p>`,
-                status: 'published'
-            });
-
-            assert(comment.toJSON().html);
-
-            comment.set('status', 'deleted');
-
-            assert(comment.toJSON().html === null);
-
-            comment.set('status', 'hidden');
-
-            assert(comment.toJSON().html === null);
-        });
-    });
-
     describe('permissible', function () {
         function getCommentModel(id, memberId) {
             const obj = {

--- a/ghost/core/test/unit/server/models/comment.test.js
+++ b/ghost/core/test/unit/server/models/comment.test.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const sinon = require('sinon');
 const models = require('../../../../core/server/models');
 const testUtils = require('../../../utils');
@@ -9,6 +10,25 @@ describe('Unit: models/comment', function () {
 
     afterEach(function () {
         sinon.restore();
+    });
+
+    describe('toJSON', function () {
+        it('Will not return html unless comment is published', function () {
+            const comment = models.Comment.forge({
+                html: `<p>It's gonna be lights out and away we go for Lewis Hamilton only</p>`,
+                status: 'published'
+            });
+
+            assert(comment.toJSON().html);
+
+            comment.set('status', 'deleted');
+
+            assert(comment.toJSON().html === null);
+
+            comment.set('status', 'hidden');
+
+            assert(comment.toJSON().html === null);
+        });
     });
 
     describe('permissible', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1745

I've done this at the model layer, which works for now, but isn't great
if we eventually create some kind of Admin section, in which case we'll
want to expose the html of the comment, regardless of status. This is
something we can address as/when we get to it.
