### PR TITLE
Added back button from editor to analytics

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item-clicks.js
+++ b/ghost/admin/app/components/posts-list/list-item-clicks.js
@@ -25,20 +25,7 @@ export default class PostsListItemClicks extends Component {
     }
 
     get isAnalytics() {
-        return !this.session.user.isContributor
-            && this.settings.get('membersSignupAccess') !== 'none'
-            && this.args.post.isPost
-            && (
-                (
-                    // We have clicks or opens data
-                    (this.args.post.isSent || (this.args.post.isPublished && this.args.post.email)) 
-                        && (this.settings.get('emailTrackClicks') || this.settings.get('emailTrackOpens'))
-                ) 
-                || (
-                    // We have attribution data for pubished posts
-                    this.args.post.isPublished && this.feature.get('memberAttribution')
-                )
-            );
+        return this.args.post.hasAnalytics;
     }
 
     get routeForLink() {

--- a/ghost/admin/app/controllers/editor.js
+++ b/ghost/admin/app/controllers/editor.js
@@ -112,6 +112,10 @@ export default class EditorController extends Controller {
     showUpgradeModal = false;
     showSettingsMenu = false;
     hostLimitError = null;
+    /**
+     * Flag used to determine if we should return to the analytics page or to the posts/pages overview
+     */
+    fromAnalytics = false;
 
     // koenig related properties
     wordcount = null;
@@ -298,11 +302,6 @@ export default class EditorController extends Controller {
     @action
     updateWordCount(counts) {
         this.set('wordCount', counts);
-    }
-
-    get isAnalytics() {
-        return !this.session.user.isContributor
-            && this.post.hasAnalytics;
     }
 
     @action

--- a/ghost/admin/app/controllers/editor.js
+++ b/ghost/admin/app/controllers/editor.js
@@ -300,6 +300,11 @@ export default class EditorController extends Controller {
         this.set('wordCount', counts);
     }
 
+    get isAnalytics() {
+        return !this.session.user.isContributor
+            && this.post.hasAnalytics;
+    }
+
     @action
     setFeatureImage(url) {
         this.post.set('featureImage', url);

--- a/ghost/admin/app/routes/editor.js
+++ b/ghost/admin/app/routes/editor.js
@@ -15,6 +15,16 @@ export default AuthenticatedRoute.extend({
         this.ui.set('isFullScreen', true);
     },
 
+    setupController(controller, model, transition) {
+        if (transition.from?.name === 'posts.analytics') {
+            controller.fromAnalytics = true;
+        }
+    },
+
+    resetController(controller) {
+        controller.fromAnalytics = false;
+    },
+
     deactivate() {
         this._super(...arguments);
         this.ui.set('isFullScreen', false);

--- a/ghost/admin/app/templates/editor.hbs
+++ b/ghost/admin/app/templates/editor.hbs
@@ -16,7 +16,7 @@
                 >
                     <div class="flex items-center pe-auto h-100">
                         {{#if this.ui.isFullScreen}}
-                            {{#if this.isAnalytics }}
+                            {{#if this.fromAnalytics }}
                                 <LinkTo @route="posts.analytics" @model={{this.post}} class="gh-btn-editor gh-editor-back-button">
                                     <span>
                                         {{svg-jar "arrow-left"}}
@@ -32,7 +32,7 @@
                                 </LinkTo>
                             {{/if}}
                         {{/if}}
-                        {{#if (or (not this.ui.isFullScreen) (not this.isAnalytics)) }}
+                        {{#if (or (not this.ui.isFullScreen) (not this.fromAnalytics)) }}
                             <div class="gh-editor-post-status">
                                 <span>
                                     <GhEditorPostStatus

--- a/ghost/admin/app/templates/editor.hbs
+++ b/ghost/admin/app/templates/editor.hbs
@@ -16,23 +16,34 @@
                 >
                     <div class="flex items-center pe-auto h-100">
                         {{#if this.ui.isFullScreen}}
-                            <LinkTo @route={{pluralize this.post.displayName }} class="gh-btn-editor gh-editor-back-button" data-test-link={{pluralize this.post.displayName}}>
-                                <span>
-                                    {{svg-jar "arrow-left"}}
-                                    {{capitalize (pluralize this.post.displayName)}}
-                                </span>
-                            </LinkTo>
+                            {{#if this.isAnalytics }}
+                                <LinkTo @route="posts.analytics" @model={{this.post}} class="gh-btn-editor gh-editor-back-button">
+                                    <span>
+                                        {{svg-jar "arrow-left"}}
+                                        Analytics
+                                    </span>
+                                </LinkTo>
+                            {{else}}
+                                <LinkTo @route={{pluralize this.post.displayName }} class="gh-btn-editor gh-editor-back-button" data-test-link={{pluralize this.post.displayName}}>
+                                    <span>
+                                        {{svg-jar "arrow-left"}}
+                                        {{capitalize (pluralize this.post.displayName)}}
+                                    </span>
+                                </LinkTo>
+                            {{/if}}
                         {{/if}}
-                        <div class="gh-editor-post-status">
-                            <span>
-                                <GhEditorPostStatus
-                                    @post={{this.post}}
-                                    @hasDirtyAttributes={{this.hasDirtyAttributes}}
-                                    @isSaving={{or this.autosaveTask.isRunning this.saveTasks.isRunning}}
-                                    @openUpdateFlow={{publishManagement.openUpdateFlow}}
-                                />
-                            </span>
-                        </div>
+                        {{#if (or (not this.ui.isFullScreen) (not this.isAnalytics)) }}
+                            <div class="gh-editor-post-status">
+                                <span>
+                                    <GhEditorPostStatus
+                                        @post={{this.post}}
+                                        @hasDirtyAttributes={{this.hasDirtyAttributes}}
+                                        @isSaving={{or this.autosaveTask.isRunning this.saveTasks.isRunning}}
+                                        @openUpdateFlow={{publishManagement.openUpdateFlow}}
+                                    />
+                                </span>
+                            </div>
+                        {{/if}}
                     </div>
 
                     <section class="flex items-center pe-auto h-100">


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1992

When you edit a post via the editor, the back button on the top of the editor should go back to the analytics page and the status at the top should be removed. 