### PR TITLE
🐛 Fixed broken redemption count for offers

### DIFF
--- a/ghost/members-api/lib/controllers/router.js
+++ b/ghost/members-api/lib/controllers/router.js
@@ -186,6 +186,9 @@ module.exports = class RouterController {
             offer = await this._offersAPI.getOffer({id: offerId});
             tier = await this._tiersService.api.read(offer.tier.id);
             cadence = offer.cadence;
+            // Attach offer information to stripe metadata for free trial offers
+            // free trial offers don't have associated stripe coupons
+            metadata.offer = offer.id;
         } else {
             offer = null;
             tier = await this._tiersService.api.read(tierId);

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -914,13 +914,6 @@ module.exports = class MemberRepository {
             }
         } else if (offerId) {
             offer = await this._offerRepository.getById(offerId, {transacting: options.transacting});
-            if (offer) {
-                offerId = offer.id;
-            } else {
-                // Reset offer id to null as it is not valid
-                offerId = null;
-                logging.error(`Received an unknown offer id (${offerId}) for subscription - ${subscription.id}.`);
-            }
         }
 
         const subscriptionData = {

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -914,6 +914,13 @@ module.exports = class MemberRepository {
             }
         } else if (offerId) {
             offer = await this._offerRepository.getById(offerId, {transacting: options.transacting});
+            if (offer) {
+                offerId = offer.id;
+            } else {
+                // Reset offer id to null as it is not valid
+                offerId = null;
+                logging.error(`Received an unknown offer id (${offerId}) for subscription - ${subscription.id}.`);
+            }
         }
 
         const subscriptionData = {
@@ -1033,7 +1040,7 @@ module.exports = class MemberRepository {
                 tierId: ghostProduct?.get('id'),
                 memberId: member.id,
                 subscriptionId: subscriptionModel.get('id'),
-                offerId: data.offerId,
+                offerId: offerId,
                 attribution: data.attribution,
                 batchId: options.batch_id
             });

--- a/ghost/members-api/test/unit/lib/controllers/router.test.js
+++ b/ghost/members-api/test/unit/lib/controllers/router.test.js
@@ -1,0 +1,93 @@
+const sinon = require('sinon');
+const RouterController = require('../../../../lib/controllers/router');
+
+describe('RouterController', function () {
+    describe('createCheckoutSession', function (){
+        let offersAPI;
+        let paymentsService;
+        let tiersService;
+        let stripeAPIService;
+        let labsService;
+        let getPaymentLinkSpy;
+
+        beforeEach(async function () {
+            getPaymentLinkSpy = sinon.spy();
+
+            tiersService = {
+                api: {
+                    read: sinon.stub().resolves({
+                        id: 'tier_123'
+                    })
+                }
+            };
+
+            paymentsService = {
+                getPaymentLink: getPaymentLinkSpy
+            };
+
+            offersAPI = {
+                getOffer: sinon.stub().resolves({
+                    id: 'offer_123',
+                    tier: {
+                        id: 'tier_123'
+                    }
+                }),
+                findOne: sinon.stub().resolves({
+                    related: () => {
+                        return {
+                            query: sinon.stub().returns({
+                                fetchOne: sinon.stub().resolves({})
+                            }),
+                            toJSON: sinon.stub().returns([]),
+                            fetch: sinon.stub().resolves({
+                                toJSON: sinon.stub().returns({})
+                            })
+                        };
+                    },
+                    toJSON: sinon.stub().returns({})
+                }),
+                edit: sinon.stub().resolves({
+                    attributes: {},
+                    _previousAttributes: {}
+                })
+            };
+
+            stripeAPIService = {
+                configured: true
+            };
+            labsService = {
+                isSet: sinon.stub().returns(true)
+            };
+        });
+
+        it('passes offer metadata to payment link method', async function (){
+            const routerController = new RouterController({
+                tiersService,
+                paymentsService,
+                offersAPI,
+                stripeAPIService,
+                labsService
+            });
+
+            await routerController.createCheckoutSession({
+                body: {
+                    offerId: 'offer_123'
+                }
+            }, {
+                writeHead: () => {},
+                end: () => {}
+            });
+
+            getPaymentLinkSpy.calledOnce.should.be.true();
+
+            // Payment link is called with the offer id in metadata
+            getPaymentLinkSpy.calledWith(sinon.match({
+                metadata: {offer: 'offer_123'}
+            })).should.be.true();
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2369

- offer id was not getting attached to stripe checkout metadata, causing the checkout event to not store any offer information for a subscription. This got changed in a prev refactor [here](https://github.com/TryGhost/Ghost/commit/25d8d694a051781e9f45e3542b75143462c69ec4#diff-b7dfcd660902a2a20dff7da5e886d8e10234bda4ba78228255afc8d4a8e78cf6L206)
- cleans up offer id handling for checkout session event