### PR TITLE
Fixed verification trigger usage of Event Repository

### DIFF
--- a/ghost/verification-trigger/lib/verification-trigger.js
+++ b/ghost/verification-trigger/lib/verification-trigger.js
@@ -67,8 +67,10 @@ class VerificationTrigger {
             const createdAt = new Date();
             createdAt.setDate(createdAt.getDate() - 30);
             const events = await this._eventRepository.getCreatedEvents({}, {
-                'data.source': `data.source:'${source}'`,
-                'data.created_at': `data.created_at:>'${createdAt.toISOString().replace('T', ' ').substring(0, 19)}'`
+                source: source,
+                created_at: {
+                    $gt: createdAt.toISOString().replace('T', ' ').substring(0, 19)
+                }
             });
 
             if (events.meta.pagination.total > sourceThreshold) {
@@ -100,8 +102,10 @@ class VerificationTrigger {
         const createdAt = new Date();
         createdAt.setDate(createdAt.getDate() - 30);
         const events = await this._eventRepository.getCreatedEvents({}, {
-            'data.source': `data.source:'import'`,
-            'data.created_at': `data.created_at:>'${createdAt.toISOString().replace('T', ' ').substring(0, 19)}'`
+            source: 'import',
+            created_at: {
+                $gt: createdAt.toISOString().replace('T', ' ').substring(0, 19)
+            }
         });
 
         const membersTotal = await this._membersStats.getTotalMembers();

--- a/ghost/verification-trigger/test/verification-trigger.test.js
+++ b/ghost/verification-trigger/test/verification-trigger.test.js
@@ -185,10 +185,11 @@ describe('Email verification flow', function () {
         }, new Date()));
 
         eventStub.callCount.should.eql(1);
-        eventStub.lastCall.lastArg.should.have.property('data.source');
-        eventStub.lastCall.lastArg.should.have.property('data.created_at');
-        eventStub.lastCall.lastArg['data.source'].should.eql(`data.source:'api'`);
-        eventStub.lastCall.lastArg['data.created_at'].should.startWith(`data.created_at:>'`);
+        eventStub.lastCall.lastArg.should.have.property('source');
+        eventStub.lastCall.lastArg.source.should.eql('api');
+        eventStub.lastCall.lastArg.should.have.property('created_at');
+        eventStub.lastCall.lastArg.created_at.should.have.property('$gt');
+        eventStub.lastCall.lastArg.created_at.$gt.should.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
     });
 
     it('Triggers when a number of members are imported', async function () {
@@ -221,10 +222,11 @@ describe('Email verification flow', function () {
         await trigger.testImportThreshold();
 
         eventStub.callCount.should.eql(1);
-        eventStub.lastCall.lastArg.should.have.property('data.source');
-        eventStub.lastCall.lastArg.should.have.property('data.created_at');
-        eventStub.lastCall.lastArg['data.source'].should.eql(`data.source:'import'`);
-        eventStub.lastCall.lastArg['data.created_at'].should.startWith(`data.created_at:>'`);
+        eventStub.lastCall.lastArg.should.have.property('source');
+        eventStub.lastCall.lastArg.source.should.eql('import');
+        eventStub.lastCall.lastArg.should.have.property('created_at');
+        eventStub.lastCall.lastArg.created_at.should.have.property('$gt');
+        eventStub.lastCall.lastArg.created_at.$gt.should.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
         emailStub.callCount.should.eql(1);
         emailStub.lastCall.firstArg.should.eql({
@@ -268,10 +270,11 @@ describe('Email verification flow', function () {
         });
 
         eventStub.callCount.should.eql(1);
-        eventStub.lastCall.lastArg.should.have.property('data.source');
-        eventStub.lastCall.lastArg.should.have.property('data.created_at');
-        eventStub.lastCall.lastArg['data.source'].should.eql(`data.source:'admin'`);
-        eventStub.lastCall.lastArg['data.created_at'].should.startWith(`data.created_at:>'`);
+        eventStub.lastCall.lastArg.should.have.property('source');
+        eventStub.lastCall.lastArg.source.should.eql('admin');
+        eventStub.lastCall.lastArg.should.have.property('created_at');
+        eventStub.lastCall.lastArg.created_at.should.have.property('$gt');
+        eventStub.lastCall.lastArg.created_at.$gt.should.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
         emailStub.callCount.should.eql(1);
         emailStub.lastCall.firstArg.should.eql({
@@ -316,10 +319,11 @@ describe('Email verification flow', function () {
         });
 
         eventStub.callCount.should.eql(1);
-        eventStub.lastCall.lastArg.should.have.property('data.source');
-        eventStub.lastCall.lastArg.should.have.property('data.created_at');
-        eventStub.lastCall.lastArg['data.source'].should.eql(`data.source:'api'`);
-        eventStub.lastCall.lastArg['data.created_at'].should.startWith(`data.created_at:>'`);
+        eventStub.lastCall.lastArg.should.have.property('source');
+        eventStub.lastCall.lastArg.source.should.eql('api');
+        eventStub.lastCall.lastArg.should.have.property('created_at');
+        eventStub.lastCall.lastArg.created_at.should.have.property('$gt');
+        eventStub.lastCall.lastArg.created_at.$gt.should.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
 
         emailStub.callCount.should.eql(1);
         emailStub.lastCall.firstArg.should.eql({


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2192

The method signatures of the Event Repository have been updated to take mongo filter objects, but this call-site was not updated.

Long term we should really be using NQL filter strings for our filtering API and the mongo filter objects should be an implementation detail, however we don't have time right now to rectify this.
