### PR TITLE
Fixed Action event `resource_type` from `page` to `post`

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.11/2022-08-23-13-59-fix-page-resource-type.js
+++ b/ghost/core/core/server/data/migrations/versions/5.11/2022-08-23-13-59-fix-page-resource-type.js
@@ -1,0 +1,22 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info(`Changing Action event 'page' resource_type to 'post'`);
+
+        const affectedRows = await knex('actions')
+            .update({
+                resource_type: 'post',
+                context: JSON.stringify({
+                    type: 'page'
+                })
+            })
+            .where('resource_type', 'page');
+
+        logging.info(`Updated ${affectedRows} Action events from 'page' to 'post'`);
+    },
+    async function down() {
+        // no-op: we don't want to put `pages` back as a resource type
+    }
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/356
refs https://github.com/TryGhost/Ghost/commit/3a9016639cb58759bbe852859d64077414cc5a48

- I misunderstood the purpose of a column, and changed the values that
  are inserted into it, which broke relation includes in Bookshelf
- I've since reverted that in the commit above but this migration is to
  fixup the data that got stored in the DB
- we want to replace `resource_type` = `page` back to `post`, but then
  use the `context` column as described in the referenced commit to
  store that the type is actually a `page`, so we can link to it
  from the audit log accordingly
- I'm overwriting the `context` column without taking into account the
  current contents but that's ok because this bug existed before we
  started using `context`