### PR TITLE
🐛 Fixed amp-youtube being too small

### DIFF
--- a/ghost/core/core/frontend/apps/amp/lib/helpers/amp_content.js
+++ b/ghost/core/core/frontend/apps/amp/lib/helpers/amp_content.js
@@ -108,7 +108,7 @@ allowedAMPAttributes = {
     'amp-audio': ['src', 'width', 'height', 'autoplay', 'loop', 'muted', 'controls'],
     'amp-iframe': ['src', 'srcdoc', 'width', 'height', 'layout', 'frameborder', 'allowfullscreen', 'allowtransparency',
         'sandbox', 'referrerpolicy'],
-    'amp-youtube': ['src', 'width', 'height', 'layout', 'frameborder', 'autoplay', 'loop', 'data-videoid', 'data-live-channelid']
+    'amp-youtube': ['src', 'layout', 'frameborder', 'autoplay', 'loop', 'data-videoid', 'data-live-channelid']
 };
 
 function getAmperizeHTML(html, post) {

--- a/ghost/core/core/frontend/apps/amp/lib/views/amp.hbs
+++ b/ghost/core/core/frontend/apps/amp/lib/views/amp.hbs
@@ -182,6 +182,11 @@
     amp-img img {
         object-fit: cover;
     }
+    
+    amp-youtube {
+        height: calc(100vw / 1.78);
+        width: 100vw;
+    }
 
     .page-header {
         padding: 50px 5vmin 30px;


### PR DESCRIPTION
## Summary

This is one potential solution to issue #14020 that I'd like to suggest. The impact of this bug is that it is difficult to view YouTube videos in blog posts via Google search, because the video is too small to view and the "full-screen" button is not clickable at this size. ([See example here](https://blog.tryexponent.com/top-aws-interview-questions/amp/))

The solution proposed here is to add CSS for `amp-youtube` to set the dimensions of the iframe instead of passing explicit height and width attributes. Instead we set the video width to the viewport width and then set the height to a standard 16:9 ratio of YouTube videos.

I acknowledge this is likely not the "best" solution and would definitely be open to other ideas! 

## Screenshots

| Before | After | 
| --- | --- |
| <img width="300" alt="Screen Shot 2022-11-14 at 6 46 44 PM" src="https://user-images.githubusercontent.com/1131461/201814307-50692d0b-f042-45a1-8ca8-97e4ce052e91.png"> | <img width="300" alt="Screen Shot 2022-11-14 at 6 46 37 PM" src="https://user-images.githubusercontent.com/1131461/201814312-3e1541db-94cd-424d-a14a-9753f1b3776b.png">


## Checklist
- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)
