### PR TITLE
Added e2e tests for `page.deleted` webhook

### DIFF
--- a/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
@@ -147,6 +147,82 @@ Object {
 }
 `;
 
+exports[`page.* events page.deleted event is triggered 1: [headers] 1`] = `
+Object {
+  "accept-encoding": "gzip, deflate",
+  "content-length": Any<Number>,
+  "content-type": "application/json",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "user-agent": StringMatching /Ghost\\\\/\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+\\\\s\\\\\\(https:\\\\/\\\\/github\\.com\\\\/TryGhost\\\\/Ghost\\\\\\)/,
+}
+`;
+
+exports[`page.* events page.deleted event is triggered 2: [body] 1`] = `
+Object {
+  "page": Object {
+    "current": Object {},
+    "previous": Object {
+      "authors": Array [
+        Object {
+          "accessibility": null,
+          "bio": "bio",
+          "comment_notifications": true,
+          "cover_image": null,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "email": "jbloggs@example.com",
+          "facebook": null,
+          "free_member_signup_notification": true,
+          "id": "1",
+          "last_seen": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "location": "location",
+          "meta_description": null,
+          "meta_title": null,
+          "name": "Joe Bloggs",
+          "paid_subscription_canceled_notification": false,
+          "paid_subscription_started_notification": true,
+          "profile_image": "https://example.com/super_photo.jpg",
+          "roles": Array [
+            Object {
+              "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+              "description": "Blog Owner",
+              "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+              "name": "Owner",
+              "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+            },
+          ],
+          "slug": "joe-bloggs",
+          "status": "active",
+          "tour": null,
+          "twitter": null,
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "url": StringMatching /http:\\\\/\\\\/127\\.0\\.0\\.1:2369\\\\/\\[A-Za-z0-9_-\\]\\+\\\\//,
+          "website": null,
+        },
+      ],
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "comment_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "custom_excerpt": null,
+      "custom_template": null,
+      "feature_image": null,
+      "featured": false,
+      "html": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "mobiledoc": "{\\"version\\":\\"0.3.1\\",\\"ghostVersion\\":\\"4.0\\",\\"markups\\":[],\\"atoms\\":[],\\"cards\\":[],\\"sections\\":[[1,\\"p\\",[[0,[],0,\\"\\"]]]]}",
+      "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "slug": "testing-page-deleted-webhook",
+      "status": "published",
+      "title": "testing page.deleted webhook",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "visibility": "public",
+    },
+  },
+}
+`;
+
 exports[`page.* events page.edited event is triggered 1: [headers] 1`] = `
 Object {
   "accept-encoding": "gzip, deflate",

--- a/ghost/core/test/e2e-webhooks/pages.test.js
+++ b/ghost/core/test/e2e-webhooks/pages.test.js
@@ -62,6 +62,17 @@ const buildPageSnapshotWithTiers = ({
 };
 
 const buildPreviousPageSnapshotWithTiers = (tiersCount) => {
+    if (tiersCount === 0) {
+        return {
+            id: anyObjectId,
+            uuid: anyUuid,
+            comment_id: anyObjectId,
+            published_at: anyISODateTime,
+            created_at: anyISODateTime,
+            updated_at: anyISODateTime,
+            authors: new Array(1).fill(buildAuthorSnapshot(true))
+        };
+    }
     return {
         tiers: new Array(tiersCount).fill(tierSnapshot),
         updated_at: anyISODateTime
@@ -210,7 +221,6 @@ describe('page.* events', function () {
             .expectStatus(201);
 
         const id = res.body.pages[0].id;
-        const pageToDelete = res.body.pages[0];
 
         await adminAPIAgent
             .delete('pages/' + id)
@@ -228,15 +238,7 @@ describe('page.* events', function () {
             .matchBodySnapshot({
                 page: {
                     current: {},
-                    previous: {
-                        id: anyObjectId,
-                        uuid: anyUuid,
-                        comment_id: anyObjectId,
-                        published_at: anyISODateTime,
-                        created_at: anyISODateTime,
-                        updated_at: anyISODateTime,
-                        authors: new Array(1).fill(buildAuthorSnapshot(true))
-                    }
+                    previous: buildPreviousPageSnapshotWithTiers(0)
                 }
             });
     });


### PR DESCRIPTION
Contributes to this issue: https://github.com/TryGhost/Ghost/issues/15537

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

Also, if you'd be interested in writing code like this for us more regularly, we're hiring:
https://careers.ghost.org
