### PR TITLE
Added `email_track_clicks` setting

### DIFF
--- a/ghost/admin/app/components/settings/newsletters.hbs
+++ b/ghost/admin/app/components/settings/newsletters.hbs
@@ -162,6 +162,30 @@
                     </div>
                 </div>
             </div>
+
+            {{#if this.feature.emailClicks }}
+                <div class="gh-expandable-block">
+                    <div class="gh-expandable-header">
+                        <div>
+                            <h4 class="gh-expandable-title">Enable newsletter click tracking</h4>
+                            <p class="gh-expandable-description">Track how many members are clicking on links in your emails</p>
+                        </div>
+                        <div class="for-switch">
+                            <label class="switch" data-test-label="email-track-opens">
+                                <input
+                                    id="email-track-clicks"
+                                    type="checkbox"
+                                    checked={{this.settings.emailTrackClicks}}
+                                    class="gh-input"
+                                    {{on "change" this.toggleEmailTrackClicks}}
+                                    data-test-checkbox="email-track-clicks"
+                                >
+                                <span class="input-toggle-component mt1"></span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            {{/if}}
         </div>
     </section>
 {{/if}}

--- a/ghost/admin/app/components/settings/newsletters.js
+++ b/ghost/admin/app/components/settings/newsletters.js
@@ -9,6 +9,7 @@ const EU = {flag: '🇪🇺', name: 'EU', baseUrl: 'https://api.eu.mailgun.net/v
 export default class Newsletters extends Component {
     @service config;
     @service settings;
+    @service feature;
 
     // set recipientsSelectValue as a static property because within this
     // component's lifecycle it's not always derived from the settings values.
@@ -67,6 +68,14 @@ export default class Newsletters extends Component {
             event.preventDefault();
         }
         this.settings.set('emailTrackOpens', !this.settings.get('emailTrackOpens'));
+    }
+
+    @action
+    toggleEmailTrackClicks(event) {
+        if (event) {
+            event.preventDefault();
+        }
+        this.settings.set('emailTrackClicks', !this.settings.get('emailTrackClicks'));
     }
 
     @action

--- a/ghost/admin/app/models/setting.js
+++ b/ghost/admin/app/models/setting.js
@@ -43,6 +43,7 @@ export default Model.extend(ValidationEngine, {
     mailgunDomain: attr('string'),
     mailgunBaseUrl: attr('string'),
     emailTrackOpens: attr('boolean'),
+    emailTrackClicks: attr('boolean'),
     portalButton: attr('boolean'),
     portalName: attr('boolean'),
     portalPlans: attr('json-string'),

--- a/ghost/admin/mirage/fixtures/settings.js
+++ b/ghost/admin/mirage/fixtures/settings.js
@@ -86,6 +86,7 @@ export default [
     setting('email', 'mailgun_api_key', null),
     setting('email', 'mailgun_base_url', null),
     setting('email', 'email_track_opens', 'true'),
+    setting('email', 'email_track_clicks', 'true'),
     setting('email', 'email_verification_required', 'false'),
 
     // AMP

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -47,6 +47,7 @@ const EDITABLE_SETTINGS = [
     'mailgun_domain',
     'mailgun_base_url',
     'email_track_opens',
+    'email_track_clicks',
     'amp',
     'amp_gtag_id',
     'slack_url',

--- a/ghost/core/core/server/data/migrations/utils/settings.js
+++ b/ghost/core/core/server/data/migrations/utils/settings.js
@@ -32,9 +32,7 @@ function addSetting({key, value, type, group}) {
                     group,
                     type,
                     created_at: now,
-                    created_by: MIGRATION_USER,
-                    updated_at: now,
-                    updated_by: MIGRATION_USER
+                    created_by: MIGRATION_USER
                 });
         },
         async function down(connection) {

--- a/ghost/core/core/server/data/migrations/versions/5.15/2022-09-14-12-46-add-email-track-clicks-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.15/2022-09-14-12-46-add-email-track-clicks-setting.js
@@ -1,0 +1,59 @@
+const logging = require('@tryghost/logging');
+const ObjectId = require('bson-objectid').default;
+const {createTransactionalMigration} = require('../../utils');
+
+const {MIGRATION_USER} = require('../../utils/constants');
+const key = 'email_track_clicks';
+const cloneValueOf = 'email_track_opens';
+const defaultValue = 'true';
+const group = 'email';
+const type = 'boolean';
+
+// Note: we cannot use the addSetting helper here because we need to base the value on the current value of email_track_opens
+module.exports = createTransactionalMigration(
+    async function up(connection) {
+        const settingExists = await connection('settings')
+            .where('key', '=', key)
+            .first();
+        if (settingExists) {
+            logging.warn(`Skipping adding setting: ${key} - setting already exists`);
+            return;
+        }
+
+        // Value is based on the email_track_opens value
+        const reuseValueOfSetting = await connection('settings')
+            .where('key', '=', cloneValueOf)
+            .first();
+
+        logging.info(`Adding setting: ${key}`);
+        const now = connection.raw('CURRENT_TIMESTAMP');
+
+        return connection('settings')
+            .insert({
+                id: ObjectId().toHexString(),
+                key,
+                value: reuseValueOfSetting ? reuseValueOfSetting.value : defaultValue,
+                group,
+                type,
+                created_at: now,
+                created_by: MIGRATION_USER,
+                updated_at: now,
+                updated_by: MIGRATION_USER
+            });
+    },
+    async function down(connection) {
+        const settingExists = await connection('settings')
+            .where('key', '=', key)
+            .first();
+
+        if (!settingExists) {
+            logging.warn(`Skipping dropping setting: ${key} - setting does not exist`);
+            return;
+        }
+
+        logging.info(`Dropping setting: ${key}`);
+        return connection('settings')
+            .where('key', '=', key)
+            .del();
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/5.15/2022-09-14-12-46-add-email-track-clicks-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.15/2022-09-14-12-46-add-email-track-clicks-setting.js
@@ -1,59 +1,8 @@
-const logging = require('@tryghost/logging');
-const ObjectId = require('bson-objectid').default;
-const {createTransactionalMigration} = require('../../utils');
+const {addSetting} = require('../../utils');
 
-const {MIGRATION_USER} = require('../../utils/constants');
-const key = 'email_track_clicks';
-const cloneValueOf = 'email_track_opens';
-const defaultValue = 'true';
-const group = 'email';
-const type = 'boolean';
-
-// Note: we cannot use the addSetting helper here because we need to base the value on the current value of email_track_opens
-module.exports = createTransactionalMigration(
-    async function up(connection) {
-        const settingExists = await connection('settings')
-            .where('key', '=', key)
-            .first();
-        if (settingExists) {
-            logging.warn(`Skipping adding setting: ${key} - setting already exists`);
-            return;
-        }
-
-        // Value is based on the email_track_opens value
-        const reuseValueOfSetting = await connection('settings')
-            .where('key', '=', cloneValueOf)
-            .first();
-
-        logging.info(`Adding setting: ${key}`);
-        const now = connection.raw('CURRENT_TIMESTAMP');
-
-        return connection('settings')
-            .insert({
-                id: ObjectId().toHexString(),
-                key,
-                value: reuseValueOfSetting ? reuseValueOfSetting.value : defaultValue,
-                group,
-                type,
-                created_at: now,
-                created_by: MIGRATION_USER,
-                updated_at: now,
-                updated_by: MIGRATION_USER
-            });
-    },
-    async function down(connection) {
-        const settingExists = await connection('settings')
-            .where('key', '=', key)
-            .first();
-
-        if (!settingExists) {
-            logging.warn(`Skipping dropping setting: ${key} - setting does not exist`);
-            return;
-        }
-
-        logging.info(`Dropping setting: ${key}`);
-        return connection('settings')
-            .where('key', '=', key)
-            .del();
-    }
-);
+module.exports = addSetting({
+    key: 'email_track_clicks',
+    value: 'true',
+    type: 'boolean',
+    group: 'email'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -360,6 +360,14 @@
             },
             "type": "boolean"
         },
+        "email_track_clicks": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
+        },
         "email_verification_required": {
             "defaultValue": "false",
             "validations": {

--- a/ghost/core/core/server/services/link-replacement/index.js
+++ b/ghost/core/core/server/services/link-replacement/index.js
@@ -1,5 +1,3 @@
-const urlUtils = require('../../../shared/url-utils');
-
 class LinkReplacementServiceWrapper {
     init() {
         if (this.service) {
@@ -9,13 +7,16 @@ class LinkReplacementServiceWrapper {
 
         // Wire up all the dependencies
         const LinkReplacementService = require('@tryghost/link-replacement');
+        const urlUtils = require('../../../shared/url-utils');
+        const settingsCache = require('../../../shared/settings-cache');
 
         // Expose the service
         this.service = new LinkReplacementService({
             linkRedirectService: require('../link-redirection').service,
             linkClickTrackingService: require('../link-click-tracking').service,
             attributionService: require('../member-attribution').service,
-            urlUtils
+            urlUtils,
+            settingsCache
         });
     }
 }

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -336,8 +336,10 @@ const PostEmailSerializer = {
 
         // Also replace the links in the HTML version
         if (labs.isSet('emailClicks')) {
-            if ((!options.isBrowserPreview && !options.isTestEmail) || process.env.NODE_ENV === 'development') {
-                content.html = await linkReplacement.service.replaceLinks(content.html, newsletter, postModel);
+            if (settingsCache.get('email_track_clicks')) {
+                if ((!options.isBrowserPreview && !options.isTestEmail) || process.env.NODE_ENV === 'development') {
+                    content.html = await linkReplacement.service.replaceLinks(content.html, newsletter, postModel);
+                }
             }
         }
 

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -336,10 +336,8 @@ const PostEmailSerializer = {
 
         // Also replace the links in the HTML version
         if (labs.isSet('emailClicks')) {
-            if (settingsCache.get('email_track_clicks')) {
-                if ((!options.isBrowserPreview && !options.isTestEmail) || process.env.NODE_ENV === 'development') {
-                    content.html = await linkReplacement.service.replaceLinks(content.html, newsletter, postModel);
-                }
+            if ((!options.isBrowserPreview && !options.isTestEmail) || process.env.NODE_ENV === 'development') {
+                content.html = await linkReplacement.service.replaceLinks(content.html, newsletter, postModel);
             }
         }
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -209,6 +209,10 @@ Object {
       "value": true,
     },
     Object {
+      "key": "email_track_clicks",
+      "value": true,
+    },
+    Object {
       "key": "email_verification_required",
       "value": false,
     },
@@ -548,6 +552,10 @@ Object {
       "value": true,
     },
     Object {
+      "key": "email_track_clicks",
+      "value": true,
+    },
+    Object {
       "key": "email_verification_required",
       "value": false,
     },
@@ -619,7 +627,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3408",
+  "content-length": "3450",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",
@@ -834,6 +842,10 @@ Object {
     },
     Object {
       "key": "email_track_opens",
+      "value": true,
+    },
+    Object {
+      "key": "email_track_clicks",
       "value": true,
     },
     Object {
@@ -1122,6 +1134,10 @@ Object {
     },
     Object {
       "key": "email_track_opens",
+      "value": true,
+    },
+    Object {
+      "key": "email_track_clicks",
       "value": true,
     },
     Object {
@@ -1418,6 +1434,10 @@ Object {
       "value": true,
     },
     Object {
+      "key": "email_track_clicks",
+      "value": true,
+    },
+    Object {
       "key": "email_verification_required",
       "value": false,
     },
@@ -1703,6 +1723,10 @@ Object {
     },
     Object {
       "key": "email_track_opens",
+      "value": true,
+    },
+    Object {
+      "key": "email_track_clicks",
       "value": true,
     },
     Object {
@@ -2054,6 +2078,10 @@ Object {
     },
     Object {
       "key": "email_track_opens",
+      "value": true,
+    },
+    Object {
+      "key": "email_track_clicks",
       "value": true,
     },
     Object {

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -7,7 +7,7 @@ const {stringMatching, anyEtag, anyUuid, anyStringNumber} = matchers;
 const models = require('../../../core/server/models');
 const {anyErrorId} = matchers;
 
-const CURRENT_SETTINGS_COUNT = 67;
+const CURRENT_SETTINGS_COUNT = 68;
 
 const settingsMatcher = {};
 
@@ -27,9 +27,9 @@ const matchSettingsArray = (length) => {
         settingsArray[25] = publicHashSettingMatcher;
     }
 
-    if (length > 56) {
+    if (length > 57) {
         // Item at index 56 is the lab settings, which changes as we add and remove features
-        settingsArray[56] = labsSettingMatcher;
+        settingsArray[57] = labsSettingMatcher;
     }
 
     return settingsArray;

--- a/ghost/core/test/regression/models/model_settings.test.js
+++ b/ghost/core/test/regression/models/model_settings.test.js
@@ -5,7 +5,7 @@ const db = require('../../../core/server/data/db');
 // Stuff we are testing
 const models = require('../../../core/server/models');
 
-const SETTINGS_LENGTH = 77;
+const SETTINGS_LENGTH = 78;
 
 describe('Settings Model', function () {
     before(models.init);

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -234,7 +234,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 70;
+            const allowedKeysLength = 71;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '9cc4c1dae2237d960081d77aa4a528cc';
     const currentFixturesHash = '8cf221f0ed930ac1fe8030a58e60d64b';
-    const currentSettingsHash = 'd54210758b7054e2174fd34aa2320ad7';
+    const currentSettingsHash = '2978a5684a2d5fcf089f61f5d368a0c0';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -360,6 +360,14 @@
             },
             "type": "boolean"
         },
+        "email_track_clicks": {
+            "defaultValue": "true",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [["true", "false"]]
+            },
+            "type": "boolean"
+        },
         "email_verification_required": {
             "defaultValue": "false",
             "validations": {

--- a/ghost/link-replacement/lib/link-replacement.js
+++ b/ghost/link-replacement/lib/link-replacement.js
@@ -24,6 +24,11 @@
  * @prop {(...parts: string[]) => string} urlJoin
  */
 
+/**
+ * @typedef {object} SettingsCache
+ * @prop {(key: string) => any} get
+ */
+
 class LinkReplacementService {
     /** @type ILinkRedirectService */
     #linkRedirectService;
@@ -33,6 +38,8 @@ class LinkReplacementService {
     #attributionService;
     /** @type UrlUtils */
     #urlUtils;
+    /** @type SettingsCache */
+    #settingsCache;
 
     /**
      * @param {object} deps
@@ -40,12 +47,14 @@ class LinkReplacementService {
      * @param {ILinkClickTrackingService} deps.linkClickTrackingService
      * @param {IAttributionService} deps.attributionService
      * @param {UrlUtils} deps.urlUtils
+     * @param {SettingsCache} deps.settingsCache
      */
     constructor(deps) {
         this.#linkRedirectService = deps.linkRedirectService;
         this.#linkClickTrackingService = deps.linkClickTrackingService;
         this.#attributionService = deps.attributionService;
         this.#urlUtils = deps.urlUtils;
+        this.#settingsCache = deps.settingsCache;
     }
 
     /**
@@ -68,11 +77,12 @@ class LinkReplacementService {
     async replaceLink(url, newsletter, post) {
         // Can probably happen in one call to the MemberAttributionService (but just to make clear what happens here)
         const isSite = this.isSiteDomain(url);
+        const enableTracking = this.#settingsCache.get('email_track_clicks');
 
         // 1. Add attribution
         url = this.#attributionService.addEmailSourceAttributionTracking(url, newsletter);
 
-        if (isSite) {
+        if (isSite && enableTracking) {
             // Only add attribution links to our own site (except for the newsletter referrer)
             url = this.#attributionService.addPostAttributionTracking(url, post);
         }
@@ -81,7 +91,10 @@ class LinkReplacementService {
         const redirect = await this.#linkRedirectService.addRedirect(url);
 
         // 3. Add click tracking by members
-        if (isSite) {
+        // Note: we can always add the tracking params (even when isSite === false)
+        // because they are added to the redirect and not the destination URL
+
+        if (enableTracking) {
             return this.#linkClickTrackingService.addTrackingToRedirect(redirect, '--uuid--');
         }
 

--- a/ghost/link-replacement/lib/link-replacement.js
+++ b/ghost/link-replacement/lib/link-replacement.js
@@ -26,7 +26,7 @@
 
 /**
  * @typedef {object} SettingsCache
- * @prop {(key: string) => any} get
+ * @prop {(key: string, options?: any) => any} get
  */
 
 class LinkReplacementService {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1900
refs https://github.com/TryGhost/Team/issues/1901

- Defaults to the same value as the current email_track_opens setting for existing installations, otherwise defaults to true
- Had to use a custom migration because the `addSetting` helper doesn't support using an existing setting as current value
- Added a minimal UI to change the setting, but this still needs some design magic 🪄✨
- Link replacement is disabled if `email_track_clicks` is disabled. In the future we might consider to still do parial additions, such as source attribution and maybe redirects (to discuss).