### PR TITLE
Added handling for unsuccessful comments API requests

### DIFF
--- a/ghost/core/core/frontend/src/comment-counts/js/comment-counts.js
+++ b/ghost/core/core/frontend/src/comment-counts/js/comment-counts.js
@@ -76,6 +76,10 @@
             body: JSON.stringify({ids})
         });
 
+        if (rawRes.status !== 200) {
+            return;
+        }
+
         const res = await rawRes.json();
 
         for (const [id, count] of Object.entries(res)) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2082

- in the event the API doesn't return a 200 OK, we shouldn't be processing the response from it, as we can end up doing weird things if, for example, an error object is returned
