### PR TITLE
Fixed error logging in importer

### DIFF
--- a/ghost/core/core/server/data/importer/import-manager.js
+++ b/ghost/core/core/server/data/importer/import-manager.js
@@ -436,9 +436,7 @@ class ImportManager {
 
             return importResult;
         } catch (err) {
-            logging.error(`Content import was unsuccessful`, {
-                error: err
-            });
+            logging.error(err, 'Content import was unsuccessful');
             importResult = {data: {errors: [err]}};
         } finally {
             // Step 5: Cleanup any files


### PR DESCRIPTION
 refs: https://github.com/TryGhost/Toolbox/issues/431

- the error logging was only outputting 'Content import was unsuccessful' and not outputting the associated error