### PR TITLE
Updated amp-youtube placeholder image position

### DIFF
--- a/ghost/core/core/frontend/apps/amp/lib/views/amp.hbs
+++ b/ghost/core/core/frontend/apps/amp/lib/views/amp.hbs
@@ -186,6 +186,11 @@
     amp-youtube {
         height: calc(100vw / 1.78);
         width: 100vw;
+        position: relative;
+    }
+
+    amp-youtube img {
+        position: absolute;
     }
 
     .page-header {


### PR DESCRIPTION
## Summary

This is a follow-up to #15826 that I forgot to include in the first commit. Fixes an issue where the placeholder image would offset the youtube iframe embed on initial load.

Sorry for the confusion @ErisDS! 

## Screenshot

<img width="300" alt="Screen Shot 2022-11-15 at 9 29 55 AM" src="https://user-images.githubusercontent.com/1131461/201986927-8d01eefc-3956-4952-af9a-4ec66a71c958.png">


