### PR TITLE
Updated feedback button links

### DIFF
--- a/ghost/audience-feedback/lib/AudienceFeedbackService.js
+++ b/ghost/audience-feedback/lib/AudienceFeedbackService.js
@@ -25,11 +25,7 @@ class AudienceFeedbackService {
             postUrl = this.#baseURL;
         }
         const url = new URL(postUrl);
-        url.searchParams.set('action', 'feedback');
-        url.searchParams.set('post', postId);
-        url.searchParams.set('uuid', uuid);
-        url.searchParams.set('score', `${score}`);
-
+        url.hash = `#/feedback/${postId}/${score}/?uuid=${encodeURIComponent(uuid)}`;
         return url;
     }
 }

--- a/ghost/audience-feedback/test/AudienceFeedbackService.test.js
+++ b/ghost/audience-feedback/test/AudienceFeedbackService.test.js
@@ -24,7 +24,7 @@ describe('audienceFeedbackService', function () {
                 }
             });
             const link = instance.buildLink(mockData.uuid, mockData.postId, mockData.score);
-            const expectedLink = `https://localhost:2368/${mockData.postTitle}/?action=feedback&post=${mockData.postId}&uuid=${mockData.uuid}&score=${mockData.score}`;
+            const expectedLink = `https://localhost:2368/${mockData.postTitle}/#/feedback/${mockData.postId}/${mockData.score}/?uuid=${mockData.uuid}`;
             assert.equal(link.href, expectedLink);
         });
 
@@ -38,7 +38,7 @@ describe('audienceFeedbackService', function () {
                 }
             });
             const link = instance.buildLink(mockData.uuid, mockData.postId, mockData.score);
-            const expectedLink = `https://localhost:2368/?action=feedback&post=${mockData.postId}&uuid=${mockData.uuid}&score=${mockData.score}`;
+            const expectedLink = `https://localhost:2368/#/feedback/${mockData.postId}/${mockData.score}/?uuid=${mockData.uuid}`;
             assert.equal(link.href, expectedLink);
         });
     });

--- a/ghost/portal/src/App.js
+++ b/ghost/portal/src/App.js
@@ -405,26 +405,29 @@ export default class App extends React.Component {
                 }
             };
         }
-
-        if (qParams.get('uuid') && qParams.get('action') === 'feedback' && qParams.get('score') && qParams.get('post')) {
-            const score = parseInt(qParams.get('score'));
+        const [path, hashQueryString] = window.location.hash.substr(1).split('?');
+        const hashQuery = new URLSearchParams(hashQueryString ?? '');
+        const productMonthlyPriceQueryRegex = /^(?:(\w+?))?\/monthly$/;
+        const productYearlyPriceQueryRegex = /^(?:(\w+?))?\/yearly$/;
+        const offersRegex = /^offers\/(\w+?)\/?$/;
+        const linkRegex = /^\/portal\/?(?:\/(\w+(?:\/\w+)*))?\/?$/;
+        const feedbackRegex = /^\/feedback\/(\w+?)\/(\w+?)\/?$/;
+        
+        if (path && feedbackRegex.test(path) && hashQuery.get('uuid')) {
+            const [, postId, scoreString] = path.match(feedbackRegex);
+            const score = parseInt(scoreString);
             if (score === 1 || score === 0) {
                 return {
                     showPopup: true,
                     page: 'feedback',
                     pageData: {
-                        uuid: qParams.get('uuid'),
-                        postId: qParams.get('post'),
+                        uuid: hashQuery.get('uuid'),
+                        postId,
                         score
                     }
                 };
             }
         }
-        const productMonthlyPriceQueryRegex = /^(?:(\w+?))?\/monthly$/;
-        const productYearlyPriceQueryRegex = /^(?:(\w+?))?\/yearly$/;
-        const offersRegex = /^offers\/(\w+?)\/?$/;
-        const [path] = window.location.hash.substr(1).split('?');
-        const linkRegex = /^\/portal\/?(?:\/(\w+(?:\/\w+)*))?\/?$/;
         if (path && linkRegex.test(path)) {
             const [,pagePath] = path.match(linkRegex);
             const {page, pageQuery} = this.getPageFromLinkPath(pagePath) || {};


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2174

The feedback links now use a hash instead of a querystring, so it won't pass by the server.

New format: https://site.ghost/post-slug/#/feedback/6359174f2eb251019d14d6fb/0?uuid=13924399-c3ae-413b-a045-0b8294d71f64