### PR TITLE
🐛 Fixed missing accent color for default content cta

### DIFF
--- a/ghost/core/core/frontend/helpers/tpl/content-cta.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/content-cta.hbs
@@ -11,7 +11,7 @@
             <h2>This {{#is "page"}}page{{else}}post{{/is}} is for subscribers on the {{tiers}} only </h2>
         {{/has}}
         {{#if @member}}
-            <a class="gh-btn" data-portal="account/plans" style="color:{{@site.accentColor}}">Upgrade your account</a>
+            <a class="gh-btn" data-portal="account/plans" style="color:{{@site.accent_color}}">Upgrade your account</a>
         {{else}}
             <a class="gh-btn" data-portal="signup" style="color:{{@site.accent_color}}">Subscribe now</a>
             <p><small>Already have an account? <a data-portal="signin">Sign in</a></small></p>

--- a/ghost/core/test/unit/frontend/helpers/content.test.js
+++ b/ghost/core/test/unit/frontend/helpers/content.test.js
@@ -150,6 +150,18 @@ describe('{{content}} helper with no access', function () {
         rendered.string.should.containEql('"background-color: #abcdef"');
         rendered.string.should.containEql('This page is for');
     });
+
+    it('can render default template for upgrade case', function () {
+        // html will be included when there is free content available
+        const html = 'Free content';
+        optionsData.data.member = {
+            id: '123'
+        };
+        const rendered = content.call({html: html, access: false, visibility: 'members'}, optionsData);
+        rendered.string.should.containEql('Free content');
+        rendered.string.should.containEql('Upgrade your account');
+        rendered.string.should.containEql('color:#abcdef');
+    });
 });
 
 describe('{{content}} helper with custom template', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Casper/issues/901

- the site accent color property on default cta for upgrade link had a typo and was using wrong property