### PR TITLE
Fixed permissions for links endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/links.js
+++ b/ghost/core/core/server/api/endpoints/links.js
@@ -6,7 +6,7 @@ module.exports = {
         options: [
             'filter'
         ],
-        permissions: false,
+        permissions: true,
         async query(frame) {
             const links = await linkTrackingService.service.getLinks(frame.options);
 

--- a/ghost/core/core/server/data/migrations/versions/5.20/2022-10-19-11-17-add-link-browse-permissions.js
+++ b/ghost/core/core/server/data/migrations/versions/5.20/2022-10-19-11-17-add-link-browse-permissions.js
@@ -1,0 +1,10 @@
+const {addPermissionWithRoles} = require('../../utils');
+
+module.exports = addPermissionWithRoles({
+    name: 'Browse links',
+    action: 'browse',
+    object: 'link'
+}, [
+    'Administrator',
+    'Admin Integration'
+]);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -618,6 +618,11 @@
                     "name": "Report comments",
                     "action_type": "report",
                     "object_type": "comment"
+                },
+                {
+                    "name": "Browse links",
+                    "action_type": "browse",
+                    "object_type": "link"
                 }
             ]
         },
@@ -747,7 +752,8 @@
                     "members_stripe_connect": "auth",
                     "newsletter": "all",
                     "explore": "read",
-                    "comment": "all"
+                    "comment": "all",
+                    "link": "all"
                 },
                 "DB Backup Integration": {
                     "db": "all"
@@ -781,7 +787,8 @@
                     "offer": ["browse", "read", "add", "edit"],
                     "newsletter": ["browse", "read", "add", "edit"],
                     "explore": "read",
-                    "comment": "all"
+                    "comment": "all",
+                    "link": "all"
                 },
                 "Editor": {
                     "notification": "all",

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -45,7 +45,7 @@ describe('Database Migration (special functions)', function () {
             const permissions = this.obj;
 
             // If you have to change this number, please add the relevant `havePermission` checks below
-            permissions.length.should.eql(106);
+            permissions.length.should.eql(107);
 
             permissions.should.havePermission('Export database', ['Administrator', 'DB Backup Integration']);
             permissions.should.havePermission('Import database', ['Administrator', 'DB Backup Integration']);
@@ -179,6 +179,7 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Like comments', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Unlike comments', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Report comments', ['Administrator', 'Admin Integration']);
+            permissions.should.havePermission('Browse links', ['Administrator', 'Admin Integration']);
         });
 
         describe('Populate', function () {

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -199,7 +199,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
-                const FIXTURE_COUNT = 94;
+                const FIXTURE_COUNT = 96;
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '76cfd2230c02c428e9505f6b9a3936ec';
-    const currentFixturesHash = '05e2151eeba95aac474f0a7a7e63297f';
+    const currentFixturesHash = '6110a18edb75e3b7465d69385915984d';
     const currentSettingsHash = '2978a5684a2d5fcf089f61f5d368a0c0';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -618,6 +618,11 @@
                     "name": "Report comments",
                     "action_type": "report",
                     "object_type": "comment"
+                },
+                {
+                    "name": "Browse links",
+                    "action_type": "browse",
+                    "object_type": "link"
                 }
             ]
         },
@@ -923,7 +928,8 @@
                     "members_stripe_connect": "auth",
                     "newsletter": "all",
                     "explore": "read",
-                    "comment": "all"
+                    "comment": "all",
+                    "link": "all"
                 },
                 "DB Backup Integration": {
                     "db": "all"
@@ -957,7 +963,8 @@
                     "offer": ["browse", "read", "add", "edit"],
                     "newsletter": ["browse", "read", "add", "edit"],
                     "explore": "read",
-                    "comment": "all"
+                    "comment": "all",
+                    "link": "all"
                 },
                 "Editor": {
                     "notification": "all",


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/5fcf5098a84eea5aed82a412718e6dde8d2b725a

- links browse endpoint had permissions switched off unintentionally and was also missing the necessary permissions in fixtures.
- enables permissions for browse endpoint and adds migration insert permissions in DB
