### PR TITLE
🐛 Fixed note field keyboard save in admin members form

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -57,7 +57,7 @@
                             @class="gh-member-details-textarea"
                             @tabindex="3"
                             @value={{this.scratchMember.note}}
-                            @input={{fn this.setProperty "note" this.scratchMember.note}}
+                            {{on "input" this.updateProperty}}
                             data-test-input="member-note"
                         />
                         <GhErrorMessage @errors={{this.member.errors}} @property="note" />

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -57,7 +57,7 @@
                             @class="gh-member-details-textarea"
                             @tabindex="3"
                             @value={{this.scratchMember.note}}
-                            @focus-out={{fn this.setProperty "note" this.scratchMember.note}}
+                            @input={{fn this.setProperty "note" this.scratchMember.note}}
                             data-test-input="member-note"
                         />
                         <GhErrorMessage @errors={{this.member.errors}} @property="note" />

--- a/ghost/admin/app/components/gh-member-settings-form.js
+++ b/ghost/admin/app/components/gh-member-settings-form.js
@@ -156,6 +156,11 @@ export default class extends Component {
     }
 
     @action
+    updateProperty(event){
+        this.args.setProperty(event.currentTarget.name, event.target.value);
+    }
+
+    @action
     setLabels(labels) {
         this.member.set('labels', labels);
     }


### PR DESCRIPTION
closes #15450

- the object property "note" was updated only on focus out
  - this is wrong
- the property should be updated on input 
  - this problem occured only for TextArea component