### PR TITLE
Added table to store email recipient failures

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -25,6 +25,7 @@ const BACKUP_TABLES = [
     'post_revisions',
     'email_batches',
     'email_recipients',
+    'email_recipient_failures',
     'members_cancel_events',
     'members_payment_events',
     'members_login_events',

--- a/ghost/core/core/server/data/migrations/versions/5.25/2022-11-29-08-30-add-error-recipient-failures-table.js
+++ b/ghost/core/core/server/data/migrations/versions/5.25/2022-11-29-08-30-add-error-recipient-failures-table.js
@@ -1,0 +1,20 @@
+const utils = require('../../utils');
+
+module.exports = utils.addTable('email_recipient_failures', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    email_id: {type: 'string', maxlength: 24, nullable: false, references: 'emails.id'},
+    member_id: {type: 'string', maxlength: 24, nullable: true},
+    email_recipient_id: {type: 'string', maxlength: 24, nullable: false, references: 'email_recipients.id'},
+    code: {type: 'integer', nullable: false, unsigned: true},
+    enhanced_code: {type: 'string', maxlength: 50, nullable: true},
+    message: {type: 'string', maxlength: 2000, nullable: false},
+    severity: {
+        type: 'string',
+        maxlength: 50,
+        nullable: false,
+        defaultTo: 'permanent',
+        validations: {isIn: [['temporary', 'permanent']]}
+    },
+    failed_at: {type: 'dateTime', nullable: false},
+    event_id: {type: 'string', maxlength: 255, nullable: true}
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -835,6 +835,24 @@ module.exports = {
             ['email_id', 'member_email']
         ]
     },
+    email_recipient_failures: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        email_id: {type: 'string', maxlength: 24, nullable: false, references: 'emails.id'},
+        member_id: {type: 'string', maxlength: 24, nullable: true},
+        email_recipient_id: {type: 'string', maxlength: 24, nullable: false, references: 'email_recipients.id'},
+        code: {type: 'integer', nullable: false, unsigned: true},
+        enhanced_code: {type: 'string', maxlength: 50, nullable: true},
+        message: {type: 'string', maxlength: 2000, nullable: false},
+        severity: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'permanent',
+            validations: {isIn: [['temporary', 'permanent']]}
+        },
+        failed_at: {type: 'dateTime', nullable: false},
+        event_id: {type: 'string', maxlength: 255, nullable: true}
+    },
     tokens: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         token: {type: 'string', maxlength: 32, nullable: false, index: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '0b8a04ed7ba1029d8e2d6869c886ac59';
+    const currentSchemaHash = '4b749aee6b3c823c3ea27e2c936cde17';
     const currentFixturesHash = 'dcb7ba7c66b4b98d6c26a722985e756a';
     const currentSettingsHash = '9acce72858e75420b831297718595bbd';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2291

When sending out mails to individual recipients, its possible that recipient gets a temporary or permanent failure for receiving the mail. Temporary failures can generally get resolved after a bit when the recipient’s mail server accepts the email, unlike permanent failures. For both customer visibility and easier debugging on what went wrong while delivering to a particular recipient, we’ll store the permanent/temporary failure for a recipient.

- migration adds a new table that stores the failure information for the recipients