### PR TITLE
Improved Sentry server side error reporting 

### DIFF
--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -4,7 +4,7 @@ const errors = require('@tryghost/errors');
 
 if (sentryConfig && !sentryConfig.disabled) {
     const Sentry = require('@sentry/node');
-    const version = require('../../package.json').version;
+    const version = require('@tryghost/version').full;
     const environment = config.get('env');
     Sentry.init({
         dsn: sentryConfig.dsn,
@@ -34,9 +34,11 @@ if (sentryConfig && !sentryConfig.disabled) {
         next();
     };
 
+    const noop = () => {};
+
     module.exports = {
         requestHandler: expressNoop,
         errorHandler: expressNoop,
-        captureException: () => {}
+        captureException: noop
     };
 }

--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -9,7 +9,27 @@ if (sentryConfig && !sentryConfig.disabled) {
     Sentry.init({
         dsn: sentryConfig.dsn,
         release: 'ghost@' + version,
-        environment: environment
+        environment: environment,
+        beforeSend: function (event, hint) {
+            const exception = hint.originalException;
+
+            event.tags = event.tags || {};
+
+            if (errors.utils.isGhostError(exception)) {
+                // Unexpected errors have a generic error message, set it back to context if there is one
+                if (exception.code === 'UNEXPECTED_ERROR' && exception.context !== null) {
+                    event.exception.values[0].type = exception.context;
+                }
+
+                // This is a Ghost Error, copy all our extra data to tags
+                event.tags.type = exception.errorType;
+                event.tags.code = exception.code;
+                event.tags.id = exception.id;
+                event.tags.statusCode = exception.statusCode;
+            }
+
+            return event;
+        }
     });
 
     module.exports = {

--- a/ghost/core/test/unit/shared/sentry.test.js
+++ b/ghost/core/test/unit/shared/sentry.test.js
@@ -49,6 +49,7 @@ describe('UNIT: sentry', function () {
             assert.equal(initArgs[0].dsn, fakeDSN, 'shoudl be our fake dsn');
             assert.match(initArgs[0].release, /ghost@\d+\.\d+\.\d+/, 'should be a valid version');
             assert.equal(initArgs[0].environment, 'testing', 'should be the testing env');
+            assert.ok(initArgs[0].hasOwnProperty('beforeSend'), 'should have a beforeSend function');
         });
     });
 });

--- a/ghost/core/test/unit/shared/sentry.test.js
+++ b/ghost/core/test/unit/shared/sentry.test.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const configUtils = require('../../utils/configUtils');
+
+const Sentry = require('@sentry/node');
+const {asset} = require('../../../core/frontend/services/theme-engine/handlebars/template');
+
+const fakeDSN = 'https://aaabbbccc000111222333444555667@sentry.io/1234567';
+let sentry;
+
+describe('UNIT: sentry', function () {
+    afterEach(function () {
+        configUtils.restore();
+        sinon.restore();
+    });
+
+    describe('No sentry config', function () {
+        beforeEach(function () {
+            delete require.cache[require.resolve('../../../core/shared/sentry')];
+            sentry = require('../../../core/shared/sentry');
+        });
+
+        it('returns expected function signature', function () {
+            assert.equal(sentry.requestHandler.name, 'expressNoop', 'Should return noop');
+            assert.equal(sentry.errorHandler.name, 'expressNoop', 'Should return noop');
+            assert.equal(sentry.captureException.name, 'noop', 'Should return noop');
+        });
+    });
+
+    describe('With sentry config', function () {
+        beforeEach(function () {
+            configUtils.set({sentry: {disabled: false, dsn: fakeDSN}});
+            delete require.cache[require.resolve('../../../core/shared/sentry')];
+
+            sinon.spy(Sentry, 'init');
+
+            sentry = require('../../../core/shared/sentry');
+        });
+
+        it('returns expected function signature', function () {
+            assert.equal(sentry.requestHandler.name, 'sentryRequestMiddleware', 'Should return sentry');
+            assert.equal(sentry.errorHandler.name, 'sentryErrorMiddleware', 'Should return sentry');
+            assert.equal(sentry.captureException.name, 'captureException', 'Should return sentry');
+        });
+
+        it('initialises sentry correctly', function () {
+            const initArgs = Sentry.init.getCall(0).args;
+
+            assert.equal(initArgs[0].dsn, fakeDSN, 'shoudl be our fake dsn');
+            assert.match(initArgs[0].release, /ghost@\d+\.\d+\.\d+/, 'should be a valid version');
+            assert.equal(initArgs[0].environment, 'testing', 'should be the testing env');
+        });
+    });
+});

--- a/ghost/mw-error-handler/lib/mw-error-handler.js
+++ b/ghost/mw-error-handler/lib/mw-error-handler.js
@@ -93,7 +93,8 @@ module.exports.prepareError = (err, req, res, next) => {
                 err: err,
                 message: tpl(messages.genericError),
                 context: err.message,
-                statusCode: err.statusCode
+                statusCode: err.statusCode,
+                code: 'UNEXPECTED_ERROR'
             });
         }
     }

--- a/ghost/mw-error-handler/test/error-handler.test.js
+++ b/ghost/mw-error-handler/test/error-handler.test.js
@@ -26,6 +26,7 @@ describe('Prepare Error', function () {
             err.name.should.eql('InternalServerError');
             err.message.should.eql('An unexpected error occurred, please try again.');
             err.context.should.eql('test!');
+            err.code.should.eql('UNEXPECTED_ERROR');
             err.stack.should.startWith('Error: test!');
             done();
         });
@@ -80,7 +81,7 @@ describe('Prepare Error', function () {
         }, (err) => {
             err.statusCode.should.eql(400);
             err.name.should.eql('IncorrectUsageError');
-            // TODO: the message shouldn't be trusted here
+            // TODO: consider if the message should be trusted here
             err.message.should.eql('obscure handlebars message!');
             err.stack.should.startWith('Error: obscure handlebars message!');
             done();
@@ -98,7 +99,6 @@ describe('Prepare Error', function () {
         }, (err) => {
             err.statusCode.should.eql(400);
             err.name.should.eql('IncorrectUsageError');
-            // TODO: the message shouldn't be trusted here
             err.message.should.eql('obscure express-hbs message!');
             err.stack.should.startWith('Error: obscure express-hbs message!');
             done();


### PR DESCRIPTION
refs: TryGhost/Team#2289
refs: TryGhost/express-hbs#161

- Themes that resuse layouts as templates trigger horrible errors, which are thrown as 500s
- But there's nothing the server is doing wrong, it's a theme user, so we downgrade these to 400s
- There is more to do here to improve the errors shown, but this is just a first step to ensure that theme issues don't look like server failuresGot some code for us? Awesome 🎊!

