### PR TITLE
Fixed allowing multiple shutdown procedures

### DIFF
--- a/ghost/core/core/server/ghost-server.js
+++ b/ghost/core/core/server/ghost-server.js
@@ -137,7 +137,14 @@ class GhostServer {
      * Called on SIGINT or SIGTERM
      */
     async shutdown(code = 0) {
+        // Prevent this function being run multiple times by checking whether we're
+        // already shutting down
+        if (this.isShuttingDown) {
+            return;
+        }
+
         try {
+            this.isShuttingDown = true;
             logging.warn(tpl(messages.ghostIsShuttingDown));
             await this.stop();
             setTimeout(() => {


### PR DESCRIPTION
- Ghost doesn't prevent itself from running the `shutdown` procedure more than once
- if you spam Ctrl-C, you can reproduce this
  - this might not be the case when running using `yarn dev` because
    some Grunt code captures the SIGINT/SIGTERM, but that is changing
    very soon
- whilst not necessary a problem now, we might introduce code that runs
  during a shutdown but only expects to happen once
- this commit introduces a flag to say that Ghost is shutting down, and
  prevents the `shutdown` function from executing further once true
