### PR TITLE
Improved server-side error handling

### DIFF
--- a/ghost/mw-error-handler/test/error-handler.test.js
+++ b/ghost/mw-error-handler/test/error-handler.test.js
@@ -17,13 +17,28 @@ const {
 } = require('../');
 
 describe('Prepare Error', function () {
-    it('Correctly prepares a normal error', function (done) {
+    it('Correctly prepares a non-Ghost error', function (done) {
         prepareError(new Error('test!'), {}, {
             set: () => {}
         }, (err) => {
             err.statusCode.should.eql(500);
             err.name.should.eql('InternalServerError');
+            err.message.should.eql('An unexpected error occurred, please try again.');
+            err.context.should.eql('test!');
             err.stack.should.startWith('Error: test!');
+            done();
+        });
+    });
+
+    it('Correctly prepares a Ghost error', function (done) {
+        prepareError(new InternalServerError({message: 'Handled Error', context: 'Details'}), {}, {
+            set: () => {}
+        }, (err) => {
+            err.statusCode.should.eql(500);
+            err.name.should.eql('InternalServerError');
+            err.message.should.eql('Handled Error');
+            err.context.should.eql('Details');
+            err.stack.should.startWith('InternalServerError: Handled Error');
             done();
         });
     });


### PR DESCRIPTION
refs: TryGhost/Team#1121
refs: dfffa30

- This makes a fundamental change to Ghost's server side error handling, so that no unhandled errors are used as API responses
- Anything that has been handled and rethrown as a Ghost error cna be trusted
- We also already trust a couple of known errors from bookshelf and handlebars
- Everything else is assumed to be a code error, and should not be shown as the main message
- Instead we use our generic fallback message and use the OG error as contextGot some code for us? Awesome 🎊!

