### PR TITLE
Moved attribution event handler to events service

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -281,6 +281,7 @@ async function initServices({config}) {
     const comments = require('./server/services/comments');
     const staffService = require('./server/services/staff');
     const memberAttribution = require('./server/services/member-attribution');
+    const membersEvents = require('./server/services/members-events');
 
     const urlUtils = require('./shared/url-utils');
 
@@ -296,6 +297,7 @@ async function initServices({config}) {
         memberAttribution.init(),
         staffService.init(),
         members.init(),
+        membersEvents.init(),
         permissions.init(),
         xmlrpc.listen(),
         slack.listen(),

--- a/ghost/core/core/server/services/member-attribution/index.js
+++ b/ghost/core/core/server/services/member-attribution/index.js
@@ -1,17 +1,15 @@
 const urlService = require('../url');
-const labsService = require('../../../shared/labs');
-const DomainEvents = require('@tryghost/domain-events');
 const urlUtils = require('../../../shared/url-utils');
 
 class MemberAttributionServiceWrapper {
     init() {
-        if (this.eventHandler) {
-            // Prevent creating duplicate DomainEvents subscribers
+        if (this.service) {
+            // Already done
             return;
         }
 
         // Wire up all the dependencies
-        const {MemberAttributionService, UrlTranslator, AttributionBuilder, EventHandler} = require('@tryghost/member-attribution');
+        const {MemberAttributionService, UrlTranslator, AttributionBuilder} = require('@tryghost/member-attribution');
         const models = require('../../models');
 
         const urlTranslator = new UrlTranslator({
@@ -32,20 +30,8 @@ class MemberAttributionServiceWrapper {
                 MemberCreatedEvent: models.MemberCreatedEvent,
                 SubscriptionCreatedEvent: models.SubscriptionCreatedEvent
             },
-            attributionBuilder: this.attributionBuilder,
-            labsService
+            attributionBuilder: this.attributionBuilder
         });
-
-        // Listen for events and store them in the database
-        this.eventHandler = new EventHandler({
-            models: {
-                MemberCreatedEvent: models.MemberCreatedEvent,
-                SubscriptionCreatedEvent: models.SubscriptionCreatedEvent
-            }, 
-            DomainEvents, 
-            labsService
-        });
-        this.eventHandler.subscribe();
     }
 }
 

--- a/ghost/core/core/server/services/members-events/index.js
+++ b/ghost/core/core/server/services/members-events/index.js
@@ -1,0 +1,40 @@
+const labsService = require('../../../shared/labs');
+const DomainEvents = require('@tryghost/domain-events');
+const settingsCache = require('../../../shared/settings-cache');
+const members = require('../members');
+
+class MembersEventsServiceWrapper {
+    init() {
+        if (this.eventStorage) {
+            // Prevent creating duplicate DomainEvents subscribers
+            return;
+        }
+
+        // Wire up all the dependencies
+        const {EventStorage, LastSeenAtUpdater} = require('@tryghost/members-events-service');
+        const models = require('../../models');
+
+        // Listen for events and store them in the database
+        this.eventStorage = new EventStorage({
+            models: {
+                MemberCreatedEvent: models.MemberCreatedEvent,
+                SubscriptionCreatedEvent: models.SubscriptionCreatedEvent
+            }, 
+            labsService
+        });
+
+        this.lastSeenAtUpdater = new LastSeenAtUpdater({
+            services: {
+                settingsCache
+            },
+            async getMembersApi() {
+                return members.api;
+            }
+        });
+
+        this.eventStorage.subscribe(DomainEvents);
+        this.lastSeenAtUpdater.subscribe(DomainEvents);
+    }
+}
+
+module.exports = new MembersEventsServiceWrapper();

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -17,8 +17,6 @@ const models = require('../../models');
 const {GhostMailer} = require('../mail');
 const jobsService = require('../jobs');
 const VerificationTrigger = require('@tryghost/verification-trigger');
-const DomainEvents = require('@tryghost/domain-events');
-const {LastSeenAtUpdater} = require('@tryghost/members-events-service');
 const DatabaseInfo = require('@tryghost/database-info');
 const settingsHelpers = require('../settings-helpers');
 
@@ -131,16 +129,6 @@ module.exports = {
             membersStats,
             Settings: models.Settings,
             eventRepository: membersApi.events
-        });
-
-        new LastSeenAtUpdater({
-            services: {
-                domainEvents: DomainEvents,
-                settingsCache
-            },
-            async getMembersApi() {
-                return membersApi;
-            }
         });
 
         (async () => {

--- a/ghost/member-attribution/index.js
+++ b/ghost/member-attribution/index.js
@@ -1,6 +1,5 @@
 module.exports = {
     MemberAttributionService: require('./lib/service'),
-    EventHandler: require('./lib/event-handler'),
     AttributionBuilder: require('./lib/attribution'),
     UrlTranslator: require('./lib/url-translator')
 };

--- a/ghost/members-events-service/lib/event-storage.js
+++ b/ghost/members-events-service/lib/event-storage.js
@@ -1,23 +1,28 @@
 const {MemberCreatedEvent, SubscriptionCreatedEvent} = require('@tryghost/member-events');
 
-class MemberAttributionEventHandler {
+/**
+ * Store events in the database
+ */
+class EventStorage {
     /**
      * 
      * @param {Object} deps 
-     * @param {Object} deps.DomainEvents
      * @param {Object} deps.labsService
      * @param {Object} deps.models
      * @param {Object} deps.models.MemberCreatedEvent
      * @param {Object} deps.models.SubscriptionCreatedEvent
      */
-    constructor({DomainEvents, labsService, models}) {
+    constructor({labsService, models}) {
         this.models = models;
-        this.DomainEvents = DomainEvents;
         this.labsService = labsService;
     }
 
-    subscribe() {
-        this.DomainEvents.subscribe(MemberCreatedEvent, async (event) => {
+    /**
+     * Subscribe to events of this domainEvents service
+     * @param {Object} domainEvents The DomainEvents service
+     */
+    subscribe(domainEvents) {
+        domainEvents.subscribe(MemberCreatedEvent, async (event) => {
             let attribution = event.data.attribution;
 
             if (!this.labsService.isSet('memberAttribution')){
@@ -36,7 +41,7 @@ class MemberAttributionEventHandler {
             });
         });
 
-        this.DomainEvents.subscribe(SubscriptionCreatedEvent, async (event) => {
+        domainEvents.subscribe(SubscriptionCreatedEvent, async (event) => {
             let attribution = event.data.attribution;
 
             if (!this.labsService.isSet('memberAttribution')){
@@ -57,4 +62,4 @@ class MemberAttributionEventHandler {
     }
 }
 
-module.exports = MemberAttributionEventHandler;
+module.exports = EventStorage;

--- a/ghost/members-events-service/lib/index.js
+++ b/ghost/members-events-service/lib/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-    LastSeenAtUpdater: require('./last-seen-at-updater')
+    LastSeenAtUpdater: require('./last-seen-at-updater'),
+    EventStorage: require('./event-storage')
 };

--- a/ghost/members-events-service/lib/last-seen-at-updater.js
+++ b/ghost/members-events-service/lib/last-seen-at-updater.js
@@ -10,13 +10,11 @@ class LastSeenAtUpdater {
      * Initializes the event subscriber
      * @param {Object} deps dependencies
      * @param {Object} deps.services The list of service dependencies
-     * @param {any} deps.services.domainEvents The DomainEvents service
      * @param {any} deps.services.settingsCache The settings service
      * @param {() => object} deps.getMembersApi - A function which returns an instance of members-api
      */
     constructor({
         services: {
-            domainEvents,
             settingsCache
         },
         getMembersApi
@@ -26,14 +24,18 @@ class LastSeenAtUpdater {
         }
 
         this._getMembersApi = getMembersApi;
-        this._domainEventsService = domainEvents;
         this._settingsCacheService = settingsCache;
-
-        this._domainEventsService.subscribe(MemberPageViewEvent, async (event) => {
+    }
+    /**
+     * Subscribe to events of this domainEvents service
+     * @param {any} domainEvents The DomainEvents service
+     */
+    subscribe(domainEvents) {
+        domainEvents.subscribe(MemberPageViewEvent, async (event) => {
             await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
         });
 
-        this._domainEventsService.subscribe(MemberCommentEvent, async (event) => {
+        domainEvents.subscribe(MemberCommentEvent, async (event) => {
             await this.updateLastCommentedAt(event.data.memberId, event.timestamp);
         });
     }

--- a/ghost/members-events-service/test/event-storage.test.js
+++ b/ghost/members-events-service/test/event-storage.test.js
@@ -2,12 +2,12 @@
 // const testUtils = require('./utils');
 require('./utils');
 const {MemberCreatedEvent, SubscriptionCreatedEvent} = require('@tryghost/member-events');
-const MemberAttributionEventHandler = require('../lib/event-handler');
+const EventStorage = require('../lib/event-storage');
 
-describe('MemberAttributionEventHandler', function () {
+describe('EventStorage', function () {
     describe('Constructor', function () {
         it('doesn\'t throw', function () {
-            new MemberAttributionEventHandler({});
+            new EventStorage({});
         });
     });
 
@@ -27,12 +27,11 @@ describe('MemberAttributionEventHandler', function () {
             const MemberCreatedEventModel = {add: sinon.stub()};
             const labsService = {isSet: sinon.stub().returns(true)};
             const subscribeSpy = sinon.spy(DomainEvents, 'subscribe');
-            const eventHandler = new MemberAttributionEventHandler({
-                DomainEvents,
+            const eventHandler = new EventStorage({
                 models: {MemberCreatedEvent: MemberCreatedEventModel},
                 labsService
             });
-            eventHandler.subscribe();
+            eventHandler.subscribe(DomainEvents);
             sinon.assert.calledOnceWithMatch(MemberCreatedEventModel.add, {
                 member_id: '123',
                 created_at: new Date(0),
@@ -61,12 +60,11 @@ describe('MemberAttributionEventHandler', function () {
             const MemberCreatedEventModel = {add: sinon.stub()};
             const labsService = {isSet: sinon.stub().returns(true)};
             const subscribeSpy = sinon.spy(DomainEvents, 'subscribe');
-            const eventHandler = new MemberAttributionEventHandler({
-                DomainEvents,
+            const eventHandler = new EventStorage({
                 models: {MemberCreatedEvent: MemberCreatedEventModel},
                 labsService
             });
-            eventHandler.subscribe();
+            eventHandler.subscribe(DomainEvents);
             sinon.assert.calledOnceWithMatch(MemberCreatedEventModel.add, {
                 member_id: '123',
                 created_at: new Date(0),
@@ -98,12 +96,11 @@ describe('MemberAttributionEventHandler', function () {
             const MemberCreatedEventModel = {add: sinon.stub()};
             const labsService = {isSet: sinon.stub().returns(false)};
             const subscribeSpy = sinon.spy(DomainEvents, 'subscribe');
-            const eventHandler = new MemberAttributionEventHandler({
-                DomainEvents,
+            const eventHandler = new EventStorage({
                 models: {MemberCreatedEvent: MemberCreatedEventModel},
                 labsService
             });
-            eventHandler.subscribe();
+            eventHandler.subscribe(DomainEvents);
             sinon.assert.calledOnceWithMatch(MemberCreatedEventModel.add, {
                 member_id: '123',
                 created_at: new Date(0),
@@ -132,12 +129,11 @@ describe('MemberAttributionEventHandler', function () {
             const SubscriptionCreatedEventModel = {add: sinon.stub()};
             const labsService = {isSet: sinon.stub().returns(true)};
             const subscribeSpy = sinon.spy(DomainEvents, 'subscribe');
-            const eventHandler = new MemberAttributionEventHandler({
-                DomainEvents,
+            const eventHandler = new EventStorage({
                 models: {SubscriptionCreatedEvent: SubscriptionCreatedEventModel},
                 labsService
             });
-            eventHandler.subscribe();
+            eventHandler.subscribe(DomainEvents);
             sinon.assert.calledOnceWithMatch(SubscriptionCreatedEventModel.add, {
                 member_id: '123',
                 subscription_id: '456',
@@ -166,12 +162,11 @@ describe('MemberAttributionEventHandler', function () {
             const SubscriptionCreatedEventModel = {add: sinon.stub()};
             const labsService = {isSet: sinon.stub().returns(true)};
             const subscribeSpy = sinon.spy(DomainEvents, 'subscribe');
-            const eventHandler = new MemberAttributionEventHandler({
-                DomainEvents,
+            const eventHandler = new EventStorage({
                 models: {SubscriptionCreatedEvent: SubscriptionCreatedEventModel},
                 labsService
             });
-            eventHandler.subscribe();
+            eventHandler.subscribe(DomainEvents);
             sinon.assert.calledOnceWithMatch(SubscriptionCreatedEventModel.add, {
                 member_id: '123',
                 subscription_id: '456',
@@ -203,12 +198,11 @@ describe('MemberAttributionEventHandler', function () {
             const SubscriptionCreatedEventModel = {add: sinon.stub()};
             const labsService = {isSet: sinon.stub().returns(false)};
             const subscribeSpy = sinon.spy(DomainEvents, 'subscribe');
-            const eventHandler = new MemberAttributionEventHandler({
-                DomainEvents,
+            const eventHandler = new EventStorage({
                 models: {SubscriptionCreatedEvent: SubscriptionCreatedEventModel},
                 labsService
             });
-            eventHandler.subscribe();
+            eventHandler.subscribe(DomainEvents);
             sinon.assert.calledOnceWithMatch(SubscriptionCreatedEventModel.add, {
                 member_id: '123',
                 subscription_id: '456',


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1821

This change moves all the event storage logic to one new place: the event storage class in the MembersEventsService, which is initialised in a new members events service wrapper.

Apart from this, this includes some improvements:
- Removed DomainEvents from the constructor arguments to the subscribe method (to make it more clear where to subscribe to and decrease dependencies)
- LastSeenAtUpdater doesn't subscribe in the constructor any longer (removes unclear side effect)
- Moved LastSeenAtUpdater initialisation to new members events service wrapper
- Added missing tests to LastSeenAtUpdater to assure that the MembersEventsService package has 100% coverage.