### PR TITLE
Fixed use of static class field

### DIFF
--- a/ghost/mailgun-client/lib/mailgun-client.js
+++ b/ghost/mailgun-client/lib/mailgun-client.js
@@ -36,7 +36,7 @@ module.exports = class MailgunClient {
             return null;
         }
 
-        if (Object.keys(recipientData).length > module.exports.BATCH_SIZE) {
+        if (Object.keys(recipientData).length > MailgunClient.BATCH_SIZE) {
             // TODO: what to do here?
         }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/3d80fd982c5f897062de5c4c8a9f3806fed81842

- referenced commit moved it from an exported field to a static class
  variable, but I forgot to update it here
