### PR TITLE
🐛 Fixed errors of old events from deleted members

### DIFF
--- a/ghost/email-service/package.json
+++ b/ghost/email-service/package.json
@@ -34,6 +34,7 @@
     "@tryghost/color-utils": "0.1.21",
     "@tryghost/html-to-plaintext": "0.0.0",
     "juice": "8.1.0",
-    "cheerio": "0.22.0"
+    "cheerio": "0.22.0",
+    "@tryghost/logging": "2.3.2"
   }
 }

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -431,7 +431,7 @@ module.exports = class MemberRepository {
         if (requiredRelations.length > 0) {
             initialMember = await this._Member.findOne({
                 id: options.id
-            }, {...sharedOptions, withRelated: requiredRelations});
+            }, {...sharedOptions, withRelated: requiredRelations, require: false});
 
             // Make sure we throw the right error if it doesn't exist
             if (!initialMember) {
@@ -729,7 +729,7 @@ module.exports = class MemberRepository {
                     filter: `newsletter_id:${data.newsletter}+member_id:[${membersArr}]`
                 });
                 const toUnsubscribe = unsubscribeRows.map(row => row.id);
-                
+
                 return await this._MemberNewsletter.bulkDestroy(toUnsubscribe);
             }
             if (!hasNewsletterSelected) {

--- a/ghost/members-events-service/lib/last-seen-at-updater.js
+++ b/ghost/members-events-service/lib/last-seen-at-updater.js
@@ -37,7 +37,7 @@ class LastSeenAtUpdater {
             try {
                 await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
             } catch (err) {
-                logging.error('Error in LastSeenAtUpdater.MemberPageViewEvent listener');
+                logging.error(`Error in LastSeenAtUpdater.MemberPageViewEvent listener for member ${event.data.memberId}`);
                 logging.error(err);
             }
         });
@@ -46,7 +46,7 @@ class LastSeenAtUpdater {
             try {
                 await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
             } catch (err) {
-                logging.error('Error in LastSeenAtUpdater.MemberLinkClickEvent listener');
+                logging.error(`Error in LastSeenAtUpdater.MemberLinkClickEvent listener for member ${event.data.memberId}`);
                 logging.error(err);
             }
         });
@@ -55,7 +55,7 @@ class LastSeenAtUpdater {
             try {
                 await this.updateLastCommentedAt(event.data.memberId, event.timestamp);
             } catch (err) {
-                logging.error('Error in LastSeenAtUpdater.MemberCommentEvent listener');
+                logging.error(`Error in LastSeenAtUpdater.MemberCommentEvent listener for member ${event.data.memberId}`);
                 logging.error(err);
             }
         });
@@ -64,7 +64,7 @@ class LastSeenAtUpdater {
             try {
                 await this.updateLastSeenAtWithoutKnownLastSeen(event.memberId, event.timestamp);
             } catch (err) {
-                logging.error('Error in LastSeenAtUpdater.EmailOpenedEvent listener');
+                logging.error(`Error in LastSeenAtUpdater.EmailOpenedEvent listener for member ${event.memberId}, emailRecipientId ${event.emailRecipientId}`);
                 logging.error(err);
             }
         });

--- a/ghost/members-events-service/lib/last-seen-at-updater.js
+++ b/ghost/members-events-service/lib/last-seen-at-updater.js
@@ -2,6 +2,7 @@ const {MemberPageViewEvent, MemberCommentEvent, MemberLinkClickEvent} = require(
 const moment = require('moment-timezone');
 const {IncorrectUsageError} = require('@tryghost/errors');
 const {EmailOpenedEvent} = require('@tryghost/email-events');
+const logging = require('@tryghost/logging');
 
 /**
  * Listen for `MemberViewEvent` to update the `member.last_seen_at` timestamp
@@ -33,19 +34,39 @@ class LastSeenAtUpdater {
      */
     subscribe(domainEvents) {
         domainEvents.subscribe(MemberPageViewEvent, async (event) => {
-            await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
+            try {
+                await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
+            } catch (err) {
+                logging.error('Error in LastSeenAtUpdater.MemberPageViewEvent listener');
+                logging.error(err);
+            }
         });
 
         domainEvents.subscribe(MemberLinkClickEvent, async (event) => {
-            await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
+            try {
+                await this.updateLastSeenAt(event.data.memberId, event.data.memberLastSeenAt, event.timestamp);
+            } catch (err) {
+                logging.error('Error in LastSeenAtUpdater.MemberLinkClickEvent listener');
+                logging.error(err);
+            }
         });
 
         domainEvents.subscribe(MemberCommentEvent, async (event) => {
-            await this.updateLastCommentedAt(event.data.memberId, event.timestamp);
+            try {
+                await this.updateLastCommentedAt(event.data.memberId, event.timestamp);
+            } catch (err) {
+                logging.error('Error in LastSeenAtUpdater.MemberCommentEvent listener');
+                logging.error(err);
+            }
         });
 
         domainEvents.subscribe(EmailOpenedEvent, async (event) => {
-            await this.updateLastSeenAtWithoutKnownLastSeen(event.memberId, event.timestamp);
+            try {
+                await this.updateLastSeenAtWithoutKnownLastSeen(event.memberId, event.timestamp);
+            } catch (err) {
+                logging.error('Error in LastSeenAtUpdater.EmailOpenedEvent listener');
+                logging.error(err);
+            }
         });
     }
 
@@ -61,8 +82,10 @@ class LastSeenAtUpdater {
         // Fetch manually
         const membersApi = this._getMembersApi();
         const member = await membersApi.members.get({id: memberId}, {require: true});
-        const memberLastSeenAt = member.get('last_seen_at');
-        await this.updateLastSeenAt(memberId, memberLastSeenAt, timestamp);
+        if (member) {
+            const memberLastSeenAt = member.get('last_seen_at');
+            await this.updateLastSeenAt(memberId, memberLastSeenAt, timestamp);
+        }
     }
 
     /**

--- a/ghost/members-events-service/package.json
+++ b/ghost/members-events-service/package.json
@@ -26,6 +26,7 @@
     "@tryghost/domain-events": "0.0.0",
     "@tryghost/errors": "1.2.18",
     "@tryghost/member-events": "0.0.0",
-    "moment-timezone": "0.5.34"
+    "moment-timezone": "0.5.34",
+    "@tryghost/logging": "2.3.2"
   }
 }


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1670215917451249

When a member is deleted, and we receive an opened event for an email to that member. We threw an uncaught Bookshelf EmptyResponse error.

- This change makes fetching the member not a requirement when handling that event in the last seen at updater.
- It also adds try catches for all event listeners in the last seen at updater