### PR TITLE
🐛 Fixed redirect to signin modal not shown when logged out

### DIFF
--- a/ghost/admin/app/controllers/editor.js
+++ b/ghost/admin/app/controllers/editor.js
@@ -124,6 +124,7 @@ export default class EditorController extends Controller {
 
     _leaveConfirmed = false;
     _previousTagNames = null; // set by setPost and _postSaved, used in hasDirtyAttributes
+    _reAuthenticateModalToggle = false;
 
     /* computed properties ---------------------------------------------------*/
 
@@ -476,6 +477,9 @@ export default class EditorController extends Controller {
 
             post.set('statusScratch', null);
 
+            // Clear any error notification (if any)
+            this.notifications.clearAll();
+
             if (!options.silent) {
                 this._showSaveNotification(prevStatus, post.get('status'), isNew ? true : false);
             }
@@ -490,6 +494,11 @@ export default class EditorController extends Controller {
 
             return post;
         } catch (error) {
+            if (!this.session.isAuthenticated && !this._reAuthenticateModalToggle) {
+                this.toggleProperty('showReAuthenticateModal');
+            }
+
+            this._reAuthenticateModalToggle = false;
             if (this.showReAuthenticateModal) {
                 this._reauthSave = true;
                 this._reauthSaveOptions = options;

--- a/ghost/admin/app/controllers/editor.js
+++ b/ghost/admin/app/controllers/editor.js
@@ -265,6 +265,8 @@ export default class EditorController extends Controller {
 
     @action
     toggleReAuthenticateModal() {
+        this._reAuthenticateModalToggle = true;
+
         if (this.showReAuthenticateModal) {
             // closing, re-attempt save if needed
             if (this._reauthSave) {

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -120,6 +120,7 @@ export default class LexicalEditorController extends Controller {
 
     _leaveConfirmed = false;
     _previousTagNames = null; // set by setPost and _postSaved, used in hasDirtyAttributes
+    _reAuthenticateModalToggle = false;
 
     /* computed properties ---------------------------------------------------*/
 
@@ -260,6 +261,8 @@ export default class LexicalEditorController extends Controller {
 
     @action
     toggleReAuthenticateModal() {
+        this._reAuthenticateModalToggle = true;
+
         if (this.showReAuthenticateModal) {
             // closing, re-attempt save if needed
             if (this._reauthSave) {
@@ -473,6 +476,9 @@ export default class LexicalEditorController extends Controller {
 
             post.set('statusScratch', null);
 
+            // Clear any error notification (if any)
+            this.notifications.clearAll();
+
             if (!options.silent) {
                 this._showSaveNotification(prevStatus, post.get('status'), isNew ? true : false);
             }
@@ -487,6 +493,11 @@ export default class LexicalEditorController extends Controller {
 
             return post;
         } catch (error) {
+            if (!this.session.isAuthenticated && !this._reAuthenticateModalToggle) {
+                this.toggleProperty('showReAuthenticateModal');
+            }
+
+            this._reAuthenticateModalToggle = false;
             if (this.showReAuthenticateModal) {
                 this._reauthSave = true;
                 this._reauthSaveOptions = options;

--- a/ghost/admin/app/routes/authenticated.js
+++ b/ghost/admin/app/routes/authenticated.js
@@ -3,8 +3,28 @@ import {inject as service} from '@ember/service';
 
 export default class AuthenticatedRoute extends Route {
     @service session;
+    @service notifications;
 
-    beforeModel(transition) {
+    async beforeModel(transition) {
+        await this.checkForActiveSession();
         this.session.requireAuthentication(transition, 'signin');
+    }
+
+    /**
+     * Always try to re-setup session & retry the original transition
+     * if user data is still available in session store although the
+     * session unauthenticated.
+     *
+     * If success, it will retry the original transition.
+     * If failed, it will be handled by the redirect to sign in.
+     */
+    async checkForActiveSession() {
+        if (!this.session.isAuthenticated) {
+            if (this.session.user) {
+                await this.session.setup();
+                this.session.forceTransition = true;
+                this.notifications.clearAll();
+            }
+        }
     }
 }

--- a/ghost/admin/app/routes/authenticated.js
+++ b/ghost/admin/app/routes/authenticated.js
@@ -3,28 +3,8 @@ import {inject as service} from '@ember/service';
 
 export default class AuthenticatedRoute extends Route {
     @service session;
-    @service notifications;
 
     async beforeModel(transition) {
-        await this.checkForActiveSession();
         this.session.requireAuthentication(transition, 'signin');
-    }
-
-    /**
-     * Always try to re-setup session & retry the original transition
-     * if user data is still available in session store although the
-     * session unauthenticated.
-     *
-     * If success, it will retry the original transition.
-     * If failed, it will be handled by the redirect to sign in.
-     */
-    async checkForActiveSession() {
-        if (!this.session.isAuthenticated) {
-            if (this.session.user) {
-                await this.session.setup();
-                this.session.forceTransition = true;
-                this.notifications.clearAll();
-            }
-        }
     }
 }

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -95,6 +95,7 @@ export default class SessionService extends ESASessionService {
 
         // retry previous transition if there is active session
         if (this.forceTransition) {
+            this.forceTransition = false;
             transition.retry();
             return;
         }

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -77,33 +77,13 @@ export default class SessionService extends ESASessionService {
     }
 
     async requireAuthentication(transition, route) {
-        if (!this.isAuthenticated) {
-            /**
-             * Always try to re-setup session if user data is still available
-             * although the session is invalid and retry the original transition.
-             * If success, it will retry the original transition.
-             * If failed, it will be handled by the redirect to sign in.
-             */
-            await this.reSetupSession(transition);
-        }
-
-        super.requireAuthentication(transition, route);
-    }
-
-    // TODO: feels a bit hacky, maybe got a better way to handle this
-    async reSetupSession(transition) {
-        if (this.user) {
-            await this.setup();
-            this.forceTransition = true;
-            this.notifications.clearAll();
-        }
-
-        // retry previous transition if there is active session
         if (this.forceTransition) {
             this.forceTransition = false;
             transition.retry();
             return;
         }
+
+        super.requireAuthentication(transition, route);
     }
 
     handleInvalidation() {

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -76,11 +76,26 @@ export default class SessionService extends ESASessionService {
         });
     }
 
+    /**
+     * Always try to re-setup session & retry the original transition
+     * if user data is still available in session store although the
+     * ember-session is unauthenticated.
+     *
+     * If success, it will retry the original transition.
+     * If failed, it will be handled by the redirect to sign in.
+     */
     async requireAuthentication(transition, route) {
-        if (this.forceTransition) {
-            this.forceTransition = false;
-            transition.retry();
-            return;
+        // Only when ember session invalidated
+        if (!this.isAuthenticated) {
+            transition.abort();
+
+            if (this.user) {
+                await this.setup();
+                this.forceTransition = true;
+                this.notifications.clearAll();
+
+                transition.retry();
+            }
         }
 
         super.requireAuthentication(transition, route);

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -91,9 +91,7 @@ export default class SessionService extends ESASessionService {
 
             if (this.user) {
                 await this.setup();
-                this.forceTransition = true;
                 this.notifications.clearAll();
-
                 transition.retry();
             }
         }

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -78,14 +78,19 @@ export default class SessionService extends ESASessionService {
 
     async requireAuthentication(transition, route) {
         if (!this.isAuthenticated) {
-            // try to re-setup session if user data is still available
+            /**
+             * Always try to re-setup session if user data is still available
+             * although the session is invalid and retry the original transition.
+             * If success, it will retry the original transition.
+             * If failed, it will be handled by the redirect to sign in.
+             */
             await this.reSetupSession(transition);
         }
 
         super.requireAuthentication(transition, route);
     }
 
-    // TODO: feels a bit hacky to re-setup session if user data is available
+    // TODO: feels a bit hacky, maybe got a better way to handle this
     async reSetupSession(transition) {
         if (this.user) {
             await this.setup();

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -22,7 +22,6 @@ export default class SessionService extends ESASessionService {
     @tracked user = null;
 
     skipAuthSuccessHandler = false;
-    forceTransition = false;
 
     async populateUser(options = {}) {
         if (this.user) {

--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -165,6 +165,7 @@ describe('Acceptance: Authentication', function () {
             expect(findAll('.gh-alert').length, 'no of alerts').to.equal(0);
 
             // update the post
+            testOn = 'edit';
             await fillIn('.__mobiledoc-editor', 'Edited post body');
             await triggerKeyEvent('.gh-editor-title', 'keydown', 83, {
                 metaKey: ctrlOrCmd === 'command',

--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -69,6 +69,27 @@ describe('Acceptance: Authentication', function () {
             expect(currentURL(), 'url after 401').to.equal('/signin');
         });
 
+        it('invalidates session on 403 API response', async function () {
+            // return a 401 when attempting to retrieve users
+            this.server.get('/users/', () => new Response(403, {}, {
+                errors: [
+                    {message: 'Authorization failed', type: 'NoPermissionError'}
+                ]
+            }));
+
+            await authenticateSession();
+            await visit('/settings/staff');
+
+            // running `visit(url)` inside windowProxy.replaceLocation breaks
+            // the async behaviour so we need to run `visit` here to simulate
+            // the browser visiting the new page
+            if (newLocation) {
+                await visit(newLocation);
+            }
+
+            expect(currentURL(), 'url after 403').to.equal('/signin');
+        });
+
         it('doesn\'t show navigation menu on invalid url when not authenticated', async function () {
             await invalidateSession();
 

--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -50,7 +50,7 @@ describe('Acceptance: Authentication', function () {
 
         it('invalidates session on 401 API response', async function () {
             // return a 401 when attempting to retrieve users
-            this.server.get('/users/', () => new Response(401, {}, {
+            this.server.get('/users/me', () => new Response(401, {}, {
                 errors: [
                     {message: 'Access denied.', type: 'UnauthorizedError'}
                 ]
@@ -71,7 +71,7 @@ describe('Acceptance: Authentication', function () {
 
         it('invalidates session on 403 API response', async function () {
             // return a 401 when attempting to retrieve users
-            this.server.get('/users/', () => new Response(403, {}, {
+            this.server.get('/users/me', () => new Response(403, {}, {
                 errors: [
                     {message: 'Authorization failed', type: 'NoPermissionError'}
                 ]


### PR DESCRIPTION
fixes #15291

- An attempt to improve re-authenticate modal toggle - show re-authenticate modal everytime use save (ctrl/cmd + s)
- An attempt to fix redirection when user re-login on different tab. Prevent redirection to sign-in page since the user already logged in on another tab.
- Re-enable `editor` test on `authentication-test.js`
