### PR TITLE
🐛 Fixed upgrading Subscriptions to new Tiers

### DIFF
--- a/ghost/members-api/lib/MembersAPI.js
+++ b/ghost/members-api/lib/MembersAPI.js
@@ -150,14 +150,6 @@ module.exports = function MembersAPI({
         getSubject
     });
 
-    const memberController = new MemberController({
-        memberRepository,
-        productRepository,
-        StripePrice,
-        tokenService,
-        sendEmailWithMagicLink
-    });
-
     const paymentsService = new PaymentsService({
         StripeProduct,
         StripePrice,
@@ -165,6 +157,16 @@ module.exports = function MembersAPI({
         Offer,
         offersAPI,
         stripeAPIService
+    });
+
+    const memberController = new MemberController({
+        memberRepository,
+        productRepository,
+        paymentsService,
+        tiersService,
+        StripePrice,
+        tokenService,
+        sendEmailWithMagicLink
     });
 
     const routerController = new RouterController({

--- a/ghost/members-api/test/unit/lib/controllers/member/index.test.js
+++ b/ghost/members-api/test/unit/lib/controllers/member/index.test.js
@@ -27,6 +27,24 @@ describe('MemberController', function () {
                 })
             };
 
+            const tier = {
+                id: 'whatever'
+            };
+
+            const price = {
+                id: 'stripe_price_id'
+            };
+
+            const tiersService = {
+                api: {
+                    read: sinon.fake.resolves(tier)
+                }
+            };
+
+            const paymentsService = {
+                getPriceForTierCadence: sinon.fake.resolves(price)
+            };
+
             const productRepository = {
                 get: sinon.fake.resolves({
                     get() {
@@ -38,6 +56,8 @@ describe('MemberController', function () {
             const controller = new MemberController({
                 memberRepository,
                 productRepository,
+                tiersService,
+                paymentsService,
                 StripePrice,
                 tokenService
             });
@@ -45,7 +65,8 @@ describe('MemberController', function () {
             const req = {
                 body: {
                     identity: 'token',
-                    priceId: 'plan_name'
+                    tierId: 'tier_id',
+                    cadence: 'yearly'
                 },
                 params: {
                     id: 'subscription_id'


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2204

This was found during Tiers flows testing, the logic for fetching price information from Tiers had not been updated to use the new Tiers package and Payments service. This only affects Tiers created since 5.22.x
