### PR TITLE
🐛 Fixed archiving Tiers

### DIFF
--- a/ghost/tiers/lib/TiersAPI.js
+++ b/ghost/tiers/lib/TiersAPI.js
@@ -105,7 +105,7 @@ module.exports = class TiersAPI {
             'benefits',
             'description',
             'visibility',
-            'active',
+            'status',
             'trialDays',
             'welcomePageURL'
         ];

--- a/ghost/tiers/test/TiersAPI.test.js
+++ b/ghost/tiers/test/TiersAPI.test.js
@@ -85,8 +85,8 @@ describe('TiersAPI', function () {
     it('Can browse tiers', async function () {
         const page = await api.browse();
 
-        assert(page.data.length === 2);
-        assert(page.meta.pagination.total === 2);
+        assert(page.data.length === 3);
+        assert(page.meta.pagination.total === 3);
     });
 
     it('Can read a default tier', async function () {

--- a/ghost/tiers/test/TiersAPI.test.js
+++ b/ghost/tiers/test/TiersAPI.test.js
@@ -66,6 +66,22 @@ describe('TiersAPI', function () {
         assert(updated.name === 'Updated');
     });
 
+    it('Can archive a tier', async function () {
+        const tier = await api.add({
+            name: 'My testing Tier',
+            type: 'paid',
+            monthlyPrice: 5000,
+            yearlyPrice: 50000,
+            currency: 'usd'
+        });
+
+        const updated = await api.edit(tier.id.toHexString(), {
+            status: 'archived'
+        });
+
+        assert(updated.status === 'archived');
+    });
+
     it('Can browse tiers', async function () {
         const page = await api.browse();
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2204

The TiersAPI was incorrectly using the `active` property rather than `status` property when editing Tiers.
