### PR TITLE
Fixed suppression list handling of spam complaint events

### DIFF
--- a/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
+++ b/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
@@ -95,12 +95,12 @@ class MailgunEmailSuppressionList extends AbstractEmailSuppressionList {
     }
 
     async init() {
-        const handleEvent = async (event) => {
+        const handleEvent = reason => async (event) => {
             try {
                 await this.Suppression.add({
                     email_address: event.email,
                     email_id: event.emailId,
-                    reason: 'bounce',
+                    reason: reason,
                     created_at: event.timestamp
                 });
             } catch (err) {
@@ -109,8 +109,8 @@ class MailgunEmailSuppressionList extends AbstractEmailSuppressionList {
                 }
             }
         };
-        DomainEvents.subscribe(EmailBouncedEvent, handleEvent);
-        DomainEvents.subscribe(SpamComplaintEvent, handleEvent);
+        DomainEvents.subscribe(EmailBouncedEvent, handleEvent('bounce'));
+        DomainEvents.subscribe(SpamComplaintEvent, handleEvent('spam'));
     }
 }
 

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -734,7 +734,7 @@ describe('EmailEventStorage', function () {
         const emailBatch = fixtureManager.get('email_batches', 0);
         const emailId = emailBatch.email_id;
 
-        const emailRecipient = fixtureManager.get('email_recipients', 0);
+        const emailRecipient = fixtureManager.get('email_recipients', 1);
         assert(emailRecipient.batch_id === emailBatch.id);
         const memberId = emailRecipient.member_id;
         const providerId = emailBatch.provider_id;
@@ -746,6 +746,9 @@ describe('EmailEventStorage', function () {
         // Check not unsubscribed
         const {body: {events: [notSpamEvent]}} = await agent.get(eventsURI);
         assert.notEqual(notSpamEvent.type, 'email_complaint_event', 'This test requires a member that does not have a spam event');
+
+        const {body: {members: [member]}} = await agent.get(`/members/${memberId}`);
+        assert.equal(member.email_suppression.suppressed, false, 'This test requires a member that does not have a suppressed email');
 
         events = [{
             event: 'complained',
@@ -777,6 +780,10 @@ describe('EmailEventStorage', function () {
         // Check if event exists
         const {body: {events: [spamComplaintEvent]}} = await agent.get(eventsURI);
         assert.equal(spamComplaintEvent.type, 'email_complaint_event');
+
+        const {body: {members: [memberAfter]}} = await agent.get(`/members/${memberId}`);
+        assert.equal(memberAfter.email_suppression.suppressed, true, 'The member should have a suppressed email');
+        assert.equal(memberAfter.email_suppression.info.reason, 'spam');
     });
 
     it('Can handle unsubscribe events', async function () {

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -1,14 +1,11 @@
 const sinon = require('sinon');
 const {agentProvider, fixtureManager, sleep} = require('../../../utils/e2e-framework');
 const assert = require('assert');
-const models = require('../../../../core/server/models');
 const domainEvents = require('@tryghost/domain-events');
 const MailgunClient = require('@tryghost/mailgun-client');
-const {run} = require('../../../../core/server/services/email-analytics/jobs/fetch-latest/run.js');
-const membersService = require('../../../../core/server/services/members');
 const {EmailDeliveredEvent} = require('@tryghost/email-events');
 
-async function resetFailures(emailId) {
+async function resetFailures(models, emailId) {
     await models.EmailRecipientFailure.destroy({
         destroyBy: {
             email_id: emailId
@@ -22,13 +19,19 @@ describe('EmailEventStorage', function () {
     let agent;
     let events = [];
     let jobsService;
+    let models;
+    let run;
+    let membersService;
 
     before(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('newsletters', 'members:newsletters', 'members:emails');
         await agent.loginAsOwner();
 
-        // Only create reference to jobsService after Ghost boot
+        // Only reference services after Ghost boot
+        models = require('../../../../core/server/models');
+        run = require('../../../../core/server/services/email-analytics/jobs/fetch-latest/run.js').run;
+        membersService = require('../../../../core/server/services/members');
         jobsService = require('../../../../core/server/services/jobs');
 
         sinon.stub(MailgunClient.prototype, 'fetchEvents').callsFake(async function (_, batchHandler) {
@@ -405,7 +408,7 @@ describe('EmailEventStorage', function () {
         await models.EmailRecipient.edit({failed_at: null}, {
             id: emailRecipient.id
         });
-        await resetFailures(emailId);
+        await resetFailures(models, emailId);
 
         events = [{
             event: 'failed',


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2351

We were storing all suppressions with a reason of bounced, rather than
spam for spam complaint events.