### PR TITLE
Wired up link-replacement to store links against posts in the DB

### DIFF
--- a/ghost/core/core/server/services/link-replacement/index.js
+++ b/ghost/core/core/server/services/link-replacement/index.js
@@ -10,13 +10,20 @@ class LinkReplacementServiceWrapper {
         const urlUtils = require('../../../shared/url-utils');
         const settingsCache = require('../../../shared/settings-cache');
 
+        const store = [];
+
         // Expose the service
         this.service = new LinkReplacementService({
             linkRedirectService: require('../link-redirection').service,
             linkClickTrackingService: require('../link-click-tracking').service,
             attributionService: require('../member-attribution').service,
             urlUtils,
-            settingsCache
+            settingsCache,
+            postLinkRepository: {
+                async save(postLink) {
+                    store.push(postLink);
+                }
+            }
         });
     }
 }

--- a/ghost/link-replacement/lib/PostLink.js
+++ b/ghost/link-replacement/lib/PostLink.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {import('bson-objectid').default} ObjectID
+ */
+
+class PostLink {
+    /** @type {ObjectID} */
+    post_id;
+    /** @type {ObjectID} */
+    link_id;
+
+    /**
+     * @param {object} data
+     * @param {ObjectID} data.post_id
+     * @param {ObjectID} data.link_id
+     */
+    constructor(data) {
+        this.post_id = data.post_id;
+        this.link_id = data.link_id;
+    }
+}
+
+module.exports = PostLink;

--- a/ghost/link-replacement/test/link-replacement.test.js
+++ b/ghost/link-replacement/test/link-replacement.test.js
@@ -81,6 +81,11 @@ describe('LinkReplacementService', function () {
             },
             settingsCache: {
                 get: () => true
+            },
+            postLinkRepository: {
+                save: () => {
+                    return Promise.resolve();
+                }
             }
         });
 
@@ -106,6 +111,11 @@ describe('LinkReplacementService', function () {
             },
             settingsCache: {
                 get: () => false
+            },
+            postLinkRepository: {
+                save: () => {
+                    return Promise.resolve();
+                }
             }
         });
 
@@ -121,19 +131,19 @@ describe('LinkReplacementService', function () {
 
         describe('replaceLink', function () {
             it('returns the redirected URL with uuid', async function () {
-                const replaced = await service.replaceLink(new URL('http://localhost:2368/dir/path'), {}, {id: 'post_id'});
+                const replaced = await service.replaceLink(new URL('http://localhost:2368/dir/path'), {}, {id: '6006c9208d4c560039f1d0ff'});
                 assert.equal(replaced.toString(), 'https://redirected.service/r/ro0sdD92?m=--uuid--');
-                assert(redirectSpy.calledOnceWithExactly(new URL('http://localhost:2368/dir/path?rel=newsletter&attribution_id=post_id'), 'slug'));
+                assert(redirectSpy.calledOnceWithExactly(new URL('http://localhost:2368/dir/path?rel=newsletter&attribution_id=6006c9208d4c560039f1d0ff'), 'slug'));
             });
 
             it('does not add attribution for external sites', async function () {
-                const replaced = await service.replaceLink(new URL('http://external.domain/dir/path'), {}, {id: 'post_id'});
+                const replaced = await service.replaceLink(new URL('http://external.domain/dir/path'), {}, {id: '6006c9208d4c560039f1d0ff'});
                 assert.equal(replaced.toString(), 'https://redirected.service/r/ro0sdD92?m=--uuid--');
                 assert(redirectSpy.calledOnceWithExactly(new URL('http://external.domain/dir/path?rel=newsletter'), 'slug'));
             });
 
             it('does not add attribution or member tracking if click tracking is disabled', async function () {
-                const replaced = await disabledService.replaceLink(new URL('http://external.domain/dir/path'), {}, {id: 'post_id'});
+                const replaced = await disabledService.replaceLink(new URL('http://external.domain/dir/path'), {}, {id: '6006c9208d4c560039f1d0ff'});
                 assert.equal(replaced.toString(), 'https://redirected.service/r/ro0sdD92');
                 assert(redirectSpy.calledOnceWithExactly(new URL('http://external.domain/dir/path?rel=newsletter'), 'slug'));
             });
@@ -144,7 +154,7 @@ describe('LinkReplacementService', function () {
                 const html = '<a href="http://localhost:2368/dir/path">link</a>';
                 const expected = '<a href="https://redirected.service/r/ro0sdD92?m=%%{uuid}%%">link</a>';
 
-                const replaced = await service.replaceLinks(html, {}, {id: 'post_id'});
+                const replaced = await service.replaceLinks(html, {}, {id: '6006c9208d4c560039f1d0ff'});
                 assert.equal(replaced, expected);
             });
 
@@ -152,7 +162,7 @@ describe('LinkReplacementService', function () {
                 const html = '<a href="%%{unsubscribe_url}%%">link</a>';
                 const expected = '<a href="%%{unsubscribe_url}%%">link</a>';
 
-                const replaced = await service.replaceLinks(html, {}, {id: 'post_id'});
+                const replaced = await service.replaceLinks(html, {}, {id: '6006c9208d4c560039f1d0ff'});
                 assert.equal(replaced, expected);
             });
         });


### PR DESCRIPTION
https://github.com/TryGhost/Team/issues/1916

This uses an in-memory store for now which is essentially a noop because we're not doing anything with the data. It should be simple enough to update the repository implementation with the real DB models once they've been created & merged.