### PR TITLE
Added backfill migration for members created events

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.11/2022-08-23-13-41-backfill-members-created-events.js
+++ b/ghost/core/core/server/data/migrations/versions/5.11/2022-08-23-13-41-backfill-members-created-events.js
@@ -8,6 +8,11 @@ module.exports = createTransactionalMigration(
         const members = await knex('members')
             .select('id', 'created_at');
 
+        if (members.length === 0) {
+            logging.warn(`Skipping migration because no members found`);
+            return;
+        }
+
         const toInsert = members.map((member) => {
             return {
                 id: ObjectID().toHexString(),

--- a/ghost/core/core/server/data/migrations/versions/5.11/2022-08-23-13-41-backfill-members-created-events.js
+++ b/ghost/core/core/server/data/migrations/versions/5.11/2022-08-23-13-41-backfill-members-created-events.js
@@ -8,23 +8,20 @@ module.exports = createTransactionalMigration(
         const members = await knex('members')
             .select('id', 'created_at');
 
-        const toInsert = [];
-
-        // eslint-disable-next-line no-restricted-syntax
-        for (const member of members) {
-            toInsert.push({
+        const toInsert = members.map((member) => {
+            return {
                 id: ObjectID().toHexString(),
                 member_id: member.id,
                 created_at: member.created_at,
                 source: 'member'
-            });
-        }
+            };
+        });
 
         logging.info(`Inserting ${toInsert.length} members created events`);
         await knex.batchInsert('members_created_events', toInsert);
     },
     async function down(knex) {
         logging.info(`Clearing all members created events`);
-        await knex('members_created_events').truncate();
+        await knex('members_created_events').del();
     }
 );

--- a/ghost/core/core/server/data/migrations/versions/5.11/2022-08-23-13-41-backfill-members-created-events.js
+++ b/ghost/core/core/server/data/migrations/versions/5.11/2022-08-23-13-41-backfill-members-created-events.js
@@ -1,0 +1,30 @@
+const ObjectID = require('bson-objectid').default;
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const members = await knex('members')
+            .select('id', 'created_at');
+
+        const toInsert = [];
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const member of members) {
+            toInsert.push({
+                id: ObjectID().toHexString(),
+                member_id: member.id,
+                created_at: member.created_at,
+                source: 'member'
+            });
+        }
+
+        logging.info(`Inserting ${toInsert.length} members created events`);
+        await knex.batchInsert('members_created_events', toInsert);
+    },
+    async function down(knex) {
+        logging.info(`Clearing all members created events`);
+        await knex('members_created_events').truncate();
+    }
+);


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1836

- Uses the timestamps from the members table to determine the timestamps for the events
- Clears the table when downgrading to prevent having multiple rows for the same member