### PR TITLE
Added link tracking to paywall

### DIFF
--- a/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
+++ b/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
@@ -173,10 +173,8 @@ module.exports = {
             // Load newsletter data on email
             await emailBatchModel.relations.email.getLazyRelation('newsletter', {require: false, ...knexOptions});
 
-            if (labs.isSet('newsletterPaywall')) {
-                // Load post data on email - for content gating on paywall
-                await emailBatchModel.relations.email.getLazyRelation('post', {require: false, ...knexOptions});
-            }
+            // Load post data on email - for content gating on paywall
+            await emailBatchModel.relations.email.getLazyRelation('post', {require: false, ...knexOptions});
 
             // send the email
             const sendResponse = await this.send(emailBatchModel.relations.email.toJSON(), recipientRows, memberSegment);

--- a/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
+++ b/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
@@ -7,7 +7,6 @@ const logging = require('@tryghost/logging');
 const models = require('../../models');
 const MailgunClient = require('@tryghost/mailgun-client');
 const sentry = require('../../../shared/sentry');
-const labs = require('../../../shared/labs');
 const debug = require('@tryghost/debug')('mega');
 const postEmailSerializer = require('../mega/post-email-serializer');
 const configService = require('../../../shared/config');

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -329,28 +329,49 @@ const PostEmailSerializer = {
         let htmlTemplate = render({post, site: this.getSite(), templateSettings, newsletter: newsletter.toJSON()});
 
         // The plaintext version that is returned here is actually never really used for sending because we'll use htmlToPlaintext again later
-        let content = {
+        let result = {
             html: this.formatHtmlForEmail(htmlTemplate),
             plaintext: post.plaintext
         };
 
-        // Also replace the links in the HTML version
+        /** 
+         *  If a part of the email is for members only, already add a paywall.
+         *  Just before sending the email, we'll hide the paywall or paid content depending on the member segment it is sent to.
+         *  But we need to add the paywall to the email here because we need to do link replacements on the HTML already.
+         *  We cannot do link replacement later for each email batch and member segment because links should only be created once for tracking metrics.
+        */
+        // TODO: never add paywall if target is only to paid members (because then we'll have ghost links)
+        const recipientsIncludeFreeMembers = true; 
+
+        const paywallIndex = (result.html || '').indexOf('<!--members-only-->');
+        if (paywallIndex !== -1 && recipientsIncludeFreeMembers) {
+            const postContentEndIdx = result.html.search(/[\s\n\r]+?<!-- POST CONTENT END -->/);
+
+            if (postContentEndIdx !== -1) {
+                const paywallHTML = '<!-- PAYWALL -->' + this.renderPaywallCTA(post);
+
+                // Append it just before the end of the post content
+                result.html = result.html.slice(0, postContentEndIdx) + paywallHTML + result.html.slice(postContentEndIdx);
+            }
+        }
+
+        // Now replace the links in the HTML version
         if (labs.isSet('emailClicks')) {
             if ((!options.isBrowserPreview && !options.isTestEmail) || process.env.NODE_ENV === 'development') {
-                content.html = await linkReplacement.service.replaceLinks(content.html, newsletter, postModel);
+                result.html = await linkReplacement.service.replaceLinks(result.html, newsletter, postModel);
             }
         }
 
         // Clean up any unknown replacements strings to get our final content
-        const {html, plaintext} = this.normalizeReplacementStrings(content);
+        const {html, plaintext} = this.normalizeReplacementStrings(result);
         const data = {
             subject: post.email_subject || post.title,
             html,
             plaintext
         };
-        if (labs.isSet('newsletterPaywall')) {
-            data.post = post;
-        }
+
+        // Add post for checking access in renderEmailForSegment (only for previews)
+        data.post = post;
         return data;
     },
 
@@ -400,26 +421,36 @@ const PostEmailSerializer = {
 
         const result = {...email};
 
-        /** Checks and hides content for newsletter behind paywall card
-         *  based on member's status and post access
-         *  Adds CTA in case content is hidden.
-        */
-        if (labs.isSet('newsletterPaywall')) {
-            const paywallIndex = (result.html || '').indexOf('<!--members-only-->');
-            if (paywallIndex !== -1 && memberSegment && result.post) {
+        // Note about link tracking:
+        // Don't add new HTML in here, but add it in the serialize method and surround it with the required comments or attributes
+        // This is because we can't replace links at this point (this is executed multiple times, once per batch and we don't want to generate duplicate links for the same email)
+
+        // Check if we need to hide the paywall or the members-only content (both should be present)
+        const startMembersOnlyContent = (result.html || '').indexOf('<!--members-only-->');
+
+        if (startMembersOnlyContent !== -1) {
+            // By default remove the paywall if no memberSegment is passed
+            let memberHasAccess = true;
+
+            if (memberSegment && result.post) {
                 let statusFilter = memberSegment === 'status:free' ? {status: 'free'} : {status: 'paid'};
                 const postVisiblity = result.post.visibility;
 
                 // For newsletter paywall, specific tiers visibility is considered on par to paid tiers
                 result.post.visibility = postVisiblity === 'tiers' ? 'paid' : postVisiblity;
 
-                const memberHasAccess = membersService.contentGating.checkPostAccess(result.post, statusFilter);
+                memberHasAccess = membersService.contentGating.checkPostAccess(result.post, statusFilter);
+            }
 
-                if (!memberHasAccess) {
-                    const postContentEndIdx = result.html.search(/[\s\n\r]+?<!-- POST CONTENT END -->/);
-                    result.html = result.html.slice(0, paywallIndex) + this.renderPaywallCTA(result.post) + result.html.slice(postContentEndIdx);
-                    result.plaintext = htmlToPlaintext.excerpt(result.html);
-                }
+            const startPaywall = result.html.indexOf('<!-- PAYWALL -->');
+            const endPost = result.html.search(/[\s\n\r]+?<!-- POST CONTENT END -->/);
+
+            if (!memberHasAccess) {
+                // Remove the members-only content, but keep the paywall (if there is a paywall)
+                result.html = result.html.slice(0, startMembersOnlyContent) + result.html.slice(startPaywall === -1 ? endPost : startPaywall);
+            } else {
+                // Remove the paywall
+                result.html = result.html.slice(0, startPaywall) + result.html.slice(endPost);
             }
         }
 
@@ -435,7 +466,7 @@ const PostEmailSerializer = {
         });
 
         result.html = this.formatHtmlForEmail($.html());
-        result.plaintext = htmlToPlaintext.email(result.html);
+        result.plaintext = htmlToPlaintext.email(result.html); 
         delete result.post;
 
         return result;

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -421,13 +421,13 @@ const PostEmailSerializer = {
         const result = {...email};
 
         // Note about link tracking:
-        // Don't add new HTML in here, but add it in the serialize method and surround it with the required comments or attributes
+        // Don't add new HTML in here, but add it in the serialize method and surround it with the required HTML comments or attributes
         // This is because we can't replace links at this point (this is executed multiple times, once per batch and we don't want to generate duplicate links for the same email)
 
-        // Check if we need to hide the paywall or the members-only content (both should be present)
+        // Remove the paywall or members-only content based on the current member segment
         const startMembersOnlyContent = (result.html || '').indexOf('<!--members-only-->');
         const startPaywall = result.html.indexOf('<!-- PAYWALL -->');
-        let endPost = result.html.search(/[\s\n\r]*<!-- POST CONTENT END -->/);
+        let endPost = result.html.indexOf('<!-- POST CONTENT END -->');
 
         if (endPost === -1) {
             // Default to the end of the HTML (shouldn't happen, but just in case if we have members-only content that should get removed)


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1908

### Problem:
- We need tracking on the paywall links in each email. (we cannot ignore them because those buttons are probably gonna have a higher paid conversion attribution than others).
- Currently we only add the paywall HTML to an email when processing each batch. So if we batch an email to 1.000 recipients per 100, we'll generate the paywall HTML 10 times. 
- We cannot replace links in `renderEmailForSegment` because that methods will get called multiple times. We don't want to have multiple redirect instances created for the same link in the same email.

###  Solution:
- Move the generation of the paywall to the `serialize` method of the post email serializer.
- Surround the generated paywall with HTML-comments so we can remove it if required in `renderEmailForSegment` depending on the member segment we are sending the email to.

---

### Before:

**Serialize output:**
```html
<html>
    <body>
        <h1>Generated email header</h1>
        <p>Generated text</p>

        <div>
            <!-- POST CONTENT START -->
                <h1>Post title</h1>
                <p>Content visible for all members</p>
            <!--members-only-->
                <p>Content visible for paid members only</p>
            <!-- POST CONTENT END -->
        </div>
    </body>
</html>
```

To be modified later by  `renderEmailForSegment`:

**Paid members (nothing changed):**
```html
<html>
    <body>
        <h1>Generated email header</h1>
        <p>Generated text</p>

        <div>
            <!-- POST CONTENT START -->
                <h1>Post title</h1>
                <p>Content visible for all members</p>
            <!--members-only-->
                <p>Content visible for paid members only</p>
            <!-- POST CONTENT END -->
        </div>
    </body>
</html>
```

**Free members (paywall _added_):**
```html
<html>
    <body>
        <h1>Generated email header</h1>
        <p>Generated text</p>

        <div>
            <!-- POST CONTENT START -->
                <h1>Post title</h1>
                <p>Content visible for all members</p>
                <h2>Generated paywall here</h2>
                <a href="https://subscribe.com">Subscribe to read the full post</a>
            <!-- POST CONTENT END -->
        </div>
    </body>
</html>
```

### After this change:

**Serialize output:**
```html
<html>
    <body>
        <h1>Generated email header</h1>
        <p>Generated text</p>

        <div>
            <!-- POST CONTENT START -->
                <h1>Post title</h1>
                <p>Content visible for all members</p>
            <!--members-only-->
                <p>Content visible for paid members only</p>
             <!-- PAYWALL -->
                <h2>Generated paywall here</h2>
                <a href="https://subscribe.com/?tracked">Subscribe to read the full post</a>
            <!-- POST CONTENT END -->
        </div>
    </body>
</html>
```

To be modified later by  `renderEmailForSegment`:

**Paid members (paywall removed):**
```html
<html>
    <body>
        <h1>Generated email header</h1>
        <p>Generated text</p>

        <div>
            <!-- POST CONTENT START -->
                <h1>Post title</h1>
                <p>Content visible for all members</p>
            <!--members-only-->
                <p>Content visible for paid members only</p>
            <!-- POST CONTENT END -->
        </div>
    </body>
</html>
```

**Free members (members-only content removed):**
```html
<html>
    <body>
        <h1>Generated email header</h1>
        <p>Generated text</p>

        <div>
            <!-- POST CONTENT START -->
                <h1>Post title</h1>
                <p>Content visible for all members</p>
            <!-- PAYWALL -->
                <h2>Generated paywall here</h2>
                <a href="https://subscribe.com/?tracked">Subscribe to read the full post</a>
            <!-- POST CONTENT END -->
        </div>
    </body>
</html>
```