### PR TITLE
 Added `ghost_subscription_id` column to `members_stripe_customers_subscriptions`

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.20/2022-10-18-10-13-add-ghost-subscription-id-column-to-mscs.js
+++ b/ghost/core/core/server/data/migrations/versions/5.20/2022-10-18-10-13-add-ghost-subscription-id-column-to-mscs.js
@@ -1,0 +1,10 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('members_stripe_customers_subscriptions', 'ghost_subscription_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true,
+    references: 'subscriptions.id',
+    constraintName: 'mscs_ghost_subscription_id_foreign',
+    cascadeDelete: true
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -657,6 +657,7 @@ module.exports = {
     members_stripe_customers_subscriptions: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         customer_id: {type: 'string', maxlength: 255, nullable: false, unique: false, references: 'members_stripe_customers.customer_id', cascadeDelete: true},
+        ghost_subscription_id: {type: 'string', maxlength: 24, nullable: true, references: 'subscriptions.id', constraintName: 'mscs_ghost_subscription_id_foreign', cascadeDelete: true},
         subscription_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
         stripe_price_id: {type: 'string', maxlength: 255, nullable: false, unique: false, index: true, defaultTo: ''},
         status: {type: 'string', maxlength: 50, nullable: false},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '76cfd2230c02c428e9505f6b9a3936ec';
+    const currentSchemaHash = 'bb9d35d276f407c4a353e22e1e5b5538';
     const currentFixturesHash = 'dcb7ba7c66b4b98d6c26a722985e756a';
     const currentSettingsHash = '2978a5684a2d5fcf089f61f5d368a0c0';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2034

- this table will be used to link Stripe subscriptions to Ghost
  subscriptions via a foreign key that we add at a later point