### PR TITLE
Fixed unnecessary identity requests and 403s for non-Owner accounts

### DIFF
--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -68,7 +68,7 @@ export default class GhBillingIframe extends Component {
 
         const ghostIdentityUrl = this.ghostPaths.url.api('identities');
         this.ajax.request(ghostIdentityUrl).then((response) => {
-            const token = response && response.identities && response.identities[0] && response.identities[0].token;
+            const token = response?.identities?.[0]?.token;
             this.billing.getBillingIframe().contentWindow.postMessage({
                 request: 'token',
                 response: token
@@ -76,7 +76,7 @@ export default class GhBillingIframe extends Component {
 
             this.isOwner = true;
         }).catch((error) => {
-            if (error.payload?.errors && error.payload.errors[0]?.type === 'NoPermissionError') {
+            if (error.payload?.errors?.[0]?.type === 'NoPermissionError') {
                 handleNoPermission();
             } else {
                 throw error;

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -6,15 +6,15 @@ import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
 export default class GhBillingIframe extends Component {
+    @service ajax;
     @service billing;
     @service ghostPaths;
-    @service ajax;
     @service notifications;
+    @service session;
 
     @inject config;
 
     @tracked isOwner = null;
-    @tracked fetchingSubscription = false;
 
     willDestroy() {
         super.willDestroy(...arguments);
@@ -50,12 +50,25 @@ export default class GhBillingIframe extends Component {
     }
 
     _handleTokenRequest() {
-        this.fetchingSubscription = false;
-        let token;
-        const ghostIdentityUrl = this.ghostPaths.url.api('identities');
+        function handleNoPermission() {
+            // no permission means the current user requesting the token is not the owner of the site.
+            this.isOwner = false;
 
+            // Avoid letting the BMA waiting for a message and send an empty token response instead
+            this.billing.getBillingIframe().contentWindow.postMessage({
+                request: 'token',
+                response: null
+            }, '*');
+        }
+
+        if (!this.session.user?.isOwner) {
+            handleNoPermission();
+            return;
+        }
+
+        const ghostIdentityUrl = this.ghostPaths.url.api('identities');
         this.ajax.request(ghostIdentityUrl).then((response) => {
-            token = response && response.identities && response.identities[0] && response.identities[0].token;
+            const token = response && response.identities && response.identities[0] && response.identities[0].token;
             this.billing.getBillingIframe().contentWindow.postMessage({
                 request: 'token',
                 response: token
@@ -64,28 +77,11 @@ export default class GhBillingIframe extends Component {
             this.isOwner = true;
         }).catch((error) => {
             if (error.payload?.errors && error.payload.errors[0]?.type === 'NoPermissionError') {
-                // no permission means the current user requesting the token is not the owner of the site.
-                this.isOwner = false;
-
-                // Avoid letting the BMA waiting for a message and send an empty token response instead
-                this.billing.getBillingIframe().contentWindow.postMessage({
-                    request: 'token',
-                    response: null
-                }, '*');
+                handleNoPermission();
             } else {
                 throw error;
             }
         });
-
-        // NOTE: the handler is placed here to avoid additional logic to check if iframe has loaded
-        //       receiving a 'token' request is an indication that page is ready
-        if (!this.fetchingSubscription && !this.billing.subscription && token) {
-            this.fetchingSubscription = true;
-            this.billing.getBillingIframe().contentWindow.postMessage({
-                query: 'getSubscription',
-                response: 'subscription'
-            }, '*');
-        }
     }
 
     _handleForceUpgradeRequest() {

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -50,7 +50,7 @@ export default class GhBillingIframe extends Component {
     }
 
     _handleTokenRequest() {
-        function handleNoPermission() {
+        const handleNoPermission = () => {
             // no permission means the current user requesting the token is not the owner of the site.
             this.isOwner = false;
 
@@ -59,9 +59,9 @@ export default class GhBillingIframe extends Component {
                 request: 'token',
                 response: null
             }, '*');
-        }
+        };
 
-        if (!this.session.user?.isOwner) {
+        if (!this.session.user?.isOwnerOnly) {
             handleNoPermission();
             return;
         }


### PR DESCRIPTION
no issue

`<GhBillingIframe>` generates a request to the `/identities/` endpoint every time Admin is accessed for all users, however that endpoint is only accessible to users with the Owner role meaning we have a lot of unnecessary 403 errors in event logs and the developer console.

- added early exit when we know the logged in user doesn't have the Owner role
- removed the subscription fetching code that wasn't reachable (`token` was always `undefined`)
  - the BMA sends subscription data as soon as it's available so the extra fetch isn't necessary
