### PR TITLE
🐛 Fixed validation errors for duplicate members

### DIFF
--- a/ghost/admin/app/controllers/member.js
+++ b/ghost/admin/app/controllers/member.js
@@ -187,9 +187,21 @@ export default class MemberController extends Controller {
 
             return member;
         } catch (error) {
-            if (error) {
-                this.notifications.showAPIError(error, {key: 'member.save'});
+            if (error === undefined) {
+                // Validation error
+                return;
             }
+
+            if (error.payload && error.payload.errors) {
+                for (const payloadError of error.payload.errors) {
+                    if (payloadError.type === 'ValidationError' && payloadError.property && (payloadError.context || payloadError.message)) {
+                        member.errors.add(payloadError.property, payloadError.context || payloadError.message);
+                        member.hasValidated.pushObject(payloadError.property);
+                    }
+                }
+            }
+
+            throw error;
         }
     }
 

--- a/ghost/members-api/lib/services/member-bread.js
+++ b/ghost/members-api/lib/services/member-bread.js
@@ -259,7 +259,8 @@ module.exports = class MemberBREADService {
             if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
                 throw new errors.ValidationError({
                     message: tpl(messages.memberAlreadyExists),
-                    context: 'Attempting to add member with existing email address'
+                    context: 'Attempting to add member with existing email address',
+                    property: 'email'
                 });
             }
             throw error;
@@ -316,7 +317,8 @@ module.exports = class MemberBREADService {
             if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
                 throw new errors.ValidationError({
                     message: tpl(messages.memberAlreadyExists),
-                    context: 'Attempting to edit member with existing email address'
+                    context: 'Attempting to edit member with existing email address',
+                    property: 'email'
                 });
             }
 


### PR DESCRIPTION
closes #15292 

- Remove banner error and show duplicate member validation error inline
- Add `property: 'email'` to member API validation error