### PR TITLE
🐛 Fixed paid subscription alert showing incorrect offer amount

### DIFF
--- a/ghost/staff-service/lib/emails.js
+++ b/ghost/staff-service/lib/emails.js
@@ -230,7 +230,8 @@ class StaffServiceEmails {
             if (offer.type === 'percent') {
                 offAmount = `${offer.amount}% off`;
             } else if (offer.type === 'fixed') {
-                offAmount = `${this.getFormattedAmount({currency: offer.currency, amount: offer.amount})} off`;
+                const amount = this.getAmount(offer.amount);
+                offAmount = `${this.getFormattedAmount({currency: offer.currency, amount})} off`;
             } else if (offer.type === 'trial') {
                 offAmount = `${offer.amount} days free`;
             }

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -308,7 +308,7 @@ describe('StaffService', function () {
                     duration_in_months: 3,
                     type: 'fixed',
                     currency: 'USD',
-                    amount: 10
+                    amount: 1000
                 };
 
                 await service.notifyPaidSubscriptionStart({member, offer, tier, subscription}, options);
@@ -333,7 +333,7 @@ describe('StaffService', function () {
                     duration: 'forever',
                     type: 'fixed',
                     currency: 'USD',
-                    amount: 20
+                    amount: 2000
                 };
 
                 await service.notifyPaidSubscriptionStart({member, offer, tier, subscription}, options);


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1876

- the offer portion of new paid subscription alert was showing the wrong amount as the value is denoted in cents and needs conversion
- the value shown was 100x as the actual amount needs to be transformed (X/100)
