### PR TITLE
Added post scheduling Playwright test and loosened time restrictions

### DIFF
--- a/ghost/admin/app/utils/publish-options.js
+++ b/ghost/admin/app/utils/publish-options.js
@@ -47,7 +47,11 @@ export default class PublishOptions {
     @tracked scheduledAtUTC = this.minScheduledAt;
 
     get minScheduledAt() {
-        return moment.utc().add(5, 'minutes').milliseconds(0);
+        return moment.utc().add(5, 'seconds').milliseconds(0);
+    }
+
+    get defaultScheduledAt() {
+        return moment.utc().add(10, 'minutes').milliseconds(0);
     }
 
     @action
@@ -58,8 +62,8 @@ export default class PublishOptions {
 
         this.isScheduled = shouldSchedule;
 
-        if (shouldSchedule && (!this.scheduledAtUTC || this.scheduledAtUTC.isBefore(this.minScheduledAt))) {
-            this.scheduledAtUTC = this.minScheduledAt;
+        if (shouldSchedule && (!this.scheduledAtUTC || this.scheduledAtUTC.isBefore(this.defaultScheduledAt))) {
+            this.scheduledAtUTC = this.defaultScheduledAt;
         }
     }
 

--- a/ghost/admin/app/validators/post.js
+++ b/ghost/admin/app/validators/post.js
@@ -193,7 +193,7 @@ export default BaseValidator.create({
                 model.errors.add('publishedAtBlogDate', 'Must be in the past');
                 this.invalidate();
 
-            // scheduled must be at least 2 mins in the future when first scheduling
+            // scheduled must be in the future when first scheduling
             } else if ((model.changedAttributes().status || model.changedAttributes().publishedAtUTC) && status === 'scheduled' && !isInFuture) {
                 model.errors.add('publishedAtBlogDate', 'Must be in the future');
                 this.invalidate();

--- a/ghost/admin/app/validators/post.js
+++ b/ghost/admin/app/validators/post.js
@@ -186,7 +186,7 @@ export default BaseValidator.create({
             let status = model.statusScratch || model.status;
             let now = moment();
             let publishedAtBlogTZ = model.publishedAtBlogTZ;
-            let isInFuture = publishedAtBlogTZ.isSameOrAfter(now.add(2, 'minutes'));
+            let isInFuture = publishedAtBlogTZ.isSameOrAfter(now);
 
             // draft/published must be in past
             if ((status === 'draft' || status === 'published') && publishedAtBlogTZ.isSameOrAfter(now)) {
@@ -195,7 +195,7 @@ export default BaseValidator.create({
 
             // scheduled must be at least 2 mins in the future when first scheduling
             } else if ((model.changedAttributes().status || model.changedAttributes().publishedAtUTC) && status === 'scheduled' && !isInFuture) {
-                model.errors.add('publishedAtBlogDate', 'Must be at least 2 mins in the future');
+                model.errors.add('publishedAtBlogDate', 'Must be in the future');
                 this.invalidate();
             }
         }

--- a/ghost/admin/tests/acceptance/editor/publish-flow-test.js
+++ b/ghost/admin/tests/acceptance/editor/publish-flow-test.js
@@ -259,7 +259,7 @@ describe('Acceptance: Publish flow', function () {
                 .text('Right now');
 
             const siteTz = this.server.db.settings.findBy({key: 'timezone'}).value;
-            const plus5 = moment().tz(siteTz).add(5, 'minutes').set({});
+            const plus10 = moment().tz(siteTz).add(10, 'minutes').set({});
 
             await click('[data-test-setting="publish-at"] [data-test-setting-title]');
             await click('[data-test-radio="schedule"]');
@@ -267,11 +267,11 @@ describe('Acceptance: Publish flow', function () {
             // date + time inputs are shown, defaults to now+5 mins
             expect(find('[data-test-setting="publish-at"] [data-test-date-time-picker-datepicker]'), 'datepicker').to.exist;
             expect(find('[data-test-setting="publish-at"] [data-test-date-time-picker-date-input]'), 'initial datepicker value')
-                .to.have.value(plus5.format('YYYY-MM-DD'));
+                .to.have.value(plus10.format('YYYY-MM-DD'));
 
             expect(find('[data-test-setting="publish-at"] [data-test-date-time-picker-time-input]'), 'time input').to.exist;
             expect(find('[data-test-setting="publish-at"] [data-test-date-time-picker-time-input]'), 'initial time input value')
-                .to.have.value(plus5.format('HH:mm'));
+                .to.have.value(plus10.format('HH:mm'));
 
             // can set a new date and time
             const newDate = moment().tz(siteTz).add(4, 'days').add(5, 'hours').set('second', 0);

--- a/ghost/core/core/shared/config/overrides.json
+++ b/ghost/core/core/shared/config/overrides.json
@@ -70,8 +70,8 @@
         }
     },
     "times": {
-        "cannotScheduleAPostBeforeInMinutes": 2,
-        "publishAPostBySchedulerToleranceInMinutes": 2,
+        "cannotScheduleAPostBeforeInMinutes": -2,
+        "publishAPostBySchedulerToleranceInMinutes": 5,
         "getImageSizeTimeoutInMS": 5000
     },
     "maintenance": {

--- a/ghost/core/test/regression/models/model_posts.test.js
+++ b/ghost/core/test/regression/models/model_posts.test.js
@@ -943,10 +943,10 @@ describe('Post Model', function () {
                 });
             });
 
-            it('add scheduled post with published_at not in future-> we expect an error', function (done) {
+            it('add scheduled post with published_at more than 2 minutes in the past -> we expect an error', function (done) {
                 models.Post.add({
                     status: 'scheduled',
-                    published_at: moment().subtract(1, 'minute'),
+                    published_at: moment().subtract(3, 'minute'),
                     title: 'scheduled 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
                 }, context).catch(function (err) {
@@ -957,17 +957,19 @@ describe('Post Model', function () {
                 });
             });
 
-            it('add scheduled post with published_at 1 minutes in future -> we expect an error', function (done) {
-                models.Post.add({
+            it('add scheduled post with published_at 1 minutes in past -> we expect success', async function () {
+                const post = await models.Post.add({
                     status: 'scheduled',
                     published_at: moment().add(1, 'minute'),
                     title: 'scheduled 1',
                     mobiledoc: markdownToMobiledoc('This is some content')
-                }, context).catch(function (err) {
-                    (err instanceof errors.ValidationError).should.eql(true);
-                    Object.keys(eventsTriggered).length.should.eql(0);
-                    done();
-                });
+                }, context);
+                should.exist(post);
+
+                Object.keys(eventsTriggered).length.should.eql(3);
+                should.exist(eventsTriggered['post.added']);
+                should.exist(eventsTriggered['post.scheduled']);
+                should.exist(eventsTriggered['user.attached']);
             });
 
             it('add scheduled post with published_at 10 minutes in future -> we expect success', function (done) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2371

- Adds a test that schedules a post 5 seconds in the future and waits for it to be published
- Reduced the time restrictions for scheduling: 
    - The minimum time in the frontend is now 5 seconds in the future (came from 5 minutes in the future) 
    - The time picker now suggests 10 minutes in the future instead of the minimum scheduling time (came from 5 minutes) 
    - In the backend, a post will be allowed to be scheduled if it is at least 2 minutes in the past (came from 2 minutes in the future) 
    - The scheduler will publish a post if it is at least 5 minutes in the past, and maximum 5 minutes in the future (came from 2 minutes)
