### PR TITLE
Used the higher of click count and open count for email open count

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
@@ -110,6 +110,18 @@ module.exports = async (model, frame, options = {}) => {
         });
     }
 
+    if (labs.isSet('emailClicks')) {
+        if (jsonModel.email && jsonModel.count) {
+            jsonModel.email.opened_count = Math.min(
+                Math.max(
+                    jsonModel.email.opened_count,
+                    jsonModel.count.clicks
+                ),
+                jsonModel.email.email_count
+            );
+        }
+    }
+
     if (!labs.isSet('memberAttribution') && !labs.isSet('emailClicks')) {
         delete jsonModel.count;
     }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
@@ -114,8 +114,8 @@ module.exports = async (model, frame, options = {}) => {
         if (jsonModel.email && jsonModel.count) {
             jsonModel.email.opened_count = Math.min(
                 Math.max(
-                    jsonModel.email.opened_count,
-                    jsonModel.count.clicks
+                    jsonModel.email.opened_count || 0,
+                    jsonModel.count.clicks || 0
                 ),
                 jsonModel.email.email_count
             );


### PR DESCRIPTION
We process clicks much faster than we process Mailgun events which can result in a higher click rater than open rate shown on the dashboard. This ensures that the open rate will never be lower than the click rate. This is a stopgap solution until we can get click events updating the opened_at time for email_recipients
