### PR TITLE
Added member last seen update on link click

### DIFF
--- a/ghost/core/core/server/services/link-click-tracking/index.js
+++ b/ghost/core/core/server/services/link-click-tracking/index.js
@@ -16,6 +16,9 @@ class LinkTrackingServiceWrapper {
 
         // Wire up all the dependencies
         const models = require('../../models');
+        const {MemberLinkClickEvent} = require('@tryghost/member-events');
+        const DomainEvents = require('@tryghost/domain-events');
+
         const {LinkTrackingService} = require('@tryghost/link-tracking');
 
         const postLinkRepository = new PostLinkRepository({
@@ -24,8 +27,10 @@ class LinkTrackingServiceWrapper {
         });
 
         const linkClickRepository = new LinkClickRepository({
-            MemberLinkClickEvent: models.MemberLinkClickEvent,
-            Member: models.Member
+            MemberLinkClickEventModel: models.MemberLinkClickEvent,
+            Member: models.Member,
+            MemberLinkClickEvent: MemberLinkClickEvent,
+            DomainEvents
         });
 
         // Expose the service

--- a/ghost/member-events/index.js
+++ b/ghost/member-events/index.js
@@ -9,5 +9,6 @@ module.exports = {
     MemberPageViewEvent: require('./lib/MemberPageViewEvent'),
     SubscriptionCreatedEvent: require('./lib/SubscriptionCreatedEvent'),
     MemberCommentEvent: require('./lib/MemberCommentEvent'),
-    SubscriptionCancelledEvent: require('./lib/SubscriptionCancelledEvent')
+    SubscriptionCancelledEvent: require('./lib/SubscriptionCancelledEvent'),
+    MemberLinkClickEvent: require('./lib/MemberLinkClickEvent')
 };

--- a/ghost/member-events/lib/MemberLinkClickEvent.js
+++ b/ghost/member-events/lib/MemberLinkClickEvent.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {object} MemberLinkClickEventData
+ * @prop {string} memberId
+ * @prop {string} memberLastSeenAt
+ * @prop {string} linkId
+ */
+
+/**
+ * Server-side event firing on page views (page, post, tags...)
+ */
+module.exports = class MemberLinkClickEvent {
+    /**
+     * @param {MemberLinkClickEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {MemberLinkClickEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new MemberLinkClickEvent(data, timestamp || new Date);
+    }
+};

--- a/ghost/members-events-service/lib/last-seen-at-updater.js
+++ b/ghost/members-events-service/lib/last-seen-at-updater.js
@@ -1,4 +1,4 @@
-const {MemberPageViewEvent, MemberCommentEvent} = require('@tryghost/member-events');
+const {MemberPageViewEvent, MemberCommentEvent, MemberLinkClickEvent} = require('@tryghost/member-events');
 const moment = require('moment-timezone');
 const {IncorrectUsageError} = require('@tryghost/errors');
 
@@ -32,6 +32,10 @@ class LastSeenAtUpdater {
      */
     subscribe(domainEvents) {
         domainEvents.subscribe(MemberPageViewEvent, async (event) => {
+            await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
+        });
+
+        domainEvents.subscribe(MemberLinkClickEvent, async (event) => {
             await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
         });
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1952

Adds a new MemberLinkClickEvent event that is fired when a member clicks a link. This code has been added to the `linkClickRepository` because that is the only place that has access to the member model (and the event requires the id and current last seen at value). The LastSeenAtUpdater listens for this event and updates the timestamp if required.