### PR TITLE
Added post sentiment

### DIFF
--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -90,6 +90,13 @@
                 </div>
             {{/if}}
         {{/if}}
+
+        {{#if this.post.showAudienceFeedback }}
+            <div class="gh-post-analytics-item">
+                <h3>{{format-number this.post.count.positive_feedback}}</h3>
+                <p>More like this &mdash; <strong>{{this.post.count.sentiment}}%</strong></p>
+            </div>
+        {{/if}}
     </div>
 
     {{#if this.isLoaded }}

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -195,6 +195,10 @@ export default Model.extend(Comparable, ValidationEngine, {
             && this.email && this.email.status === 'failed';
     }),
 
+    showAudienceFeedback: computed('count', function () {
+        return this.feature.get('audienceFeedback') && this.count.sentiment !== undefined;
+    }),
+
     showEmailOpenAnalytics: computed('hasBeenEmailed', 'isSent', 'isPublished', function () {
         return this.hasBeenEmailed
             && !this.session.user.isContributor

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -6,6 +6,7 @@ const localUtils = require('../../index');
 const mobiledoc = require('../../../../../lib/mobiledoc');
 const postsMetaSchema = require('../../../../../data/schema').tables.posts_meta;
 const clean = require('./utils/clean');
+const labs = require('../../../../../../shared/labs');
 
 function removeSourceFormats(frame) {
     if (frame.options.formats?.includes('mobiledoc') || frame.options.formats?.includes('lexical')) {
@@ -24,7 +25,11 @@ function defaultRelations(frame) {
         return false;
     }
 
-    frame.options.withRelated = ['tags', 'authors', 'authors.roles', 'email', 'tiers', 'newsletter', 'count.signups', 'count.paid_conversions', 'count.clicks'];
+    if (labs.isSet('audienceFeedback')) {
+        frame.options.withRelated = ['tags', 'authors', 'authors.roles', 'email', 'tiers', 'newsletter', 'count.signups', 'count.paid_conversions', 'count.clicks', 'count.sentiment', 'count.positive_feedback'];
+    } else {
+        frame.options.withRelated = ['tags', 'authors', 'authors.roles', 'email', 'tiers', 'newsletter', 'count.signups', 'count.paid_conversions', 'count.clicks'];
+    }
 }
 
 function setDefaultOrder(frame) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
@@ -119,5 +119,13 @@ module.exports = async (model, frame, options = {}) => {
         );
     }
 
+    if (jsonModel.count && !jsonModel.count.sentiment) {
+        jsonModel.count.sentiment = 0;
+    }
+
+    if (jsonModel.count && !jsonModel.count.positive_feedback) {
+        jsonModel.count.positive_feedback = 0;
+    }
+
     return jsonModel;
 };

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -1354,6 +1354,30 @@ Post = ghostBookshelf.Model.extend({
                         .whereRaw('posts.id = redirects.post_id')
                         .as('count__clicks');
                 });
+            },
+            sentiment(modelOrCollection) {
+                modelOrCollection.query('columns', 'posts.*', (qb) => {
+                    qb.select(qb.client.raw('ROUND(AVG(score) * 100)'))
+                        .from('members_feedback')
+                        .whereRaw('posts.id = members_feedback.post_id')
+                        .as('count__sentiment');
+                });
+            },
+            negative_feedback(modelOrCollection) {
+                modelOrCollection.query('columns', 'posts.*', (qb) => {
+                    qb.count('*')
+                        .from('members_feedback')
+                        .whereRaw('posts.id = members_feedback.post_id AND members_feedback.score = 0')
+                        .as('count__positive_feedback');
+                });
+            },
+            positive_feedback(modelOrCollection) {
+                modelOrCollection.query('columns', 'posts.*', (qb) => {
+                    qb.sum('score')
+                        .from('members_feedback')
+                        .whereRaw('posts.id = members_feedback.post_id')
+                        .as('count__positive_feedback');
+                });
             }
         };
     }

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -33,13 +33,13 @@ const loadMemberSession = async function (req, res, next) {
  */
 const authMemberByUuid = async function (req, res, next) {
     try {
-        if (res.locals.member && req.member) {
-            // Already authenticated via session
-            return next();
-        }
-
         const uuid = req.query.uuid;
         if (!uuid) {
+            if (res.locals.member && req.member) {
+                // Already authenticated via session
+                return next();
+            }
+            
             throw new errors.UnauthorizedError({
                 messsage: tpl(messages.missingUuid)
             });

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -22,6 +22,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -70,6 +72,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -119,7 +123,7 @@ exports[`Posts API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "9926",
+  "content-length": "9998",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
@@ -149,6 +153,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -201,6 +207,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -272,7 +280,7 @@ exports[`Posts API Can browse with formats 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "12792",
+  "content-length": "12864",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
@@ -292,6 +300,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -342,7 +352,7 @@ exports[`Posts API Create Can create a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3759",
+  "content-length": "3795",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/posts\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -363,6 +373,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -413,7 +425,7 @@ exports[`Posts API Create Can create a post with mobiledoc 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3575",
+  "content-length": "3611",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/posts\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -535,6 +547,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -585,7 +599,7 @@ exports[`Posts API Update Can update a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3710",
+  "content-length": "3746",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/posts\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -606,6 +620,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -656,7 +672,7 @@ exports[`Posts API Update Can update a post with lexical 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3707",
+  "content-length": "3743",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
@@ -677,6 +693,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -727,7 +745,7 @@ exports[`Posts API Update Can update a post with mobiledoc 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3520",
+  "content-length": "3556",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/posts\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
@@ -748,6 +766,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
@@ -798,7 +818,7 @@ exports[`Posts API Update Can update a post with mobiledoc 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3517",
+  "content-length": "3553",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",

--- a/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
@@ -202,6 +202,8 @@ Object {
       "count": Object {
         "clicks": 0,
         "paid_conversions": 0,
+        "positive_feedback": 0,
+        "sentiment": 0,
         "signups": 0,
       },
       "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -346,6 +346,12 @@ describe('Unit: models/post', function () {
             filter.should.equal('type:post+status:published');
         });
     });
+
+    describe('countRelations', function () {
+        it('can include all count relations', function () {
+            return models.Post.findAll({withRelated: ['count.signups', 'count.paid_conversions', 'count.clicks', 'count.sentiment', 'count.negative_feedback', 'count.positive_feedback']});
+        });
+    });
 });
 
 describe('Unit: models/post: uses database (@TODO: fix me)', function () {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2054

This change adds the sentiment and positive_feedback counts to the posts models. This change isn't really ideal because there are some problems here:
- sentiment isn't really a count
- we don't need to include the sentiment and positive_feedback as a default for posts (but the same is true for attribution)

It would make sense to move this to separate endpoints that only fetch the analytics for a given post when the analytics page is opened. But for our initial skateboard version of audience feedback this should be a good start to already see the data.