### PR TITLE
Added member attribution to member details page

### DIFF
--- a/ghost/admin/app/components/gh-member-details.hbs
+++ b/ghost/admin/app/components/gh-member-details.hbs
@@ -46,6 +46,12 @@
                     {{svg-jar "member-add"}}
                     Created on {{moment-format (moment-site-tz @member.createdAtUTC) "D MMM YYYY"}}
                 </p>
+                {{#if (and @member.attribution @member.attribution.url @member.attribution.title) }}
+                    <p>
+                        {{svg-jar "satellite"}}
+                        <a href="{{@member.attribution.url}}" target="_blank" rel="noopener noreferrer">{{ @member.attribution.title }}</a>
+                    </p>
+                {{/if}}
                 <p class="gh-member-last-seen">
                     {{svg-jar "eye"}}
                     {{#if (not (is-empty @member.lastSeenAtUTC))}}

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -159,8 +159,8 @@
                                                 <span class="gh-cp-membertier-renewal">Has access until {{sub.validUntil}}</span>
                                                 <span class="gh-badge archived" data-test-text="member-subscription-status">Cancelled</span>
                                             {{else if sub.trialUntil}}
-                                                    <span class="gh-cp-membertier-renewal">Ends {{sub.trialUntil}}</span>
-                                                    <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
+                                                <span class="gh-cp-membertier-renewal">Ends {{sub.trialUntil}}</span>
+                                                <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                             {{else}}
                                                 <span class="gh-cp-membertier-renewal">Renews {{sub.validUntil}}</span>
                                                 <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
@@ -189,8 +189,11 @@
                                                 </div>
                                             {{/if}}
                                         {{/if}}
-                                        <div class="gh-membertier-created">
-                                            Created on {{sub.startDate}}
+                                        <div>
+                                            <span class="gh-membertier-created">Created on {{sub.startDate}}</span>
+                                            <span class="gh-membertier-separator">·</span>
+                                            {{!-- TODO: You can simply add a <a /> for this when a page is available --}}
+                                            <span class="gh-membertier-started">Started on —</span>
                                         </div>
                                     </div>
 

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -190,10 +190,12 @@
                                             {{/if}}
                                         {{/if}}
                                         <div>
-                                            <span class="gh-membertier-created">Created on {{sub.startDate}}</span>
-                                            <span class="gh-membertier-separator">·</span>
-                                            {{!-- TODO: You can simply add a <a /> for this when a page is available --}}
-                                            <span class="gh-membertier-started">Started on —</span>
+                                            <span class="gh-membertier-created">Created on {{sub.startDate}}</span>                                            
+                                            {{#if (and sub.attribution sub.attribution.url sub.attribution.title) }}
+                                                <span class="gh-membertier-separator">·</span>
+                                                <span class="gh-membertier-started">Attributed to <a href="{{sub.attribution.url}}" target="_blank" rel="noopener noreferrer">{{ sub.attribution.title }}</a></span>
+                                            {{/if}}
+
                                         </div>
                                     </div>
 

--- a/ghost/admin/app/models/member.js
+++ b/ghost/admin/app/models/member.js
@@ -13,6 +13,7 @@ export default Model.extend(ValidationEngine, {
     createdAtUTC: attr('moment-utc'),
     lastSeenAtUTC: attr('moment-utc'),
     subscriptions: attr('member-subscription'),
+    attribution: attr(),
     subscribed: attr('boolean', {defaultValue: true}),
     comped: attr('boolean', {defaultValue: false}),
     geolocation: attr('json-string'),

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -707,6 +707,8 @@ label[for="member-description"] + p {
 .gh-member-details-meta p {
     display: flex;
     align-items: center;
+    white-space: nowrap;
+    min-width: 0;
 }
 
 .gh-member-details-meta .gh-member-last-seen {
@@ -717,6 +719,16 @@ label[for="member-description"] + p {
     width: 1.6rem;
     height: 1.6rem;
     margin-right: .8rem;
+    flex-shrink: 0;
+}
+
+/* WIP style for attribution link*/
+.gh-member-details-meta p a {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    text-decoration: underline;
+    margin-left: 2px;
 }
 
 .gh-member-details-meta svg path {

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -2143,9 +2143,23 @@ p.gh-members-import-errordetail:first-of-type {
     border-top: 1px solid var(--whitegrey);
 }
 
-.gh-membertier-created {
+.gh-membertier-created,
+.gh-membertier-started {
     color: var(--midgrey-d1);
     font-size: 1.25rem;
+    font-weight: 500;
+}
+
+.gh-membertier-started a {
+    color: var(--black);
+    font-weight: 500;
+}
+
+.gh-membertier-separator {
+    color: var(--midgrey-d1);
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin: 0 0.25em;
 }
 
 .gh-membertier-archived .gh-membertier-name {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
@@ -128,7 +128,8 @@ function serializeMember(member, options) {
         email_open_rate: json.email_open_rate,
         email_recipients: json.email_recipients,
         status: json.status,
-        last_seen_at: json.last_seen_at
+        last_seen_at: json.last_seen_at,
+        attribution: json.attribution
     };
 
     if (json.products) {

--- a/ghost/core/core/server/services/member-attribution/index.js
+++ b/ghost/core/core/server/services/member-attribution/index.js
@@ -13,6 +13,9 @@ class MemberAttributionServiceWrapper {
 
         // For now we don't need to expose anything (yet)
         this.service = new MemberAttributionService({
+            Post: models.Post,
+            User: models.User,
+            Tag: models.Tag,
             MemberCreatedEvent: models.MemberCreatedEvent,
             SubscriptionCreatedEvent: models.SubscriptionCreatedEvent,
             urlService,

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -123,6 +123,9 @@ describe('Members API without Stripe', function () {
 
     beforeEach(function () {
         mockManager.mockMail();
+
+        // For some reason it is enabled by default?
+        mockManager.mockLabsDisabled('memberAttribution');
     });
 
     afterEach(function () {
@@ -164,6 +167,9 @@ describe('Members API', function () {
     beforeEach(function () {
         mockManager.mockStripe();
         mockManager.mockMail();
+        
+        // For some reason it is enabled by default?
+        mockManager.mockLabsDisabled('memberAttribution');
     });
 
     afterEach(function () {

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -30,10 +30,19 @@ describe('Member Attribution Service', function () {
                     time: 123
                 }
             ]);
-            attribution.should.eql(({
+            attribution.should.match(({
                 id: post.id,
                 url,
                 type: 'post'
+            }));
+
+            const absoluteUrl = urlService.getUrlByResourceId(post.id, {absolute: true});
+
+            (await attribution.getResource()).should.match(({
+                id: post.id,
+                url: absoluteUrl,
+                type: 'post',
+                title: post.get('title')
             }));
         });
 
@@ -50,10 +59,19 @@ describe('Member Attribution Service', function () {
                     time: 123
                 }
             ]);
-            attribution.should.eql(({
+            attribution.should.match(({
                 id: post.id,
                 url,
                 type: 'page'
+            }));
+
+            const absoluteUrl = urlService.getUrlByResourceId(post.id, {absolute: true});
+
+            (await attribution.getResource()).should.match(({
+                id: post.id,
+                url: absoluteUrl,
+                type: 'page',
+                title: post.get('title')
             }));
         });
 
@@ -68,10 +86,19 @@ describe('Member Attribution Service', function () {
                     time: 123
                 }
             ]);
-            attribution.should.eql(({
+            attribution.should.match(({
                 id: tag.id,
                 url,
                 type: 'tag'
+            }));
+
+            const absoluteUrl = urlService.getUrlByResourceId(tag.id, {absolute: true});
+
+            (await attribution.getResource()).should.match(({
+                id: tag.id,
+                url: absoluteUrl,
+                type: 'tag',
+                title: tag.get('name')
             }));
         });
 
@@ -86,10 +113,19 @@ describe('Member Attribution Service', function () {
                     time: 123
                 }
             ]);
-            attribution.should.eql(({
+            attribution.should.match(({
                 id: author.id,
                 url,
                 type: 'author'
+            }));
+
+            const absoluteUrl = urlService.getUrlByResourceId(author.id, {absolute: true});
+
+            (await attribution.getResource()).should.match(({
+                id: author.id,
+                url: absoluteUrl,
+                type: 'author',
+                title: author.get('name')
             }));
         });
     });

--- a/ghost/member-attribution/lib/attribution.js
+++ b/ghost/member-attribution/lib/attribution.js
@@ -1,9 +1,70 @@
 /**
- * @typedef {object} Attribution
- * @prop {string|null} [id]
- * @prop {string|null} [url]
- * @prop {string} [type]
+ * @typedef {object} AttributionResource
+ * @prop {string|null} id
+ * @prop {string|null} url
+ * @prop {'page'|'post'|'author'|'tag'|'url'} type
+ * @prop {string|null} title
  */
+
+class Attribution {
+    #urlTranslator;
+
+    /**
+     * @param {object} data
+     * @param {string|null} [data.id]
+     * @param {string|null} [data.url]
+     * @param {'page'|'post'|'author'|'tag'|'url'} [data.type]
+     */
+    constructor({id, url, type}, {urlTranslator}) {
+        /** @type {string|null} */
+        this.id = id;
+        
+        /** @type {string|null} */
+        this.url = url;
+
+        /** @type {'page'|'post'|'author'|'tag'|'url'} */
+        this.type = type;
+
+        /**
+         * @private
+         */
+        this.#urlTranslator = urlTranslator;
+    }
+
+    /**
+     * Convert the instance to a parsed instance with more information about the resource included.
+     * It does:
+     * - Fetch the resource and add some information about it to the attribution
+     * - If the resource exists and have a new url, it updates the url if possible
+     * - Returns an absolute URL instead of a relative one
+     * @returns {Promise<AttributionResource>}
+     */
+    async getResource() {
+        if (!this.id || this.type === 'url' || !this.type) {
+            return {
+                id: null,
+                type: 'url',
+                // TODO: make url absolute
+                url: this.url,
+                title: this.url
+            };
+        }
+
+        const resource = await this.#urlTranslator.getResourceById(this.id, this.type, {absolute: true});
+
+        if (resource) {
+            return resource;
+        }
+
+        return {
+            id: null,
+            type: 'url',
+            // TODO: make url absolute
+            url: this.url,
+            title: this.url
+        };
+    }
+}
 
 /**
  * Convert a UrlHistory to an attribution object
@@ -16,17 +77,28 @@ class AttributionBuilder {
     }
 
     /**
+     * Creates an Attribution object with the dependencies injected
+     */
+    build({id, url, type}) {
+        return new Attribution({
+            id,
+            url,
+            type
+        }, {urlTranslator: this.urlTranslator});
+    }
+
+    /**
      * Last Post Algorithm™️
      * @param {UrlHistory} history
      * @returns {Attribution}
      */
     getAttribution(history) {
         if (history.length === 0) {
-            return {
+            return this.build({
                 id: null,
                 url: null,
                 type: null
-            };
+            });
         }
 
         // TODO: if something is wrong with the attribution script, and it isn't loading
@@ -38,10 +110,10 @@ class AttributionBuilder {
             const typeId = this.urlTranslator.getTypeAndId(item.path);
 
             if (typeId && typeId.type === 'post') {
-                return {
+                return this.build({
                     url: item.path,
                     ...typeId
-                };
+                });
             }
         }
 
@@ -51,20 +123,20 @@ class AttributionBuilder {
             const typeId = this.urlTranslator.getTypeAndId(item.path);
 
             if (typeId) {
-                return {
+                return this.build({
                     url: item.path,
                     ...typeId
-                };
+                });
             }
         }
 
         // Default to last URL
         // In the future we might decide to exclude certain URLs, that can happen here
-        return {
+        return this.build({
             id: null,
             url: history.last.path,
             type: 'url'
-        };
+        });
     }
 }
 

--- a/ghost/member-attribution/lib/service.js
+++ b/ghost/member-attribution/lib/service.js
@@ -5,11 +5,19 @@ const AttributionBuilder = require('./attribution');
 const UrlHistory = require('./history');
 
 class MemberAttributionService {
-    constructor({MemberCreatedEvent, SubscriptionCreatedEvent, urlService, labsService}) {
+    constructor({Post, User, Tag, MemberCreatedEvent, SubscriptionCreatedEvent, urlService, labsService}) {
         const eventHandler = new MemberAttributionEventHandler({MemberCreatedEvent, SubscriptionCreatedEvent, DomainEvents, labsService});
         eventHandler.subscribe();
 
-        const urlTranslator = new UrlTranslator({urlService});
+        this.urlService = urlService;
+        this.models = {MemberCreatedEvent, SubscriptionCreatedEvent};
+
+        const urlTranslator = new UrlTranslator({
+            urlService, 
+            models: {
+                Post, User, Tag
+            }
+        });
         this.attributionBuilder = new AttributionBuilder({urlTranslator});
     }
 
@@ -21,6 +29,42 @@ class MemberAttributionService {
     getAttribution(historyArray) {
         const history = new UrlHistory(historyArray);
         return this.attributionBuilder.getAttribution(history);
+    }
+
+    /**
+     * Returns the parsed attribution for a member creation event
+     * @param {string} memberId 
+     * @returns {Promise<import('./attribution').AttributionResource|null>}
+     */
+    async getMemberCreatedAttribution(memberId) {
+        const memberCreatedEvent = await this.models.MemberCreatedEvent.findOne({member_id: memberId}, {require: false});
+        if (!memberCreatedEvent || !memberCreatedEvent.get('attribution_type')) {
+            return null;
+        }
+        const attribution = this.attributionBuilder.build({
+            id: memberCreatedEvent.get('attribution_id'),
+            url: memberCreatedEvent.get('attribution_url'),
+            type: memberCreatedEvent.get('attribution_type')
+        });
+        return await attribution.getResource();
+    }
+
+    /**
+     * Returns the last attribution for a given subscription ID
+     * @param {string} subscriptionId 
+     * @returns {Promise<import('./attribution').AttributionResource|null>}
+     */
+    async getSubscriptionCreatedAttribution(subscriptionId) {
+        const subscriptionCreatedEvent = await this.models.SubscriptionCreatedEvent.findOne({subscription_id: subscriptionId}, {require: false});
+        if (!subscriptionCreatedEvent || !subscriptionCreatedEvent.get('attribution_type')) {
+            return null;
+        }
+        const attribution = this.attributionBuilder.build({
+            id: subscriptionCreatedEvent.get('attribution_id'),
+            url: subscriptionCreatedEvent.get('attribution_url'),
+            type: subscriptionCreatedEvent.get('attribution_type')
+        });
+        return await attribution.getResource();
     }
 }
 

--- a/ghost/member-attribution/lib/url-translator.js
+++ b/ghost/member-attribution/lib/url-translator.js
@@ -1,20 +1,27 @@
 /**
  * @typedef {Object} UrlService
  * @prop {(resourceId: string) => Object} getResource
+ *  @prop {(resourceId: string, options) => string} getUrlByResourceId
  * 
  */
 
 /**
  * Translate a url into a type and id
+ * And also in reverse
  */
 class UrlTranslator {
     /**
      * 
      * @param {Object} deps 
      * @param {UrlService} deps.urlService
+     * @param {Object} deps.models
+     * @param {Object} deps.models.Post
+     * @param {Object} deps.models.Tag
+     * @param {Object} deps.models.User
      */
-    constructor({urlService}) {
+    constructor({urlService, models}) {
         this.urlService = urlService;
+        this.models = models;
     }
 
     getTypeAndId(url) {
@@ -50,6 +57,54 @@ class UrlTranslator {
                 id: resource.data.id
             };
         }
+    }
+
+    async getResourceById(id, type, options = {absolute: true}) {
+        const url = this.urlService.getUrlByResourceId(id, options);
+
+        switch (type) {
+        case 'post':
+        case 'page': {
+            const post = await this.models.Post.findOne({id}, {require: false});
+            if (!post) {
+                return null;
+            }
+    
+            return {
+                id: post.id,
+                type,
+                url,
+                title: post.get('title')
+            };
+        }
+        case 'author': {
+            const user = await this.models.User.findOne({id}, {require: false});
+            if (!user) {
+                return null;
+            }
+    
+            return {
+                id: user.id,
+                type,
+                url,
+                title: user.get('name')
+            };
+        }
+        case 'tag': {
+            const tag = await this.models.Tag.findOne({id}, {require: false});
+            if (!tag) {
+                return null;
+            }
+    
+            return {
+                id: tag.id,
+                type,
+                url,
+                title: tag.get('name')
+            };
+        }
+        }
+        return null;
     }
 }
 

--- a/ghost/member-attribution/test/url-translator.test.js
+++ b/ghost/member-attribution/test/url-translator.test.js
@@ -71,4 +71,99 @@ describe('UrlTranslator', function () {
             should(translator.getTypeAndId('/other')).eql(undefined);
         });
     });
+
+    describe('getResourceById', function () {
+        let translator;
+        before(function () {
+            translator = new UrlTranslator({
+                urlService: {
+                    getUrlByResourceId: () => {
+                        return '/path';
+                    }
+                },
+                models: {
+                    Post: {
+                        findOne({id}) {
+                            if (id === 'invalid') {
+                                return null;
+                            }
+                            return {id: 'post_id', get: () => 'Title'};
+                        }
+                    },
+                    User: {
+                        findOne({id}) {
+                            if (id === 'invalid') {
+                                return null;
+                            }
+                            return {id: 'user_id', get: () => 'Title'};
+                        }
+                    },
+                    Tag: {
+                        findOne({id}) {
+                            if (id === 'invalid') {
+                                return null;
+                            }
+                            return {id: 'tag_id', get: () => 'Title'};
+                        }
+                    }
+                }
+            });
+        });
+
+        it('returns for post', async function () {
+            should(await translator.getResourceById('id', 'post')).eql({
+                type: 'post',
+                id: 'post_id',
+                title: 'Title',
+                url: '/path'
+            });
+        });
+
+        it('returns for page', async function () {
+            should(await translator.getResourceById('id', 'page')).eql({
+                type: 'page',
+                id: 'post_id',
+                title: 'Title',
+                url: '/path'
+            });
+        });
+
+        it('returns for tag', async function () {
+            should(await translator.getResourceById('id', 'tag')).eql({
+                type: 'tag',
+                id: 'tag_id',
+                title: 'Title',
+                url: '/path'
+            });
+        });
+
+        it('returns for user', async function () {
+            should(await translator.getResourceById('id', 'author')).eql({
+                type: 'author',
+                id: 'user_id',
+                title: 'Title',
+                url: '/path'
+            });
+        });
+
+        it('returns for invalid', async function () {
+            should(await translator.getResourceById('id', 'invalid')).eql(null);
+        });
+
+        it('returns null for not found post', async function () {
+            should(await translator.getResourceById('invalid', 'post')).eql(null);
+        });
+
+        it('returns null for not found page', async function () {
+            should(await translator.getResourceById('invalid', 'page')).eql(null);
+        });
+
+        it('returns null for not found author', async function () {
+            should(await translator.getResourceById('invalid', 'author')).eql(null);
+        });
+
+        it('returns null for not found tag', async function () {
+            should(await translator.getResourceById('invalid', 'tag')).eql(null);
+        });
+    });
 });

--- a/ghost/members-api/lib/MembersAPI.js
+++ b/ghost/members-api/lib/MembersAPI.js
@@ -124,7 +124,8 @@ module.exports = function MembersAPI({
             }
         },
         labsService,
-        stripeService: stripeAPIService
+        stripeService: stripeAPIService,
+        memberAttributionService
     });
 
     const geolocationService = new GeolocationSerice();


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1817

- This PR adds the attribution property when you fetch a single member.
- Added `attribution` which returns null or the AttributionResource (same as attribution but with a title and up to date url)
- Added `subscriptions[x].attribution` that contains the attribution resource for each subscription
- Implemented these new properties in admin and make them visible (needs more design improvements, but just visible for now)

These properties are only added when the `memberAttribution` labs flag is enabled. We might swap this with an option in the future.