### PR TITLE
Added member labels to template options

### DIFF
--- a/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
+++ b/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
@@ -33,6 +33,7 @@ function updateLocalTemplateOptions(req, res, next) {
                 default_payment_card_last4: sub.default_payment_card_last4 || '****'
             });
         }),
+        labels: req.member.labels,
         paid: req.member.status !== 'free',
         status: req.member.status
     } : null;


### PR DESCRIPTION
Being able to access a member's labels from the theme template allows customizing the user experience based on the type of member.

Trivial example:

```
{{#foreach @member.labels}}
    {{#match name "=" "vip"}}
        Thanks for being a VIP!
    {{/match}}
{{/foreach}}
```

I think there are many potential use cases that would be enabled by allowing labels to be used like this. For example, you could build a simple tier-like system (separate to the existing Stripe tier system) that hides certain post's content based on a member's tier label.

If we're happy exposing labels to theme templates, a useful next step could be adding label support to the `has` handlebars helper to make it easier to query whether or not a member has a given label.