### PR TITLE
Updated showAlert to send only errors to sentry

### DIFF
--- a/ghost/admin/app/services/notifications.js
+++ b/ghost/admin/app/services/notifications.js
@@ -103,15 +103,15 @@ export default class NotificationsService extends Service {
                     ghost: {
                         displayed_message: displayedMessage,
                         ghost_error_code: options.ghostErrorCode,
-                        full_error: message,
-                        source: 'showAlert'
+                        full_error: message
                     }
                 };
 
-                Sentry.captureException(displayedMessage, {
+                Sentry.captureMessage(displayedMessage, {
                     contexts,
                     tags: {
-                        shown_to_user: true
+                        shown_to_user: true,
+                        source: 'showAlert'
                     }
                 });
             }
@@ -196,12 +196,12 @@ export default class NotificationsService extends Service {
                     ghost: {
                         ghost_error_code: resp.ghostErrorCode,
                         displayed_message: msg,
-                        full_error: resp,
-                        source: 'showAPIError'
+                        full_error: resp
                     }
                 },
                 tags: {
-                    shown_to_user: true
+                    shown_to_user: true,
+                    source: 'showAPIError'
                 }
             });
         }

--- a/ghost/admin/app/services/notifications.js
+++ b/ghost/admin/app/services/notifications.js
@@ -94,7 +94,7 @@ export default class NotificationsService extends Service {
     showAlert(message, options = {}) {
         options = options || {};
 
-        if (!options.isApiError) {
+        if (!options.isApiError && (!options.type || options.type === 'error')) {
             if (this.config.get('sentry_dsn')) {
                 // message could be a htmlSafe object rather than a string
                 const displayedMessage = message.string || message;


### PR DESCRIPTION
refs: TryGhost/Team#1121

- Reviewing the list of errors in sentry, some of the most common ones are:
   - success messages like "Password changed"
   - info messages like "Please check your email for instructions."
   - warnings like "You need to sign out to register as a new user."
- None of these are errors, so they shouldn't appear in sentryGot some code for us? Awesome 🎊!

Before I push this @kevinansfield two quick questions:

1. Can you think of any reason why we shouldn't use captureMessage here? We use it elsewhere, afaict it's more relevant for a single string rather than an error, which should be what `showAlert` always gets.
1. Do you remember why source was added in context previously? I think it's more useful as a tag to filter. So far I've added it but not cleaned up the context - can you think of any reason not to clean it up?
