### PR TITLE
Backfilled missing columns in products table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.22/2022-10-31-12-03-backfill-new-product-columns.js
+++ b/ghost/core/core/server/data/migrations/versions/5.22/2022-10-31-12-03-backfill-new-product-columns.js
@@ -1,0 +1,35 @@
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const rows = await knex('products as t') // eslint-disable-line no-restricted-syntax
+            .select(
+                't.id as id',
+                'mp.amount as monthly_price',
+                'yp.amount as yearly_price',
+                knex.raw('coalesce(yp.currency, mp.currency) as currency')
+            )
+            .leftJoin('stripe_prices AS mp', 't.monthly_price_id', 'mp.id')
+            .leftJoin('stripe_prices AS yp', 't.yearly_price_id', 'yp.id')
+            .where({
+                't.type': 'paid',
+                't.currency': null
+            });
+
+        if (!rows.length) {
+            logging.info('Did not find any active paid Tiers');
+            return;
+        } else {
+            logging.info(`Updating ${rows.length} Tiers with price and currency information`);
+        }
+
+        for (const row of rows) { // eslint-disable-line no-restricted-syntax
+            await knex('products').update(row).where('id', row.id);
+        }
+    },
+    async function down() {
+        // no-op: we don't want to reintroduce the missing data
+    }
+);


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/464

- due to a bug with the content importer, importing a JSON file where the `products`
  do not contain price info will store null values in the table instead of the defaults
- this ends up causing further issues because we're not populating the 
  table for paid products
- this commit is a copy of the 5.19 migration
  `2022-09-02-20-52-backfill-new-product-columns.js`, but adds a check
  for a null `t.currency`, which combined with the `t.type === paid`,
  should identify the rows we want to update