### PR TITLE
🐛 Fixed archived tiers appearing in Portal Links UI

### DIFF
--- a/ghost/admin/app/components/gh-portal-links.js
+++ b/ghost/admin/app/components/gh-portal-links.js
@@ -68,7 +68,7 @@ export default class GhPortalLinks extends Component {
     }
 
     @task(function* () {
-        const tiers = yield this.store.query('tier', {filter: 'type:paid', include: 'monthly_price,yearly_price'}) || [];
+        const tiers = yield this.store.query('tier', {filter: 'type:paid+active:true', include: 'monthly_price,yearly_price'}) || [];
         this.set('tiers', tiers);
         if (tiers.length > 0) {
             this.set('selectedTier', {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/15293

Add additional `active:true` filter to tier fetching query to filter only get paid and active tiers.