### PR TITLE
Added property cleaning to tag relations on pages + posts

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
@@ -5,6 +5,7 @@ const url = require('./utils/url');
 const slugFilterOrder = require('./utils/slug-filter-order');
 const localUtils = require('../../index');
 const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
+const clean = require('./utils/clean');
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -159,6 +160,8 @@ module.exports = {
                     frame.data.pages[0].tags[index] = {
                         name: tag
                     };
+                } else {
+                    frame.data.pages[0].tags[index] = clean.pagesTag(tag);
                 }
             });
         }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -5,6 +5,7 @@ const slugFilterOrder = require('./utils/slug-filter-order');
 const localUtils = require('../../index');
 const mobiledoc = require('../../../../../lib/mobiledoc');
 const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
+const clean = require('./utils/clean');
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -175,6 +176,8 @@ module.exports = {
                     frame.data.posts[0].tags[index] = {
                         name: tag
                     };
+                } else {
+                    frame.data.posts[0].tags[index] = clean.postsTag(tag);
                 }
             });
         }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/clean.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/clean.js
@@ -1,0 +1,12 @@
+const _ = require('lodash');
+
+const tagRelation = (attrs) => {
+    return _.pick(attrs, [
+        'id',
+        'name',
+        'slug'
+    ]);
+};
+
+module.exports.pagesTag = tagRelation;
+module.exports.postsTag = tagRelation;

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
@@ -158,6 +158,25 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
         });
     });
 
+    it('tags relation is stripped of unknown properties', function () {
+        const apiConfig = {};
+
+        const frame = {
+            options: {},
+            data: {
+                pages: [
+                    {
+                        id: 'id1',
+                        tags: [{slug: 'slug1', name: 'hey', parent: null}, {slug: 'slug2'}]
+                    }
+                ]
+            }
+        };
+
+        serializers.input.pages.edit(apiConfig, frame);
+        frame.data.pages[0].tags.should.eql([{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
+    });
+
     describe('Ensure relations format', function () {
         it('relations is array of objects', function () {
             const apiConfig = {};

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -274,6 +274,25 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             });
         });
 
+        it('tags relation is stripped of unknown properties', function () {
+            const apiConfig = {};
+
+            const frame = {
+                options: {},
+                data: {
+                    posts: [
+                        {
+                            id: 'id1',
+                            tags: [{slug: 'slug1', name: 'hey', parent: null}, {slug: 'slug2'}]
+                        }
+                    ]
+                }
+            };
+
+            serializers.input.posts.edit(apiConfig, frame);
+            frame.data.posts[0].tags.should.eql([{slug: 'slug1', name: 'hey'}, {slug: 'slug2'}]);
+        });
+
         describe('Ensure relations format', function () {
             it('relations is array of objects', function () {
                 const apiConfig = {};


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/15375

- we currently pass all properties for the `tags` property of a `page`/`post` body down further into Ghost, which is causing issues because it's handling properties it doesn't expect
- this is showing up because it's triggering save history events for tags when a post is edited
- this commit introduces a clean util which has an allowlist of properties allows on tag relations
- this list was taken from the schema: https://github.com/TryGhost/SDK/blob/128f8fb006ca0846cad4f3702a538998f834ee2a/packages/admin-api-schema/lib/schemas/posts.json#L214-L227