### PR TITLE
Backfilled subscription created events

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.14/2022-09-06-14-51-backfill-subscription-created-events.js
+++ b/ghost/core/core/server/data/migrations/versions/5.14/2022-09-06-14-51-backfill-subscription-created-events.js
@@ -8,7 +8,7 @@ module.exports = createTransactionalMigration(
         // Join all subscriptions without a subscription created event
         // We need to filter this because new subscriptions will already have the events
         const subscriptions = await knex('members_stripe_customers_subscriptions as s')
-            .select('s.id', 's.created_at', 'c.member_id')
+            .select('s.id', 's.start_date as created_at', 'c.member_id')
             .join('members_stripe_customers as c', 'c.customer_id', 's.customer_id')
             .whereNotExists(function () {
                 this.select('*')

--- a/ghost/core/core/server/data/migrations/versions/5.14/2022-09-06-14-51-backfill-subscription-created-events.js
+++ b/ghost/core/core/server/data/migrations/versions/5.14/2022-09-06-14-51-backfill-subscription-created-events.js
@@ -1,0 +1,39 @@
+const ObjectID = require('bson-objectid').default;
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        // Join all subscriptions without a subscription created event
+        // We need to filter this because new subscriptions will already have the events
+        const subscriptions = await knex('members_stripe_customers_subscriptions as s')
+            .select('s.id', 's.created_at', 'c.member_id')
+            .join('members_stripe_customers as c', 'c.customer_id', 's.customer_id')
+            .whereNotExists(function () {
+                this.select('*')
+                    .from('members_subscription_created_events as e')
+                    .whereRaw('e.subscription_id = s.id');
+            });
+
+        if (subscriptions.length === 0) {
+            logging.warn(`Skipping migration because no subscriptions without events found`);
+            return;
+        }
+
+        const toInsert = subscriptions.map((subscription) => {
+            return {
+                id: ObjectID().toHexString(),
+                subscription_id: subscription.id,
+                member_id: subscription.member_id,
+                created_at: subscription.created_at
+            };
+        });
+
+        logging.info(`Inserting ${toInsert.length} subscriptions created events`);
+        await knex.batchInsert('members_subscription_created_events', toInsert);
+    },
+    async function down() {
+        // no-op (attribution data will be lost otherwise)
+    }
+);

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -289,7 +289,7 @@ module.exports = class WebhookController {
                     url: session.metadata.attribution_url ?? null,
                     type: session.metadata.attribution_type ?? null
                 }
-            });
+            }, session.start_date);
 
             DomainEvents.dispatch(event);
 

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -289,7 +289,7 @@ module.exports = class WebhookController {
                     url: session.metadata.attribution_url ?? null,
                     type: session.metadata.attribution_type ?? null
                 }
-            }, session.start_date);
+            }, subscription.get('start_date'));
 
             DomainEvents.dispatch(event);
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1857

- Create new subscription created events for subscriptions that don't have one yet
- Some subscriptions already have a subscription created event
- Down operation is no-op because we don't want to loose data, and running the up operation multiple times will not add duplicate events