### PR TITLE
🐛 Fixed paid email preview stopped working in emails

### DIFF
--- a/ghost/core/core/server/services/mega/template.js
+++ b/ghost/core/core/server/services/mega/template.js
@@ -28,9 +28,10 @@ const sanitizeKeys = (obj, keys) => {
 module.exports = ({post, site, newsletter, templateSettings}) => {
     const date = new Date();
     const hasFeatureImageCaption = templateSettings.showFeatureImage && post.feature_image && post.feature_image_caption;
-    const cleanPost = sanitizeKeys(post, ['title', 'excerpt', 'feature_image_alt', 'feature_image_caption']);
+    const cleanPost = sanitizeKeys(post, ['title', 'excerpt', 'authors', 'feature_image_alt', 'feature_image_caption']);
     const cleanSite = sanitizeKeys(site, ['title']);
     const cleanNewsletter = sanitizeKeys(newsletter, ['name']);
+
     return `<!doctype html>
 <html>
 

--- a/ghost/core/core/server/services/mega/template.js
+++ b/ghost/core/core/server/services/mega/template.js
@@ -28,7 +28,7 @@ const sanitizeKeys = (obj, keys) => {
 module.exports = ({post, site, newsletter, templateSettings}) => {
     const date = new Date();
     const hasFeatureImageCaption = templateSettings.showFeatureImage && post.feature_image && post.feature_image_caption;
-    const cleanPost = sanitizeKeys(post, ['title', 'excerpt', 'html', 'feature_image_alt', 'feature_image_caption']);
+    const cleanPost = sanitizeKeys(post, ['title', 'excerpt', 'feature_image_alt', 'feature_image_caption']);
     const cleanSite = sanitizeKeys(site, ['title']);
     const cleanNewsletter = sanitizeKeys(newsletter, ['name']);
     return `<!doctype html>

--- a/ghost/core/test/unit/server/services/mega/template.test.js
+++ b/ghost/core/test/unit/server/services/mega/template.test.js
@@ -120,9 +120,11 @@ describe('Mega template', function () {
     });
 
     it('Correctly escapes the contents', function () {
+        // TODO: check html escaping based on mobiledoc instead of invalid html: https://github.com/TryGhost/Team/issues/1871
+
         const post = {
             title: 'I <3 Posts',
-            html: '<div class="post-content-html">I am <100 years old</div>',
+            html: '<div class="post-content-html">I am &lt;100 years old</div>',
             feature_image: 'https://example.com/image.jpg',
             feature_image_alt: 'I <3 alt text',
             feature_image_caption: 'I <3 images'
@@ -196,7 +198,7 @@ describe('Mega template', function () {
 
         should(html).containEql('class="custom"');
         // note that some part of rendering/sanitisation removes spaces from the style description
-        should(html).containEql('style="font-weight:900;display:flex"');
+        should(html).containEql('style="font-weight: 900; display: flex;"');
     });
 
     it('Uses the post title as a fallback for the excerpt', function () {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1870

Disables email sanitization that was enabled earlier because this bug is more important and urgent.

The recently introduced email sanitzation removes HTML comments from the post html.
- This breaks the email paid preview, because it depends on the `<!--members-only-->` comment.
- Breaks the Outlook comments `<!--[if !mso !vml]-->`

This commit reverts this change.