### PR TITLE
🐛 Fixed OpenSEa NFT OEmbeds

### DIFF
--- a/ghost/core/core/server/services/nft-oembed.js
+++ b/ghost/core/core/server/services/nft-oembed.js
@@ -3,7 +3,7 @@
  * @typedef {import('./oembed').IExternalRequest} IExternalRequest
  */
 
-const OPENSEA_PATH_REGEX = /^\/assets\/(0x[a-f0-9]+)\/(\d+)/;
+const OPENSEA_ETH_PATH_REGEX = /^\/assets\/ethereum\/(0x[a-f0-9]+)\/(\d+)/;
 
 /**
  * @implements ICustomProvider
@@ -11,6 +11,8 @@ const OPENSEA_PATH_REGEX = /^\/assets\/(0x[a-f0-9]+)\/(\d+)/;
 class NFTOEmbedProvider {
     /**
      * @param {object} dependencies
+     * @param {object} dependencies.config
+     * @param {string} [dependencies.config.apiKey] - An OpenSea API key
      */
     constructor(dependencies) {
         this.dependencies = dependencies;
@@ -21,7 +23,7 @@ class NFTOEmbedProvider {
      * @returns {Promise<boolean>}
      */
     async canSupportRequest(url) {
-        return url.host === 'opensea.io' && OPENSEA_PATH_REGEX.test(url.pathname);
+        return url.host === 'opensea.io' && OPENSEA_ETH_PATH_REGEX.test(url.pathname);
     }
 
     /**
@@ -31,7 +33,7 @@ class NFTOEmbedProvider {
      * @returns {Promise<object>}
      */
     async getOEmbedData(url, externalRequest) {
-        const [match, transaction, asset] = url.pathname.match(OPENSEA_PATH_REGEX);
+        const [match, transaction, asset] = url.pathname.match(OPENSEA_ETH_PATH_REGEX);
         if (!match) {
             return null;
         }

--- a/ghost/core/test/unit/server/services/nft-oembed.test.js
+++ b/ghost/core/test/unit/server/services/nft-oembed.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const NFTOembedProvider = require('../../../../core/server/services/nft-oembed');
+
+describe('NFTOEmbedProvider', function () {
+    it('Can support requests for OpenSea Ethereum NTFs', async function () {
+        const provider = new NFTOembedProvider({
+            config: {
+                apiKey: 'fake-api-key'
+            }
+        });
+
+        const ethereumNFTURL = new URL(
+            'https://opensea.io/assets/ethereum/0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb/9998'
+        );
+
+        const supportsRequest = await provider.canSupportRequest(ethereumNFTURL);
+
+        assert(supportsRequest, 'Should support ethereum NFT URL');
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1879

OpenSea updated their URL format for NFTs after adding support for Solana
which broke our regex, this updates to support the new format.
