### PR TITLE
Promoted Member Attribution to a private beta

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -24,14 +24,14 @@ const GA_FEATURES = [
 // NOTE: this allowlist is meant to be used to filter out any unexpected
 //       input for the "labs" setting value
 const BETA_FEATURES = [
-    'activitypub'
+    'activitypub',
+    'memberAttribution'
 ];
 
 const ALPHA_FEATURES = [
     'auditLog',
     'urlCache',
     'beforeAfterCard',
-    'memberAttribution',
     'emailAlerts'
 ];
 


### PR DESCRIPTION
We promote from alpha -> beta so that we don't require the
enableDeveloperExperiments flag, and remove the toggle from the UI so
it's not possible to enable without modifying the DB/using API.
