### PR TITLE
🐛 Fixed broken email prefs link in comment emails

### DIFF
--- a/ghost/core/core/server/services/comments/emails.js
+++ b/ghost/core/core/server/services/comments/emails.js
@@ -45,7 +45,7 @@ class CommentsServiceEmails {
                 accentColor: this.settingsCache.get('accent_color'),
                 fromEmail: this.notificationFromAddress,
                 toEmail: to,
-                staffUrl: `${this.urlUtils.getAdminUrl()}ghost/#/settings/staff/${author.get('slug')}`
+                staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${author.get('slug')}`)
             };
 
             const {html, text} = await this.renderEmailTemplate('new-comment', templateData);
@@ -132,7 +132,7 @@ class CommentsServiceEmails {
             commentHtml: comment.get('html'),
             commentText: htmlToPlaintext.comment(comment.get('html')),
             commentDate: moment(comment.get('created_at')).tz(this.settingsCache.get('timezone')).format('D MMM YYYY'),
-            
+
             reporterName: reporter.name,
             reporterEmail: reporter.email,
             reporter: reporter.name ? `${reporter.name} (${reporter.email})` : reporter.email,
@@ -144,7 +144,7 @@ class CommentsServiceEmails {
             accentColor: this.settingsCache.get('accent_color'),
             fromEmail: this.notificationFromAddress,
             toEmail: to,
-            staffUrl: `${this.urlUtils.getAdminUrl()}ghost/#/settings/staff/${owner.get('slug')}`
+            staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${owner.get('slug')}`)
         };
 
         const {html, text} = await this.renderEmailTemplate('report', templateData);


### PR DESCRIPTION
closes: https://github.com/TryGhost/Ghost/issues/15251

- getAdminUrl is a config helper that returns the direct value from config
- change to using urlJoin and urlFor helpers to generate the correct URL
- not entirely happy with this fix as there's no test, but I've verified it locally

