### PR TITLE
Swapped member limit verification trigger event

### DIFF
--- a/ghost/members-api/lib/repositories/event.js
+++ b/ghost/members-api/lib/repositories/event.js
@@ -267,6 +267,10 @@ module.exports = class EventRepository {
             };
         }
 
+        return this.getCreatedEvents(options, filters);
+    }
+
+    async getCreatedEvents(options = {}, filters = {}) {
         options = {
             ...options,
             withRelated: ['member', 'postAttribution', 'userAttribution', 'tagAttribution'],
@@ -277,6 +281,9 @@ module.exports = class EventRepository {
         }
         if (filters['data.member_id']) {
             options.filter.push(filters['data.member_id'].replace(/data.member_id:/g, 'member_id:'));
+        }
+        if (filters['data.source']) {
+            options.filter.push(filters['data.source'].replace(/data.source:/g, 'source:'));
         }
         options.filter = options.filter.join('+');
 

--- a/ghost/verification-trigger/lib/verification-trigger.js
+++ b/ghost/verification-trigger/lib/verification-trigger.js
@@ -1,6 +1,6 @@
 const errors = require('@tryghost/errors');
 const DomainEvents = require('@tryghost/domain-events');
-const {MemberSubscribeEvent} = require('@tryghost/member-events');
+const {MemberCreatedEvent} = require('@tryghost/member-events');
 
 const messages = {
     emailVerificationNeeded: `We're hard at work processing your import. To make sure you get great deliverability, we'll need to enable some extra features for your account. A member of our team will be in touch with you by email to review your account make sure everything is configured correctly so you're ready to go.`,
@@ -45,15 +45,15 @@ class VerificationTrigger {
         this._Settings = Settings;
         this._eventRepository = eventRepository;
 
-        this._handleMemberSubscribeEvent = this._handleMemberSubscribeEvent.bind(this);
-        DomainEvents.subscribe(MemberSubscribeEvent, this._handleMemberSubscribeEvent);
+        this._handleMemberCreatedEvent = this._handleMemberCreatedEvent.bind(this);
+        DomainEvents.subscribe(MemberCreatedEvent, this._handleMemberCreatedEvent);
     }
 
     /**
      * 
-     * @param {MemberSubscribeEvent} event 
+     * @param {MemberCreatedEvent} event 
      */
-    async _handleMemberSubscribeEvent(event) {
+    async _handleMemberCreatedEvent(event) {
         const source = event.data?.source;
         let sourceThreshold;
 
@@ -66,7 +66,7 @@ class VerificationTrigger {
         if (['api', 'admin'].includes(source) && isFinite(sourceThreshold)) {
             const createdAt = new Date();
             createdAt.setDate(createdAt.getDate() - 30);
-            const events = await this._eventRepository.getNewsletterSubscriptionEvents({}, {
+            const events = await this._eventRepository.getCreatedEvents({}, {
                 'data.source': `data.source:'${source}'`,
                 'data.created_at': `data.created_at:>'${createdAt.toISOString().replace('T', ' ').substring(0, 19)}'`
             });
@@ -99,7 +99,7 @@ class VerificationTrigger {
 
         const createdAt = new Date();
         createdAt.setDate(createdAt.getDate() - 30);
-        const events = await this._eventRepository.getNewsletterSubscriptionEvents({}, {
+        const events = await this._eventRepository.getCreatedEvents({}, {
             'data.source': `data.source:'import'`,
             'data.created_at': `data.created_at:>'${createdAt.toISOString().replace('T', ' ').substring(0, 19)}'`
         });

--- a/ghost/verification-trigger/test/verification-trigger.test.js
+++ b/ghost/verification-trigger/test/verification-trigger.test.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 require('./utils');
 const VerificationTrigger = require('../index');
 const DomainEvents = require('@tryghost/domain-events');
-const {MemberSubscribeEvent} = require('@tryghost/member-events');
+const {MemberCreatedEvent} = require('@tryghost/member-events');
 
 describe('Import threshold', function () {
     it('Creates a threshold based on config', async function () {
@@ -175,11 +175,11 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getNewsletterSubscriptionEvents: eventStub
+                getCreatedEvents: eventStub
             }
         });
 
-        DomainEvents.dispatch(MemberSubscribeEvent.create({
+        DomainEvents.dispatch(MemberCreatedEvent.create({
             memberId: 'hello!',
             source: 'api'
         }, new Date()));
@@ -214,7 +214,7 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getNewsletterSubscriptionEvents: eventStub
+                getCreatedEvents: eventStub
             }
         });
 
@@ -257,11 +257,11 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getNewsletterSubscriptionEvents: eventStub
+                getCreatedEvents: eventStub
             }
         });
 
-        await trigger._handleMemberSubscribeEvent({
+        await trigger._handleMemberCreatedEvent({
             data: {
                 source: 'admin'
             }
@@ -305,11 +305,11 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getNewsletterSubscriptionEvents: eventStub
+                getCreatedEvents: eventStub
             }
         });
 
-        await trigger._handleMemberSubscribeEvent({
+        await trigger._handleMemberCreatedEvent({
             data: {
                 source: 'api'
             }
@@ -352,7 +352,7 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getNewsletterSubscriptionEvents: eventStub
+                getCreatedEvents: eventStub
             }
         });
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Toolbox/issues/399

- The MemberCreatedEvent event is more accurate representation of the limit nature - counting the number of members created. The previous MemberSubscribeEvent was slightly hacky solution because a member could be subscribed/unsubscribed multiple times and distorting the limit counts.

Yo @allouis! The part I wanted to check on here is extraction of a separate `getCreatedEvents` method in the event repository. Was thinking of using the `getSignupEvents` originally, but it had mixed returns based on the `memberAttribution` flag, so decided to go with a very explicit separate method (less probability for events to mixup in the future). Lemme know if you'd do things differently!