### PR TITLE
Fixed gh-date-time-picker not using site's timezone for min/max date

### DIFF
--- a/ghost/admin/app/components/gh-date-time-picker.js
+++ b/ghost/admin/app/components/gh-date-time-picker.js
@@ -121,7 +121,7 @@ export default class GhDateTimePicker extends Component {
 
         // unless min/max date is at midnight moment will disable that day
         if (minDate === 'now') {
-            this.set('_minDate', moment(moment().format(DATE_FORMAT)));
+            this.set('_minDate', moment.tz(moment().format(DATE_FORMAT)), blogTimezone);
         } else if (!isBlank(minDate)) {
             this.set('_minDate', moment(moment(minDate).format(DATE_FORMAT)));
         } else {
@@ -129,7 +129,7 @@ export default class GhDateTimePicker extends Component {
         }
 
         if (maxDate === 'now') {
-            this.set('_maxDate', moment(moment().format(DATE_FORMAT)));
+            this.set('_maxDate', moment.tz(moment().format(DATE_FORMAT)), blogTimezone);
         } else if (!isBlank(maxDate)) {
             this.set('_maxDate', moment(moment(maxDate).format(DATE_FORMAT)));
         } else {

--- a/ghost/admin/app/components/gh-date-time-picker.js
+++ b/ghost/admin/app/components/gh-date-time-picker.js
@@ -121,7 +121,7 @@ export default class GhDateTimePicker extends Component {
 
         // unless min/max date is at midnight moment will disable that day
         if (minDate === 'now') {
-            this.set('_minDate', moment.tz(moment().format(DATE_FORMAT)), blogTimezone);
+            this.set('_minDate', moment.tz(moment().tz(blogTimezone).format(DATE_FORMAT), blogTimezone));
         } else if (!isBlank(minDate)) {
             this.set('_minDate', moment(moment(minDate).format(DATE_FORMAT)));
         } else {
@@ -129,7 +129,7 @@ export default class GhDateTimePicker extends Component {
         }
 
         if (maxDate === 'now') {
-            this.set('_maxDate', moment.tz(moment().format(DATE_FORMAT)), blogTimezone);
+            this.set('_maxDate', moment.tz(moment().tz(blogTimezone).format(DATE_FORMAT), blogTimezone));
         } else if (!isBlank(maxDate)) {
             this.set('_maxDate', moment(moment(maxDate).format(DATE_FORMAT)));
         } else {


### PR DESCRIPTION
#### Summary
+ Expected behavior of the default `'now'` option for both min and max date available was not met. `'now'` option for min/max date used `moment()` function which did not consider the timezone of the site. Now `moment.tz()` is used instead of `moment()`, and blogTimezone attribute is provided as the timezone. With this change, default `'now'` option will use the site's timezone.
+ Fixes: #15497 

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)
