### PR TITLE
✨ Allowed fixing newsletter links

### DIFF
--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -284,19 +284,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
-                            <h4 class="gh-expandable-title">Fix newsletter links</h4>
-                            <p class="gh-expandable-description">
-                               Allow publishers to edit newsletter links after sending.
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                           <GhFeatureFlag @flag="fixNewsletterLinks" />
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
         {{/if}}

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -19,7 +19,8 @@ const GA_FEATURES = [
     'freeTrial',
     'compExpiring',
     'searchHelper',
-    'emailAlerts'
+    'emailAlerts',
+    'fixNewsletterLinks'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -35,8 +36,7 @@ const ALPHA_FEATURES = [
     'beforeAfterCard',
     'lexicalEditor',
     'exploreApp',
-    'audienceFeedback',
-    'fixNewsletterLinks'
+    'audienceFeedback'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -627,7 +627,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3450",
+  "content-length": "3478",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2116

- allows site owners to edit a link in a post that has already been sent out, fixing any typos or other mistakes
- resets click counter for the edited link back to 0 so site owners can see the clicks on new link, doesn't change the overall click count