### PR TITLE
Improved email concurrency sending

### DIFF
--- a/ghost/job-manager/lib/job-manager.js
+++ b/ghost/job-manager/lib/job-manager.js
@@ -39,7 +39,7 @@ class JobManager {
      * @param {Object} [options.domainEvents] - domain events emitter
      */
     constructor({errorHandler, workerMessageHandler, JobModel, domainEvents}) {
-        this.queue = fastq(this, worker, 1);
+        this.queue = fastq(this, worker, 3);
         this._jobMessageHandler = this._jobMessageHandler.bind(this);
         this._jobErrorHandler = this._jobErrorHandler.bind(this);
         this.#domainEvents = domainEvents;

--- a/ghost/job-manager/lib/job-manager.js
+++ b/ghost/job-manager/lib/job-manager.js
@@ -39,7 +39,7 @@ class JobManager {
      * @param {Object} [options.domainEvents] - domain events emitter
      */
     constructor({errorHandler, workerMessageHandler, JobModel, domainEvents}) {
-        this.queue = fastq(this, worker, 3);
+        this.queue = fastq(this, worker, 1);
         this._jobMessageHandler = this._jobMessageHandler.bind(this);
         this._jobErrorHandler = this._jobErrorHandler.bind(this);
         this.#domainEvents = domainEvents;


### PR DESCRIPTION
no issue

- Send 10 batches at the same time
- Increase job manager concurrency to 3 (allows to send emails and have a member import at the same time).