### PR TITLE
Disabled members migrations in test environment

### DIFF
--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -148,15 +148,17 @@ module.exports = {
             }
         })();
 
-        const membersMigrationJobName = 'members-migrations';
-        if (!(await jobsService.hasExecutedSuccessfully(membersMigrationJobName))) {
-            jobsService.addOneOffJob({
-                name: membersMigrationJobName,
-                offloaded: false,
-                job: stripeService.migrations.execute.bind(stripeService.migrations)
-            });
+        if (!env?.startsWith('testing')) {
+            const membersMigrationJobName = 'members-migrations';
+            if (!(await jobsService.hasExecutedSuccessfully(membersMigrationJobName))) {
+                jobsService.addOneOffJob({
+                    name: membersMigrationJobName,
+                    offloaded: false,
+                    job: stripeService.migrations.execute.bind(stripeService.migrations)
+                });
 
-            await jobsService.awaitCompletion(membersMigrationJobName);
+                await jobsService.awaitCompletion(membersMigrationJobName);
+            }
         }
     },
     contentGating: require('./content-gating'),


### PR DESCRIPTION
- it turns out we're running the members migration job in tests, and
  these run every time we boot Ghost. Given we wipe the DB each time,
  this forces the job to run, which is just burning valuable test time
- the reason this block of code is slow is because it waits 500ms to see
  if the job has completed
- we run this 55 times, as of writing, during the E2E tests, so that's
  over 27s of idle time
- this commit gates running the migrations to outside of the test environment
