### PR TITLE
members-api: escape HTML

### DIFF
--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -36,7 +36,9 @@ const deleteSession = async function (req, res) {
         res.writeHead(204);
         res.end();
     } catch (err) {
-        res.writeHead(err.statusCode);
+        res.writeHead(err.statusCode, {
+            'Content-Type': 'text/plain;charset=UTF-8'
+        });
         res.end(err.message);
     }
 };
@@ -130,7 +132,9 @@ const updateMemberData = async function (req, res) {
             res.json(null);
         }
     } catch (err) {
-        res.writeHead(err.statusCode);
+        res.writeHead(err.statusCode, {
+            'Content-Type': 'text/plain'
+        });
         res.end(err.message);
     }
 };

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -133,7 +133,7 @@ const updateMemberData = async function (req, res) {
         }
     } catch (err) {
         res.writeHead(err.statusCode, {
-            'Content-Type': 'text/plain'
+            'Content-Type': 'text/plain;charset=UTF-8'
         });
         res.end(err.message);
     }

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -128,6 +128,23 @@ describe('Front-end members behavior', function () {
                 .expect(400);
         });
 
+        it('should error for invalid subscription id on members create update session endpoint', async function () {
+            const membersService = require('../../core/server/services/members');
+            const email = 'test-member-create-update-session@email.com';
+            await membersService.api.members.create({email});
+            const token = await membersService.api.getMemberIdentityToken(email);
+            await request.post('/members/api/create-stripe-update-session')
+                .send({
+                    identity: token,
+                    subscription_id: 'invalid'
+                })
+                .expect(404)
+                .expect('Content-Type', 'text/plain;charset=UTF-8')
+                .expect((res) => {
+                    res.text.should.eql('Could not find subscription invalid');
+                });
+        });
+
         it('should error for invalid data on members subscription endpoint', async function () {
             await request.put('/members/api/subscriptions/123')
                 .expect(400);

--- a/ghost/members-api/lib/controllers/member.js
+++ b/ghost/members-api/lib/controllers/member.js
@@ -183,7 +183,9 @@ module.exports = class MemberController {
             res.writeHead(204);
             res.end();
         } catch (err) {
-            res.writeHead(err.statusCode || 500);
+            res.writeHead(err.statusCode || 500, {
+                'Content-Type': 'text/plain;charset=UTF-8'
+            });
             res.end(err.message);
         }
     }

--- a/ghost/members-api/lib/controllers/router.js
+++ b/ghost/members-api/lib/controllers/router.js
@@ -2,6 +2,7 @@ const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const _ = require('lodash');
 const {BadRequestError, NoPermissionError, NotFoundError, UnauthorizedError} = require('@tryghost/errors');
+const escape = require('escape-html');
 
 const messages = {
     badRequest: 'Bad Request.',
@@ -111,7 +112,7 @@ module.exports = class RouterController {
 
             if (!subscription) {
                 res.writeHead(404);
-                res.end(`Could not find subscription ${req.body.subscription_id}`);
+                res.end(`Could not find subscription ${escape(req.body.subscription_id)}`);
             }
             customer = await this._stripeAPIService.getCustomer(subscription.get('customer_id'));
         }

--- a/ghost/members-api/lib/controllers/router.js
+++ b/ghost/members-api/lib/controllers/router.js
@@ -2,7 +2,6 @@ const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const _ = require('lodash');
 const {BadRequestError, NoPermissionError, NotFoundError, UnauthorizedError} = require('@tryghost/errors');
-const escape = require('escape-html');
 
 const messages = {
     badRequest: 'Bad Request.',
@@ -111,8 +110,10 @@ module.exports = class RouterController {
             });
 
             if (!subscription) {
-                res.writeHead(404);
-                res.end(`Could not find subscription ${escape(req.body.subscription_id)}`);
+                res.writeHead(404, {
+                    'Content-Type': 'text/plain;charset=UTF-8'
+                });
+                return res.end(`Could not find subscription ${req.body.subscription_id}`);
             }
             customer = await this._stripeAPIService.getCustomer(subscription.get('customer_id'));
         }

--- a/ghost/members-ssr/example.js
+++ b/ghost/members-ssr/example.js
@@ -32,7 +32,9 @@ const server = require('http').createServer(async (req, res) => {
             res.writeHead(200);
             res.end();
         } catch (err) {
-            res.writeHead(err.statusCode);
+            res.writeHead(err.statusCode, {
+                'Content-Type': 'text/plain;charset=UTF-8'
+            });
             res.end(err.message);
         }
     } else {
@@ -43,7 +45,9 @@ const server = require('http').createServer(async (req, res) => {
             });
             res.end(JSON.stringify(member));
         } catch (err) {
-            res.writeHead(err.statusCode);
+            res.writeHead(err.statusCode, {
+                'Content-Type': 'text/plain;charset=UTF-8'
+            });
             res.end(err.message);
         }
     }


### PR DESCRIPTION
The response returned by createCheckoutSetupSession() when a valid identity exists but not a valid subscription ID is susceptible to an XSS vulnerability; the response from the body is equivalent to the request body.