### PR TITLE
🐛 Fixed error deleting post with comment replies

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.10/2022-08-19-14-15-fix-comments-deletion-strategy.js
+++ b/ghost/core/core/server/data/migrations/versions/5.10/2022-08-19-14-15-fix-comments-deletion-strategy.js
@@ -1,0 +1,45 @@
+const {addForeign, dropForeign} = require('../../../schema/commands');
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Adding on delete CASCADE for comments parent_id');
+
+        await dropForeign({
+            fromTable: 'comments',
+            fromColumn: 'parent_id',
+            toTable: 'comments',
+            toColumn: 'id',
+            transaction: knex
+        });
+
+        await addForeign({
+            fromTable: 'comments',
+            fromColumn: 'parent_id',
+            toTable: 'comments',
+            toColumn: 'id',
+            cascadeDelete: true,
+            transaction: knex
+        });
+    },
+    async function down(knex) {
+        logging.info('Restoring foreign key for comments parent_id');
+
+        await dropForeign({
+            fromTable: 'comments',
+            fromColumn: 'parent_id',
+            toTable: 'comments',
+            toColumn: 'id',
+            transaction: knex
+        });
+
+        await addForeign({
+            fromTable: 'comments',
+            fromColumn: 'parent_id',
+            toTable: 'comments',
+            toColumn: 'id',
+            transaction: knex
+        });
+    }
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -773,7 +773,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         post_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'posts.id', cascadeDelete: true},
         member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id', setNullDelete: true},
-        parent_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'comments.id'},
+        parent_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'comments.id', cascadeDelete: true},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'published', validations: {isIn: [['published', 'hidden', 'deleted']]}},
         html: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         edited_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'ec9f46178cb70d3297d266203659ef4c';
+    const currentSchemaHash = 'ebc73ecd26ac795c34eaec6d8ec06304';
     const currentFixturesHash = '0ae1887dd0b42508be946bdbd20d41c8';
     const currentSettingsHash = 'd54210758b7054e2174fd34aa2320ad7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes: https://github.com/TryGhost/Ghost/issues/15252

- comments are deleted when posts are deleted. Without cascade delete on parent_id, replies cannot be deleted
- this change means that deleting a post will delete all comments and replies without error


