### PR TITLE
Reduced number of hashing rounds during tests

### DIFF
--- a/ghost/security/lib/password.js
+++ b/ghost/security/lib/password.js
@@ -1,6 +1,13 @@
 const bcrypt = require('bcryptjs');
+
+let HASH_ROUNDS = 10;
+
+if (process.env.NODE_ENV.startsWith('testing')) {
+    HASH_ROUNDS = 1;
+}
+
 module.exports.hash = async function hash(plainPassword) {
-    const salt = await bcrypt.genSalt();
+    const salt = await bcrypt.genSalt(HASH_ROUNDS);
     return bcrypt.hash(plainPassword, salt);
 };
 


### PR DESCRIPTION
- one of the reasons our tests are so slow is because we're running 10
  rounds of bcrypt hashing on shared hardware, nearly 300 times during
  the database tests
- we don't particularly care about password hash strength during tests
  so this commit reduces the number of rounds to 1 if we're running in a
  test environment
- this drops the time to produce an individual hash from ~140ms to ~3ms,
  saving us a lot of time overall
