### PR TITLE
Fixed Explore iframe route handling hijacking routes on reload

### DIFF
--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -20,7 +20,8 @@ export default class GhBillingIframe extends Component {
         this.billing.getBillingIframe().src = this.billing.getIframeURL();
 
         window.addEventListener('message', (event) => {
-            if (event?.data) {
+            // only process messages coming from the billing iframe
+            if (event?.data && this.billing.getIframeURL().includes(event?.origin)) {
                 if (event.data?.request === 'token') {
                     this._handleTokenRequest();
                 }

--- a/ghost/admin/app/components/gh-explore-iframe.js
+++ b/ghost/admin/app/components/gh-explore-iframe.js
@@ -12,7 +12,8 @@ export default class GhExploreIframe extends Component {
         this.explore.getExploreIframe().src = this.explore.getIframeURL();
 
         window.addEventListener('message', async (event) => {
-            if (event?.data) {
+            // only process messages coming from the explore iframe
+            if (event?.data && this.explore.getIframeURL().includes(event?.origin)) {
                 if (event.data?.request === 'apiUrl') {
                     this._handleUrlRequest();
                 }

--- a/ghost/admin/app/services/explore.js
+++ b/ghost/admin/app/services/explore.js
@@ -67,7 +67,7 @@ export default class ExploreService extends Service {
             }
         }
 
-        return url += '/';
+        return url;
     }
 
     // Sends a route update to a child route in the BMA, because we can't control


### PR DESCRIPTION
no issue

- Ensure the event origin matches the correct iframe URL before handling the message data
