### PR TITLE
🐛 fixed error message code for HB translate helper

### DIFF
--- a/ghost/core/core/frontend/helpers/t.js
+++ b/ghost/core/core/frontend/helpers/t.js
@@ -11,8 +11,20 @@
 // {{tags prefix=(t " on ")}}
 
 const {themeI18n} = require('../services/handlebars');
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    oopsErrorTemplateHasError: 'Oops, seems there is an error in the template.'
+};
 
 module.exports = function t(text, options) {
+    if (text === undefined && options === undefined) {
+        throw new errors.IncorrectUsageError({
+            message: tpl(messages.oopsErrorTemplateHasError)
+        });
+    }
+
     const bindings = {};
     let prop;
     for (prop in options.hash) {


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

#15500 - Ghost has a policy to never throw 500 Internal Server errors for theme issues. Updated error handing to return a 400 error and a better error message "Oops, seems there is an error in the template."

This change adds a check inside of `ghost\core\core\frontend\helpers\t.js` if `text` or `options` is undefined, to throw an `IncorrectUsageError` error within the function.

Messaging was borrowed from `ghost\core\core\frontend\web\middleware\error-handler.js`.

![image](https://user-images.githubusercontent.com/16121690/193972455-3fd64590-00d8-44ca-b816-96e55f5044d8.png)

## Steps to Reproduce

1. Open the default.hbs file of the current active theme
2. Paste in the example translate helper with smart quotes {{t “This causes an error”}}
3. Try to visit any page
4. See the 400 error in the logs

```bash
[ghost] [2022-10-05 03:02:34] ERROR "GET /" 400 401ms
[ghost]
[ghost] [default.hbs] Oops, seems there is an error in the template.
[ghost]
[ghost] Error ID:
[ghost]     28e7d1e0-445a-11ed-adf2-afe89389d316
[ghost]
[ghost] ----------------------------------------
[ghost]
[ghost] IncorrectUsageError: [default.hbs] Oops, seems there is an error in the template.
[ghost]     at Object.t (C:\projects\Ghost\ghost\core\core\frontend\helpers\t.js:23:15)
[ghost]     at Object.wrapper (C:\projects\Ghost\node_modules\handlebars\dist\cjs\handlebars\internal\wrapHelper.js:15:19)
[ghost]     at Object.eval [as main] (eval at createFunctionContext (C:\projects\Ghost\node_modules\handlebars\dist\cjs\handlebars\compiler\javascript-compiler.js:262:23), <anonymous>:54:92)
[ghost]     at main (C:\projects\Ghost\node_modules\handlebars\dist\cjs\handlebars\runtime.js:208:32)
[ghost]     at ret (C:\projects\Ghost\node_modules\handlebars\dist\cjs\handlebars\runtime.js:212:12)
[ghost]     at ret (C:\projects\Ghost\node_modules\handlebars\dist\cjs\handlebars\compiler\compiler.js:519:21)
[ghost]     at renderTemplate (C:\projects\Ghost\node_modules\express-hbs\lib\hbs.js:490:13)
[ghost]     at _stackRenderer (C:\projects\Ghost\node_modules\express-hbs\lib\hbs.js:519:9)
[ghost]     at renderTemplate (C:\projects\Ghost\node_modules\express-hbs\lib\hbs.js:499:5)
[ghost]     at render (C:\projects\Ghost\node_modules\express-hbs\lib\hbs.js:526:5)
[ghost]     at renderIt (C:\projects\Ghost\node_modules\express-hbs\lib\hbs.js:588:18)
[ghost]     at C:\projects\Ghost\node_modules\express-hbs\lib\hbs.js:598:11
[ghost]     at _returnLayouts (C:\projects\Ghost\node_modules\express-hbs\lib\hbs.js:124:7)
[ghost]     at C:\projects\Ghost\node_modules\express-hbs\lib\hbs.js:135:7
[ghost]     at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3)
[ghost]
```

### Ghost Version
5.17.x

I know the original issue stated v4.42.1, but I was consistently able to reproduce the issue in this version as well. If there is a need for that version as well, I am happy to investigate that as well.

When `{{t “This causes an error”})` is used, `text` is coming into the `t()` function as undefined. I'm using Windows - unsure if that's causing something different as well, since someone else reported it was working fine in the issue.

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

Also, if you'd be interested in writing code like this for us more regularly, we're hiring:
https://careers.ghost.org
