### PR TITLE
🐛 Fixed VerificationTrigger

### DIFF
--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -135,7 +135,9 @@ module.exports = {
             },
             membersStats,
             Settings: models.Settings,
-            eventRepository: membersApi.events
+            eventRepository: {
+                getCreatedEvents: membersApi.events.getSignupEvents.bind(membersApi.events)
+            }
         });
 
         (async () => {


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2266

The getCreatedEvents method required by the VerificationTrigger was replaced with the getSignupEvents method, but was not updated everywhere. This was causing error messages to be shown when importing members thought the importer. This fixes the instantiation of the VerificationTrigger to pass the expected interface.

