### PR TITLE
🐛 Fixed settings overriden when updated from multiple tabs

### DIFF
--- a/ghost/admin/app/adapters/setting.js
+++ b/ghost/admin/app/adapters/setting.js
@@ -1,4 +1,5 @@
 import ApplicationAdapter from 'ghost-admin/adapters/application';
+import {pluralize} from 'ember-inflector';
 
 export default class Setting extends ApplicationAdapter {
     updateRecord(store, type, record) {
@@ -11,6 +12,14 @@ export default class Setting extends ApplicationAdapter {
         // use the SettingSerializer to transform the model back into
         // an array of settings objects like the API expects
         serializer.serializeIntoHash(data, type, record);
+
+        // Do not send empty data to the API
+        // This can probably be removed then this is fixed:
+        // https://github.com/TryGhost/Ghost/blob/main/ghost/api-framework/lib/validators/input/all.js#L128
+        let root = pluralize(type.modelName);
+        if (data[root].length === 0) {
+            return Promise.resolve();
+        }
 
         // use the ApplicationAdapter's buildURL method but do not
         // pass in an id.

--- a/ghost/admin/app/controllers/settings/navigation.js
+++ b/ghost/admin/app/controllers/settings/navigation.js
@@ -124,6 +124,14 @@ export default class NavigationController extends Controller {
 
         try {
             yield RSVP.all(validationPromises);
+
+            // If some attributes have been changed, rebuild
+            // the model arrays or changes will not be detected
+            if (this.dirtyAttributes) {
+                this.settings.navigation = [...this.settings.navigation];
+                this.settings.secondaryNavigation = [...this.settings.secondaryNavigation];
+            }
+
             this.dirtyAttributes = false;
             return yield this.settings.save();
         } catch (error) {

--- a/ghost/admin/tests/acceptance/settings/slack-test.js
+++ b/ghost/admin/tests/acceptance/settings/slack-test.js
@@ -96,6 +96,9 @@ describe('Acceptance: Settings - Integrations - Slack', function () {
             expect(find('[data-test-error="slack-url"]'), 'inline validation response')
                 .to.not.exist;
 
+            // modify model data or there will be no api call
+            await fillIn('[data-test-slack-url-input]', 'https://hooks.slack.com/services/1275958431');
+
             this.server.put('/settings/', function () {
                 return new Response(422, {}, {
                     errors: [

--- a/ghost/admin/tests/integration/components/settings/navigation/nav-item-test.js
+++ b/ghost/admin/tests/integration/components/settings/navigation/nav-item-test.js
@@ -5,7 +5,7 @@ import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {setupRenderingTest} from 'ember-mocha';
 
-describe('Integration: Component: gh-navitem', function () {
+describe('Integration: Component: settings/navigation/nav-item', function () {
     setupRenderingTest();
 
     beforeEach(function () {
@@ -15,7 +15,7 @@ describe('Integration: Component: gh-navitem', function () {
     it('renders', async function () {
         this.set('navItem', NavItem.create({label: 'Test', url: '/url'}));
 
-        await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl}}`);
+        await render(hbs`<Settings::Navigation::NavItem @navItem={{this.navItem}} @baseUrl={{this.baseUrl}} />`);
         let item = find('.gh-blognav-item');
 
         expect(item.querySelector('.gh-blognav-grab')).to.exist;
@@ -32,7 +32,7 @@ describe('Integration: Component: gh-navitem', function () {
     it('doesn\'t show drag handle for new items', async function () {
         this.set('navItem', NavItem.create({label: 'Test', url: '/url', isNew: true}));
 
-        await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl}}`);
+        await render(hbs`<Settings::Navigation::NavItem @navItem={{this.navItem}} @baseUrl={{this.baseUrl}} />`);
         let item = find('.gh-blognav-item');
 
         expect(item.querySelector('.gh-blognav-grab')).to.not.exist;
@@ -41,7 +41,7 @@ describe('Integration: Component: gh-navitem', function () {
     it('shows add button for new items', async function () {
         this.set('navItem', NavItem.create({label: 'Test', url: '/url', isNew: true}));
 
-        await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl}}`);
+        await render(hbs`<Settings::Navigation::NavItem @navItem={{this.navItem}} @baseUrl={{this.baseUrl}} />`);
         let item = find('.gh-blognav-item');
 
         expect(item.querySelector('.gh-blognav-add')).to.exist;
@@ -57,7 +57,7 @@ describe('Integration: Component: gh-navitem', function () {
             deleteActionCallCount += 1;
         });
 
-        await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl deleteItem=(action deleteItem)}}`);
+        await render(hbs`<Settings::Navigation::NavItem @navItem={{this.navItem}} @baseUrl={{this.baseUrl}} @deleteItem={{this.deleteItem}} />`);
         await click('.gh-blognav-delete');
 
         expect(deleteActionCallCount).to.equal(1);
@@ -71,7 +71,7 @@ describe('Integration: Component: gh-navitem', function () {
             addActionCallCount += 1;
         });
 
-        await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl addItem=(action add)}}`);
+        await render(hbs`<Settings::Navigation::NavItem @navItem={{this.navItem}} @baseUrl={{this.baseUrl}} @addItem={{this.add}} />`);
         await click('.gh-blognav-add');
 
         expect(addActionCallCount).to.equal(1);
@@ -86,7 +86,7 @@ describe('Integration: Component: gh-navitem', function () {
             return value;
         });
 
-        await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl updateUrl=(action update)}}`);
+        await render(hbs`<Settings::Navigation::NavItem @navItem={{this.navItem}} @baseUrl={{this.baseUrl}} @updateUrl={{this.update}} />`);
         await triggerEvent('.gh-blognav-url input', 'blur');
 
         expect(updateActionCallCount).to.equal(1);
@@ -101,7 +101,7 @@ describe('Integration: Component: gh-navitem', function () {
             return value;
         });
 
-        await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl updateLabel=(action update)}}`);
+        await render(hbs`<Settings::Navigation::NavItem @navItem={{this.navItem}} @baseUrl={{this.baseUrl}} @updateLabel={{this.update}} />`);
         await triggerEvent('.gh-blognav-label input', 'blur');
 
         expect(updateActionCallCount).to.equal(2);
@@ -111,7 +111,7 @@ describe('Integration: Component: gh-navitem', function () {
         this.set('navItem', NavItem.create({label: '', url: ''}));
         this.navItem.validate();
 
-        await render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl}}`);
+        await render(hbs`<Settings::Navigation::NavItem @navItem={{this.navItem}} @baseUrl={{this.baseUrl}} />`);
         let item = find('.gh-blognav-item');
 
         expect(item).to.have.class('gh-blognav-item--error');

--- a/ghost/admin/tests/integration/components/settings/navigation/nav-item-url-input-test.js
+++ b/ghost/admin/tests/integration/components/settings/navigation/nav-item-url-input-test.js
@@ -8,7 +8,7 @@ import {setupRenderingTest} from 'ember-mocha';
 // handled as expected (browser auto-sets the domain when using a.href)
 let currentUrl = `${window.location.protocol}//${window.location.host}/`;
 
-describe('Integration: Component: gh-navitem-url-input', function () {
+describe('Integration: Component: settings/navigation/nav-item-url-input', function () {
     setupRenderingTest();
 
     beforeEach(function () {
@@ -23,7 +23,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
 
     it('renders correctly with blank url', async function () {
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @clearErrors={{this.clearErrors}} />
         `);
 
         expect(findAll('input')).to.have.length(1);
@@ -34,7 +34,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
     it('renders correctly with relative urls', async function () {
         this.set('url', '/about');
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @clearErrors={{this.clearErrors}} />
         `);
 
         expect(find('input')).to.have.value(`${currentUrl}about`);
@@ -46,7 +46,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
     it('renders correctly with absolute urls', async function () {
         this.set('url', 'https://example.com:2368/#test');
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @clearErrors={{this.clearErrors}} />
         `);
 
         expect(find('input')).to.have.value('https://example.com:2368/#test');
@@ -66,7 +66,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
 
     it('deletes base URL on backspace', async function () {
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @clearErrors={{this.clearErrors}} />
         `);
 
         expect(find('input')).to.have.value(currentUrl);
@@ -76,7 +76,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
 
     it('deletes base URL on delete', async function () {
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @clearErrors={{this.clearErrors}} />
         `);
 
         expect(find('input')).to.have.value(currentUrl);
@@ -87,7 +87,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
     it('adds base url to relative urls on blur', async function () {
         this.set('updateUrl', val => val);
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         await fillIn('input', '/about');
@@ -99,7 +99,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
     it('adds "mailto:" to email addresses on blur', async function () {
         this.set('updateUrl', val => val);
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         await fillIn('input', 'test@example.com');
@@ -115,7 +115,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
     it('doesn\'t add base url to invalid urls on blur', async function () {
         this.set('updateUrl', val => val);
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         let changeValue = async (value) => {
@@ -133,7 +133,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
     it('doesn\'t mangle invalid urls on blur', async function () {
         this.set('updateUrl', val => val);
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         await fillIn('input', `${currentUrl} /test`);
@@ -149,7 +149,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         this.set('baseUrl', 'http://exämple.com');
 
         await render(hbs`
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
         await fillIn('input', `${currentUrl}/test`);
         await blur('input');
@@ -165,7 +165,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         });
 
         await render(hbs `
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
         await click('input');
         await blur('input');
@@ -181,7 +181,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         });
 
         await render(hbs `
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
         await triggerKeyEvent('input', 'keypress', 13);
 
@@ -196,7 +196,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         });
 
         await render(hbs `
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
         await triggerKeyEvent('input', 'keydown', 83, {
             metaKey: true
@@ -214,7 +214,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         });
 
         await render(hbs `
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         let testUrl = async (url) => {
@@ -243,7 +243,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         });
 
         await render(hbs `
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         let testUrl = async (url) => {
@@ -268,7 +268,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         });
 
         await render(hbs `
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         expectedUrl = 'http://test.example.com/';
@@ -286,7 +286,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         });
 
         await render(hbs `
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         let testUrl = async (url) => {
@@ -308,7 +308,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         });
 
         await render(hbs `
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         let testUrl = async (url) => {
@@ -332,7 +332,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
         });
 
         await render(hbs `
-            {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+            <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
         `);
 
         let testUrl = async (url) => {
@@ -361,7 +361,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
             });
 
             await render(hbs `
-                {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+                <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
             `);
 
             let testUrl = async (url) => {
@@ -384,7 +384,7 @@ describe('Integration: Component: gh-navitem-url-input', function () {
             });
 
             await render(hbs `
-                {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew update=(action updateUrl) clearErrors=(action clearErrors)}}
+                <Settings::Navigation::NavItemUrlInput @baseUrl={{this.baseUrl}} @url={{this.url}} @isNew={{this.isNew}} @update={{this.updateUrl}} @clearErrors={{this.clearErrors}} />
             `);
 
             let testUrl = async (url) => {

--- a/ghost/core/test/regression/api/admin/settings.test.js
+++ b/ghost/core/test/regression/api/admin/settings.test.js
@@ -225,6 +225,22 @@ describe('Settings API', function () {
                 .expect(422);
         });
 
+        // If this test fails, it can be safely removed
+        // but the front-end should be updated accordingly, 
+        // removing the workaround in place for this specific usecase 
+        it('Cannot send an empty array', async function () {
+            const settingsToChange = {
+                settings: []
+            };
+
+            await request.put(localUtils.API.getApiQuery('settings/'))
+                .set('Origin', config.get('url'))
+                .send(settingsToChange)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(400);
+        });
+
         it('Cannot edit notifications key through API', async function () {
             await checkCantEdit('notifications', JSON.stringify(['do not touch me']));
         });


### PR DESCRIPTION
closes #15470
When multiple browser tabs are open, each manipulate a different copy of ember data model, changes to the model in one tab are not reflected in the model of the other tab. When updating some settings, all current settings were sent to the API. As a result, when updating two different categories of settings (navigation/code inspection) in different tabs, the second update was overriding the first one. From a user perspective, this is not a natural behaviour. Only settings visible on-screen when clicking save should be modified.
