### PR TITLE
Fixed odd behavior with saving complimentary members

### DIFF
--- a/ghost/admin/app/serializers/member.js
+++ b/ghost/admin/app/serializers/member.js
@@ -18,6 +18,7 @@ export default class MemberSerializer extends ApplicationSerializer.extend(Embed
         delete json.geolocation;
         delete json.status;
         delete json.last_seen_at;
+        delete json.comped;
 
         // Normalize properties
         json.name = json.name || '';


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1715
refs https://github.com/TryGhost/Members/pull/407

- when comped boolean was brought back for backwards compatibility, it accidentally opened a path from admin to set comped stripe subscriptions on members on save, as Admin always sends back `comped` value
- since we don't allow stripe comped subscriptions anymore, this caused weird behavior with assigning the default tier on comped stripe subscription.
- this change removes the `json.comped` value to be sent up from Admin to avoid any weird comped changes to the member