### PR TITLE
Unsubscribe members with suppressed emails

### DIFF
--- a/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
+++ b/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
@@ -1,4 +1,4 @@
-const {AbstractEmailSuppressionList, EmailSuppressionData} = require('@tryghost/email-suppression-list');
+const {AbstractEmailSuppressionList, EmailSuppressionData, EmailSuppressedEvent} = require('@tryghost/email-suppression-list');
 const {SpamComplaintEvent, EmailBouncedEvent} = require('@tryghost/email-events');
 const DomainEvents = require('@tryghost/domain-events');
 const logging = require('@tryghost/logging');
@@ -103,6 +103,11 @@ class MailgunEmailSuppressionList extends AbstractEmailSuppressionList {
                     reason: 'bounce',
                     created_at: event.timestamp
                 });
+                DomainEvents.dispatch(EmailSuppressedEvent.create({
+                    emailAddress: event.email,
+                    emailId: event.emailId,
+                    reason: reason
+                }, event.timestamp));
             } catch (err) {
                 if (err.code !== 'ER_DUP_ENTRY') {
                     logging.error(err);

--- a/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
+++ b/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
@@ -95,12 +95,12 @@ class MailgunEmailSuppressionList extends AbstractEmailSuppressionList {
     }
 
     async init() {
-        const handleEvent = async (event) => {
+        const handleEvent = reason => async (event) => {
             try {
                 await this.Suppression.add({
                     email_address: event.email,
                     email_id: event.emailId,
-                    reason: 'bounce',
+                    reason: reason,
                     created_at: event.timestamp
                 });
                 DomainEvents.dispatch(EmailSuppressedEvent.create({
@@ -114,8 +114,8 @@ class MailgunEmailSuppressionList extends AbstractEmailSuppressionList {
                 }
             }
         };
-        DomainEvents.subscribe(EmailBouncedEvent, handleEvent);
-        DomainEvents.subscribe(SpamComplaintEvent, handleEvent);
+        DomainEvents.subscribe(EmailBouncedEvent, handleEvent('bounce'));
+        DomainEvents.subscribe(SpamComplaintEvent, handleEvent('spam'));
     }
 }
 

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -741,8 +741,9 @@ describe('EmailEventStorage', function () {
         );
 
         // Check not unsubscribed
-        const {body: {events: [notSpamEvent]}} = await agent.get(eventsURI);
-        assert.notEqual(notSpamEvent.type, 'email_complaint_event', 'This test requires a member that does not have a spam event');
+        const {body: {events: eventsBefore}} = await agent.get(eventsURI);
+        const existingSpamEvent = eventsBefore.find(event => event.type === 'email_complaint_event');
+        assert.equal(existingSpamEvent, null, 'This test requires a member that does not have a spam event');
 
         events = [{
             event: 'complained',
@@ -772,7 +773,8 @@ describe('EmailEventStorage', function () {
         await sleep(200);
 
         // Check if event exists
-        const {body: {events: [spamComplaintEvent]}} = await agent.get(eventsURI);
+        const {body: {events: eventsAfter}} = await agent.get(eventsURI);
+        const spamComplaintEvent = eventsAfter.find(event => event.type === 'email_complaint_event');
         assert.equal(spamComplaintEvent.type, 'email_complaint_event');
     });
 

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -1,14 +1,11 @@
 const sinon = require('sinon');
 const {agentProvider, fixtureManager, sleep} = require('../../../utils/e2e-framework');
 const assert = require('assert');
-const models = require('../../../../core/server/models');
 const domainEvents = require('@tryghost/domain-events');
 const MailgunClient = require('@tryghost/mailgun-client');
-const {run} = require('../../../../core/server/services/email-analytics/jobs/fetch-latest/run.js');
-const membersService = require('../../../../core/server/services/members');
 const {EmailDeliveredEvent} = require('@tryghost/email-events');
 
-async function resetFailures(emailId) {
+async function resetFailures(models, emailId) {
     await models.EmailRecipientFailure.destroy({
         destroyBy: {
             email_id: emailId
@@ -22,13 +19,19 @@ describe('EmailEventStorage', function () {
     let agent;
     let events = [];
     let jobsService;
+    let models;
+    let run;
+    let membersService;
 
     before(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('newsletters', 'members:newsletters', 'members:emails');
         await agent.loginAsOwner();
 
-        // Only create reference to jobsService after Ghost boot
+        // Only reference services after Ghost boot
+        models = require('../../../../core/server/models');
+        run = require('../../../../core/server/services/email-analytics/jobs/fetch-latest/run.js').run;
+        membersService = require('../../../../core/server/services/members');
         jobsService = require('../../../../core/server/services/jobs');
 
         sinon.stub(MailgunClient.prototype, 'fetchEvents').callsFake(async function (_, batchHandler) {
@@ -405,7 +408,7 @@ describe('EmailEventStorage', function () {
         await models.EmailRecipient.edit({failed_at: null}, {
             id: emailRecipient.id
         });
-        await resetFailures(emailId);
+        await resetFailures(models, emailId);
 
         events = [{
             event: 'failed',

--- a/ghost/email-suppression-list/lib/email-suppression-list.js
+++ b/ghost/email-suppression-list/lib/email-suppression-list.js
@@ -84,7 +84,41 @@ class AbstractEmailSuppressionList {
     }
 }
 
+class EmailSuppressedEvent {
+    /**
+     * @readonly
+     * @type {{emailId: string, emailAddress: string, reason: string}}
+     */
+    data;
+
+    /**
+     * @readonly
+     * @type {Date}
+     */
+    timestamp;
+
+    /**
+     * @private
+     */
+    constructor({emailAddress, emailId, reason, timestamp}) {
+        this.data = {
+            emailAddress,
+            emailId,
+            reason
+        };
+        this.timestamp = timestamp;
+    }
+
+    static create(data, timestamp) {
+        return new EmailSuppressedEvent({
+            ...data,
+            timestamp: timestamp || new Date
+        });
+    }
+}
+
 module.exports = {
     AbstractEmailSuppressionList,
-    EmailSuppressionData
+    EmailSuppressionData,
+    EmailSuppressedEvent
 };

--- a/ghost/email-suppression-list/test/lib/email-suppression-list.test.js
+++ b/ghost/email-suppression-list/test/lib/email-suppression-list.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const {EmailSuppressionData} = require('../../lib/email-suppression-list');
+const {EmailSuppressionData, EmailSuppressedEvent} = require('../../lib/email-suppression-list');
 
 describe('EmailSuppressionData', function () {
     it('Has null info when not suppressed', function () {
@@ -12,7 +12,7 @@ describe('EmailSuppressionData', function () {
         assert(data.suppressed === false);
         assert(data.info === null);
     });
-    it('', function () {
+    it('Has info when suppressed', function () {
         const now = new Date();
         const data = new EmailSuppressionData(true, {
             reason: 'spam',
@@ -22,5 +22,17 @@ describe('EmailSuppressionData', function () {
         assert(data.suppressed === true);
         assert(data.info.reason === 'spam');
         assert(data.info.timestamp === now);
+    });
+});
+
+describe('EmailSuppressedEvent', function () {
+    it('Exposes a create factory method', function () {
+        const event = EmailSuppressedEvent.create({
+            emailAddress: 'test@test.com',
+            emailId: '1234567890abcdef',
+            reason: 'spam'
+        });
+        assert(event instanceof EmailSuppressedEvent);
+        assert(event.timestamp);
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2367

This ensures that a Member is not considered subscribed to any emails, so that
counts for newsletter recipients are correct. Eventually we will filter members
on their email suppression status but this is not implemented yet.

refs https://github.com/TryGhost/Team/issues/2351

We were storing all suppressions with a reason of bounced, rather than
spam for spam complaint events.