### PR TITLE
Added playwright test for paid member plan switch on Portal

### DIFF
--- a/ghost/portal/src/components/common/ActionButton.js
+++ b/ghost/portal/src/components/common/ActionButton.js
@@ -88,7 +88,11 @@ const Styles = ({brandColor, retry, disabled, style = {}, isPrimary}) => {
     };
 };
 
-function ActionButton({label, type = undefined, onClick, disabled = false, retry = false, brandColor, isRunning, isPrimary = true, isDestructive = false, classes = '', style = {}, tabindex = undefined}) {
+function ActionButton({
+    label, onClick, disabled = false, retry = false,
+    brandColor, isRunning, isPrimary = true, isDestructive = false, classes = '',
+    style = {}, tabindex = undefined, dataTestId
+}) {
     let Style = Styles({disabled, retry, brandColor, style, isPrimary});
 
     let className = 'gh-portal-btn';
@@ -106,7 +110,7 @@ function ActionButton({label, type = undefined, onClick, disabled = false, retry
     }
     const loaderClassName = isPrimary ? 'gh-portal-loadingicon' : 'gh-portal-loadingicon dark';
     return (
-        <button className={className} style={Style.button} onClick={e => onClick(e)} disabled={disabled} type='submit' tabIndex={tabindex}>
+        <button className={className} style={Style.button} onClick={e => onClick(e)} disabled={disabled} type='submit' tabIndex={tabindex} data-test-button={dataTestId}>
             {isRunning ? <LoaderIcon className={loaderClassName} /> : label}
         </button>
     );

--- a/ghost/portal/src/components/common/ProductsSection.js
+++ b/ghost/portal/src/components/common/ProductsSection.js
@@ -661,7 +661,7 @@ function FreeProductCard({products, handleChooseSignup}) {
             <div className={cardClass} onClick={(e) => {
                 e.stopPropagation();
                 setSelectedProduct('free');
-            }}>
+            }} data-test-tier="free">
                 <div className='gh-portal-product-card-header'>
                     <h4 className="gh-portal-product-name">{getFreeTierTitle({site})}</h4>
                     {(!hasOnlyFree ?
@@ -683,6 +683,7 @@ function FreeProductCard({products, handleChooseSignup}) {
                         <div className='gh-portal-btn-product'>
                             {}
                             <button
+                                data-test-button='select-tier'
                                 className='gh-portal-btn'
                                 disabled={disabled}
                                 onClick={(e) => {
@@ -738,7 +739,7 @@ function ProductCard({product, products, selectedInterval, handleChooseSignup}) 
             <div className={cardClass} key={product.id} onClick={(e) => {
                 e.stopPropagation();
                 setSelectedProduct(product.id);
-            }}>
+            }} data-test-tier="paid">
                 <div className='gh-portal-product-card-header'>
                     <h4 className="gh-portal-product-name">{product.name}</h4>
                     <ProductCardPrice product={product} />
@@ -752,6 +753,7 @@ function ProductCard({product, products, selectedInterval, handleChooseSignup}) 
                     </div>
                     <div className='gh-portal-btn-product'>
                         <button
+                            data-test-button='select-tier'
                             disabled={disabled}
                             className='gh-portal-btn'
                             onClick={(e) => {
@@ -815,12 +817,24 @@ function ProductPriceSwitch({products, selectedInterval, setSelectedInterval}) {
     return (
         <div className='gh-portal-logged-out-form-container'>
             <div className={'gh-portal-products-pricetoggle' + (selectedInterval === 'month' ? ' left' : '')}>
-                <button className={'gh-portal-btn' + (selectedInterval === 'month' ? ' active' : '')} onClick={(e) => {
-                    setSelectedInterval('month');
-                }}>Monthly</button>
-                <button className={'gh-portal-btn' + (selectedInterval === 'year' ? ' active' : '')} onClick={(e) => {
-                    setSelectedInterval('year');
-                }}>Yearly</button>
+                <button
+                    data-test-button='switch-monthly'
+                    className={'gh-portal-btn' + (selectedInterval === 'month' ? ' active' : '')}
+                    onClick={(e) => {
+                        setSelectedInterval('month');
+                    }}
+                >
+                    Monthly
+                </button>
+                <button
+                    data-test-button='switch-yearly'
+                    className={'gh-portal-btn' + (selectedInterval === 'year' ? ' active' : '')}
+                    onClick={(e) => {
+                        setSelectedInterval('year');
+                    }}
+                >
+                    Yearly
+                </button>
             </div>
         </div>
     );
@@ -1006,7 +1020,7 @@ function ChangeProductCard({product, onPlanSelect}) {
         <div className={cardClass + (currentPlan ? ' disabled' : '')} key={product.id} onClick={(e) => {
             e.stopPropagation();
             setSelectedProduct(product.id);
-        }}>
+        }} data-test-tier="paid">
             <div className='gh-portal-product-card-header'>
                 <h4 className="gh-portal-product-name">{product.name}</h4>
                 <ProductCardPrice product={product} />
@@ -1023,6 +1037,7 @@ function ChangeProductCard({product, onPlanSelect}) {
                     :
                     <div className='gh-portal-btn-product'>
                         <button
+                            data-test-button='select-tier'
                             className='gh-portal-btn'
                             onClick={() => {
                                 onPlanSelect(null, selectedPrice?.id);

--- a/ghost/portal/src/components/pages/AccountHomePage/components/PaidAccountActions.js
+++ b/ghost/portal/src/components/pages/AccountHomePage/components/PaidAccountActions.js
@@ -89,7 +89,12 @@ const PaidAccountActions = () => {
             return null;
         }
         return (
-            <button className='gh-portal-btn gh-portal-btn-list' onClick={e => openUpdatePlan(e)}>Change</button>
+            <button
+                className='gh-portal-btn gh-portal-btn-list' onClick={e => openUpdatePlan(e)}
+                data-test-button='change-plan'
+            >
+                Change
+            </button>
         );
     };
 
@@ -120,7 +125,13 @@ const PaidAccountActions = () => {
                     <h3>Billing info</h3>
                     <CardLabel defaultCardLast4={defaultCardLast4} />
                 </div>
-                <button className='gh-portal-btn gh-portal-btn-list' onClick={e => onEditBilling(e)}>{label}</button>
+                <button
+                    className='gh-portal-btn gh-portal-btn-list'
+                    onClick={e => onEditBilling(e)}
+                    data-test-button='update-billing'
+                >
+                    {label}
+                </button>
             </section>
         );
     };
@@ -193,4 +204,3 @@ function getOfferLabel({offer, price, subscriptionStartDate}) {
 }
 
 export default PaidAccountActions;
-

--- a/ghost/portal/src/components/pages/SigninPage.js
+++ b/ghost/portal/src/components/pages/SigninPage.js
@@ -84,6 +84,7 @@ export default class SigninPage extends React.Component {
         }
         return (
             <ActionButton
+                dataTestId='signin'
                 retry={retry}
                 style={{width: '100%'}}
                 onClick={e => this.handleSignin(e)}
@@ -100,7 +101,14 @@ export default class SigninPage extends React.Component {
         return (
             <div className='gh-portal-signup-message'>
                 <div>Don't have an account?</div>
-                <button className='gh-portal-btn gh-portal-btn-link' style={{color: brandColor}} onClick={() => this.context.onAction('switchPage', {page: 'signup'})}><span>Sign up</span></button>
+                <button
+                    data-test-button='signup-switch'
+                    className='gh-portal-btn gh-portal-btn-link'
+                    style={{color: brandColor}}
+                    onClick={() => this.context.onAction('switchPage', {page: 'signup'})}
+                >
+                    <span>Sign up</span>
+                </button>
             </div>
         );
     }

--- a/ghost/portal/src/components/pages/SignupPage.js
+++ b/ghost/portal/src/components/pages/SignupPage.js
@@ -473,6 +473,7 @@ class SignupPage extends React.Component {
                 <div className='gh-portal-signup-message'>
                     <div>Already a member?</div>
                     <button
+                        data-test-button='signin-switch'
                         className='gh-portal-btn gh-portal-btn-link'
                         style={{color: brandColor}}
                         onClick={() => onAction('switchPage', {page: 'signin'})}


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2371

- adds `data-test-*` attributes to portal across pages to allow easily capturing buttons/switches for playwright tests
- tests that a paid member can switch between monthly and yearly plans after logging in

