### PR TITLE
✨ Enabled member email alerts for site owners

### DIFF
--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -252,19 +252,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
-                            <h4 class="gh-expandable-title">Email alerts</h4>
-                            <p class="gh-expandable-description">
-                               Receive email notifications when somebody signs up, becomes paid, or cancels subscription
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                           <GhFeatureFlag @flag="emailAlerts" />
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
         {{/if}}

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -18,7 +18,8 @@ const GA_FEATURES = [
     'newsletterPaywall',
     'freeTrial',
     'compExpiring',
-    'searchHelper'
+    'searchHelper',
+    'emailAlerts'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -31,8 +32,7 @@ const BETA_FEATURES = [
 const ALPHA_FEATURES = [
     'auditLog',
     'urlCache',
-    'beforeAfterCard',
-    'emailAlerts'
+    'beforeAfterCard'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -619,7 +619,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3387",
+  "content-length": "3408",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1825
closes https://github.com/TryGhost/Team/issues/1826

- allows site owners/admins to receive email notifications when somebody signs up, becomes paid, or cancels subscription
- owners/admins can set their email preference from staff settings