### PR TITLE
Enabled free trials via tiers, offers and complimentary subscriptions

### DIFF
--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -229,19 +229,6 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
-                            <h4 class="gh-expandable-title">Free trial</h4>
-                            <p class="gh-expandable-description">
-                               Add support for free trials
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                           <GhFeatureFlag @flag="freeTrial" />
-                        </div>
-                    </div>
-                </div>
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
                             <h4 class="gh-expandable-title">Cardless trials</h4>
                             <p class="gh-expandable-description">
                                Add support for expiring complimentary subscriptions

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -229,19 +229,6 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
-                            <h4 class="gh-expandable-title">Cardless trials</h4>
-                            <p class="gh-expandable-description">
-                               Add support for expiring complimentary subscriptions
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                           <GhFeatureFlag @flag="compExpiring" />
-                        </div>
-                    </div>
-                </div>
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
                             <h4 class="gh-expandable-title">Member Attribution</h4>
                             <p class="gh-expandable-description">
                                Track which posts & pages are driving Member Subscriptions & Paid Conversions

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -15,7 +15,8 @@ const messages = {
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
-    'newsletterPaywall'
+    'newsletterPaywall',
+    'freeTrial'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -28,7 +29,6 @@ const ALPHA_FEATURES = [
     'auditLog',
     'urlCache',
     'beforeAfterCard',
-    'freeTrial',
     'memberAttribution',
     'searchHelper',
     'compExpiring'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -16,7 +16,8 @@ const messages = {
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
     'newsletterPaywall',
-    'freeTrial'
+    'freeTrial',
+    'compExpiring'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -30,8 +31,7 @@ const ALPHA_FEATURES = [
     'urlCache',
     'beforeAfterCard',
     'memberAttribution',
-    'searchHelper',
-    'compExpiring'
+    'searchHelper'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -619,7 +619,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3324",
+  "content-length": "3365",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -908,7 +908,7 @@ exports[`Settings API Edit cannot edit uneditable settings 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3391",
+  "content-length": "3432",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1196,7 +1196,7 @@ exports[`Settings API Edit does not trigger email verification flow if members_s
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3403",
+  "content-length": "3444",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1489,7 +1489,7 @@ exports[`Settings API Edit editing members_support_address triggers email verifi
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3444",
+  "content-length": "3485",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -1777,7 +1777,7 @@ exports[`Settings API Edit removes image size prefixes when setting the icon 2: 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3391",
+  "content-length": "3432",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -2128,7 +2128,7 @@ exports[`Settings API verify key update can update members_support_address via t
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3403",
+  "content-length": "3444",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
+++ b/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
@@ -25,35 +25,7 @@ describe('Unit: models/stripe-customer-subscription', function () {
             sinon.restore();
         });
 
-        it('ignores trial details when flag is off', function () {
-            const trialStartAt = new Date();
-            const trialEndAt = new Date(Date.now() + 7 * 86400 * 1000); // trial ending 7 days from now
-            const stripeSubscription = {
-                customer_id: 'fake_customer_id',
-                subscription_id: 'fake_subscription_id',
-                plan_id: 'fake_plan_id',
-                stripe_price_id: 'fake_plan_id',
-                plan_amount: 1337,
-                plan_nickname: 'e-LEET',
-                plan_interval: 'year',
-                plan_currency: 'btc',
-                status: 'active',
-                start_date: new Date(),
-                current_period_end: new Date(),
-                cancel_at_period_end: false,
-                trial_start_at: trialStartAt,
-                trial_end_at: trialEndAt
-            };
-
-            const json = serialize(stripeSubscription);
-            should.exist(json.plan);
-            should.exist(json.customer);
-            should.not.exist(json.trial_start_at);
-            should.not.exist(json.trial_end_at);
-        });
-
-        it('returns trial details with flag enabled', function () {
-            sinon.stub(labs, 'isSet').returns(true);
+        it('returns subscription trial start and end details', function () {
             const trialStartAt = new Date();
             const trialEndAt = new Date(Date.now() + 7 * 86400 * 1000); // trial ending 7 days from now
             const stripeSubscription = {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1724
refs https://github.com/TryGhost/Team/issues/1726
refs https://github.com/TryGhost/Team/issues/1727

- allows site owners to add a default free trial period to their tiers
- allows site owners to create custom offers that allow free trials on tiers
- allows site owners to give cardless free trials to members by setting expiry on complimentary subscriptions
- also allows complimentary members to upgrade as paid member