### PR TITLE
[Under discussion] Updated attribution data in member api when missing type

### DIFF
--- a/ghost/member-attribution/lib/service.js
+++ b/ghost/member-attribution/lib/service.js
@@ -99,7 +99,7 @@ class MemberAttributionService {
      */
     async getMemberCreatedAttribution(memberId) {
         const memberCreatedEvent = await this.models.MemberCreatedEvent.findOne({member_id: memberId}, {require: false, withRelated: []});
-        if (!memberCreatedEvent || !memberCreatedEvent.get('attribution_type')) {
+        if (!memberCreatedEvent) {
             return null;
         }
         const attribution = this.attributionBuilder.build({
@@ -120,7 +120,7 @@ class MemberAttributionService {
      */
     async getSubscriptionCreatedAttribution(subscriptionId) {
         const subscriptionCreatedEvent = await this.models.SubscriptionCreatedEvent.findOne({subscription_id: subscriptionId}, {require: false, withRelated: []});
-        if (!subscriptionCreatedEvent || !subscriptionCreatedEvent.get('attribution_type')) {
+        if (!subscriptionCreatedEvent) {
             return null;
         }
         const attribution = this.attributionBuilder.build({


### PR DESCRIPTION
- previously, we hid the whole attribution data from api on missing the attribution type value, as for page/post attribution it didn't make sense to include anything
- with referrer attribution also included as part of attribution object now, we cannot set the whole object as null now as that hides the referrer information