### PR TITLE
🐛 Fixed Comments administration for self hosters

### DIFF
--- a/ghost/core/core/server/web/admin/app.js
+++ b/ghost/core/core/server/web/admin/app.js
@@ -23,7 +23,7 @@ module.exports = function setupAdminApp() {
     ));
 
     adminApp.use('/auth-frame', serveStatic(
-        config.get('paths').adminAuthAssets
+        path.join(config.getContentPath('public'), 'admin-auth')
     ));
 
     // Ember CLI's live-reload script

--- a/ghost/core/core/shared/config/overrides.json
+++ b/ghost/core/core/shared/config/overrides.json
@@ -3,7 +3,6 @@
         "appRoot": ".",
         "corePath": "core/",
         "adminAssets": "core/built/admin",
-        "adminAuthAssets": "content/public/admin-auth",
         "helperTemplates": "core/frontend/helpers/tpl/",
         "defaultViews": "core/server/views/",
         "defaultRouteSettings": "core/server/services/route-settings/",

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -102,7 +102,6 @@ describe('Config Loader', function () {
                 'appRoot',
                 'corePath',
                 'adminAssets',
-                'adminAuthAssets',
                 'helperTemplates',
                 'defaultViews',
                 'defaultRouteSettings',


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1799

Rather than using the `adminAuthAssets` config which is not updated to
be aware of running in a different directory to the cwd, we use the
getContentPath method which handles all of the directory checking.

Without this, we were unable to serve the admin-auth iframe, as the
directory was incorrect for self hosters.
