### PR TITLE
Clarified "Complimentary Plan" in the importer

### DIFF
--- a/ghost/admin/app/components/modal-import-members.hbs
+++ b/ghost/admin/app/components/modal-import-members.hbs
@@ -56,6 +56,7 @@
                 @setMappingResult={{action "setMappingResult"}}
                 @setFileData={{action "setMappingFileData"}}
                 @showErrors={{this.showMappingErrors}}
+                @hasMappedComplimentaryPlan={{this.hasMappedComplimentaryPlan}}
                 @disabled={{if (or (eq this.state 'UPLOADING') (eq this.mappingResult.membersCount 0)) true false}}
             />
         {{/if}}

--- a/ghost/admin/app/components/modal-import-members.js
+++ b/ghost/admin/app/components/modal-import-members.js
@@ -62,6 +62,20 @@ export default ModalComponent.extend({
         return formData;
     }),
 
+    hasMappedComplimentaryPlan: computed('mappingResult', function () {
+        if (this.mappingResult?.mapping) {
+            let mapping = this.mappingResult.mapping.toJSON();
+            
+            for (const prop in mapping) {
+                if (mapping[prop] === 'complimentary_plan') {
+                    return true;
+                }
+            }
+        } 
+
+        return false;
+    }),
+
     actions: {
         setFile(file) {
             this.set('file', file);

--- a/ghost/admin/app/components/modal-import-members/csv-file-mapping.hbs
+++ b/ghost/admin/app/components/modal-import-members/csv-file-mapping.hbs
@@ -16,6 +16,10 @@
             <p class="pt2">If an email address in your CSV matches an existing member, they will be updated with the mapped values.</p>
         {{/if}}
 
+        {{#if this.hasMappedComplimentaryPlan}}
+            <p class="pt2">When "Complimentary plan" data contains a "true" value, the importer member will get assigned to the cheapest paid active tier.</p>
+        {{/if}}
+
         <div class="mt6">
             <label for="label-input"><span class="fw6 f8 dib mb1">Label these members</span></label>
             <GhMemberLabelInput @labels={{this.labels}} @onChange={{this.updateLabels}} @disabled={{@disabled}} @triggerId="label-input" />

--- a/ghost/admin/app/components/modal-import-members/csv-file-mapping.js
+++ b/ghost/admin/app/components/modal-import-members/csv-file-mapping.js
@@ -37,6 +37,10 @@ export default class CsvFileMapping extends Component {
         return !isNone(this.fileData);
     }
 
+    get hasMappedComplimentaryPlan() {
+        return this.args.hasMappedComplimentaryPlan;
+    }
+
     @action
     setMapping(mapping) {
         if (this.fileData.length === 0) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/15814

- There's often a confusion around the logic of what makes "Complimentary Plan". It's especially confusing during the import process, where a bulk of members gets assigned to complimentary plan. This is a "quick and dirty" fix for the problem, something more holistic will be worked out in the future