### PR TITLE
Restricted existing prices to thos that are active

### DIFF
--- a/ghost/members-api/lib/repositories/product.js
+++ b/ghost/members-api/lib/repositories/product.js
@@ -421,7 +421,8 @@ class ProductRepository {
                         amount: data.monthly_price.amount,
                         currency: data.monthly_price.currency,
                         type: 'recurring',
-                        interval: 'month'
+                        interval: 'month',
+                        active: true
                     }, options);
                     let priceModel;
                     if (existingPrice) {
@@ -468,7 +469,8 @@ class ProductRepository {
                         amount: data.yearly_price.amount,
                         currency: data.yearly_price.currency,
                         type: 'recurring',
-                        interval: 'year'
+                        interval: 'year',
+                        active: true
                     }, options);
                     let priceModel;
 


### PR DESCRIPTION
Without this check, an inactive price in our database will just be
reactivated each time it is required. This can cause issues when
prices have been deleted.

By adding this constraint to the query, we will create a new price in
Stripe and our database when attempting to use an inactive price, this
is particularly useful when trying to fix problems caused by Stripe
prices being deleted.
