### PR TITLE
Updated member email alerts to trigger via events

### DIFF
--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -13,7 +13,6 @@ const SingleUseTokenProvider = require('./SingleUseTokenProvider');
 const urlUtils = require('../../../shared/url-utils');
 const labsService = require('../../../shared/labs');
 const offersService = require('../offers');
-const staffService = require('../staff');
 const newslettersService = require('../newsletters');
 const memberAttributionService = require('../member-attribution');
 
@@ -198,7 +197,6 @@ function createApiInstance(config) {
         },
         stripeAPIService: stripeService.api,
         offersAPI: offersService.api,
-        staffService: staffService.api,
         labsService: labsService,
         newslettersService: newslettersService,
         memberAttributionService: memberAttributionService.service

--- a/ghost/core/core/server/services/staff/index.js
+++ b/ghost/core/core/server/services/staff/index.js
@@ -1,5 +1,11 @@
+const DomainEvents = require('@tryghost/domain-events');
 class StaffServiceWrapper {
     init() {
+        if (this.api) {
+            // Prevent creating duplicate DomainEvents subscribers
+            return;
+        }
+
         const StaffService = require('@tryghost/staff-service');
 
         const logging = require('@tryghost/logging');
@@ -16,8 +22,11 @@ class StaffServiceWrapper {
             mailer,
             settingsHelpers,
             settingsCache,
-            urlUtils
+            urlUtils,
+            DomainEvents
         });
+
+        this.api.subscribeEvents();
     }
 }
 

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -3,6 +3,12 @@ const should = require('should');
 
 let membersAgent, membersService;
 
+async function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
 describe('sendMagicLink', function () {
     before(async function () {
         const agents = await agentProvider.getAgentsForMembers();
@@ -127,6 +133,8 @@ describe('sendMagicLink', function () {
         // Get member data from token
         const data = await membersService.api.getMemberDataFromMagicLinkToken(token);
 
+        // Wait for the dispatched events (because this happens async)
+        await sleep(250);
         // Check member alert is sent to site owners
         mockManager.assert.sentEmail({
             to: 'jbloggs@example.com',

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -43,6 +43,12 @@ async function assertSubscription(subscriptionId, asserts) {
     models.Base.Model.prototype.serialize.call(subscription).should.match(asserts);
 }
 
+async function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
 describe('Members API', function () {
     // @todo: Test what happens when a complimentary subscription ends (should create comped -> free event)
     // @todo: Test what happens when a complimentary subscription starts a paid subscription
@@ -658,11 +664,6 @@ describe('Members API', function () {
             assert.equal(member.subscriptions.length, 1, 'The member should have a single subscription');
 
             mockManager.assert.sentEmail({
-                subject: '💸 Paid subscription started: checkout-webhook-test@email.com',
-                to: 'jbloggs@example.com'
-            });
-
-            mockManager.assert.sentEmail({
                 subject: '🙌 Thank you for signing up to Ghost!',
                 to: 'checkout-webhook-test@email.com'
             });
@@ -705,6 +706,14 @@ describe('Members API', function () {
                         mrr_delta: 500
                     }
                 ]
+            });
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+
+            mockManager.assert.sentEmail({
+                subject: '💸 Paid subscription started: checkout-webhook-test@email.com',
+                to: 'jbloggs@example.com'
             });
         });
 

--- a/ghost/core/test/unit/server/services/staff/index.test.js
+++ b/ghost/core/test/unit/server/services/staff/index.test.js
@@ -1,0 +1,235 @@
+const sinon = require('sinon');
+
+const staffService = require('../../../../../core/server/services/staff');
+
+const DomainEvents = require('@tryghost/domain-events');
+const {mockManager} = require('../../../../utils/e2e-framework');
+const models = require('../../../../../core/server/models');
+
+const {SubscriptionCreatedEvent, SubscriptionCancelledEvent, MemberCreatedEvent} = require('@tryghost/member-events');
+
+async function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+describe('Staff Service:', function () {
+    before(function () {
+        models.init();
+    });
+
+    beforeEach(function () {
+        mockManager.mockMail();
+        sinon.stub(models.User, 'getEmailAlertUsers').resolves([{
+            email: 'owner@ghost.org',
+            slug: 'ghost'
+        }]);
+
+        sinon.stub(models.Member, 'findOne').resolves({
+            toJSON: sinon.stub().returns({
+                id: '1',
+                email: 'jamie@example.com',
+                name: 'Jamie',
+                status: 'free',
+                geolocation: null,
+                created_at: '2022-08-01T07:30:39.882Z'
+            })
+        });
+
+        sinon.stub(models.Product, 'findOne').resolves({
+            toJSON: sinon.stub().returns({
+                id: 'tier-1',
+                name: 'Tier 1'
+            })
+        });
+
+        sinon.stub(models.Offer, 'findOne').resolves({
+            toJSON: sinon.stub().returns({
+                discount_amount: 1000,
+                duration: 'forever',
+                discount_type: 'fixed',
+                name: 'Test offer',
+                duration_in_months: null
+            })
+        });
+
+        sinon.stub(models.StripeCustomerSubscription, 'findOne').resolves({
+            toJSON: sinon.stub().returns({
+                id: 'sub-1',
+                plan: {
+                    amount: 5000,
+                    currency: 'USD',
+                    interval: 'month'
+                },
+                start_date: new Date('2022-08-01T07:30:39.882Z'),
+                current_period_end: '2024-08-01T07:30:39.882Z',
+                cancellation_reason: 'Changed my mind!'
+            })
+        });
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        mockManager.restore();
+    });
+
+    describe('free member created event:', function () {
+        let eventData = {
+            memberId: '1'
+        };
+
+        it('sends email for member source', async function () {
+            await staffService.init();
+            DomainEvents.dispatch(MemberCreatedEvent.create({
+                source: 'member',
+                ...eventData
+            }));
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+            mockManager.assert.sentEmail({
+                to: 'owner@ghost.org',
+                subject: /🥳 Free member signup: Jamie/
+            });
+            mockManager.assert.sentEmailCount(1);
+        });
+
+        it('sends email for api source', async function () {
+            await staffService.init();
+            DomainEvents.dispatch(MemberCreatedEvent.create({
+                source: 'api',
+                ...eventData
+            }));
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+            mockManager.assert.sentEmail({
+                to: 'owner@ghost.org',
+                subject: /🥳 Free member signup: Jamie/
+            });
+            mockManager.assert.sentEmailCount(1);
+        });
+
+        it('does not send email for importer source', async function () {
+            await staffService.init();
+            DomainEvents.dispatch(MemberCreatedEvent.create({
+                source: 'import',
+                ...eventData
+            }));
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+            mockManager.assert.sentEmailCount(0);
+        });
+    });
+
+    describe('paid subscription start event:', function () {
+        let eventData = {
+            memberId: '1',
+            tierId: 'tier-1',
+            subscriptionId: 'sub-1',
+            offerId: 'offer-1'
+        };
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('sends email for member source', async function () {
+            await staffService.init();
+            DomainEvents.dispatch(SubscriptionCreatedEvent.create({
+                source: 'member',
+                ...eventData
+            }));
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+            mockManager.assert.sentEmail({
+                to: 'owner@ghost.org',
+                subject: /💸 Paid subscription started: Jamie/
+            });
+            mockManager.assert.sentEmailCount(1);
+        });
+
+        it('sends email for api source', async function () {
+            await staffService.init();
+            DomainEvents.dispatch(SubscriptionCreatedEvent.create({
+                source: 'api',
+                ...eventData
+            }));
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+            mockManager.assert.sentEmail({
+                to: 'owner@ghost.org',
+                subject: /💸 Paid subscription started: Jamie/
+            });
+            mockManager.assert.sentEmailCount(1);
+        });
+
+        it('does not send email for importer source', async function () {
+            await staffService.init();
+            DomainEvents.dispatch(SubscriptionCreatedEvent.create({
+                source: 'import',
+                ...eventData
+            }));
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+            mockManager.assert.sentEmailCount(0);
+        });
+    });
+
+    describe('paid subscription cancel event:', function () {
+        let eventData = {
+            memberId: '1',
+            tierId: 'tier-1',
+            subscriptionId: 'sub-1'
+        };
+
+        it('sends email for member source', async function () {
+            await staffService.init();
+            DomainEvents.dispatch(SubscriptionCancelledEvent.create({
+                source: 'member',
+                ...eventData
+            }, new Date()));
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+            mockManager.assert.sentEmail({
+                to: 'owner@ghost.org',
+                subject: /⚠️ Cancellation: Jamie/
+            });
+            mockManager.assert.sentEmailCount(1);
+        });
+
+        it('sends email for api source', async function () {
+            await staffService.init();
+            DomainEvents.dispatch(SubscriptionCancelledEvent.create({
+                source: 'api',
+                ...eventData
+            }));
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+            mockManager.assert.sentEmail({
+                to: 'owner@ghost.org',
+                subject: /⚠️ Cancellation: Jamie/
+            });
+            mockManager.assert.sentEmailCount(1);
+        });
+
+        it('does not send email for importer source', async function () {
+            await staffService.init();
+            DomainEvents.dispatch(SubscriptionCancelledEvent.create({
+                source: 'import',
+                ...eventData
+            }));
+
+            // Wait for the dispatched events (because this happens async)
+            await sleep(250);
+            mockManager.assert.sentEmailCount(0);
+        });
+    });
+});

--- a/ghost/member-events/index.js
+++ b/ghost/member-events/index.js
@@ -8,5 +8,6 @@ module.exports = {
     MemberPaidCancellationEvent: require('./lib/MemberPaidCancellationEvent'),
     MemberPageViewEvent: require('./lib/MemberPageViewEvent'),
     SubscriptionCreatedEvent: require('./lib/SubscriptionCreatedEvent'),
-    MemberCommentEvent: require('./lib/MemberCommentEvent')
+    MemberCommentEvent: require('./lib/MemberCommentEvent'),
+    SubscriptionCancelledEvent: require('./lib/SubscriptionCancelledEvent')
 };

--- a/ghost/member-events/lib/SubscriptionCancelledEvent.js
+++ b/ghost/member-events/lib/SubscriptionCancelledEvent.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {object} SubscriptionCancelledEventData
+ * @prop {string} source
+ * @prop {string} memberId
+ * @prop {string} tierId
+ * @prop {string} subscriptionId
+ */
+
+module.exports = class SubscriptionCancelledEvent {
+    /**
+     * @param {SubscriptionCancelledEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {SubscriptionCancelledEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new SubscriptionCancelledEvent(data, timestamp || new Date);
+    }
+};

--- a/ghost/member-events/lib/SubscriptionCreatedEvent.js
+++ b/ghost/member-events/lib/SubscriptionCreatedEvent.js
@@ -1,6 +1,8 @@
 /**
  * @typedef {object} SubscriptionCreatedEventData
+ * @prop {string} source
  * @prop {string} memberId
+ * @prop {string} tierId
  * @prop {string} subscriptionId
  * @prop {string} offerId
  * @prop {import('@tryghost/member-attribution/lib/attribution').Attribution} [attribution]

--- a/ghost/members-api/lib/MembersAPI.js
+++ b/ghost/members-api/lib/MembersAPI.js
@@ -61,7 +61,6 @@ module.exports = function MembersAPI({
     },
     stripeAPIService,
     offersAPI,
-    staffService,
     labsService,
     newslettersService,
     memberAttributionService
@@ -87,7 +86,6 @@ module.exports = function MembersAPI({
         stripeAPIService,
         tokenService,
         newslettersService,
-        staffService,
         labsService,
         productRepository,
         Member,
@@ -152,7 +150,6 @@ module.exports = function MembersAPI({
         productRepository,
         StripePrice,
         tokenService,
-        staffService,
         sendEmailWithMagicLink
     });
 

--- a/ghost/members-api/lib/MembersAPI.js
+++ b/ghost/members-api/lib/MembersAPI.js
@@ -232,11 +232,6 @@ module.exports = function MembersAPI({
 
         const newMember = await users.create({name, email, labels, newsletters, attribution, geolocation});
 
-        // Notify staff users of new free member signup
-        if (labsService.isSet('emailAlerts')) {
-            await staffService.notifyFreeMemberSignup(newMember.toJSON());
-        }
-
         await MemberLoginEvent.add({member_id: newMember.id});
         return getMemberIdentityData(email);
     }

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -39,7 +39,6 @@ module.exports = class MemberRepository {
      * @param {any} deps.OfferRedemption
      * @param {import('../../services/stripe-api')} deps.stripeAPIService
      * @param {any} deps.labsService
-     * @param {any} deps.staffService
      * @param {any} deps.productRepository
      * @param {any} deps.offerRepository
      * @param {ITokenService} deps.tokenService
@@ -61,7 +60,6 @@ module.exports = class MemberRepository {
         productRepository,
         offerRepository,
         tokenService,
-        staffService,
         newslettersService
     }) {
         this._Member = Member;
@@ -77,7 +75,6 @@ module.exports = class MemberRepository {
         this._productRepository = productRepository;
         this._offerRepository = offerRepository;
         this.tokenService = tokenService;
-        this.staffService = staffService;
         this._newslettersService = newslettersService;
         this._labsService = labsService;
 

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -778,6 +778,7 @@ module.exports = class MemberRepository {
      * @param {String} data.id - member ID
      * @param {Object} data.subscription
      * @param {String} data.offerId
+     * @param {import('@tryghost/member-attribution/lib/history').Attribution} data.attribution
      * @param {*} options
      * @returns
      */
@@ -994,14 +995,23 @@ module.exports = class MemberRepository {
             const context = options?.context || {};
             const source = this._resolveContextSource(context);
 
-            // Notify paid member subscription start
-            if (this._labsService.isSet('emailAlerts') && ['member', 'api'].includes(source)) {
-                await this.staffService.notifyPaidSubscriptionStart({
-                    member: member.toJSON(),
-                    offer: offer ? this._offerRepository.toJSON(offer) : null,
-                    tier: ghostProduct?.toJSON(),
-                    subscription: subscriptionData
-                }, {transacting: options.transacting, forUpdate: true});
+            const event = SubscriptionCreatedEvent.create({
+                source,
+                tierId: ghostProduct?.get('id'),
+                memberId: member.id,
+                subscriptionId: model.get('id'),
+                offerId: data.offerId,
+                attribution: data.attribution
+            });
+
+            if (options?.transacting) {
+                // Only dispatch the event after the transaction has finished
+                // Because else the offer won't be committed to the database yet
+                options.transacting.executionPromise.then(() => {
+                    DomainEvents.dispatch(event);
+                });
+            } else {
+                DomainEvents.dispatch(event);
             }
         }
 
@@ -1258,22 +1268,6 @@ module.exports = class MemberRepository {
                     member_id: member.id,
                     from_plan: subscriptionModel.get('plan_id')
                 }, sharedOptions);
-
-                if (this._labsService.isSet('emailAlerts')) {
-                    const subscriptionPriceData = _.get(updatedSubscription, 'items.data[0].price');
-                    let ghostProduct;
-                    try {
-                        ghostProduct = await this._productRepository.get({stripe_product_id: subscriptionPriceData.product}, {...sharedOptions, forUpdate: true});
-                    } catch (e) {
-                        ghostProduct = null;
-                    }
-                    await this.staffService.notifyPaidSubscriptionCancel({
-                        member: member.toJSON(),
-                        subscription: updatedSubscription,
-                        cancellationReason: data.subscription.cancellationReason,
-                        tier: ghostProduct?.toJSON()
-                    });
-                }
             } else {
                 updatedSubscription = await this._stripeAPIService.continueSubscriptionAtPeriodEnd(
                     data.subscription.subscription_id
@@ -1286,6 +1280,42 @@ module.exports = class MemberRepository {
                 id: member.id,
                 subscription: updatedSubscription
             }, options);
+
+            // Dispatch cancellation event
+            if (data.subscription.cancel_at_period_end) {
+                const stripeProductId = _.get(updatedSubscription, 'items.data[0].price.product');
+
+                let ghostProduct;
+                try {
+                    ghostProduct = await this._productRepository.get(
+                        {stripe_product_id: stripeProductId},
+                        {...sharedOptions, forUpdate: true}
+                    );
+                } catch (e) {
+                    ghostProduct = null;
+                }
+
+                const context = options?.context || {};
+                const source = this._resolveContextSource(context);
+                const cancellationTimestamp = updatedSubscription.canceled_at
+                    ? new Date(updatedSubscription.canceled_at * 1000)
+                    : new Date();
+                const cancelEventData = {
+                    source,
+                    memberId: member.id,
+                    subscriptionId: subscriptionModel.get('id'),
+                    tierId: ghostProduct?.get('id')
+                };
+                if (options?.transacting) {
+                    // Only dispatch the event after the transaction has finished
+                    // Because else the offer won't be committed to the database yet
+                    options.transacting.executionPromise.then(() => {
+                        DomainEvents.dispatch(SubscriptionCancelledEvent.create(cancelEventData, cancellationTimestamp));
+                    });
+                } else {
+                    DomainEvents.dispatch(SubscriptionCancelledEvent.create(cancelEventData, cancellationTimestamp));
+                }
+            }
         }
     }
 

--- a/ghost/offers/lib/application/OfferRepository.js
+++ b/ghost/offers/lib/application/OfferRepository.js
@@ -4,7 +4,6 @@ const DomainEvents = require('@tryghost/domain-events');
 const OfferCodeChangeEvent = require('../domain/events/OfferCodeChange');
 const OfferCreatedEvent = require('../domain/events/OfferCreated');
 const Offer = require('../domain/models/Offer');
-const OfferMapper = require('./OfferMapper');
 const OfferStatus = require('../domain/models/OfferStatus');
 
 const statusTransformer = mapKeyValues({
@@ -122,13 +121,6 @@ class OfferRepository {
                 name: json.product.name
             }
         }, null);
-    }
-    /**
-     * @param {Offer} offer
-     * @returns {OfferMapper.OfferDTO}
-     */
-    toJSON(offer) {
-        return OfferMapper.toDTO(offer);
     }
 
     /**

--- a/ghost/staff-service/lib/emails.js
+++ b/ghost/staff-service/lib/emails.js
@@ -1,6 +1,5 @@
 const {promises: fs} = require('fs');
 const path = require('path');
-const _ = require('lodash');
 const moment = require('moment');
 
 class StaffServiceEmails {
@@ -55,16 +54,16 @@ class StaffServiceEmails {
 
             const subject = `💸 Paid subscription started: ${memberData.name}`;
 
-            const amount = this.getAmount(subscription?.plan_amount);
-            const formattedAmount = this.getFormattedAmount({currency: subscription?.plan_currency, amount});
-            const interval = subscription?.plan_interval || '';
+            const amount = this.getAmount(subscription?.amount);
+            const formattedAmount = this.getFormattedAmount({currency: subscription?.currency, amount});
+            const interval = subscription?.interval || '';
             const tierData = {
                 name: tier?.name || '',
                 details: `${formattedAmount}/${interval}`
             };
 
             const subscriptionData = {
-                startedOn: this.getFormattedDate(subscription.start_date)
+                startedOn: this.getFormattedDate(subscription.startDate)
             };
 
             let offerData = this.getOfferData(offer);
@@ -94,17 +93,17 @@ class StaffServiceEmails {
         }
     }
 
-    async notifyPaidSubscriptionCanceled({member, cancellationReason, tier, subscription}, options = {}) {
+    async notifyPaidSubscriptionCanceled({member, tier, subscription}, options = {}) {
         const users = await this.models.User.getEmailAlertUsers('paid-canceled', options);
-        const subscriptionPriceData = _.get(subscription, 'items.data[0].price');
+
         for (const user of users) {
             const to = user.email;
             const memberData = this.getMemberData(member);
             const subject = `⚠️ Cancellation: ${memberData.name}`;
 
-            const amount = this.getAmount(subscriptionPriceData?.unit_amount);
-            const formattedAmount = this.getFormattedAmount({currency: subscriptionPriceData?.currency, amount});
-            const interval = subscriptionPriceData?.recurring?.interval;
+            const amount = this.getAmount(subscription?.amount);
+            const formattedAmount = this.getFormattedAmount({currency: subscription?.currency, amount});
+            const interval = subscription?.interval;
             const tierDetail = `${formattedAmount}/${interval}`;
             const tierData = {
                 name: tier?.name || '',
@@ -112,9 +111,9 @@ class StaffServiceEmails {
             };
 
             const subscriptionData = {
-                expiryAt: this.getFormattedStripeDate(subscription.cancel_at),
-                canceledAt: this.getFormattedStripeDate(subscription.canceled_at),
-                cancellationReason: cancellationReason || ''
+                expiryAt: this.getFormattedDate(subscription.cancelAt),
+                canceledAt: this.getFormattedDate(subscription.canceledAt),
+                cancellationReason: subscription.cancellationReason || ''
             };
 
             const templateData = {
@@ -203,16 +202,6 @@ class StaffServiceEmails {
     }
 
     /** @private */
-    getFormattedStripeDate(stripeDate) {
-        if (!stripeDate) {
-            return '';
-        }
-        const date = new Date(stripeDate * 1000);
-
-        return this.getFormattedDate(date);
-    }
-
-    /** @private */
     getOfferData(offer) {
         if (offer) {
             let offAmount = '';
@@ -221,7 +210,7 @@ class StaffServiceEmails {
             if (offer.duration === 'once') {
                 offDuration = ', first payment';
             } else if (offer.duration === 'repeating') {
-                offDuration = `, first ${offer.duration_in_months} months`;
+                offDuration = `, first ${offer.durationInMonths} months`;
             } else if (offer.duration === 'forever') {
                 offDuration = `, forever`;
             } else if (offer.duration === 'trial') {

--- a/ghost/staff-service/lib/staff-service.js
+++ b/ghost/staff-service/lib/staff-service.js
@@ -1,10 +1,13 @@
+const {MemberCreatedEvent, SubscriptionCancelledEvent, SubscriptionCreatedEvent} = require('@tryghost/member-events');
+
 class StaffService {
-    constructor({logging, models, mailer, settingsCache, settingsHelpers, urlUtils}) {
+    constructor({logging, models, mailer, settingsCache, settingsHelpers, urlUtils, DomainEvents}) {
         this.logging = logging;
 
         /** @private */
         this.settingsCache = settingsCache;
         this.models = models;
+        this.DomainEvents = DomainEvents;
 
         const Emails = require('./emails');
 
@@ -19,28 +22,115 @@ class StaffService {
         });
     }
 
-    async notifyFreeMemberSignup(member, options) {
-        try {
-            await this.emails.notifyFreeMemberSignup(member, options);
-        } catch (e) {
-            this.logging.error(`Failed to notify free member signup - ${member?.id}`);
+    /** @private */
+    getSerializedData({member, tier = null, subscription = null, offer = null}) {
+        return {
+            offer: offer ? {
+                name: offer.name,
+                type: offer.discount_type,
+                currency: offer.currency,
+                duration: offer.duration,
+                durationInMonths: offer.duration_in_months,
+                amount: offer.discount_amount
+            } : null,
+            subscription: subscription ? {
+                id: subscription.id,
+                amount: subscription.plan?.amount,
+                interval: subscription.plan?.interval,
+                currency: subscription.plan?.currency,
+                startDate: subscription.start_date,
+                cancelAt: subscription.current_period_end,
+                cancellationReason: subscription.cancellation_reason
+            } : null,
+            member: member ? {
+                id: member.id,
+                name: member.name,
+                email: member.email,
+                geolocation: member.geolocation,
+                status: member.status,
+                created_at: member.created_at
+            } : null,
+            tier: tier ? {
+                id: tier.id,
+                name: tier.name
+            } : null
+        };
+    }
+
+    /** @private */
+    async getDataFromIds({memberId, tierId = null, subscriptionId = null, offerId = null}) {
+        const memberModel = memberId ? await this.models.Member.findOne({id: memberId}) : null;
+        const tierModel = tierId ? await this.models.Product.findOne({id: tierId}) : null;
+        const subscriptionModel = subscriptionId ? await this.models.StripeCustomerSubscription.findOne({id: subscriptionId}) : null;
+        const offerModel = offerId ? await this.models.Offer.findOne({id: offerId}) : null;
+
+        return this.getSerializedData({
+            member: memberModel?.toJSON(),
+            tier: tierModel?.toJSON(),
+            subscription: subscriptionModel?.toJSON(),
+            offer: offerModel?.toJSON()
+        });
+    }
+
+    /** @private */
+    async handleEvent(type, event) {
+        if (!['api', 'member'].includes(event.data.source)) {
+            return;
+        }
+
+        const {member, tier, subscription, offer} = await this.getDataFromIds({
+            memberId: event.data.memberId,
+            tierId: event.data.tierId,
+            subscriptionId: event.data.subscriptionId,
+            offerId: event.data.offerId
+        });
+
+        if (type === MemberCreatedEvent && member.status === 'free') {
+            await this.emails.notifyFreeMemberSignup(member);
+        } else if (type === SubscriptionCreatedEvent) {
+            await this.emails.notifyPaidSubscriptionStarted({
+                member,
+                offer,
+                tier,
+                subscription
+            });
+        } else if (type === SubscriptionCancelledEvent) {
+            subscription.canceledAt = event.timestamp;
+            await this.emails.notifyPaidSubscriptionCanceled({
+                member,
+                tier,
+                subscription
+            });
         }
     }
 
-    async notifyPaidSubscriptionStart({member, offer, tier, subscription}, options) {
-        try {
-            await this.emails.notifyPaidSubscriptionStarted({member, offer, tier, subscription}, options);
-        } catch (e) {
-            this.logging.error(`Failed to notify paid member subscription start - ${member?.id}`);
-        }
-    }
+    subscribeEvents() {
+        // Trigger email for free member signup
+        this.DomainEvents.subscribe(MemberCreatedEvent, async (event) => {
+            try {
+                await this.handleEvent(MemberCreatedEvent, event);
+            } catch (e) {
+                this.logging.error(`Failed to notify free member signup - ${event?.data?.memberId}`);
+            }
+        });
 
-    async notifyPaidSubscriptionCancel({member, cancellationReason, tier, subscription}, options) {
-        try {
-            await this.emails.notifyPaidSubscriptionCanceled({member, cancellationReason, tier, subscription}, options);
-        } catch (e) {
-            this.logging.error(`Failed to notify paid member subscription cancel - ${member?.id}`);
-        }
+        // Trigger email on paid subscription start
+        this.DomainEvents.subscribe(SubscriptionCreatedEvent, async (event) => {
+            try {
+                await this.handleEvent(SubscriptionCreatedEvent, event);
+            } catch (e) {
+                this.logging.error(`Failed to notify paid member subscription start - ${event?.data?.memberId}`);
+            }
+        });
+
+        // Trigger email when a member cancels their subscription
+        this.DomainEvents.subscribe(SubscriptionCancelledEvent, async (event) => {
+            try {
+                await this.handleEvent(SubscriptionCancelledEvent, event);
+            } catch (e) {
+                this.logging.error(`Failed to notify paid member subscription cancel - ${event?.data?.memberId}`);
+            }
+        });
     }
 }
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1864
closes https://github.com/TryGhost/Team/issues/1865
closes https://github.com/TryGhost/Team/issues/1867
refs https://github.com/TryGhost/Team/issues/1881

- updates sending member alert emails using events instead of adding a direct dependency which is harder to maintain long term
- using events also allows decoupling the actual email sending from the main request for an action like cancel subscription or paid subscription