### PR TITLE
Fixed portal data attributes

### DIFF
--- a/ghost/portal/src/data-attributes.js
+++ b/ghost/portal/src/data-attributes.js
@@ -121,15 +121,18 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
             }
             return res.json();
         });
-    }).then(function (result) {
-        let stripe = window.Stripe(result.publicKey);
-        return stripe.redirectToCheckout({
-            sessionId: result.sessionId
-        });
-    }).then(function (result) {
-        if (result.error) {
-            throw new Error(result.error.message);
+    }).then(function (responseBody) {
+        if (responseBody.url) {
+            return window.location.assign(responseBody.url);
         }
+        const stripe = window.Stripe(responseBody.publicKey);
+        return stripe.redirectToCheckout({
+            sessionId: responseBody.sessionId
+        }).then(function (redirectResult) {
+            if (redirectResult.error) {
+                throw new Error(redirectResult.error.message);
+            }
+        });
     }).catch(function (err) {
         console.error(err);
         el.addEventListener('click', clickHandler);

--- a/ghost/portal/src/data-attributes.js
+++ b/ghost/portal/src/data-attributes.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import {getQueryPrice, getUrlHistory} from './utils/helpers';
+import {getCheckoutSessionDataFromPlanAttribute, getUrlHistory} from './utils/helpers';
 import {HumanReadableError} from './utils/errors';
 
 export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}) {
@@ -68,11 +68,7 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
     el.removeEventListener('click', clickHandler);
     event.preventDefault();
     let plan = el.dataset.membersPlan;
-    let priceId = '';
-    if (plan) {
-        const price = getQueryPrice({site, priceId: plan.toLowerCase()});
-        priceId = price ? price.id : plan;
-    }
+    let requestData = getCheckoutSessionDataFromPlanAttribute(site, plan);
     let successUrl = el.dataset.membersSuccess;
     let cancelUrl = el.dataset.membersCancel;
     let checkoutSuccessUrl;
@@ -113,7 +109,7 @@ export function planClickHandler({event, el, errorEl, siteUrl, site, member, cli
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                priceId: priceId,
+                ...requestData,
                 identity: identity,
                 successUrl: checkoutSuccessUrl,
                 cancelUrl: checkoutCancelUrl,

--- a/ghost/portal/src/tests/data-attributes.test.js
+++ b/ghost/portal/src/tests/data-attributes.test.js
@@ -165,7 +165,6 @@ describe('Member Data attributes:', () => {
             const {event, errorEl, siteUrl, clickHandler, site, member, element} = getMockData();
 
             const paidTier = site.products.find(p => p.type === 'paid');
-            const plan = paidTier.monthlyPrice.id;
 
             await planClickHandler({event, errorEl, siteUrl, clickHandler, site, member, el: element});
             expect(window.fetch).toHaveBeenNthCalledWith(1,
@@ -174,7 +173,8 @@ describe('Member Data attributes:', () => {
                 }
             );
             const expectedBody = {
-                priceId: plan,
+                cadence: 'month',
+                tierId: paidTier.id,
                 identity: 'session-identity',
                 successUrl: 'https://portal.localhost/success',
                 cancelUrl: 'https://portal.localhost/cancel',
@@ -205,14 +205,14 @@ describe('Member Data attributes:', () => {
             let {event, errorEl, siteUrl, clickHandler, site, member, element} = getMockData();
             member = FixtureMember.free;
             const paidTier = site.products.find(p => p.type === 'paid');
-            const plan = paidTier.monthlyPrice.id;
 
             await planClickHandler({event, errorEl, siteUrl, clickHandler, site, member, el: element});
             expect(window.fetch).toHaveBeenNthCalledWith(1, 'https://portal.localhost/members/api/session', {
                 credentials: 'same-origin'
             });
             const expectedBody = {
-                priceId: plan,
+                cadence: 'month',
+                tierId: paidTier.id,
                 identity: 'session-identity',
                 successUrl: 'https://portal.localhost/success',
                 cancelUrl: 'https://portal.localhost/cancel',

--- a/ghost/portal/src/utils/helpers.js
+++ b/ghost/portal/src/utils/helpers.js
@@ -179,6 +179,26 @@ export function hasPrice({site = {}, plan}) {
     return false;
 }
 
+export function getCheckoutSessionDataFromPlanAttribute(site, plan) {
+    const products = getAvailableProducts({site});
+    const defaultTier = products.find(p => p.type === 'paid');
+    if (plan === 'monthly') {
+        return {
+            cadence: 'month',
+            tierId: defaultTier.id
+        };
+    }
+    if (plan === 'yearly') {
+        return {
+            cadence: 'year',
+            tierId: defaultTier.id
+        };
+    }
+    return {
+        priceId: plan
+    };
+}
+
 export function getQueryPrice({site = {}, priceId}) {
     const prices = getAvailablePrices({site});
     if (priceId === 'free') {


### PR DESCRIPTION
### Updated data-members-plan handling to send Tier & Cadence

Sending a price id was supposed to have been cleaned up but the
data-attributes file was missed.

### Fixed creating checkout sessions with data-attribute-plan

The data-attribute handler was not using the utils/api package but
instead re-implemented the logic to create checkout sessions, this was
missed when moving to a redirect for checkout and so wasn't working
correctly.