### PR TITLE
🐛 Removed redirects from search engine indexing

### DIFF
--- a/ghost/core/core/frontend/public/robots.txt
+++ b/ghost/core/core/frontend/public/robots.txt
@@ -3,3 +3,4 @@ Sitemap: {{blog-url}}/sitemap.xml
 Disallow: /ghost/
 Disallow: /p/
 Disallow: /email/
+Disallow: /r/

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -326,7 +326,8 @@ describe('Default Frontend routing', function () {
                 'User-agent: *\n' +
                 'Sitemap: http://127.0.0.1:2369/sitemap.xml\nDisallow: /ghost/\n' +
                 'Disallow: /p/\n' +
-                'Disallow: /email/\n'
+                'Disallow: /email/\n' +
+                'Disallow: /r/\n'
             );
         });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2072

Google is indexing our redirects and storign the redirected content against the redirect URL in search results. This seems to be caused by us using a 302 redirect rather than 301. We don't want to switch to a 301 however, so that we can support the ability to update redirects in the future.