### PR TITLE
fix: missing "the" in sentence regarding trial

### DIFF
--- a/ghost/portal/src/components/pages/SignupPage.js
+++ b/ghost/portal/src/components/pages/SignupPage.js
@@ -459,7 +459,7 @@ class SignupPage extends React.Component {
         const {site} = this.context;
         if (hasFreeTrialTier({site})) {
             return (
-                <p className='gh-portal-free-trial-notification'>After a free trial ends, you will be charged regular price for the tier you’ve chosen. You can always cancel before then.</p>
+                <p className='gh-portal-free-trial-notification'>After a free trial ends, you will be charged the regular price for the tier you’ve chosen. You can always cancel before then.</p>
             );
         }
         return null;


### PR DESCRIPTION
- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

There seems to be a missing "the" in the trial message on the signup page of the portal. The senctence just sounds a bit off without it.