### PR TITLE
Fixed sending emails when using `MembersAgent.loginAs`

### DIFF
--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -292,10 +292,6 @@ describe('Comments API', function () {
                 await membersAgent.loginAs('member@example.com');
                 member = await models.Member.findOne({email: 'member@example.com'}, {require: true});
                 await membersAgent2.loginAs('member2@example.com');
-
-                // Wait before we mock emails from newly created members
-                // todo: in the future we need a way to wait for DomainEvents to be fired and handled correctly
-                await sleep(200);
             });
 
             beforeEach(function () {

--- a/ghost/core/test/utils/agents/members-api-test-agent.js
+++ b/ghost/core/test/utils/agents/members-api-test-agent.js
@@ -18,7 +18,16 @@ class MembersAPITestAgent extends TestAgent {
 
     async loginAs(email) {
         const membersService = require('../../../core/server/services/members');
-        const magicLink = await membersService.api.getMagicLink(email, 'signup');
+        const memberRepository = membersService.api.members;
+
+        const member = await memberRepository.get({email});
+
+        if (!member) {
+            // Create the member first with context internal if it doesn't exist to prevent sending a signup email
+            await memberRepository.create({name: '', email}, {context: {internal: true}});
+        }
+
+        const magicLink = await membersService.api.getMagicLink(email, 'signin');
         const magicLinkUrl = new URL(magicLink);
         const token = magicLinkUrl.searchParams.get('token');
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/1903

MembersAgent.loginAs sends email, asynchronously via events. Which conflicts with tests that also test emails. We cannot properly await these events, so this is currently fixed with a timeout of 200ms. But this was too random and unreliable.