### PR TITLE
Fixed transforming numbers into booleans in schema validator

### DIFF
--- a/ghost/core/core/server/data/schema/validator.js
+++ b/ghost/core/core/server/data/schema/validator.js
@@ -63,7 +63,7 @@ function validateSchema(tableName, model, options) {
 
         // validate boolean columns
         if (Object.prototype.hasOwnProperty.call(schema[tableName][columnKey], 'type')
-            && schema[tableName][columnKey].type === 'bool') {
+            && (schema[tableName][columnKey].type === 'bool' || schema[tableName][columnKey].type === 'boolean')) {
             if (!(validator.isBoolean(strVal) || validator.isEmpty(strVal))) {
                 message = tpl(messages.valueMustBeBoolean, {
                     tableName: tableName,

--- a/ghost/core/test/unit/server/data/schema/validator.test.js
+++ b/ghost/core/test/unit/server/data/schema/validator.test.js
@@ -64,7 +64,7 @@ describe('Validate Schema', function () {
             );
         });
 
-        it('transforms 0 and 1', function () {
+        it('transforms 0 and 1 (bool)', function () {
             const post = models.Post.forge(testUtils.DataGenerator.forKnex.createPost({slug: 'test', featured: 0}));
             post.get('featured').should.eql(0);
 
@@ -72,6 +72,14 @@ describe('Validate Schema', function () {
                 .then(function () {
                     post.get('featured').should.eql(false);
                 });
+        });
+
+        it('transforms 0 and 1 (boolean)', async function () {
+            const user = models.User.forge(testUtils.DataGenerator.forKnex.createUser({email: 'test@example.com', comment_notifications: 0}));
+            user.get('comment_notifications').should.eql(0);
+
+            await validateSchema('users', user, {method: 'insert'});
+            user.get('comment_notifications').should.eql(false);
         });
 
         it('keeps true or false', function () {


### PR DESCRIPTION
- I'm currently working on cleaning up our uses of `bool` and `boolean` in favor of `boolean`, and I've noticed we only handle converting numbers into booleans when the type is `bool`, so validation would otherwise fail
- given these can be used interchangeably, we should also support converting the numbers into booleans when the type is `boolean`
- this is going to get cleaned up again when I remove `bool` but this fixes the validation bug for now
