### PR TITLE
Added redirect to Email Preferences in Portal after resubscribing

### DIFF
--- a/ghost/portal/src/components/pages/EmailSuppressedPage.js
+++ b/ghost/portal/src/components/pages/EmailSuppressedPage.js
@@ -25,6 +25,9 @@ export default function EmailSuppressedPage() {
                     page: 'accountEmail',
                     lastPage: 'accountHome'
                 });
+                onAction('showPopupNotification', {
+                    message: 'You have been successfully resubscribed'
+                });
             } else {
                 onAction('back');
             }

--- a/ghost/portal/src/components/pages/EmailSuppressedPage.js
+++ b/ghost/portal/src/components/pages/EmailSuppressedPage.js
@@ -1,22 +1,35 @@
 import AppContext from 'AppContext';
 import {useContext, useEffect} from 'react';
+import {hasCommentsEnabled, hasMultipleNewsletters} from 'utils/helpers';
 import CloseButton from 'components/common/CloseButton';
 import BackButton from 'components/common/BackButton';
 import ActionButton from 'components/common/ActionButton';
 import {ReactComponent as EmailDeliveryFailedIcon} from 'images/icons/email-delivery-failed.svg';
 
 export default function EmailSuppressedPage() {
-    const {brandColor, lastPage, onAction, action} = useContext(AppContext);
+    const {brandColor, lastPage, onAction, action, site} = useContext(AppContext);
 
     useEffect(() => {
         if (['removeEmailFromSuppressionList:success'].includes(action)) {
             onAction('refreshMemberData');
         }
 
-        if (['removeEmailFromSuppressionList:failed', 'refreshMemberData:success', 'refreshMemberData:failed'].includes(action)) {
+        if (['removeEmailFromSuppressionList:failed', 'refreshMemberData:failed'].includes(action)) {
             onAction('back');
         }
-    }, [action, onAction]);
+
+        if (['refreshMemberData:success'].includes(action)) {
+            const showEmailPreferences = hasMultipleNewsletters({site}) || hasCommentsEnabled({site});
+            if (showEmailPreferences) {
+                onAction('switchPage', {
+                    page: 'accountEmail',
+                    lastPage: 'accountHome'
+                });
+            } else {
+                onAction('back');
+            }
+        }
+    }, [action, onAction, site]);
 
     const isRunning = ['removeEmailFromSuppressionList:running', 'refreshMemberData:running'].includes(action);
 


### PR DESCRIPTION
closes TryGhost/Team#2360
- Redirect member to Email Preferences after email removed from suppression list.
