### PR TITLE
Changed tag for imported content to be internal

### DIFF
--- a/ghost/core/core/server/api/endpoints/db.js
+++ b/ghost/core/core/server/api/endpoints/db.js
@@ -83,7 +83,7 @@ module.exports = {
         permissions: true,
         query(frame) {
             const siteTimezone = settingsCache.get('timezone');
-            const importTag = `Import ${moment().tz(siteTimezone).format('YYYY-MM-DD HH:mm')}`;
+            const importTag = `#Import ${moment().tz(siteTimezone).format('YYYY-MM-DD HH:mm')}`;
             return importer.importFromFile(frame.file, {
                 user: {
                     email: frame.user.get('email')

--- a/ghost/core/core/server/data/importer/importers/data/data-importer.js
+++ b/ghost/core/core/server/data/importer/importers/data/data-importer.js
@@ -55,7 +55,7 @@ DataImporter = {
             importData.data.tags.push({
                 id: tagId,
                 name: importOptions.importTag,
-                slug: slugify(importOptions.importTag)
+                slug: slugify(importOptions.importTag.replace(/^#/, 'hash-'))
             });
             if (!('posts_tags' in importData.data)) {
                 importData.data.posts_tags = [];


### PR DESCRIPTION
No issue

When importing content from a JSON file in Settings > Labs, a public tag like `Import 2022-12-03 19:57` gets added to each newly imported post.

I believe this tag should not be public. It definitely serves a useful purpose but has no useful function for readers of the site and should not be shown to readers.

As an example, if the imported content has no other tags (which is common when coming from some other platforms), the import tag becomes the primary tag and is shown front & center to readers. Here's an example from Casper.

<img width="458" alt="screenshot-08-09-20-03-12-2022" src="https://user-images.githubusercontent.com/390392/205459950-93bcd2db-70a5-4a6a-a44e-2727337b44a5.png">

With this change, the tag is now internal `#Import 2022-12-03 19:57` & `hash-import 2022-12-03 19:57`. Its utility is the same, but won't clutter the front-end anymore.

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)
