### PR TITLE
Added `post_revisions` table

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -21,7 +21,7 @@ const BACKUP_TABLES = [
     'tokens',
     'sessions',
     'mobiledoc_revisions',
-    'lexical_revisions',
+    'post_revisions',
     'email_batches',
     'email_recipients',
     'members_cancel_events',

--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -21,6 +21,7 @@ const BACKUP_TABLES = [
     'tokens',
     'sessions',
     'mobiledoc_revisions',
+    'lexical_revisions',
     'email_batches',
     'email_recipients',
     'members_cancel_events',

--- a/ghost/core/core/server/data/migrations/versions/5.15/2022-09-16-08-22-add-post-revisions-table.js
+++ b/ghost/core/core/server/data/migrations/versions/5.15/2022-09-16-08-22-add-post-revisions-table.js
@@ -1,0 +1,9 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('post_revisions', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    post_id: {type: 'string', maxlength: 24, nullable: false, index: true},
+    lexical: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+    created_at_ts: {type: 'bigInteger', nullable: false},
+    created_at: {type: 'dateTime', nullable: false}
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -387,6 +387,13 @@ module.exports = {
         created_at_ts: {type: 'bigInteger', nullable: false},
         created_at: {type: 'dateTime', nullable: false}
     },
+    post_revisions: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        post_id: {type: 'string', maxlength: 24, nullable: false, index: true},
+        lexical: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+        created_at_ts: {type: 'bigInteger', nullable: false},
+        created_at: {type: 'dateTime', nullable: false}
+    },
     members: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         uuid: {type: 'string', maxlength: 36, nullable: true, unique: true, validations: {isUUID: true}},

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -61,6 +61,7 @@ describe('Exporter', function () {
                 'permissions',
                 'permissions_roles',
                 'permissions_users',
+                'post_revisions',
                 'posts',
                 'posts_authors',
                 'posts_meta',

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '9cc4c1dae2237d960081d77aa4a528cc';
+    const currentSchemaHash = 'cd7c94ce33c1e22b05335f05ab4fd86c';
     const currentFixturesHash = '8cf221f0ed930ac1fe8030a58e60d64b';
     const currentSettingsHash = '2978a5684a2d5fcf089f61f5d368a0c0';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
no issue

- initially this will perform the same function as `mobiledoc_revisions` but storing `lexical` instead of `mobiledoc`
- naming is intentionally generic ready for later expansions
