### PR TITLE
Allowed storing attribution data on member events

### DIFF
--- a/ghost/members-events-service/lib/event-storage.js
+++ b/ghost/members-events-service/lib/event-storage.js
@@ -25,12 +25,6 @@ class EventStorage {
         domainEvents.subscribe(MemberCreatedEvent, async (event) => {
             let attribution = event.data.attribution;
 
-            if (!this.labsService.isSet('memberAttribution')){
-                // Prevent storing attribution
-                // Can replace this later with a privacy toggle
-                attribution = {};
-            }
-
             await this.models.MemberCreatedEvent.add({
                 member_id: event.data.memberId,
                 created_at: event.timestamp,
@@ -46,12 +40,6 @@ class EventStorage {
 
         domainEvents.subscribe(SubscriptionCreatedEvent, async (event) => {
             let attribution = event.data.attribution;
-
-            if (!this.labsService.isSet('memberAttribution')){
-                // Prevent storing attribution
-                // Can replace this later with a privacy toggle
-                attribution = {};
-            }
 
             await this.models.SubscriptionCreatedEvent.add({
                 member_id: event.data.memberId,

--- a/ghost/members-events-service/test/event-storage.test.js
+++ b/ghost/members-events-service/test/event-storage.test.js
@@ -104,10 +104,13 @@ describe('EventStorage', function () {
             sinon.assert.calledOnceWithMatch(MemberCreatedEventModel.add, {
                 member_id: '123',
                 created_at: new Date(0),
-                attribution_id: null,
-                attribution_type: null,
-                attribution_url: null,
-                source: 'test'
+                attribution_id: '123',
+                attribution_type: 'post',
+                attribution_url: 'url',
+                source: 'test',
+                referrer_source: null,
+                referrer_medium: null,
+                referrer_url: null
             });
             sinon.assert.calledTwice(subscribeSpy);
         });
@@ -178,7 +181,7 @@ describe('EventStorage', function () {
             sinon.assert.calledTwice(subscribeSpy);
         });
 
-        it('filters if disabled', function () {
+        it('works with flag disabled', function () {
             const DomainEvents = {
                 subscribe: (type, handler) => {
                     if (type === SubscriptionCreatedEvent) {
@@ -207,9 +210,12 @@ describe('EventStorage', function () {
                 member_id: '123',
                 subscription_id: '456',
                 created_at: new Date(0),
-                attribution_id: null,
-                attribution_type: null,
-                attribution_url: null
+                attribution_id: '123',
+                attribution_type: 'post',
+                attribution_url: 'url',
+                referrer_source: null,
+                referrer_medium: null,
+                referrer_url: null
             });
             sinon.assert.calledTwice(subscribeSpy);
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/90034577b84ad37f686c34143415c83792281800

- this change was missed in above commit and would have blocked capturing attribution data for sites without the flag