### PR TITLE
🪞🪞HTTP caching improvements

### DIFF
--- a/ghost/core/core/frontend/web/middleware/error-handler.js
+++ b/ghost/core/core/frontend/web/middleware/error-handler.js
@@ -7,7 +7,7 @@ const config = require('../../../shared/config');
 const renderer = require('../../services/rendering');
 
 // @TODO: make this properly shared code
-const {prepareError, prepareStack} = require('@tryghost/mw-error-handler');
+const {prepareError, prepareErrorCacheControl, prepareStack} = require('@tryghost/mw-error-handler');
 
 const messages = {
     oopsErrorTemplateHasError: 'Oops, seems there is an error in the error template.',
@@ -86,6 +86,8 @@ const themeErrorRenderer = (err, req, res, next) => {
 module.exports.handleThemeResponse = [
     // Make sure the error can be served
     prepareError,
+    // Add cache-control header
+    prepareErrorCacheControl,
     // Handle the error in Sentry
     sentry.errorHandler,
     // Format the stack for the user

--- a/ghost/core/core/frontend/web/middleware/error-handler.js
+++ b/ghost/core/core/frontend/web/middleware/error-handler.js
@@ -87,7 +87,7 @@ module.exports.handleThemeResponse = [
     // Make sure the error can be served
     prepareError,
     // Add cache-control header
-    prepareErrorCacheControl,
+    prepareErrorCacheControl(),
     // Handle the error in Sentry
     sentry.errorHandler,
     // Format the stack for the user

--- a/ghost/core/core/server/web/api/endpoints/content/app.js
+++ b/ghost/core/core/server/web/api/endpoints/content/app.js
@@ -20,8 +20,10 @@ module.exports = function setupApiApp() {
     // Query parsing
     apiApp.use(boolParser());
 
-    // API shouldn't be cached
-    apiApp.use(shared.middleware.cacheControl('private'));
+    // Content API should allow public caching
+    apiApp.use(shared.middleware.cacheControl('public', {
+        maxAge: 0
+    }));
 
     // Routing
     apiApp.use(routes());

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -74,6 +74,7 @@
     "@tryghost/express-dynamic-redirects": "0.0.0",
     "@tryghost/helpers": "1.1.74",
     "@tryghost/html-to-plaintext": "0.0.0",
+    "@tryghost/http-cache-utils": "0.1.0",
     "@tryghost/image-transform": "1.2.2",
     "@tryghost/job-manager": "0.0.0",
     "@tryghost/kg-card-factory": "3.1.5",

--- a/ghost/core/test/e2e-api/content/__snapshots__/newsletters.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/newsletters.test.js.snap
@@ -56,7 +56,7 @@ Object {
 exports[`Newsletters Content API Can request only active newsletters 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "1000",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -121,7 +121,7 @@ Object {
 exports[`Newsletters Content API Cannot override filters to fetch archived newsletters 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "1000",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/content/__snapshots__/offers.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/offers.test.js.snap
@@ -28,7 +28,7 @@ Object {
 exports[`Offers Content API Can read offer details from id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "331",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/content/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/pages.test.js.snap
@@ -47,7 +47,7 @@ Hopefully you don't find it a bore.",
 exports[`Pages Content API Can request page 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "1083",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -273,7 +273,7 @@ Hopefully you don't find it a bore.",
 exports[`Pages Content API Can request pages 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "9149",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/content/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/posts.test.js.snap
@@ -56,7 +56,7 @@ Object {
 exports[`Posts Content API Can filter by published date 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "4576",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -133,7 +133,7 @@ Object {
 exports[`Posts Content API Can filter by published date 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "5867",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -198,7 +198,7 @@ Object {
 exports[`Posts Content API Can filter by published date 6: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "4577",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1049,7 +1049,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 exports[`Posts Content API Can filter posts by authors 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "54906",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1427,7 +1427,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 exports[`Posts Content API Can filter posts by tag 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "13977",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2309,7 +2309,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 exports[`Posts Content API Can include relations 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "65235",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2364,7 +2364,7 @@ Object {
 exports[`Posts Content API Can request a single post 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "2362",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2426,7 +2426,7 @@ Object {
 exports[`Posts Content API Can request fields of posts 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "587",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2910,7 +2910,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 exports[`Posts Content API Can request posts 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "46354",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3394,7 +3394,7 @@ Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac tu
 exports[`Posts Content API Can request posts from different origin 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "46354",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/settings.test.js.snap
@@ -84,7 +84,7 @@ Object {
 exports[`Settings Content API Can request settings 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": StringMatching /\\\\d\\+/,
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/content/__snapshots__/tiers.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/tiers.test.js.snap
@@ -51,7 +51,7 @@ Object {
 exports[`Tiers Content API Can request only active tiers 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": "730",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/content/authors.test.js
+++ b/ghost/core/test/e2e-api/content/authors.test.js
@@ -27,7 +27,7 @@ describe('Authors Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`authors/?key=${validKey}`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         should.not.exist(res.headers['x-cache-invalidate']);
@@ -56,7 +56,7 @@ describe('Authors Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`authors/?key=${validKey}&include=count.posts&order=count.posts ASC`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         const jsonResponse = res.body;
@@ -86,7 +86,7 @@ describe('Authors Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`authors/slug/ghost/?key=${validKey}`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         should.not.exist(res.headers['x-cache-invalidate']);
@@ -103,7 +103,7 @@ describe('Authors Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`authors/1/?key=${validKey}&include=count.posts`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         should.not.exist(res.headers['x-cache-invalidate']);

--- a/ghost/core/test/e2e-api/content/key_authentication.test.js
+++ b/ghost/core/test/e2e-api/content/key_authentication.test.js
@@ -26,7 +26,7 @@ describe('Content API key authentication', function () {
 
         await request.get(localUtils.API.getApiQuery(`posts/?key=${key}`))
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
     });
 

--- a/ghost/core/test/e2e-api/content/key_authentication.test.js
+++ b/ghost/core/test/e2e-api/content/key_authentication.test.js
@@ -61,7 +61,7 @@ describe('Content API key authentication', function () {
             // CASE: explore endpoint can only be reached by Admin API
             const secondResponse = await request.get(localUtils.API.getApiQuery('explore/'))
                 .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404);
 
             secondResponse.body.errors[0].type.should.equal('NotFoundError');

--- a/ghost/core/test/e2e-api/content/tags.test.js
+++ b/ghost/core/test/e2e-api/content/tags.test.js
@@ -28,7 +28,7 @@ describe('Tags Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`tags/?key=${validKey}`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         should.not.exist(res.headers['x-cache-invalidate']);
@@ -59,7 +59,7 @@ describe('Tags Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`tags/?limit=all&key=${validKey}`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         should.not.exist(res.headers['x-cache-invalidate']);
@@ -75,7 +75,7 @@ describe('Tags Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`tags/?limit=3&key=${validKey}`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         should.not.exist(res.headers['x-cache-invalidate']);
@@ -91,7 +91,7 @@ describe('Tags Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`tags/?key=${validKey}&include=count.posts`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         const jsonResponse = res.body;
@@ -110,7 +110,7 @@ describe('Tags Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`tags/?key=${validKey}&fields=url,name`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         const jsonResponse = res.body;
@@ -129,7 +129,7 @@ describe('Tags Content API', function () {
         const res = await request.get(localUtils.API.getApiQuery(`tags/?key=${validKey}&fields=url`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200);
 
         const jsonResponse = res.body;

--- a/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
+++ b/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
@@ -504,7 +504,7 @@ Object {
 exports[`API Versioning Content API responds with 404 error when the resource cannot be found 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "no-cache, max-age=0, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": StringMatching /\\\\d\\+/,
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,

--- a/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
+++ b/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
@@ -471,7 +471,7 @@ Object {
 exports[`API Versioning Content API Does an internal rewrite with accept version set when version is included in the URL 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": StringMatching /\\\\d\\+/,
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
@@ -598,7 +598,7 @@ Object {
 exports[`API Versioning Content API responds with current content version header when requested version is BEHIND current version and CAN respond 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": StringMatching /\\\\d\\+/,
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
@@ -692,7 +692,7 @@ Object {
 exports[`API Versioning Content API responds with no content version header when accept version header is NOT PRESENT 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
-  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "cache-control": "public, max-age=0",
   "content-length": StringMatching /\\\\d\\+/,
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -38,7 +38,7 @@ describe('Default Frontend routing', function () {
     describe('Error', function () {
         it('should 404 for unknown post', async function () {
             await request.get('/spectacular/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .expect(assertCorrectFrontendHeaders);
@@ -46,7 +46,7 @@ describe('Default Frontend routing', function () {
 
         it('should 404 for unknown file', async function () {
             await request.get('/content/images/some/file/that/doesnt-exist.jpg')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Image not found/)
                 .expect(assertCorrectFrontendHeaders);
@@ -137,7 +137,7 @@ describe('Default Frontend routing', function () {
             const date = moment().format('YYYY/MM/DD');
 
             await request.get('/' + date + '/welcome/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .expect(assertCorrectFrontendHeaders);
@@ -155,7 +155,7 @@ describe('Default Frontend routing', function () {
 
         it('should 404 for non-edit parameter', async function () {
             await request.get('/welcome/notedit/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .expect(assertCorrectFrontendHeaders);
@@ -178,7 +178,7 @@ describe('Default Frontend routing', function () {
 
             it('/edit/ should NOT redirect to the editor', async function () {
                 await request.get('/welcome/edit/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(assertCorrectFrontendHeaders);
             });
@@ -226,7 +226,7 @@ describe('Default Frontend routing', function () {
                 const date = moment().format('YYYY/MM/DD');
 
                 await request.get('/' + date + '/welcome/amp/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
                     .expect(assertCorrectFrontendHeaders);

--- a/ghost/core/test/regression/api/content/authors.test.js
+++ b/ghost/core/test/regression/api/content/authors.test.js
@@ -23,7 +23,7 @@ describe('Authors Content API', function () {
         return request.get(localUtils.API.getApiQuery(`authors/1/?key=${validKey}&fields=name`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
                 should.not.exist(res.headers['x-cache-invalidate']);
@@ -36,7 +36,7 @@ describe('Authors Content API', function () {
     it('browse authors with slug filter, should order in slug order', function () {
         return request.get(localUtils.API.getApiQuery(`authors/?key=${validKey}&filter=slug:[joe-bloggs,ghost,slimer-mcectoplasm]`))
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
                 const jsonResponse = res.body;

--- a/ghost/core/test/regression/api/content/pages.test.js
+++ b/ghost/core/test/regression/api/content/pages.test.js
@@ -46,7 +46,7 @@ describe('api/endpoints/content/pages', function () {
             .get(localUtils.API.getApiQuery(`pages/${testUtils.DataGenerator.Content.posts[0].id}/?key=${key}`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.noCache)
             .expect(404);
     });
 });

--- a/ghost/core/test/regression/api/content/pages.test.js
+++ b/ghost/core/test/regression/api/content/pages.test.js
@@ -31,7 +31,7 @@ describe('api/endpoints/content/pages', function () {
     it('browse pages with slug filter, should order in slug order', function () {
         return request.get(localUtils.API.getApiQuery(`pages/?key=${key}&filter=slug:[static-page-test]`))
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
                 const jsonResponse = res.body;

--- a/ghost/core/test/regression/api/content/posts.test.js
+++ b/ghost/core/test/regression/api/content/posts.test.js
@@ -193,7 +193,7 @@ describe('api/endpoints/content/posts', function () {
             .get(localUtils.API.getApiQuery(`posts/${testUtils.DataGenerator.Content.posts[5].id}/?key=${validKey}`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.noCache)
             .expect(404);
     });
 

--- a/ghost/core/test/regression/api/content/posts.test.js
+++ b/ghost/core/test/regression/api/content/posts.test.js
@@ -27,7 +27,7 @@ describe('api/endpoints/content/posts', function () {
         request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -68,7 +68,7 @@ describe('api/endpoints/content/posts', function () {
         request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&include=authors,tags`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -121,7 +121,7 @@ describe('api/endpoints/content/posts', function () {
     it('browse posts with published and draft status, should not return drafts', function (done) {
         request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&filter=status:published,status:draft`))
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -138,7 +138,7 @@ describe('api/endpoints/content/posts', function () {
     it('browse posts with slug filter, should order in slug order', function () {
         return request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&filter=slug:[write,ghostly-kitchen-sink,grow]`))
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
                 const jsonResponse = res.body;
@@ -153,7 +153,7 @@ describe('api/endpoints/content/posts', function () {
     it('browse posts with slug filter should order taking order parameter into account', function () {
         return request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}&order=slug%20DESC&filter=slug:[write,ghostly-kitchen-sink,grow]`))
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
                 const jsonResponse = res.body;
@@ -204,7 +204,7 @@ describe('api/endpoints/content/posts', function () {
             .get(localUtils.API.getApiQuery(`posts/${complexPostId}/?key=${validKey}&fields=title,slug,excerpt&formats=plaintext`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
                 localUtils.API.checkResponse(res.body.posts[0], 'post', null, null, ['id', 'title', 'slug', 'excerpt', 'plaintext']);
@@ -256,7 +256,7 @@ describe('api/endpoints/content/posts', function () {
                 .get(localUtils.API.getApiQuery(`posts/${publicPost.id}/?key=${validKey}&fields=slug,html,plaintext&formats=html,plaintext`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.public)
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
@@ -275,7 +275,7 @@ describe('api/endpoints/content/posts', function () {
                 .get(localUtils.API.getApiQuery(`posts/${membersPost.id}/?key=${validKey}`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.public)
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
@@ -294,7 +294,7 @@ describe('api/endpoints/content/posts', function () {
                 .get(localUtils.API.getApiQuery(`posts/${paidPost.id}/?key=${validKey}`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.public)
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
@@ -313,7 +313,7 @@ describe('api/endpoints/content/posts', function () {
                 .get(localUtils.API.getApiQuery(`posts/${membersPost.id}/?key=${validKey}&formats=html,plaintext&fields=html,plaintext`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.public)
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
@@ -331,7 +331,7 @@ describe('api/endpoints/content/posts', function () {
                 .get(localUtils.API.getApiQuery(`posts/${membersPostWithPaywallCard.id}/?key=${validKey}&formats=html,plaintext`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.public)
                 .expect(200)
                 .then((res) => {
                     const jsonResponse = res.body;
@@ -349,7 +349,7 @@ describe('api/endpoints/content/posts', function () {
             return request.get(localUtils.API.getApiQuery(`posts/?key=${validKey}`))
                 .set('Origin', testUtils.API.getURL())
                 .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.public)
                 .expect(200)
                 .then((res) => {
                     res.headers.vary.should.eql('Accept-Encoding');

--- a/ghost/core/test/regression/api/content/tags.test.js
+++ b/ghost/core/test/regression/api/content/tags.test.js
@@ -26,7 +26,7 @@ describe('api/endpoints/content/tags', function () {
             .get(localUtils.API.getApiQuery(`tags/${testUtils.DataGenerator.Content.tags[0].id}/?key=${validKey}&fields=name,slug`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
                 localUtils.API.checkResponse(res.body.tags[0], 'tag', null, null, ['id', 'name', 'slug']);
@@ -39,7 +39,7 @@ describe('api/endpoints/content/tags', function () {
             .set('Origin', testUtils.API.getURL())
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
                 should.not.exist(res.headers['x-cache-invalidate']);
@@ -68,7 +68,7 @@ describe('api/endpoints/content/tags', function () {
     it('Browse tags with slug filter, should order in slug order', function () {
         return request.get(localUtils.API.getApiQuery(`tags/?key=${validKey}&filter=slug:[kitchen-sink,bacon,chorizo]`))
             .expect('Content-Type', /json/)
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect('Cache-Control', testUtils.cacheRules.public)
             .expect(200)
             .then((res) => {
                 const jsonResponse = res.body;

--- a/ghost/core/test/regression/site/dynamic_routing.test.js
+++ b/ghost/core/test/regression/site/dynamic_routing.test.js
@@ -74,7 +74,7 @@ describe('Dynamic Routing', function () {
 
         it('should not have a third page', function (done) {
             request.get('/page/3/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .end(doEnd(done));
@@ -103,7 +103,7 @@ describe('Dynamic Routing', function () {
 
             request.get('/' + date + '/static-page-test/')
                 .expect('Content-Type', /html/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .end(doEnd(done));
         });
@@ -152,7 +152,7 @@ describe('Dynamic Routing', function () {
 
         it('should 404 for /tag/ route', function (done) {
             request.get('/tag/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .end(doEnd(done));
@@ -160,7 +160,7 @@ describe('Dynamic Routing', function () {
 
         it('should 404 for unknown tag', function (done) {
             request.get('/tag/spectacular/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .end(doEnd(done));
@@ -168,7 +168,7 @@ describe('Dynamic Routing', function () {
 
         it('should 404 for unknown tag with invalid characters', function (done) {
             request.get('/tag/~$pectacular~/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .end(doEnd(done));
@@ -211,7 +211,7 @@ describe('Dynamic Routing', function () {
 
             it('should 404 for non-edit parameter', function (done) {
                 request.get('/tag/getting-started/notedit/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
                     .end(doEnd(done));
@@ -250,7 +250,7 @@ describe('Dynamic Routing', function () {
             it('should not redirect to admin', function (done) {
                 request.get('/tag/getting-started/edit/')
                     .expect(404)
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .end(doEnd(done));
             });
         });
@@ -316,7 +316,7 @@ describe('Dynamic Routing', function () {
 
         it('should 404 for /author/ route', function (done) {
             request.get('/author/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .end(doEnd(done));
@@ -324,7 +324,7 @@ describe('Dynamic Routing', function () {
 
         it('should 404 for unknown author', function (done) {
             request.get('/author/spectacular/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .end(doEnd(done));
@@ -332,7 +332,7 @@ describe('Dynamic Routing', function () {
 
         it('should 404 for unknown author with invalid characters', function (done) {
             request.get('/author/ghost!user^/')
-                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect('Cache-Control', testUtils.cacheRules.noCache)
                 .expect(404)
                 .expect(/Page not found/)
                 .end(doEnd(done));
@@ -413,7 +413,7 @@ describe('Dynamic Routing', function () {
 
             it('should 404 for something that isn\'t edit', function (done) {
                 request.get('/author/ghost-owner/notedit/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
                     .end(doEnd(done));
@@ -451,7 +451,7 @@ describe('Dynamic Routing', function () {
 
             it('should not redirect to admin', function (done) {
                 request.get('/author/ghost-owner/edit/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .end(doEnd(done));
             });
@@ -502,7 +502,7 @@ describe('Dynamic Routing', function () {
 
             it('should 404 if page too high', function (done) {
                 request.get('/author/ghost-owner/page/6/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
                     .end(doEnd(done));
@@ -510,7 +510,7 @@ describe('Dynamic Routing', function () {
 
             it('should 404 if page too low', function (done) {
                 request.get('/author/ghost-owner/page/0/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
                     .end(doEnd(done));
@@ -519,7 +519,7 @@ describe('Dynamic Routing', function () {
             describe('RSS', function () {
                 it('should 404 if index attempted with 0', function (done) {
                     request.get('/author/ghost-owner/rss/0/')
-                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect('Cache-Control', testUtils.cacheRules.noCache)
                         .expect(404)
                         .expect(/Page not found/)
                         .end(doEnd(done));
@@ -527,7 +527,7 @@ describe('Dynamic Routing', function () {
 
                 it('should 404 if index attempted with 1', function (done) {
                     request.get('/author/ghost-owner/rss/1/')
-                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect('Cache-Control', testUtils.cacheRules.noCache)
                         .expect(404)
                         .expect(/Page not found/)
                         .end(doEnd(done));
@@ -535,7 +535,7 @@ describe('Dynamic Routing', function () {
 
                 it('should 404 for other pages', function (done) {
                     request.get('/author/ghost-owner/rss/2/')
-                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect('Cache-Control', testUtils.cacheRules.noCache)
                         .expect(404)
                         .expect(/Page not found/)
                         .end(doEnd(done));

--- a/ghost/core/test/regression/site/frontend.test.js
+++ b/ghost/core/test/regression/site/frontend.test.js
@@ -65,7 +65,7 @@ describe('Frontend Routing', function () {
         describe('Error', function () {
             it('should 404 for unknown post with invalid characters', function (done) {
                 request.get('/$pec+acular~/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
                     .end(doEnd(done));
@@ -74,7 +74,7 @@ describe('Frontend Routing', function () {
             it('should 404 for unknown frontend route', function (done) {
                 request.get('/spectacular/marvellous/')
                     .set('Accept', 'application/json')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
                     .end(doEnd(done));
@@ -82,7 +82,7 @@ describe('Frontend Routing', function () {
 
             it('should 404 for encoded char not 301 from uncapitalise', function (done) {
                 request.get('/|/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect('Cache-Control', testUtils.cacheRules.noCache)
                     .expect(404)
                     .expect(/Page not found/)
                     .end(doEnd(done));
@@ -192,7 +192,7 @@ describe('Frontend Routing', function () {
 
                 it('should 404 for non-edit parameter', async function () {
                     await request.get('/static-page-test/notedit/')
-                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect('Cache-Control', testUtils.cacheRules.noCache)
                         .expect(404)
                         .expect(/Page not found/)
                         .expect(assertCorrectFrontendHeaders);
@@ -231,7 +231,7 @@ describe('Frontend Routing', function () {
                 it('should not redirect to editor', function (done) {
                     request.get('/static-page-test/edit/')
                         .expect(404)
-                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect('Cache-Control', testUtils.cacheRules.noCache)
                         .end(doEnd(done));
                 });
             });
@@ -245,7 +245,7 @@ describe('Frontend Routing', function () {
                         // NOTE: only post pages are supported so the router doesn't have a way to distinguish if
                         //       the request was done after AMP 'Page' or 'Post'
                         request.get('/static-page-test/amp/')
-                            .expect('Cache-Control', testUtils.cacheRules.private)
+                            .expect('Cache-Control', testUtils.cacheRules.noCache)
                             .expect(404)
                             .expect(/Post not found/)
                             .end(doEnd(done));

--- a/ghost/core/test/utils/fixtures/cache-rules.js
+++ b/ghost/core/test/utils/fixtures/cache-rules.js
@@ -4,5 +4,6 @@ module.exports = {
     day: 'public, max-age=' + 86400,
     year: 'public, max-age=' + 31536000,
     yearImmutable: 'public, max-age=' + 31536000 + ', immutable',
-    private: 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
+    private: 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0',
+    noCache: 'no-cache, max-age=0, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
 };

--- a/ghost/mw-error-handler/lib/mw-error-handler.js
+++ b/ghost/mw-error-handler/lib/mw-error-handler.js
@@ -3,6 +3,7 @@ const semver = require('semver');
 const debug = require('@tryghost/debug')('error-handler');
 const errors = require('@tryghost/errors');
 const {prepareStackForUser} = require('@tryghost/errors').utils;
+const {isReqResUserSpecific, cacheControlValues} = require('@tryghost/http-cache-utils');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
@@ -99,7 +100,14 @@ module.exports.prepareStack = (err, req, res, next) => { // eslint-disable-line 
     next(clonedError);
 };
 
-const jsonErrorRenderer = (err, req, res, next) => { // eslint-disable-line no-unused-vars
+/**
+ * @private the method is exposed for testing purposes only
+ * @param {Object} err
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+module.exports.jsonErrorRenderer = (err, req, res, next) => { // eslint-disable-line no-unused-vars
     const userError = prepareUserMessage(err, req);
 
     res.json({
@@ -117,15 +125,29 @@ const jsonErrorRenderer = (err, req, res, next) => { // eslint-disable-line no-u
     });
 };
 
-module.exports.prepareErrorCacheControl = (err, req, res, next) => {
-    // never cache errors
-    let cacheControl = 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0';
+/**
+ * 
+ * @param {String} [cacheControlHeaderValue] cache-control header value
+ */
+module.exports.prepareErrorCacheControl = (cacheControlHeaderValue) => {
+    return (err, req, res, next) => {
+        let cacheControl = cacheControlHeaderValue;
+        if (!cacheControlHeaderValue) {
+            // never cache errors unless it's a 404
+            cacheControl = cacheControlValues.private;
 
-    res.set({
-        'Cache-Control': cacheControl
-    });
+            // Do not include 'private' cache-control directive for 404 responses
+            if (err.statusCode === 404 && req.method === 'GET' && !isReqResUserSpecific(req, res)) {
+                cacheControl = cacheControlValues.noCacheDynamic;
+            }
+        }
 
-    next(err);
+        res.set({
+            'Cache-Control': cacheControl
+        });
+
+        next(err);
+    };
 };
 
 const prepareUserMessage = (err, req) => {
@@ -228,18 +250,20 @@ module.exports.handleJSONResponse = sentry => [
     // Make sure the error can be served
     module.exports.prepareError,
     // Add cache-control header
-    module.exports.prepareErrorCacheControl,
+    module.exports.prepareErrorCacheControl(),
     // Handle the error in Sentry
     sentry.errorHandler,
     // Format the stack for the user
     module.exports.prepareStack,
     // Render the error using JSON format
-    jsonErrorRenderer
+    module.exports.jsonErrorRenderer
 ];
 
 module.exports.handleHTMLResponse = sentry => [
     // Make sure the error can be served
     module.exports.prepareError,
+    // Add cache-control header
+    module.exports.prepareErrorCacheControl(cacheControlValues.private),
     // Handle the error in Sentry
     sentry.errorHandler,
     // Format the stack for the user

--- a/ghost/mw-error-handler/lib/mw-error-handler.js
+++ b/ghost/mw-error-handler/lib/mw-error-handler.js
@@ -90,11 +90,6 @@ module.exports.prepareError = (err, req, res, next) => {
     // alternative for res.status();
     res.statusCode = err.statusCode;
 
-    // never cache errors
-    res.set({
-        'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-    });
-
     next(err);
 };
 
@@ -120,6 +115,17 @@ const jsonErrorRenderer = (err, req, res, next) => { // eslint-disable-line no-u
             ghostErrorCode: err.ghostErrorCode || null
         }]
     });
+};
+
+module.exports.prepareErrorCacheControl = (err, req, res, next) => {
+    // never cache errors
+    let cacheControl = 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0';
+
+    res.set({
+        'Cache-Control': cacheControl
+    });
+
+    next(err);
 };
 
 const prepareUserMessage = (err, req) => {
@@ -221,6 +227,8 @@ module.exports.pageNotFound = (req, res, next) => {
 module.exports.handleJSONResponse = sentry => [
     // Make sure the error can be served
     module.exports.prepareError,
+    // Add cache-control header
+    module.exports.prepareErrorCacheControl,
     // Handle the error in Sentry
     sentry.errorHandler,
     // Format the stack for the user

--- a/ghost/mw-error-handler/package.json
+++ b/ghost/mw-error-handler/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@tryghost/debug": "0.1.18",
     "@tryghost/errors": "1.2.16",
+    "@tryghost/http-cache-utils": "0.1.3",
     "@tryghost/tpl": "0.1.18",
     "lodash": "4.17.21",
     "semver": "7.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3812,6 +3812,16 @@
     "@tryghost/mobiledoc-kit" "^0.12.4-ghost.1"
     jsdom "^20.0.0"
 
+"@tryghost/http-cache-utils@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/http-cache-utils/-/http-cache-utils-0.1.0.tgz#a5a023434f8c312c846560bc375a34e43f09bbfc"
+  integrity sha512-vWuseNuS4UqBIoVntYWw2LrhgEUABunLLJ7hPTq4QO1sPbpazITqNDi4rbO3BUf2k60cVf0N2W4wfs4AVHoT1w==
+
+"@tryghost/http-cache-utils@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/http-cache-utils/-/http-cache-utils-0.1.3.tgz#a3a07e55dbe3a62b7d51e98f19c063d03a1ef804"
+  integrity sha512-QganheP/zhcpFnDLPJYlQ4gBIhd+lAEMh8byx7ocCPM37nuEQ3zlmcM6KzDfUmKYwU+5oI/ya/0Wn0kmnyZ37A==
+
 "@tryghost/http-stream@^0.1.12":
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/@tryghost/http-stream/-/http-stream-0.1.12.tgz#91d271d5a1b97af3c414a06cac106de2d008b10a"


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/410

This PR is here to make tracking of HTTP cache improvements easier to port to Ghost 4.x and get review from the engineers who are maintaining HTTP cache-related features in shared caches.

@jloh @JoeeGrigg I will be adding more caching improvements here based on the doc I've shared privately. Needs your eyes to check if the changes are compatible with our caching infra 🪞🪞 The check for "user specific" request/response is here in the framework's [http-cache-utils pacakge](https://github.com/TryGhost/framework/blob/a7f15287452cb8b50e6c26389f7a44677bdb1542/packages/http-cache-utils/lib/http-cache-utils.js).
