### PR TITLE
Fixed feature flags not being correct immediately after completing sign-in process

### DIFF
--- a/ghost/admin/tests/integration/services/feature-test.js
+++ b/ghost/admin/tests/integration/services/feature-test.js
@@ -1,5 +1,4 @@
 import EmberError from '@ember/error';
-import FeatureService, {feature} from 'ghost-admin/services/feature';
 import Pretender from 'pretender';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {describe, it} from 'mocha';
@@ -9,7 +8,9 @@ import {settled} from '@ember/test-helpers';
 import {setupTest} from 'ember-mocha';
 
 function stubSettings(server, labs, validSave = true) {
-    let settings = [
+    const site = [];
+
+    const settings = [
         {
             id: '1',
             type: 'labs',
@@ -17,6 +18,10 @@ function stubSettings(server, labs, validSave = true) {
             value: JSON.stringify(labs)
         }
     ];
+
+    server.get(`${ghostPaths().apiRoot}/site/`, function () {
+        return [200, {'Content-Type': 'application/json'}, JSON.stringify({site})];
+    });
 
     server.get(`${ghostPaths().apiRoot}/settings/`, function () {
         return [200, {'Content-Type': 'application/json'}, JSON.stringify({settings})];
@@ -64,13 +69,6 @@ function stubUser(server, accessibility, validSave = true) {
     });
 }
 
-function addTestFlag() {
-    FeatureService.reopen({
-        testFlag: feature('testFlag'),
-        testUserFlag: feature('testUserFlag', {user: true})
-    });
-}
-
 describe('Integration: Service: feature', function () {
     setupTest();
 
@@ -88,24 +86,20 @@ describe('Integration: Service: feature', function () {
         stubSettings(server, {testFlag: true});
         stubUser(server, {testUserFlag: true});
 
-        addTestFlag();
-
         let session = this.owner.lookup('service:session');
         await session.populateUser();
 
         let service = this.owner.lookup('service:feature');
 
         return service.fetch().then(() => {
-            expect(service.get('testFlag')).to.be.true;
-            expect(service.get('testUserFlag')).to.be.true;
+            expect(service.get('testFlag'), 'testFlag').to.be.true;
+            expect(service.get('testUserFlag'), 'testUserFlag').to.be.true;
         });
     });
 
     it('returns false for set flag with config false and labs false', async function () {
         stubSettings(server, {testFlag: false});
         stubUser(server, {});
-
-        addTestFlag();
 
         let session = this.owner.lookup('service:session');
         await session.populateUser();
@@ -123,8 +117,6 @@ describe('Integration: Service: feature', function () {
         stubSettings(server, {testFlag: false});
         stubUser(server, {});
 
-        addTestFlag();
-
         let session = this.owner.lookup('service:session');
         await session.populateUser();
 
@@ -140,8 +132,6 @@ describe('Integration: Service: feature', function () {
     it('returns true for set flag with config false and labs true', async function () {
         stubSettings(server, {testFlag: true});
         stubUser(server, {});
-
-        addTestFlag();
 
         let session = this.owner.lookup('service:session');
         await session.populateUser();
@@ -159,8 +149,6 @@ describe('Integration: Service: feature', function () {
         stubSettings(server, {testFlag: true});
         stubUser(server, {});
 
-        addTestFlag();
-
         let session = this.owner.lookup('service:session');
         await session.populateUser();
 
@@ -177,8 +165,6 @@ describe('Integration: Service: feature', function () {
         stubSettings(server, {});
         stubUser(server, {testUserFlag: false});
 
-        addTestFlag();
-
         let session = this.owner.lookup('service:session');
         await session.populateUser();
 
@@ -194,8 +180,6 @@ describe('Integration: Service: feature', function () {
         stubSettings(server, {});
         stubUser(server, {testUserFlag: true});
 
-        addTestFlag();
-
         let session = this.owner.lookup('service:session');
         await session.populateUser();
 
@@ -210,8 +194,6 @@ describe('Integration: Service: feature', function () {
     it('saves labs setting correctly', async function () {
         stubSettings(server, {testFlag: false});
         stubUser(server, {testUserFlag: false});
-
-        addTestFlag();
 
         let session = this.owner.lookup('service:session');
         await session.populateUser();
@@ -237,15 +219,13 @@ describe('Integration: Service: feature', function () {
         stubSettings(server, {});
         stubUser(server, {testUserFlag: false});
 
-        addTestFlag();
-
         let session = this.owner.lookup('service:session');
         await session.populateUser();
 
         let service = this.owner.lookup('service:feature');
 
         return service.fetch().then(() => {
-            expect(service.get('testUserFlag')).to.be.false;
+            expect(service.get('testUserFlag'), 'testUserFlag before set').to.be.false;
 
             run(() => {
                 service.set('testUserFlag', true);
@@ -253,7 +233,7 @@ describe('Integration: Service: feature', function () {
 
             return settled().then(() => {
                 expect(server.handlers[3].numberOfCalls).to.equal(1);
-                expect(service.get('testUserFlag')).to.be.true;
+                expect(service.get('testUserFlag'), 'testUserFlag after set').to.be.true;
             });
         });
     });
@@ -261,8 +241,6 @@ describe('Integration: Service: feature', function () {
     it('notifies for server errors on labs save', async function () {
         stubSettings(server, {testFlag: false}, false);
         stubUser(server, {});
-
-        addTestFlag();
 
         let session = this.owner.lookup('service:session');
         await session.populateUser();
@@ -297,8 +275,6 @@ describe('Integration: Service: feature', function () {
         stubSettings(server, {});
         stubUser(server, {testUserFlag: false}, false);
 
-        addTestFlag();
-
         let session = this.owner.lookup('service:session');
         await session.populateUser();
 
@@ -331,16 +307,14 @@ describe('Integration: Service: feature', function () {
         stubSettings(server, {testFlag: false}, true, false);
         stubUser(server, {});
 
-        addTestFlag();
-
         let session = this.owner.lookup('service:session');
         await session.populateUser();
 
         let service = this.owner.lookup('service:feature');
-        service.get('config').set('testFlag', false);
+        service.config.testFlag = false;
 
         return service.fetch().then(() => {
-            expect(service.get('testFlag')).to.be.false;
+            expect(service.get('testFlag'), 'testFlag before set').to.be.false;
 
             run(() => {
                 expect(() => {
@@ -350,9 +324,27 @@ describe('Integration: Service: feature', function () {
 
             return settled().then(() => {
                 // ensure validation is happening before the API is hit
-                expect(server.handlers[1].numberOfCalls).to.equal(0);
-                expect(service.get('testFlag')).to.be.false;
+                expect(server.handlers[2].numberOfCalls).to.equal(0);
+                expect(service.get('testFlag'), 'testFlag after set').to.be.false;
             });
         });
+    });
+
+    it('has correct labs flags when accessed before and after settings load', async function () {
+        stubSettings(server, {testFlag: true});
+        stubUser(server, {});
+
+        const settingsService = this.owner.lookup('service:settings');
+        const featureService = this.owner.lookup('service:feature');
+
+        expect(settingsService.labs).to.be.undefined;
+        expect(featureService.testFlag, 'testFlag before settings fetch').to.be.false;
+
+        await settingsService.fetch();
+
+        expect(settingsService.labs, 'settings.labs after settings fetch').to.equal('{"testFlag":true}');
+        expect(featureService.settings.labs, 'feature.settings.labs after settings fetch').to.equal('{"testFlag":true}');
+        expect(featureService.labs, 'feature.labs after settings fetch').to.deep.equal({testFlag: true});
+        expect(featureService.testFlag, 'feature.testFlag after settings fetch').to.be.true;
     });
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2110

- added failing test showing feature service @feature properties weren't updating after no-auth->authed updates of config service
  - shows `labs` and feature properties on the `feature` service are not reacting to changes in the `settings` service
  - removing the `@computed` on the `feature.labs` getter stops it being cached but it then fails on the `feature.testFlag` property
- removed usage of `Ember.computed` to avoid any caching behaviour and let properties act like normal getters/setters
