### PR TITLE
Fixed upgrades for paid members

### DIFF
--- a/ghost/portal/src/utils/helpers.js
+++ b/ghost/portal/src/utils/helpers.js
@@ -105,13 +105,13 @@ export function getUpgradeProducts({site, member}) {
         return availableProducts;
     }
     return availableProducts.filter((product) => {
-        return (getProductCurrency({product}) === activePriceCurrency);
+        return (isSameCurrency(getProductCurrency({product}), activePriceCurrency));
     });
 }
 
 export function getFilteredPrices({prices, currency}) {
     return prices.filter((d) => {
-        return (d.currency || '').toLowerCase() === (currency || '').toLowerCase();
+        return isSameCurrency((d.currency || ''), (currency || ''));
     });
 }
 


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2202

Some parts of the codebase were not using the isSameCurrency helper which meant that we were incorrectly filtering out tiers from the upgrade screen. Tiers used to *usually* have a lowercased currency property, but they now _always_ have an uppercased.
