### PR TITLE
🐛 Fixed race condition when sending email

### DIFF
--- a/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
+++ b/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
@@ -71,6 +71,7 @@ module.exports = {
 
     // accepts an ID rather than an Email model to better support running via a job queue
     async processEmail({emailModel, options}) {
+        const knexOptions = _.pick(options, ['transacting', 'forUpdate']);
         const emailId = emailModel.get('id');
 
         // get batch IDs via knex to avoid model instantiation

--- a/ghost/core/core/server/services/mega/mega.js
+++ b/ghost/core/core/server/services/mega/mega.js
@@ -321,13 +321,12 @@ async function sendEmailJob({emailId, options}) {
             }
     
             if (emailModel.get('status') !== 'pending') {
-                // todo: maybe we shouldn't throw this error and only log it.
-                // because we don't want to alter the status to failed when this happens.
-                // throw new errors.IncorrectUsageError({
-                //     message: 'Emails can only be processed when in the "pending" state',
-                //     context: `Email "${emailId}" has state "${emailModel.get('status')}"`,
-                //     code: 'EMAIL_NOT_PENDING'
-                // });
+                // We don't throw this, because we don't want to mark this email as failed
+                logging.error(new errors.IncorrectUsageError({
+                    message: 'Emails can only be processed when in the "pending" state',
+                    context: `Email "${emailId}" has state "${emailModel.get('status')}"`,
+                    code: 'EMAIL_NOT_PENDING'
+                }));
                 return;
             }
 

--- a/ghost/core/core/server/services/mega/mega.js
+++ b/ghost/core/core/server/services/mega/mega.js
@@ -369,10 +369,10 @@ async function sendEmailJob({emailId, options}) {
             errorMessage = errorMessage.substring(0, 2000);
         }
 
-        await emailModel.save({
+        await models.Email.edit({
             status: 'failed',
             error: errorMessage
-        }, {patch: true});
+        }, {id: emailId});
 
         throw new errors.InternalServerError({
             err: error,

--- a/ghost/core/test/integration/services/mega.test.js
+++ b/ghost/core/test/integration/services/mega.test.js
@@ -79,7 +79,7 @@ describe('MEGA', function () {
             const emailModel = await createPublishedPostEmail();
 
             // Launch email job
-            await _sendEmailJob({emailModel, options: {}});
+            await _sendEmailJob({emailId: emailModel.id, options: {}});
 
             await emailModel.refresh();
             emailModel.get('status').should.eql('submitted');
@@ -95,7 +95,7 @@ describe('MEGA', function () {
             const emailModel = await createPublishedPostEmail();
 
             // Launch email job
-            await _sendEmailJob({emailModel, options: {}});
+            await _sendEmailJob({emailId: emailModel.id, options: {}});
 
             await emailModel.refresh();
             emailModel.get('status').should.eql('failed');
@@ -143,7 +143,7 @@ describe('MEGA', function () {
             const emailModel = await createPublishedPostEmail();
 
             // Launch email job
-            await _sendEmailJob({emailModel, options: {}});
+            await _sendEmailJob({emailId: emailModel.id, options: {}});
 
             await emailModel.refresh();
             emailModel.get('status').should.eql('submitted');

--- a/ghost/core/test/integration/services/mega.test.js
+++ b/ghost/core/test/integration/services/mega.test.js
@@ -85,6 +85,31 @@ describe('MEGA', function () {
             emailModel.get('status').should.eql('submitted');
         });
 
+        it('Protects the email job from being run multiple times at the same time', async function () {
+            sinon.stub(_mailgunClient, 'getInstance').returns({});
+            sinon.stub(_mailgunClient, 'send').callsFake(async () => {
+                return {
+                    id: 'stubbed-email-id'
+                };
+            });
+
+            // Prepare a post and email model
+            const emailModel = await createPublishedPostEmail();
+
+            // Launch a lot of email jobs in the hope to mimic a possible race condition
+            const promises = [];
+            for (let i = 0; i < 100; i++) {
+                promises.push(_sendEmailJob({emailId: emailModel.id, options: {}}));
+            }
+            await Promise.all(promises);
+
+            await emailModel.refresh();
+            assert.equal(emailModel.get('status'), 'submitted');
+
+            const batchCount = await emailModel.related('emailBatches').count('id');
+            assert.equal(batchCount, 1, 'Should only have created one batch');
+        });
+
         it('Can handle a failed post email', async function () {
             sinon.stub(_mailgunClient, 'getInstance').returns({});
             sinon.stub(_mailgunClient, 'send').callsFake(async () => {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2246

- This change helps avoid race conditions due to a lack of a transaction in the email job. It also moves the status check before creating the email batches (can take a while) to prevent other timing issues in case the job got scheduled multiple times.
- Sets the patch option to true when changing the status of an email batch. If we don't do this, the bookshelf-relations plugin might try to save relations too. This could have caused a 'no rows updated' error.
- Added a test that tests if the email job can only run once
- Added logging to batching logic