### PR TITLE
🐛 Fixed using Offers with Stripe Checkout v2

### DIFF
--- a/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
+++ b/ghost/core/test/e2e-api/members/create-stripe-checkout-session.test.js
@@ -165,7 +165,7 @@ describe('Create Stripe Checkout Session', function () {
                 if (uri === '/v1/checkout/sessions') {
                     const bodyJSON = querystring.parse(body);
                     // TODO: Actually work out what Stripe checks and when/how it errors
-                    if (bodyJSON.customerEmail) {
+                    if (Reflect.has(bodyJSON, 'customerEmail')) {
                         return [400, {error: 'Invalid Email'}];
                     }
                     return [200, {id: 'cs_123', url: 'https://site.com'}];

--- a/ghost/payments/lib/payments.js
+++ b/ghost/payments/lib/payments.js
@@ -88,14 +88,19 @@ class PaymentsService {
 
         const email = options.email || null;
 
-        const session = await this.stripeAPIService.createCheckoutSession(price.id, customer, {
+        const data = {
             metadata,
             successUrl: options.successUrl,
             cancelUrl: options.cancelUrl,
-            customerEmail: customer ? email : null,
             trialDays: trialDays ?? tier.trialDays,
             coupon: coupon?.id
-        });
+        };
+
+        if (!customer && email) {
+            data.customerEmail = email;
+        }
+
+        const session = await this.stripeAPIService.createCheckoutSession(price.id, customer, data);
 
         return session.url;
     }
@@ -108,9 +113,7 @@ class PaymentsService {
         for (const row of rows) {
             const customer = await this.stripeAPIService.getCustomer(row.customer_id);
             if (!customer.deleted) {
-                return {
-                    id: customer.id
-                };
+                return customer;
             }
         }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/1f300fb781f0

The Stripe API was giving inconsistent responses when passing the customerEmail param, sometimes it would allow a null/empty value and sometimes it wouldn't. In order to support both behaviours we need to not attach the customerEmail at all unless necessary.
