### PR TITLE
Added passthrough + saving of lexical property on posts/pages

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/validators/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/posts.js
@@ -4,7 +4,8 @@ const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
-    invalidVisibilityFilter: 'Invalid filter in visibility_filter property'
+    invalidVisibilityFilter: 'Invalid filter in visibility_filter property',
+    onlySingleContentSource: 'It\'s only possible to save mobiledoc or lexical properties, not both'
 };
 
 const validateVisibility = async function (frame) {
@@ -33,15 +34,29 @@ const validateVisibility = async function (frame) {
     }
 };
 
+const validateSingleContentSource = async function (frame) {
+    if (!frame.data.posts?.[0]) {
+        return;
+    }
+
+    const [post] = frame.data.posts;
+    if (post.mobiledoc && post.lexical) {
+        return Promise.reject(new ValidationError({
+            message: tpl(messages.onlySingleContentSource),
+            property: 'lexical'
+        }));
+    }
+};
+
 module.exports = {
-    add(apiConfig, frame) {
-        return jsonSchema.validate(...arguments).then(() => {
-            return validateVisibility(frame);
-        });
+    async add(apiConfig, frame) {
+        await jsonSchema.validate(...arguments);
+        await validateVisibility(frame);
+        await validateSingleContentSource(frame);
     },
-    edit(apiConfig, frame) {
-        return jsonSchema.validate(...arguments).then(() => {
-            return validateVisibility(frame);
-        });
+    async edit(apiConfig, frame) {
+        await jsonSchema.validate(...arguments);
+        await validateVisibility(frame);
+        await validateSingleContentSource(frame);
     }
 };

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -596,7 +596,7 @@ Post = ghostBookshelf.Model.extend({
             });
         }
 
-        if (!this.get('mobiledoc')) {
+        if (!this.get('mobiledoc') && !this.get('lexical')) {
             this.set('mobiledoc', JSON.stringify(mobiledocLib.blankDocument));
         }
 

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -55,7 +55,7 @@
     "@sentry/node": "7.12.1",
     "@tryghost/adapter-base-cache": "0.1.2",
     "@tryghost/adapter-manager": "0.0.0",
-    "@tryghost/admin-api-schema": "4.1.1",
+    "@tryghost/admin-api-schema": "4.2.0",
     "@tryghost/api-framework": "0.0.0",
     "@tryghost/api-version-compatibility-service": "0.0.0",
     "@tryghost/bookshelf-plugins": "0.5.0",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -18,7 +18,7 @@ Object {
       "canonical_url": null,
       "codeinjection_foot": null,
       "codeinjection_head": null,
-      "comment_id": "618ba1ffbe2896088840a6ed",
+      "comment_id": Any<String>,
       "count": Object {
         "conversions": 0,
         "signups": 0,
@@ -65,7 +65,7 @@ Object {
       "canonical_url": null,
       "codeinjection_foot": null,
       "codeinjection_head": null,
-      "comment_id": "618ba1ffbe2896088840a6e5",
+      "comment_id": Any<String>,
       "count": Object {
         "conversions": 0,
         "signups": 0,
@@ -143,7 +143,7 @@ Object {
       "canonical_url": null,
       "codeinjection_foot": null,
       "codeinjection_head": null,
-      "comment_id": "618ba1ffbe2896088840a6ed",
+      "comment_id": Any<String>,
       "count": Object {
         "conversions": 0,
         "signups": 0,
@@ -194,7 +194,7 @@ Object {
       "canonical_url": null,
       "codeinjection_foot": null,
       "codeinjection_head": null,
-      "comment_id": "618ba1ffbe2896088840a6e5",
+      "comment_id": Any<String>,
       "count": Object {
         "conversions": 0,
         "signups": 0,
@@ -269,6 +269,172 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "12760",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Posts API Create Can create a post with lexical 1: [body] 1`] = `
+Object {
+  "posts": Array [
+    Object {
+      "authors": Any<Array>,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "comment_id": Any<String>,
+      "count": Object {
+        "conversions": 0,
+        "signups": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "custom_excerpt": null,
+      "custom_template": null,
+      "email": null,
+      "email_only": false,
+      "email_segment": "all",
+      "email_subject": null,
+      "excerpt": null,
+      "feature_image": null,
+      "feature_image_alt": null,
+      "feature_image_caption": null,
+      "featured": false,
+      "frontmatter": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "lexical": "{\\"editorState\\":{\\"root\\":{\\"children\\":[{\\"children\\":[{\\"detail\\":0,\\"format\\":0,\\"mode\\":\\"normal\\",\\"style\\":\\"\\",\\"text\\":\\"Testing post creation with lexical\\",\\"type\\":\\"text\\",\\"version\\":1}],\\"direction\\":\\"ltr\\",\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"paragraph\\",\\"version\\":1}],\\"direction\\":\\"ltr\\",\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"root\\",\\"version\\":1}},\\"lastSaved\\":1663081361393,\\"source\\":\\"Playground\\",\\"version\\":\\"0.4.1\\"}",
+      "meta_description": null,
+      "meta_title": null,
+      "mobiledoc": null,
+      "newsletter": null,
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "primary_author": Any<Object>,
+      "primary_tag": Any<Object>,
+      "published_at": null,
+      "slug": "lexical-test",
+      "status": "draft",
+      "tags": Any<Array>,
+      "tiers": Any<Array>,
+      "title": "Lexical test",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "url": Any<String>,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "visibility": "public",
+    },
+  ],
+}
+`;
+
+exports[`Posts API Create Can create a post with lexical 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "3737",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/posts\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Posts API Create Can create a post with mobiledoc 1: [body] 1`] = `
+Object {
+  "posts": Array [
+    Object {
+      "authors": Any<Array>,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "comment_id": Any<String>,
+      "count": Object {
+        "conversions": 0,
+        "signups": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "custom_excerpt": null,
+      "custom_template": null,
+      "email": null,
+      "email_only": false,
+      "email_segment": "all",
+      "email_subject": null,
+      "excerpt": "Testing post creation with mobiledoc",
+      "feature_image": null,
+      "feature_image_alt": null,
+      "feature_image_caption": null,
+      "featured": false,
+      "frontmatter": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "lexical": null,
+      "meta_description": null,
+      "meta_title": null,
+      "mobiledoc": "{\\"version\\":\\"0.3.1\\",\\"ghostVersion\\":\\"4.0\\",\\"markups\\":[],\\"atoms\\":[],\\"cards\\":[],\\"sections\\":[[1,\\"p\\",[[0,[],0,\\"Testing post creation with mobiledoc\\"]]]]}",
+      "newsletter": null,
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "primary_author": Any<Object>,
+      "primary_tag": Any<Object>,
+      "published_at": null,
+      "slug": "mobiledoc-test",
+      "status": "draft",
+      "tags": Any<Array>,
+      "tiers": Any<Array>,
+      "title": "Mobiledoc test",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "url": Any<String>,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "visibility": "public",
+    },
+  ],
+}
+`;
+
+exports[`Posts API Create Can create a post with mobiledoc 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "3489",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/posts\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Posts API Create Errors if both mobiledoc and lexical are present 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "It's only possible to save mobiledoc or lexical properties, not both",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Validation error, cannot save post.",
+      "property": "lexical",
+      "type": "ValidationError",
+    },
+  ],
+}
+`;
+
+exports[`Posts API Create Errors if both mobiledoc and lexical are present 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "294",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -1,10 +1,11 @@
 const assert = require('assert');
 const {agentProvider, fixtureManager, mockManager, matchers} = require('../../utils/e2e-framework');
-const {anyArray, anyEtag, anyErrorId, anyObject, anyObjectId, anyISODateTime, anyString, anyUuid} = matchers;
+const {anyArray, anyEtag, anyErrorId, anyLocationFor, anyObject, anyObjectId, anyISODateTime, anyString, anyUuid} = matchers;
 
 const matchPostShallowIncludes = {
     id: anyObjectId,
     uuid: anyUuid,
+    comment_id: anyString,
     url: anyString,
     authors: anyArray,
     primary_author: anyObject,
@@ -49,6 +50,155 @@ describe('Posts API', function () {
             .matchBodySnapshot({
                 posts: new Array(2).fill(matchPostShallowIncludes)
             });
+    });
+
+    describe('Create', function () {
+        it('Can create a post with mobiledoc', async function () {
+            const post = {
+                title: 'Mobiledoc test',
+                mobiledoc: JSON.stringify({
+                    version: '0.3.1',
+                    ghostVersion: '4.0',
+                    markups: [],
+                    atoms: [],
+                    cards: [],
+                    sections: [
+                        [1, 'p', [
+                            [0, [], 0, 'Testing post creation with mobiledoc']
+                        ]]
+                    ]
+                })
+            };
+
+            await agent
+                .post('/posts/?formats=mobiledoc,lexical')
+                .body({posts: [post]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    posts: [Object.assign(matchPostShallowIncludes, {published_at: null})]
+                })
+                .matchHeaderSnapshot({
+                    etag: anyEtag,
+                    location: anyLocationFor('posts')
+                });
+        });
+
+        it('Can create a post with lexical', async function () {
+            const post = {
+                title: 'Lexical test',
+                lexical: JSON.stringify({
+                    editorState: {
+                        root: {
+                            children: [
+                                {
+                                    children: [
+                                        {
+                                            detail: 0,
+                                            format: 0,
+                                            mode: 'normal',
+                                            style: '',
+                                            text: 'Testing post creation with lexical',
+                                            type: 'text',
+                                            version: 1
+                                        }
+                                    ],
+                                    direction: 'ltr',
+                                    format: '',
+                                    indent: 0,
+                                    type: 'paragraph',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'root',
+                            version: 1
+                        }
+                    },
+                    lastSaved: 1663081361393,
+                    source: 'Playground',
+                    version: '0.4.1'
+                })
+            };
+
+            await agent
+                .post('/posts/?formats=mobiledoc,lexical')
+                .body({posts: [post]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    posts: [Object.assign(matchPostShallowIncludes, {published_at: null})]
+                })
+                .matchHeaderSnapshot({
+                    etag: anyEtag,
+                    location: anyLocationFor('posts')
+                });
+        });
+
+        it('Errors if both mobiledoc and lexical are present', async function () {
+            const post = {
+                title: 'Mobiledoc+lexical test',
+                mobiledoc: JSON.stringify({
+                    version: '0.3.1',
+                    ghostVersion: '4.0',
+                    markups: [],
+                    atoms: [],
+                    cards: [],
+                    sections: [
+                        [1, 'p', [
+                            [0, [], 0, 'Testing post creation with mobiledoc']
+                        ]]
+                    ]
+                }),
+                lexical: JSON.stringify({
+                    editorState: {
+                        root: {
+                            children: [
+                                {
+                                    children: [
+                                        {
+                                            detail: 0,
+                                            format: 0,
+                                            mode: 'normal',
+                                            style: '',
+                                            text: 'Testing post creation with lexical',
+                                            type: 'text',
+                                            version: 1
+                                        }
+                                    ],
+                                    direction: 'ltr',
+                                    format: '',
+                                    indent: 0,
+                                    type: 'paragraph',
+                                    version: 1
+                                }
+                            ],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            type: 'root',
+                            version: 1
+                        }
+                    },
+                    lastSaved: 1663081361393,
+                    source: 'Playground',
+                    version: '0.4.1'
+                })
+            };
+
+            await agent
+                .post('/posts/?formats=mobiledoc,lexical')
+                .body({posts: [post]})
+                .expectStatus(422)
+                .matchBodySnapshot({
+                    errors: [{
+                        id: anyErrorId
+                    }]
+                })
+                .matchHeaderSnapshot({
+                    etag: anyEtag
+                });
+        });
     });
 
     describe('Delete', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,10 +3178,10 @@
   resolved "https://registry.yarnpkg.com/@tryghost/adapter-base-cache/-/adapter-base-cache-0.1.2.tgz#5b923ffa8f06b2f7130965d1dd2f10563d57b618"
   integrity sha512-NrwPt431c3s8zdjZYaQd8MERcGy/8UYwkRRUGLhY+iGl439FTkl2V5dRhVyjQrcj12gxCs9WXjU9yzswn3y3Ng==
 
-"@tryghost/admin-api-schema@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-4.1.1.tgz#9165dce1c40a340fa446b5e9f08ee467f3c0e7f6"
-  integrity sha512-hRze5ZVWJCpcM848s2tz4z3wTMTGjUmDIBfoLzd01AYN9Q5/Ae1ZhqOWbcc+E2hpRXuBjY+bPa29joOTv9sOeg==
+"@tryghost/admin-api-schema@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/admin-api-schema/-/admin-api-schema-4.2.0.tgz#536b8016b75c64271f051753fbebc33aa59067e7"
+  integrity sha512-um+CTV9O+sss9Z+fdgLxfi93fdE2HDRjycO0cv2/piKx4RIXJxwHITw5rARpiUZDCKZNiBX5V2pyGZXI7Xwg5g==
   dependencies:
     "@tryghost/errors" "^1.0.0"
     ajv "^6.12.6"


### PR DESCRIPTION
no issue

- bumped `@tryghost/admin-api-schema` to allow passthrough of the `lexical` property on post and page API endpoints
- prevented saving of blank document in the `mobiledoc` field if `lexical` is provided
- prevented API input containing both `mobiledoc` and `lexical` fields to avoid issues when both are present:
  - not possible to know which content is latest/has precedence
  - not possible to know which editor should be displayed in Admin
