### PR TITLE
🐛 Fixed member importer crash for failed imports

### DIFF
--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -340,17 +340,13 @@ module.exports = class MemberRepository {
         if (options?.transacting) {
             // Only dispatch the event after the transaction has finished
             options.transacting.executionPromise.then(async () => {
-                // make sure member exists before inserting event.
-                //its possible that trnx is rolled back, which still triggers the event
-                // https://knexjs.org/guide/transactions.html
-                const createdMember = await this.get({id: member.id});
-                if (createdMember) {
-                    DomainEvents.dispatch(MemberCreatedEvent.create({
-                        memberId: member.id,
-                        attribution: data.attribution,
-                        source
-                    }, eventData.created_at));
-                }
+                DomainEvents.dispatch(MemberCreatedEvent.create({
+                    memberId: member.id,
+                    attribution: data.attribution,
+                    source
+                }, eventData.created_at));
+            }).catch(() => {
+                // ignore errors for transaction rollback and don't dispatch event
             });
         } else {
             DomainEvents.dispatch(MemberCreatedEvent.create({

--- a/ghost/members-importer/lib/importer.js
+++ b/ghost/members-importer/lib/importer.js
@@ -134,7 +134,9 @@ module.exports = class MembersCSVImporter {
         const result = await rows.reduce(async (resultPromise, row) => {
             const resultAccumulator = await resultPromise;
 
-            const trx = await this._knex.transaction();
+            // Use doNotReject config to reject `executionPromise` on rollback
+            // https://github.com/knex/knex/blob/master/UPGRADING.md
+            const trx = await this._knex.transaction(undefined, {doNotRejectOnRollback: false});
             const options = {
                 transacting: trx,
                 context: this._context


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2004

- for imports, members are created inside a transaction, which causes the member created events to be dispatched.
- its possible that transactions for import can be rolled back if for some reason there is an error down the line while inserting other member properties. The rollback doesn't commit the member to DB, but the event dispatched earlier will still try to create the member created event which fails due to missing member id.
- knex transactions resolve the `executionPromise` both in case of explicit commit or rollback from the user, so just the transaction end check will not be good enough to make sure the member exists in DB
- adds explicit config to knex to reject transaction in case of explicit rollback, which is then caught and event is not dispatched