### PR TITLE
🐛 Fixed Admin UI freezing when interacting with dropdown lists

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -37,7 +37,7 @@
     "@ember/test-helpers": "2.8.1",
     "@embroider/macros": "1.8.3",
     "@glimmer/component": "1.1.2",
-    "@html-next/vertical-collection": "3.1.0",
+    "@html-next/vertical-collection": "3.0.0",
     "@joeattardi/emoji-button": "4.6.4",
     "@sentry/ember": "7.9.0",
     "@tryghost/color-utils": "0.1.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,10 +2499,10 @@
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
   integrity sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==
 
-"@html-next/vertical-collection@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@html-next/vertical-collection/-/vertical-collection-3.1.0.tgz#3e271fe36bbf381b5e6f7702fde72f8c6880ae0d"
-  integrity sha512-7mzdEhPA0SzIAqZA/HUwmAYVxzbsKp4l8vB7oBc6A71IGusrNZQUMLl09Vi9wgHahvhBV89LST474cu9k2Iw1Q==
+"@html-next/vertical-collection@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@html-next/vertical-collection/-/vertical-collection-3.0.0.tgz#ba16bd2df413e9c25d245ae37ddb1950a5ccdbca"
+  integrity sha512-kpLYZXr3tlYkrSiyhww+f1YkyLMEhCm9h55A+PWPzJXBTZkV12sC5mIbxVcWD7q5QNjy634m6MMvmxfFgDmGoQ==
   dependencies:
     babel6-plugin-strip-class-callcheck "^6.0.0"
     broccoli-funnel "^2.0.2"


### PR DESCRIPTION
reverts https://github.com/TryGhost/Ghost/pull/15170

- causes browser-freezing errors when vertical-collection is used in `<PowerSelectVerticalCollectionOptions>` and search/filtering is applied updating the displayed list
- error: `Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`
