### PR TITLE
🔥 Removed unused support email verificaton endpoints

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/validators/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/settings.js
@@ -1,6 +1,6 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
-const {ValidationError, BadRequestError} = require('@tryghost/errors');
+const {ValidationError} = require('@tryghost/errors');
 const validator = require('@tryghost/validator');
 const tpl = require('@tryghost/tpl');
 
@@ -70,25 +70,6 @@ module.exports = {
 
         if (errors.length) {
             return Promise.reject(errors[0]);
-        }
-    },
-
-    /**
-     * @deprecated
-     */
-    updateMembersEmail(apiConfig, frame) {
-        const {email, type} = frame.data;
-
-        if (typeof email !== 'string' || !validator.isEmail(email)) {
-            throw new BadRequestError({
-                message: messages.invalidEmailReceived
-            });
-        }
-
-        if (!type || !['supportAddressUpdate'].includes(type)) {
-            throw new BadRequestError({
-                message: messages.invalidEmailTypeReceived
-            });
         }
     }
 };

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -65,13 +65,6 @@ module.exports = function apiRoutes() {
     router.get('/settings', mw.authAdminApi, http(api.settings.browse));
     router.put('/settings', mw.authAdminApi, http(api.settings.edit));
     router.put('/settings/verifications/', mw.authAdminApi, http(api.settings.verifyKeyUpdate));
-
-    /** @deprecated This endpoint is part of the old email verification flow for the support email */
-    router.get('/settings/members/email', http(api.settings.validateMembersEmailUpdate));
-    
-    /** @deprecated This endpoint is part of the old email verification flow for the support email */
-    router.post('/settings/members/email', mw.authAdminApi, http(api.settings.updateMembersEmail));
-
     router.del('/settings/stripe/connect', mw.authAdminApi, http(api.settings.disconnectStripeConnectIntegration));
 
     // ## Users

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -403,48 +403,4 @@ describe('Settings API', function () {
                 });
         });
     });
-
-    // @TODO We can drop these tests once we removed the deprecated endpoints
-    describe('deprecated', function () {
-        it('can do updateMembersEmail', async function () {
-            await agent
-                .post('settings/members/email/')
-                .body({
-                    email: 'test@test.com',
-                    type: 'supportAddressUpdate'
-                })
-                .expectStatus(204)
-                .expectEmptyBody()
-                .matchHeaderSnapshot({
-                    etag: anyEtag
-                });
-
-            mockManager.assert.sentEmail({
-                subject: 'Verify email address',
-                to: 'test@test.com'
-            });
-        });
-
-        it('can do validateMembersEmailUpdate', async function () {
-            const magicLink = await membersService.api.getMagicLink('test@test.com');
-            const magicLinkUrl = new URL(magicLink);
-            const token = magicLinkUrl.searchParams.get('token');
-
-            await agent
-                .get(`settings/members/email/?token=${token}&action=supportAddressUpdate`)
-                .expectStatus(302)
-                .expectEmptyBody()
-                .matchHeaderSnapshot();
-
-            // Assert that the setting is changed as a side effect
-            // NOTE: cannot use read here :/
-            await agent.get('settings/')
-                .expect(({body}) => {
-                    const fromAddress = body.settings.find((setting) => {
-                        return setting.key === 'members_support_address';
-                    });
-                    assert.equal(fromAddress.value, 'test@test.com');
-                });
-        });
-    });
 });


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1679

These endpoints are safe to be removed, as they are only used by the admin app and usage has been removed over there. It is very unlikely that this endpoint has been used in a third party integration (in which case they will get a notification email).