### PR TITLE
Wired email alert settings for staff users on admin

### DIFF
--- a/ghost/admin/app/controllers/settings/staff/user.js
+++ b/ghost/admin/app/controllers/settings/staff/user.js
@@ -21,6 +21,7 @@ export default Controller.extend({
     session: service(),
     slugGenerator: service(),
     utils: service(),
+    membersUtils: service(),
 
     personalToken: null,
     limitErrorMessage: null,
@@ -47,6 +48,8 @@ export default Controller.extend({
 
     canChangeEmail: not('isAdminUserOnOwnerProfile'),
     canChangePassword: not('isAdminUserOnOwnerProfile'),
+    canToggleMemberAlerts: or('currentUser.isOwnerOnly', 'isAdminUserOnOwnProfile'),
+    isAdminUserOnOwnProfile: and('currentUser.isAdminOnly', 'isOwnProfile'),
     canMakeOwner: and('currentUser.isOwnerOnly', 'isNotOwnProfile', 'user.isAdminOnly', 'isNotSuspended'),
     isAdminUserOnOwnerProfile: and('currentUser.isAdminOnly', 'user.isOwnerOnly'),
     isNotOwnersProfile: not('user.isOwnerOnly'),
@@ -383,6 +386,16 @@ export default Controller.extend({
 
     toggleCommentNotifications: action(function (event) {
         this.user.commentNotifications = event.target.checked;
+    }),
+
+    toggleMemberEmailAlerts: action(function (type, event) {
+        if (type === 'free-signup') {
+            this.user.freeMemberSignupNotification = event.target.checked;
+        } else if (type === 'paid-started') {
+            this.user.paidSubscriptionStartedNotification = event.target.checked;
+        } else if (type === 'paid-canceled') {
+            this.user.paidSubscriptionCanceledNotification = event.target.checked;
+        }
     }),
 
     deleteUser: task(function *() {

--- a/ghost/admin/app/models/user.js
+++ b/ghost/admin/app/models/user.js
@@ -36,6 +36,9 @@ export default BaseModel.extend(ValidationEngine, {
     twitter: attr('twitter-url-user'),
     tour: attr('json-string'),
     commentNotifications: attr(),
+    freeMemberSignupNotification: attr(),
+    paidSubscriptionStartedNotification: attr(),
+    paidSubscriptionCanceledNotification: attr(),
 
     ghostPaths: service(),
     ajax: service(),

--- a/ghost/admin/app/styles/layouts/user.css
+++ b/ghost/admin/app/styles/layouts/user.css
@@ -196,7 +196,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-top: 12px;
+    margin-top: 20px;
 }
 
 .user-setting-toggle label {
@@ -205,4 +205,8 @@
 
 .user-setting-toggle p {
     margin-top: 0;
+}
+
+.user-settings-subgroup .for-switch {
+    width: 38px !important;
 }

--- a/ghost/admin/app/templates/settings/staff/user.hbs
+++ b/ghost/admin/app/templates/settings/staff/user.hbs
@@ -336,7 +336,7 @@
                                             <p>Every time a new free member signs up</p>
                                         </div>
                                         <div class="for-switch small">
-                                            <label class="switch" for="free-signup-notifications">
+                                            <label class="switch" for="free-signup-notifications" data-test-label="free-signup-notifications">
                                                 <input
                                                     id="free-signup-notifications"
                                                     type="checkbox"
@@ -356,7 +356,7 @@
                                             <p>Every time a member starts a new paid subscription</p>
                                         </div>
                                         <div class="for-switch small">
-                                            <label class="switch" for="paid-started-notifications">
+                                            <label class="switch" for="paid-started-notifications" data-test-label="paid-started-notifications">
                                                 <input
                                                     id="paid-started-notifications"
                                                     type="checkbox"
@@ -375,7 +375,7 @@
                                             <p>Every time a member cancels their paid subscription</p>
                                         </div>
                                         <div class="for-switch small">
-                                            <label class="switch" for="paid-canceled-notifications">
+                                            <label class="switch" for="paid-canceled-notifications" data-test-label="paid-canceled-notifications">
                                                 <input
                                                     id="paid-canceled-notifications"
                                                     type="checkbox"

--- a/ghost/admin/app/templates/settings/staff/user.hbs
+++ b/ghost/admin/app/templates/settings/staff/user.hbs
@@ -306,16 +306,16 @@
                                 You've used {{gh-count-down-characters this.user.bio 200}}
                             </p>
                         </GhFormGroup>
-
+                        {{#if this.membersUtils.isMembersEnabled}}
                         <div class="user-settings-subgroup">
                             <h4 class="user-settings-heading">Email notifications</h4>
                             <GhFormGroup @errors={{this.user.errors}} @hasValidated={{this.user.hasValidated}} @property="email">
                                 <div class="user-setting-toggle">
                                     <div>
                                         <label for="user-email">Comments</label>
-                                        <p>Receive notifications when members comment on one of your posts</p>
+                                        <p>Every time a member comments on one of your posts</p>
                                     </div>
-                                    <div class="for-switch">
+                                    <div class="for-switch small">
                                         <label class="switch" for="comment-notifications">
                                             <input
                                                 id="comment-notifications"
@@ -329,8 +329,70 @@
                                         </label>
                                     </div>
                                 </div>
+                                {{#if (and this.canToggleMemberAlerts (feature 'emailAlerts'))}}
+                                    <div class="user-setting-toggle">
+                                        <div>
+                                            <label for="user-email">New signups</label>
+                                            <p>Every time a new free member signs up</p>
+                                        </div>
+                                        <div class="for-switch small">
+                                            <label class="switch" for="free-signup-notifications">
+                                                <input
+                                                    id="free-signup-notifications"
+                                                    type="checkbox"
+                                                    checked={{this.user.freeMemberSignupNotification}}
+                                                    class="gh-input"
+                                                    {{on "change" (fn this.toggleMemberEmailAlerts 'free-signup')}}
+                                                    data-test-checkbox="free-signup-notifications"
+                                                >
+                                                <span class="input-toggle-component"></span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    {{#if this.membersUtils.paidMembersEnabled}}
+                                    <div class="user-setting-toggle">
+                                        <div>
+                                            <label for="user-email">New paid members</label>
+                                            <p>Every time a member starts a new paid subscription</p>
+                                        </div>
+                                        <div class="for-switch small">
+                                            <label class="switch" for="paid-started-notifications">
+                                                <input
+                                                    id="paid-started-notifications"
+                                                    type="checkbox"
+                                                    checked={{this.user.paidSubscriptionStartedNotification}}
+                                                    class="gh-input"
+                                                    {{on "change" (fn this.toggleMemberEmailAlerts 'paid-started')}}
+                                                    data-test-checkbox="paid-started-notifications"
+                                                >
+                                                <span class="input-toggle-component"></span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="user-setting-toggle">
+                                        <div>
+                                            <label for="user-email">Paid member cancellations</label>
+                                            <p>Every time a member cancels their paid subscription</p>
+                                        </div>
+                                        <div class="for-switch small">
+                                            <label class="switch" for="paid-canceled-notifications">
+                                                <input
+                                                    id="paid-canceled-notifications"
+                                                    type="checkbox"
+                                                    checked={{this.user.paidSubscriptionCanceledNotification}}
+                                                    class="gh-input"
+                                                    {{on "change" (fn this.toggleMemberEmailAlerts 'paid-canceled')}}
+                                                    data-test-checkbox="paid-canceled-notifications"
+                                                >
+                                                <span class="input-toggle-component"></span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    {{/if}}
+                                {{/if}}
                             </GhFormGroup>
                         </div>
+                        {{/if}}
                     </fieldset>
                 </div>
 

--- a/ghost/admin/tests/helpers/members.js
+++ b/ghost/admin/tests/helpers/members.js
@@ -2,6 +2,10 @@ export function enableMembers(server) {
     server.db.settings.find({key: 'members_signup_access'})
         ? server.db.settings.update({key: 'members_signup_access'}, {value: 'all'})
         : server.create('setting', {key: 'members_signup_access', value: 'all', group: 'members'});
+
+    server.db.settings.find({key: 'members_enabled'})
+        ? server.db.settings.update({key: 'members_enabled'}, {value: true})
+        : server.create('setting', {key: 'members_enabled', value: true, group: 'members'});
 }
 
 export function disableMembers(server) {


### PR DESCRIPTION
refs TryGhost/Team#1826

- enables staff users to manage email alert settings for free and paid subscriptions
- allows owner and admin users to manage their email alert preferences
- doesn't allow non owner users to manage other user's alert preferences