### PR TITLE
Fixed error showing on Stripe Checkout

### DIFF
--- a/ghost/portal/src/utils/api.js
+++ b/ghost/portal/src/utils/api.js
@@ -391,20 +391,18 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                     throw new Error(errMssg);
                 }
                 return res.json();
-            }).then(function (result) {
-                if (result.url) {
-                    return window.location.assign(result.url);
+            }).then(function (responseBody) {
+                if (responseBody.url) {
+                    return window.location.assign(responseBody.url);
                 }
-                const stripe = window.Stripe(result.publicKey);
+                const stripe = window.Stripe(responseBody.publicKey);
                 return stripe.redirectToCheckout({
-                    sessionId: result.sessionId
+                    sessionId: responseBody.sessionId
+                }).then(function (redirectResult) {
+                    if (redirectResult.error) {
+                        throw new Error(redirectResult.error.message);
+                    }
                 });
-            }).then(function (result) {
-                if (result.error) {
-                    throw new Error(result.error.message);
-                }
-            }).catch(function (err) {
-                throw err;
             });
         },
 


### PR DESCRIPTION
`window.location.assign` does not return anything, so `result.error` was failing because `result` was undefined. We've moved the handling of the result of `redirectToCheckout` to be specific to that promise. We've also removed the use of `catch` because all it did was rethrow the error, which is default behaviour.