### PR TITLE
Removed icon files from packaged tarball

### DIFF
--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -23,8 +23,10 @@ module.exports = {
         // copy the index.html file
         fs.copySync(`${results.directory}/index.html`, `${assetsOut}/index.html`, {overwrite: true, dereference: true});
 
-        // copy all the `/assets` files
-        const assets = walkSync(results.directory + '/assets');
+        // copy all the `/assets` files, except the `icons` folder
+        const assets = walkSync(results.directory + '/assets', {
+            ignore: ['icons']
+        });
 
         assets.forEach(function (relativePath) {
             if (relativePath.slice(-1) === '/') { return; }


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/6290fd6deb60b6ec437c01ffd06b6f1ce940bf52

- following the referenced commit, all SVG icons should only be used
  with svg-jar and not externally loaded
- this means we are now shipping all the icon files in the packaged tarball, but
  they're unused once Admin is built
- this commit prevents the icons from being copied and bundled
