### PR TITLE
🐛 Fixed comped member creation via Admin API

### DIFF
--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -1394,10 +1394,11 @@ module.exports = class MemberRepository {
         const activeSubscriptions = subscriptions.models.filter((subscription) => {
             return this.isActiveSubscriptionStatus(subscription.get('status'));
         });
+        const sharedOptions = _.pick(options, ['context', 'transacting']);
 
         const ghostProductModel = await this._productRepository.getDefaultProduct({
             withRelated: ['stripePrices'],
-            ...options
+            ...sharedOptions
         });
 
         const defaultProduct = ghostProductModel?.toJSON();
@@ -1454,7 +1455,7 @@ module.exports = class MemberRepository {
                 await this.linkSubscription({
                     id: member.id,
                     subscription: updatedSubscription
-                }, options);
+                }, sharedOptions);
             }
         } else {
             const stripeCustomer = await this._stripeAPIService.createCustomer({
@@ -1466,7 +1467,7 @@ module.exports = class MemberRepository {
                 member_id: data.id,
                 email: stripeCustomer.email,
                 name: stripeCustomer.name
-            }, options);
+            }, sharedOptions);
 
             let zeroValuePrice = zeroValuePrices[0];
 
@@ -1482,7 +1483,7 @@ module.exports = class MemberRepository {
                         interval: 'year',
                         amount: 0
                     }]
-                }, options)).toJSON();
+                }, sharedOptions)).toJSON();
                 zeroValuePrice = product.stripePrices.find((price) => {
                     return price.currency.toLowerCase() === 'usd' && price.amount === 0;
                 });
@@ -1497,7 +1498,7 @@ module.exports = class MemberRepository {
             await this.linkSubscription({
                 id: member.id,
                 subscription
-            }, options);
+            }, sharedOptions);
         }
     }
 

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -99,6 +99,38 @@ describe('MemberRepository', function () {
                 assert.equal(err.message, 'Could not find Product "default"');
             }
         });
+
+        it('uses the right options for fetching default product', async function () {
+            productRepository = {
+                getDefaultProduct: sinon.stub().resolves({
+                    toJSON: () => {
+                        return null;
+                    }
+                })
+            };
+
+            const repo = new MemberRepository({
+                Member,
+                stripeAPIService: {
+                    configured: true
+                },
+                productRepository
+            });
+
+            try {
+                await repo.setComplimentarySubscription({
+                    id: 'member_id_123'
+                }, {
+                    transacting: true,
+                    withRelated: ['labels']
+                });
+
+                assert.fail('setComplimentarySubscription should have thrown');
+            } catch (err) {
+                productRepository.getDefaultProduct.calledWith({withRelated: ['stripePrices'], transacting: true}).should.be.true();
+                assert.equal(err.message, 'Could not find Product "default"');
+            }
+        });
     });
 
     describe('linkSubscription', function (){


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2184

Comped members can be created via Admin API in 2 different ways - one is the old legacy method of using `comped:true` that picks the first default product, and the other is passing a tier in the API directly that creates a comped subscription for that tier.

This bug happened when using the old legacy method of `comped:true` was used along with passing labels for the member. The API call fails with `Internal Server error` and the member was created as free on the site.

- patches the options sent for fetching default product to only pick the relevant keys, as it was picking up the `withRelated` for `labels` that caused the API failure