### PR TITLE
Fixed missing column values for default paid tiers

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.21/2022-10-25-12-05-backfill-missed-products-columns.js
+++ b/ghost/core/core/server/data/migrations/versions/5.21/2022-10-25-12-05-backfill-missed-products-columns.js
@@ -1,0 +1,35 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info(`Fixing currency/monthly_price/yearly_price values for default paid tiers`);
+
+        const currencyUpdated = await knex('products')
+            .update('currency', 'usd')
+            .where({
+                currency: null,
+                type: 'paid'
+            });
+        logging.info(`Updated ${currencyUpdated} tier(s) where currency=null, type=paid to currency=USD`);
+
+        const monthlyPriceUpdated = await knex('products')
+            .update('monthly_price', 500)
+            .where({
+                monthly_price: null,
+                type: 'paid'
+            });
+        logging.info(`Updated ${monthlyPriceUpdated} tier(s) where monthly_price=null, type=paid to monthly_price=500`);
+
+        const yearlyPriceUpdated = await knex('products')
+            .update('yearly_price', 5000)
+            .where({
+                yearly_price: null,
+                type: 'paid'
+            });
+        logging.info(`Updated ${yearlyPriceUpdated} tier(s) where yearly_price=null, type=paid to yearly_price=5000`);
+    },
+    async function down(/* knex */) {
+        // no-op: we don't want to revert to bad data
+    }
+);


### PR DESCRIPTION
fixes https://github.com/TryGhost/Toolbox/issues/455 refs https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/server/data/migrations/versions/5.19/2022-09-02-20-52-backfill-new-product-columns.js

- the referenced migration does not handle backfilling the currency/monthly_price/yearly_price for the default paid tiers where they do not originate from Stripe
- this is causing issues in Ghost because of the missing data
- this migration backfills the columns for products where they are paid but do not currently contain values due to the bug above
