### PR TITLE
Handled storing referrer data in DB

### DIFF
--- a/ghost/member-attribution/lib/referrer-translator.js
+++ b/ghost/member-attribution/lib/referrer-translator.js
@@ -2,7 +2,7 @@
  * @typedef {Object} ReferrerData
  * @prop {string|null} [refSource]
  * @prop {string|null} [refMedium]
- * @prop {URL|null} [refUrl]
+ * @prop {string|null} [refUrl]
  */
 
 const knownReferrers = require('@tryghost/referrers');
@@ -29,7 +29,11 @@ class ReferrerTranslator {
      */
     getReferrerDetails(history) {
         if (history.length === 0) {
-            return null;
+            return {
+                refSource: 'Direct',
+                refMedium: null,
+                refUrl: null
+            };
         }
 
         for (const item of history) {
@@ -42,7 +46,7 @@ class ReferrerTranslator {
                 return {
                     refSource: 'Ghost Explore',
                     refMedium: 'Ghost Network',
-                    refUrl: refUrl
+                    refUrl: refUrl?.hostname ?? null
                 };
             }
 
@@ -51,7 +55,7 @@ class ReferrerTranslator {
                 return {
                     refSource: 'Ghost.org',
                     refMedium: 'Ghost Network',
-                    refUrl: refUrl
+                    refUrl: refUrl?.hostname
                 };
             }
 
@@ -60,7 +64,7 @@ class ReferrerTranslator {
                 return {
                     refSource: refSource.replace(/-/g, ' '),
                     refMedium: 'Email',
-                    refUrl: refUrl
+                    refUrl: refUrl?.hostname ?? null
                 };
             }
 
@@ -70,7 +74,7 @@ class ReferrerTranslator {
                 return {
                     refSource: refSource,
                     refMedium: refMedium || urlData?.medium || null,
-                    refUrl: refUrl
+                    refUrl: refUrl?.hostname ?? null
                 };
             }
 
@@ -78,30 +82,28 @@ class ReferrerTranslator {
             if (refUrl && !this.isSiteDomain(refUrl)) {
                 const urlData = this.getDataFromUrl(refUrl);
 
+                // Use known source/medium if available
                 if (urlData) {
                     return {
-                        refSource: urlData?.source,
-                        refMedium: urlData?.medium,
-                        refUrl: refUrl
+                        refSource: urlData?.source ?? null,
+                        refMedium: urlData?.medium ?? null,
+                        refUrl: refUrl?.hostname ?? null
                     };
                 }
-            }
-        }
-
-        // Return any referrer URL in history that is not site domain
-        for (const item of history) {
-            const refUrl = this.getUrlFromStr(item.refUrl);
-
-            if (refUrl && !this.isSiteDomain(refUrl)) {
+                // Use the hostname as a source
                 return {
-                    refSource: null,
+                    refSource: refUrl?.hostname ?? null,
                     refMedium: null,
-                    refUrl: refUrl
+                    refUrl: refUrl?.hostname ?? null
                 };
             }
         }
 
-        return null;
+        return {
+            refSource: 'Direct',
+            refMedium: null,
+            refUrl: null
+        };
     }
 
     // Fetches referrer data from known external URLs

--- a/ghost/member-attribution/test/referrer-translator.test.js
+++ b/ghost/member-attribution/test/referrer-translator.test.js
@@ -63,7 +63,7 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 refSource: 'Ghost Explore',
                 refMedium: 'Ghost Network',
-                refUrl: new URL('https://ghost.org/explore')
+                refUrl: 'ghost.org'
             });
         });
 
@@ -87,7 +87,7 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 refSource: 'Ghost Explore',
                 refMedium: 'Ghost Network',
-                refUrl: new URL('https://admin.example.com/ghost/#/dashboard')
+                refUrl: 'admin.example.com'
             });
         });
 
@@ -135,7 +135,7 @@ describe('ReferrerTranslator', function () {
             ])).eql({
                 refSource: 'Ghost.org',
                 refMedium: 'Ghost Network',
-                refUrl: new URL('https://ghost.org/creators/')
+                refUrl: 'ghost.org'
             });
         });
 
@@ -189,7 +189,7 @@ describe('ReferrerTranslator', function () {
                 ])).eql({
                     refSource: 'Google Product Search',
                     refMedium: 'search',
-                    refUrl: new URL('https://google.ac/products')
+                    refUrl: 'google.ac'
                 });
             });
 
@@ -213,12 +213,12 @@ describe('ReferrerTranslator', function () {
                 ])).eql({
                     refSource: 'Twitter',
                     refMedium: 'social',
-                    refUrl: new URL('https://t.co/')
+                    refUrl: 't.co'
                 });
             });
         });
 
-        it('returns external ref url if nothing matches', async function () {
+        it('returns external ref url as source', async function () {
             should(translator.getReferrerDetails([
                 {
                     refSource: null,
@@ -229,16 +229,25 @@ describe('ReferrerTranslator', function () {
                     refSource: null,
                     refMedium: null,
                     refUrl: 'https://sample.com'
+                },
+                {
+                    refSource: 'publisher-weekly-newsletter',
+                    refMedium: null,
+                    refUrl: null
                 }
             ])).eql({
-                refSource: null,
+                refSource: 'sample.com',
                 refMedium: null,
-                refUrl: new URL('https://sample.com')
+                refUrl: 'sample.com'
             });
         });
 
         it('returns null for empty history', async function () {
-            should(translator.getReferrerDetails([])).eql(null);
+            should(translator.getReferrerDetails([])).eql({
+                refSource: 'Direct',
+                refMedium: null,
+                refUrl: null
+            });
         });
 
         it('returns null for history with only site url', async function () {
@@ -248,7 +257,11 @@ describe('ReferrerTranslator', function () {
                     refMedium: null,
                     refUrl: 'https://example.com'
                 }
-            ])).eql(null);
+            ])).eql({
+                refSource: 'Direct',
+                refMedium: null,
+                refUrl: null
+            });
         });
     });
 });

--- a/ghost/members-api/lib/controllers/router.js
+++ b/ghost/members-api/lib/controllers/router.js
@@ -228,15 +228,15 @@ module.exports = class RouterController {
             }
 
             if (attribution.refSource) {
-                metadata.attribution_ref_source = attribution.refSource;
+                metadata.referrer_source = attribution.refSource;
             }
 
             if (attribution.refMedium) {
-                metadata.attribution_ref_medium = attribution.refMedium;
+                metadata.referrer_medium = attribution.refMedium;
             }
 
             if (attribution.refUrl) {
-                metadata.attribution_ref_url = attribution.refUrl;
+                metadata.referrer_url = attribution.refUrl;
             }
         }
 

--- a/ghost/members-events-service/lib/event-storage.js
+++ b/ghost/members-events-service/lib/event-storage.js
@@ -5,8 +5,8 @@ const {MemberCreatedEvent, SubscriptionCreatedEvent} = require('@tryghost/member
  */
 class EventStorage {
     /**
-     * 
-     * @param {Object} deps 
+     *
+     * @param {Object} deps
      * @param {Object} deps.labsService
      * @param {Object} deps.models
      * @param {Object} deps.models.MemberCreatedEvent
@@ -37,7 +37,10 @@ class EventStorage {
                 attribution_id: attribution?.id ?? null,
                 attribution_url: attribution?.url ?? null,
                 attribution_type: attribution?.type ?? null,
-                source: event.data.source
+                source: event.data.source,
+                referrer_source: attribution?.refSource ?? null,
+                referrer_medium: attribution?.refMedium ?? null,
+                referrer_url: attribution?.refUrl ?? null
             });
         });
 
@@ -56,7 +59,10 @@ class EventStorage {
                 created_at: event.timestamp,
                 attribution_id: attribution?.id ?? null,
                 attribution_url: attribution?.url ?? null,
-                attribution_type: attribution?.type ?? null
+                attribution_type: attribution?.type ?? null,
+                referrer_source: attribution?.refSource ?? null,
+                referrer_medium: attribution?.refMedium ?? null,
+                referrer_url: attribution?.refUrl ?? null
             });
         });
     }

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -226,7 +226,10 @@ module.exports = class WebhookController {
                 const attribution = {
                     id: session.metadata.attribution_id ?? null,
                     url: session.metadata.attribution_url ?? null,
-                    type: session.metadata.attribution_type ?? null
+                    type: session.metadata.attribution_type ?? null,
+                    refSource: session.metadata.referrer_source ?? null,
+                    refMedium: session.metadata.referrer_medium ?? null,
+                    refUrl: session.metadata.referrer_url ?? null
                 };
 
                 const payerName = _.get(customer, 'subscriptions.data[0].default_payment_method.billing_details.name');
@@ -254,7 +257,10 @@ module.exports = class WebhookController {
                 const attribution = {
                     id: session.metadata?.attribution_id ?? null,
                     url: session.metadata?.attribution_url ?? null,
-                    type: session.metadata?.attribution_type ?? null
+                    type: session.metadata?.attribution_type ?? null,
+                    refSource: session.metadata.referrer_source ?? null,
+                    refMedium: session.metadata.referrer_medium ?? null,
+                    refUrl: session.metadata.referrer_url ?? null
                 };
 
                 if (payerName && !member.get('name')) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1931
refs https://github.com/TryGhost/Team/issues/1907

- stores `referrer_source`, `referrer_medium` and `referrer_url` in event tables for new members and paid subscriptions
- assigns top-level domain as source for external referrers that don't have known mapping
- returns `Direct` as source for new members when no referrer information is found