### PR TITLE
Added clicks to activity feed

### DIFF
--- a/ghost/admin/app/components/member/activity-feed.hbs
+++ b/ghost/admin/app/components/member/activity-feed.hbs
@@ -37,6 +37,11 @@
                                                                 <GhEmailPreviewLink @data={{event.email}} />
                                                             {{/if}}
                                                         </span>
+                                                        {{#if event.description}}
+                                                            <div>
+                                                                {{event.description}}
+                                                            </div>
+                                                        {{/if}}
                                                     </span>
                                                 </div>
                                                 <div class="gh-member-feed-time">

--- a/ghost/admin/app/components/members-activity/table-row.hbs
+++ b/ghost/admin/app/components/members-activity/table-row.hbs
@@ -32,6 +32,11 @@
                             <span class="{{if (feature "memberAttribution") 'hidden'}}"><GhEmailPreviewLink @data={{event.email}} /></span>
                         {{/if}}
                     </span>
+                    {{#if event.description}}
+                        <div>
+                            {{event.description}}
+                        </div>
+                    {{/if}}
                 </div>
             </div>
         </div>

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -11,6 +11,7 @@ export default class ParseMemberEventHelper extends Helper {
         const icon = this.getIcon(event);
         const action = this.getAction(event, hasMultipleNewsletters);
         const info = this.getInfo(event);
+        const description = this.getDescription(event);
 
         const join = this.getJoin(event);
         const object = this.getObject(event);
@@ -28,6 +29,7 @@ export default class ParseMemberEventHelper extends Helper {
             join,
             object,
             info,
+            description,
             url,
             timestamp
         };
@@ -79,6 +81,10 @@ export default class ParseMemberEventHelper extends Helper {
 
         if (event.type === 'comment_event') {
             icon = 'comment';
+        }
+
+        if (event.type === 'click_event') {
+            icon = 'click';
         }
 
         return 'event-' + icon + (this.feature.get('memberAttribution') ? '--feature-attribution' : '');
@@ -148,6 +154,10 @@ export default class ParseMemberEventHelper extends Helper {
             }
             return 'commented';
         }
+
+        if (event.type === 'click_event') {
+            return 'clicked email';
+        }
     }
 
     /**
@@ -191,6 +201,12 @@ export default class ParseMemberEventHelper extends Helper {
             }
         }
 
+        if (event.type === 'click_event') {
+            if (event.data.post) {
+                return event.data.post.title;
+            }
+        }
+
         return '';
     }
 
@@ -207,11 +223,34 @@ export default class ParseMemberEventHelper extends Helper {
         return;
     }
 
+    getDescription(event) {
+        if (event.type === 'click_event') {
+            // Clean URL
+            try {
+                const parsedURL = new URL(event.data.link.to);
+
+                // Remove protocol, querystring and hash
+                // + strip trailing /
+                return 'URL: ' + parsedURL.host + (parsedURL.pathname === '/' ? '' : parsedURL.pathname);
+            } catch (e) {
+                // Invalid URL
+            }
+            return 'URL: ' + event.data.link.to;
+        }
+        return;
+    }
+
     /**
      * Make the object clickable
      */
     getURL(event) {
         if (event.type === 'comment_event') {
+            if (event.data.post) {
+                return event.data.post.url;
+            }
+        }
+
+        if (event.type === 'click_event') {
             if (event.data.post) {
                 return event.data.post.url;
             }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/activity-feed-events.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/activity-feed-events.js
@@ -1,4 +1,6 @@
 const mapComment = require('./comments');
+const url = require('../utils/url');
+const _ = require('lodash');
 
 const commentEventMapper = (json, frame) => {
     return {
@@ -7,9 +9,58 @@ const commentEventMapper = (json, frame) => {
     };
 };
 
+const clickEventMapper = (json, frame) => {
+    const memberFields = [
+        'id',
+        'uuid',
+        'name',
+        'email',
+        'avatar_image'
+    ];
+
+    const linkFields = [
+        'from',
+        'to'
+    ];
+
+    const postFields = [
+        'id',
+        'uuid',
+        'title',
+        'url'
+    ];
+
+    const data = json.data;
+    const response = {};
+
+    if (data.link && data.link.post) {
+        // We could use the post mapper here, but we need less field + don't need al the async behavior support
+        url.forPost(data.link.post.id, data.link.post, frame);
+        response.post = _.pick(data.link.post, postFields);
+    }
+
+    if (data.link) {
+        response.link = _.pick(data.link, linkFields);
+    }
+
+    if (data.member) {
+        response.member = _.pick(data.member, memberFields);
+    } else {
+        response.member = null;
+    }
+
+    return {
+        ...json,
+        data: response
+    };
+};
+
 const activityFeedMapper = (event, frame) => {
     if (event.type === 'comment_event') {
         return commentEventMapper(event, frame);
+    }
+    if (event.type === 'click_event') {
+        return clickEventMapper(event, frame);
     }
     return event;
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -18,6 +18,15 @@ const memberFields = [
     'avatar_image'
 ];
 
+const memberFieldsAdmin = [
+    'id',
+    'uuid',
+    'name',
+    'email',
+    'expertise',
+    'avatar_image'
+];
+
 const postFields = [
     'id',
     'uuid',
@@ -36,7 +45,7 @@ const commentMapper = (model, frame) => {
     const response = _.pick(jsonModel, commentFields);
 
     if (jsonModel.member) {
-        response.member = _.pick(jsonModel.member, memberFields);
+        response.member = _.pick(jsonModel.member, utils.isMembersAPI(frame) ? memberFields : memberFieldsAdmin);
     } else {
         response.member = null;
     }

--- a/ghost/core/core/server/models/link-redirect.js
+++ b/ghost/core/core/server/models/link-redirect.js
@@ -1,10 +1,29 @@
 const ghostBookshelf = require('./base');
+const urlUtils = require('../../shared/url-utils');
 
 const LinkRedirect = ghostBookshelf.Model.extend({
     tableName: 'link_redirects',
 
     post() {
         return this.belongsTo('Post', 'post_id');
+    },
+
+    formatOnWrite(attrs) {
+        if (attrs.to) {
+            attrs.to = urlUtils.absoluteToTransformReady(attrs.to);
+        }
+
+        return attrs;
+    },
+
+    parse() {
+        const attrs = ghostBookshelf.Model.prototype.parse.apply(this, arguments);
+
+        if (attrs.to) {
+            attrs.to = urlUtils.transformReadyToAbsolute(attrs.to);
+        }
+
+        return attrs;
     }
 }, {
 });

--- a/ghost/core/core/server/services/link-redirection/LinkRedirectRepository.js
+++ b/ghost/core/core/server/services/link-redirection/LinkRedirectRepository.js
@@ -4,17 +4,13 @@ const ObjectID = require('bson-objectid').default;
 module.exports = class LinkRedirectRepository {
     /** @type {Object} */
     #LinkRedirect;
-    /** @type {Object} */
-    #urlUtils;
 
     /**
      * @param {object} deps
      * @param {object} deps.LinkRedirect Bookshelf Model
-     * @param {object} deps.urlUtils 
      */
     constructor(deps) {
         this.#LinkRedirect = deps.LinkRedirect;
-        this.#urlUtils = deps.urlUtils;
     }
 
     /**
@@ -25,7 +21,7 @@ module.exports = class LinkRedirectRepository {
         const model = await this.#LinkRedirect.add({
             // Only store the parthname (no support for variable query strings)
             from: linkRedirect.from.pathname, 
-            to: this.#urlUtils.absoluteToTransformReady(linkRedirect.to.href)
+            to: linkRedirect.to.href
         }, {});
 
         linkRedirect.link_id = ObjectID.createFromHexString(model.id);
@@ -47,7 +43,7 @@ module.exports = class LinkRedirectRepository {
             return new LinkRedirect({
                 id: linkRedirect.id,
                 from: url,
-                to: new URL(this.#urlUtils.transformReadyToAbsolute(linkRedirect.get('to')))
+                to: new URL(linkRedirect.get('to'))
             });
         }
     }

--- a/ghost/core/core/server/services/link-redirection/index.js
+++ b/ghost/core/core/server/services/link-redirection/index.js
@@ -14,8 +14,7 @@ class LinkRedirectsServiceWrapper {
         const {LinkRedirectsService} = require('@tryghost/link-redirects');
 
         const linkRedirectRepository = new LinkRedirectRepository({
-            LinkRedirect: models.LinkRedirect,
-            urlUtils
+            LinkRedirect: models.LinkRedirect
         });
 
         // Expose the service

--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -187,6 +187,7 @@ function createApiInstance(config) {
             MemberAnalyticEvent: models.MemberAnalyticEvent,
             MemberCreatedEvent: models.MemberCreatedEvent,
             SubscriptionCreatedEvent: models.SubscriptionCreatedEvent,
+            MemberLinkClickEvent: models.MemberLinkClickEvent,
             OfferRedemption: models.OfferRedemption,
             Offer: models.Offer,
             StripeProduct: models.StripeProduct,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -3805,7 +3805,7 @@ exports[`Members API Returns comments in activity feed 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1093",
+  "content-length": "1147",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Origin, Accept-Encoding",

--- a/ghost/members-api/lib/MembersAPI.js
+++ b/ghost/members-api/lib/MembersAPI.js
@@ -51,6 +51,7 @@ module.exports = function MembersAPI({
         MemberAnalyticEvent,
         MemberCreatedEvent,
         SubscriptionCreatedEvent,
+        MemberLinkClickEvent,
         Offer,
         OfferRedemption,
         StripeProduct,
@@ -110,6 +111,7 @@ module.exports = function MembersAPI({
         MemberLoginEvent,
         MemberCreatedEvent,
         SubscriptionCreatedEvent,
+        MemberLinkClickEvent,
         Comment,
         labsService,
         memberAttributionService


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1933

- Added click_events to activity feed
- Added support for parsing click_events in the frontend
- Moved url parsing (transform ready) to model layer of LinkRedirect
- Moved `getEventTimeline` method to the top of the event repository
- Added description field to parsed events in the frontend (because we need a second line)
- Fixed: member email not returned in comment_event