### PR TITLE
Fix scriptUrl code

### DIFF
--- a/ghost/core/core/frontend/utils/frontend-apps.js
+++ b/ghost/core/core/frontend/utils/frontend-apps.js
@@ -4,7 +4,7 @@ function getFrontendAppConfig(app) {
     const appVersion = config.get(`${app}:version`);
     let scriptUrl = config.get(`${app}:url`);
     let stylesUrl = config.get(`${app}:styles`);
-    if (scriptUrl.includes('{version}')) {
+    if (scriptUrl?.includes('{version}')) {
         scriptUrl = scriptUrl.replace('{version}', appVersion);
     }
     if (stylesUrl?.includes('{version}')) {


### PR DESCRIPTION
`scriptUrl` can be a boolean (if set to `false`), but the code assumes it is a string and crashes on the `String.prototype.includes()` call.

This PR aligns the code with the line below, which does `stylesUrl` correctly.

P.S. You should really start migrating to typescript to avoid such kind of bugs and make the life of OSS contributors easier. At least for the framework (storage plugins etc.) code.

