### PR TITLE
Fixed empty mock data for paid subscriptions chart on dashboard

### DIFF
--- a/ghost/admin/app/components/dashboard/charts/paid-breakdown.js
+++ b/ghost/admin/app/components/dashboard/charts/paid-breakdown.js
@@ -198,13 +198,13 @@ export default class PaidBreakdown extends Component {
     get chartData() {
         const stats = this.dashboardStats.filledSubscriptionCountStats;
         const labels = stats.map(stat => stat.date);
-        const newData = stats.map(stat => stat.signups);
-        const canceledData = stats.map(stat => -stat.cancellations);
+        const newData = stats.map(stat => stat.signups || 0);
+        const canceledData = stats.map(stat => -(stat.cancellations || 0));
         let barThickness = 5;
 
         if (newData.length >= 30 + 1 && newData.length < 90) {
             barThickness = 3.5;
-        } else if (newData.length >= 90) {   
+        } else if (newData.length >= 90) {
             barThickness = 1.5;
         }
 
@@ -271,7 +271,7 @@ export default class PaidBreakdown extends Component {
                     if (tooltip.opacity === 0) {
                         tooltipEl.style.display = 'none';
                         tooltipEl.style.opacity = 0;
-                        return; 
+                        return;
                     }
 
                     let offsetX = 0;
@@ -284,7 +284,7 @@ export default class PaidBreakdown extends Component {
                     tooltipEl.style.opacity = 1;
                     tooltipEl.style.position = 'absolute';
                     tooltipEl.style.left = tooltip.x - offsetX + 'px';
-                    tooltipEl.style.top = '70px';    
+                    tooltipEl.style.top = '70px';
                 },
                 callbacks: {
                     label: (tooltipItems, data) => {

--- a/ghost/admin/app/services/dashboard-mocks.js
+++ b/ghost/admin/app/services/dashboard-mocks.js
@@ -294,11 +294,14 @@ export default class DashboardMocksService extends Service {
 
         this.memberCountStats = stats;
         this.subscriptionCountStats = stats.map((data) => {
+            const signups = (data.paidSubscribed - data.paidCanceled);
             return {
                 date: data.date,
                 count: data.paid,
                 positiveDelta: data.paidSubscribed,
-                negativeDelta: data.paidCanceled
+                negativeDelta: data.paidCanceled,
+                signups: signups < 0 ? 0 : signups,
+                cancellations: Math.floor(signups * 0.3) ? Math.floor(signups * 0.3) : 0
             };
         });
 


### PR DESCRIPTION
- the paid subscribers chart was empty when using with fake data due to missing values