### PR TITLE
Added `core` integration type /w migration

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/integrations.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/integrations.js
@@ -3,9 +3,9 @@ const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:
 
 function setDefaultFilter(frame) {
     if (frame.options.filter) {
-        frame.options.filter = `(${frame.options.filter})+type:[custom,builtin]`;
+        frame.options.filter = `(${frame.options.filter})+type:[custom,builtin,core]`;
     } else {
-        frame.options.filter = 'type:[custom,builtin]';
+        frame.options.filter = 'type:[custom,builtin,core]';
     }
 }
 

--- a/ghost/core/core/server/data/migrations/versions/5.9/2022-08-09-08-32-added-new-integration-type.js
+++ b/ghost/core/core/server/data/migrations/versions/5.9/2022-08-09-08-32-added-new-integration-type.js
@@ -1,0 +1,24 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Changing Ghost Explore Integration to type "core"');
+        await knex('integrations')
+            .where({
+                name: 'Ghost Explore',
+                slug: 'ghost-explore'
+            })
+            .update('type', 'core');
+    },
+    async function down(knex) {
+        logging.info('Changing Ghost Explore Integration to type "builtin"');
+
+        await knex('integrations')
+            .where({
+                name: 'Ghost Explore',
+                slug: 'ghost-explore'
+            })
+            .update('type', 'builtin');
+    }
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -672,7 +672,7 @@
                     "slug": "ghost-explore",
                     "name": "Ghost Explore",
                     "description": "Built-in Ghost Explore integration",
-                    "type": "builtin",
+                    "type": "core",
                     "api_keys": [{"type": "admin", "role": "Ghost Explore Integration"}]
                 },
                 {

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -319,7 +319,7 @@ module.exports = {
             maxlength: 50,
             nullable: false,
             defaultTo: 'custom',
-            validations: {isIn: [['internal', 'builtin', 'custom']]}
+            validations: {isIn: [['internal', 'builtin', 'custom', 'core']]}
         },
         name: {type: 'string', maxlength: 191, nullable: false},
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},

--- a/ghost/core/core/server/services/auth/api-key/admin.js
+++ b/ghost/core/core/server/services/auth/api-key/admin.js
@@ -127,11 +127,7 @@ const authenticateWithToken = async (req, res, next, {token, JWT_OPTIONS}) => {
 
         // CASE: blocking all non-internal: "custom" and "builtin" integration requests when the limit is reached
         if (limitService.isLimited('customIntegrations')
-            && (apiKey.relations.integration
-                && !['internal'].includes(apiKey.relations.integration.get('type'))
-                && !['ghost-explore'].includes(apiKey.relations.integration.get('slug'))
-            )
-        ) {
+            && (apiKey.relations.integration && !['internal', 'core'].includes(apiKey.relations.integration.get('type')))) {
             // NOTE: using "checkWouldGoOverLimit" instead of "checkIsOverLimit" here because flag limits don't have
             //       a concept of measuring if the limit has been surpassed
             await limitService.errorIfWouldGoOverLimit('customIntegrations');

--- a/ghost/core/core/server/services/auth/api-key/content.js
+++ b/ghost/core/core/server/services/auth/api-key/content.js
@@ -43,11 +43,7 @@ const authenticateContentApiKey = async function authenticateContentApiKey(req, 
 
         // CASE: blocking all non-internal: "custom" and "builtin" integration requests when the limit is reached
         if (limitService.isLimited('customIntegrations')
-            && (apiKey.relations.integration
-                && !['internal'].includes(apiKey.relations.integration.get('type'))
-                && !['ghost-explore'].includes(apiKey.relations.integration.get('slug'))
-            )
-        ) {
+            && (apiKey.relations.integration && !['internal', 'core'].includes(apiKey.relations.integration.get('type')))) {
             // NOTE: using "checkWouldGoOverLimit" instead of "checkIsOverLimit" here because flag limits don't have
             //       a concept of measuring if the limit has been surpassed
             await limitService.errorIfWouldGoOverLimit('customIntegrations');

--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -23,7 +23,7 @@ describe('Integrations API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200);
 
-        should.equal(res.body.integrations.length, 3);
+        should.equal(res.body.integrations.length, 5);
 
         // there is no enforced order for integrations which makes order different on SQLite and MySQL
         const zapierIntegration = _.find(res.body.integrations, {name: 'Zapier'}); // from migrations
@@ -31,6 +31,9 @@ describe('Integrations API', function () {
 
         const testIntegration = _.find(res.body.integrations, {name: 'Test Integration'}); // from fixtures
         should.exist(testIntegration);
+
+        const exploreIntegration = _.find(res.body.integrations, {name: 'Test Core Integration'}); // from fixtures
+        should.exist(exploreIntegration);
     });
 
     it('Can not read internal integration', async function () {

--- a/ghost/core/test/e2e-api/admin/utils.js
+++ b/ghost/core/test/e2e-api/admin/utils.js
@@ -219,10 +219,10 @@ module.exports = {
         return testUtils.API.doAuth(`${API_URL}session/`, ...args);
     },
 
-    getValidAdminToken(audience) {
+    getValidAdminToken(audience, keyid = 0) {
         const jwt = require('jsonwebtoken');
         const JWT_OPTIONS = {
-            keyid: testUtils.DataGenerator.Content.api_keys[0].id,
+            keyid: testUtils.DataGenerator.Content.api_keys[keyid].id,
             algorithm: 'HS256',
             expiresIn: '5m',
             audience: audience
@@ -230,7 +230,7 @@ module.exports = {
 
         return jwt.sign(
             {},
-            Buffer.from(testUtils.DataGenerator.Content.api_keys[0].secret, 'hex'),
+            Buffer.from(testUtils.DataGenerator.Content.api_keys[keyid].secret, 'hex'),
             JWT_OPTIONS
         );
     },

--- a/ghost/core/test/e2e-api/content/key_authentication.test.js
+++ b/ghost/core/test/e2e-api/content/key_authentication.test.js
@@ -45,17 +45,26 @@ describe('Content API key authentication', function () {
 
             // NOTE: need to do a full reboot to reinitialize hostSettings
             await localUtils.startGhost();
+            await testUtils.initFixtures('integrations');
             await testUtils.initFixtures('api_keys');
 
             const key = localUtils.getValidKey();
 
-            const response = await request.get(localUtils.API.getApiQuery(`posts/?key=${key}`))
+            const firstResponse = await request.get(localUtils.API.getApiQuery(`posts/?key=${key}`))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(403);
 
-            response.body.errors[0].type.should.equal('HostLimitError');
-            response.body.errors[0].message.should.equal('Custom limit error message');
+            firstResponse.body.errors[0].type.should.equal('HostLimitError');
+            firstResponse.body.errors[0].message.should.equal('Custom limit error message');
+
+            // CASE: explore endpoint can only be reached by Admin API
+            const secondResponse = await request.get(localUtils.API.getApiQuery('explore/'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404);
+
+            secondResponse.body.errors[0].type.should.equal('NotFoundError');
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/integrations.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/integrations.test.js
@@ -12,7 +12,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.integrations.browse(apiConfig, frame);
-            frame.options.filter.should.eql('type:[custom,builtin]');
+            frame.options.filter.should.eql('type:[custom,builtin,core]');
         });
 
         it('combines filters', function () {
@@ -25,7 +25,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.integrations.browse(apiConfig, frame);
-            frame.options.filter.should.eql('(type:internal)+type:[custom,builtin]');
+            frame.options.filter.should.eql('(type:internal)+type:[custom,builtin,core]');
         });
     });
 
@@ -39,7 +39,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.integrations.read(apiConfig, frame);
-            frame.options.filter.should.eql('type:[custom,builtin]');
+            frame.options.filter.should.eql('type:[custom,builtin,core]');
         });
 
         it('combines filters', function () {
@@ -52,7 +52,7 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
             };
 
             serializers.input.integrations.read(apiConfig, frame);
-            frame.options.filter.should.eql('(type:internal)+type:[custom,builtin]');
+            frame.options.filter.should.eql('(type:internal)+type:[custom,builtin,core]');
         });
     });
 });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '45337ae85129a98e4c1b551cc91790da';
-    const currentFixturesHash = 'a75211a41f515202280be7cb287e101f';
+    const currentFixturesHash = '0ae1887dd0b42508be946bdbd20d41c8';
     const currentSettingsHash = 'd54210758b7054e2174fd34aa2320ad7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/unit/server/models/integration.test.js
+++ b/ghost/core/test/unit/server/models/integration.test.js
@@ -60,11 +60,11 @@ describe('Unit: models/integration', function () {
             return models.Integration.findOne({
                 id: '123'
             }, {
-                filter: 'type:[custom,builtin]'
+                filter: 'type:[custom,builtin,core]'
             }).then(() => {
                 queries.length.should.eql(1);
-                queries[0].sql.should.eql('select `integrations`.* from `integrations` where `integrations`.`type` in (?, ?) and `integrations`.`id` = ? limit ?');
-                queries[0].bindings.should.eql(['custom', 'builtin', '123', 1]);
+                queries[0].sql.should.eql('select `integrations`.* from `integrations` where `integrations`.`type` in (?, ?, ?) and `integrations`.`id` = ? limit ?');
+                queries[0].bindings.should.eql(['custom', 'builtin', 'core', '123', 1]);
             });
         });
     });

--- a/ghost/core/test/utils/fixtures/data-generator.js
+++ b/ghost/core/test/utils/fixtures/data-generator.js
@@ -651,6 +651,18 @@ DataGenerator.Content = {
             name: 'Test Internal Integration',
             slug: 'test-internal-integration',
             type: 'internal'
+        },
+        {
+            id: ObjectId().toHexString(),
+            name: 'Test Builtin Integration',
+            slug: 'test-builtin-integration',
+            type: 'builtin'
+        },
+        {
+            id: ObjectId().toHexString(),
+            name: 'Test Core Integration',
+            slug: 'test-core-integration',
+            type: 'core'
         }
     ],
 
@@ -670,7 +682,20 @@ DataGenerator.Content = {
         {
             id: ObjectId().toHexString(),
             type: 'admin',
+            secret: _.repeat('b', 64),
             integration_id: undefined // "internal"
+        },
+        {
+            id: ObjectId().toHexString(),
+            type: 'admin',
+            secret: _.repeat('d', 26),
+            integration_id: undefined // "builtin"
+        },
+        {
+            id: ObjectId().toHexString(),
+            type: 'admin',
+            secret: _.repeat('e', 64),
+            integration_id: undefined // "core"
         }
     ],
 
@@ -800,6 +825,8 @@ DataGenerator.Content = {
 // set up belongs_to relationships
 DataGenerator.Content.api_keys[0].integration_id = DataGenerator.Content.integrations[0].id;
 DataGenerator.Content.api_keys[1].integration_id = DataGenerator.Content.integrations[0].id;
+DataGenerator.Content.api_keys[3].integration_id = DataGenerator.Content.integrations[2].id;
+DataGenerator.Content.api_keys[4].integration_id = DataGenerator.Content.integrations[3].id;
 DataGenerator.Content.webhooks[0].integration_id = DataGenerator.Content.integrations[0].id;
 DataGenerator.Content.webhooks[1].integration_id = DataGenerator.Content.integrations[0].id;
 DataGenerator.Content.emails[0].post_id = DataGenerator.Content.posts[0].id;
@@ -1464,13 +1491,17 @@ DataGenerator.forKnex = (function () {
 
     const integrations = [
         createBasic(DataGenerator.Content.integrations[0]),
-        createBasic(DataGenerator.Content.integrations[1])
+        createBasic(DataGenerator.Content.integrations[1]),
+        createBasic(DataGenerator.Content.integrations[2]),
+        createBasic(DataGenerator.Content.integrations[3])
     ];
 
     const api_keys = [
         createBasic(DataGenerator.Content.api_keys[0]),
         createBasic(DataGenerator.Content.api_keys[1]),
-        createBasic(DataGenerator.Content.api_keys[2])
+        createBasic(DataGenerator.Content.api_keys[2]),
+        createBasic(DataGenerator.Content.api_keys[3]),
+        createBasic(DataGenerator.Content.api_keys[4])
     ];
 
     const emails = [

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -845,7 +845,7 @@
                     "slug": "ghost-explore",
                     "name": "Ghost Explore",
                     "description": "Built-in Ghost Explore integration",
-                    "type": "builtin",
+                    "type": "core",
                     "api_keys": [{"type": "admin", "role": "Ghost Explore Integration"}]
                 },
                 {


### PR DESCRIPTION
no issue

- The previous integration type is insufficient and we needed to utilise a new type `core`
- Added `core` integration to Admin API serializer whitelist
- Updated tests and fixtures to test `core` integrations with host limits