### PR TITLE
Disabled link replacement when link click tracking is disabled

### DIFF
--- a/ghost/link-tracking/lib/LinkClickTrackingService.js
+++ b/ghost/link-tracking/lib/LinkClickTrackingService.js
@@ -78,7 +78,8 @@ class LinkClickTrackingService {
         });
     }
 
-    /**
+    /** 
+     * @private (not using # to allow tests)
      * Replace URL with a redirect that redirects to the original URL, and link that redirect with the given post
      */
     async addRedirectToUrl(url, post) {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1988

- We don't want to replace links when link click tracking is disabled (also not add ref)
- Cleaned up some comments and methods