### PR TITLE
Ensured Member Newsletters relation is ordered by sort_order

### DIFF
--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -158,6 +158,7 @@ const Member = ghostBookshelf.Model.extend({
 
     newsletters() {
         return this.belongsToMany('Newsletter', 'members_newsletters', 'member_id', 'newsletter_id')
+            .query('orderBy', 'sort_order', 'ASC')
             .query((qb) => {
                 // avoids bookshelf adding a `DISTINCT` to the query
                 // we know the result set will already be unique and DISTINCT hurts query performance

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -158,6 +158,7 @@ const Member = ghostBookshelf.Model.extend({
 
     newsletters() {
         return this.belongsToMany('Newsletter', 'members_newsletters', 'member_id', 'newsletter_id')
+            .withPivot('sort_order')
             .query('orderBy', 'sort_order', 'ASC')
             .query((qb) => {
                 // avoids bookshelf adding a `DISTINCT` to the query


### PR DESCRIPTION
Without this we can get inconsistent ordering in the API which can cause tests to fail
