### PR TITLE
Added e2e test for `site.changed` webhook event

### DIFF
--- a/ghost/core/test/e2e-webhooks/__snapshots__/site.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/site.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`site.* events site.changed event is triggered 1: [headers] 1`] = `
+Object {
+  "accept-encoding": "gzip, deflate",
+  "content-length": Any<Number>,
+  "content-type": "application/json",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "user-agent": StringMatching /Ghost\\\\/\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\\\s\\\\\\(https:\\\\/\\\\/github\\.com\\\\/TryGhost\\\\/Ghost\\\\\\)/,
+}
+`;
+
+exports[`site.* events site.changed event is triggered 2: [body] 1`] = `Object {}`;

--- a/ghost/core/test/e2e-webhooks/site.test.js
+++ b/ghost/core/test/e2e-webhooks/site.test.js
@@ -1,0 +1,57 @@
+const {agentProvider, mockManager, fixtureManager, matchers} = require('../utils/e2e-framework');
+const {anyGhostAgent, anyContentVersion, anyNumber} = matchers;
+
+describe('site.* events', function () {
+    let adminAPIAgent;
+    let webhookMockReceiver;
+
+    before(async function () {
+        adminAPIAgent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('integrations');
+        await adminAPIAgent.loginAsOwner();
+    });
+
+    beforeEach(function () {
+        webhookMockReceiver = mockManager.mockWebhookRequests();
+    });
+
+    afterEach(function () {
+        mockManager.restore();
+    });
+
+    it('site.changed event is triggered', async function () {
+        const webhookURL = 'https://test-webhook-receiver.com/site-changed';
+        await webhookMockReceiver.mock(webhookURL);
+        await fixtureManager.insertWebhook({
+            event: 'site.changed',
+            url: webhookURL
+        });
+
+        const res = await adminAPIAgent
+            .post('posts/')
+            .body({
+                posts: [{
+                    title: 'webhookz',
+                    status: 'published',
+                    mobiledoc: fixtureManager.get('posts', 1).mobiledoc
+                }]
+            })
+            .expectStatus(201);
+
+        const id = res.body.posts[0].id;
+
+        await adminAPIAgent
+            .delete('posts/' + id)
+            .expectStatus(204);
+
+        await webhookMockReceiver.receivedRequest();
+
+        webhookMockReceiver
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                'content-length': anyNumber,
+                'user-agent': anyGhostAgent
+            })
+            .matchBodySnapshot();
+    });
+});

--- a/ghost/core/test/e2e-webhooks/site.test.js
+++ b/ghost/core/test/e2e-webhooks/site.test.js
@@ -38,12 +38,6 @@ describe('site.* events', function () {
             })
             .expectStatus(201);
 
-        const id = res.body.posts[0].id;
-
-        await adminAPIAgent
-            .delete('posts/' + id)
-            .expectStatus(204);
-
         await webhookMockReceiver.receivedRequest();
 
         webhookMockReceiver


### PR DESCRIPTION
#15537 
There's a lot of API calls that can trigger a `site.changed` webhook event. I just cherry-picked deleting a post. If there's a more generic way to write this test I'm all ears. 
