### PR TITLE
Fixed unnecessary requests with loading comment counts

### DIFF
--- a/ghost/core/core/frontend/src/comment-counts/js/comment-counts.js
+++ b/ghost/core/core/frontend/src/comment-counts/js/comment-counts.js
@@ -63,6 +63,10 @@
         const ids = Array.from(fetchingIds);
         fetchingIds.clear();
 
+        if (!ids.length) {
+            return;
+        }
+
         const rawRes = await fetch(api, {
             method: 'POST',
             headers: {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2082

- if a site has comments enabled but doesn't use the `comments_count` helper, the comments-count.min.js will still be loaded and it'll send a POST request to Ghost with an empty array of post IDs to fetch
- this is unnecessary and we should avoid this extra request for pages that don't need to show comment counts
- this commit prevents the comment-counts JS from sending the request if there are no post IDs to fetch