### PR TITLE
Revert "Updated admin api schema to include trial days on tiers"

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@sentry/node": "7.9.0",
     "@tryghost/adapter-manager": "0.0.0",
-    "@tryghost/admin-api-schema": "4.1.0",
+    "@tryghost/admin-api-schema": "4.0.0",
     "@tryghost/api-version-compatibility-service": "0.0.0",
     "@tryghost/bookshelf-plugins": "0.4.3",
     "@tryghost/bootstrap-socket": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,10 +3085,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@tryghost/admin-api-schema@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-4.1.0.tgz#8f4a5d30f795864f83e3fede8344c50465eda1e9"
-  integrity sha512-nJ/QQbU177rxVMlH4/6fqcq0J1dPrJSFYt2f18yZoL87EHAZv5h22+ufkJVipPhxLjx48kiXpwDniiDqLeHYmA==
+"@tryghost/admin-api-schema@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-4.0.0.tgz#97e528931fab8478d00b6b91e7e3d4a2b4c4c597"
+  integrity sha512-Yo4nV34aZY8M92dVMp+zEI2ZuHyFDcDHHvQ9yY1ZEOKhqkdKw6DxdR2HcAkQi/PSnM99N7CWk5WBKe9Vnm8+jA==
   dependencies:
     "@tryghost/errors" "^1.0.0"
     ajv "^6.12.6"


### PR DESCRIPTION
This reverts commit a58efd6ba1b09d5f5c39787b94b6f022011fb197.

The admin-api-schema has been updated to require the `trial_days` property on Tiers, but the Admin has not been updated to send it, causing errors when saving membership settings