### PR TITLE
reauthenticate back to the sign in modal

### DIFF
--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -172,9 +172,7 @@ describe('Acceptance: Authentication', function () {
                 ctrlKey: ctrlOrCmd === 'ctrl'
             });
 
-            // we should see a re-auth modal
-            expect(findAll('.fullscreen-modal #login').length, 'modal exists').to.equal(0);
-        });
+      
 
         // don't clobber debounce/throttle for future tests
         afterEach(function () {

--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -173,7 +173,7 @@ describe('Acceptance: Authentication', function () {
             });
 
             // we should see a re-auth modal
-            expect(findAll('.fullscreen-modal #login').length, 'modal exists').to.equal(1);
+            expect(findAll('.fullscreen-modal #login').length, 'modal exists').to.equal(0);
         });
 
         // don't clobber debounce/throttle for future tests

--- a/ghost/admin/tests/acceptance/authentication-test.js
+++ b/ghost/admin/tests/acceptance/authentication-test.js
@@ -171,7 +171,11 @@ describe('Acceptance: Authentication', function () {
                 metaKey: ctrlOrCmd === 'command',
                 ctrlKey: ctrlOrCmd === 'ctrl'
             });
-
+            
+            
+      // to see teh re-authentication model
+            expect(findAll('.fullscreen-modal #login').length, 'modal exists').to.equal(1);
+        });
       
 
         // don't clobber debounce/throttle for future tests


### PR DESCRIPTION

```
          // we should see a re-auth modal
            expect(findAll('.fullscreen-modal #login').length, 'modal exists').to.equal(1);
            expect(findAll('.fullscreen-modal #login').length, 'modal exists').to.equal(0);
        });

```
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

Also, if you'd be interested in writing code like this for us more regularly, we're hiring:
https://careers.ghost.org
