### PR TITLE
Updated geolocation handling for email alerts

### DIFF
--- a/ghost/members-api/lib/controllers/router.js
+++ b/ghost/members-api/lib/controllers/router.js
@@ -27,6 +27,7 @@ module.exports = class RouterController {
      * @param {import('@tryghost/members-stripe-service')} deps.stripeAPIService
      * @param {import('@tryghost/member-attribution')} deps.memberAttributionService
      * @param {any} deps.tokenService
+     * @param {any} deps.sendEmailWithMagicLink
      * @param {{isSet(name: string): boolean}} deps.labsService
      */
     constructor({
@@ -401,7 +402,9 @@ module.exports = class RouterController {
                 }
             } else {
                 const tokenData = _.pick(req.body, ['labels', 'name', 'newsletters']);
-
+                if (req.ip) {
+                    tokenData.reqIp = req.ip;
+                }
                 // Save attribution data in the tokenData
                 tokenData.attribution = this._memberAttributionService.getAttribution(req.body.urlHistory);
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1826

Geolocation was prev. loaded after member was created and then updated in member data. This was mostly due to historical context where we couldn't earlier store data on magic link token.
Since email alerts go out at the time of member creation, this flow missed out on attaching member's location to email. This change -

- stores request ip when a member asks for magic link in the token
- loads request ip from token when member uses magic link, and for new members loads their geolocation and stores it with member creation