### PR TITLE
Removed out of date history items from UrlHistory

### DIFF
--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -116,7 +116,7 @@ describe('Create Stripe Checkout Session', function () {
                         urlHistory: [
                             {
                                 path: '/test',
-                                time: 123
+                                time: Date.now()
                             }
                         ]
                     }
@@ -160,7 +160,7 @@ describe('Create Stripe Checkout Session', function () {
                         urlHistory: [
                             {
                                 path: url,
-                                time: 123
+                                time: Date.now()
                             }
                         ]
                     }

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -100,7 +100,7 @@ describe('sendMagicLink', function () {
                 urlHistory: [
                     {
                         path: '/test-path',
-                        time: 123
+                        time: Date.now()
                     }
                 ]
             })

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -24,7 +24,7 @@ describe('Member Attribution Service', function () {
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
                 attribution.should.match(({
@@ -32,7 +32,7 @@ describe('Member Attribution Service', function () {
                     url: subdomainRelative,
                     type: 'url'
                 }));
-        
+
                 (await attribution.fetchResource()).should.match(({
                     id: null,
                     url: absoluteUrl,
@@ -45,11 +45,11 @@ describe('Member Attribution Service', function () {
                 const id = fixtureManager.get('posts', 0).id;
                 const post = await models.Post.where('id', id).fetch({require: true});
                 const url = urlService.getUrlByResourceId(post.id, {absolute: false, withSubdirectory: true});
-    
+
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
                 attribution.should.match(({
@@ -57,9 +57,9 @@ describe('Member Attribution Service', function () {
                     url,
                     type: 'post'
                 }));
-    
+
                 const absoluteUrl = urlService.getUrlByResourceId(post.id, {absolute: true, withSubdirectory: true});
-    
+
                 (await attribution.fetchResource()).should.match(({
                     id: post.id,
                     url: absoluteUrl,
@@ -78,7 +78,7 @@ describe('Member Attribution Service', function () {
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
 
@@ -101,18 +101,18 @@ describe('Member Attribution Service', function () {
 
                 await models.Post.edit({status: 'published'}, {id});
             });
-    
+
             it('resolves pages', async function () {
                 const id = fixtureManager.get('posts', 5).id;
                 const post = await models.Post.where('id', id).fetch({require: true});
                 should(post.get('type')).eql('page');
-    
+
                 const url = urlService.getUrlByResourceId(post.id, {absolute: false, withSubdirectory: true});
-    
+
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
                 attribution.should.match(({
@@ -120,9 +120,9 @@ describe('Member Attribution Service', function () {
                     url,
                     type: 'page'
                 }));
-    
+
                 const absoluteUrl = urlService.getUrlByResourceId(post.id, {absolute: true, withSubdirectory: true});
-    
+
                 (await attribution.fetchResource()).should.match(({
                     id: post.id,
                     url: absoluteUrl,
@@ -130,16 +130,16 @@ describe('Member Attribution Service', function () {
                     title: post.get('title')
                 }));
             });
-    
+
             it('resolves tags', async function () {
                 const id = fixtureManager.get('tags', 0).id;
                 const tag = await models.Tag.where('id', id).fetch({require: true});
                 const url = urlService.getUrlByResourceId(tag.id, {absolute: false, withSubdirectory: true});
-    
+
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
                 attribution.should.match(({
@@ -147,9 +147,9 @@ describe('Member Attribution Service', function () {
                     url,
                     type: 'tag'
                 }));
-    
+
                 const absoluteUrl = urlService.getUrlByResourceId(tag.id, {absolute: true, withSubdirectory: true});
-    
+
                 (await attribution.fetchResource()).should.match(({
                     id: tag.id,
                     url: absoluteUrl,
@@ -157,16 +157,16 @@ describe('Member Attribution Service', function () {
                     title: tag.get('name')
                 }));
             });
-    
+
             it('resolves authors', async function () {
                 const id = fixtureManager.get('users', 0).id;
                 const author = await models.User.where('id', id).fetch({require: true});
                 const url = urlService.getUrlByResourceId(author.id, {absolute: false, withSubdirectory: true});
-    
+
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
                 attribution.should.match(({
@@ -174,9 +174,9 @@ describe('Member Attribution Service', function () {
                     url,
                     type: 'author'
                 }));
-    
+
                 const absoluteUrl = urlService.getUrlByResourceId(author.id, {absolute: true, withSubdirectory: true});
-    
+
                 (await attribution.fetchResource()).should.match(({
                     id: author.id,
                     url: absoluteUrl,
@@ -190,7 +190,7 @@ describe('Member Attribution Service', function () {
             beforeEach(function () {
                 configUtils.set('url', 'https://siteurl.com/subdirectory/');
             });
-        
+
             afterEach(function () {
                 configUtils.restore();
             });
@@ -203,7 +203,7 @@ describe('Member Attribution Service', function () {
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
                 attribution.should.match(({
@@ -211,7 +211,7 @@ describe('Member Attribution Service', function () {
                     url: subdomainRelative,
                     type: 'url'
                 }));
-        
+
                 (await attribution.fetchResource()).should.match(({
                     id: null,
                     url: absoluteUrl,
@@ -232,7 +232,7 @@ describe('Member Attribution Service', function () {
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
 
@@ -266,7 +266,7 @@ describe('Member Attribution Service', function () {
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
 
@@ -299,7 +299,7 @@ describe('Member Attribution Service', function () {
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
                 attribution.should.match(({
@@ -327,7 +327,7 @@ describe('Member Attribution Service', function () {
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
                 attribution.should.match(({
@@ -355,7 +355,7 @@ describe('Member Attribution Service', function () {
                 const attribution = memberAttributionService.service.getAttribution([
                     {
                         path: url,
-                        time: 123
+                        time: Date.now()
                     }
                 ]);
                 attribution.should.match(({

--- a/ghost/member-attribution/lib/history.js
+++ b/ghost/member-attribution/lib/history.js
@@ -1,19 +1,24 @@
 /**
- * @typedef {UrlHistoryItem[]} UrlHistoryArray
- */
-
-/**
  * @typedef {Object} UrlHistoryItem
  * @prop {string} path
  * @prop {number} time
  */
 
 /**
+ * @typedef {UrlHistoryItem[]} UrlHistoryArray
+ */
+
+/**
  * Represents a validated history
  */
 class UrlHistory {
+    /**
+     * @private
+     * @param {UrlHistoryArray} urlHistory
+     */
     constructor(urlHistory) {
-        this.history = urlHistory && UrlHistory.isValidHistory(urlHistory) ? urlHistory : [];
+        /** @private */
+        this.history = urlHistory;
     }
 
     get length() {
@@ -27,12 +32,34 @@ class UrlHistory {
         yield* this.history.slice().reverse();
     }
 
+    /**
+     * @private
+     * @param {any[]} history
+     * @returns {boolean}
+     */
     static isValidHistory(history) {
-        return Array.isArray(history) && !history.find(item => !this.isValidHistoryItem(item));
+        for (const item of history) {
+            if (typeof item?.path !== 'string' || !Number.isSafeInteger(item?.time)) {
+                return false;
+            }
+        }
+        return true;
     }
 
-    static isValidHistoryItem(item) {
-        return !!item && !!item.path && !!item.time && typeof item.path === 'string' && typeof item.time === 'number' && Number.isSafeInteger(item.time);
+    /**
+     * @param {unknown} urlHistory
+     * @returns {UrlHistory}
+     */
+    static create(urlHistory) {
+        if (!Array.isArray(urlHistory)) {
+            return new UrlHistory([]);
+        }
+
+        if (!this.isValidHistory(urlHistory)) {
+            return new UrlHistory([]);
+        }
+
+        return new UrlHistory(urlHistory);
     }
 }
 

--- a/ghost/member-attribution/lib/history.js
+++ b/ghost/member-attribution/lib/history.js
@@ -59,8 +59,18 @@ class UrlHistory {
             return new UrlHistory([]);
         }
 
-        return new UrlHistory(urlHistory);
+        const now = Date.now();
+        const filteredHistory = urlHistory.filter((item) => {
+            return now - item.time < this.MAX_AGE;
+        });
+
+        return new UrlHistory(filteredHistory);
     }
+
+    /**
+     * @private
+     */
+    static MAX_AGE = 1000 * 60 * 60 * 24;
 }
 
 module.exports = UrlHistory;

--- a/ghost/member-attribution/lib/service.js
+++ b/ghost/member-attribution/lib/service.js
@@ -2,8 +2,8 @@ const UrlHistory = require('./history');
 
 class MemberAttributionService {
     /**
-     * 
-     * @param {Object} deps 
+     *
+     * @param {Object} deps
      * @param {Object} deps.attributionBuilder
      * @param {Object} deps.models
      * @param {Object} deps.models.MemberCreatedEvent
@@ -15,12 +15,12 @@ class MemberAttributionService {
     }
 
     /**
-     * 
-     * @param {import('./history').UrlHistoryArray} historyArray 
+     *
+     * @param {import('./history').UrlHistoryArray} historyArray
      * @returns {import('./attribution').Attribution}
      */
     getAttribution(historyArray) {
-        const history = new UrlHistory(historyArray);
+        const history = UrlHistory.create(historyArray);
         return this.attributionBuilder.getAttribution(history);
     }
 
@@ -60,7 +60,7 @@ class MemberAttributionService {
 
     /**
      * Returns the parsed attribution for a member creation event
-     * @param {string} memberId 
+     * @param {string} memberId
      * @returns {Promise<import('./attribution').AttributionResource|null>}
      */
     async getMemberCreatedAttribution(memberId) {
@@ -78,7 +78,7 @@ class MemberAttributionService {
 
     /**
      * Returns the last attribution for a given subscription ID
-     * @param {string} subscriptionId 
+     * @param {string} subscriptionId
      * @returns {Promise<import('./attribution').AttributionResource|null>}
      */
     async getSubscriptionCreatedAttribution(subscriptionId) {

--- a/ghost/member-attribution/test/attribution.test.js
+++ b/ghost/member-attribution/test/attribution.test.js
@@ -6,8 +6,10 @@ const AttributionBuilder = require('../lib/attribution');
 
 describe('AttributionBuilder', function () {
     let attributionBuilder;
+    let now;
 
     before(function () {
+        now = Date.now();
         attributionBuilder = new AttributionBuilder({
             urlTranslator: {
                 getTypeAndId(path) {
@@ -61,33 +63,33 @@ describe('AttributionBuilder', function () {
     });
 
     it('Returns last url', function () {
-        const history = UrlHistory.create([{path: '/dir/not-last', time: 123}, {path: '/dir/test/', time: 123}]);
+        const history = UrlHistory.create([{path: '/dir/not-last', time: now + 123}, {path: '/dir/test/', time: now + 123}]);
         should(attributionBuilder.getAttribution(history)).match({type: 'url', id: null, url: '/test/'});
     });
 
     it('Returns last post', function () {
         const history = UrlHistory.create([
-            {path: '/dir/my-post', time: 123},
-            {path: '/dir/test', time: 124},
-            {path: '/dir/unknown-page', time: 125}
+            {path: '/dir/my-post', time: now + 123},
+            {path: '/dir/test', time: now + 124},
+            {path: '/dir/unknown-page', time: now + 125}
         ]);
         should(attributionBuilder.getAttribution(history)).match({type: 'post', id: 123, url: '/my-post'});
     });
 
     it('Returns last post even when it found pages', function () {
         const history = UrlHistory.create([
-            {path: '/dir/my-post', time: 123},
-            {path: '/dir/my-page', time: 124},
-            {path: '/dir/unknown-page', time: 125}
+            {path: '/dir/my-post', time: now + 123},
+            {path: '/dir/my-page', time: now + 124},
+            {path: '/dir/unknown-page', time: now + 125}
         ]);
         should(attributionBuilder.getAttribution(history)).match({type: 'post', id: 123, url: '/my-post'});
     });
 
     it('Returns last page if no posts', function () {
         const history = UrlHistory.create([
-            {path: '/dir/other', time: 123},
-            {path: '/dir/my-page', time: 124},
-            {path: '/dir/unknown-page', time: 125}
+            {path: '/dir/other', time: now + 123},
+            {path: '/dir/my-page', time: now + 124},
+            {path: '/dir/unknown-page', time: now + 125}
         ]);
         should(attributionBuilder.getAttribution(history)).match({type: 'page', id: 845, url: '/my-page'});
     });

--- a/ghost/member-attribution/test/attribution.test.js
+++ b/ghost/member-attribution/test/attribution.test.js
@@ -56,18 +56,18 @@ describe('AttributionBuilder', function () {
     });
 
     it('Returns empty if empty history', function () {
-        const history = new UrlHistory([]);
+        const history = UrlHistory.create([]);
         should(attributionBuilder.getAttribution(history)).match({id: null, type: null, url: null});
     });
 
     it('Returns last url', function () {
-        const history = new UrlHistory([{path: '/dir/not-last', time: 123}, {path: '/dir/test/', time: 123}]);
+        const history = UrlHistory.create([{path: '/dir/not-last', time: 123}, {path: '/dir/test/', time: 123}]);
         should(attributionBuilder.getAttribution(history)).match({type: 'url', id: null, url: '/test/'});
     });
 
     it('Returns last post', function () {
-        const history = new UrlHistory([
-            {path: '/dir/my-post', time: 123}, 
+        const history = UrlHistory.create([
+            {path: '/dir/my-post', time: 123},
             {path: '/dir/test', time: 124},
             {path: '/dir/unknown-page', time: 125}
         ]);
@@ -75,25 +75,25 @@ describe('AttributionBuilder', function () {
     });
 
     it('Returns last post even when it found pages', function () {
-        const history = new UrlHistory([
-            {path: '/dir/my-post', time: 123}, 
-            {path: '/dir/my-page', time: 124}, 
+        const history = UrlHistory.create([
+            {path: '/dir/my-post', time: 123},
+            {path: '/dir/my-page', time: 124},
             {path: '/dir/unknown-page', time: 125}
         ]);
         should(attributionBuilder.getAttribution(history)).match({type: 'post', id: 123, url: '/my-post'});
     });
 
     it('Returns last page if no posts', function () {
-        const history = new UrlHistory([
-            {path: '/dir/other', time: 123}, 
-            {path: '/dir/my-page', time: 124}, 
+        const history = UrlHistory.create([
+            {path: '/dir/other', time: 123},
+            {path: '/dir/my-page', time: 124},
             {path: '/dir/unknown-page', time: 125}
         ]);
         should(attributionBuilder.getAttribution(history)).match({type: 'page', id: 845, url: '/my-page'});
     });
 
     it('Returns all null for invalid histories', function () {
-        const history = new UrlHistory('invalid');
+        const history = UrlHistory.create('invalid');
         should(attributionBuilder.getAttribution(history)).match({
             type: null,
             id: null,
@@ -102,7 +102,7 @@ describe('AttributionBuilder', function () {
     });
 
     it('Returns all null for empty histories', function () {
-        const history = new UrlHistory([]);
+        const history = UrlHistory.create([]);
         should(attributionBuilder.getAttribution(history)).match({
             type: null,
             id: null,

--- a/ghost/member-attribution/test/history.test.js
+++ b/ghost/member-attribution/test/history.test.js
@@ -4,72 +4,56 @@ require('./utils');
 const UrlHistory = require('../lib/history');
 
 describe('UrlHistory', function () {
-    describe('Constructor', function () {
-        it('sets history to empty array if invalid', function () {
-            const history = new UrlHistory('invalid');
-            should(history.history).eql([]);
-        });
-        it('sets history to empty array if missing', function () {
-            const history = new UrlHistory();
-            should(history.history).eql([]);
-        });
-    });
-
-    describe('Validation', function () {
-        it('isValidHistory returns false for non arrays', function () {
-            should(UrlHistory.isValidHistory('string')).eql(false);
-            should(UrlHistory.isValidHistory()).eql(false);
-            should(UrlHistory.isValidHistory(12)).eql(false);
-            should(UrlHistory.isValidHistory(null)).eql(false);
-            should(UrlHistory.isValidHistory({})).eql(false);
-            should(UrlHistory.isValidHistory(NaN)).eql(false);
-
-            should(UrlHistory.isValidHistory([
+    it('sets history to empty array if invalid', function () {
+        const inputs = [
+            'string',
+            undefined,
+            12,
+            null,
+            {},
+            NaN,
+            [
                 {
                     time: 1,
                     path: '/test'
                 },
                 't'
-            ])).eql(false);
-        });
-
-        it('isValidHistory returns true for valid arrays', function () {
-            should(UrlHistory.isValidHistory([])).eql(true);
-            should(UrlHistory.isValidHistory([
-                {
-                    time: 1,
-                    path: '/test'
-                }
-            ])).eql(true);
-        });
-
-        it('isValidHistoryItem returns false for invalid objects', function () {
-            should(UrlHistory.isValidHistoryItem({})).eql(false);
-            should(UrlHistory.isValidHistoryItem('test')).eql(false);
-            should(UrlHistory.isValidHistoryItem(0)).eql(false);
-            should(UrlHistory.isValidHistoryItem()).eql(false);
-            should(UrlHistory.isValidHistoryItem(NaN)).eql(false);
-            should(UrlHistory.isValidHistoryItem([])).eql(false);
-
-            should(UrlHistory.isValidHistoryItem({
+            ],
+            [{}],
+            ['test'],
+            [0],
+            [undefined],
+            [NaN],
+            [[]],
+            [{
                 time: 'test',
                 path: 'test'
-            })).eql(false);
-
-            should(UrlHistory.isValidHistoryItem({
+            }],
+            [{
                 path: 'test'
-            })).eql(false);
-
-            should(UrlHistory.isValidHistoryItem({
+            }],
+            [{
                 time: 123
-            })).eql(false);
-        });
+            }]
+        ];
 
-        it('isValidHistoryItem returns true for valid objects', function () {
-            should(UrlHistory.isValidHistoryItem({
-                time: 123,
-                path: '/time'
-            })).eql(true);
-        });
+        for (const input of inputs) {
+            const history = UrlHistory.create(input);
+            should(history.history).eql([]);
+        }
+    });
+
+    it('sets history for valid arrays', function () {
+        const inputs = [
+            [],
+            [{
+                time: Date.now(),
+                path: '/test'
+            }]
+        ];
+        for (const input of inputs) {
+            const history = UrlHistory.create(input);
+            should(history.history).eql(input);
+        }
     });
 });

--- a/ghost/member-attribution/test/history.test.js
+++ b/ghost/member-attribution/test/history.test.js
@@ -56,4 +56,16 @@ describe('UrlHistory', function () {
             should(history.history).eql(input);
         }
     });
+
+    it('removes entries older than 24 hours', function () {
+        const input = [{
+            time: Date.now() - 1000 * 60 * 60 * 25,
+            path: '/old'
+        }, {
+            time: Date.now() - 1000 * 60 * 60 * 23,
+            path: '/not-old'
+        }];
+        const history = UrlHistory.create(input);
+        should(history.history).eql([input[1]]);
+    });
 });


### PR DESCRIPTION
This keeps the constructor clean, relying on types for validation,
whilst preserving the validation when creating the instance. The
constructor is now private so that the factory which handles
validation is always used.

The tests have also been updated to test the public factory interface
rather than the internal validation methods. Validation has been
rolled into a single method and slightly improved in the way of
readability.

In case there is an issue with the filtering of items in our client
side attribution script, we also check for and remove out of date
items here. This ensures that we do not erroneously attribute signups
or conversion to webpages from more than 24h ago.
