### PR TITLE
🐛 Fixed feature image caption escaped twice in newsletters

### DIFF
--- a/ghost/core/core/server/services/mega/template.js
+++ b/ghost/core/core/server/services/mega/template.js
@@ -26,7 +26,7 @@ const sanitizeKeys = (obj, keys) => {
 module.exports = ({post, site, newsletter, templateSettings}) => {
     const date = new Date();
     const hasFeatureImageCaption = templateSettings.showFeatureImage && post.feature_image && post.feature_image_caption;
-    const cleanPost = sanitizeKeys(post, ['url', 'published_at', 'title', 'excerpt', 'authors', 'feature_image', 'feature_image_alt', 'feature_image_caption']);
+    const cleanPost = sanitizeKeys(post, ['url', 'published_at', 'title', 'excerpt', 'authors', 'feature_image', 'feature_image_alt']);
     const cleanSite = sanitizeKeys(site, ['title']);
     const cleanNewsletter = sanitizeKeys(newsletter, ['name']);
 

--- a/ghost/core/test/unit/server/services/mega/post-email-serializer.test.js
+++ b/ghost/core/test/unit/server/services/mega/post-email-serializer.test.js
@@ -51,7 +51,7 @@ describe('Post Email Serializer', function () {
                     excerpt: 'This is a blog post test <3</body>',
                     authors: 'This is a blog post test <3</body>',
                     feature_image_alt: 'This is a blog post test <3</body>',
-                    feature_image_caption: 'This is a blog post test <3</body>',
+                    feature_image_caption: 'This is escaped in the frontend',
 
                     // This is a markdown post with all cards that contain <3 in all fields + </body> tags
                     // Note that some fields are already escaped in the frontend

--- a/ghost/core/test/unit/server/services/mega/template.test.js
+++ b/ghost/core/test/unit/server/services/mega/template.test.js
@@ -125,7 +125,7 @@ describe('Mega template', function () {
             html: '<div class="post-content-html">I am &lt;100 years old</div>',
             feature_image: 'https://example.com/image.jpg',
             feature_image_alt: 'I <3 alt text',
-            feature_image_caption: 'I <3 images'
+            feature_image_caption: 'I &lt;3 images' // escaped in frontend
         };
         const site = {
             iconUrl: 'site icon url',


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1909

- The feature image caption is already escaped on the frontend
- Doing it again in the backend breaks the possibility to add links to the caption
- I checked and the `feature_image_alt` is not escaped in the frontend. 