### PR TITLE
🐛 Fixed default content CTA message for page vs post

### DIFF
--- a/ghost/core/core/frontend/helpers/content.js
+++ b/ghost/core/core/frontend/helpers/content.js
@@ -18,9 +18,12 @@ const createFrame = hbs.handlebars.createFrame;
 function restrictedCta(options) {
     options = options || {};
     options.data = options.data || {};
+
     _.merge(this, {
+        // @deprecated in Ghost 5.16.1 - not documented & removed from core templates
         accentColor: (options.data.site && options.data.site.accent_color)
     });
+
     const data = createFrame(options.data);
     return templates.execute('content-cta', this, {data});
 }

--- a/ghost/core/core/frontend/helpers/tpl/content-cta.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/content-cta.hbs
@@ -1,6 +1,6 @@
 {{{html}}}
 <aside class="gh-post-upgrade-cta">
-    <div class="gh-post-upgrade-cta-content" style="background-color: {{accentColor}}">
+    <div class="gh-post-upgrade-cta-content" style="background-color: {{@site.accent_color}}">
         {{#has visibility="paid"}}
             <h2>This {{#is "page"}}page{{else}}post{{/is}} is for paying subscribers only</h2>
         {{/has}}
@@ -11,9 +11,9 @@
             <h2>This {{#is "page"}}page{{else}}post{{/is}} is for subscribers on the {{tiers}} only </h2>
         {{/has}}
         {{#if @member}}
-            <a class="gh-btn" data-portal="account/plans" style="color:{{accentColor}}">Upgrade your account</a>
+            <a class="gh-btn" data-portal="account/plans" style="color:{{@site.accentColor}}">Upgrade your account</a>
         {{else}}
-            <a class="gh-btn" data-portal="signup" style="color:{{accentColor}}">Subscribe now</a>
+            <a class="gh-btn" data-portal="signup" style="color:{{@site.accent_color}}">Subscribe now</a>
             <p><small>Already have an account? <a data-portal="signin">Sign in</a></small></p>
         {{/if}}
     </div>

--- a/ghost/core/core/frontend/helpers/tpl/content-cta.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/content-cta.hbs
@@ -2,13 +2,13 @@
 <aside class="gh-post-upgrade-cta">
     <div class="gh-post-upgrade-cta-content" style="background-color: {{accentColor}}">
         {{#has visibility="paid"}}
-            <h2>This post is for paying subscribers only</h2>
+            <h2>This {{#is "page"}}page{{else}}post{{/is}} is for paying subscribers only</h2>
         {{/has}}
         {{#has visibility="members"}}
-            <h2>This post is for subscribers only</h2>
+            <h2>This {{#is "page"}}page{{else}}post{{/is}} is for subscribers only</h2>
         {{/has}}
         {{#has visibility="tiers"}}
-            <h2>This post is for subscribers on the {{tiers}} only </h2>
+            <h2>This {{#is "page"}}page{{else}}post{{/is}} is for subscribers on the {{tiers}} only </h2>
         {{/has}}
         {{#if @member}}
             <a class="gh-btn" data-portal="account/plans" style="color:{{accentColor}}">Upgrade your account</a>

--- a/ghost/core/test/unit/frontend/helpers/content.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content.test.js
@@ -5,6 +5,8 @@ const path = require('path');
 
 // Stuff we are testing
 const content = require('../../../../core/frontend/helpers/content');
+const has = require('../../../../core/frontend/helpers/has');
+const is = require('../../../../core/frontend/helpers/is');
 
 describe('{{content}} helper', function () {
     before(function (done) {
@@ -85,6 +87,9 @@ describe('{{content}} helper with no access', function () {
         hbs.cachePartials(function () {
             done();
         });
+
+        hbs.registerHelper('has', has);
+        hbs.registerHelper('is', is);
     });
 
     beforeEach(function () {
@@ -116,6 +121,34 @@ describe('{{content}} helper with no access', function () {
         rendered.string.should.containEql('gh-post-upgrade-cta-content');
         rendered.string.should.containEql('"background-color: #abcdef"');
     });
+
+    it('can render default template with right message for post resource', function () {
+        // html will be included when there is free content available
+        const html = 'Free content';
+        optionsData.data.root = {
+            post: {}
+        };
+        const rendered = content.call({html: html, access: false, visibility: 'members'}, optionsData);
+        rendered.string.should.containEql('Free content');
+        rendered.string.should.containEql('gh-post-upgrade-cta');
+        rendered.string.should.containEql('gh-post-upgrade-cta-content');
+        rendered.string.should.containEql('"background-color: #abcdef"');
+        rendered.string.should.containEql('This post is for');
+    });
+
+    it('can render default template with right message for page resource', function () {
+        // html will be included when there is free content available
+        const html = 'Free content';
+        optionsData.data.root = {
+            context: ['page']
+        };
+        const rendered = content.call({html: html, access: false, visibility: 'members'}, optionsData);
+        rendered.string.should.containEql('Free content');
+        rendered.string.should.containEql('gh-post-upgrade-cta');
+        rendered.string.should.containEql('gh-post-upgrade-cta-content');
+        rendered.string.should.containEql('"background-color: #abcdef"');
+        rendered.string.should.containEql('This page is for');
+    });
 });
 
 describe('{{content}} helper with custom template', function () {
@@ -126,6 +159,9 @@ describe('{{content}} helper with custom template', function () {
         hbs.cachePartials(function () {
             done();
         });
+
+        hbs.registerHelper('has', has);
+        hbs.registerHelper('is', is);
     });
 
     it('can render custom template', function () {
@@ -136,5 +172,21 @@ describe('{{content}} helper with custom template', function () {
         rendered.string.should.containEql('custom-post-upgrade-cta-content');
 
         should.exist(rendered);
+    });
+
+    it('can correctly render message for page', function () {
+        // html will be included when there is free content available
+        const html = 'Free content';
+        const rendered = content.call({html: html, access: false, visibility: 'members'}, {
+            data: {
+                root: {
+                    context: ['page']
+                }
+            }
+        });
+        rendered.string.should.not.containEql('gh-post-upgrade-cta');
+        rendered.string.should.containEql('custom-post-upgrade-cta');
+        rendered.string.should.containEql('custom-post-upgrade-cta-content');
+        rendered.string.should.containEql('This page is for');
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/content.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content.test.js
@@ -108,6 +108,7 @@ describe('{{content}} helper with no access', function () {
         rendered.string.should.containEql('gh-post-upgrade-cta');
         rendered.string.should.containEql('gh-post-upgrade-cta-content');
         rendered.string.should.containEql('"background-color: #abcdef"');
+        rendered.string.should.containEql('"color:#abcdef"');
 
         should.exist(rendered);
     });

--- a/ghost/core/test/unit/frontend/helpers/test_tpl/content-cta.hbs
+++ b/ghost/core/test/unit/frontend/helpers/test_tpl/content-cta.hbs
@@ -1,13 +1,25 @@
 <aside class="custom-post-upgrade-cta">
     <div class="custom-post-upgrade-cta-content" style="background-color: {{accentColor}}">
         {{#has visibility="paid"}}
-            <h2>This post is for paying subscribers only</h2>
+            {{#is "page"}}
+                <h2>This page is for paying subscribers only</h2>
+            {{else}}
+                <h2>This post is for paying subscribers only</h2>
+            {{/is}}
         {{/has}}
         {{#has visibility="members"}}
-            <h2>This post is for subscribers only</h2>
+            {{#is "page"}}
+                <h2>This page is for subscribers only</h2>
+            {{else}}
+                <h2>This post is for subscribers only</h2>
+            {{/is}}
         {{/has}}
         {{#has visibility="tiers"}}
-            <h2>This post is for subscribers on the {{tiers}} only </h2>
+            {{#is "page"}}
+                <h2>This page is for subscribers on the {{tiers}} only </h2>
+            {{else}}
+                <h2>This post is for subscribers on the {{tiers}} only </h2>
+            {{/is}}
         {{/has}}
         {{#if @member}}
             <a class="gh-btn" data-portal="account/plans" style="color:{{accentColor}}">Account upgrade link</a>

--- a/ghost/core/test/unit/frontend/helpers/test_tpl/content-cta.hbs
+++ b/ghost/core/test/unit/frontend/helpers/test_tpl/content-cta.hbs
@@ -1,5 +1,5 @@
 <aside class="custom-post-upgrade-cta">
-    <div class="custom-post-upgrade-cta-content" style="background-color: {{accentColor}}">
+    <div class="custom-post-upgrade-cta-content" style="background-color: {{@site.accent_color}}">
         {{#has visibility="paid"}}
             {{#is "page"}}
                 <h2>This page is for paying subscribers only</h2>
@@ -22,9 +22,9 @@
             {{/is}}
         {{/has}}
         {{#if @member}}
-            <a class="gh-btn" data-portal="account/plans" style="color:{{accentColor}}">Account upgrade link</a>
+            <a class="gh-btn" data-portal="account/plans" style="color:{{@site.accent_color}}">Account upgrade link</a>
         {{else}}
-            <a class="gh-btn" data-portal="signup" style="color:{{accentColor}}">Subscribe now</a>
+            <a class="gh-btn" data-portal="signup" style="color:{{@site.accent_color}}">Subscribe now</a>
             <p><small>Already have an account? <a data-portal="signin">Sign in</a></small></p>
         {{/if}}
     </div>


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/1898

- the default content cta always used the terminology as `post` when showing message that users don't have access to some content
- this caused confusion when users were looking at a page and message showed "This post is for subscribers only"
- updates the message to correctly reflect `page` vs `post` on the default cta
- updates default cta to use accent color from global site property instead of local value(which is same)