### PR TITLE
Added `__GHOST_URL__` transform support to `posts.lexical` field

### DIFF
--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -130,6 +130,7 @@ Post = ghostBookshelf.Model.extend({
         // transform URLs from __GHOST_URL__ to absolute
         [
             'mobiledoc',
+            'lexical',
             'html',
             'plaintext',
             'custom_excerpt',
@@ -158,6 +159,7 @@ Post = ghostBookshelf.Model.extend({
                     cardTransformers: mobiledocLib.cards
                 }
             },
+            lexical: 'lexicalToTransformReady',
             html: 'htmlToTransformReady',
             plaintext: 'plaintextToTransformReady',
             custom_excerpt: 'htmlToTransformReady',

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -120,7 +120,7 @@
     "@tryghost/string": "0.2.1",
     "@tryghost/tpl": "0.1.18",
     "@tryghost/update-check-service": "0.0.0",
-    "@tryghost/url-utils": "4.0.3",
+    "@tryghost/url-utils": "4.1.0",
     "@tryghost/validator": "0.1.27",
     "@tryghost/verification-trigger": "0.0.0",
     "@tryghost/version": "0.1.16",

--- a/ghost/core/test/regression/models/model_posts.test.js
+++ b/ghost/core/test/regression/models/model_posts.test.js
@@ -1185,6 +1185,21 @@ describe('Post Model', function () {
                     done();
                 }).catch(done);
             });
+
+            // NOTE: separate to the test above because mobiledoc+lexical cannot co-exist
+            it('stores lexical as transform-ready and reads as absolute', async function () {
+                const post = {
+                    title: 'Absolute->Transform-ready Lexical URL Transform Test',
+                    lexical: `{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"local link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"http://127.0.0.1:2369/local"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"external link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com/external"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`
+                };
+
+                const createdPost = await models.Post.add(post, context);
+                createdPost.get('lexical').should.equal(`{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"local link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"http://127.0.0.1:2369/local"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"external link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com/external"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}`, 'Post.add result');
+
+                const knexResult = await db.knex('posts').where({id: createdPost.id});
+                const [knexPost] = knexResult;
+                knexPost.lexical.should.equal('{"root":{"children":[{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"local link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"__GHOST_URL__/local"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1},{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"external link","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"link","version":1,"rel":null,"target":null,"url":"https://example.com/external"}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}', 'knex result');
+            });
         });
 
         describe('destroy', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4189,10 +4189,10 @@
   dependencies:
     lodash.template "^4.5.0"
 
-"@tryghost/url-utils@4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@tryghost/url-utils/-/url-utils-4.0.3.tgz#a019ecd7b453c456abcac0e6657afcba106cf669"
-  integrity sha512-rbMfsrdGQvgwoXbCwOdPuTYpBfyOSHPQJtN3ulo07gdWvIWyxTA18mkzHH9gyLG4tP/nK0JQsBMshYtvKUm29A==
+"@tryghost/url-utils@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/url-utils/-/url-utils-4.1.0.tgz#b07aa36dee52322fe989617a8cbff530dc12fbda"
+  integrity sha512-ou0F8/7ql8d53FqoJWCmYZx1I0NgmiWOxWvlzyfZviSwzpw2qYcIj56FOYMcdTxYCShjQel6lP1jgoFEURUpHA==
   dependencies:
     cheerio "^0.22.0"
     moment "^2.27.0"


### PR DESCRIPTION
no issue

- bumped `@tryghost/url-utils` to get access to the new lexical transform utilities
- updated the Post model's `parse()` and `formatOnWrite()` methods to transform the `lexical` field contents when reading/writing to ensure any links in content point at the correct place with `site.url` config changes
