### PR TITLE
Fetched actor record to display real name when listing audit log events

### DIFF
--- a/ghost/admin/app/helpers/parse-audit-log-event.js
+++ b/ghost/admin/app/helpers/parse-audit-log-event.js
@@ -1,14 +1,23 @@
-export default function parseAuditLogEvent(ev) {
-    const actorName = getActorName(ev);
-    const action = getAction(ev);
-    const actionIcon = getActionIcon(ev);
+import Helper from '@ember/component/helper';
+import {inject as service} from '@ember/service';
 
-    return {
-        actorName,
-        actionIcon,
-        action,
-        original: ev
-    };
+export default class ParseAuditLogEvent extends Helper {
+    @service store;
+
+    compute([ev]) {
+        const action = getAction(ev);
+        const actionIcon = getActionIcon(ev);
+        const getActor = () => this.store.findRecord('user', ev.actor_id, {reload: false});
+
+        return {
+            get actor() {
+                return getActor();
+            },
+            actionIcon,
+            action,
+            original: ev
+        };
+    }
 }
 
 function getActionIcon(ev) {
@@ -20,10 +29,6 @@ function getActionIcon(ev) {
     case 'deleted':
         return 'cross-circle';
     }
-}
-
-function getActorName(ev) {
-    return ev.actor_id;
 }
 
 function getAction(ev) {

--- a/ghost/admin/app/templates/settings/audit-log.hbs
+++ b/ghost/admin/app/templates/settings/audit-log.hbs
@@ -25,7 +25,7 @@
                          <div class="gh-list-data">
                              <div class="flex items-center">
                                  <div class="w-80">
-                                     <h3 class="ma0 pa0 gh-members-list-name">{{ev.actorName}}</h3>
+                                     <h3 class="ma0 pa0 gh-members-list-name">{{ev.actor.name}}</h3>
                                  </div>
                              </div>
                          </div>


### PR DESCRIPTION
no issue

- switched `parse-audit-log-event` to a class helper to get access to dependency injection
- added `get actor()` to the parsed event object
  - uses the store to find the related user record, returning an already loaded record if it exists otherwise fetches the record
  - allows use of `event.actor.*` in templates because they are promise-aware and will be filled in once the record is loaded
