### PR TITLE
Added opened, clicked and received email filtering to members

### DIFF
--- a/ghost/admin/app/components/gh-resource-select.hbs
+++ b/ghost/admin/app/components/gh-resource-select.hbs
@@ -7,7 +7,7 @@
     @renderInPlace={{this.renderInPlace}}
     @onChange={{this.onChange}}
     @class="select-members"
-    @placeholder="Select a page/post"
+    @placeholder={{this.placeholderText}}
     as |resource|
 >
     {{resource.name}}

--- a/ghost/admin/app/components/gh-resource-select.js
+++ b/ghost/admin/app/components/gh-resource-select.js
@@ -48,9 +48,26 @@ export default class GhResourceSelect extends Component {
         this.args.onChange(options);
     }
 
+    get placeholderText() {
+        if (this.args.type === 'email') {
+            return 'Select an email';
+        }
+        return 'Select a page/post';
+    }
+
     @task
     *fetchOptionsTask() {
         const options = yield [];
+        
+        if (this.args.type === 'email') {
+            const posts = yield this.store.query('post', {filter: '(status:published,status:sent)+newsletter_id:-null', limit: 'all'});
+            options.push({
+                groupName: 'Emails',
+                options: posts.map(mapResource)
+            });
+            this._options = options;
+            return;
+        }
 
         const posts = yield this.store.query('post', {filter: 'status:published', limit: 'all'});
         const pages = yield this.store.query('page', {filter: 'status:published', limit: 'all'});

--- a/ghost/admin/app/components/members/filter-value.hbs
+++ b/ghost/admin/app/components/members/filter-value.hbs
@@ -42,19 +42,12 @@
         />
     </div>
 
-{{else if (eq @filter.type 'conversion')}}
+{{else if this.isResourceFilter }}
     <div class="relative">
          <GhResourceSelect
-            @onChange={{fn this.setConversionAttributionFilterValue @filter}}
-            @resources={{this.conversionAttributionFilterValue}}
-        />
-    </div>
-
-{{else if (eq @filter.type 'signup')}}
-    <div class="relative">
-         <GhResourceSelect
-            @onChange={{fn this.setSignupAttributionFilterValue @filter}}
-            @resources={{this.signupAttributionFilterValue}}
+            @onChange={{fn this.setResourceFilterValue @filter}}
+            @type={{this.resourceFilterType}}
+            @resources={{this.resourceFilterValue}}
         />
     </div>
 

--- a/ghost/admin/app/components/members/filter-value.js
+++ b/ghost/admin/app/components/members/filter-value.js
@@ -48,30 +48,6 @@ export default class MembersFilterValue extends Component {
         return [];
     }
 
-    get signupAttributionFilterValue() {
-        if (this.args.filter?.type === 'signup') {
-            const resources = this.args.filter?.value || [];
-            return resources.map((resource) => {
-                return {
-                    id: resource
-                };
-            });
-        }
-        return [];
-    }
-
-    get conversionAttributionFilterValue() {
-        if (this.args.filter?.type === 'conversion') {
-            const resources = this.args.filter?.value || [];
-            return resources.map((resource) => {
-                return {
-                    id: resource
-                };
-            });
-        }
-        return [];
-    }
-
     @action
     setInputFilterValue(filter, event) {
         this.filterValue = event.target.value;
@@ -103,13 +79,36 @@ export default class MembersFilterValue extends Component {
         this.args.setFilterValue(filter, tiers.map(tier => tier.slug));
     }
 
-    @action
-    setConversionAttributionFilterValue(filter, resources) {
-        this.args.setFilterValue(filter, resources.map(resource => resource.id));
+    get isResourceFilter() {
+        return ['signup', 'conversion', 'emails.post_id', 'opened_emails.post_id', 'clicked_links.post_id'].includes(this.args.filter?.type);
+    }
+
+    get resourceFilterType() {
+        if (!this.isResourceFilter) {
+            return '';
+        }
+
+        if (['emails.post_id', 'opened_emails.post_id', 'clicked_links.post_id'].includes(this.args.filter?.type)) {
+            return 'email';
+        }
+
+        return '';
+    }
+
+    get resourceFilterValue() {
+        if (!this.isResourceFilter) {
+            return [];
+        }
+        const resources = this.args.filter?.value || [];
+        return resources.map((resource) => {
+            return {
+                id: resource
+            };
+        });
     }
 
     @action
-    setSignupAttributionFilterValue(filter, resources) {
+    setResourceFilterValue(filter, resources) {
         this.args.setFilterValue(filter, resources.map(resource => resource.id));
     }
 }

--- a/ghost/admin/app/components/members/filter.js
+++ b/ghost/admin/app/components/members/filter.js
@@ -30,7 +30,11 @@ const FILTER_PROPERTIES = [
     // Emails
     {label: 'Emails sent (all time)', name: 'email_count', group: 'Email'},
     {label: 'Emails opened (all time)', name: 'email_opened_count', group: 'Email'},
-    {label: 'Open rate (all time)', name: 'email_open_rate', group: 'Email'}
+    {label: 'Open rate (all time)', name: 'email_open_rate', group: 'Email'},
+    {label: 'Received email', name: 'emails.post_id', group: 'Email', valueType: 'array', feature: 'emailClicks'},
+    {label: 'Opened email', name: 'opened_emails.post_id', group: 'Email', valueType: 'array', feature: 'emailClicks'},
+    {label: 'Clicked email', name: 'clicked_links.post_id', group: 'Email', valueType: 'array', feature: 'emailClicks'}
+
     // {label: 'Emails sent (30 days)', name: 'x', group: 'Email'},
     // {label: 'Emails opened (30 days)', name: 'x', group: 'Email'},
     // {label: 'Open rate (30 days)', name: 'x', group: 'Email'},
@@ -86,7 +90,10 @@ const FILTER_RELATIONS_OPTIONS = {
     email_opened_count: NUMBER_RELATION_OPTIONS,
     email_open_rate: NUMBER_RELATION_OPTIONS,
     signup: MATCH_RELATION_OPTIONS,
-    conversion: MATCH_RELATION_OPTIONS
+    conversion: MATCH_RELATION_OPTIONS,
+    'emails.post_id': MATCH_RELATION_OPTIONS,
+    'clicked_links.post_id': MATCH_RELATION_OPTIONS,
+    'opened_emails.post_id': MATCH_RELATION_OPTIONS
 };
 
 const FILTER_VALUE_OPTIONS = {

--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -183,7 +183,7 @@ export default class MembersController extends Controller {
         };
         return this.filterColumns.filter((d) => {
             // Exclude Signup and conversions (data not yet available in backend when browsing members)
-            return !['signup', 'conversion'].includes(d);
+            return !['signup', 'conversion', 'emails.post_id', 'clicked_links.post_id', 'opened_emails.post_id'].includes(d);
         }).map((d) => {
             return {
                 name: d,

--- a/ghost/admin/app/templates/posts/analytics.hbs
+++ b/ghost/admin/app/templates/posts/analytics.hbs
@@ -46,21 +46,27 @@
     <div class="gh-post-analytics-box">
         {{#if (or this.post.isSent (and this.post.isPublished this.post.email))}}
             <div class="gh-post-analytics-item">
-                <h3>{{format-number this.post.email.emailCount}}</h3>
-                <p>Sent</p>
+                <LinkTo @route="members" @query={{hash filterParam=(concat "emails.post_id:[" this.post.id "]") }}>
+                    <h3>{{format-number this.post.email.emailCount}}</h3>
+                    <p>Sent</p>
+                </LinkTo>
             </div>
 
             {{#if (and this.post.email.trackOpens this.settings.emailTrackOpens) }}
                 <div class="gh-post-analytics-item">
-                    <h3>{{this.post.email.openRate}}<sup>%</sup></h3>
-                    <p><strong>{{format-number this.post.email.openedCount}}</strong> opened</p>
+                    <LinkTo @route="members" @query={{hash filterParam=(concat "opened_emails.post_id:[" this.post.id "]") }}>
+                        <h3>{{this.post.email.openRate}}<sup>%</sup></h3>
+                        <p><strong>{{format-number this.post.email.openedCount}}</strong> opened</p>
+                    </LinkTo>
                 </div>
             {{/if}}
 
             {{#if this.settings.emailTrackClicks}}
                 <div class="gh-post-analytics-item">
-                    <h3>{{this.post.clickRate}}<sup>%</sup></h3>
-                    <p><strong>{{format-number this.post.count.clicks}}</strong> clicked</p>
+                    <LinkTo @route="members" @query={{hash filterParam=(concat "clicked_links.post_id:[" this.post.id "]") }}>
+                        <h3>{{this.post.clickRate}}<sup>%</sup></h3>
+                        <p><strong>{{format-number this.post.count.clicks}}</strong> clicked</p>
+                    </LinkTo>
                 </div>
             {{/if}}
         {{/if}}

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -47,9 +47,6 @@ const Member = ghostBookshelf.Model.extend({
             key: 'conversion',
             replacement: 'conversions.attribution_id'
         }, {
-            key: 'clicked_links',
-            replacement: 'clicked_links'
-        }, {
             key: 'opened_emails.post_id',
             replacement: 'emails.post_id',
             expansion: 'email_recipients.opened_at:>=emails.created_at' // this is a tiny hack for mongo-knex not supporting value based checks

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -46,6 +46,13 @@ const Member = ghostBookshelf.Model.extend({
         }, {
             key: 'conversion',
             replacement: 'conversions.attribution_id'
+        }, {
+            key: 'clicked_links',
+            replacement: 'clicked_links'
+        }, {
+            key: 'opened_emails.post_id',
+            replacement: 'emails.post_id',
+            expansion: 'email_recipients.opened_at:>=emails.created_at' // this is a tiny hack for mongo-knex not supporting value based checks
         }];
     },
 
@@ -92,6 +99,22 @@ const Member = ghostBookshelf.Model.extend({
                 tableNameAs: 'conversions',
                 type: 'oneToOne',
                 joinFrom: 'member_id'
+            },
+            clicked_links: {
+                tableName: 'link_redirects',
+                tableNameAs: 'clicked_links',
+                type: 'manyToMany',
+                joinTable: 'members_link_click_events',
+                joinFrom: 'member_id',
+                joinTo: 'link_id'
+            },
+            emails: {
+                tableName: 'emails',
+                tableNameAs: 'emails',
+                type: 'manyToMany',
+                joinTable: 'email_recipients',
+                joinFrom: 'member_id',
+                joinTo: 'email_id'
             }
         };
     },

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -49,7 +49,9 @@ const Member = ghostBookshelf.Model.extend({
         }, {
             key: 'opened_emails.post_id',
             replacement: 'emails.post_id',
-            expansion: 'email_recipients.opened_at:>=emails.created_at' // this is a tiny hack for mongo-knex not supporting value based checks
+            // Currently we cannot expand on values such as null or a string in mongo-knex
+            // But the line below is essentially the same as: `email_recipients.opened_at:-null`
+            expansion: 'email_recipients.opened_at:>=0' 
         }];
     },
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1993

- Allows filtering members by opened, clicked and received email
- Adds clicked_links filter relation to Member model.
- Adds emails filter relation to Member model.
- Adds opened_emails filter expansion to Member model.
- Updated GhResourceSelect to be able to only show list posts by setting the `type` attribute to `email`.
- Improved code reuse in `filter-value` component.
