### PR TITLE
🐛 Fixed redirects with special characters

### DIFF
--- a/ghost/express-dynamic-redirects/lib/DynamicRedirectManager.js
+++ b/ghost/express-dynamic-redirects/lib/DynamicRedirectManager.js
@@ -94,6 +94,13 @@ class DynamicRedirectManager {
      */
     addRedirect(from, to, options = {}) {
         try {
+            // encode "from" only if it's not a regex
+            try {
+                new RegExp(from);
+            } catch (e) {
+                from = encodeURI(from);
+            }
+
             const fromRegex = this.buildRegex(from);
             const redirectId = from;
 

--- a/ghost/express-dynamic-redirects/test/DynamicRedirectManager.test.js
+++ b/ghost/express-dynamic-redirects/test/DynamicRedirectManager.test.js
@@ -363,6 +363,26 @@ describe('DynamicRedirectManager', function () {
                 should.equal(location, 'https://ghost.org/docs');
             });
         });
+
+        describe('Url with special character redirect', function () {
+            it('redirects urls with special characters', function () {
+                const from = '/joloonii-surgaltuud/а-анлал/';
+                const to = '/joloonii-angilal/а-ангилал';
+
+                manager.addRedirect(from, to);
+
+                req.url = from;
+
+                manager.handleRequest(req, res, function next() {
+                    should.fail(true, false, 'next should NOT have been called');
+                });
+
+                // NOTE: max-age is "0" because it's not a permanent redirect
+                should.equal(headers['Cache-Control'], 'public, max-age=0');
+                should.equal(status, 302);
+                should.equal(location, '/joloonii-angilal/а-ангилал');
+            });
+        });
     });
 
     describe('with subdirectory configuration', function () {


### PR DESCRIPTION
refs/closes #15267
Custom redirect URLs with special characters showing 404 instead of redirection 
This was because the URLs were not being encoded before adding to the router.

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

The issue is solved by encoding the URL before its added to the router.

```
301:
    /joloonii-surgaltuud/b-angilal/: /joloonii-angilal/#в-ангилал
    /joloonii-surgaltuud/а-ангилал/: /joloonii-angilal/#а-ангилал
```
Here, the first one resolves perfectly as it does not have any special characters but the second one fails to redirect.

I tried adding the encoded version of `/joloonii-surgaltuud/а-ангилал/` ie.
`/joloonii-surgaltuud/%D0%B0-%D0%B0%D0%BD%D0%B3%D0%B8%D0%BB%D0%B0%D0%BB` into the yaml and it resolved perfectly. 

So the issue was in encoding as `/joloonii-surgaltuud/а-ангилал/` never existed on the router but the encoded one did.

