### PR TITLE
🐛 Fixed question marks replacement for some characters in Outlook

### DIFF
--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -49,7 +49,8 @@ const PostEmailSerializer = {
         juicedHtml = juicedHtml.replace(/&apos;/g, '&#39;');
         juicedHtml = juicedHtml.replace(/→/g, '&rarr;');
         juicedHtml = juicedHtml.replace(/–/g, '&ndash;');
-
+        juicedHtml = juicedHtml.replace(/“/g, '&ldquo;');
+        juicedHtml = juicedHtml.replace(/”/g, '&rdquo;');
         return juicedHtml;
     },
 

--- a/ghost/core/core/server/services/mega/post-email-serializer.js
+++ b/ghost/core/core/server/services/mega/post-email-serializer.js
@@ -47,6 +47,8 @@ const PostEmailSerializer = {
 
         // Fix any unsupported chars in Outlook
         juicedHtml = juicedHtml.replace(/&apos;/g, '&#39;');
+        juicedHtml = juicedHtml.replace(/→/g, '&rarr;');
+        juicedHtml = juicedHtml.replace(/–/g, '&ndash;');
 
         return juicedHtml;
     },


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C025584CA/p1668101893895139

Added HTML encoding for some special characters that are not always correctly shown in Outlook. Tested on Litmus.