### PR TITLE
Removed `bthreads` dependency in favor of native `worker_threads`

### DIFF
--- a/ghost/core/core/server/data/db/connection.js
+++ b/ghost/core/core/server/data/db/connection.js
@@ -31,10 +31,6 @@ function configure(dbConfig) {
             }
         };
 
-        // Force bthreads to use child_process backend until a worker_thread-compatible version of sqlite3 is published
-        // https://github.com/mapbox/node-sqlite3/issues/1386
-        process.env.BTHREADS_BACKEND = 'child_process';
-
         // In the default SQLite test config we set the path to /tmp/ghost-test.db,
         // but this won't work on Windows, so we need to replace the /tmp bit with
         // the Windows temp folder

--- a/ghost/core/core/server/run-update-check.js
+++ b/ghost/core/core/server/run-update-check.js
@@ -1,4 +1,4 @@
-const {parentPort} = require('bthreads');
+const {parentPort} = require('worker_threads');
 
 const postParentPortMessage = (message) => {
     if (parentPort) {

--- a/ghost/core/core/server/services/email-analytics/jobs/fetch-latest.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/fetch-latest.js
@@ -1,4 +1,4 @@
-const {parentPort} = require('bthreads');
+const {parentPort} = require('worker_threads');
 const debug = require('@tryghost/debug')('jobs:email-analytics:fetch-latest');
 
 // recurring job to fetch analytics since the most recently seen event timestamp

--- a/ghost/core/core/server/web/api/testmode/jobs/graceful-job.js
+++ b/ghost/core/core/server/web/api/testmode/jobs/graceful-job.js
@@ -1,4 +1,4 @@
-const {parentPort} = require('bthreads');
+const {parentPort} = require('worker_threads');
 const util = require('util');
 
 let shutdown = false;

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -123,7 +123,6 @@
     "bookshelf-relations": "2.4.0",
     "brute-knex": "4.0.1",
     "bson-objectid": "2.0.3",
-    "bthreads": "0.5.1",
     "chalk": "4.1.2",
     "cheerio": "0.22.0",
     "common-tags": "1.8.2",

--- a/ghost/job-manager/test/jobs/graceful.js
+++ b/ghost/job-manager/test/jobs/graceful.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 const setTimeoutPromise = require('util').promisify(setTimeout);
-const {isMainThread, parentPort} = require('bthreads');
+const {isMainThread, parentPort} = require('worker_threads');
 
 let shutdown = false;
 

--- a/ghost/job-manager/test/jobs/message.js
+++ b/ghost/job-manager/test/jobs/message.js
@@ -1,4 +1,4 @@
-const {parentPort} = require('bthreads');
+const {parentPort} = require('worker_threads');
 
 setInterval(() => { }, 10);
 

--- a/ghost/job-manager/test/jobs/timed-job.js
+++ b/ghost/job-manager/test/jobs/timed-job.js
@@ -1,4 +1,4 @@
-const {isMainThread, parentPort, workerData} = require('bthreads');
+const {isMainThread, parentPort, workerData} = require('worker_threads');
 const util = require('util');
 const setTimeoutPromise = util.promisify(setTimeout);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6780,7 +6780,7 @@ bson-objectid@2.0.3:
   resolved "https://registry.yarnpkg.com/bson-objectid/-/bson-objectid-2.0.3.tgz#d840185172846b2f10c42ce2bcdb4a50956a9db5"
   integrity sha512-WYwVtY9yqk179EPMNuF3vcxufdrGLEo2XwqdRVbfLVe9X6jLt7WKZQgP+ObOcprakBGbHxzl76tgTaieqsH29g==
 
-bthreads@0.5.1, bthreads@^0.5.1:
+bthreads@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/bthreads/-/bthreads-0.5.1.tgz#c7a4dacc2d159c50de08b37b1e2a7da836171063"
   integrity sha512-nK7Jo9ll+r1FRMNPWEFRTZMQrX6HhX8JjPAofxmbTNILHqWVIJPmWzCi9JlX/K0DL5AKZTFZg2Qser5C6gVs9A==
@@ -10285,7 +10285,6 @@ ember-power-calendar@^0.16.3:
 
 ember-power-datepicker@cibernox/ember-power-datepicker:
   version "0.8.1"
-  uid da580474a2c449b715444934ddb626b7c07f46a7
   resolved "https://codeload.github.com/cibernox/ember-power-datepicker/tar.gz/da580474a2c449b715444934ddb626b7c07f46a7"
   dependencies:
     ember-basic-dropdown "^3.0.11"
@@ -12620,7 +12619,6 @@ globrex@^0.1.2:
 
 "google-caja-bower@https://github.com/acburdine/google-caja-bower#ghost":
   version "6011.0.0"
-  uid "275cb75249f038492094a499756a73719ae071fd"
   resolved "https://github.com/acburdine/google-caja-bower#275cb75249f038492094a499756a73719ae071fd"
 
 got@9.6.0:
@@ -14781,7 +14779,6 @@ keygrip@~1.1.0:
 
 "keymaster@https://github.com/madrobby/keymaster.git":
   version "1.6.3"
-  uid f8f43ddafad663b505dc0908e72853bcf8daea49
   resolved "https://github.com/madrobby/keymaster.git#f8f43ddafad663b505dc0908e72853bcf8daea49"
 
 keypair@1.0.4:
@@ -16549,7 +16546,6 @@ mocha@^2.5.3:
 
 mock-knex@TryGhost/mock-knex#8ecb8c227bf463c991c3d820d33f59efc3ab9682:
   version "0.4.9"
-  uid "8ecb8c227bf463c991c3d820d33f59efc3ab9682"
   resolved "https://codeload.github.com/TryGhost/mock-knex/tar.gz/8ecb8c227bf463c991c3d820d33f59efc3ab9682"
   dependencies:
     bluebird "^3.4.1"
@@ -20498,7 +20494,6 @@ simple-update-notifier@^1.0.7:
 
 "simplemde@https://github.com/kevinansfield/simplemde-markdown-editor.git#ghost":
   version "1.11.2"
-  uid "4c39702de7d97f9b32d5c101f39237b6dab7c3ee"
   resolved "https://github.com/kevinansfield/simplemde-markdown-editor.git#4c39702de7d97f9b32d5c101f39237b6dab7c3ee"
 
 sinon@14.0.0:


### PR DESCRIPTION
fixes https://github.com/TryGhost/Toolbox/issues/370

- we no longer need `bthreads` because we can use native
  `worker_threads` now we don't have to support Node 10 any longer
- this allows us to clean up a dependency and stick with native
  libraries
- the referenced node-sqlite3 issue should be fixed (or at least, we now
  maintain it so we can fix it if not)
