### PR TITLE
Fixed attribution table missing on cascade delete

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.10/2022-08-16-14-25-add-subscription-created-events-table.js
+++ b/ghost/core/core/server/data/migrations/versions/5.10/2022-08-16-14-25-add-subscription-created-events-table.js
@@ -4,7 +4,7 @@ module.exports = addTable('members_subscription_created_events', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     created_at: {type: 'dateTime', nullable: false},
     member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-    subscription_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_stripe_customers_subscriptions.id'},
+    subscription_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_stripe_customers_subscriptions.id', cascadeDelete: true},
     attribution_id: {type: 'string', maxlength: 24, nullable: true},
     attribution_type: {type: 'string', maxlength: 50, nullable: true},
     attribution_url: {type: 'string', maxlength: 2000, nullable: true}

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -608,7 +608,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         created_at: {type: 'dateTime', nullable: false},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-        subscription_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_stripe_customers_subscriptions.id'},
+        subscription_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_stripe_customers_subscriptions.id', cascadeDelete: true},
         attribution_id: {type: 'string', maxlength: 24, nullable: true},
         attribution_type: {type: 'string', maxlength: 50, nullable: true},
         attribution_url: {type: 'string', maxlength: 2000, nullable: true}

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '75ee5448311cbfb4c65e3843b6750d29';
+    const currentSchemaHash = 'ec9f46178cb70d3297d266203659ef4c';
     const currentFixturesHash = '0ae1887dd0b42508be946bdbd20d41c8';
     const currentSettingsHash = 'd54210758b7054e2174fd34aa2320ad7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs: https://github.com/TryGhost/Ghost/issues/15252

- all columns with a foreign key (references prop) must have a deletion strategy
- we just found a bug with this in the comments table - see referenced issue
- this fix adjusts the schema and migration for this change before its released so we don't have to write a horrible migration later

