### PR TITLE
🐛 Fixed setting delivered_at to null after hard bounce

### DIFF
--- a/ghost/email-service/lib/email-event-storage.js
+++ b/ghost/email-service/lib/email-event-storage.js
@@ -68,17 +68,17 @@ class EmailEventStorage {
 
     async handleDelivered(event) {
         // To properly handle events that are received out of order (this happens because of polling)
-        // we only can set an email recipient to delivered if they are not already marked as failed
-        // Why handle this her?  An email can be 'delivered' and later have a delayed bounce event. So we need to prevent that delivered_at is set again.
+        // only set if delivered_at is null
         await this.#db.knex('email_recipients')
             .where('id', '=', event.emailRecipientId)
-            .whereNull('failed_at')
             .update({
                 delivered_at: this.#db.knex.raw('COALESCE(delivered_at, ?)', [moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss')])
             });
     }
 
     async handleOpened(event) {
+        // To properly handle events that are received out of order (this happens because of polling)
+        // only set if opened_at is null
         await this.#db.knex('email_recipients')
             .where('id', '=', event.emailRecipientId)
             .update({
@@ -87,11 +87,12 @@ class EmailEventStorage {
     }
 
     async handlePermanentFailed(event) {
+        // To properly handle events that are received out of order (this happens because of polling)
+        // only set if failed_at is null
         await this.#db.knex('email_recipients')
             .where('id', '=', event.emailRecipientId)
             .update({
-                failed_at: this.#db.knex.raw('COALESCE(failed_at, ?)', [moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss')]),
-                delivered_at: null // Reset in case we have a delayed bounce event
+                failed_at: this.#db.knex.raw('COALESCE(failed_at, ?)', [moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss')])
             });
         await this.saveFailure('permanent', event);
     }

--- a/ghost/email-service/test/email-event-storage.test.js
+++ b/ghost/email-service/test/email-event-storage.test.js
@@ -128,7 +128,6 @@ describe('Email event storage', function () {
         await waitPromise;
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(db.update.firstCall.args[0].delivered_at === null);
         assert(existing.save.calledOnce);
     });
 
@@ -174,7 +173,6 @@ describe('Email event storage', function () {
         await waitPromise;
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(db.update.firstCall.args[0].delivered_at === null);
         assert(EmailRecipientFailure.add.calledOnce);
     });
 
@@ -231,7 +229,6 @@ describe('Email event storage', function () {
         await waitPromise;
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].failed_at);
-        assert(db.update.firstCall.args[0].delivered_at === null);
         assert(EmailRecipientFailure.findOne.called);
         assert(!existing.save.called);
     });


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1670075366333929?thread_ts=1669963540.980309&cid=C02G9E68C

When we receive a permanent bounce/failure, we set delivered_at to null. But we don't want to lose this information.

Instead we should be able to handle recipients that both have failed_at and delivered_at set.