### PR TITLE
Improved URL syncing between Admin and Explore

### DIFF
--- a/ghost/admin/app/components/gh-explore-iframe.js
+++ b/ghost/admin/app/components/gh-explore-iframe.js
@@ -45,6 +45,6 @@ export default class GhExploreIframe extends Component {
     }
 
     _handleSiteDataUpdate(data) {
-        this.explore.siteData = data.siteData;
+        this.explore.siteData = data?.siteData ?? {};
     }
 }

--- a/ghost/admin/app/controllers/explore.js
+++ b/ghost/admin/app/controllers/explore.js
@@ -20,6 +20,7 @@ export default class ExploreController extends Controller {
     @action
     closeConnect() {
         if (this.explore.isIframeTransition) {
+            this.explore.sendRouteUpdate({path: '/explore'});
             this.router.transitionTo('/explore');
         } else {
             this.router.transitionTo('/dashboard');
@@ -43,6 +44,7 @@ export default class ExploreController extends Controller {
             // to the submit page and fetch the required site data
             setTimeout(() => {
                 this.explore.toggleExploreWindow(true);
+                this.explore.sendRouteUpdate({path: '/explore'});
                 this.router.transitionTo('explore');
             }, 500);
         } else {

--- a/ghost/admin/app/controllers/explore.js
+++ b/ghost/admin/app/controllers/explore.js
@@ -44,8 +44,6 @@ export default class ExploreController extends Controller {
             // to the submit page and fetch the required site data
             setTimeout(() => {
                 this.explore.toggleExploreWindow(true);
-                this.explore.sendRouteUpdate({path: '/explore'});
-                this.router.transitionTo('explore');
             }, 500);
         } else {
             // Ghost Explore URL to submit a new site

--- a/ghost/admin/app/routes/explore.js
+++ b/ghost/admin/app/routes/explore.js
@@ -1,0 +1,10 @@
+import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import {inject as service} from '@ember/service';
+
+export default class ExploreRoute extends AuthenticatedRoute {
+    @service store;
+
+    model() {
+        return this.store.findAll('integration');
+    }
+}

--- a/ghost/admin/app/routes/explore/index.js
+++ b/ghost/admin/app/routes/explore/index.js
@@ -31,7 +31,7 @@ export default class ExploreRoute extends AuthenticatedRoute {
     }
 
     @action
-    async willTransition(transition) {
+    willTransition(transition) {
         let isExploreTransition = false;
 
         if (transition) {
@@ -46,9 +46,14 @@ export default class ExploreRoute extends AuthenticatedRoute {
                 this.explore.isIframeTransition = isExploreTransition;
 
                 if (destinationUrl?.includes('/explore/submit')) {
-                    // Ensure the model is loaded before sending the controller action
-                    const model = await this.model;
-                    this.controllerFor('explore').submitExploreSite(model);
+                    // only show the submit page if the site is already submitted
+                    // and redirect to the connect page if not.
+                    if (Object.keys(this?.explore?.siteData).length >= 1) {
+                        this.controllerFor('explore').submitExploreSite();
+                    } else {
+                        transition.abort();
+                        return this.router.transitionTo('explore.connect');
+                    }
                 } else {
                     let path = destinationUrl.replace(/explore\//, '');
                     path = path === '/' ? '/explore/' : path;

--- a/ghost/admin/app/routes/explore/index.js
+++ b/ghost/admin/app/routes/explore/index.js
@@ -43,11 +43,10 @@ export default class ExploreRoute extends AuthenticatedRoute {
 
             if (destinationUrl?.includes('/explore')) {
                 isExploreTransition = true;
-
+                let path = destinationUrl.replace(/explore\//, '');
+                path = path === '/' ? '/explore' : path;
                 // Send the updated route to the iframe
-                if (transition?.to?.params?.sub) {
-                    this.explore.sendRouteUpdate({path: transition.to.params.sub});
-                }
+                this.explore.sendRouteUpdate({path});
             }
         }
 

--- a/ghost/admin/app/routes/explore/index.js
+++ b/ghost/admin/app/routes/explore/index.js
@@ -2,7 +2,7 @@ import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
-export default class ExploreRoute extends AuthenticatedRoute {
+export default class ExploreIndexRoute extends AuthenticatedRoute {
     @service explore;
     @service store;
     @service router;

--- a/ghost/admin/app/routes/explore/index.js
+++ b/ghost/admin/app/routes/explore/index.js
@@ -31,7 +31,7 @@ export default class ExploreRoute extends AuthenticatedRoute {
     }
 
     @action
-    willTransition(transition) {
+    async willTransition(transition) {
         let isExploreTransition = false;
 
         if (transition) {
@@ -43,10 +43,23 @@ export default class ExploreRoute extends AuthenticatedRoute {
 
             if (destinationUrl?.includes('/explore')) {
                 isExploreTransition = true;
-                let path = destinationUrl.replace(/explore\//, '');
-                path = path === '/' ? '/explore' : path;
-                // Send the updated route to the iframe
-                this.explore.sendRouteUpdate({path});
+                this.explore.isIframeTransition = isExploreTransition;
+
+                if (destinationUrl?.includes('/explore/submit')) {
+                    // Ensure the model is loaded before sending the controller action
+                    const model = await this.model;
+                    this.controllerFor('explore').submitExploreSite(model);
+                } else {
+                    let path = destinationUrl.replace(/explore\//, '');
+                    path = path === '/' ? '/explore/' : path;
+
+                    if (destinationUrl?.includes('/explore/about')) {
+                        window.open(`${this.explore.exploreUrl}about/`, '_blank').focus();
+                        path = '/explore/';
+                    }
+                    // Send the updated route to the iframe
+                    this.explore.sendRouteUpdate({path});
+                }
             }
         }
 


### PR DESCRIPTION
no issue

Improve the route communication between Ghost Admin and Ghost Explore to reflect route changes in the URL and correctly navigate to Explore sub routes
