### PR TITLE
🐛 Fixed sending emails from email domain that includes www subdomain

### DIFF
--- a/ghost/core/core/server/services/comments/emails.js
+++ b/ghost/core/core/server/services/comments/emails.js
@@ -3,15 +3,15 @@ const path = require('path');
 const moment = require('moment');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 const postEmailSerializer = require('../mega/post-email-serializer');
-const settingsService = require('../settings/settings-service');
 
 class CommentsServiceEmails {
-    constructor({config, logging, models, mailer, settingsCache, urlService, urlUtils}) {
+    constructor({config, logging, models, mailer, settingsCache, settingsHelpers, urlService, urlUtils}) {
         this.config = config;
         this.logging = logging;
         this.models = models;
         this.mailer = mailer;
         this.settingsCache = settingsCache;
+        this.settingsHelpers = settingsHelpers;
         this.urlService = urlService;
         this.urlUtils = urlUtils;
 
@@ -168,7 +168,7 @@ class CommentsServiceEmails {
     }
 
     get notificationFromAddress() {
-        return settingsService.helpers.getMembersSupportAddress();
+        return this.settingsHelpers.getMembersSupportAddress();
     }
 
     extractInitials(name = '') {

--- a/ghost/core/core/server/services/comments/emails.js
+++ b/ghost/core/core/server/services/comments/emails.js
@@ -3,6 +3,7 @@ const path = require('path');
 const moment = require('moment');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 const postEmailSerializer = require('../mega/post-email-serializer');
+const settingsService = require('../settings/settings-service');
 
 class CommentsServiceEmails {
     constructor({config, logging, models, mailer, settingsCache, urlService, urlUtils}) {
@@ -166,25 +167,12 @@ class CommentsServiceEmails {
         return siteDomain;
     }
 
-    get membersAddress() {
-        // TODO: get from address of default newsletter?
-        return `noreply@${this.siteDomain}`;
-    }
-
-    // TODO: duplicated from services/members/config - exrtact to settings?
-    get supportAddress() {
-        const supportAddress = this.settingsCache.get('members_support_address') || 'noreply';
-
-        // Any fromAddress without domain uses site domain, like default setting `noreply`
-        if (supportAddress.indexOf('@') < 0) {
-            return `${supportAddress}@${this.siteDomain}`;
-        }
-
-        return supportAddress;
+    get defaultEmailDomain() {
+        return settingsService.getDefaultEmailDomain();
     }
 
     get notificationFromAddress() {
-        return this.supportAddress || this.membersAddress;
+        return settingsService.getMembersSupportAddress();
     }
 
     extractInitials(name = '') {

--- a/ghost/core/core/server/services/comments/emails.js
+++ b/ghost/core/core/server/services/comments/emails.js
@@ -167,12 +167,8 @@ class CommentsServiceEmails {
         return siteDomain;
     }
 
-    get defaultEmailDomain() {
-        return settingsService.getDefaultEmailDomain();
-    }
-
     get notificationFromAddress() {
-        return settingsService.getMembersSupportAddress();
+        return settingsService.helpers.getMembersSupportAddress();
     }
 
     extractInitials(name = '') {

--- a/ghost/core/core/server/services/comments/index.js
+++ b/ghost/core/core/server/services/comments/index.js
@@ -14,6 +14,7 @@ class CommentsServiceWrapper {
         const urlUtils = require('../../../shared/url-utils');
         const membersService = require('../members');
         const db = require('../../data/db');
+        const settingsHelpers = require('../settings-helpers');
 
         this.api = new CommentsService({
             config,
@@ -21,6 +22,7 @@ class CommentsServiceWrapper {
             models,
             mailer,
             settingsCache,
+            settingsHelpers,
             urlService,
             urlUtils,
             contentGating: membersService.contentGating

--- a/ghost/core/core/server/services/comments/service.js
+++ b/ghost/core/core/server/services/comments/service.js
@@ -15,7 +15,7 @@ const messages = {
 };
 
 class CommentsService {
-    constructor({config, logging, models, mailer, settingsCache, urlService, urlUtils, contentGating}) {
+    constructor({config, logging, models, mailer, settingsCache, settingsHelpers, urlService, urlUtils, contentGating}) {
         /** @private */
         this.models = models;
 
@@ -33,6 +33,7 @@ class CommentsService {
             models,
             mailer,
             settingsCache,
+            settingsHelpers,
             urlService,
             urlUtils
         });

--- a/ghost/core/core/server/services/members/config.js
+++ b/ghost/core/core/server/services/members/config.js
@@ -24,7 +24,7 @@ class MembersConfigProvider {
     }
 
     get defaultEmailDomain() {
-        return settingsService.getDefaultEmailDomain();
+        return settingsService.helpers.getDefaultEmailDomain();
     }
 
     getEmailFromAddress() {
@@ -33,7 +33,7 @@ class MembersConfigProvider {
     }
 
     getEmailSupportAddress() {
-        return settingsService.getMembersSupportAddress();
+        return settingsService.helpers.getMembersSupportAddress();
     }
 
     getAuthEmailFromAddress() {
@@ -62,27 +62,8 @@ class MembersConfigProvider {
         };
     }
 
-    /**
-     * @returns {{publicKey: string, secretKey: string} | null}
-     */
-    getActiveStripeKeys() {
-        const stripeDirect = this._config.get('stripeDirect');
-
-        if (stripeDirect) {
-            return this.getStripeKeys('direct');
-        }
-
-        const connectKeys = this.getStripeKeys('connect');
-
-        if (!connectKeys) {
-            return this.getStripeKeys('direct');
-        }
-
-        return connectKeys;
-    }
-
     isStripeConnected() {
-        return this.getActiveStripeKeys() !== null;
+        return settingsService.getActiveStripeKeys() !== null;
     }
 
     getAuthSecret() {

--- a/ghost/core/core/server/services/members/config.js
+++ b/ghost/core/core/server/services/members/config.js
@@ -63,7 +63,7 @@ class MembersConfigProvider {
     }
 
     isStripeConnected() {
-        return settingsService.getActiveStripeKeys() !== null;
+        return settingsService.helpers.getActiveStripeKeys() !== null;
     }
 
     getAuthSecret() {

--- a/ghost/core/core/server/services/members/config.js
+++ b/ghost/core/core/server/services/members/config.js
@@ -4,6 +4,7 @@ const tpl = require('@tryghost/tpl');
 const {URL} = require('url');
 const crypto = require('crypto');
 const createKeypair = require('keypair');
+const settingsService = require('../settings/settings-service');
 
 const messages = {
     incorrectKeyType: 'type must be one of "direct" or "connect".'
@@ -22,35 +23,21 @@ class MembersConfigProvider {
         this._urlUtils = options.urlUtils;
     }
 
-    /**
-     * @private
-     */
-    _getDomain() {
-        const url = this._urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
-        const domain = (url && url[1]) || '';
-        if (domain.startsWith('www.')) {
-            return domain.replace(/^(www)\.(?=[^/]*\..{2,5})/, '');
-        }
-        return domain;
+    get defaultEmailDomain() {
+        return settingsService.getDefaultEmailDomain();
     }
 
     getEmailFromAddress() {
         // Individual from addresses are set per newsletter - this is the fallback address
-        return `noreply@${this._getDomain()}`;
+        return `noreply@${this.defaultEmailDomain}`;
     }
 
     getEmailSupportAddress() {
-        const supportAddress = this._settingsCache.get('members_support_address') || 'noreply';
-
-        // Any fromAddress without domain uses site domain, like default setting `noreply`
-        if (supportAddress.indexOf('@') < 0) {
-            return `${supportAddress}@${this._getDomain()}`;
-        }
-        return supportAddress;
+        return settingsService.getMembersSupportAddress();
     }
 
     getAuthEmailFromAddress() {
-        return this.getEmailSupportAddress() || this.getEmailFromAddress();
+        return this.getEmailSupportAddress();
     }
 
     /**

--- a/ghost/core/core/server/services/members/config.js
+++ b/ghost/core/core/server/services/members/config.js
@@ -4,7 +4,6 @@ const tpl = require('@tryghost/tpl');
 const {URL} = require('url');
 const crypto = require('crypto');
 const createKeypair = require('keypair');
-const settingsService = require('../settings/settings-service');
 
 const messages = {
     incorrectKeyType: 'type must be one of "direct" or "connect".'
@@ -14,17 +13,17 @@ class MembersConfigProvider {
     /**
      * @param {object} options
      * @param {{get: (key: string) => any}} options.settingsCache
-     * @param {{get: (key: string) => any}} options.config
+     * @param {{getDefaultEmailDomain(): string, getMembersSupportAddress(): string, getActiveStripeKeys(): {publicKey: string, secretKey: string}|null}} options.settingsHelpers
      * @param {any} options.urlUtils
      */
-    constructor(options) {
-        this._settingsCache = options.settingsCache;
-        this._config = options.config;
-        this._urlUtils = options.urlUtils;
+    constructor({settingsCache, settingsHelpers, urlUtils}) {
+        this._settingsCache = settingsCache;
+        this._settingsHelpers = settingsHelpers;
+        this._urlUtils = urlUtils;
     }
 
     get defaultEmailDomain() {
-        return settingsService.helpers.getDefaultEmailDomain();
+        return this._settingsHelpers.getDefaultEmailDomain();
     }
 
     getEmailFromAddress() {
@@ -33,7 +32,7 @@ class MembersConfigProvider {
     }
 
     getEmailSupportAddress() {
-        return settingsService.helpers.getMembersSupportAddress();
+        return this._settingsHelpers.getMembersSupportAddress();
     }
 
     getAuthEmailFromAddress() {
@@ -63,7 +62,7 @@ class MembersConfigProvider {
     }
 
     isStripeConnected() {
-        return settingsService.helpers.getActiveStripeKeys() !== null;
+        return this._settingsHelpers.getActiveStripeKeys() !== null;
     }
 
     getAuthSecret() {

--- a/ghost/core/core/server/services/members/config.js
+++ b/ghost/core/core/server/services/members/config.js
@@ -1,19 +1,13 @@
-const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
-const tpl = require('@tryghost/tpl');
 const {URL} = require('url');
 const crypto = require('crypto');
 const createKeypair = require('keypair');
-
-const messages = {
-    incorrectKeyType: 'type must be one of "direct" or "connect".'
-};
 
 class MembersConfigProvider {
     /**
      * @param {object} options
      * @param {{get: (key: string) => any}} options.settingsCache
-     * @param {{getDefaultEmailDomain(): string, getMembersSupportAddress(): string, getActiveStripeKeys(): {publicKey: string, secretKey: string}|null}} options.settingsHelpers
+     * @param {{getDefaultEmailDomain(): string, getMembersSupportAddress(): string, isStripeConnected(): boolean}} options.settingsHelpers
      * @param {any} options.urlUtils
      */
     constructor({settingsCache, settingsHelpers, urlUtils}) {
@@ -39,30 +33,8 @@ class MembersConfigProvider {
         return this.getEmailSupportAddress();
     }
 
-    /**
-     * @param {'direct' | 'connect'} type - The "type" of keys to fetch from settings
-     * @returns {{publicKey: string, secretKey: string} | null}
-     */
-    getStripeKeys(type) {
-        if (type !== 'direct' && type !== 'connect') {
-            throw new errors.IncorrectUsageError({message: tpl(messages.incorrectKeyType)});
-        }
-
-        const secretKey = this._settingsCache.get(`stripe_${type === 'connect' ? 'connect_' : ''}secret_key`);
-        const publicKey = this._settingsCache.get(`stripe_${type === 'connect' ? 'connect_' : ''}publishable_key`);
-
-        if (!secretKey || !publicKey) {
-            return null;
-        }
-
-        return {
-            secretKey,
-            publicKey
-        };
-    }
-
     isStripeConnected() {
-        return this._settingsHelpers.getActiveStripeKeys() !== null;
+        return this._settingsHelpers.isStripeConnected();
     }
 
     getAuthSecret() {

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -20,6 +20,7 @@ const VerificationTrigger = require('@tryghost/verification-trigger');
 const DomainEvents = require('@tryghost/domain-events');
 const {LastSeenAtUpdater} = require('@tryghost/members-events-service');
 const DatabaseInfo = require('@tryghost/database-info');
+const settingsHelpers = require('../settings-helpers');
 
 const messages = {
     noLiveKeysInDevelopment: 'Cannot use live stripe keys in development. Please restart in production mode.',
@@ -30,7 +31,7 @@ const messages = {
 const ghostMailer = new GhostMailer();
 
 const membersConfig = new MembersConfigProvider({
-    config,
+    settingsHelpers,
     settingsCache,
     urlUtils
 });

--- a/ghost/core/core/server/services/settings-helpers/index.js
+++ b/ghost/core/core/server/services/settings-helpers/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./settings-helpers');

--- a/ghost/core/core/server/services/settings-helpers/index.js
+++ b/ghost/core/core/server/services/settings-helpers/index.js
@@ -1,1 +1,6 @@
-module.exports = require('./settings-helpers');
+const settingsCache = require('../../../shared/settings-cache');
+const urlUtils = require('../../../shared/url-utils');
+const config = require('../../../shared/config');
+const SettingsHelpers = require('./settings-helpers');
+
+module.exports = new SettingsHelpers({settingsCache, urlUtils, config});

--- a/ghost/core/core/server/services/settings-helpers/settings-helpers.js
+++ b/ghost/core/core/server/services/settings-helpers/settings-helpers.js
@@ -61,8 +61,12 @@ class SettingsHelpers {
         return connectKeys;
     }
 
+    isStripeConnected() {
+        return this.getActiveStripeKeys() !== null;
+    }
+
     arePaidMembersEnabled() {
-        return this.isMembersEnabled() && this.getActiveStripeKeys() !== null;
+        return this.isMembersEnabled() && this.isStripeConnected();
     }
 
     getFirstpromoterId() {

--- a/ghost/core/core/server/services/settings-helpers/settings-helpers.js
+++ b/ghost/core/core/server/services/settings-helpers/settings-helpers.js
@@ -1,0 +1,95 @@
+const tpl = require('@tryghost/tpl');
+const errors = require('@tryghost/errors');
+
+const messages = {
+    incorrectKeyType: 'type must be one of "direct" or "connect".'
+};
+
+class SettingsHelpers {
+    constructor({settingsCache, urlUtils, config}) {
+        this.settingsCache = settingsCache;
+        this.urlUtils = urlUtils;
+        this.config = config;
+    }
+
+    isMembersEnabled() {
+        return this.settingsCache.get('members_signup_access') !== 'none';
+    }
+
+    isMembersInviteOnly() {
+        return this.settingsCache.get('members_signup_access') === 'invite';
+    }
+
+    /**
+     * @param {'direct' | 'connect'} type - The "type" of keys to fetch from settings
+     * @returns {{publicKey: string, secretKey: string} | null}
+     */
+    getStripeKeys(type) {
+        if (type !== 'direct' && type !== 'connect') {
+            throw new errors.IncorrectUsageError({message: tpl(messages.incorrectKeyType)});
+        }
+
+        const secretKey = this.settingsCache.get(`stripe_${type === 'connect' ? 'connect_' : ''}secret_key`);
+        const publicKey = this.settingsCache.get(`stripe_${type === 'connect' ? 'connect_' : ''}publishable_key`);
+
+        if (!secretKey || !publicKey) {
+            return null;
+        }
+
+        return {
+            secretKey,
+            publicKey
+        };
+    }
+
+    /**
+     * @returns {{publicKey: string, secretKey: string} | null}
+     */
+    getActiveStripeKeys() {
+        const stripeDirect = this.config.get('stripeDirect');
+
+        if (stripeDirect) {
+            return this.getStripeKeys('direct');
+        }
+
+        const connectKeys = this.getStripeKeys('connect');
+
+        if (!connectKeys) {
+            return this.getStripeKeys('direct');
+        }
+
+        return connectKeys;
+    }
+
+    arePaidMembersEnabled() {
+        return this.isMembersEnabled() && this.getActiveStripeKeys() !== null;
+    }
+
+    getFirstpromoterId() {
+        if (!this.settingsCache.get('firstpromoter')) {
+            return null;
+        }
+        return this.settingsCache.get('firstpromoter_id');
+    }
+
+    getDefaultEmailDomain() {
+        const url = this.urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
+        const domain = (url && url[1]) || '';
+        if (domain.startsWith('www.')) {
+            return domain.replace(/^(www)\.(?=[^/]*\..{2,5})/, '');
+        }
+        return domain;
+    }
+
+    getMembersSupportAddress() {
+        const supportAddress = this.settingsCache.get('members_support_address') || 'noreply';
+
+        // Any fromAddress without domain uses site domain, like default setting `noreply`
+        if (supportAddress.indexOf('@') < 0) {
+            return `${supportAddress}@${this.getDefaultEmailDomain()}`;
+        }
+        return supportAddress;
+    }
+}
+
+module.exports = SettingsHelpers;

--- a/ghost/core/core/server/services/settings-helpers/settings-helpers.js
+++ b/ghost/core/core/server/services/settings-helpers/settings-helpers.js
@@ -80,7 +80,7 @@ class SettingsHelpers {
         const url = this.urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
         const domain = (url && url[1]) || '';
         if (domain.startsWith('www.')) {
-            return domain.replace(/^(www)\.(?=[^/]*\..{2,5})/, '');
+            return domain.substring('www.'.length);
         }
         return domain;
     }

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -5,7 +5,6 @@
 const events = require('../../lib/common/events');
 const models = require('../../models');
 const labs = require('../../../shared/labs');
-const config = require('../../../shared/config');
 const adapterManager = require('../adapter-manager');
 const SettingsCache = require('../../../shared/settings-cache');
 const SettingsBREADService = require('./settings-bread-service');
@@ -15,7 +14,7 @@ const SingleUseTokenProvider = require('../members/SingleUseTokenProvider');
 const urlUtils = require('../../../shared/url-utils');
 
 const ObjectId = require('bson-objectid');
-const SettingsHelpers = require('../settings-helpers/settings-helpers');
+const settingsHelpers = require('../settings-helpers');
 
 const MAGIC_LINK_TOKEN_VALIDITY = 24 * 60 * 60 * 1000;
 
@@ -66,8 +65,6 @@ module.exports = {
         SettingsCache.init(events, settingsCollection, this.getCalculatedFields(), cacheStore);
     },
 
-    helpers: new SettingsHelpers({settingsCache: SettingsCache, urlUtils, config}),
-
     /**
      * Restore the cache, used during e2e testing only
      */
@@ -81,10 +78,10 @@ module.exports = {
     getCalculatedFields() {
         const fields = [];
 
-        fields.push(new CalculatedField({key: 'members_enabled', type: 'boolean', group: 'members', fn: this.helpers.isMembersEnabled.bind(this.helpers), dependents: ['members_signup_access']}));
-        fields.push(new CalculatedField({key: 'members_invite_only', type: 'boolean', group: 'members', fn: this.helpers.isMembersInviteOnly.bind(this.helpers), dependents: ['members_signup_access']}));
-        fields.push(new CalculatedField({key: 'paid_members_enabled', type: 'boolean', group: 'members', fn: this.helpers.arePaidMembersEnabled.bind(this.helpers), dependents: ['members_signup_access', 'stripe_secret_key', 'stripe_publishable_key', 'stripe_connect_secret_key', 'stripe_connect_publishable_key']}));
-        fields.push(new CalculatedField({key: 'firstpromoter_account', type: 'string', group: 'firstpromoter', fn: this.helpers.getFirstpromoterId.bind(this.helpers), dependents: ['firstpromoter', 'firstpromoter_id']}));
+        fields.push(new CalculatedField({key: 'members_enabled', type: 'boolean', group: 'members', fn: settingsHelpers.isMembersEnabled.bind(settingsHelpers), dependents: ['members_signup_access']}));
+        fields.push(new CalculatedField({key: 'members_invite_only', type: 'boolean', group: 'members', fn: settingsHelpers.isMembersInviteOnly.bind(settingsHelpers), dependents: ['members_signup_access']}));
+        fields.push(new CalculatedField({key: 'paid_members_enabled', type: 'boolean', group: 'members', fn: settingsHelpers.arePaidMembersEnabled.bind(settingsHelpers), dependents: ['members_signup_access', 'stripe_secret_key', 'stripe_publishable_key', 'stripe_connect_secret_key', 'stripe_connect_publishable_key']}));
+        fields.push(new CalculatedField({key: 'firstpromoter_account', type: 'string', group: 'firstpromoter', fn: settingsHelpers.getFirstpromoterId.bind(settingsHelpers), dependents: ['firstpromoter', 'firstpromoter_id']}));
 
         return fields;
     },

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -139,6 +139,25 @@ module.exports = {
         return SettingsCache.get('firstpromoter_id');
     },
 
+    getDefaultEmailDomain() {
+        const url = urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
+        const domain = (url && url[1]) || '';
+        if (domain.startsWith('www.')) {
+            return domain.replace(/^(www)\.(?=[^/]*\..{2,5})/, '');
+        }
+        return domain;
+    },
+
+    getMembersSupportAddress() {
+        const supportAddress = SettingsCache.get('members_support_address') || 'noreply';
+
+        // Any fromAddress without domain uses site domain, like default setting `noreply`
+        if (supportAddress.indexOf('@') < 0) {
+            return `${supportAddress}@${this.getDefaultEmailDomain()}`;
+        }
+        return supportAddress;
+    },
+
     /**
      *
      */

--- a/ghost/core/core/server/services/staff/index.js
+++ b/ghost/core/core/server/services/staff/index.js
@@ -1,23 +1,23 @@
+const settingsService = require('../settings/settings-service');
+
 class StaffServiceWrapper {
     init() {
         const StaffService = require('@tryghost/staff-service');
 
-        const config = require('../../../shared/config');
         const logging = require('@tryghost/logging');
         const models = require('../../models');
         const {GhostMailer} = require('../mail');
         const mailer = new GhostMailer();
         const settingsCache = require('../../../shared/settings-cache');
-        const urlService = require('../url');
         const urlUtils = require('../../../shared/url-utils');
+        const settingsHelpers = settingsService.helpers;
 
         this.api = new StaffService({
-            config,
             logging,
             models,
             mailer,
+            settingsHelpers,
             settingsCache,
-            urlService,
             urlUtils
         });
     }

--- a/ghost/core/core/server/services/staff/index.js
+++ b/ghost/core/core/server/services/staff/index.js
@@ -1,5 +1,3 @@
-const settingsService = require('../settings/settings-service');
-
 class StaffServiceWrapper {
     init() {
         const StaffService = require('@tryghost/staff-service');
@@ -10,7 +8,7 @@ class StaffServiceWrapper {
         const mailer = new GhostMailer();
         const settingsCache = require('../../../shared/settings-cache');
         const urlUtils = require('../../../shared/url-utils');
-        const settingsHelpers = settingsService.helpers;
+        const settingsHelpers = require('../settings-helpers');
 
         this.api = new StaffService({
             logging,

--- a/ghost/core/core/server/services/stripe/config.js
+++ b/ghost/core/core/server/services/stripe/config.js
@@ -1,6 +1,5 @@
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
-const SettingsHelpers = require('../settings-helpers');
 
 const messages = {
     remoteWebhooksInDevelopment: 'Cannot use remote webhooks in development. See https://ghost.org/docs/webhooks/#stripe-webhooks for developing with Stripe.'
@@ -17,7 +16,7 @@ const messages = {
  */
 
 module.exports = {
-    getConfig(settings, config, urlUtils) {
+    getConfig({config, urlUtils, settingsHelpers}) {
         /**
          * @returns {StripeURLConfig}
          */
@@ -42,8 +41,7 @@ module.exports = {
             };
         }
 
-        const helpers = new SettingsHelpers({settingsCache: settings, config, urlUtils});
-        const keys = helpers.getActiveStripeKeys();
+        const keys = settingsHelpers.getActiveStripeKeys();
         if (!keys) {
             return null;
         }

--- a/ghost/core/core/server/services/stripe/config.js
+++ b/ghost/core/core/server/services/stripe/config.js
@@ -1,5 +1,6 @@
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
+const SettingsHelpers = require('../settings-helpers');
 
 const messages = {
     remoteWebhooksInDevelopment: 'Cannot use remote webhooks in development. See https://ghost.org/docs/webhooks/#stripe-webhooks for developing with Stripe.'
@@ -41,43 +42,8 @@ module.exports = {
             };
         }
 
-        /**
-         * @param {'direct' | 'connect'} type - The "type" of keys to fetch from settings
-         * @returns {{publicKey: string, secretKey: string} | null}
-         */
-        function getStripeKeys(type) {
-            const secretKey = settings.get(`stripe_${type === 'connect' ? 'connect_' : ''}secret_key`);
-            const publicKey = settings.get(`stripe_${type === 'connect' ? 'connect_' : ''}publishable_key`);
-
-            if (!secretKey || !publicKey) {
-                return null;
-            }
-
-            return {
-                secretKey,
-                publicKey
-            };
-        }
-
-        /**
-         * @returns {{publicKey: string, secretKey: string} | null}
-         */
-        function getActiveStripeKeys() {
-            const stripeDirect = config.get('stripeDirect');
-
-            if (stripeDirect) {
-                return getStripeKeys('direct');
-            }
-
-            const connectKeys = getStripeKeys('connect');
-
-            if (!connectKeys) {
-                return getStripeKeys('direct');
-            }
-
-            return connectKeys;
-        }
-        const keys = getActiveStripeKeys();
+        const helpers = new SettingsHelpers({settingsCache: settings, config, urlUtils});
+        const keys = helpers.getActiveStripeKeys();
         if (!keys) {
             return null;
         }

--- a/ghost/core/core/server/services/stripe/service.js
+++ b/ghost/core/core/server/services/stripe/service.js
@@ -8,9 +8,10 @@ const urlUtils = require('../../../shared/url-utils');
 const events = require('../../lib/common/events');
 const models = require('../../models');
 const {getConfig} = require('./config');
+const settingsHelpers = require('../settings-helpers');
 
 async function configureApi() {
-    const cfg = getConfig(settings, config, urlUtils);
+    const cfg = getConfig({settingsHelpers, config, urlUtils});
     if (cfg) {
         cfg.testEnv = process.env.NODE_ENV.startsWith('test');
         await module.exports.configure(cfg);

--- a/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
+++ b/ghost/core/test/e2e-api/members-comments/__snapshots__/comments.test.js.snap
@@ -1854,7 +1854,7 @@ Object {
 
 exports[`Comments API when commenting enabled for all when authenticated Can fetch counts 1: [body] 1`] = `
 Object {
-  "618ba1ffbe2896088840a6df": 13,
+  "618ba1ffbe2896088840a6df": 15,
   "618ba1ffbe2896088840a6e1": 0,
   "618ba1ffbe2896088840a6e3": 0,
 }
@@ -2270,6 +2270,86 @@ Object {
 }
 `;
 
+exports[`Comments API when commenting enabled for all when authenticated Can reply to a comment with custom support email 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "This is a reply",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "bio": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can reply to a comment with custom support email 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "342",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can reply to a comment with www domain 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+        "replies": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "This is a reply",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "bio": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "replies": Array [],
+      "status": "published",
+    },
+  ],
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can reply to a comment with www domain 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "342",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/comments\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Comments API when commenting enabled for all when authenticated Can reply to your own comment 1: [body] 1`] = `
 Object {
   "comments": Array [
@@ -2315,6 +2395,53 @@ Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can request last page of replies 1: [body] 1`] = `
+Object {
+  "comments": Array [
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "This is a reply",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "bio": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "status": "published",
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 3,
+      "next": null,
+      "page": 3,
+      "pages": 3,
+      "prev": 2,
+      "total": 7,
+    },
+  },
+}
+`;
+
+exports[`Comments API when commenting enabled for all when authenticated Can request last page of replies 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "401",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
   "x-powered-by": "Express",
 }
 `;
@@ -2477,6 +2604,42 @@ Object {
       },
       "status": "published",
     },
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "This is a reply",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "bio": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "status": "published",
+    },
+    Object {
+      "count": Object {
+        "likes": Any<Number>,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "edited_at": null,
+      "html": "This is a reply",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "liked": Any<Boolean>,
+      "member": Object {
+        "avatar_image": null,
+        "bio": null,
+        "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        "name": null,
+        "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      },
+      "status": "published",
+    },
   ],
   "meta": Object {
     "pagination": Object {
@@ -2485,7 +2648,7 @@ Object {
       "page": 1,
       "pages": 1,
       "prev": null,
-      "total": 5,
+      "total": 7,
     },
   },
 }
@@ -2495,7 +2658,7 @@ exports[`Comments API when commenting enabled for all when authenticated Can ret
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1629",
+  "content-length": "2235",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Encoding",

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -1,0 +1,93 @@
+const should = require('should');
+const sinon = require('sinon');
+const configUtils = require('../../../../utils/configUtils');
+const SettingsHelpers = require('../../../../../core/server/services/settings-helpers/settings-helpers');
+
+function createSettingsMock({setDirect, setConnect}) {
+    const getStub = sinon.stub();
+
+    getStub.withArgs('members_signup_access').returns('all');
+    getStub.withArgs('stripe_secret_key').returns(setDirect ? 'direct_secret' : null);
+    getStub.withArgs('stripe_publishable_key').returns(setDirect ? 'direct_publishable' : null);
+    getStub.withArgs('stripe_plans').returns([{
+        name: 'Monthly',
+        currency: 'usd',
+        interval: 'month',
+        amount: 1000
+    }, {
+        name: 'Yearly',
+        currency: 'usd',
+        interval: 'year',
+        amount: 10000
+    }]);
+
+    getStub.withArgs('stripe_connect_secret_key').returns(setConnect ? 'connect_secret' : null);
+    getStub.withArgs('stripe_connect_publishable_key').returns(setConnect ? 'connect_publishable' : null);
+    getStub.withArgs('stripe_connect_livemode').returns(true);
+    getStub.withArgs('stripe_connect_display_name').returns('Test');
+    getStub.withArgs('stripe_connect_account_id').returns('ac_XXXXXXXXXXXXX');
+
+    return {
+        get: getStub
+    };
+}
+
+describe('Settings Helpers - getActiveStripeKeys', function () {
+    beforeEach(function () {
+        configUtils.set({
+            url: 'http://domain.tld/subdir',
+            admin: {url: 'http://sub.domain.tld'}
+        });
+    });
+
+    afterEach(function () {
+        configUtils.restore();
+    });
+
+    it('Uses direct keys when stripeDirect is true, regardles of which keys exist', function () {
+        const fakeSettings = createSettingsMock({setDirect: true, setConnect: true});
+        configUtils.set({
+            stripeDirect: true
+        });
+        const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}});
+        const keys = settingsHelpers.getActiveStripeKeys();
+
+        should.equal(keys.publicKey, 'direct_publishable');
+        should.equal(keys.secretKey, 'direct_secret');
+    });
+
+    it('Does not use connect keys if stripeDirect is true, and the direct keys do not exist', function () {
+        const fakeSettings = createSettingsMock({setDirect: false, setConnect: true});
+        configUtils.set({
+            stripeDirect: true
+        });
+        const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}});
+        const keys = settingsHelpers.getActiveStripeKeys();
+
+        should.equal(keys, null);
+    });
+
+    it('Uses connect keys when stripeDirect is false, and the connect keys exist', function () {
+        const fakeSettings = createSettingsMock({setDirect: true, setConnect: true});
+        configUtils.set({
+            stripeDirect: false
+        });
+        const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}});
+        const keys = settingsHelpers.getActiveStripeKeys();
+
+        should.equal(keys.publicKey, 'connect_publishable');
+        should.equal(keys.secretKey, 'connect_secret');
+    });
+
+    it('Uses direct keys when stripeDirect is false, but the connect keys do not exist', function () {
+        const fakeSettings = createSettingsMock({setDirect: true, setConnect: false});
+        configUtils.set({
+            stripeDirect: false
+        });
+        const settingsHelpers = new SettingsHelpers({settingsCache: fakeSettings, config: configUtils.config, urlUtils: {}});
+        const keys = settingsHelpers.getActiveStripeKeys();
+
+        should.equal(keys.publicKey, 'direct_publishable');
+        should.equal(keys.secretKey, 'direct_secret');
+    });
+});

--- a/ghost/core/test/unit/server/services/stripe/config.test.js
+++ b/ghost/core/test/unit/server/services/stripe/config.test.js
@@ -6,37 +6,12 @@ const configUtils = require('../../../../utils/configUtils');
 
 const {getConfig} = require('../../../../../core/server/services/stripe/config');
 
-/**
- * @param {object} options
- * @param {boolean} options.setDirect - Whether the "direct" keys should be set
- * @param {boolean} options.setConnect - Whether the connect_integration keys should be set
- */
-function createSettingsMock({setDirect, setConnect}) {
-    const getStub = sinon.stub();
-
-    getStub.withArgs('members_signup_access').returns('all');
-    getStub.withArgs('stripe_secret_key').returns(setDirect ? 'direct_secret' : null);
-    getStub.withArgs('stripe_publishable_key').returns(setDirect ? 'direct_publishable' : null);
-    getStub.withArgs('stripe_plans').returns([{
-        name: 'Monthly',
-        currency: 'usd',
-        interval: 'month',
-        amount: 1000
-    }, {
-        name: 'Yearly',
-        currency: 'usd',
-        interval: 'year',
-        amount: 10000
-    }]);
-
-    getStub.withArgs('stripe_connect_secret_key').returns(setConnect ? 'connect_secret' : null);
-    getStub.withArgs('stripe_connect_publishable_key').returns(setConnect ? 'connect_publishable' : null);
-    getStub.withArgs('stripe_connect_livemode').returns(true);
-    getStub.withArgs('stripe_connect_display_name').returns('Test');
-    getStub.withArgs('stripe_connect_account_id').returns('ac_XXXXXXXXXXXXX');
-
+function createSettingsHelpersMock() {
     return {
-        get: getStub
+        getActiveStripeKeys: sinon.stub().returns({
+            secretKey: 'direct_secret',
+            publicKey: 'direct_publishable'
+        })
     };
 }
 
@@ -71,67 +46,35 @@ describe('Stripe - config', function () {
         configUtils.restore();
     });
 
-    it('Uses direct keys when stripeDirect is true, regardles of which keys exist', function () {
-        const fakeSettings = createSettingsMock({setDirect: true, setConnect: true});
-        configUtils.set({
-            stripeDirect: true
-        });
-        const fakeUrlUtils = createUrlUtilsMock();
-
-        const config = getConfig(fakeSettings, configUtils.config, fakeUrlUtils);
-
-        should.equal(config.publicKey, 'direct_publishable');
-        should.equal(config.secretKey, 'direct_secret');
-    });
-
-    it('Does not use connect keys if stripeDirect is true, and the direct keys do not exist', function () {
-        const fakeSettings = createSettingsMock({setDirect: false, setConnect: true});
-        configUtils.set({
-            stripeDirect: true
-        });
-        const fakeUrlUtils = createUrlUtilsMock();
-
-        const config = getConfig(fakeSettings, configUtils.config, fakeUrlUtils);
-
-        should.equal(config, null);
-    });
-
-    it('Uses connect keys when stripeDirect is false, and the connect keys exist', function () {
-        const fakeSettings = createSettingsMock({setDirect: true, setConnect: true});
-        configUtils.set({
-            stripeDirect: false
-        });
-        const fakeUrlUtils = createUrlUtilsMock();
-
-        const config = getConfig(fakeSettings, configUtils.config, fakeUrlUtils);
-
-        should.equal(config.publicKey, 'connect_publishable');
-        should.equal(config.secretKey, 'connect_secret');
-    });
-
-    it('Uses direct keys when stripeDirect is false, but the connect keys do not exist', function () {
-        const fakeSettings = createSettingsMock({setDirect: true, setConnect: false});
-        configUtils.set({
-            stripeDirect: false
-        });
-        const fakeUrlUtils = createUrlUtilsMock();
-
-        const config = getConfig(fakeSettings, configUtils.config, fakeUrlUtils);
-
-        should.equal(config.publicKey, 'direct_publishable');
-        should.equal(config.secretKey, 'direct_secret');
-    });
-
-    it('Includes the subdirectory in the webhookHandlerUrl', function () {
+    it('Returns null if Stripe not connected', function () {
         configUtils.set({
             stripeDirect: false,
             url: 'http://site.com/subdir'
         });
-        const fakeSettings = createSettingsMock({setDirect: true, setConnect: false});
+        const settingsHelpers = {
+            getActiveStripeKeys: sinon.stub().returns(null)
+        };
+        const config = getConfig({settingsHelpers, config: configUtils.config, urlUtils: {}});
+        
+        should.equal(config, null);
+    });
+
+    it('Includes the subdirectory in the webhookHandlerUrl', function () {
+        configUtils.set({
+            url: 'http://site.com/subdir'
+        });
+        const settingsHelpers = createSettingsHelpersMock();
         const fakeUrlUtils = createUrlUtilsMock();
 
-        const config = getConfig(fakeSettings, configUtils.config, fakeUrlUtils);
-
+        const config = getConfig({settingsHelpers, config: configUtils.config, urlUtils: fakeUrlUtils});
+        
+        should.equal(config.secretKey, 'direct_secret');
+        should.equal(config.publicKey, 'direct_publishable');
         should.equal(config.webhookHandlerUrl, 'http://site.com/subdir/members/webhooks/stripe/');
+        
+        should.exist(config.checkoutSessionSuccessUrl);
+        should.exist(config.checkoutSessionCancelUrl);
+        should.exist(config.checkoutSetupSessionSuccessUrl);
+        should.exist(config.checkoutSetupSessionCancelUrl);
     });
 });

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -75,6 +75,8 @@ const sentEmail = (matchers) => {
 
     let spyCall = mocks.mail.getCall(emailCount);
 
+    assert.notEqual(spyCall, null, 'Expected at least ' + (emailCount + 1) + ' emails sent.');
+
     // We increment here so that the messaging has an index of 1, whilst getting the call has an index of 0
     emailCount += 1;
 

--- a/ghost/staff-service/lib/emails.js
+++ b/ghost/staff-service/lib/emails.js
@@ -2,13 +2,13 @@ const {promises: fs} = require('fs');
 const path = require('path');
 const _ = require('lodash');
 const moment = require('moment');
-const settingsService = require('../../core/core/server/services/settings/settings-service');
 
 class StaffServiceEmails {
-    constructor({logging, models, mailer, settingsCache, urlUtils}) {
+    constructor({logging, models, mailer, settingsHelpers, settingsCache, urlUtils}) {
         this.logging = logging;
         this.models = models;
         this.mailer = mailer;
+        this.settingsHelpers = settingsHelpers;
         this.settingsCache = settingsCache;
         this.urlUtils = urlUtils;
 
@@ -250,7 +250,7 @@ class StaffServiceEmails {
     }
 
     get defaultEmailDomain() {
-        return settingsService.getDefaultEmailDomain();
+        return this.settingsHelpers.getDefaultEmailDomain();
     }
 
     get membersAddress() {

--- a/ghost/staff-service/lib/emails.js
+++ b/ghost/staff-service/lib/emails.js
@@ -2,6 +2,7 @@ const {promises: fs} = require('fs');
 const path = require('path');
 const _ = require('lodash');
 const moment = require('moment');
+const settingsService = require('../../core/core/server/services/settings/settings-service');
 
 class StaffServiceEmails {
     constructor({logging, models, mailer, settingsCache, urlUtils}) {
@@ -248,29 +249,17 @@ class StaffServiceEmails {
         return siteDomain;
     }
 
+    get defaultEmailDomain() {
+        return settingsService.getDefaultEmailDomain();
+    }
+
     get membersAddress() {
         // TODO: get from address of default newsletter?
-        return `noreply@${this.siteDomain}`;
+        return `noreply@${this.defaultEmailDomain}`;
     }
 
     get fromEmailAddress() {
-        return `ghost@${this.siteDomain}`;
-    }
-
-    // TODO: duplicated from services/members/config - exrtact to settings?
-    get supportAddress() {
-        const supportAddress = this.settingsCache.get('members_support_address') || 'noreply';
-
-        // Any fromAddress without domain uses site domain, like default setting `noreply`
-        if (supportAddress.indexOf('@') < 0) {
-            return `${supportAddress}@${this.siteDomain}`;
-        }
-
-        return supportAddress;
-    }
-
-    get notificationFromAddress() {
-        return this.supportAddress || this.membersAddress;
+        return `ghost@${this.defaultEmailDomain}`;
     }
 
     extractInitials(name = '') {

--- a/ghost/staff-service/lib/staff-service.js
+++ b/ghost/staff-service/lib/staff-service.js
@@ -1,5 +1,5 @@
 class StaffService {
-    constructor({logging, models, mailer, settingsCache, urlUtils}) {
+    constructor({logging, models, mailer, settingsCache, settingsHelpers, urlUtils}) {
         this.logging = logging;
 
         /** @private */
@@ -13,6 +13,7 @@ class StaffService {
             logging,
             models,
             mailer,
+            settingsHelpers,
             settingsCache,
             urlUtils
         });

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -140,7 +140,7 @@ describe('StaffService', function () {
         const settingsHelpers = {
             getDefaultEmailDomain: () => {
                 return 'ghost.example';
-            },
+            }
         };
 
         beforeEach(function () {

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -113,6 +113,36 @@ describe('StaffService', function () {
             forUpdate: true
         };
         let stubs;
+
+        const settingsCache = {
+            get: (setting) => {
+                if (setting === 'title') {
+                    return 'Ghost Site';
+                } else if (setting === 'accent_color') {
+                    return '#ffffff';
+                }
+                return '';
+            }
+        };
+
+        const urlUtils = {
+            getSiteUrl: () => {
+                return 'https://ghost.example';
+            },
+            urlJoin: (adminUrl,hash,path) => {
+                return `${adminUrl}/${hash}${path}`;
+            },
+            urlFor: () => {
+                return 'https://admin.ghost.example';
+            }
+        };
+
+        const settingsHelpers = {
+            getDefaultEmailDomain: () => {
+                return 'ghost.example';
+            },
+        };
+
         beforeEach(function () {
             mailStub = sinon.stub().resolves();
             getEmailAlertUsersStub = sinon.stub().resolves([{
@@ -132,27 +162,9 @@ describe('StaffService', function () {
                 mailer: {
                     send: mailStub
                 },
-                settingsCache: {
-                    get: (setting) => {
-                        if (setting === 'title') {
-                            return 'Ghost Site';
-                        } else if (setting === 'accent_color') {
-                            return '#ffffff';
-                        }
-                        return '';
-                    }
-                },
-                urlUtils: {
-                    getSiteUrl: () => {
-                        return 'https://ghost.example';
-                    },
-                    urlJoin: (adminUrl,hash,path) => {
-                        return `${adminUrl}/${hash}${path}`;
-                    },
-                    urlFor: () => {
-                        return 'https://admin.ghost.example';
-                    }
-                }
+                settingsCache,
+                urlUtils,
+                settingsHelpers
             });
             stubs = {mailStub, getEmailAlertUsersStub};
         });


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1855
fixes https://github.com/TryGhost/Team/issues/1866

This commit moves all duplicate methods to get the support email address to a single location. Also methods to get the default email domain are moved.

For the location, I initially wanted to put it at the settings service. But that service doesn't feel like the right place. Instead I created a new settings helpers service. This service takes the settingsCache, urlUtils and config and calculates some special 'calculated' settings based on those:

- Support email methods
- Stripe (active) keys / stripe connected (also removed some duplicate code that calculated the keys in a couple of places)
- All the calculated settings are moved to the settings helpers

I'm not 100% confident in whether this is the right place to put the helpers. Suggestions are welcome.