### PR TITLE
Fixed minifier for Windows users

### DIFF
--- a/ghost/minifier/README.md
+++ b/ghost/minifier/README.md
@@ -16,6 +16,6 @@ minifier.minify({
 
 - Minfier constructor requires a src and a dest
 - minify() function takes an object with destination file as the key and source glob as the value
-    - globs can be anything tiny-glob supports
+    - globs can be anything tiny-glob supports (must use forward slash regardless of platform)
     - destination files must end with .css or .js
     - src files will be minified according to their destination file extension

--- a/ghost/minifier/lib/minifier.js
+++ b/ghost/minifier/lib/minifier.js
@@ -6,6 +6,7 @@ const terser = require('terser');
 const glob = require('tiny-glob');
 const path = require('path');
 const fs = require('fs').promises;
+const isWin = process.platform === 'win32';
 
 const messages = {
     badDestination: {
@@ -69,7 +70,12 @@ class Minifier {
     }
 
     async getMatchingFiles(src) {
-        return await glob(this.getFullSrc(src));
+        let fullSrc = this.getFullSrc(src);
+        // must feed glob forward slashes to function properly
+        if (isWin) { 
+            fullSrc = fullSrc.replace(/\\/g,'/');
+        };
+        return await glob(fullSrc);
     }
 
     async readFiles(files) {
@@ -84,7 +90,9 @@ class Minifier {
 
     async getSrcFileContents(src) {
         try {
+            debug(`files for `,src)
             const files = await this.getMatchingFiles(src);
+            debug(`found files `,files)
 
             if (files) {
                 return await this.readFiles(files);

--- a/ghost/minifier/test/minifier.test.js
+++ b/ghost/minifier/test/minifier.test.js
@@ -28,23 +28,23 @@ describe('Minifier', function () {
             let result = await minifier.getMatchingFiles('css/*.css');
 
             result.should.be.an.Array().with.lengthOf(3);
-            result[0].should.eql('test/fixtures/basic-cards/css/bookmark.css');
-            result[1].should.eql('test/fixtures/basic-cards/css/empty.css');
-            result[2].should.eql('test/fixtures/basic-cards/css/gallery.css');
-        });
+            result[0].should.eql(path.join('test','fixtures','basic-cards','css','bookmark.css'));
+            result[1].should.eql(path.join('test','fixtures','basic-cards','css','empty.css'));
+            result[2].should.eql(path.join('test','fixtures','basic-cards','css','gallery.css'));
+    });
 
         it('reverse match glob e.g. css/!(bookmark).css', async function () {
             let result = await minifier.getMatchingFiles('css/!(bookmark).css');
 
             result.should.be.an.Array().with.lengthOf(2);
-            result[0].should.eql('test/fixtures/basic-cards/css/empty.css');
-            result[1].should.eql('test/fixtures/basic-cards/css/gallery.css');
+            result[0].should.eql(path.join('test','fixtures','basic-cards','css','empty.css'));
+            result[1].should.eql(path.join('test','fixtures','basic-cards','css','gallery.css'));
         });
         it('reverse match glob e.g. css/!(bookmark|gallery).css', async function () {
             let result = await minifier.getMatchingFiles('css/!(bookmark|gallery).css');
 
             result.should.be.an.Array().with.lengthOf(1);
-            result[0].should.eql('test/fixtures/basic-cards/css/empty.css');
+            result[0].should.eql(path.join('test','fixtures','basic-cards','css','empty.css'));
         });
     });
 

--- a/ghost/minifier/test/minifier.test.js
+++ b/ghost/minifier/test/minifier.test.js
@@ -123,7 +123,6 @@ describe('Minifier', function () {
         it('can handle missing files and folders gracefully', async function () {
             try {
                 await minifier.minify({
-                    'card.min.ts': 'ts/*.ts',
                     'card.min.js': 'js/fake.js'
                 });
                 should.fail(minifier, 'Should have errored');


### PR DESCRIPTION
Resolves #14278.

Updated Minifier to use only forward slashes when specifying globs regardless of platform.

PR https://github.com/TryGhost/Ghost/pull/15807 has some additional history. After more testing - and despite globalyzer (dependency of tiny-glob) failing on Windows - tiny-glob does seem to work on Windows as it indicates when you specify a glob using forward slashes. I suppose I ended up going too deep with the initial troubleshooting and missed the more obvious piece here.

This should alleviate your concerns about performance hits from changing packages, although I still feel there would be no impact moving to node-glob as we're fully aware of the directory of the files we want here so no crawling is necessary. 