### PR TITLE
🐛 Fixed missing unsaved changes modal for member newsletters

### DIFF
--- a/ghost/admin/app/controllers/member.js
+++ b/ghost/admin/app/controllers/member.js
@@ -225,19 +225,19 @@ export default class MemberController extends Controller {
         }
 
         // member.labels is an array so hasDirtyAttributes doesn't pick up
-        // changes unless the array ref is changed
-        let currentLabels = (this._labels || []).join(', ');
-        let previousLabels = (this._previousLabels || []).join(', ');
-        console.log(currentLabels + '==' + previousLabels)
+        // changes unless the array ref is changed.
+        // use sort() to sort of detect same item is re-added
+        let currentLabels = (this._labels.sort() || []).join(', ');
+        let previousLabels = (this._previousLabels.sort() || []).join(', ');
         if (currentLabels !== previousLabels) {
             return true;
         }
 
         // member.newsletters is an array so hasDirtyAttributes doesn't pick up
         // changes unless the array ref is changed
-        let currentNewsletters = (this._newsletters || []).join(', ');
-        let previousNewsletters = (this._previousNewsletters || []).join(', ');
-        console.log(currentNewsletters + '==' + previousNewsletters)
+        // use sort() to sort of detect same item is re-enabled
+        let currentNewsletters = (this._newsletters.sort() || []).join(', ');
+        let previousNewsletters = (this._previousNewsletters.sort() || []).join(', ');
         if (currentNewsletters !== previousNewsletters) {
             return true;
         }

--- a/ghost/admin/app/routes/member.js
+++ b/ghost/admin/app/routes/member.js
@@ -50,7 +50,7 @@ export default class MembersRoute extends AdminRoute {
 
     @action
     async willTransition(transition) {
-        let hasDirtyAttributes = this.controller.model?.hasDirtyAttributes || this.controller.dirtyAttributes;
+        let hasDirtyAttributes = this.controller.dirtyAttributes;
 
         // wait for any existing confirm modal to be closed before allowing transition
         if (this.confirmModal) {

--- a/ghost/admin/app/routes/member.js
+++ b/ghost/admin/app/routes/member.js
@@ -29,7 +29,6 @@ export default class MembersRoute extends AdminRoute {
 
     setupController(controller, member) {
         super.setupController(...arguments);
-        controller.setInitialRelationshipValues();
         if (this._requiresBackgroundRefresh) {
             // `member` is passed directly in `<LinkTo>` so it can be a proxy
             // object used by the sparse list requiring the use of .get()

--- a/ghost/admin/app/routes/member.js
+++ b/ghost/admin/app/routes/member.js
@@ -51,42 +51,39 @@ export default class MembersRoute extends AdminRoute {
 
     @action
     async willTransition(transition) {
-        if (this.hasConfirmed) {
-            return true;
-        }
-
-        transition.abort();
+        let hasDirtyAttributes = this.controller.model?.hasDirtyAttributes || this.controller.dirtyAttributes;
 
         // wait for any existing confirm modal to be closed before allowing transition
         if (this.confirmModal) {
             return;
         }
 
-        if (this.controller.saveTask?.isRunning) {
-            await this.controller.saveTask.last;
-        }
+        if (!this.hasConfirmed && hasDirtyAttributes) {
+            transition.abort();
 
-        const shouldLeave = await this.confirmUnsavedChanges();
+            if (this.controller.saveTask?.isRunning) {
+                await this.controller.saveTask.last;
+                transition.retry();
+            }
 
-        if (shouldLeave) {
-            this.controller.model.rollbackAttributes();
-            this.hasConfirmed = true;
-            return transition.retry();
+            const shouldLeave = await this.confirmUnsavedChanges();
+
+            if (shouldLeave) {
+                this.controller.model.rollbackAttributes();
+                this.hasConfirmed = true;
+                return transition.retry();
+            }
         }
     }
 
     async confirmUnsavedChanges() {
-        if (this.controller.model?.hasDirtyAttributes || this.controller.dirtyAttributes) {
-            this.confirmModal = this.modals
-                .open(ConfirmUnsavedChangesModal)
-                .finally(() => {
-                    this.confirmModal = null;
-                });
+        this.confirmModal = this.modals
+            .open(ConfirmUnsavedChangesModal)
+            .finally(() => {
+                this.confirmModal = null;
+            });
 
-            return this.confirmModal;
-        }
-
-        return true;
+        return this.confirmModal;
     }
 
     closeImpersonateModal(transition) {

--- a/ghost/admin/app/routes/member.js
+++ b/ghost/admin/app/routes/member.js
@@ -29,6 +29,7 @@ export default class MembersRoute extends AdminRoute {
 
     setupController(controller, member) {
         super.setupController(...arguments);
+        controller.setInitialRelationshipValues();
         if (this._requiresBackgroundRefresh) {
             // `member` is passed directly in `<LinkTo>` so it can be a proxy
             // object used by the sparse list requiring the use of .get()
@@ -75,7 +76,7 @@ export default class MembersRoute extends AdminRoute {
     }
 
     async confirmUnsavedChanges() {
-        if (this.controller.model?.hasDirtyAttributes) {
+        if (this.controller.model?.hasDirtyAttributes || this.controller.dirtyAttributes) {
             this.confirmModal = this.modals
                 .open(ConfirmUnsavedChangesModal)
                 .finally(() => {


### PR DESCRIPTION
fix #15507 

manually handle relationship changes detection labels and newsletters

add `dirtyAttributes` controller property - return newsletters and labels dirty attributes status

-------
- [x] yarn test:all
- [x] yarn lint
