### PR TITLE
🐛 Fixed missing email alerts for adding new members via API

### DIFF
--- a/ghost/members-api/lib/MembersAPI.js
+++ b/ghost/members-api/lib/MembersAPI.js
@@ -235,11 +235,6 @@ module.exports = function MembersAPI({
 
         const newMember = await users.create({name, email, labels, newsletters, attribution, geolocation});
 
-        // Notify staff users of new free member signup
-        if (labsService.isSet('emailAlerts')) {
-            await staffService.notifyFreeMemberSignup(newMember.toJSON());
-        }
-
         await MemberLoginEvent.add({member_id: newMember.id});
         return getMemberIdentityData(email);
     }

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -229,11 +229,11 @@ module.exports = class WebhookController {
                     id: session.metadata.attribution_id ?? null,
                     url: session.metadata.attribution_url ?? null,
                     type: session.metadata.attribution_type ?? null
-                }; 
+                };
 
                 const payerName = _.get(customer, 'subscriptions.data[0].default_payment_method.billing_details.name');
                 const name = metadataName || payerName || null;
-                
+
                 const memberData = {email: customer.email, name, attribution};
                 if (metadataNewsletters) {
                     try {
@@ -242,7 +242,7 @@ module.exports = class WebhookController {
                         logging.error(`Ignoring invalid newsletters data - ${metadataNewsletters}.`);
                     }
                 }
-                member = await this.deps.memberRepository.create(memberData);
+                member = await this.deps.memberRepository.create(memberData, {flag: 'stripe'});
             } else {
                 const payerName = _.get(customer, 'subscriptions.data[0].default_payment_method.billing_details.name');
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1864
closes https://github.com/TryGhost/Ghost/issues/15324

- email alerts for free member was previously setup to trigger only on magic link verification
- moves free member alert trigger to member creation, triggers for both members added via API and direct signup
- ignores email alert for members created via stripe webhook as they'll trigger the paid member alert