### PR TITLE
Fixed Stripe Checkout not having the email prefilled from Portal

### DIFF
--- a/ghost/members-api/lib/controllers/router.js
+++ b/ghost/members-api/lib/controllers/router.js
@@ -259,6 +259,7 @@ module.exports = class RouterController {
 
         options.successUrl = req.body.successUrl;
         options.cancelUrl = req.body.cancelUrl;
+        options.email = req.body.customerEmail;
 
         if (!member && req.body.customerEmail && !req.body.successUrl) {
             options.successUrl = await this._magicLinkService.getMagicLink({


### PR DESCRIPTION
We need to pass the customerEmail param along so that Stripe Checkout will prefill it for us, this was missed in the refactor.
