### PR TITLE
Fixed PromiseObject related errors thrown from members activity list

### DIFF
--- a/ghost/admin/app/controllers/members-activity.js
+++ b/ghost/admin/app/controllers/members-activity.js
@@ -1,8 +1,10 @@
 import Controller from '@ember/controller';
+import MemberFetcher from 'ghost-admin/helpers/member-fetcher';
 import {EMAIL_EVENTS, NEWSLETTER_EVENTS} from 'ghost-admin/helpers/members-event-filter';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
+import {use} from 'ember-could-get-used-to-this';
 
 export default class MembersActivityController extends Controller {
     @service router;
@@ -13,6 +15,8 @@ export default class MembersActivityController extends Controller {
 
     @tracked excludedEvents = null;
     @tracked member = null;
+
+    @use memberRecord = new MemberFetcher(() => [this.member]);
 
     // we don't want to show or allow filtering of certain events in some situations
     // - no member selected = don't show email events, they flood the list and the API can't paginate correctly
@@ -33,16 +37,6 @@ export default class MembersActivityController extends Controller {
 
     get fullExcludedEvents() {
         return (this.excludedEvents || '').split(',').concat(this.hiddenEvents);
-    }
-
-    get memberRecord() {
-        if (!this.member) {
-            return null;
-        }
-
-        // TODO: {reload: true} here shouldn't be needed but without it
-        // the template renders nothing if the record is already in the store
-        return this.store.findRecord('member', this.member, {reload: true});
     }
 
     @action

--- a/ghost/admin/app/helpers/member-fetcher.js
+++ b/ghost/admin/app/helpers/member-fetcher.js
@@ -1,0 +1,26 @@
+import {Resource} from 'ember-could-get-used-to-this';
+import {inject as service} from '@ember/service';
+import {tracked} from '@glimmer/tracking';
+
+class MemberFetcher extends Resource {
+    @service store;
+
+    @tracked loadedMember = null;
+
+    get value() {
+        return this.loadedMember;
+    }
+
+    async setup() {
+        const [memberId] = this.args.positional;
+
+        if (!memberId) {
+            return;
+        }
+
+        const record = await this.store.findRecord('member', memberId);
+        this.loadedMember = record;
+    }
+}
+
+export default MemberFetcher;


### PR DESCRIPTION
no issue

- the `memberRecord` getter on the members activity controller was returning the direct result of `store.findRecord()` which in reality is a `PromiseObject` that is a type of proxy. Although templates handle this OK, any JS code using the object needs to know that it's not a typical type of object and has to use `.get()` for all property access to avoid errors
- switched `memberRecord` from a getter to a resource so we have more control over the returned object and loading lifecycle
  - added a `MemberFetcher` resource class that awaits the result of the store find and only then sets the value meaning we always have a fully resolved model object
  - being a resource the fetch will only occur when the `member` id property changes, unlike the getter which performed the fetch every time it was accessed
