### PR TITLE
Handled referrer attribution capture and storage

### DIFF
--- a/ghost/core/core/server/services/member-attribution/index.js
+++ b/ghost/core/core/server/services/member-attribution/index.js
@@ -9,20 +9,27 @@ class MemberAttributionServiceWrapper {
         }
 
         // Wire up all the dependencies
-        const {MemberAttributionService, UrlTranslator, AttributionBuilder} = require('@tryghost/member-attribution');
+        const {
+            MemberAttributionService, UrlTranslator, ReferrerTranslator, AttributionBuilder
+        } = require('@tryghost/member-attribution');
         const models = require('../../models');
 
         const urlTranslator = new UrlTranslator({
-            urlService, 
+            urlService,
             urlUtils,
             models: {
-                Post: models.Post, 
-                User: models.User, 
+                Post: models.Post,
+                User: models.User,
                 Tag: models.Tag
             }
         });
 
-        this.attributionBuilder = new AttributionBuilder({urlTranslator});
+        const referrerTranslator = new ReferrerTranslator({
+            siteUrl: urlUtils.urlFor('home', true),
+            adminUrl: urlUtils.urlFor('admin', true)
+        });
+
+        this.attributionBuilder = new AttributionBuilder({urlTranslator, referrerTranslator});
 
         // Expose the service
         this.service = new MemberAttributionService({

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -375,4 +375,30 @@ describe('Member Attribution Service', function () {
             });
         });
     });
+
+    /**
+     * Test that getAttribution correctly resolves all model types that are supported
+     */
+    describe('getAttribution for referrer', function () {
+        it('resolves urls', async function () {
+            const attribution = await memberAttributionService.service.getAttribution([
+                {
+                    id: null,
+                    path: '/',
+                    time: Date.now(),
+                    refSource: 'ghost-explore',
+                    refMedium: null,
+                    refUrl: null
+                }
+            ]);
+            attribution.should.match(({
+                id: null,
+                url: '/',
+                type: 'url',
+                refSource: 'Ghost Explore',
+                refMedium: 'Ghost Network',
+                refUrl: null
+            }));
+        });
+    });
 });

--- a/ghost/member-attribution/index.js
+++ b/ghost/member-attribution/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     MemberAttributionService: require('./lib/service'),
     AttributionBuilder: require('./lib/attribution'),
-    UrlTranslator: require('./lib/url-translator')
+    UrlTranslator: require('./lib/url-translator'),
+    ReferrerTranslator: require('./lib/referrer-translator')
 };

--- a/ghost/member-attribution/lib/history.js
+++ b/ghost/member-attribution/lib/history.js
@@ -3,6 +3,9 @@
  * @prop {string} [path]
  * @prop {string} [id]
  * @prop {string} [type]
+ * @prop {string} [refSource]
+ * @prop {string} [refMedium]
+ * @prop {string} [refUrl]
  * @prop {number} time
  */
 

--- a/ghost/member-attribution/lib/referrer-translator.js
+++ b/ghost/member-attribution/lib/referrer-translator.js
@@ -1,0 +1,183 @@
+/**
+ * @typedef {Object} ReferrerData
+ * @prop {string|null} [refSource]
+ * @prop {string|null} [refMedium]
+ * @prop {URL|null} [refUrl]
+ */
+
+/**
+ * Translates referrer info into Source and Medium
+ */
+class ReferrerTranslator {
+    /**
+     *
+     * @param {Object} deps
+     * @param {string} deps.siteUrl
+     * @param {string} deps.adminUrl
+     */
+    constructor({adminUrl, siteUrl}) {
+        this.adminUrl = this.getUrlFromStr(adminUrl);
+        this.siteUrl = this.getUrlFromStr(siteUrl);
+    }
+
+    /**
+     * Calculate referrer details from history
+     * @param {import('./history').UrlHistoryArray} history
+     * @returns {ReferrerData|null}
+     */
+    getReferrerDetails(history) {
+        if (history.length === 0) {
+            return null;
+        }
+
+        for (const item of history) {
+            const refUrl = this.getUrlFromStr(item.refUrl);
+            const refSource = item.refSource;
+            const refMedium = item.refMedium;
+
+            // If referrer is Ghost Explore
+            if (this.isGhostExploreRef({refUrl, refSource})) {
+                return {
+                    refSource: 'Ghost Explore',
+                    refMedium: 'Ghost Network',
+                    refUrl: refUrl
+                };
+            }
+
+            // If referrer is Ghost.org
+            if (this.isGhostOrgUrl(refUrl)) {
+                return {
+                    refSource: 'Ghost.org',
+                    refMedium: 'Ghost Network',
+                    refUrl: refUrl
+                };
+            }
+
+            // If referrer is Ghost Newsletter
+            if (this.isGhostNewsletter({refSource})) {
+                return {
+                    refSource: refSource.replace(/-/g, ' '),
+                    refMedium: 'Email',
+                    refUrl: refUrl
+                };
+            }
+
+            // If referrer is from query params
+            if (refSource) {
+                const urlData = this.getDataFromUrl() || {};
+                return {
+                    refSource: refSource,
+                    refMedium: refMedium || urlData?.medium || null,
+                    refUrl: refUrl
+                };
+            }
+
+            // If referrer is known external URL
+            // TODO: Use list of known external urls to fetch source/medium
+            if (refUrl && !this.isSiteDomain(refUrl)) {
+                const urlData = this.getDataFromUrl();
+
+                if (urlData) {
+                    return {
+                        refSource: urlData?.source,
+                        refMedium: urlData?.medium,
+                        refUrl: refUrl
+                    };
+                }
+            }
+        }
+
+        return null;
+    }
+
+    // Fetches referrer data from known external URLs
+    //TODO: Use list of known external urls to fetch source/medium
+    getDataFromUrl() {
+        return null;
+    }
+
+    /**
+     * @private
+     * Return URL object for provided URL string
+     * @param {string} url
+     * @returns {URL|null}
+     */
+    getUrlFromStr(url) {
+        try {
+            return new URL(url);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    /**
+     * @private
+     * Return whether the provided URL is a link to the site
+     * @param {URL} url
+     * @returns {boolean}
+     */
+    isSiteDomain(url) {
+        try {
+            if (this.siteUrl && this.siteUrl?.hostname === url?.hostname) {
+                if (url?.pathname?.startsWith(this.siteUrl?.pathname)) {
+                    return true;
+                }
+                return false;
+            }
+            return false;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    /**
+     * @private
+     * Return whether provided ref is a Ghost newsletter
+     * @param {Object} deps
+     * @param {string|null} deps.refSource
+     * @returns {boolean}
+     */
+    isGhostNewsletter({refSource}) {
+        // if refferer source ends with -newsletter
+        return refSource?.endsWith('-newsletter');
+    }
+
+    /**
+     * @private
+     * Return whether provided ref is a Ghost.org URL
+     * @param {URL|null} refUrl
+     * @returns {boolean}
+     */
+    isGhostOrgUrl(refUrl) {
+        return refUrl?.hostname === 'ghost.org';
+    }
+
+    /**
+     * @private
+     * Return whether provided ref is Ghost Explore
+     * @param {Object} deps
+     * @param {URL|null} deps.refUrl
+     * @param {string|null} deps.refSource
+     * @returns {boolean}
+     */
+    isGhostExploreRef({refUrl, refSource}) {
+        if (refSource === 'ghost-explore') {
+            return true;
+        }
+
+        if (refUrl?.hostname
+            && this.adminUrl?.hostname === refUrl?.hostname
+            && refUrl?.pathname?.startsWith(this.adminUrl?.pathname)
+        ) {
+            return true;
+        }
+
+        if (refUrl?.hostname === 'ghost.org' && refUrl?.pathname?.startsWith('/explore')) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+module.exports = ReferrerTranslator;

--- a/ghost/member-attribution/test/history.test.js
+++ b/ghost/member-attribution/test/history.test.js
@@ -77,6 +77,14 @@ describe('UrlHistory', function () {
                 time: Date.now(),
                 type: 'post',
                 id: '123'
+            }],
+            [{
+                time: Date.now(),
+                type: 'post',
+                id: '123',
+                refSource: 'ghost-explore',
+                refMedium: null,
+                refUrl: 'https://ghost.org'
             }]
         ];
         for (const input of inputs) {

--- a/ghost/member-attribution/test/referrer-translator.test.js
+++ b/ghost/member-attribution/test/referrer-translator.test.js
@@ -1,0 +1,180 @@
+// Switch these lines once there are useful utils
+// const testUtils = require('./utils');
+require('./utils');
+const ReferrerTranslator = require('../lib/referrer-translator');
+
+describe('ReferrerTranslator', function () {
+    describe('Constructor', function () {
+        it('doesn\'t throw', function () {
+            new ReferrerTranslator({});
+        });
+    });
+
+    describe('getReferrerDetails', function () {
+        let translator;
+        before(function () {
+            translator = new ReferrerTranslator({
+                siteUrl: 'https://example.com',
+                adminUrl: 'https://admin.example.com/ghost'
+            });
+        });
+
+        it('returns ghost explore from source ref for valid history', async function () {
+            should(translator.getReferrerDetails([
+                {
+                    refSource: 'ghost-explore',
+                    refMedium: null,
+                    refUrl: null
+                },
+                {
+                    refSource: 'ghost-newsletter',
+                    refMedium: null,
+                    refUrl: null
+                },
+                {
+                    refSource: 'ghost-newsletter',
+                    refMedium: null,
+                    refUrl: 'https://t.co'
+                }
+            ])).eql({
+                refSource: 'Ghost Explore',
+                refMedium: 'Ghost Network',
+                refUrl: null
+            });
+        });
+
+        it('returns ghost explore from url for valid history', async function () {
+            should(translator.getReferrerDetails([
+                {
+                    refSource: null,
+                    refMedium: null,
+                    refUrl: 'https://ghost.org/explore'
+                },
+                {
+                    refSource: 'ghost-newsletter',
+                    refMedium: null,
+                    refUrl: null
+                },
+                {
+                    refSource: 'ghost-newsletter',
+                    refMedium: null,
+                    refUrl: 'https://t.co'
+                }
+            ])).eql({
+                refSource: 'Ghost Explore',
+                refMedium: 'Ghost Network',
+                refUrl: new URL('https://ghost.org/explore')
+            });
+        });
+
+        it('returns ghost explore from admin url for valid history', async function () {
+            should(translator.getReferrerDetails([
+                {
+                    refSource: null,
+                    refMedium: null,
+                    refUrl: 'https://admin.example.com/ghost/#/dashboard'
+                },
+                {
+                    refSource: 'ghost-newsletter',
+                    refMedium: null,
+                    refUrl: null
+                },
+                {
+                    refSource: 'ghost-newsletter',
+                    refMedium: null,
+                    refUrl: 'https://t.co'
+                }
+            ])).eql({
+                refSource: 'Ghost Explore',
+                refMedium: 'Ghost Network',
+                refUrl: new URL('https://admin.example.com/ghost/#/dashboard')
+            });
+        });
+
+        it('returns ghost newsletter ref for valid history', async function () {
+            should(translator.getReferrerDetails([
+                {
+                    refSource: 'publisher-weekly-newsletter',
+                    refMedium: null,
+                    refUrl: null
+                },
+                {
+                    refSource: 'ghost-explore',
+                    refMedium: null,
+                    refUrl: null
+                },
+                {
+                    refSource: 'ghost-newsletter',
+                    refMedium: null,
+                    refUrl: 'https://t.co'
+                }
+            ])).eql({
+                refSource: 'publisher weekly newsletter',
+                refMedium: 'Email',
+                refUrl: null
+            });
+        });
+
+        it('returns ghost.org ref for valid history', async function () {
+            should(translator.getReferrerDetails([
+                {
+                    refSource: null,
+                    refMedium: null,
+                    refUrl: 'https://ghost.org/creators/'
+                },
+                {
+                    refSource: 'publisher-weekly-newsletter',
+                    refMedium: null,
+                    refUrl: null
+                },
+                {
+                    refSource: 'ghost-explore',
+                    refMedium: null,
+                    refUrl: null
+                }
+            ])).eql({
+                refSource: 'Ghost.org',
+                refMedium: 'Ghost Network',
+                refUrl: new URL('https://ghost.org/creators/')
+            });
+        });
+
+        it('returns ref source for valid history', async function () {
+            should(translator.getReferrerDetails([
+                {
+                    refSource: 'twitter',
+                    refMedium: null,
+                    refUrl: null
+                },
+                {
+                    refSource: 'publisher-weekly-newsletter',
+                    refMedium: null,
+                    refUrl: null
+                },
+                {
+                    refSource: 'ghost-explore',
+                    refMedium: null,
+                    refUrl: null
+                }
+            ])).eql({
+                refSource: 'twitter',
+                refMedium: null,
+                refUrl: null
+            });
+        });
+
+        it('returns null for empty history', async function () {
+            should(translator.getReferrerDetails([])).eql(null);
+        });
+
+        it('returns null for history with only site url', async function () {
+            should(translator.getReferrerDetails([
+                {
+                    refSource: null,
+                    refMedium: null,
+                    refUrl: 'https://example.com'
+                }
+            ])).eql(null);
+        });
+    });
+});

--- a/ghost/members-api/lib/controllers/router.js
+++ b/ghost/members-api/lib/controllers/router.js
@@ -226,6 +226,18 @@ module.exports = class RouterController {
             if (attribution.type) {
                 metadata.attribution_type = attribution.type;
             }
+
+            if (attribution.refSource) {
+                metadata.attribution_ref_source = attribution.refSource;
+            }
+
+            if (attribution.refMedium) {
+                metadata.attribution_ref_medium = attribution.refMedium;
+            }
+
+            if (attribution.refUrl) {
+                metadata.attribution_ref_url = attribution.refUrl;
+            }
         }
 
         if (!ghostPriceId) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1906, https://github.com/TryGhost/Team/issues/1907

- updates member attribution script to capture referrer url/source/medium information and store it in the history for later usage
  - stores `refUrl`, `refSource` and `refMedium` in history
- updates attribution service to use referrer data from history, and translate it to referrer source and medium using `ReferrerTranslator`
- includes referrer source/medium/url to stripe checkout metadata, allowing storing it in event later when a member completes payment