### PR TITLE
Added subscriptions table creation migration

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -20,6 +20,7 @@ const BACKUP_TABLES = [
     'webhooks',
     'tokens',
     'sessions',
+    'subscriptions',
     'mobiledoc_revisions',
     'post_revisions',
     'email_batches',

--- a/ghost/core/core/server/data/migrations/versions/5.19/2022-10-10-06-58-add-subscriptions-table.js
+++ b/ghost/core/core/server/data/migrations/versions/5.19/2022-10-10-06-58-add-subscriptions-table.js
@@ -1,0 +1,19 @@
+const {addTable} = require('../../utils');
+
+module.exports = addTable('subscriptions', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    type: {type: 'string', maxlength: 50, nullable: false},
+    status: {type: 'string', maxlength: 50, nullable: false},
+    member_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'members.id', cascadeDelete: true},
+    tier_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'products.id'},
+    cadence: {type: 'string', maxlength: 50, nullable: true},
+    currency: {type: 'string', maxlength: 50, nullable: true},
+    amount: {type: 'integer', nullable: true},
+    payment_provider: {type: 'string', maxlength: 50, nullable: true},
+    payment_subscription_url: {type: 'string', maxlength: 2000, nullable: true},
+    payment_user_url: {type: 'string', maxlength: 2000, nullable: true},
+    offer_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'offers.id'},
+    expires_at: {type: 'dateTime', nullable: true},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: true}
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -605,6 +605,43 @@ module.exports = {
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true}
     },
+    subscriptions: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        type: {
+            type: 'string', maxlength: 50, nullable: false, validations: {
+                isIn: [['free', 'comped', 'paid']]
+            }
+        },
+        status: {
+            type: 'string', maxlength: 50, nullable: false, validations: {
+                isIn: [['active', 'expired', 'cancelled']]
+            }
+        },
+        member_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'members.id', cascadeDelete: true},
+        tier_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'products.id'},
+
+        // These are null if type !== 'paid'
+        cadence: {
+            type: 'string', maxlength: 50, nullable: true, validations: {
+                isIn: [['month', 'year']]
+            }
+        },
+        currency: {type: 'string', maxlength: 50, nullable: true},
+        amount: {type: 'integer', nullable: true},
+
+        // e.g. 'stripe'
+        payment_provider: {type: 'string', maxlength: 50, nullable: true},
+        // e.g. Stripe Subscription Link
+        payment_subscription_url: {type: 'string', maxlength: 2000, nullable: true},
+        // e.g. Stripe Customer Link
+        payment_user_url: {type: 'string', maxlength: 2000, nullable: true},
+
+        offer_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'offers.id'},
+
+        expires_at: {type: 'dateTime', nullable: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: true}
+    },
     members_stripe_customers_subscriptions: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'members_stripe_customers.customer_id', cascadeDelete: true},

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -75,6 +75,7 @@ describe('Exporter', function () {
                 'products_benefits',
                 'stripe_products',
                 'stripe_prices',
+                'subscriptions',
                 'roles',
                 'roles_users',
                 'sessions',

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '769321183f98f2af801b7fa4494b8f2d';
+    const currentSchemaHash = '361ef1e24dc7f370df30dd1479a35d0e';
     const currentFixturesHash = '8cf221f0ed930ac1fe8030a58e60d64b';
     const currentSettingsHash = '2978a5684a2d5fcf089f61f5d368a0c0';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2030

- Adds `subscriptions` table to the DB schema.
- The new table is aimed to support a native "subscription" primitive in Ghost that most resembles previously used `members_stripe_customers_subscriptions` table

WIP for the upcoming `subscriptions` table changes.