### PR TITLE
Added email sent events

### DIFF
--- a/ghost/admin/app/components/member/activity-feed.hbs
+++ b/ghost/admin/app/components/member/activity-feed.hbs
@@ -6,7 +6,7 @@
         </div>
     </div>
 {{else}}
-    {{#let (members-event-fetcher filter=(members-event-filter member=@member.id) pageSize=5) as |eventsFetcher|}}
+    {{#let (members-event-fetcher filter=(members-event-filter member=@member.id excludedEvents=this.excludedEventTypes) pageSize=5) as |eventsFetcher|}}
         <div class="gh-main-section-content grey {{if eventsFetcher.data "" "mt8"}}">
             <div class="gh-member-feed {{if eventsFetcher.data "" "gh-member-feed-no-data"}}" ...attributes>
                 <div class="flex-auto flex flex-column items-stretch {{if eventsFetcher.data "justify-between" "h-100 justify-center"}}">

--- a/ghost/admin/app/components/member/activity-feed.js
+++ b/ghost/admin/app/components/member/activity-feed.js
@@ -3,6 +3,7 @@ import {action} from '@ember/object';
 
 export default class ActivityFeed extends Component {
     linkScrollerTimeout = null; // needs to be global so can be cleared when needed across functions
+    excludedEventTypes = ['email_sent_event'];
 
     @action
     enterLinkURL(event) {

--- a/ghost/admin/app/components/posts/post-activity-feed.js
+++ b/ghost/admin/app/components/posts/post-activity-feed.js
@@ -6,6 +6,7 @@ const allEvents = [
     'click_event',
     'signup_event',
     'subscription_event',
+    'email_sent_event',
     'email_delivered_event',
     'email_opened_event',
     'email_failed_event',
@@ -13,7 +14,7 @@ const allEvents = [
 ];
 
 const eventTypes = {
-    sent: ['email_delivered_event'],
+    sent: ['email_sent_event'],
     opened: ['email_opened_event'],
     clicked: ['click_event'],
     feedback: ['feedback_event'],

--- a/ghost/admin/app/controllers/members-activity.js
+++ b/ghost/admin/app/controllers/members-activity.js
@@ -26,6 +26,9 @@ export default class MembersActivityController extends Controller {
 
         if (!this.member) {
             hiddenEvents.push(...EMAIL_EVENTS);
+        } else {
+            // Always hide sent event
+            hiddenEvents.push('email_sent_event');
         }
 
         if (this.settings.editorDefaultEmailRecipients === 'disabled') {

--- a/ghost/admin/app/helpers/members-event-filter.js
+++ b/ghost/admin/app/helpers/members-event-filter.js
@@ -3,7 +3,7 @@ import classic from 'ember-classic-decorator';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
 
-export const EMAIL_EVENTS = ['email_delivered_event','email_opened_event','email_failed_event'];
+export const EMAIL_EVENTS = ['email_sent_event', 'email_delivered_event', 'email_opened_event','email_failed_event'];
 export const NEWSLETTER_EVENTS = ['newsletter_event'];
 
 @classic

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -72,7 +72,7 @@ export default class ParseMemberEventHelper extends Helper {
             icon = 'opened-email';
         }
 
-        if (event.type === 'email_delivered_event') {
+        if (event.type === 'email_delivered_event' || event.type === 'email_sent_event') {
             icon = 'received-email';
         }
 
@@ -149,7 +149,7 @@ export default class ParseMemberEventHelper extends Helper {
             return 'opened email';
         }
 
-        if (event.type === 'email_delivered_event') {
+        if (event.type === 'email_delivered_event' || event.type === 'email_sent_event') {
             return 'received email';
         }
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/activity-feed.test.js.snap
@@ -43,15 +43,35 @@ Object {
       "data": Any<Object>,
       "type": Any<String>,
     },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
   ],
   "meta": Object {
     "pagination": Object {
-      "limit": 10,
+      "limit": "20",
       "next": null,
       "page": null,
       "pages": 1,
       "prev": null,
-      "total": 10,
+      "total": 15,
     },
   },
 }
@@ -61,7 +81,7 @@ exports[`Activity Feed API Can filter events by post id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "17358",
+  "content-length": "23031",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
@@ -86,9 +106,9 @@ Object {
       "limit": "2",
       "next": null,
       "page": null,
-      "pages": 5,
+      "pages": 8,
       "prev": null,
-      "total": 10,
+      "total": 15,
     },
   },
 }
@@ -415,6 +435,55 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "1243",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Activity Feed API Returns email sent events in activity feed 1: [body] 1`] = `
+Object {
+  "events": Array [
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+    Object {
+      "data": Any<Object>,
+      "type": Any<String>,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 10,
+      "next": null,
+      "page": null,
+      "pages": 1,
+      "prev": null,
+      "total": 5,
+    },
+  },
+}
+`;
+
+exports[`Activity Feed API Returns email sent events in activity feed 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "5774",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",

--- a/ghost/core/test/e2e-api/admin/activity-feed.test.js
+++ b/ghost/core/test/e2e-api/admin/activity-feed.test.js
@@ -126,6 +126,26 @@ describe('Activity Feed API', function () {
             });
     });
 
+    it('Returns email sent events in activity feed', async function () {
+        // Check activity feed
+        await agent
+            .get(`/members/events?filter=type:email_sent_event`)
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                events: new Array(5).fill({
+                    type: anyString,
+                    data: anyObject
+                })
+            })
+            .expect(({body}) => {
+                assert(body.events.find(e => e.type === 'email_sent_event'), 'Expected an email sent event');
+                assert(!body.events.find(e => e.type !== 'email_sent_event'), 'Expected only email sent events');
+            });
+    });
+
     it('Returns email delivered events in activity feed', async function () {
         // Check activity feed
         await agent
@@ -170,13 +190,13 @@ describe('Activity Feed API', function () {
         const postId = fixtureManager.get('posts', 0).id;
 
         await agent
-            .get(`/members/events?filter=data.post_id:${postId}`)
+            .get(`/members/events?filter=data.post_id:${postId}&limit=20`)
             .expectStatus(200)
             .matchHeaderSnapshot({
                 etag: anyEtag
             })
             .matchBodySnapshot({
-                events: new Array(10).fill({
+                events: new Array(15).fill({
                     type: anyString,
                     data: anyObject
                 })
@@ -191,10 +211,11 @@ describe('Activity Feed API', function () {
                 assert(body.events.find(e => e.type === 'signup_event'), 'Expected a signup event');
                 assert(body.events.find(e => e.type === 'subscription_event'), 'Expected a subscription event');
                 assert(body.events.find(e => e.type === 'email_delivered_event'), 'Expected an email delivered event');
+                assert(body.events.find(e => e.type === 'email_sent_event'), 'Expected an email sent event');
                 assert(body.events.find(e => e.type === 'email_opened_event'), 'Expected an email opened event');
 
                 // Assert total is correct
-                assert.equal(body.meta.pagination.total, 10);
+                assert.equal(body.meta.pagination.total, 15);
             });
     });
 
@@ -216,7 +237,7 @@ describe('Activity Feed API', function () {
                 assert(!body.events.find(e => (e.data?.post?.id ?? e.data?.attribution?.id ?? e.data?.email?.post_id) !== postId), 'Should only return events for the post');
 
                 // Assert total is correct
-                assert.equal(body.meta.pagination.total, 10);
+                assert.equal(body.meta.pagination.total, 15);
             });
     });
 });


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2137

For the analytics page, we need the sent events to show up immediately after sending an email. Otherwise we need to wait for emails to be marked as received (which takes too long) before being able to show them on the analytics page.

This adds the email_sent_event, which is hidden by default everywhere and used on the analytics page.