### PR TITLE
Fixed incorrect maximum length definition in schema

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/4.0/11-add-members-paid-subscription-events-table.js
+++ b/ghost/core/core/server/data/migrations/versions/4.0/11-add-members-paid-subscription-events-table.js
@@ -5,7 +5,7 @@ module.exports = addTable('members_paid_subscription_events', {
     member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
     from_plan: {type: 'string', maxlength: 255, nullable: true},
     to_plan: {type: 'string', maxlength: 255, nullable: true},
-    currency: {type: 'string', maxLength: 3, nullable: false},
+    currency: {type: 'string', maxlength: 191, nullable: false},
     source: {type: 'string', maxlength: 50, nullable: false},
     mrr_delta: {type: 'integer', nullable: false},
     created_at: {type: 'dateTime', nullable: false}

--- a/ghost/core/core/server/data/migrations/versions/4.0/13-add-members-payment-events-table.js
+++ b/ghost/core/core/server/data/migrations/versions/4.0/13-add-members-payment-events-table.js
@@ -4,7 +4,7 @@ module.exports = addTable('members_payment_events', {
     id: {type: 'string', maxlength: 24, nullable: false, primary: true},
     member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
     amount: {type: 'integer', nullable: false},
-    currency: {type: 'string', maxLength: 3, nullable: false},
+    currency: {type: 'string', maxlength: 191, nullable: false},
     source: {type: 'string', maxlength: 50, nullable: false},
     created_at: {type: 'dateTime', nullable: false}
 });

--- a/ghost/core/core/server/data/migrations/versions/4.3/06-add-stripe-prices-table.js
+++ b/ghost/core/core/server/data/migrations/versions/4.3/06-add-stripe-prices-table.js
@@ -6,7 +6,7 @@ module.exports = addTable('stripe_prices', {
     stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'stripe_products.stripe_product_id', cascadeDelete: true},
     active: {type: 'boolean', nullable: false},
     nickname: {type: 'string', maxlength: 50, nullable: true},
-    currency: {type: 'string', maxLength: 3, nullable: false},
+    currency: {type: 'string', maxlength: 191, nullable: false},
     amount: {type: 'integer', nullable: false},
     type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'recurring', validations: {isIn: [['recurring', 'one_time']]}},
     interval: {type: 'string', maxlength: 50, nullable: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -517,7 +517,9 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
         amount: {type: 'integer', nullable: false},
-        currency: {type: 'string', maxLength: 3, nullable: false},
+        // @note: this is longer than originally intended due to a bug - https://github.com/TryGhost/Ghost/pull/15606
+        // so we should decide whether we should reduce it down in the future
+        currency: {type: 'string', maxlength: 191, nullable: false},
         source: {type: 'string', maxlength: 50, nullable: false},
         created_at: {type: 'dateTime', nullable: false}
     },
@@ -566,7 +568,9 @@ module.exports = {
         subscription_id: {type: 'string', maxlength: 24, nullable: true},
         from_plan: {type: 'string', maxlength: 255, nullable: true},
         to_plan: {type: 'string', maxlength: 255, nullable: true},
-        currency: {type: 'string', maxLength: 3, nullable: false},
+        // @note: this is longer than originally intended due to a bug - https://github.com/TryGhost/Ghost/pull/15606
+        // so we should decide whether we should reduce it down in the future
+        currency: {type: 'string', maxlength: 191, nullable: false},
         source: {
             type: 'string', maxlength: 50, nullable: false, validations: {
                 isIn: [['stripe']]
@@ -625,7 +629,9 @@ module.exports = {
         plan_nickname: {type: 'string', maxlength: 50, nullable: false},
         plan_interval: {type: 'string', maxlength: 50, nullable: false},
         plan_amount: {type: 'integer', nullable: false},
-        plan_currency: {type: 'string', maxLength: 3, nullable: false}
+        // @note: this is longer than originally intended due to a bug - https://github.com/TryGhost/Ghost/pull/15606
+        // so we should decide whether we should reduce it down in the future
+        plan_currency: {type: 'string', maxlength: 191, nullable: false}
     },
     members_subscription_created_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
@@ -675,7 +681,9 @@ module.exports = {
         stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'stripe_products.stripe_product_id'},
         active: {type: 'boolean', nullable: false},
         nickname: {type: 'string', maxlength: 50, nullable: true},
-        currency: {type: 'string', maxLength: 3, nullable: false},
+        // @note: this is longer than originally intended due to a bug - https://github.com/TryGhost/Ghost/pull/15606
+        // so we should decide whether we should reduce it down in the future
+        currency: {type: 'string', maxlength: 191, nullable: false},
         amount: {type: 'integer', nullable: false},
         type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'recurring', validations: {isIn: [['recurring', 'one_time']]}},
         interval: {type: 'string', maxlength: 50, nullable: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '7f8c1a992b307dff960165b0cfa1d2db';
+    const currentSchemaHash = '769321183f98f2af801b7fa4494b8f2d';
     const currentFixturesHash = '8cf221f0ed930ac1fe8030a58e60d64b';
     const currentSettingsHash = '2978a5684a2d5fcf089f61f5d368a0c0';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -23,7 +23,6 @@ const VALID_KEYS = {
     ],
     string: [
         'maxlength',
-        'maxLength', // this is the result of a bug and should NOT be used, will be deleted soon
         'nullable',
         'primary',
         'unique',


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/441

- whilst reviewing another PR, I noticed we were incorrectly using `maxLength` instead of `maxlength` in the schema column definition
- it turns out we've already been doing this wrong for a while with other columns
- this key is not acted upon, so the maximum column length was not applied
- fixing up the DB to the correct maximum length is something to fix in the future but right now, the schema does not reflect the size of the column that actually got created
- the fallback when `maxlength` is not provided is currently 191 [0], so this commit switches the schema and migrations to using the correct key name and column length that they are using when applied

[0]: https://github.com/TryGhost/Ghost/blob/24670aa555e2b39d2505853c6cb19f6c976c2738/ghost/core/core/server/data/schema/commands.js#L27
