### PR TITLE
🐛 Fixed large mailgun replacements

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/emails.js
@@ -7,7 +7,7 @@ module.exports = (model, frame) => {
     // TODO: extract this to a utility, it's duplicated in the email-preview API controller
     const replacements = mega.postEmailSerializer.parseReplacements(jsonModel);
     replacements.forEach((replacement) => {
-        jsonModel[replacement.format] = jsonModel[replacement.format].replace(
+        jsonModel[replacement.format] = jsonModel[replacement.format].replaceAll(
             replacement.match,
             replacement.fallback || ''
         );

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/emails.js
@@ -7,8 +7,8 @@ module.exports = (model, frame) => {
     // TODO: extract this to a utility, it's duplicated in the email-preview API controller
     const replacements = mega.postEmailSerializer.parseReplacements(jsonModel);
     replacements.forEach((replacement) => {
-        jsonModel[replacement.format] = jsonModel[replacement.format].replaceAll(
-            replacement.match,
+        jsonModel[replacement.format] = jsonModel[replacement.format].replace(
+            replacement.regexp,
             replacement.fallback || ''
         );
     });

--- a/ghost/core/core/server/services/mega/email-preview.js
+++ b/ghost/core/core/server/services/mega/email-preview.js
@@ -31,8 +31,8 @@ class EmailPreview {
         const replacements = postEmailSerializer.parseReplacements(emailContent);
 
         replacements.forEach((replacement) => {
-            emailContent[replacement.format] = emailContent[replacement.format].replaceAll(
-                replacement.match,
+            emailContent[replacement.format] = emailContent[replacement.format].replace(
+                replacement.regexp,
                 replacement.fallback || ''
             );
         });

--- a/ghost/core/core/server/services/mega/email-preview.js
+++ b/ghost/core/core/server/services/mega/email-preview.js
@@ -31,7 +31,7 @@ class EmailPreview {
         const replacements = postEmailSerializer.parseReplacements(emailContent);
 
         replacements.forEach((replacement) => {
-            emailContent[replacement.format] = emailContent[replacement.format].replace(
+            emailContent[replacement.format] = emailContent[replacement.format].replaceAll(
                 replacement.match,
                 replacement.fallback || ''
             );

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -181,6 +181,10 @@ const PostEmailSerializer = {
         const EMAIL_REPLACEMENT_REGEX = /%%(\{.*?\})%%/g;
         const REPLACEMENT_STRING_REGEX = /\{(?<recipientProperty>\w*?)(?:,? *(?:"|&quot;)(?<fallback>.*?)(?:"|&quot;))?\}/;
 
+        function escapeRegExp(string) {
+            return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        }
+
         const replacements = [];
 
         ['html', 'plaintext'].forEach((format) => {
@@ -204,6 +208,7 @@ const PostEmailSerializer = {
                             format,
                             id,
                             match: replacementMatch,
+                            regexp: new RegExp(escapeRegExp(replacementMatch), 'g'),
                             recipientProperty: `member_${recipientProperty}`,
                             fallback
                         });

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -187,6 +187,11 @@ const PostEmailSerializer = {
             let result;
             while ((result = EMAIL_REPLACEMENT_REGEX.exec(email[format])) !== null) {
                 const [replacementMatch, replacementStr] = result;
+
+                // Did we already found this match and added it to the replacements array?
+                if (replacements.find(r => r.match === replacementMatch && r.format === format)) {
+                    continue;
+                }
                 const match = replacementStr.match(REPLACEMENT_STRING_REGEX);
 
                 if (match) {

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -17,6 +17,7 @@ const linkReplacer = require('@tryghost/link-replacer');
 const linkTracking = require('../link-tracking');
 const memberAttribution = require('../member-attribution');
 const feedbackButtons = require('./feedback-buttons');
+const labs = require('../../../shared/labs');
 
 const ALLOWED_REPLACEMENTS = ['first_name', 'uuid'];
 
@@ -109,20 +110,16 @@ const PostEmailSerializer = {
     },
 
     /**
-     * createUserLinks
+     * replaceFeedbackLinks
      *
-     * Generate personalised links for each user
+     * Replace the button template links with real links
      *
-     * @param {string} memberUuid member uuid
-     * @param {Object} email
+     * @param {string} html
+     * @param {string} postId (will be url encoded)
+     * @param {string} memberUuid member uuid to use in the URL (will be url encoded)
      */
-    createUserLinks(email, memberUuid) {
-        const result = {...email};
-
-        result.html = feedbackButtons.generateLinks(result.post.id, memberUuid, result.html);
-        result.plaintext = htmlToPlaintext.email(result.html);
-
-        return result;
+    replaceFeedbackLinks(html, postId, memberUuid) {
+        return feedbackButtons.generateLinks(postId, memberUuid, html);
     },
 
     // NOTE: serialization is needed to make sure we do post transformations such as image URL transformation from relative to absolute
@@ -405,6 +402,14 @@ const PostEmailSerializer = {
             });
         }
 
+        // Add buttons
+        if (labs.isSet('audienceFeedback')) {
+            // create unique urls for every recipient (for example, for feedback buttons)
+            // Note, we need to use a different member uuid in the links because `%%{uuid}%%` would get escaped by the URL object when set as a search param
+            const urlSafeToken = '--' + new Date().getTime() + 'url-safe-uuid--';
+            result.html = this.replaceFeedbackLinks(result.html, post.id, urlSafeToken).replace(new RegExp(urlSafeToken, 'g'), '%%{uuid}%%');
+        }
+
         // Clean up any unknown replacements strings to get our final content
         const {html, plaintext} = this.normalizeReplacementStrings(result);
         const data = {
@@ -530,7 +535,6 @@ module.exports = {
     serialize: PostEmailSerializer.serialize.bind(PostEmailSerializer),
     createUnsubscribeUrl: PostEmailSerializer.createUnsubscribeUrl.bind(PostEmailSerializer),
     createPostSignupUrl: PostEmailSerializer.createPostSignupUrl.bind(PostEmailSerializer),
-    createUserLinks: PostEmailSerializer.createUserLinks.bind(PostEmailSerializer),
     renderEmailForSegment: PostEmailSerializer.renderEmailForSegment.bind(PostEmailSerializer),
     parseReplacements: PostEmailSerializer.parseReplacements.bind(PostEmailSerializer),
     // Export for tests

--- a/ghost/core/test/integration/services/mega.test.js
+++ b/ghost/core/test/integration/services/mega.test.js
@@ -190,6 +190,9 @@ describe('MEGA', function () {
                 // Check if the link is a tracked link
                 assert(href.includes('?m=' + memberUuid), href + ' is not tracked');
 
+                // Check if this link is also present in the plaintext version (with the right replacements)
+                assert(emailData.plaintext.includes(href), href + ' is not present in the plaintext version');
+
                 if (!firstLink) {
                     firstLink = new URL(href);
                 }

--- a/ghost/core/test/integration/services/mega.test.js
+++ b/ghost/core/test/integration/services/mega.test.js
@@ -157,13 +157,13 @@ describe('MEGA', function () {
 
             // Do the actual replacements for the first member, so we don't have to worry about them anymore
             replacements.forEach((replacement) => {
-                emailData[replacement.format] = emailData[replacement.format].replace(
+                emailData[replacement.format] = emailData[replacement.format].replaceAll(
                     replacement.match,
                     recipient[replacement.id]
                 );
 
                 // Also force Mailgun format
-                emailData[replacement.format] = emailData[replacement.format].replace(
+                emailData[replacement.format] = emailData[replacement.format].replaceAll(
                     `%recipient.${replacement.id}%`,
                     recipient[replacement.id]
                 );

--- a/ghost/core/test/integration/services/mega.test.js
+++ b/ghost/core/test/integration/services/mega.test.js
@@ -157,14 +157,14 @@ describe('MEGA', function () {
 
             // Do the actual replacements for the first member, so we don't have to worry about them anymore
             replacements.forEach((replacement) => {
-                emailData[replacement.format] = emailData[replacement.format].replaceAll(
-                    replacement.match,
+                emailData[replacement.format] = emailData[replacement.format].replace(
+                    replacement.regexp,
                     recipient[replacement.id]
                 );
 
                 // Also force Mailgun format
-                emailData[replacement.format] = emailData[replacement.format].replaceAll(
-                    `%recipient.${replacement.id}%`,
+                emailData[replacement.format] = emailData[replacement.format].replace(
+                    new RegExp(`%recipient.${replacement.id}%`, 'g'),
                     recipient[replacement.id]
                 );
             });

--- a/ghost/core/test/unit/server/services/mega/post-email-serializer.test.js
+++ b/ghost/core/test/unit/server/services/mega/post-email-serializer.test.js
@@ -34,6 +34,46 @@ describe('Post Email Serializer', function () {
         assert.equal(replaced[1].recipientProperty, 'member_first_name');
     });
 
+    it('reuses the same replacement pattern when used multiple times', function () {
+        const html = '<html>Hey %%{first_name}%%, what is up? Just repeating %%{first_name}%%</html>';
+        const plaintext = 'Hey %%{first_name}%%, what is up? Just repeating %%{first_name}%%';
+
+        const replaced = parseReplacements({
+            html,
+            plaintext
+        });
+
+        assert.equal(replaced.length, 2);
+        assert.equal(replaced[0].format, 'html');
+        assert.equal(replaced[0].recipientProperty, 'member_first_name');
+
+        assert.equal(replaced[1].format, 'plaintext');
+        assert.equal(replaced[1].recipientProperty, 'member_first_name');
+    });
+
+    it('creates multiple replacement pattern for valid format and value', function () {
+        const html = '<html>Hey %%{first_name}%%, %%{uuid}%% %%{first_name}%% %%{uuid}%%</html>';
+        const plaintext = 'Hey %%{first_name}%%, %%{uuid}%% %%{first_name}%% %%{uuid}%%';
+
+        const replaced = parseReplacements({
+            html,
+            plaintext
+        });
+
+        assert.equal(replaced.length, 4);
+        assert.equal(replaced[0].format, 'html');
+        assert.equal(replaced[0].recipientProperty, 'member_first_name');
+
+        assert.equal(replaced[1].format, 'html');
+        assert.equal(replaced[1].recipientProperty, 'member_uuid');
+
+        assert.equal(replaced[2].format, 'plaintext');
+        assert.equal(replaced[2].recipientProperty, 'member_first_name');
+
+        assert.equal(replaced[3].format, 'plaintext');
+        assert.equal(replaced[3].recipientProperty, 'member_uuid');
+    });
+
     it('does not create replacements for unsupported variable names', function () {
         const html = '<html>Hey %%{last_name}%%, what is up?</html>';
         const plaintext = 'Hey %%{age}%%, what is up?';

--- a/ghost/mailgun-client/lib/mailgun-client.js
+++ b/ghost/mailgun-client/lib/mailgun-client.js
@@ -50,7 +50,7 @@ module.exports = class MailgunClient {
 
             // update content to use Mailgun variable syntax for replacements
             replacements.forEach((replacement) => {
-                messageContent[replacement.format] = messageContent[replacement.format].replace(
+                messageContent[replacement.format] = messageContent[replacement.format].replaceAll(
                     replacement.match,
                     `%recipient.${replacement.id}%`
                 );

--- a/ghost/mailgun-client/lib/mailgun-client.js
+++ b/ghost/mailgun-client/lib/mailgun-client.js
@@ -50,8 +50,8 @@ module.exports = class MailgunClient {
 
             // update content to use Mailgun variable syntax for replacements
             replacements.forEach((replacement) => {
-                messageContent[replacement.format] = messageContent[replacement.format].replaceAll(
-                    replacement.match,
+                messageContent[replacement.format] = messageContent[replacement.format].replace(
+                    replacement.regexp,
                     `%recipient.${replacement.id}%`
                 );
             });


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2096

When generating the recipient data for emails, the email clicks implementation is resulting in a recipient variable being added called replacement_xxx once for each link containing the same UUID.

This generates a lot of unnecessary data overhead for emails, and it turns out that mailgun has a 25MB message limit. We wouldn't have come close if we only included the uuid once.