### PR TITLE
Updated naming for referrer source, medium and url

### DIFF
--- a/ghost/core/core/frontend/src/member-attribution/member-attribution.js
+++ b/ghost/core/core/frontend/src/member-attribution/member-attribution.js
@@ -87,9 +87,9 @@ const LIMIT = 15;
             console.error('[Member Attribution] Parsing referrer from querystring failed', e);
         }
 
-        const refSource = refParam || sourceParam || utmSourceParam || null;
-        const refMedium = utmMediumParam || null;
-        const refUrl = window.document.referrer || null;
+        const referrerSource = refParam || sourceParam || utmSourceParam || null;
+        const referrerMedium = utmMediumParam || null;
+        const referrerUrl = window.document.referrer || null;
 
         // Do we have attributions in the query string?
         try {
@@ -101,9 +101,9 @@ const LIMIT = 15;
                     time: currentTime,
                     id: params.get('attribution_id'),
                     type: params.get('attribution_type'),
-                    refSource,
-                    refMedium,
-                    refUrl
+                    referrerSource,
+                    referrerMedium,
+                    referrerUrl
                 });
 
                 // Remove attribution from query string
@@ -122,19 +122,19 @@ const LIMIT = 15;
             history.push({
                 path: currentPath,
                 time: currentTime,
-                refSource,
-                refMedium,
-                refUrl
+                referrerSource,
+                referrerMedium,
+                referrerUrl
             });
         } else if (history.length > 0) {
             history[history.length - 1].time = currentTime;
             // Update referrer information for same path if available (e.g. when opening a link on same path via external referrer)
-            if (refSource) {
-                history[history.length - 1].refSource = refSource;
-                history[history.length - 1].refMedium = refMedium;
+            if (referrerSource) {
+                history[history.length - 1].referrerSource = referrerSource;
+                history[history.length - 1].referrerMedium = referrerMedium;
             }
-            if (refUrl) {
-                history[history.length - 1].refUrl = refUrl;
+            if (referrerUrl) {
+                history[history.length - 1].referrerUrl = referrerUrl;
             }
         }
 

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -193,9 +193,9 @@ describe('Members API - member attribution', function () {
                 id,
                 url: '/out-of-date/',
                 type: 'post',
-                refSource: null,
-                refMedium: null,
-                refUrl: null
+                referrerSource: null,
+                referrerMedium: null,
+                referrerUrl: null
             })
         });
 
@@ -235,9 +235,9 @@ describe('Members API - member attribution', function () {
                 id,
                 url: '/out-of-date/',
                 type: 'page',
-                refSource: null,
-                refMedium: null,
-                refUrl: null
+                referrerSource: null,
+                referrerMedium: null,
+                referrerUrl: null
             })
         });
 
@@ -277,9 +277,9 @@ describe('Members API - member attribution', function () {
                 id,
                 url: '/out-of-date/',
                 type: 'tag',
-                refSource: null,
-                refMedium: null,
-                refUrl: null
+                referrerSource: null,
+                referrerMedium: null,
+                referrerUrl: null
             })
         });
 
@@ -319,9 +319,9 @@ describe('Members API - member attribution', function () {
                 id,
                 url: '/out-of-date/',
                 type: 'author',
-                refSource: null,
-                refMedium: null,
-                refUrl: null
+                referrerSource: null,
+                referrerMedium: null,
+                referrerUrl: null
             })
         });
 
@@ -358,9 +358,9 @@ describe('Members API - member attribution', function () {
                 id: null,
                 url: '/a-static-page/',
                 type: 'url',
-                refSource: null,
-                refMedium: null,
-                refUrl: null
+                referrerSource: null,
+                referrerMedium: null,
+                referrerUrl: null
             })
         });
 

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -386,18 +386,18 @@ describe('Member Attribution Service', function () {
                     id: null,
                     path: '/',
                     time: Date.now(),
-                    refSource: 'ghost-explore',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'ghost-explore',
+                    referrerMedium: null,
+                    referrerUrl: null
                 }
             ]);
             attribution.should.match(({
                 id: null,
                 url: '/',
                 type: 'url',
-                refSource: 'Ghost Explore',
-                refMedium: 'Ghost Network',
-                refUrl: null
+                referrerSource: 'Ghost Explore',
+                referrerMedium: 'Ghost Network',
+                referrerUrl: null
             }));
         });
     });

--- a/ghost/member-attribution/lib/attribution.js
+++ b/ghost/member-attribution/lib/attribution.js
@@ -18,19 +18,19 @@ class Attribution {
      * @param {string|null} [data.id]
      * @param {string|null} [data.url] Relative to subdirectory
      * @param {'page'|'post'|'author'|'tag'|'url'} [data.type]
-     * @param {string|null} [data.refSource]
-     * @param {string|null} [data.refMedium]
-     * @param {string|null} [data.refUrl]
+     * @param {string|null} [data.referrerSource]
+     * @param {string|null} [data.referrerMedium]
+     * @param {string|null} [data.referrerUrl]
      */
     constructor({
-        id, url, type, refSource, refMedium, refUrl
+        id, url, type, referrerSource, referrerMedium, referrerUrl
     }, {urlTranslator}) {
         this.id = id;
         this.url = url;
         this.type = type;
-        this.refSource = refSource;
-        this.refMedium = refMedium;
-        this.refUrl = refUrl;
+        this.referrerSource = referrerSource;
+        this.referrerMedium = referrerMedium;
+        this.referrerUrl = referrerUrl;
 
         /**
          * @private
@@ -54,9 +54,9 @@ class Attribution {
                 type: 'url',
                 url: this.#urlTranslator.relativeToAbsolute(this.url),
                 title: this.#urlTranslator.getUrlTitle(this.url),
-                referrerSource: this.refSource,
-                referrerMedium: this.refMedium,
-                referrerUrl: this.refUrl
+                referrerSource: this.referrerSource,
+                referrerMedium: this.referrerMedium,
+                referrerUrl: this.referrerUrl
             };
         }
 
@@ -67,9 +67,9 @@ class Attribution {
             type: this.type,
             url: updatedUrl,
             title: model.get('title') ?? model.get('name') ?? this.#urlTranslator.getUrlTitle(this.url),
-            referrerSource: this.refSource,
-            referrerMedium: this.refMedium,
-            referrerUrl: this.refUrl
+            referrerSource: this.referrerSource,
+            referrerMedium: this.referrerMedium,
+            referrerUrl: this.referrerUrl
         };
     }
 
@@ -94,6 +94,8 @@ class Attribution {
 class AttributionBuilder {
     /** @type {import('./url-translator')} */
     urlTranslator;
+    /** @type {import('./referrer-translator')} */
+    referrerTranslator;
 
     /**
      */
@@ -105,14 +107,14 @@ class AttributionBuilder {
     /**
      * Creates an Attribution object with the dependencies injected
      */
-    build({id, url, type, refSource, refMedium, refUrl}) {
+    build({id, url, type, referrerSource, referrerMedium, referrerUrl}) {
         return new Attribution({
             id,
             url,
             type,
-            refSource,
-            refMedium,
-            refUrl
+            referrerSource,
+            referrerMedium,
+            referrerUrl
         }, {urlTranslator: this.urlTranslator});
     }
 
@@ -127,16 +129,16 @@ class AttributionBuilder {
                 id: null,
                 url: null,
                 type: null,
-                refSource: null,
-                refMedium: null,
-                refUrl: null
+                referrerSource: null,
+                referrerMedium: null,
+                referrerUrl: null
             });
         }
 
         const referrerData = this.referrerTranslator.getReferrerDetails(history) || {
-            refSource: null,
-            refMedium: null,
-            refUrl: null
+            referrerSource: null,
+            referrerMedium: null,
+            referrerUrl: null
         };
 
         // Start at the end. Return the first post we find

--- a/ghost/member-attribution/lib/history.js
+++ b/ghost/member-attribution/lib/history.js
@@ -3,9 +3,9 @@
  * @prop {string} [path]
  * @prop {string} [id]
  * @prop {string} [type]
- * @prop {string} [refSource]
- * @prop {string} [refMedium]
- * @prop {string} [refUrl]
+ * @prop {string} [referrerSource]
+ * @prop {string} [referrerMedium]
+ * @prop {string} [referrerUrl]
  * @prop {number} time
  */
 

--- a/ghost/member-attribution/lib/referrer-translator.js
+++ b/ghost/member-attribution/lib/referrer-translator.js
@@ -1,8 +1,8 @@
 /**
  * @typedef {Object} ReferrerData
- * @prop {string|null} [refSource]
- * @prop {string|null} [refMedium]
- * @prop {string|null} [refUrl]
+ * @prop {string|null} [referrerSource]
+ * @prop {string|null} [referrerMedium]
+ * @prop {string|null} [referrerUrl]
  */
 
 const knownReferrers = require('@tryghost/referrers');
@@ -31,79 +31,79 @@ class ReferrerTranslator {
         // Empty history will return null as it means script is not loaded
         if (history.length === 0) {
             return {
-                refSource: null,
-                refMedium: null,
-                refUrl: null
+                referrerSource: null,
+                referrerMedium: null,
+                referrerUrl: null
             };
         }
 
         for (const item of history) {
-            const refUrl = this.getUrlFromStr(item.refUrl);
-            const refSource = item.refSource;
-            const refMedium = item.refMedium;
+            const referrerUrl = this.getUrlFromStr(item.referrerUrl);
+            const referrerSource = item.referrerSource;
+            const referrerMedium = item.referrerMedium;
 
             // If referrer is Ghost Explore
-            if (this.isGhostExploreRef({refUrl, refSource})) {
+            if (this.isGhostExploreRef({referrerUrl, referrerSource})) {
                 return {
-                    refSource: 'Ghost Explore',
-                    refMedium: 'Ghost Network',
-                    refUrl: refUrl?.hostname ?? null
+                    referrerSource: 'Ghost Explore',
+                    referrerMedium: 'Ghost Network',
+                    referrerUrl: referrerUrl?.hostname ?? null
                 };
             }
 
             // If referrer is Ghost.org
-            if (this.isGhostOrgUrl(refUrl)) {
+            if (this.isGhostOrgUrl(referrerUrl)) {
                 return {
-                    refSource: 'Ghost.org',
-                    refMedium: 'Ghost Network',
-                    refUrl: refUrl?.hostname
+                    referrerSource: 'Ghost.org',
+                    referrerMedium: 'Ghost Network',
+                    referrerUrl: referrerUrl?.hostname
                 };
             }
 
             // If referrer is Ghost Newsletter
-            if (this.isGhostNewsletter({refSource})) {
+            if (this.isGhostNewsletter({referrerSource})) {
                 return {
-                    refSource: refSource.replace(/-/g, ' '),
-                    refMedium: 'Email',
-                    refUrl: refUrl?.hostname ?? null
+                    referrerSource: referrerSource.replace(/-/g, ' '),
+                    referrerMedium: 'Email',
+                    referrerUrl: referrerUrl?.hostname ?? null
                 };
             }
 
             // If referrer is from query params
-            if (refSource) {
-                const urlData = refUrl ? this.getDataFromUrl(refUrl) : null;
+            if (referrerSource) {
+                const urlData = referrerUrl ? this.getDataFromUrl(referrerUrl) : null;
                 return {
-                    refSource: refSource,
-                    refMedium: refMedium || urlData?.medium || null,
-                    refUrl: refUrl?.hostname ?? null
+                    referrerSource: referrerSource,
+                    referrerMedium: referrerMedium || urlData?.medium || null,
+                    referrerUrl: referrerUrl?.hostname ?? null
                 };
             }
 
             // If referrer is known external URL
-            if (refUrl && !this.isSiteDomain(refUrl)) {
-                const urlData = this.getDataFromUrl(refUrl);
+            if (referrerUrl && !this.isSiteDomain(referrerUrl)) {
+                const urlData = this.getDataFromUrl(referrerUrl);
 
                 // Use known source/medium if available
                 if (urlData) {
                     return {
-                        refSource: urlData?.source ?? null,
-                        refMedium: urlData?.medium ?? null,
-                        refUrl: refUrl?.hostname ?? null
+                        referrerSource: urlData?.source ?? null,
+                        referrerMedium: urlData?.medium ?? null,
+                        referrerUrl: referrerUrl?.hostname ?? null
                     };
                 }
                 // Use the hostname as a source
                 return {
-                    refSource: refUrl?.hostname ?? null,
-                    refMedium: null,
-                    refUrl: refUrl?.hostname ?? null
+                    referrerSource: referrerUrl?.hostname ?? null,
+                    referrerMedium: null,
+                    referrerUrl: referrerUrl?.hostname ?? null
                 };
             }
         }
 
         return {
-            refSource: 'Direct',
-            refMedium: null,
-            refUrl: null
+            referrerSource: 'Direct',
+            referrerMedium: null,
+            referrerUrl: null
         };
     }
 
@@ -159,45 +159,45 @@ class ReferrerTranslator {
      * @private
      * Return whether provided ref is a Ghost newsletter
      * @param {Object} deps
-     * @param {string|null} deps.refSource
+     * @param {string|null} deps.referrerSource
      * @returns {boolean}
      */
-    isGhostNewsletter({refSource}) {
+    isGhostNewsletter({referrerSource}) {
         // if refferer source ends with -newsletter
-        return refSource?.endsWith('-newsletter');
+        return referrerSource?.endsWith('-newsletter');
     }
 
     /**
      * @private
      * Return whether provided ref is a Ghost.org URL
-     * @param {URL|null} refUrl
+     * @param {URL|null} referrerUrl
      * @returns {boolean}
      */
-    isGhostOrgUrl(refUrl) {
-        return refUrl?.hostname === 'ghost.org';
+    isGhostOrgUrl(referrerUrl) {
+        return referrerUrl?.hostname === 'ghost.org';
     }
 
     /**
      * @private
      * Return whether provided ref is Ghost Explore
      * @param {Object} deps
-     * @param {URL|null} deps.refUrl
-     * @param {string|null} deps.refSource
+     * @param {URL|null} deps.referrerUrl
+     * @param {string|null} deps.referrerSource
      * @returns {boolean}
      */
-    isGhostExploreRef({refUrl, refSource}) {
-        if (refSource === 'ghost-explore') {
+    isGhostExploreRef({referrerUrl, referrerSource}) {
+        if (referrerSource === 'ghost-explore') {
             return true;
         }
 
-        if (refUrl?.hostname
-            && this.adminUrl?.hostname === refUrl?.hostname
-            && refUrl?.pathname?.startsWith(this.adminUrl?.pathname)
+        if (referrerUrl?.hostname
+            && this.adminUrl?.hostname === referrerUrl?.hostname
+            && referrerUrl?.pathname?.startsWith(this.adminUrl?.pathname)
         ) {
             return true;
         }
 
-        if (refUrl?.hostname === 'ghost.org' && refUrl?.pathname?.startsWith('/explore')) {
+        if (referrerUrl?.hostname === 'ghost.org' && referrerUrl?.pathname?.startsWith('/explore')) {
             return true;
         }
 

--- a/ghost/member-attribution/lib/service.js
+++ b/ghost/member-attribution/lib/service.js
@@ -70,9 +70,9 @@ class MemberAttributionService {
             id: eventModel.get('attribution_id'),
             url: eventModel.get('attribution_url'),
             type: eventModel.get('attribution_type'),
-            refSource: eventModel.get('referrer_source'),
-            refMedium: eventModel.get('referrer_medium'),
-            refUrl: eventModel.get('referrer_url')
+            referrerSource: eventModel.get('referrer_source'),
+            referrerMedium: eventModel.get('referrer_medium'),
+            referrerUrl: eventModel.get('referrer_url')
         });
 
         if (_attribution.type !== 'url') {
@@ -106,9 +106,9 @@ class MemberAttributionService {
             id: memberCreatedEvent.get('attribution_id'),
             url: memberCreatedEvent.get('attribution_url'),
             type: memberCreatedEvent.get('attribution_type'),
-            refSource: memberCreatedEvent.get('referrer_source'),
-            refMedium: memberCreatedEvent.get('referrer_medium'),
-            refUrl: memberCreatedEvent.get('referrer_url')
+            referrerSource: memberCreatedEvent.get('referrer_source'),
+            referrerMedium: memberCreatedEvent.get('referrer_medium'),
+            referrerUrl: memberCreatedEvent.get('referrer_url')
         });
         return await attribution.fetchResource();
     }
@@ -127,9 +127,9 @@ class MemberAttributionService {
             id: subscriptionCreatedEvent.get('attribution_id'),
             url: subscriptionCreatedEvent.get('attribution_url'),
             type: subscriptionCreatedEvent.get('attribution_type'),
-            refSource: subscriptionCreatedEvent.get('referrer_source'),
-            refMedium: subscriptionCreatedEvent.get('referrer_medium'),
-            refUrl: subscriptionCreatedEvent.get('referrer_url')
+            referrerSource: subscriptionCreatedEvent.get('referrer_source'),
+            referrerMedium: subscriptionCreatedEvent.get('referrer_medium'),
+            referrerUrl: subscriptionCreatedEvent.get('referrer_url')
         });
         return await attribution.fetchResource();
     }

--- a/ghost/member-attribution/test/attribution.test.js
+++ b/ghost/member-attribution/test/attribution.test.js
@@ -88,9 +88,9 @@ describe('AttributionBuilder', function () {
                 getReferrerDetails(history) {
                     if (history) {
                         return {
-                            refSource: 'Ghost Explore',
-                            refMedium: 'Ghost Network',
-                            refUrl: 'https://ghost.org/explore'
+                            referrerSource: 'Ghost Explore',
+                            referrerMedium: 'Ghost Network',
+                            referrerUrl: 'https://ghost.org/explore'
                         };
                     }
                     return null;
@@ -101,7 +101,7 @@ describe('AttributionBuilder', function () {
 
     it('Returns empty if empty history', async function () {
         const history = UrlHistory.create([]);
-        should(await attributionBuilder.getAttribution(history)).match({id: null, type: null, url: null, refSource: null, refMedium: null, refUrl: null});
+        should(await attributionBuilder.getAttribution(history)).match({id: null, type: null, url: null, referrerSource: null, referrerMedium: null, referrerUrl: null});
     });
 
     it('Returns last url', async function () {
@@ -152,9 +152,9 @@ describe('AttributionBuilder', function () {
             {path: '/dir/unknown-page', time: now + 125}
         ]);
         should(await attributionBuilder.getAttribution(history)).match({
-            refSource: 'Ghost Explore',
-            refMedium: 'Ghost Network',
-            refUrl: 'https://ghost.org/explore'
+            referrerSource: 'Ghost Explore',
+            referrerMedium: 'Ghost Network',
+            referrerUrl: 'https://ghost.org/explore'
         });
     });
 
@@ -173,9 +173,9 @@ describe('AttributionBuilder', function () {
             {path: '/dir/unknown-page', time: now + 125}
         ]);
         should(await attributionBuilder.getAttribution(history)).match({
-            refSource: null,
-            refMedium: null,
-            refUrl: null
+            referrerSource: null,
+            referrerMedium: null,
+            referrerUrl: null
         });
     });
 

--- a/ghost/member-attribution/test/history.test.js
+++ b/ghost/member-attribution/test/history.test.js
@@ -82,9 +82,9 @@ describe('UrlHistory', function () {
                 time: Date.now(),
                 type: 'post',
                 id: '123',
-                refSource: 'ghost-explore',
-                refMedium: null,
-                refUrl: 'https://ghost.org'
+                referrerSource: 'ghost-explore',
+                referrerMedium: null,
+                referrerUrl: 'https://ghost.org'
             }]
         ];
         for (const input of inputs) {

--- a/ghost/member-attribution/test/referrer-translator.test.js
+++ b/ghost/member-attribution/test/referrer-translator.test.js
@@ -22,144 +22,144 @@ describe('ReferrerTranslator', function () {
         it('returns ghost explore from source ref for valid history', async function () {
             should(translator.getReferrerDetails([
                 {
-                    refSource: 'ghost-explore',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'ghost-explore',
+                    referrerMedium: null,
+                    referrerUrl: null
                 },
                 {
-                    refSource: 'ghost-newsletter',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'ghost-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: null
                 },
                 {
-                    refSource: 'ghost-newsletter',
-                    refMedium: null,
-                    refUrl: 'https://t.co'
+                    referrerSource: 'ghost-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: 'https://t.co'
                 }
             ])).eql({
-                refSource: 'Ghost Explore',
-                refMedium: 'Ghost Network',
-                refUrl: null
+                referrerSource: 'Ghost Explore',
+                referrerMedium: 'Ghost Network',
+                referrerUrl: null
             });
         });
 
         it('returns ghost explore from url for valid history', async function () {
             should(translator.getReferrerDetails([
                 {
-                    refSource: null,
-                    refMedium: null,
-                    refUrl: 'https://ghost.org/explore'
+                    referrerSource: null,
+                    referrerMedium: null,
+                    referrerUrl: 'https://ghost.org/explore'
                 },
                 {
-                    refSource: 'ghost-newsletter',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'ghost-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: null
                 },
                 {
-                    refSource: 'ghost-newsletter',
-                    refMedium: null,
-                    refUrl: 'https://t.co'
+                    referrerSource: 'ghost-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: 'https://t.co'
                 }
             ])).eql({
-                refSource: 'Ghost Explore',
-                refMedium: 'Ghost Network',
-                refUrl: 'ghost.org'
+                referrerSource: 'Ghost Explore',
+                referrerMedium: 'Ghost Network',
+                referrerUrl: 'ghost.org'
             });
         });
 
         it('returns ghost explore from admin url for valid history', async function () {
             should(translator.getReferrerDetails([
                 {
-                    refSource: null,
-                    refMedium: null,
-                    refUrl: 'https://admin.example.com/ghost/#/dashboard'
+                    referrerSource: null,
+                    referrerMedium: null,
+                    referrerUrl: 'https://admin.example.com/ghost/#/dashboard'
                 },
                 {
-                    refSource: 'ghost-newsletter',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'ghost-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: null
                 },
                 {
-                    refSource: 'ghost-newsletter',
-                    refMedium: null,
-                    refUrl: 'https://t.co'
+                    referrerSource: 'ghost-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: 'https://t.co'
                 }
             ])).eql({
-                refSource: 'Ghost Explore',
-                refMedium: 'Ghost Network',
-                refUrl: 'admin.example.com'
+                referrerSource: 'Ghost Explore',
+                referrerMedium: 'Ghost Network',
+                referrerUrl: 'admin.example.com'
             });
         });
 
         it('returns ghost newsletter ref for valid history', async function () {
             should(translator.getReferrerDetails([
                 {
-                    refSource: 'publisher-weekly-newsletter',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'publisher-weekly-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: null
                 },
                 {
-                    refSource: 'ghost-explore',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'ghost-explore',
+                    referrerMedium: null,
+                    referrerUrl: null
                 },
                 {
-                    refSource: 'ghost-newsletter',
-                    refMedium: null,
-                    refUrl: 'https://t.co'
+                    referrerSource: 'ghost-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: 'https://t.co'
                 }
             ])).eql({
-                refSource: 'publisher weekly newsletter',
-                refMedium: 'Email',
-                refUrl: null
+                referrerSource: 'publisher weekly newsletter',
+                referrerMedium: 'Email',
+                referrerUrl: null
             });
         });
 
         it('returns ghost.org ref for valid history', async function () {
             should(translator.getReferrerDetails([
                 {
-                    refSource: null,
-                    refMedium: null,
-                    refUrl: 'https://ghost.org/creators/'
+                    referrerSource: null,
+                    referrerMedium: null,
+                    referrerUrl: 'https://ghost.org/creators/'
                 },
                 {
-                    refSource: 'publisher-weekly-newsletter',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'publisher-weekly-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: null
                 },
                 {
-                    refSource: 'ghost-explore',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'ghost-explore',
+                    referrerMedium: null,
+                    referrerUrl: null
                 }
             ])).eql({
-                refSource: 'Ghost.org',
-                refMedium: 'Ghost Network',
-                refUrl: 'ghost.org'
+                referrerSource: 'Ghost.org',
+                referrerMedium: 'Ghost Network',
+                referrerUrl: 'ghost.org'
             });
         });
 
         it('returns ref source for valid history', async function () {
             should(translator.getReferrerDetails([
                 {
-                    refSource: 'twitter',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'twitter',
+                    referrerMedium: null,
+                    referrerUrl: null
                 },
                 {
-                    refSource: 'publisher-weekly-newsletter',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'publisher-weekly-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: null
                 },
                 {
-                    refSource: 'ghost-explore',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'ghost-explore',
+                    referrerMedium: null,
+                    referrerUrl: null
                 }
             ])).eql({
-                refSource: 'twitter',
-                refMedium: null,
-                refUrl: null
+                referrerSource: 'twitter',
+                referrerMedium: null,
+                referrerUrl: null
             });
         });
 
@@ -167,53 +167,53 @@ describe('ReferrerTranslator', function () {
             it('known external url with path', async function () {
                 should(translator.getReferrerDetails([
                     {
-                        refSource: null,
-                        refMedium: null,
-                        refUrl: 'https://google.ac/products'
+                        referrerSource: null,
+                        referrerMedium: null,
+                        referrerUrl: 'https://google.ac/products'
                     },
                     {
-                        refSource: null,
-                        refMedium: null,
-                        refUrl: 'https://t.co/'
+                        referrerSource: null,
+                        referrerMedium: null,
+                        referrerUrl: 'https://t.co/'
                     },
                     {
-                        refSource: 'publisher-weekly-newsletter',
-                        refMedium: null,
-                        refUrl: null
+                        referrerSource: 'publisher-weekly-newsletter',
+                        referrerMedium: null,
+                        referrerUrl: null
                     },
                     {
-                        refSource: 'ghost-explore',
-                        refMedium: null,
-                        refUrl: null
+                        referrerSource: 'ghost-explore',
+                        referrerMedium: null,
+                        referrerUrl: null
                     }
                 ])).eql({
-                    refSource: 'Google Product Search',
-                    refMedium: 'search',
-                    refUrl: 'google.ac'
+                    referrerSource: 'Google Product Search',
+                    referrerMedium: 'search',
+                    referrerUrl: 'google.ac'
                 });
             });
 
             it('known external url without path', async function () {
                 should(translator.getReferrerDetails([
                     {
-                        refSource: null,
-                        refMedium: null,
-                        refUrl: 'https://t.co/'
+                        referrerSource: null,
+                        referrerMedium: null,
+                        referrerUrl: 'https://t.co/'
                     },
                     {
-                        refSource: 'publisher-weekly-newsletter',
-                        refMedium: null,
-                        refUrl: null
+                        referrerSource: 'publisher-weekly-newsletter',
+                        referrerMedium: null,
+                        referrerUrl: null
                     },
                     {
-                        refSource: 'ghost-explore',
-                        refMedium: null,
-                        refUrl: null
+                        referrerSource: 'ghost-explore',
+                        referrerMedium: null,
+                        referrerUrl: null
                     }
                 ])).eql({
-                    refSource: 'Twitter',
-                    refMedium: 'social',
-                    refUrl: 't.co'
+                    referrerSource: 'Twitter',
+                    referrerMedium: 'social',
+                    referrerUrl: 't.co'
                 });
             });
         });
@@ -221,46 +221,46 @@ describe('ReferrerTranslator', function () {
         it('returns external ref url as source', async function () {
             should(translator.getReferrerDetails([
                 {
-                    refSource: null,
-                    refMedium: null,
-                    refUrl: 'https://example.com'
+                    referrerSource: null,
+                    referrerMedium: null,
+                    referrerUrl: 'https://example.com'
                 },
                 {
-                    refSource: null,
-                    refMedium: null,
-                    refUrl: 'https://sample.com'
+                    referrerSource: null,
+                    referrerMedium: null,
+                    referrerUrl: 'https://sample.com'
                 },
                 {
-                    refSource: 'publisher-weekly-newsletter',
-                    refMedium: null,
-                    refUrl: null
+                    referrerSource: 'publisher-weekly-newsletter',
+                    referrerMedium: null,
+                    referrerUrl: null
                 }
             ])).eql({
-                refSource: 'sample.com',
-                refMedium: null,
-                refUrl: 'sample.com'
+                referrerSource: 'sample.com',
+                referrerMedium: null,
+                referrerUrl: 'sample.com'
             });
         });
 
         it('returns null for empty history', async function () {
             should(translator.getReferrerDetails([])).eql({
-                refSource: null,
-                refMedium: null,
-                refUrl: null
+                referrerSource: null,
+                referrerMedium: null,
+                referrerUrl: null
             });
         });
 
         it('returns null for history with only site url', async function () {
             should(translator.getReferrerDetails([
                 {
-                    refSource: null,
-                    refMedium: null,
-                    refUrl: 'https://example.com'
+                    referrerSource: null,
+                    referrerMedium: null,
+                    referrerUrl: 'https://example.com'
                 }
             ])).eql({
-                refSource: 'Direct',
-                refMedium: null,
-                refUrl: null
+                referrerSource: 'Direct',
+                referrerMedium: null,
+                referrerUrl: null
             });
         });
     });

--- a/ghost/member-attribution/test/service.test.js
+++ b/ghost/member-attribution/test/service.test.js
@@ -55,9 +55,9 @@ describe('MemberAttributionService', function () {
                 type: 'url',
                 url: '/my/url/',
                 title: 'added',
-                refMedium: null,
-                refSource: null,
-                refUrl: null
+                referrerMedium: null,
+                referrerSource: null,
+                referrerUrl: null
             });
         });
 
@@ -105,9 +105,9 @@ describe('MemberAttributionService', function () {
                 type: 'user',
                 url: '/my/url/',
                 title: 'added',
-                refMedium: null,
-                refSource: null,
-                refUrl: null
+                referrerMedium: null,
+                referrerSource: null,
+                referrerUrl: null
             });
         });
     });

--- a/ghost/members-api/lib/controllers/router.js
+++ b/ghost/members-api/lib/controllers/router.js
@@ -227,16 +227,16 @@ module.exports = class RouterController {
                 metadata.attribution_type = attribution.type;
             }
 
-            if (attribution.refSource) {
-                metadata.referrer_source = attribution.refSource;
+            if (attribution.referrerSource) {
+                metadata.referrer_source = attribution.referrerSource;
             }
 
-            if (attribution.refMedium) {
-                metadata.referrer_medium = attribution.refMedium;
+            if (attribution.referrerMedium) {
+                metadata.referrer_medium = attribution.referrerMedium;
             }
 
-            if (attribution.refUrl) {
-                metadata.referrer_url = attribution.refUrl;
+            if (attribution.referrerUrl) {
+                metadata.referrer_url = attribution.referrerUrl;
             }
         }
 

--- a/ghost/members-events-service/lib/event-storage.js
+++ b/ghost/members-events-service/lib/event-storage.js
@@ -38,9 +38,9 @@ class EventStorage {
                 attribution_url: attribution?.url ?? null,
                 attribution_type: attribution?.type ?? null,
                 source: event.data.source,
-                referrer_source: attribution?.refSource ?? null,
-                referrer_medium: attribution?.refMedium ?? null,
-                referrer_url: attribution?.refUrl ?? null
+                referrer_source: attribution?.referrerSource ?? null,
+                referrer_medium: attribution?.referrerMedium ?? null,
+                referrer_url: attribution?.referrerUrl ?? null
             });
         });
 
@@ -60,9 +60,9 @@ class EventStorage {
                 attribution_id: attribution?.id ?? null,
                 attribution_url: attribution?.url ?? null,
                 attribution_type: attribution?.type ?? null,
-                referrer_source: attribution?.refSource ?? null,
-                referrer_medium: attribution?.refMedium ?? null,
-                referrer_url: attribution?.refUrl ?? null
+                referrer_source: attribution?.referrerSource ?? null,
+                referrer_medium: attribution?.referrerMedium ?? null,
+                referrer_url: attribution?.referrerUrl ?? null
             });
         });
     }

--- a/ghost/stripe/lib/WebhookController.js
+++ b/ghost/stripe/lib/WebhookController.js
@@ -227,9 +227,9 @@ module.exports = class WebhookController {
                     id: session.metadata.attribution_id ?? null,
                     url: session.metadata.attribution_url ?? null,
                     type: session.metadata.attribution_type ?? null,
-                    refSource: session.metadata.referrer_source ?? null,
-                    refMedium: session.metadata.referrer_medium ?? null,
-                    refUrl: session.metadata.referrer_url ?? null
+                    referrerSource: session.metadata.referrer_source ?? null,
+                    referrerMedium: session.metadata.referrer_medium ?? null,
+                    referrerUrl: session.metadata.referrer_url ?? null
                 };
 
                 const payerName = _.get(customer, 'subscriptions.data[0].default_payment_method.billing_details.name');
@@ -258,9 +258,9 @@ module.exports = class WebhookController {
                     id: session.metadata?.attribution_id ?? null,
                     url: session.metadata?.attribution_url ?? null,
                     type: session.metadata?.attribution_type ?? null,
-                    refSource: session.metadata.referrer_source ?? null,
-                    refMedium: session.metadata.referrer_medium ?? null,
-                    refUrl: session.metadata.referrer_url ?? null
+                    referrerSource: session.metadata.referrer_source ?? null,
+                    referrerMedium: session.metadata.referrer_medium ?? null,
+                    referrerUrl: session.metadata.referrer_url ?? null
                 };
 
                 if (payerName && !member.get('name')) {


### PR DESCRIPTION
- renames `refSource`, `refMedium` and `refUrl` to `referrerSource`, `referrerMedium` and `referrerUrl` respectively for consistent naming across packages