### PR TITLE
Added a timeout to the get helper

### DIFF
--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -58,11 +58,7 @@
         },
         "transports": [
             "stdout"
-        ],
-        "slowHelper": {
-            "level": "warn",
-            "threshold": 200
-        }
+        ]
     },
     "spam": {
         "user_login": {
@@ -143,6 +139,18 @@
         },
         "commentsCountAPI": {
             "maxAge": 0
+        }
+    },
+    "optimization": {
+        "getHelper": {
+            "timeout": {
+                "threshold": 5000,
+                "level": "error"
+            },
+            "notify": {
+                "threshold": 200,
+                "level": "warn"
+            }
         }
     },
     "imageOptimization": {


### PR DESCRIPTION
- The get helper can sometimes take a long time, and in themes that have many get helpers, the request can take far too long to respond
- This adds a timeout to the get helper, so that the page render doesn't block forever
- This won't abort the request to the DB, but instead just means the page will render sooner, and without the get block

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

Also, if you'd be interested in writing code like this for us more regularly, we're hiring:
https://careers.ghost.org
