### PR TITLE
Removed getCreatedEvents and added verification trigger test

### DIFF
--- a/ghost/core/test/utils/fixtures/csv/valid-members-import-large.csv
+++ b/ghost/core/test/utils/fixtures/csv/valid-members-import-large.csv
@@ -1,0 +1,11 @@
+email,name,note,subscribed_to_emails,labels
+test1@example.com,joe,,true,,
+test2@example.com,test,"test note",false,"test-label"
+test3@example.com,test,"test note",false,"test-label"
+test4@example.com,test,"test note",false,"test-label"
+test5@example.com,test,"test note",false,"test-label"
+test6@example.com,test,"test note",false,"test-label"
+test7@example.com,test,"test note",false,"test-label"
+test8@example.com,test,"test note",false,"test-label"
+test9@example.com,test,"test note",false,"test-label"
+test10@example.com,test,"test note",false,"test-label"

--- a/ghost/members-api/lib/repositories/event.js
+++ b/ghost/members-api/lib/repositories/event.js
@@ -294,13 +294,6 @@ module.exports = class EventRepository {
         };
     }
 
-    /**
-     * @deprecated Do not use
-     */
-    async getCreatedEvents(options = {}, filter) {
-        return await this.getSignupEvents(options, filter);
-    }
-
     async getSignupEvents(options = {}, filter) {
         options = {
             ...options,

--- a/ghost/verification-trigger/lib/verification-trigger.js
+++ b/ghost/verification-trigger/lib/verification-trigger.js
@@ -19,7 +19,7 @@ class VerificationTrigger {
      * @param {number} deps.importTriggerThreshold Threshold for triggering Import sourced verifications
      * @param {() => boolean} deps.isVerified Check Ghost config to see if we are already verified
      * @param {() => boolean} deps.isVerificationRequired Check Ghost settings to see whether verification has been requested
-     * @param {(content: {subject: string, message: string, amountTriggered: number}) => void} deps.sendVerificationEmail Sends an email to the escalation address to confirm that customer needs to be verified
+     * @param {(content: {subject: string, message: string, amountTriggered: number}) => Promise<void>} deps.sendVerificationEmail Sends an email to the escalation address to confirm that customer needs to be verified
      * @param {any} deps.membersStats MemberStats service
      * @param {any} deps.Settings Ghost Settings model
      * @param {any} deps.eventRepository For querying events
@@ -157,7 +157,7 @@ class VerificationTrigger {
                     verificationMessage = messages.emailVerificationEmailMessageAdmin;
                 }
 
-                this._sendVerificationEmail({
+                await this._sendVerificationEmail({
                     message: verificationMessage,
                     subject: messages.emailVerificationEmailSubject,
                     amountTriggered: amount

--- a/ghost/verification-trigger/lib/verification-trigger.js
+++ b/ghost/verification-trigger/lib/verification-trigger.js
@@ -66,7 +66,7 @@ class VerificationTrigger {
         if (['api', 'admin'].includes(source) && isFinite(sourceThreshold)) {
             const createdAt = new Date();
             createdAt.setDate(createdAt.getDate() - 30);
-            const events = await this._eventRepository.getCreatedEvents({}, {
+            const events = await this._eventRepository.getSignupEvents({}, {
                 source: source,
                 created_at: {
                     $gt: createdAt.toISOString().replace('T', ' ').substring(0, 19)
@@ -101,7 +101,7 @@ class VerificationTrigger {
 
         const createdAt = new Date();
         createdAt.setDate(createdAt.getDate() - 30);
-        const events = await this._eventRepository.getCreatedEvents({}, {
+        const events = await this._eventRepository.getSignupEvents({}, {
             source: 'import',
             created_at: {
                 $gt: createdAt.toISOString().replace('T', ' ').substring(0, 19)

--- a/ghost/verification-trigger/test/verification-trigger.test.js
+++ b/ghost/verification-trigger/test/verification-trigger.test.js
@@ -175,7 +175,7 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getCreatedEvents: eventStub
+                getSignupEvents: eventStub
             }
         });
 
@@ -215,7 +215,7 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getCreatedEvents: eventStub
+                getSignupEvents: eventStub
             }
         });
 
@@ -259,7 +259,7 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getCreatedEvents: eventStub
+                getSignupEvents: eventStub
             }
         });
 
@@ -308,7 +308,7 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getCreatedEvents: eventStub
+                getSignupEvents: eventStub
             }
         });
 
@@ -356,7 +356,7 @@ describe('Email verification flow', function () {
             isVerificationRequired: () => false,
             sendVerificationEmail: emailStub,
             eventRepository: {
-                getCreatedEvents: eventStub
+                getSignupEvents: eventStub
             }
         });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2266

This removes the deprecated `getCreatedEvents` method in the event repository and adds tests to the verification trigger to see if we don't break anything.

Changes extracted from https://github.com/TryGhost/Ghost/pull/15831