### PR TITLE
Updated cache invalidation on link edit

### DIFF
--- a/ghost/core/core/server/api/endpoints/links.js
+++ b/ghost/core/core/server/api/endpoints/links.js
@@ -1,4 +1,5 @@
 const linkTrackingService = require('../../services/link-tracking');
+const INVALIDATE_ALL_REDIRECTS = '/r/*';
 
 module.exports = {
     docName: 'links',
@@ -25,7 +26,7 @@ module.exports = {
     bulkEdit: {
         statusCode: 200,
         headers: {
-            cacheInvalidate: true
+            cacheInvalidate: INVALIDATE_ALL_REDIRECTS
         },
         options: [
             'filter'


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2158

- the cache invalidation header returned should be specific to the email links pattern, otherwise it blows entire cache on every link edit which is not ideal