### PR TITLE
🐛 Fixed Tier description not being set 

### DIFF
--- a/ghost/core/test/e2e-api/admin/tiers.test.js
+++ b/ghost/core/test/e2e-api/admin/tiers.test.js
@@ -126,4 +126,20 @@ describe('Tiers API', function () {
 
         assert(updatedTier.trial_days === 0, `The trial_days should have been set to 0`);
     });
+
+    it('Can edit description', async function () {
+        const {body: {tiers: [tier]}} = await agent.get('/tiers/?type:paid&limit=1');
+
+        await agent.put(`/tiers/${tier.id}/`)
+            .body({
+                tiers: [{
+                    description: 'Updated description'
+                }]
+            })
+            .expectStatus(200);
+
+        const {body: {tiers: [updatedTier]}} = await agent.get(`/tiers/${tier.id}/`);
+
+        assert.strictEqual('Updated description', updatedTier.description);
+    });
 });

--- a/ghost/tiers/lib/Tier.js
+++ b/ghost/tiers/lib/Tier.js
@@ -338,6 +338,7 @@ function validateDescription(value) {
             message: 'Tier description must be a string with a maximum of 191 characters'
         });
     }
+    return value;
 }
 
 function validateStatus(value) {

--- a/ghost/tiers/test/Tier.test.js
+++ b/ghost/tiers/test/Tier.test.js
@@ -251,5 +251,13 @@ describe('Tier', function () {
                 });
             });
         });
+
+        it('Can set the description of a Tier', async function () {
+            const tier = await Tier.create(validInput);
+
+            tier.description = 'Updated description';
+
+            assert.strictEqual('Updated description', tier.description);
+        });
     });
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/15740

The validation function for a Tier description was not returning the
validated value, which meant we were unable to set the Tier
description.