### PR TITLE
Fixed missing amp-youtube properties

### DIFF
--- a/ghost/core/core/frontend/apps/amp/lib/helpers/amp_content.js
+++ b/ghost/core/core/frontend/apps/amp/lib/helpers/amp_content.js
@@ -108,7 +108,7 @@ allowedAMPAttributes = {
     'amp-audio': ['src', 'width', 'height', 'autoplay', 'loop', 'muted', 'controls'],
     'amp-iframe': ['src', 'srcdoc', 'width', 'height', 'layout', 'frameborder', 'allowfullscreen', 'allowtransparency',
         'sandbox', 'referrerpolicy'],
-    'amp-youtube': ['src', 'layout', 'frameborder', 'autoplay', 'loop', 'data-videoid', 'data-live-channelid']
+    'amp-youtube': ['src', 'layout', 'frameborder', 'autoplay', 'loop', 'data-videoid', 'data-live-channelid', 'width', 'height']
 };
 
 function getAmperizeHTML(html, post) {
@@ -192,6 +192,10 @@ module.exports = async function amp_content() { // eslint-disable-line camelcase
         // then we have to remove remaining, invalid HTML tags.
         $('audio').children('source').remove();
         $('audio').children('track').remove();
+
+        $('amp-youtube').attr('layout', 'responsive');
+        $('amp-youtube').attr('height', '350');
+        $('amp-youtube').attr('width', '600');
 
         ampHTML = $.html();
 


### PR DESCRIPTION
Fix: https://github.com/TryGhost/Ghost/issues/15878

Fix `amp-youtube` component, add mandatory `width` and `height` properties. Also change the `layout` property to `responsive`, so that the width adapts to mobile devices.

---

Error log:
`The mandatory attribute 'height' is missing in tag 'amp-youtube'.`

Documentation `amp-youtube`: https://amp.dev/documentation/components/amp-youtube

---

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)
