### PR TITLE
Added email alert triggers for member signup and subscription

### DIFF
--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -138,16 +138,16 @@ describe('Members API', function () {
             const agents = await agentProvider.getAgentsForMembers();
             membersAgent = agents.membersAgent;
             adminAgent = agents.adminAgent;
-    
+
             await fixtureManager.init('members');
             await adminAgent.loginAsOwner();
         });
-    
+
         beforeEach(function () {
             mockManager.mockMail();
             mockManager.mockStripe();
         });
-    
+
         afterEach(function () {
             mockManager.restore();
         });
@@ -185,16 +185,16 @@ describe('Members API', function () {
             const agents = await agentProvider.getAgentsForMembers();
             membersAgent = agents.membersAgent;
             adminAgent = agents.adminAgent;
-    
+
             await fixtureManager.init('members');
             await adminAgent.loginAsOwner();
         });
-    
+
         beforeEach(function () {
             mockManager.mockMail();
             mockManager.mockStripe();
         });
-    
+
         afterEach(function () {
             mockManager.restore();
         });
@@ -572,7 +572,7 @@ describe('Members API', function () {
             const agents = await agentProvider.getAgentsForMembers();
             membersAgent = agents.membersAgent;
             adminAgent = agents.adminAgent;
-    
+
             await fixtureManager.init('members');
             await adminAgent.loginAsOwner();
 
@@ -603,12 +603,12 @@ describe('Members API', function () {
                 cancel_at_period_end: false
             });
         });
-    
+
         beforeEach(function () {
             mockManager.mockMail();
             mockManager.mockStripe();
         });
-    
+
         afterEach(function () {
             mockManager.restore();
         });
@@ -656,6 +656,11 @@ describe('Members API', function () {
 
             assert.equal(member.status, 'paid', 'The member should be "paid"');
             assert.equal(member.subscriptions.length, 1, 'The member should have a single subscription');
+
+            mockManager.assert.sentEmail({
+                subject: '💸 Paid subscription started: checkout-webhook-test@email.com',
+                to: 'jbloggs@example.com'
+            });
 
             mockManager.assert.sentEmail({
                 subject: '🙌 Thank you for signing up to Ghost!',
@@ -870,7 +875,7 @@ describe('Members API', function () {
             const agents = await agentProvider.getAgentsForMembers();
             membersAgent = agents.membersAgent;
             adminAgent = agents.adminAgent;
-    
+
             await fixtureManager.init('members');
             await adminAgent.loginAsOwner();
 
@@ -907,12 +912,12 @@ describe('Members API', function () {
                 .expectStatus(200);
             offer = body.offers[0];
         });
-    
+
         beforeEach(function () {
             mockManager.mockMail();
             mockManager.mockStripe();
         });
-    
+
         afterEach(function () {
             mockManager.restore();
         });
@@ -1092,7 +1097,7 @@ describe('Members API', function () {
         }
 
         it('Correctly includes monthly forever percentage discounts in MRR', async function () {
-            // Do you get a offer_id is null failed test here 
+            // Do you get a offer_id is null failed test here
             // -> check if members-api and members-offers package versions are in sync in yarn.lock or if both are linked in dev
             const discount = {
                 id: 'di_1Knkn7HUEDadPGIBPOQgmzIX',
@@ -1615,24 +1620,24 @@ describe('Members API', function () {
             });
         });
     });
-    
+
     // Test if the session metadata is processed correctly
     describe('Member attribution', function () {
         before(async function () {
             const agents = await agentProvider.getAgentsForMembers();
             membersAgent = agents.membersAgent;
             adminAgent = agents.adminAgent;
-    
+
             await fixtureManager.init('posts', 'products');
             await adminAgent.loginAsOwner();
         });
-    
+
         beforeEach(function () {
             mockManager.mockLabsEnabled('memberAttribution');
             mockManager.mockMail();
             mockManager.mockStripe();
         });
-    
+
         afterEach(function () {
             mockManager.restore();
         });
@@ -1673,7 +1678,7 @@ describe('Members API', function () {
         async function testWithAttribution(attribution, attributionResource) {
             const customer_id = createStripeID('cust');
             const subscription_id = createStripeID('sub');
-            
+
             const interval = 'month';
             const unit_amount = 150;
 
@@ -1750,7 +1755,7 @@ describe('Members API', function () {
 
             // Convert Stripe ID to internal model ID
             const subscriptionModel = await getSubscription(member.subscriptions[0].id);
-        
+
             await assertMemberEvents({
                 eventType: 'SubscriptionCreatedEvent',
                 memberId: member.id,

--- a/ghost/members-api/lib/MembersAPI.js
+++ b/ghost/members-api/lib/MembersAPI.js
@@ -60,6 +60,7 @@ module.exports = function MembersAPI({
     },
     stripeAPIService,
     offersAPI,
+    staffService,
     labsService,
     newslettersService,
     memberAttributionService
@@ -85,6 +86,7 @@ module.exports = function MembersAPI({
         stripeAPIService,
         tokenService,
         newslettersService,
+        staffService,
         labsService,
         productRepository,
         Member,
@@ -149,6 +151,7 @@ module.exports = function MembersAPI({
         productRepository,
         StripePrice,
         tokenService,
+        staffService,
         sendEmailWithMagicLink
     });
 
@@ -218,6 +221,12 @@ module.exports = function MembersAPI({
             return member;
         }
         const newMember = await users.create({name, email, labels, newsletters, attribution});
+
+        // Notify staff users of new free member signup
+        if (labsService.isSet('emailAlerts')) {
+            await staffService.notifyFreeMemberSignup(newMember.toJSON());
+        }
+
         await MemberLoginEvent.add({member_id: newMember.id});
         return getMemberIdentityData(email);
     }
@@ -324,7 +333,7 @@ module.exports = function MembersAPI({
         memberBREADService,
         events: eventRepository,
         productRepository,
-        
+
         // Test helpers
         getTokenDataFromMagicLinkToken
     };

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -1203,6 +1203,22 @@ module.exports = class MemberRepository {
                     member_id: member.id,
                     from_plan: subscriptionModel.get('plan_id')
                 }, sharedOptions);
+
+                if (this._labsService.isSet('emailAlerts')) {
+                    const subscriptionPriceData = _.get(updatedSubscription, 'items.data[0].price');
+                    let ghostProduct;
+                    try {
+                        ghostProduct = await this._productRepository.get({stripe_product_id: subscriptionPriceData.product}, {...sharedOptions, forUpdate: true});
+                    } catch (e) {
+                        ghostProduct = null;
+                    }
+                    await this.staffService.notifyPaidSubscriptionCancel({
+                        member: member.toJSON(),
+                        subscription: updatedSubscription,
+                        cancellationReason: data.subscription.cancellationReason,
+                        tier: ghostProduct?.toJSON()
+                    });
+                }
             } else {
                 updatedSubscription = await this._stripeAPIService.continueSubscriptionAtPeriodEnd(
                     data.subscription.subscription_id

--- a/ghost/offers/lib/application/OfferRepository.js
+++ b/ghost/offers/lib/application/OfferRepository.js
@@ -4,6 +4,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const OfferCodeChangeEvent = require('../domain/events/OfferCodeChange');
 const OfferCreatedEvent = require('../domain/events/OfferCreated');
 const Offer = require('../domain/models/Offer');
+const OfferMapper = require('./OfferMapper');
 const OfferStatus = require('../domain/models/OfferStatus');
 
 const statusTransformer = mapKeyValues({
@@ -121,6 +122,13 @@ class OfferRepository {
                 name: json.product.name
             }
         }, null);
+    }
+    /**
+     * @param {Offer} offer
+     * @returns {OfferMapper.OfferDTO}
+     */
+    toJSON(offer) {
+        return OfferMapper.toDTO(offer);
     }
 
     /**


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1826

- fires email alert on free member creation after they finish signing up via checkout link
- triggers a paid subscription start alert when a new paid subscription is linked
- triggers paid subscription cancellation alert when an active subscription is set to cancel on period end