### PR TITLE
Added post referrers stats API

### DIFF
--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -28,5 +28,17 @@ module.exports = {
         async query() {
             return await statsService.getSubscriptionCountHistory();
         }
+    },
+    postReferrers: {
+        data: [
+            'id'
+        ],
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        async query(frame) {
+            return await statsService.getPostReferrers(frame.data.id);
+        }
     }
 };

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -134,6 +134,7 @@ module.exports = function apiRoutes() {
     router.get('/stats/member_count', mw.authAdminApi, http(api.stats.memberCountHistory));
     router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
     router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
+    router.get('/stats/referrers/posts/:id', mw.authAdminApi, http(api.stats.postReferrers));
 
     // ## Labels
     router.get('/labels', mw.authAdminApi, http(api.labels.browse));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -125,3 +125,21 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Stats API Post attribution stats Can fetch attribution stats 1: [body] 1`] = `
+Object {
+  "meta": Object {},
+  "stats": Array [
+    Object {
+      "paid_conversions": 1,
+      "signups": 2,
+      "source": "Direct",
+    },
+    Object {
+      "paid_conversions": 0,
+      "signups": 1,
+      "source": "Twitter",
+    },
+  ],
+}
+`;

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -6,7 +6,7 @@ let agent;
 describe('Stats API', function () {
     before(async function () {
         agent = await agentProvider.getAdminAPIAgent();
-        await fixtureManager.init('members');
+        await fixtureManager.init('posts', 'members');
         await agent.loginAsOwner();
     });
 
@@ -62,5 +62,28 @@ describe('Stats API', function () {
             .matchHeaderSnapshot({
                 etag: anyEtag
             });
+    });
+
+    describe('Post attribution stats', function () {
+        it('Can fetch attribution stats', async function () {
+            await agent
+                .get(`/stats/referrers/posts/${fixtureManager.get('posts', 1).id}/`)
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    stats: [
+                        {
+                            source: 'Direct',
+                            signups: 2,
+                            paid_conversions: 1
+                        },
+                        {
+                            source: 'Twitter',
+                            signups: 1,
+                            paid_conversions: 0
+                        }
+                    ],
+                    meta: {}
+                });
+        });
     });
 });

--- a/ghost/core/test/utils/fixtures/data-generator.js
+++ b/ghost/core/test/utils/fixtures/data-generator.js
@@ -1542,13 +1542,26 @@ DataGenerator.forKnex = (function () {
     ];
 
     const members_created_events = members.map((member, index) => {
+        const sources = [
+            {
+                referrer_source: 'Twitter',
+                referrer_medium: 'Social',
+                referrer_url: 'https://twitter.com'
+            },
+            {
+                referrer_source: 'Direct',
+                referrer_medium: null,
+                referrer_url: null
+            }
+        ];
         return {
             id: ObjectId().toHexString(),
             member_id: member.id,
             source: 'system',
             attribution_type: 'post',
             attribution_id: DataGenerator.Content.posts[index % 3].id,
-            attribution_url: '/' + DataGenerator.Content.posts[index % 3].slug
+            attribution_url: '/' + DataGenerator.Content.posts[index % 3].slug,
+            ...sources[index % 2]
         };
     });
 
@@ -1613,6 +1626,18 @@ DataGenerator.forKnex = (function () {
     ];
 
     const members_subscription_created_events = stripe_customer_subscriptions.map((subscription, index) => {
+        const sources = [
+            {
+                referrer_source: 'Twitter',
+                referrer_medium: 'Social',
+                referrer_url: 'https://twitter.com'
+            },
+            {
+                referrer_source: 'Direct',
+                referrer_medium: null,
+                referrer_url: null
+            }
+        ];
         return {
             id: ObjectId().toHexString(),
             member_id: members[index].id,
@@ -1620,7 +1645,8 @@ DataGenerator.forKnex = (function () {
             source: 'system',
             attribution_type: 'post',
             attribution_id: DataGenerator.Content.posts[index % 3].id,
-            attribution_url: '/' + DataGenerator.Content.posts[index % 3].slug
+            attribution_url: '/' + DataGenerator.Content.posts[index % 3].slug,
+            ...sources[index % 2]
         };
     });
 

--- a/ghost/stats-service/lib/referrers.js
+++ b/ghost/stats-service/lib/referrers.js
@@ -51,14 +51,6 @@ class ReferrersStatsService {
 
         return [...map.values()].sort((a, b) => b.paid_conversions - a.paid_conversions);
     }
-
-    /**
-     * Return a list of all the attribution sources (with signup and conversion counts) grouped per date
-     * @returns {Promise<AttributionCountStatDate[]>}
-     */
-    async getHistory() {
-        // TODO: implement
-    }
 }
 
 module.exports = ReferrersStatsService;

--- a/ghost/stats-service/lib/referrers.js
+++ b/ghost/stats-service/lib/referrers.js
@@ -66,7 +66,7 @@ module.exports = ReferrersStatsService;
 /**
  * @typedef AttributionCountStat
  * @type {Object}
- * @property {number} source Attribution Source
+ * @property {string} source Attribution Source
  * @property {number} signups Total free members signed up for this source
  * @property {number} paid_conversions Total paid conversions for this source
  */

--- a/ghost/stats-service/lib/referrers.js
+++ b/ghost/stats-service/lib/referrers.js
@@ -14,7 +14,7 @@ class ReferrersStatsService {
      */
     async getForPost(postId) {
         const knex = this.knex;
-        const sigupRows = await knex('members_created_events')
+        const signupRows = await knex('members_created_events')
             .select('referrer_source')
             .select(knex.raw('COUNT(id) AS total'))
             .where('attribution_id', postId)
@@ -31,7 +31,7 @@ class ReferrersStatsService {
         // Stitch them toghether, grouping them by source
 
         const map = new Map();
-        for (const row of sigupRows) {
+        for (const row of signupRows) {
             map.set(row.referrer_source, {
                 source: row.referrer_source,
                 signups: row.total,

--- a/ghost/stats-service/lib/referrers.js
+++ b/ghost/stats-service/lib/referrers.js
@@ -1,0 +1,78 @@
+class ReferrersStatsService {
+    /**
+     * @param {object} deps
+     * @param {import('knex').Knex} deps.knex
+     **/
+    constructor({knex}) {
+        this.knex = knex;
+    }
+
+    /**
+     * Return a list of all the attribution sources for a given post, with their signup and conversion counts
+     * @param {string} postId 
+     * @returns {Promise<AttributionCountStat[]>}
+     */
+    async getForPost(postId) {
+        const knex = this.knex;
+        const sigupRows = await knex('members_created_events')
+            .select('referrer_source')
+            .select(knex.raw('COUNT(id) AS total'))
+            .where('attribution_id', postId)
+            .where('attribution_type', 'post')
+            .groupBy('referrer_source');
+
+        const conversionRows = await knex('members_subscription_created_events')
+            .select('referrer_source')
+            .select(knex.raw('COUNT(id) AS total'))
+            .where('attribution_id', postId)
+            .where('attribution_type', 'post')
+            .groupBy('referrer_source');
+
+        // Stitch them toghether, grouping them by source
+
+        const map = new Map();
+        for (const row of sigupRows) {
+            map.set(row.referrer_source, {
+                source: row.referrer_source,
+                signups: row.total,
+                paid_conversions: 0
+            });
+        }
+
+        for (const row of conversionRows) {
+            const existing = map.get(row.referrer_source) ?? {
+                source: row.referrer_source,
+                signups: 0,
+                paid_conversions: 0
+            };
+            existing.paid_conversions = row.total;
+            map.set(row.referrer_source, existing);
+        }
+
+        return [...map.values()].sort((a, b) => b.paid_conversions - a.paid_conversions);
+    }
+
+    /**
+     * Return a list of all the attribution sources (with signup and conversion counts) grouped per date
+     * @returns {Promise<AttributionCountStatDate[]>}
+     */
+    async getHistory() {
+        // TODO: implement
+    }
+}
+
+module.exports = ReferrersStatsService;
+
+/**
+ * @typedef AttributionCountStat
+ * @type {Object}
+ * @property {number} source Attribution Source
+ * @property {number} signups Total free members signed up for this source
+ * @property {number} paid_conversions Total paid conversions for this source
+ */
+
+/**
+ * @typedef AttributionCountStatDate
+ * @type {AttributionCountStat}
+ * @property {string} date The date (YYYY-MM-DD) on which these counts were recorded
+ */

--- a/ghost/stats-service/lib/stats.js
+++ b/ghost/stats-service/lib/stats.js
@@ -1,6 +1,7 @@
 const MRRService = require('./mrr');
 const MembersService = require('./members');
 const SubscriptionStatsService = require('./subscriptions');
+const ReferrersStatsService = require('./referrers');
 
 class StatsService {
     /**
@@ -8,11 +9,13 @@ class StatsService {
      * @param {MRRService} deps.mrr
      * @param {MembersService} deps.members
      * @param {SubscriptionStatsService} deps.subscriptions
+     * @param {ReferrersStatsService} deps.referrers
      **/
     constructor(deps) {
         this.mrr = deps.mrr;
         this.members = deps.members;
         this.subscriptions = deps.subscriptions;
+        this.referrers = deps.referrers;
     }
 
     async getMRRHistory() {
@@ -28,6 +31,16 @@ class StatsService {
     }
 
     /**
+     * @param {string} postId 
+     */
+    async getPostReferrers(postId) {
+        return {
+            data: await this.referrers.getForPost(postId),
+            meta: {}
+        };
+    }
+
+    /**
      * @param {object} deps
      * @param {import('knex').Knex} deps.knex
      *
@@ -37,7 +50,8 @@ class StatsService {
         return new StatsService({
             mrr: new MRRService(deps),
             members: new MembersService(deps),
-            subscriptions: new SubscriptionStatsService(deps)
+            subscriptions: new SubscriptionStatsService(deps),
+            referrers: new ReferrersStatsService(deps)
         });
     }
 }


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1942

- Added data fixtures for referrers
- Added new endpoint to fetch referrer stats for a given post: `/stats/referrers/posts/:id`
- Added new ReferrersStatsService, responsible for calculating referrer stats