### PR TITLE
Enabled configurable editable relations

### DIFF
--- a/ghost/core/core/server/models/base/bookshelf.js
+++ b/ghost/core/core/server/models/base/bookshelf.js
@@ -66,6 +66,7 @@ ghostBookshelf.plugin(require('./plugins/relations'));
 ghostBookshelf.plugin('bookshelf-relations', {
     allowedOptions: ['context', 'importing', 'migrating'],
     unsetRelations: true,
+    editRelations: false,
     extendChanged: '_changed',
     attachPreviousRelations: true,
     hooks: {

--- a/ghost/core/core/server/models/integration.js
+++ b/ghost/core/core/server/models/integration.js
@@ -10,6 +10,14 @@ const Integration = ghostBookshelf.Model.extend({
     actionsResourceType: 'integration',
 
     relationships: ['api_keys', 'webhooks'],
+    relationshipConfig: {
+        api_keys: {
+            editable: true
+        },
+        webhooks: {
+            editable: true
+        }
+    },
 
     relationshipBelongsTo: {
         api_keys: 'api_keys',

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -129,8 +129,21 @@ const Member = ghostBookshelf.Model.extend({
     // do not delete email_recipients records when a member is destroyed. Recipient
     // records are used for analytics and historical records
     relationshipConfig: {
+        products: {
+            editable: true
+        },
+        labels: {
+            editable: true
+        },
+        stripeCustomers: {
+            editable: true
+        },
         email_recipients: {
+            editable: true,
             destroyRelated: false
+        },
+        newsletters: {
+            editable: true
         }
     },
 

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -97,6 +97,23 @@ Post = ghostBookshelf.Model.extend({
     },
 
     relationships: ['tags', 'authors', 'mobiledoc_revisions', 'post_revisions', 'posts_meta', 'tiers'],
+    relationshipConfig: {
+        tags: {
+            editable: true
+        },
+        authors: {
+            editable: true
+        },
+        mobiledoc_revisions: {
+            editable: true
+        },
+        post_revisions: {
+            editable: true
+        },
+        posts_meta: {
+            editable: true
+        }
+    },
 
     // NOTE: look up object, not super nice, but was easy to implement
     relationshipBelongsTo: {


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/465

- With bookshelf-relations 2.5.0 it's possible to pass in explicit "editable" flag to relations which can be edited. Having an explicit configuration allows to have fine-grained control over which relations can be edited through parent resources.