### PR TITLE
Updated referrer attribution for empty history

### DIFF
--- a/ghost/member-attribution/lib/referrer-translator.js
+++ b/ghost/member-attribution/lib/referrer-translator.js
@@ -28,9 +28,10 @@ class ReferrerTranslator {
      * @returns {ReferrerData|null}
      */
     getReferrerDetails(history) {
+        // Empty history will return null as it means script is not loaded
         if (history.length === 0) {
             return {
-                refSource: 'Direct',
+                refSource: null,
                 refMedium: null,
                 refUrl: null
             };

--- a/ghost/member-attribution/test/referrer-translator.test.js
+++ b/ghost/member-attribution/test/referrer-translator.test.js
@@ -244,7 +244,7 @@ describe('ReferrerTranslator', function () {
 
         it('returns null for empty history', async function () {
             should(translator.getReferrerDetails([])).eql({
-                refSource: 'Direct',
+                refSource: null,
                 refMedium: null,
                 refUrl: null
             });


### PR DESCRIPTION
- empty history means attribution script is not loaded, which should be only when its behind the flag