### PR TITLE
Added new referrer history stats API

### DIFF
--- a/ghost/core/core/server/api/endpoints/stats.js
+++ b/ghost/core/core/server/api/endpoints/stats.js
@@ -40,5 +40,17 @@ module.exports = {
         async query(frame) {
             return await statsService.getPostReferrers(frame.data.id);
         }
+    },
+    referrersHistory: {
+        data: [
+            'id'
+        ],
+        permissions: {
+            docName: 'posts',
+            method: 'browse'
+        },
+        async query() {
+            return await statsService.getReferrersHistory();
+        }
     }
 };

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -135,6 +135,7 @@ module.exports = function apiRoutes() {
     router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
     router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
     router.get('/stats/referrers/posts/:id', mw.authAdminApi, http(api.stats.postReferrers));
+    router.get('/stats/referrers/history', mw.authAdminApi, http(api.stats.referrersHistory));
 
     // ## Labels
     router.get('/labels', mw.authAdminApi, http(api.labels.browse));

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -135,7 +135,7 @@ module.exports = function apiRoutes() {
     router.get('/stats/mrr', mw.authAdminApi, http(api.stats.mrr));
     router.get('/stats/subscriptions', mw.authAdminApi, http(api.stats.subscriptions));
     router.get('/stats/referrers/posts/:id', mw.authAdminApi, http(api.stats.postReferrers));
-    router.get('/stats/referrers/history', mw.authAdminApi, http(api.stats.referrersHistory));
+    router.get('/stats/referrers', mw.authAdminApi, http(api.stats.referrersHistory));
 
     // ## Labels
     router.get('/labels', mw.authAdminApi, http(api.labels.browse));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -149,13 +149,13 @@ Object {
   "meta": Object {},
   "stats": Array [
     Object {
-      "date": "2022-09-21",
+      "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "paid_conversions": 1,
       "signups": 4,
       "source": "Direct",
     },
     Object {
-      "date": "2022-09-21",
+      "date": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
       "paid_conversions": 2,
       "signups": 4,
       "source": "Twitter",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/stats.test.js.snap
@@ -143,3 +143,23 @@ Object {
   ],
 }
 `;
+
+exports[`Stats API Referrer source history stats Can fetch attribution stats 1: [body] 1`] = `
+Object {
+  "meta": Object {},
+  "stats": Array [
+    Object {
+      "date": "2022-09-21",
+      "paid_conversions": 1,
+      "signups": 4,
+      "source": "Direct",
+    },
+    Object {
+      "date": "2022-09-21",
+      "paid_conversions": 2,
+      "signups": 4,
+      "source": "Twitter",
+    },
+  ],
+}
+`;

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -86,4 +86,27 @@ describe('Stats API', function () {
                 });
         });
     });
+
+    describe('Referrer source history stats', function () {
+        it('Can fetch attribution stats', async function () {
+            await agent
+                .get(`/stats/referrers/history/`)
+                .expectStatus(200)
+                .matchBodySnapshot({
+                    stats: [
+                        {
+                            source: 'Direct',
+                            signups: 4,
+                            paid_conversions: 1
+                        },
+                        {
+                            source: 'Twitter',
+                            signups: 4,
+                            paid_conversions: 2
+                        }
+                    ],
+                    meta: {}
+                });
+        });
+    });
 });

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -90,7 +90,7 @@ describe('Stats API', function () {
     describe('Referrer source history stats', function () {
         it('Can fetch attribution stats', async function () {
             await agent
-                .get(`/stats/referrers/history/`)
+                .get(`/stats/referrers/`)
                 .expectStatus(200)
                 .matchBodySnapshot({
                     stats: [

--- a/ghost/core/test/e2e-api/admin/stats.test.js
+++ b/ghost/core/test/e2e-api/admin/stats.test.js
@@ -95,11 +95,13 @@ describe('Stats API', function () {
                 .matchBodySnapshot({
                     stats: [
                         {
+                            date: anyISODate,
                             source: 'Direct',
                             signups: 4,
                             paid_conversions: 1
                         },
                         {
+                            date: anyISODate,
                             source: 'Twitter',
                             signups: 4,
                             paid_conversions: 2

--- a/ghost/stats-service/lib/referrers.js
+++ b/ghost/stats-service/lib/referrers.js
@@ -1,3 +1,5 @@
+const moment = require('moment');
+
 class ReferrersStatsService {
     /**
      * @param {object} deps
@@ -9,7 +11,7 @@ class ReferrersStatsService {
 
     /**
      * Return a list of all the attribution sources for a given post, with their signup and conversion counts
-     * @param {string} postId 
+     * @param {string} postId
      * @returns {Promise<AttributionCountStat[]>}
      */
     async getForPost(postId) {
@@ -51,6 +53,83 @@ class ReferrersStatsService {
 
         return [...map.values()].sort((a, b) => b.paid_conversions - a.paid_conversions);
     }
+
+    /**
+     * Return a list of all the attribution sources, with their signup and conversion counts on each date
+     * @returns {Promise<{data: AttributionCountStat[], meta: {}}>}
+     */
+    async getReferrersHistory() {
+        const paidConversionEntries = await this.fetchAllPaidConversionSources();
+        const signupEntries = await this.fetchAllSignupSources();
+
+        const allEntries = signupEntries.map((entry) => {
+            return {
+                ...entry,
+                paid_conversions: 0,
+                date: moment(entry.date).format('YYYY-MM-DD')
+            };
+        });
+
+        paidConversionEntries.forEach((entry) => {
+            const entryDate = moment(entry.date).format('YYYY-MM-DD');
+            const existingEntry = allEntries.find(e => e.source === entry.source && e.date === entryDate);
+
+            if (existingEntry) {
+                existingEntry.paid_conversions = entry.paid_conversions;
+            } else {
+                allEntries.push({
+                    ...entry,
+                    signups: 0,
+                    date: entryDate
+                });
+            }
+        });
+
+        return {
+            data: allEntries,
+            meta: {}
+        };
+    }
+
+    /**
+     * @returns {Promise<PaidConversionsCountStatDate[]>}
+     **/
+    async fetchAllPaidConversionSources() {
+        const knex = this.knex;
+        const rows = await knex('members_subscription_created_events')
+            .select(knex.raw(`DATE(created_at) as date`))
+            .select(knex.raw(`COUNT(*) as paid_conversions`))
+            .select(knex.raw(`
+                CASE
+                    WHEN referrer_source IS NULL THEN 'Unavailable'
+                    ELSE referrer_source
+                END
+            as source`))
+            .groupBy('date', 'referrer_source')
+            .orderBy('date');
+
+        return rows;
+    }
+
+    /**
+     * @returns {Promise<SignupCountStatDate[]>}
+     **/
+    async fetchAllSignupSources() {
+        const knex = this.knex;
+        const rows = await knex('members_created_events')
+            .select(knex.raw(`DATE(created_at) as date`))
+            .select(knex.raw(`COUNT(*) as signups`))
+            .select(knex.raw(`
+                CASE
+                    WHEN referrer_source IS NULL THEN 'Unavailable'
+                    ELSE referrer_source
+                END
+            as source`))
+            .groupBy('date', 'referrer_source')
+            .orderBy('date');
+
+        return rows;
+    }
 }
 
 module.exports = ReferrersStatsService;
@@ -68,3 +147,19 @@ module.exports = ReferrersStatsService;
  * @type {AttributionCountStat}
  * @property {string} date The date (YYYY-MM-DD) on which these counts were recorded
  */
+
+/**
+ * @typedef {object} SignupCountStatDate
+ * @type {Object}
+ * @property {string} source Attribution Source
+ * @property {number} signups Total free members signed up for this source
+ * @property {string} date The date (YYYY-MM-DD) on which these counts were recorded
+ **/
+
+/**
+ * @typedef {object} PaidConversionsCountStatDate
+ * @type {Object}
+ * @property {string} source Attribution Source
+ * @property {number} paid_conversions Total paid conversions for this source
+ * @property {string} date The date (YYYY-MM-DD) on which these counts were recorded
+ **/

--- a/ghost/stats-service/lib/referrers.js
+++ b/ghost/stats-service/lib/referrers.js
@@ -85,6 +85,11 @@ class ReferrersStatsService {
             }
         });
 
+        // sort allEntries in date ascending format
+        allEntries.sort((a, b) => {
+            return moment(a.date).diff(moment(b.date));
+        });
+
         return {
             data: allEntries,
             meta: {}

--- a/ghost/stats-service/lib/stats.js
+++ b/ghost/stats-service/lib/stats.js
@@ -30,8 +30,12 @@ class StatsService {
         return this.subscriptions.getSubscriptionHistory();
     }
 
+    async getReferrersHistory() {
+        return this.referrers.getReferrersHistory();
+    }
+
     /**
-     * @param {string} postId 
+     * @param {string} postId
      */
     async getPostReferrers(postId) {
         return {

--- a/ghost/stats-service/test/lib/referrers.test.js
+++ b/ghost/stats-service/test/lib/referrers.test.js
@@ -74,6 +74,9 @@ describe('ReferrersStatsService', function () {
                 return result.date === date && result.source === source;
             };
 
+            // Is sorted by date
+            assert.deepStrictEqual(results.data.map(result => result.date), ['1970-01-01', '1970-01-02', '1970-01-03', '1970-01-04', '1970-01-05', '1970-01-06', '1970-01-07', '1970-01-08', '1970-01-09']);
+
             const firstDayCounts = results.data.find(finder('Twitter', '1970-01-01'));
             const secondDayCounts = results.data.find(finder('Ghost Newsletter', '1970-01-02'));
             const thirdDayCounts = results.data.find(finder('Ghost Explore', '1970-01-03'));

--- a/ghost/stats-service/test/lib/referrers.test.js
+++ b/ghost/stats-service/test/lib/referrers.test.js
@@ -1,0 +1,91 @@
+const knex = require('knex').default;
+const assert = require('assert');
+const ReferrersStatsService = require('../../lib/referrers');
+
+describe('ReferrersStatsService', function () {
+    describe('getReferrerHistory', function () {
+        /** @type {import('knex').Knex} */
+        let db;
+
+        beforeEach(async function () {
+            db = knex({
+                client: 'sqlite3',
+                useNullAsDefault: true,
+                connection: {
+                    filename: ':memory:'
+                }
+            });
+
+            await db.schema.createTable('members_created_events', function (table) {
+                table.string('referrer_source');
+                table.string('referrer_medium');
+                table.string('referrer_url');
+                table.date('created_at');
+            });
+            await db.schema.createTable('members_subscription_created_events', function (table) {
+                table.string('referrer_source');
+                table.string('referrer_medium');
+                table.string('referrer_url');
+                table.date('created_at');
+            });
+        });
+
+        afterEach(async function () {
+            await db.destroy();
+        });
+
+        async function insertEvents(sources) {
+            const {DateTime} = require('luxon');
+            const signupInsert = [];
+            const paidInsert = [];
+
+            for (let index = 0; index < sources.length; index++) {
+                const day = DateTime.fromISO('1970-01-01').plus({days: index}).toISODate();
+                if (index > 0) {
+                    signupInsert.push({
+                        referrer_source: sources[index],
+                        referrer_medium: null,
+                        referrer_url: null,
+                        created_at: day
+                    });
+                }
+
+                paidInsert.push({
+                    referrer_source: sources[index],
+                    referrer_medium: null,
+                    referrer_url: null,
+                    created_at: day
+                });
+            }
+
+            await db('members_created_events').insert(signupInsert);
+            await db('members_subscription_created_events').insert(paidInsert);
+        }
+
+        it('Responds with correct data', async function () {
+            const sources = ['Twitter', 'Ghost Newsletter', 'Ghost Explore', 'Product Hunt', 'Reddit', 'Facebook', 'Google', 'Direct', 'Other'];
+            await insertEvents(sources);
+
+            const stats = new ReferrersStatsService({knex: db});
+
+            const results = await stats.getReferrersHistory();
+
+            const finder = (source, date) => (result) => {
+                return result.date === date && result.source === source;
+            };
+
+            const firstDayCounts = results.data.find(finder('Twitter', '1970-01-01'));
+            const secondDayCounts = results.data.find(finder('Ghost Newsletter', '1970-01-02'));
+            const thirdDayCounts = results.data.find(finder('Ghost Explore', '1970-01-03'));
+
+            assert(firstDayCounts.signups === 0);
+            assert(firstDayCounts.paid_conversions === 1);
+
+            assert(secondDayCounts.signups === 1);
+            assert(secondDayCounts.paid_conversions === 1);
+
+            assert(thirdDayCounts.signups === 1);
+            assert(thirdDayCounts.paid_conversions === 1);
+        });
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/1939

- adds new `/stats/referrers` endpoint that returns historical data of sources by date and count of paid and free signups for each
- tests