### PR TITLE
Resolved power-select related deprecation warnings for loading components by string

### DIFF
--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -852,3 +852,9 @@ add|ember-template-lint|no-action|13|36|13|36|addf24b8fbd6518060e412ec8b95309a05
 add|ember-template-lint|no-action|16|32|16|32|5bf020bb7cafdcfbcf809310232be927a9f1b2e4|1663027200000|1673398800000|1678582800000|app/templates/posts-clicks.hbs
 add|ember-template-lint|no-action|19|29|19|29|e3023c525990c1f8d1a30aa6ff20eb3bad8ec53b|1663027200000|1673398800000|1678582800000|app/templates/posts-clicks.hbs
 add|ember-template-lint|no-action|22|31|22|31|cbf4e21da2010b9af11294f458ef2ad40374d4f0|1663027200000|1673398800000|1678582800000|app/templates/posts-clicks.hbs
+remove|ember-template-lint|no-duplicate-attributes|9|4|9|4|6b5f76f812df2b84f2ed9ee5a557ca1bf98710df|1662681600000|1673053200000|1678237200000|app/components/gh-members-segment-select.hbs
+remove|ember-template-lint|table-groups|29|12|29|12|5e48c01ff0ffa6804cd43bb95ef5ab978a1be2d5|1662681600000|1673053200000|1678237200000|app/templates/offers.hbs
+remove|ember-template-lint|no-unused-block-params|1|0|1|0|6640f2d788e2ebf173ee6ae789259ca65c097404|1662681600000|1673053200000|1678237200000|lib/koenig-editor/addon/components/koenig-card-email-cta.hbs
+add|ember-template-lint|no-duplicate-attributes|9|4|9|4|1bd74ed221db1070a4ef257ccb712285f6e4ebc6|1663977600000|1674349200000|1679533200000|app/components/gh-members-segment-select.hbs
+add|ember-template-lint|table-groups|29|12|29|12|fd6c7d9c26f38dac21ab2603a31d20617717ab33|1663977600000|1674349200000|1679533200000|app/templates/offers.hbs
+add|ember-template-lint|no-unused-block-params|1|0|1|0|1709beda164cdda6c0196211f71d73a81b9251dd|1663977600000|1674349200000|1679533200000|lib/koenig-editor/addon/components/koenig-card-email-cta.hbs

--- a/ghost/admin/app/components/dashboard/charts/anchor.hbs
+++ b/ghost/admin/app/components/dashboard/charts/anchor.hbs
@@ -7,7 +7,7 @@
                     @options={{this.displayOptions}}
                     @searchEnabled={{false}}
                     @onChange={{this.onDisplayChange}}
-                    @triggerComponent="gh-power-select/trigger"
+                    @triggerComponent={{component "gh-power-select/trigger"}}
                     @triggerClass="gh-contentfilter-menu-trigger"
                     @dropdownClass="gh-contentfilter-menu-dropdown is-narrow"
                     @matchTriggerWidth={{false}}
@@ -23,7 +23,7 @@
                 @value={{format-number this.totalMembers}}
                 @trends={{this.hasTrends}}
                 @percentage={{this.totalMembersTrend}}
-                @large={{true}} /> 
+                @large={{true}} />
         {{/if}}
 
         <div class="gh-dashboard-hero {{unless this.hasPaidTiers 'is-solo'}}">
@@ -33,7 +33,7 @@
                         {{#if this.loading}}
                             <div class="gh-dashboard-chart-loading">
                                 <div class="gh-loading-spinner"></div>
-                            </div>      
+                            </div>
                         {{else}}
                             <div class="gh-dashboard-fader">
                                 <EmberChart

--- a/ghost/admin/app/components/dashboard/charts/anchors.hbs
+++ b/ghost/admin/app/components/dashboard/charts/anchors.hbs
@@ -7,7 +7,7 @@
                     @options={{this.displayOptions}}
                     @searchEnabled={{false}}
                     @onChange={{this.onDisplayChange}}
-                    @triggerComponent="gh-power-select/trigger"
+                    @triggerComponent={{component "gh-power-select/trigger"}}
                     @triggerClass="gh-contentfilter-menu-trigger"
                     @dropdownClass="gh-contentfilter-menu-dropdown is-narrow"
                     @matchTriggerWidth={{false}}
@@ -21,15 +21,15 @@
                 @value={{format-number this.totalMembers}}
                 @trends={{this.hasTrends}}
                 @percentage={{this.totalMembersTrend}}
-                @large={{true}} 
-                @embedded={{true}}/> 
+                @large={{true}}
+                @embedded={{true}}/>
         {{else}}
             <Dashboard::Parts::Metric
                 @label="Total members"
                 @value={{format-number this.totalMembers}}
                 @trends={{this.hasTrends}}
                 @percentage={{this.totalMembersTrend}}
-                @large={{true}} /> 
+                @large={{true}} />
         {{/if}}
 
         <div class="gh-dashboard-hero {{unless this.hasPaidTiers 'is-solo'}} {{if (feature "sourceAttribution") 'source-attribution'}}">
@@ -39,7 +39,7 @@
                         {{#if this.loading}}
                             <div class="gh-dashboard-chart-loading">
                                 <div class="gh-loading-spinner"></div>
-                            </div>      
+                            </div>
                         {{else}}
                             <div class="gh-dashboard-fader">
                                 <EmberChart

--- a/ghost/admin/app/components/dashboard/charts/engagement.hbs
+++ b/ghost/admin/app/components/dashboard/charts/engagement.hbs
@@ -1,7 +1,7 @@
 <section class="gh-dashboard-section gh-dashboard-engagement">
     <article {{did-insert this.loadCharts}} class="gh-dashboard-box">
         <Dashboard::Parts::Metric
-            @label="Engagement" /> 
+            @label="Engagement" />
 
         <div class="gh-dashboard-columns">
             <div class="gh-dashboard-column gh-dashboard-engagement-30days">
@@ -35,7 +35,7 @@
                 @options={{this.statusOptions}}
                 @searchEnabled={{false}}
                 @onChange={{this.onSwitchStatus}}
-                @triggerComponent="gh-power-select/trigger"
+                @triggerComponent={{component "gh-power-select/trigger"}}
                 @triggerClass="gh-contentfilter-menu-trigger"
                 @dropdownClass="gh-contentfilter-menu-dropdown is-narrow"
                 @matchTriggerWidth={{false}}

--- a/ghost/admin/app/components/dashboard/charts/paid-mix.hbs
+++ b/ghost/admin/app/components/dashboard/charts/paid-mix.hbs
@@ -2,7 +2,7 @@
     <div class="gh-dashboard-content">
         <div class="gh-dashboard-data">
             <Dashboard::Parts::Metric
-                @label="Paid mix" /> 
+                @label="Paid mix" />
 
             {{#if this.isChartCadence}}
                 <div class="gh-dashboard-legend">
@@ -23,14 +23,14 @@
                             @type={{this.chartType}}
                             @data={{this.chartData}}
                             @options={{this.chartOptions}}
-                            @height={{110}} /> 
+                            @height={{110}} />
                     </div>
 
                     <div id="gh-dashboard-mix-tooltip" class="gh-dashboard-tooltip">
                         <div class="gh-dashboard-tooltip-value">
                             -
                         </div>
-                    </div> 
+                    </div>
                 </div>
             {{/if}}
         </div>
@@ -43,7 +43,7 @@
                 @options={{this.modeOptions}}
                 @searchEnabled={{false}}
                 @onChange={{this.onSwitchMode}}
-                @triggerComponent="gh-power-select/trigger"
+                @triggerComponent={{component "gh-power-select/trigger"}}
                 @triggerClass="gh-contentfilter-menu-trigger"
                 @dropdownClass="gh-contentfilter-menu-dropdown is-narrow"
                 @matchTriggerWidth={{false}}

--- a/ghost/admin/app/components/dashboard/prototype/control-panel.hbs
+++ b/ghost/admin/app/components/dashboard/prototype/control-panel.hbs
@@ -34,7 +34,7 @@
                             @options={{this.stateOptions}}
                             @searchEnabled={{false}}
                             @onChange={{this.onStateChange}}
-                            @triggerComponent="gh-power-select/trigger"
+                            @triggerComponent={{component "gh-power-select/trigger"}}
                             @triggerClass="gh-contentfilter-menu-trigger"
                             @dropdownClass="gh-contentfilter-menu-dropdown"
                             @matchTriggerWidth={{false}}

--- a/ghost/admin/app/components/editor/publish-options/email-recipients.hbs
+++ b/ghost/admin/app/components/editor/publish-options/email-recipients.hbs
@@ -14,7 +14,7 @@
                 @selected={{@publishOptions.newsletter}}
                 @options={{@publishOptions.newsletters}}
                 @onChange={{@publishOptions.setNewsletter}}
-                @triggerComponent="gh-power-select/trigger"
+                @triggerComponent={{component "gh-power-select/trigger"}}
                 @triggerClass="gh-publish-newsletter-trigger"
                 @dropdownClass="gh-publish-newsletter-dropdown"
                 as |newsletter|

--- a/ghost/admin/app/components/gh-member-label-input.hbs
+++ b/ghost/admin/app/components/gh-member-label-input.hbs
@@ -1,6 +1,6 @@
 <GhTokenInput
     @extra={{hash
-        tokenComponent="gh-token-input/label-token"
+        tokenComponent=(component "gh-token-input/label-token")
     }}
     @class="gh-member-label-input"
     @onChange={{this.updateLabels}}
@@ -10,7 +10,7 @@
     @selected={{this.selectedLabels}}
     @showCreateWhen={{this.hideCreateOptionOnMatchingLabel}}
     @triggerId={{this.triggerId}}
-    @selectedItemComponent="gh-token-input/label-selected-item"
+    @selectedItemComponent={{component "gh-token-input/label-selected-item"}}
     @disabled={{@disabled}}
     @allowCreation={{@allowCreation}}
     as |label|

--- a/ghost/admin/app/components/gh-members-recipient-select.hbs
+++ b/ghost/admin/app/components/gh-members-recipient-select.hbs
@@ -87,7 +87,7 @@
         @selected={{this.selectedSpecificOptions}}
         @disabled={{@disabled}}
         @searchMessage="All labels selected"
-        @optionsComponent="power-select/options"
+        @optionsComponent={{component "power-select/options"}}
         @allowCreation={{false}}
         @renderInPlace={{this.renderInPlace}}
         @onChange={{this.selectSpecificOptions}}

--- a/ghost/admin/app/components/gh-members-segment-select.hbs
+++ b/ghost/admin/app/components/gh-members-segment-select.hbs
@@ -2,7 +2,7 @@
     @options={{this.options}}
     @selected={{this.selectedOptions}}
     @disabled={{or @disabled this.fetchOptionsTask.isRunning}}
-    @optionsComponent="power-select/options"
+    @optionsComponent={{component "power-select/options"}}
     @allowCreation={{false}}
     @renderInPlace={{this.renderInPlace}}
     @onChange={{this.setSegment}}

--- a/ghost/admin/app/components/gh-membership-tiers-alpha.hbs
+++ b/ghost/admin/app/components/gh-membership-tiers-alpha.hbs
@@ -7,7 +7,7 @@
                 @options={{this.availableTypes}}
                 @searchEnabled={{false}}
                 @onChange={{this.onTypeChange}}
-                @triggerComponent="gh-power-select/trigger"
+                @triggerComponent={{component "gh-power-select/trigger"}}
                 @triggerClass="gh-contentfilter-menu-trigger gh-contentfilter-menu-trigger-tiers"
                 @dropdownClass="gh-contentfilter-menu-dropdown"
                 @matchTriggerWidth={{false}}

--- a/ghost/admin/app/components/gh-post-settings-menu/visibility-segment-select.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu/visibility-segment-select.hbs
@@ -2,7 +2,7 @@
     @options={{this.options}}
     @selected={{this.selectedOptions}}
     @disabled={{or @disabled this.fetchOptionsTask.isRunning}}
-    @optionsComponent="power-select/options"
+    @optionsComponent={{component "power-select/options"}}
     @allowCreation={{false}}
     @renderInPlace={{this.renderInPlace}}
     @onChange={{this.setSegment}}

--- a/ghost/admin/app/components/gh-psm-tags-input.hbs
+++ b/ghost/admin/app/components/gh-psm-tags-input.hbs
@@ -1,6 +1,6 @@
 <GhTokenInput
     @extra={{hash
-        tokenComponent="gh-token-input/tag-token"
+        tokenComponent=(component "gh-token-input/tag-token")
     }}
     @onChange={{action "updateTags"}}
     @onCreate={{action "createTag"}}

--- a/ghost/admin/app/components/gh-resource-select.hbs
+++ b/ghost/admin/app/components/gh-resource-select.hbs
@@ -2,7 +2,7 @@
     @options={{this.options}}
     @selected={{this.selectedOptions}}
     @disabled={{or @disabled this.fetchOptionsTask.isRunning}}
-    @optionsComponent="power-select/options"
+    @optionsComponent={{component "power-select/options"}}
     @allowCreation={{false}}
     @renderInPlace={{this.renderInPlace}}
     @onChange={{this.onChange}}

--- a/ghost/admin/app/components/gh-search-input.hbs
+++ b/ghost/admin/app/components/gh-search-input.hbs
@@ -6,7 +6,7 @@
             @onClose={{this.onClose}}
             @placeholder="Search site"
             @searchEnabled={{false}}
-            @triggerComponent="gh-input-with-select/trigger"
+            @triggerComponent={{component "gh-input-with-select/trigger"}}
             @renderInPlace={{true}}
             @loadingMessage="Loading"
             @extra={{hash

--- a/ghost/admin/app/components/gh-token-input.hbs
+++ b/ghost/admin/app/components/gh-token-input.hbs
@@ -31,7 +31,7 @@
     @onKeydown={{this.handleKeydown}}
     @onOpen={{@onOpen}}
     @options={{this.optionsWithoutSelected}}
-    @optionsComponent={{or @optionsComponent "power-select-vertical-collection-options"}}
+    @optionsComponent={{or @optionsComponent (component "power-select-vertical-collection-options")}}
     @placeholder={{@placeholder}}
     @placeholderComponent={{@placeholderComponent}}
     @preventScroll={{@preventScroll}}

--- a/ghost/admin/app/components/members-activity/member-filter.hbs
+++ b/ghost/admin/app/components/members-activity/member-filter.hbs
@@ -12,7 +12,7 @@
         @onChange={{@onChange}}
         @triggerClass="gh-member-filter-search-trigger"
         @dropdownClass="gh-member-filter-search-dropdown"
-        @triggerComponent="gh-input-with-select/trigger"
+        @triggerComponent={{component "gh-input-with-select/trigger"}}
         @placeholder="Search members"
         @extra={{hash showSearchMessage=false}}
         as |member|

--- a/ghost/admin/app/components/posts-list/content-filter.hbs
+++ b/ghost/admin/app/components/posts-list/content-filter.hbs
@@ -1,12 +1,12 @@
 <div class="gh-contentfilter view-actions-bottom-row" ...attributes>
-    
+
     <div class="gh-contentfilter-menu gh-contentfilter-type {{if @selectedType.value "gh-contentfilter-selected"}}" data-test-type-select="true">
         <PowerSelect
             @selected={{@selectedType}}
             @options={{@availableTypes}}
             @searchEnabled={{false}}
             @onChange={{@onTypeChange}}
-            @triggerComponent="gh-power-select/trigger"
+            @triggerComponent={{component "gh-power-select/trigger"}}
             @triggerClass="gh-contentfilter-menu-trigger"
             @dropdownClass="gh-contentfilter-menu-dropdown"
             @matchTriggerWidth={{false}}
@@ -23,7 +23,7 @@
                 @options={{@availableVisibilities}}
                 @searchEnabled={{false}}
                 @onChange={{@onVisibilityChange}}
-                @triggerComponent="gh-power-select/trigger"
+                @triggerComponent={{component "gh-power-select/trigger"}}
                 @triggerClass="gh-contentfilter-menu-trigger"
                 @dropdownClass="gh-contentfilter-menu-dropdown"
                 @matchTriggerWidth={{false}}
@@ -41,7 +41,7 @@
                 @options={{@availableAuthors}}
                 @searchField="name"
                 @onChange={{@onAuthorChange}}
-                @triggerComponent="gh-power-select/trigger"
+                @triggerComponent={{component "gh-power-select/trigger"}}
                 @triggerClass="gh-contentfilter-menu-trigger"
                 @dropdownClass="gh-contentfilter-menu-dropdown"
                 @searchPlaceholder="Search authors"
@@ -60,12 +60,12 @@
                 @options={{@availableTags}}
                 @searchField="name"
                 @onChange={{@onTagChange}}
-                @triggerComponent="gh-power-select/trigger"
+                @triggerComponent={{component "gh-power-select/trigger"}}
                 @triggerClass="gh-contentfilter-menu-trigger"
                 @dropdownClass="gh-contentfilter-menu-dropdown"
                 @searchPlaceholder="Search tags"
                 @matchTriggerWidth={{false}}
-                @optionsComponent="power-select-vertical-collection-options"
+                @optionsComponent={{component "power-select-vertical-collection-options"}}
                 as |tag|
             >
                 {{#if tag.name}}{{tag.name}}{{else}}<span class="red">Unknown tag</span>{{/if}}
@@ -79,7 +79,7 @@
             @options={{@availableOrders}}
             @searchEnabled={{false}}
             @onChange={{@onOrderChange}}
-            @triggerComponent="gh-power-select/trigger"
+            @triggerComponent={{component "gh-power-select/trigger"}}
             @triggerClass="gh-contentfilter-menu-trigger"
             @dropdownClass="gh-contentfilter-menu-dropdown"
             @matchTriggerWidth={{false}}

--- a/ghost/admin/app/components/settings/history/search.hbs
+++ b/ghost/admin/app/components/settings/history/search.hbs
@@ -12,7 +12,7 @@
         @onChange={{@onChange}}
         @triggerClass="gh-member-filter-search-trigger"
         @dropdownClass="gh-member-filter-search-dropdown"
-        @triggerComponent="gh-input-with-select/trigger"
+        @triggerComponent={{component "gh-input-with-select/trigger"}}
         @placeholder="Search staff"
         @extra={{hash showSearchMessage=false}}
         as |member|

--- a/ghost/admin/app/components/settings/newsletters.hbs
+++ b/ghost/admin/app/components/settings/newsletters.hbs
@@ -97,7 +97,7 @@
                                                     @onChange={{this.setMailgunRegion}}
                                                     @class="gh-select"
                                                     @searchEnabled={{false}}
-                                                    @triggerComponent="gh-power-select/trigger"
+                                                    @triggerComponent={{component "gh-power-select/trigger"}}
                                                     as |region|
                                                 >
                                                     {{region.flag}} {{region.name}}
@@ -222,7 +222,7 @@
                         </div>
                     </div>
                 </div>
-                
+
             {{/if}}
         </div>
     </section>

--- a/ghost/admin/app/components/settings/newsletters/newsletter-management.hbs
+++ b/ghost/admin/app/components/settings/newsletters/newsletter-management.hbs
@@ -9,7 +9,7 @@
                         @options={{this.statusFilters}}
                         @searchEnabled={{false}}
                         @onChange={{this.changeStatusFilter}}
-                        @triggerComponent="gh-power-select/trigger"
+                        @triggerComponent={{component "gh-power-select/trigger"}}
                         @triggerClass="gh-dropdown-archived ember-power-select-inline"
                         @dropdownClass="gh-contentfilter-menu-dropdown"
                         @horizontalPosition="right"

--- a/ghost/admin/app/components/tiers/segment-select.hbs
+++ b/ghost/admin/app/components/tiers/segment-select.hbs
@@ -2,7 +2,7 @@
     @options={{this.options}}
     @selected={{this.selectedOptions}}
     @disabled={{or @disabled this.fetchOptionsTask.isRunning}}
-    @optionsComponent="power-select/options"
+    @optionsComponent={{component "power-select/options"}}
     @allowCreation={{false}}
     @renderInPlace={{this.renderInPlace}}
     @onChange={{this.setSegment}}

--- a/ghost/admin/app/templates/dashboard.hbs
+++ b/ghost/admin/app/templates/dashboard.hbs
@@ -65,7 +65,7 @@
                         @options={{this.daysOptions}}
                         @searchEnabled={{false}}
                         @onChange={{this.onDaysChange}}
-                        @triggerComponent="gh-power-select/trigger"
+                        @triggerComponent={{component "gh-power-select/trigger"}}
                         @triggerClass="gh-contentfilter-menu-trigger"
                         @dropdownClass="gh-contentfilter-menu-dropdown is-narrow"
                         @matchTriggerWidth={{false}}

--- a/ghost/admin/app/templates/offers.hbs
+++ b/ghost/admin/app/templates/offers.hbs
@@ -9,7 +9,7 @@
                         @options={{this.availableTypes}}
                         @searchEnabled={{false}}
                         @onChange={{this.onTypeChange}}
-                        @triggerComponent="gh-power-select/trigger"
+                        @triggerComponent={{component "gh-power-select/trigger"}}
                         @triggerClass="gh-contentfilter-menu-trigger"
                         @dropdownClass="gh-contentfilter-menu-dropdown"
                         @matchTriggerWidth={{false}}
@@ -68,7 +68,7 @@
                                     {{/if}}
                                 {{/if}}
                                 {{#if (not (eq offer.type 'trial'))}}
-                                    <span class="dib ml1 midgrey ttc"> – 
+                                    <span class="dib ml1 midgrey ttc"> –
                                         {{if (eq offer.duration 'once') "First-payment" "Repeating"}}
                                     </span>
                                 {{/if}}

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-email-cta.hbs
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-email-cta.hbs
@@ -62,7 +62,7 @@
                         @selected={{this.selectedSegment}}
                         @onChange={{this.setSegment}}
                         @searchEnabled={{false}}
-                        @triggerComponent="gh-power-select/trigger"
+                        @triggerComponent={{component "gh-power-select/trigger"}}
                         @dropdownClass="gh-member-segment-select-dropdown"
                         as |segment|
                     >
@@ -153,7 +153,7 @@
                     </div>
                 </div>
             {{/if}}
-        </KoenigSettingsPanel>        
+        </KoenigSettingsPanel>
     {{else}}
         <div class="gh-email-cta-segment-indicator">
             <p>{{capitalize this.selectedSegment.name}}</p>


### PR DESCRIPTION
no issue

- in many places we were passing a string as an argument to a `<PowerSelect>` related component that referred to a component name, that was throwing deprecation warnings because those strings were used dynamically with `{{component}}` later on which isn't statically analyzable
- switched to passing a component explicitly with `{{component}}`
- https://github.com/embroider-build/embroider/blob/main/REPLACING-COMPONENT-HELPER.md#when-youre-passing-a-component-to-someone-else
