### PR TITLE
🐛 Fixed ref attribute in email links for external sites

### DIFF
--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -393,11 +393,16 @@ const PostEmailSerializer = {
             result.html = await linkReplacer.replace(result.html, async (url) => {
                 // Add newsletter source attribution
                 const isSite = urlUtils.isSiteUrl(url);
-                url = memberAttribution.service.addEmailSourceAttributionTracking(url, newsletter, !isSite);
 
                 if (isSite) {
+                    // Add newsletter name as ref to the URL
+                    url = memberAttribution.service.addEmailSourceAttributionTracking(url, newsletter);
+
                     // Only add post attribution to our own site (because external sites could/should not process this information)
                     url = memberAttribution.service.addPostAttributionTracking(url, post);
+                } else {
+                    // Add email source attribution without the newsletter name
+                    url = memberAttribution.service.addEmailSourceAttributionTracking(url);
                 }
 
                 // Add link click tracking

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -392,8 +392,8 @@ const PostEmailSerializer = {
         if (!options.isBrowserPreview && !options.isTestEmail && settingsCache.get('email_track_clicks')) {
             result.html = await linkReplacer.replace(result.html, async (url) => {
                 // Add newsletter source attribution
-                url = memberAttribution.service.addEmailSourceAttributionTracking(url, newsletter);
                 const isSite = urlUtils.isSiteUrl(url);
+                url = memberAttribution.service.addEmailSourceAttributionTracking(url, newsletter, !isSite);
 
                 if (isSite) {
                     // Only add post attribution to our own site (because external sites could/should not process this information)

--- a/ghost/core/core/server/services/member-attribution/index.js
+++ b/ghost/core/core/server/services/member-attribution/index.js
@@ -40,7 +40,8 @@ class MemberAttributionServiceWrapper {
                 Integration: models.Integration
             },
             attributionBuilder: this.attributionBuilder,
-            getTrackingEnabled: () => !!settingsCache.get('members_track_sources')
+            getTrackingEnabled: () => !!settingsCache.get('members_track_sources'),
+            getSiteTitle: () => settingsCache.get('title')
         });
     }
 }

--- a/ghost/member-attribution/package.json
+++ b/ghost/member-attribution/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@tryghost/domain-events": "0.0.0",
     "@tryghost/member-events": "0.0.0",
-    "@tryghost/referrers": "0.0.0"
+    "@tryghost/referrers": "0.0.0",
+    "@tryghost/string": "0.2.1"
   }
 }

--- a/ghost/member-attribution/test/service.test.js
+++ b/ghost/member-attribution/test/service.test.js
@@ -16,17 +16,7 @@ describe('MemberAttributionService', function () {
                 getSiteTitle: () => 'Hello world'
             });
             const url = new URL('https://example.com/');
-            const newsletterName = 'not used newsletter name';
-            const newsletter = {
-                get: (t) => {
-                    if (t === 'name') {
-                        return newsletterName;
-                    }
-                }
-            };
-            const isExternal = true;
-
-            const updatedUrl = await service.addEmailSourceAttributionTracking(url, newsletter, isExternal);
+            const updatedUrl = await service.addEmailSourceAttributionTracking(url);
 
             should(updatedUrl.toString()).equal('https://example.com/?ref=hello-world');
         });
@@ -44,9 +34,8 @@ describe('MemberAttributionService', function () {
                     }
                 }
             };
-            const isExternal = false;
 
-            const updatedUrl = await service.addEmailSourceAttributionTracking(url, newsletter, isExternal);
+            const updatedUrl = await service.addEmailSourceAttributionTracking(url, newsletter);
 
             should(updatedUrl.toString()).equal('https://example.com/?ref=used-newsletter-name-newsletter');
         });
@@ -64,9 +53,7 @@ describe('MemberAttributionService', function () {
                     }
                 }
             };
-            const isExternal = false;
-
-            const updatedUrl = await service.addEmailSourceAttributionTracking(url, newsletter, isExternal);
+            const updatedUrl = await service.addEmailSourceAttributionTracking(url, newsletter);
 
             should(updatedUrl.toString()).equal('https://example.com/?ref=weekly-newsletter');
         });
@@ -76,19 +63,36 @@ describe('MemberAttributionService', function () {
                 getSiteTitle: () => 'Hello world'
             });
             const url = new URL('https://facebook.com/');
-            const newsletterName = 'Weekly newsletter';
-            const newsletter = {
-                get: (t) => {
-                    if (t === 'name') {
-                        return newsletterName;
-                    }
-                }
-            };
-            const isExternal = true;
-
-            const updatedUrl = await service.addEmailSourceAttributionTracking(url, newsletter, isExternal);
+            const updatedUrl = await service.addEmailSourceAttributionTracking(url);
 
             should(updatedUrl.toString()).equal('https://facebook.com/');
+        });
+
+        it('does not add ref if utm_source is present', async function () {
+            const service = new MemberAttributionService({
+                getSiteTitle: () => 'Hello world'
+            });
+            const url = new URL('https://example.com/?utm_source=hello');
+            const updatedUrl = await service.addEmailSourceAttributionTracking(url);
+            should(updatedUrl.toString()).equal('https://example.com/?utm_source=hello');
+        });
+
+        it('does not add ref if ref is present', async function () {
+            const service = new MemberAttributionService({
+                getSiteTitle: () => 'Hello world'
+            });
+            const url = new URL('https://example.com/?ref=hello');
+            const updatedUrl = await service.addEmailSourceAttributionTracking(url);
+            should(updatedUrl.toString()).equal('https://example.com/?ref=hello');
+        });
+
+        it('does not add ref if source is present', async function () {
+            const service = new MemberAttributionService({
+                getSiteTitle: () => 'Hello world'
+            });
+            const url = new URL('https://example.com/?source=hello');
+            const updatedUrl = await service.addEmailSourceAttributionTracking(url);
+            should(updatedUrl.toString()).equal('https://example.com/?source=hello');
         });
     });
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2025 
fixes https://github.com/TryGhost/Team/issues/2023

The `ref` attribute has changed in email links:
- We now use the site name when linking to external sites
- We blacklist facebook.com because it doesn't support ref attributes
- '-newsletter' is not repeated anymore if the newsletter name already ends with 'newsletter'
- We always sluggify the ref
- We no longer overwrite existing ref, utm_source or source parameters