### PR TITLE
Removed Ghost(Valet) from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ The easiest way to get a production instance deployed is with our official **[Gh
 
 For most people this ends up being the best value option cause of [how much time it saves](https://ghost.org/docs/hosting/) — and 100% of revenue goes to the Ghost Foundation; funding the maintenance and further development of the project itself. So you’ll be supporting open source software *and* getting a great service!
 
-If you prefer to run on your own infrastructure, we also offer official 1-off installs and managed support and maintenance plans via **[Ghost(Valet)](https://valet.ghost.org)** - which can save a substantial amount of developer time and resources.
-
 &nbsp;
 
 # Quickstart install


### PR DESCRIPTION
no issue

Ghost(Valet) has been unavailable for some time so linking to it here is redundant. There are other resources available for those who need a hand setting up a self-hosted Ghost site.