### PR TITLE
Fixed limit service not allowing explore integration

### DIFF
--- a/ghost/core/core/server/services/auth/api-key/admin.js
+++ b/ghost/core/core/server/services/auth/api-key/admin.js
@@ -127,7 +127,11 @@ const authenticateWithToken = async (req, res, next, {token, JWT_OPTIONS}) => {
 
         // CASE: blocking all non-internal: "custom" and "builtin" integration requests when the limit is reached
         if (limitService.isLimited('customIntegrations')
-            && (apiKey.relations.integration && !['internal'].includes(apiKey.relations.integration.get('type')))) {
+            && (apiKey.relations.integration
+                && !['internal'].includes(apiKey.relations.integration.get('type'))
+                && !['ghost-explore'].includes(apiKey.relations.integration.get('slug'))
+            )
+        ) {
             // NOTE: using "checkWouldGoOverLimit" instead of "checkIsOverLimit" here because flag limits don't have
             //       a concept of measuring if the limit has been surpassed
             await limitService.errorIfWouldGoOverLimit('customIntegrations');

--- a/ghost/core/core/server/services/auth/api-key/content.js
+++ b/ghost/core/core/server/services/auth/api-key/content.js
@@ -43,7 +43,11 @@ const authenticateContentApiKey = async function authenticateContentApiKey(req, 
 
         // CASE: blocking all non-internal: "custom" and "builtin" integration requests when the limit is reached
         if (limitService.isLimited('customIntegrations')
-            && (apiKey.relations.integration && !['internal'].includes(apiKey.relations.integration.get('type')))) {
+            && (apiKey.relations.integration
+                && !['internal'].includes(apiKey.relations.integration.get('type'))
+                && !['ghost-explore'].includes(apiKey.relations.integration.get('slug'))
+            )
+        ) {
             // NOTE: using "checkWouldGoOverLimit" instead of "checkIsOverLimit" here because flag limits don't have
             //       a concept of measuring if the limit has been surpassed
             await limitService.errorIfWouldGoOverLimit('customIntegrations');


### PR DESCRIPTION
no issue

- Don't run limit checks for the Ghost Explore integration