### PR TITLE
Member Attribution DB & Models

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -31,6 +31,7 @@ const BACKUP_TABLES = [
     'members_paid_subscription_events',
     'members_subscribe_events',
     'members_product_events',
+    'members_created_events',
     'members_newsletters',
     'comments',
     'comment_likes',

--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -32,6 +32,7 @@ const BACKUP_TABLES = [
     'members_subscribe_events',
     'members_product_events',
     'members_created_events',
+    'members_subscription_created_events',
     'members_newsletters',
     'comments',
     'comment_likes',

--- a/ghost/core/core/server/data/migrations/versions/5.10/2022-08-16-14-25-add-member-created-events-table.js
+++ b/ghost/core/core/server/data/migrations/versions/5.10/2022-08-16-14-25-add-member-created-events-table.js
@@ -1,0 +1,11 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('members_created_events', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    created_at: {type: 'dateTime', nullable: false},
+    member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+    attribution_id: {type: 'string', maxlength: 24, nullable: true},
+    attribution_type: {type: 'string', maxlength: 50, nullable: true},
+    attribution_url: {type: 'string', maxlength: 2000, nullable: true},
+    source: {type: 'string', maxlength: 50, nullable: false}
+});

--- a/ghost/core/core/server/data/migrations/versions/5.10/2022-08-16-14-25-add-subscription-created-events-table.js
+++ b/ghost/core/core/server/data/migrations/versions/5.10/2022-08-16-14-25-add-subscription-created-events-table.js
@@ -1,0 +1,11 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('members_subscription_created_events', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    created_at: {type: 'dateTime', nullable: false},
+    member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+    subscription_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_stripe_customers_subscriptions.id'},
+    attribution_id: {type: 'string', maxlength: 24, nullable: true},
+    attribution_type: {type: 'string', maxlength: 50, nullable: true},
+    attribution_url: {type: 'string', maxlength: 2000, nullable: true}
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -603,6 +603,15 @@ module.exports = {
         plan_amount: {type: 'integer', nullable: false},
         plan_currency: {type: 'string', maxLength: 3, nullable: false}
     },
+    members_subscription_created_events: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+        subscription_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_stripe_customers_subscriptions.id'},
+        attribution_id: {type: 'string', maxlength: 24, nullable: true},
+        attribution_type: {type: 'string', maxlength: 50, nullable: true},
+        attribution_url: {type: 'string', maxlength: 2000, nullable: true}
+    },
     offer_redemptions: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         offer_id: {type: 'string', maxlength: 24, nullable: false, references: 'offers.id', cascadeDelete: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -474,6 +474,15 @@ module.exports = {
         product_id: {type: 'string', maxlength: 24, nullable: false, references: 'products.id', cascadeDelete: true},
         sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
     },
+    members_created_events: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+        attribution_id: {type: 'string', maxlength: 24, nullable: true},
+        attribution_type: {type: 'string', maxlength: 50, nullable: true},
+        attribution_url: {type: 'string', maxlength: 2000, nullable: true},
+        source: {type: 'string', maxlength: 50, nullable: false}
+    },
     members_cancel_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},

--- a/ghost/core/core/server/models/member-created-event.js
+++ b/ghost/core/core/server/models/member-created-event.js
@@ -1,0 +1,26 @@
+const errors = require('@tryghost/errors');
+const ghostBookshelf = require('./base');
+
+const MemberCreatedEvent = ghostBookshelf.Model.extend({
+    tableName: 'members_created_events',
+
+    member() {
+        return this.belongsTo('Member', 'member_id', 'id');
+    },
+
+    attribution() {
+        return this.belongsTo('Post', 'attribution_id', 'id');
+    }
+}, {
+    async edit() {
+        throw new errors.IncorrectUsageError({message: 'Cannot edit MemberCreatedEvent'});
+    },
+
+    async destroy() {
+        throw new errors.IncorrectUsageError({message: 'Cannot destroy MemberCreatedEvent'});
+    }
+});
+
+module.exports = {
+    MemberCreatedEvent: ghostBookshelf.model('MemberCreatedEvent', MemberCreatedEvent)
+};

--- a/ghost/core/core/server/models/subscription-created-event.js
+++ b/ghost/core/core/server/models/subscription-created-event.js
@@ -1,0 +1,30 @@
+const errors = require('@tryghost/errors');
+const ghostBookshelf = require('./base');
+
+const SubscriptionCreatedEvent = ghostBookshelf.Model.extend({
+    tableName: 'members_subscription_created_events',
+
+    member() {
+        return this.belongsTo('Member', 'member_id', 'id');
+    },
+
+    subscription() {
+        return this.belongsTo('StripeCustomerSubscription', 'subscription_id', 'id');
+    },
+
+    attribution() {
+        return this.belongsTo('Post', 'attribution_id', 'id');
+    }
+}, {
+    async edit() {
+        throw new errors.IncorrectUsageError({message: 'Cannot edit SubscriptionCreatedEvent'});
+    },
+
+    async destroy() {
+        throw new errors.IncorrectUsageError({message: 'Cannot destroy SubscriptionCreatedEvent'});
+    }
+});
+
+module.exports = {
+    SubscriptionCreatedEvent: ghostBookshelf.model('SubscriptionCreatedEvent', SubscriptionCreatedEvent)
+};

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -50,6 +50,8 @@ describe('Exporter', function () {
                 'members_stripe_customers',
                 'members_stripe_customers_subscriptions',
                 'members_subscribe_events',
+                'members_created_events',
+                'subscription_created_events',
                 'migrations',
                 'migrations_lock',
                 'mobiledoc_revisions',

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -51,7 +51,7 @@ describe('Exporter', function () {
                 'members_stripe_customers_subscriptions',
                 'members_subscribe_events',
                 'members_created_events',
-                'subscription_created_events',
+                'members_subscription_created_events',
                 'migrations',
                 'migrations_lock',
                 'mobiledoc_revisions',

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'f5f7bc63bf9484bf50a0e554604802b3';
+    const currentSchemaHash = '36796d1729450e8d2184bb5360067919';
     const currentFixturesHash = '0ae1887dd0b42508be946bdbd20d41c8';
     const currentSettingsHash = 'd54210758b7054e2174fd34aa2320ad7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '45337ae85129a98e4c1b551cc91790da';
+    const currentSchemaHash = 'f5f7bc63bf9484bf50a0e554604802b3';
     const currentFixturesHash = '0ae1887dd0b42508be946bdbd20d41c8';
     const currentSettingsHash = 'd54210758b7054e2174fd34aa2320ad7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1803
refs https://github.com/TryGhost/Team/issues/1802

I've left out the migrations here, because we are still waiting on whether or not we should use cascadeDelete. We can still use/merge this however as it's behind an alpha flag and the migrations will add the tables before we go to beta.

If you wanna use this locally, just start Ghost with a fresh DB to get the tables added.