### PR TITLE
Allowed free signups regardless of Portal settings

### DIFF
--- a/ghost/core/core/server/services/members/config.js
+++ b/ghost/core/core/server/services/members/config.js
@@ -57,20 +57,8 @@ class MembersConfigProvider {
             return false;
         }
 
-        // if stripe is not connected then selected plans mean nothing.
-        // disabling signup would be done by switching to "invite only" mode
-        if (!this.isStripeConnected()) {
-            return true;
-        }
-
-        // self signup must be available for free plan signup to work
-        const hasFreePlan = this._settingsCache.get('portal_plans').includes('free');
-        if (hasFreePlan) {
-            return true;
-        }
-
-        // signup access is enabled but there's no free plan, don't allow self signup
-        return false;
+        // Always allow free signup because the theme might have a form to signup regardless of the Portal settings
+        return true;
     }
 
     getTokenConfig() {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1966

- Currently you can only do a free self signup when 'free' is enabled in Portal or when Stripe is disabled
- Some themes, such as the Edition theme add a free signup form to the theme. That theme stops working if we don't allow self signup.
- The portal settings shouldn't be used to determine if free signup is allowed or not.