### PR TITLE
🐛 Fixed link click counts for duplicate links

### DIFF
--- a/ghost/admin/app/components/posts/analytics.js
+++ b/ghost/admin/app/components/posts/analytics.js
@@ -171,7 +171,14 @@ export default class Analytics extends Component {
             if (!acc[link.link.title]) {
                 acc[link.link.title] = link;
             } else {
-                acc[link.link.title].clicks += link.clicks;
+                if (!acc[link.link.title].count) {
+                    acc[link.link.title].count = {clicks: 0};
+                }
+                if (!acc[link.link.title].count.clicks) {
+                    acc[link.link.title].count.clicks = 0;
+                }
+
+                acc[link.link.title].count.clicks += (link.count?.clicks ?? 0);
             }
             return acc;
         }, {});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2213

When an email contains multiple links to the same destination, that link is only shown once on the analytics page. The total displayed count is not summed correctly.