### PR TITLE
Stored new source data for emails

### DIFF
--- a/ghost/core/core/server/services/mega/mega.js
+++ b/ghost/core/core/server/services/mega/mega.js
@@ -238,6 +238,8 @@ const addEmail = async (postModel, options) => {
             from: emailData.from,
             reply_to: emailData.replyTo,
             html: emailData.html,
+            source: emailData.html,
+            source_type: 'html',
             plaintext: emailData.plaintext,
             submitted_at: moment().toDate(),
             track_opens: !!settingsCache.get('email_track_opens'),


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2280
refs https://github.com/TryGhost/Ghost/commit/9b0c21e0a290dd24cf79c751665cf81a262f78d1

As part of the email stability work, we added new `source` and `source_type` columns to `email` table, which allows us to store the email source information. The source for all existing emails before the stability work was always `html`, while newer emails will store `mobiledoc` or `lexical` directly.

While the `source` for all existing emails was populated with the `html` as part of above migration, we also need to store the right `source` for all new emails created till the feature is under a flag.

This change updates the current email flow to also store `source` with html data, so it can be used in future with new email service and allows removing old `html` column.