### PR TITLE
Extracted sleep method to e2e framework module

### DIFF
--- a/ghost/core/test/e2e-api/admin/links.test.js
+++ b/ghost/core/test/e2e-api/admin/links.test.js
@@ -1,4 +1,4 @@
-const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers, sleep} = require('../../utils/e2e-framework');
 const {anyObjectId, anyString, anyEtag, anyNumber} = matchers;
 
 const matchLink = {
@@ -13,12 +13,6 @@ const matchLink = {
         clicks: anyNumber
     }
 };
-
-async function sleep(ms) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-}
 
 describe('Links API', function () {
     let agent;

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const {agentProvider, mockManager, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
+const {agentProvider, mockManager, fixtureManager, matchers, configUtils, sleep} = require('../../utils/e2e-framework');
 const {anyEtag, anyObjectId, anyLocationFor, anyISODateTime, anyErrorId, anyUuid, anyNumber, anyBoolean} = matchers;
 const should = require('should');
 const models = require('../../../core/server/models');
@@ -47,12 +47,6 @@ function commentMatcherWithReplies(options = {replies: 0}) {
         },
         liked: anyBoolean
     };
-}
-
-async function sleep(ms) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
 }
 
 function escapeRegExp(string) {

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -1,15 +1,9 @@
-const {agentProvider, mockManager, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {agentProvider, mockManager, fixtureManager, matchers, sleep} = require('../../utils/e2e-framework');
 const should = require('should');
 const settingsCache = require('../../../core/shared/settings-cache');
 const {anyErrorId} = matchers;
 
 let membersAgent, membersService;
-
-async function sleep(ms) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-}
 
 describe('sendMagicLink', function () {
     before(async function () {

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -4,7 +4,7 @@ const nock = require('nock');
 const should = require('should');
 const stripe = require('stripe');
 const {Product} = require('../../../core/server/models/product');
-const {agentProvider, mockManager, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {agentProvider, mockManager, fixtureManager, matchers, sleep} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
 const urlService = require('../../../core/server/services/url');
 const urlUtils = require('../../../core/shared/url-utils');
@@ -41,12 +41,6 @@ async function assertSubscription(subscriptionId, asserts) {
 
     // We use the native toJSON to prevent calling the overriden serialize method
     models.Base.Model.prototype.serialize.call(subscription).should.match(asserts);
-}
-
-async function sleep(ms) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
 }
 
 describe('Members API', function () {

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const {agentProvider, fixtureManager, mockManager} = require('../../../utils/e2e-framework');
+const {agentProvider, fixtureManager, sleep} = require('../../../utils/e2e-framework');
 const assert = require('assert');
 const models = require('../../../../core/server/models');
 const domainEvents = require('@tryghost/domain-events');
@@ -7,12 +7,6 @@ const MailgunClient = require('@tryghost/mailgun-client');
 const {run} = require('../../../../core/server/services/email-analytics/jobs/fetch-latest/run.js');
 const membersService = require('../../../../core/server/services/members');
 const {EmailDeliveredEvent} = require('@tryghost/email-events');
-
-async function sleep(ms) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-}
 
 async function resetFailures(emailId) {
     await models.EmailRecipientFailure.destroy({

--- a/ghost/core/test/integration/services/mega.test.js
+++ b/ghost/core/test/integration/services/mega.test.js
@@ -1,17 +1,11 @@
 require('should');
-const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, mockManager, sleep} = require('../../utils/e2e-framework');
 const moment = require('moment');
 const ObjectId = require('bson-objectid').default;
 const models = require('../../../core/server/models');
 const sinon = require('sinon');
 const assert = require('assert');
 let agent;
-
-async function sleep(ms) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-}
 
 async function createPublishedPostEmail() {
     const post = {

--- a/ghost/core/test/regression/api/admin/members-importer.test.js
+++ b/ghost/core/test/regression/api/admin/members-importer.test.js
@@ -9,17 +9,11 @@ const configUtils = require('../../../utils/configUtils');
 const settingsCache = require('../../../../core/shared/settings-cache');
 const models = require('../../../../core/server/models');
 
-const {mockManager} = require('../../../utils/e2e-framework');
+const {mockManager, sleep} = require('../../../utils/e2e-framework');
 const assert = require('assert');
 const {_updateVerificationTrigger} = require('../../../../core/server/services/members');
 
 let request;
-
-async function sleep(ms) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-}
 
 describe('Members Importer API', function () {
     before(async function () {

--- a/ghost/core/test/unit/server/services/staff/index.test.js
+++ b/ghost/core/test/unit/server/services/staff/index.test.js
@@ -3,16 +3,10 @@ const sinon = require('sinon');
 const staffService = require('../../../../../core/server/services/staff');
 
 const DomainEvents = require('@tryghost/domain-events');
-const {mockManager} = require('../../../../utils/e2e-framework');
+const {mockManager, sleep} = require('../../../../utils/e2e-framework');
 const models = require('../../../../../core/server/models');
 
 const {SubscriptionCreatedEvent, SubscriptionCancelledEvent, MemberCreatedEvent} = require('@tryghost/member-events');
-
-async function sleep(ms) {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-}
 
 describe('Staff Service:', function () {
     before(function () {

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -432,5 +432,6 @@ module.exports = {
     configUtils: require('./configUtils'),
     dbUtils: require('./db-utils'),
     urlUtils: require('./urlUtils'),
+    sleep: require('./sleep'),
     resetRateLimits
 };

--- a/ghost/core/test/utils/sleep.js
+++ b/ghost/core/test/utils/sleep.js
@@ -1,0 +1,15 @@
+/**
+ * Adds artificial "sleep" time that can be awaited
+ * In most cases where this module is used we are awaiting
+ * for the async event processing to trigger/finish
+ * 
+ * Can probably be substituted by timerPromises in the future
+ * ref.: https://nodejs.org/dist/latest-v18.x/docs/api/timers.html#timerspromisessettimeoutdelay-value-options
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+module.exports = ms => (
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    })
+);


### PR DESCRIPTION
no issue

- The sleep method has been used in 8 modules reimplementing the same thing over and over again. It's usually a sign of async event processing outside of the request/response loop. It's good to have a single point of implementation for a "hack" like this, so we could track it easier and address the even processing delay in a more optimal way centrally if it ever becomes a bottleneck