### PR TITLE
🐛 Fixed paid email preview stopped working in emails (old)

### DIFF
--- a/ghost/core/core/server/services/mega/template.js
+++ b/ghost/core/core/server/services/mega/template.js
@@ -14,11 +14,27 @@ const sanitizeKeys = (obj, keys) => {
 
     for (const key of keysToSanitize) {
         if (typeof sanitized[key] === 'string') {
-            // @ts-ignore
-            sanitized[key] = sanitizeHtml(sanitized[key], {
-                allowedTags: false,
-                allowedAttributes: false
-            });
+            if (key === 'html') {
+                // SanitizeHtml strips out HTML comments
+                // But we need to keep this very important one
+                const splitBy = '<!--members-only-->';
+                
+                // @ts-ignore
+                sanitized[key] = sanitized[key]
+                    .split(splitBy)
+                    .map((piece) => {
+                        return sanitizeHtml(piece, {
+                            allowedTags: false,
+                            allowedAttributes: false
+                        });
+                    }).join(splitBy);
+            } else {
+                // @ts-ignore
+                sanitized[key] = sanitizeHtml(sanitized[key], {
+                    allowedTags: false,
+                    allowedAttributes: false
+                });
+            }
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1870

The recently introduced email sanitzation removes HTML comments from the post html. This breaks the email paid preview, because it depends on the `<!--members-only-->` comment.

As a quick solution, and because sanitize-html doesn't support maintaining the html comments, I've split the html body in two pieces and sanitized each piece, and joined afterwards. This shouldn't intorduce a problem since `<!--members-only-->` should always be top level.