### PR TITLE
Removed unused parent property from tag model

### DIFF
--- a/ghost/admin/app/models/tag.js
+++ b/ghost/admin/app/models/tag.js
@@ -9,7 +9,6 @@ export default Model.extend(ValidationEngine, {
     name: attr('string'),
     slug: attr('string'),
     description: attr('string'),
-    parent: attr('string'), // unused
     metaTitle: attr('string'),
     metaDescription: attr('string'),
     twitterImage: attr('string'),


### PR DESCRIPTION
The Posts API does not strip unknown properties when dealing with relations,
which meant that tags were being sent up with a `parent` property which would
always cause the model to be considered "changed". This resulted in the update
methods being called, and leading to unexpected behaviour.

Whilst this change does fix things for the History feature, the correct fix is
to update the admin-api-schema, or the input serializers such that they only
allow through known and allowed properties.
