### PR TITLE
Fixed Stripe Checkout issues

### DIFF
--- a/ghost/core/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Create Stripe Checkout Session Can create a checkout session when using offers 1: [body] 1`] = `
+Object {
+  "url": "https://site.com",
+}
+`;
+
+exports[`Create Stripe Checkout Session Can create a checkout session when using offers 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-type": "application/json",
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Create Stripe Checkout Session Does allow to create a checkout session if the customerEmail is not associated with a paid member 1: [body] 1`] = `
 Object {
   "url": "https://site.com",

--- a/ghost/core/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/create-stripe-checkout-session.test.js.snap
@@ -16,6 +16,22 @@ Object {
 }
 `;
 
+exports[`Create Stripe Checkout Session Can create a checkout session without passing a customerEmail 1: [body] 1`] = `
+Object {
+  "url": "https://site.com",
+}
+`;
+
+exports[`Create Stripe Checkout Session Can create a checkout session without passing a customerEmail 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-type": "application/json",
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Create Stripe Checkout Session Does allow to create a checkout session if the customerEmail is not associated with a paid member 1: [body] 1`] = `
 Object {
   "url": "https://site.com",

--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -1,3 +1,4 @@
+const querystring = require('querystring');
 const {agentProvider, mockManager, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const nock = require('nock');
 const should = require('should');
@@ -127,6 +128,61 @@ describe('Create Stripe Checkout Session', function () {
             .matchHeaderSnapshot();
     });
 
+    it('Can create a checkout session without passing a customerEmail', async function () {
+        const {body: {tiers}} = await adminAgent.get('/tiers/?include=monthly_price&yearly_price');
+
+        const paidTier = tiers.find(tier => tier.type === 'paid');
+
+        nock('https://api.stripe.com')
+            .persist()
+            .get(/v1\/.*/)
+            .reply((uri, body) => {
+                const [match, resource, id] = uri.match(/\/v1\/(\w+)\/(.+)\/?/) || [null];
+                if (match) {
+                    if (resource === 'products') {
+                        return [200, {
+                            id: id,
+                            active: true
+                        }];
+                    }
+                    if (resource === 'prices') {
+                        return [200, {
+                            id: id,
+                            active: true,
+                            currency: 'usd',
+                            unit_amount: 500
+                        }];
+                    }
+                }
+
+                return [500];
+            });
+
+        nock('https://api.stripe.com')
+            .persist()
+            .post(/v1\/.*/)
+            .reply((uri, body) => {
+                if (uri === '/v1/checkout/sessions') {
+                    const bodyJSON = querystring.parse(body);
+                    // TODO: Actually work out what Stripe checks and when/how it errors
+                    if (bodyJSON.customerEmail) {
+                        return [400, {error: 'Invalid Email'}];
+                    }
+                    return [200, {id: 'cs_123', url: 'https://site.com'}];
+                }
+
+                return [500];
+            });
+
+        await membersAgent.post('/api/create-stripe-checkout-session/')
+            .body({
+                tierId: paidTier.id,
+                cadence: 'month'
+            })
+            .expectStatus(200)
+            .matchBodySnapshot()
+            .matchHeaderSnapshot();
+    });
     it('Does allow to create a checkout session if the customerEmail is not associated with a paid member', async function () {
         const {body: {tiers}} = await adminAgent.get('/tiers/?include=monthly_price&yearly_price');
 

--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -55,6 +55,78 @@ describe('Create Stripe Checkout Session', function () {
             });
     });
 
+    it('Can create a checkout session when using offers', async function () {
+        const {body: {tiers}} = await adminAgent.get('/tiers/?include=monthly_price&yearly_price');
+        const paidTier = tiers.find(tier => tier.type === 'paid');
+        const {body: {offers: [offer]}} = await adminAgent.post('/offers/').body({
+            offers: [{
+                name: 'Test Offer',
+                code: 'test-offer',
+                cadence: 'month',
+                status: 'active',
+                currency: 'usd',
+                type: 'percent',
+                amount: 20,
+                duration: 'once',
+                duration_in_months: null,
+                display_title: 'Test Offer',
+                display_description: null,
+                tier: {
+                    id: paidTier.id
+                }
+            }]
+        });
+
+        nock('https://api.stripe.com')
+            .persist()
+            .get(/v1\/.*/)
+            .reply((uri, body) => {
+                const [match, resource, id] = uri.match(/\/v1\/(\w+)\/(.+)\/?/) || [null];
+                if (match) {
+                    if (resource === 'products') {
+                        return [200, {
+                            id: id,
+                            active: true
+                        }];
+                    }
+                    if (resource === 'prices') {
+                        return [200, {
+                            id: id,
+                            active: true,
+                            currency: 'usd',
+                            unit_amount: 500
+                        }];
+                    }
+                }
+
+                return [500];
+            });
+
+        nock('https://api.stripe.com')
+            .persist()
+            .post(/v1\/.*/)
+            .reply((uri, body) => {
+                if (uri === '/v1/checkout/sessions') {
+                    return [200, {id: 'cs_123', url: 'https://site.com'}];
+                }
+
+                if (uri === '/v1/coupons') {
+                    return [200, {id: 'coupon_123', url: 'https://site.com'}];
+                }
+
+                return [500];
+            });
+
+        await membersAgent.post('/api/create-stripe-checkout-session/')
+            .body({
+                customerEmail: 'free@test.com',
+                offerId: offer.id
+            })
+            .expectStatus(200)
+            .matchBodySnapshot()
+            .matchHeaderSnapshot();
+    });
+
     it('Does allow to create a checkout session if the customerEmail is not associated with a paid member', async function () {
         const {body: {tiers}} = await adminAgent.get('/tiers/?include=monthly_price&yearly_price');
 

--- a/ghost/members-api/lib/controllers/router.js
+++ b/ghost/members-api/lib/controllers/router.js
@@ -142,7 +142,7 @@ module.exports = class RouterController {
     async createCheckoutSession(req, res) {
         let ghostPriceId = req.body.priceId;
         const tierId = req.body.tierId;
-        const cadence = req.body.cadence;
+        let cadence = req.body.cadence;
         const identity = req.body.identity;
         const offerId = req.body.offerId;
         const metadata = req.body.metadata ?? {};
@@ -185,6 +185,7 @@ module.exports = class RouterController {
         if (offerId) {
             offer = await this._offersAPI.getOffer({id: offerId});
             tier = await this._tiersService.api.read(offer.tier.id);
+            cadence = offer.cadence;
         } else {
             offer = null;
             tier = await this._tiersService.api.read(tierId);

--- a/ghost/payments/lib/payments.js
+++ b/ghost/payments/lib/payments.js
@@ -86,11 +86,13 @@ class PaymentsService {
 
         const price = await this.getPriceForTierCadence(tier, cadence);
 
+        const email = options.email || null;
+
         const session = await this.stripeAPIService.createCheckoutSession(price.id, customer, {
             metadata,
             successUrl: options.successUrl,
             cancelUrl: options.cancelUrl,
-            customerEmail: options.email,
+            customerEmail: customer ? email : null,
             trialDays: trialDays ?? tier.trialDays,
             coupon: coupon?.id
         });
@@ -119,8 +121,8 @@ class PaymentsService {
 
     async createCustomerForMember(member) {
         const customer = await this.stripeAPIService.createCustomer({
-            email: member.email,
-            name: member.name
+            email: member.get('email'),
+            name: member.get('name')
         });
 
         await this.StripeCustomerModel.add({

--- a/ghost/payments/lib/payments.js
+++ b/ghost/payments/lib/payments.js
@@ -67,7 +67,7 @@ class PaymentsService {
         let coupon = null;
         let trialDays = null;
         if (offer) {
-            if (offer.tier.id !== tier.id) {
+            if (!tier.id.equals(offer.tier.id)) {
                 throw new BadRequestError({
                     message: 'This Offer is not valid for the Tier'
                 });

--- a/ghost/portal/src/utils/helpers.js
+++ b/ghost/portal/src/utils/helpers.js
@@ -300,6 +300,11 @@ export function getAvailableProducts({site}) {
     }
 
     return products.filter(product => !!product).filter((product) => {
+        if (site.is_stripe_configured) {
+            return true;
+        }
+        return product.type !== 'paid';
+    }).filter((product) => {
         return !!(product.monthlyPrice && product.yearlyPrice);
     }).filter((product) => {
         return !!(Object.keys(product.monthlyPrice).length > 0 && Object.keys(product.yearlyPrice).length > 0);

--- a/ghost/portal/src/utils/helpers.test.js
+++ b/ghost/portal/src/utils/helpers.test.js
@@ -1,4 +1,4 @@
-import {getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getUrlHistory, hasMultipleProducts, isActiveOffer, isInviteOnlySite, isPaidMember, isSameCurrency, transformApiTiersData} from './helpers';
+import {getAvailableProducts, getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getUrlHistory, hasMultipleProducts, isActiveOffer, isInviteOnlySite, isPaidMember, isSameCurrency, transformApiTiersData} from './helpers';
 import * as Fixtures from './fixtures-generator';
 import {site as FixturesSite, member as FixtureMember, offer as FixtureOffer, transformTierFixture as TransformFixtureTiers} from '../utils/test-fixtures';
 import {isComplimentaryMember} from '../utils/helpers';
@@ -292,6 +292,19 @@ describe('Helpers - ', () => {
             const urlHistory = getUrlHistory();
             expect(localStorage.getItem).toHaveBeenCalled();
             expect(urlHistory).toBeUndefined();
+        });
+    });
+
+    describe('getAvailableProducts', () => {
+        it('Does not include paid Tiers when stripe is not configured', () => {
+            const actual = getAvailableProducts({
+                site: {
+                    ...FixturesSite.multipleTiers.basic,
+                    is_stripe_configured: false
+                }
+            });
+
+            expect(actual.length).toBe(0);
         });
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2195

The issue here is two-fold, and specific to using Offers so was not
caught by any automated tests. First, we were incorrectly comparing
the tier.id to the offer.tier.id - this is because the Tier objects id
property is an instance of ObjectID rather than a string.

Secondly we were passing through the cadence parameter from the
request body, but when using Offers this is not including in the
request, so we must pull the data off of the Offer object instead and
pass that to the payments service.

refs https://github.com/TryGhost/Team/issues/2196

We were incorrectly assuming that all requests would have the
`customerEmail` passed in the body. Instead we were incorrectly
passing `undefined` or `''` as the `customerEmail` property to stripe,
which resulted in a validation error.

We've updated the code to pass `null` in the case of a falsy value,
which the Stripe API handles without error.