### PR TITLE
Added columns to store error information for email batches

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.24/2022-11-21-15-57-add-error-columns-for-email-batches.js
+++ b/ghost/core/core/server/data/migrations/versions/5.24/2022-11-21-15-57-add-error-columns-for-email-batches.js
@@ -1,0 +1,22 @@
+const {createAddColumnMigration, combineNonTransactionalMigrations} = require('../../utils');
+
+module.exports = combineNonTransactionalMigrations(
+    createAddColumnMigration('email_batches', 'error_status_code', {
+        type: 'integer',
+        nullable: true,
+        unsigned: true
+    }),
+
+    createAddColumnMigration('email_batches', 'error_message', {
+        type: 'string',
+        maxlength: 2000,
+        nullable: true
+    }),
+
+    createAddColumnMigration('email_batches', 'error_data', {
+        type: 'text',
+        maxlength: 1000000000,
+        fieldtype: 'long',
+        nullable: true
+    })
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -805,6 +805,9 @@ module.exports = {
             validations: {isIn: [['pending', 'submitting', 'submitted', 'failed']]}
         },
         member_segment: {type: 'text', maxlength: 2000, nullable: true},
+        error_status_code: {type: 'integer', nullable: true, unsigned: true},
+        error_message: {type: 'string', maxlength: 2000, nullable: true},
+        error_data: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: false}
     },

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'bb48c3c754f74f02a6ce020af6b0e6a7';
+    const currentSchemaHash = '36df3d6b0ac6c669dffe01331a1e5720';
     const currentFixturesHash = 'dcb7ba7c66b4b98d6c26a722985e756a';
     const currentSettingsHash = '9acce72858e75420b831297718595bbd';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2290

Currently, if the whole batch of email fails to send we don’t capture any errors directly tied to the batch. This makes it hard to debug which and why a batch failed when debugging email errors. Going forward we'll store the error information for a failing email batch directly that allows easier debugging for batch.

- `error_status_code` : Captures statusCode returned by Mailgun, available in error.status from the example batch error
- `error_message` : Captures short error message from Mailgun and status, available in context object of batch error
- `error_data` : Captures while whole error json for a batch. As mentioned in pitch, this will be huge data and we’ll figure out long term how to best use this.