### PR TITLE
Mocked out Mailgun for browser-based tests

### DIFF
--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -82,6 +82,18 @@ const setupStripe = async (page, stripConnectIntegrationToken) => {
     await page.getByRole('button', {name: 'OK'}).click();
 };
 
+// Setup Mailgun with fake data, for Ghost Admin to allow bulk sending
+const setupMailgun = async (page) => {
+    await page.locator('.gh-nav a[href="#/settings/"]').click();
+    await page.locator('.gh-setting-group').filter({hasText: 'Email newsletter'}).click();
+    await page.locator('.gh-expandable-block').filter({hasText: 'Mailgun configuration'}).getByRole('button', {name: 'Expand'}).click();
+
+    await page.locator('[data-test-mailgun-domain-input]').fill('api.testgun.com');
+    await page.locator('[data-test-mailgun-api-key-input]').fill('Not an API key');
+    await page.locator('[data-test-button="save-members-settings"]').click();
+    await page.waitForSelector('[data-test-button="save-members-settings"] [data-test-task-button-state="success"]');
+};
+
 /**
  * Delete all members, 1 by 1, using the UI
  * @param {import('@playwright/test').Page} page
@@ -303,6 +315,7 @@ const createMember = async (page, {email, name, note, label = '', compedPlan}) =
 module.exports = {
     setupGhost,
     setupStripe,
+    setupMailgun,
     deleteAllMembers,
     createTier,
     createOffer,

--- a/ghost/core/test/e2e-browser/utils/global-setup.js
+++ b/ghost/core/test/e2e-browser/utils/global-setup.js
@@ -48,6 +48,13 @@ const generateStripeIntegrationToken = async () => {
     })).toString('base64');
 };
 
+const stubMailgun = () => {
+    const rewire = require('rewire');
+    const mockMailgunClient = require('../../utils/mocks/MailgunClientMock');
+    const bulkEmail = rewire('../../../core/server/services/bulk-email/bulk-email-processor');
+    bulkEmail.__set__('mailgunClient', mockMailgunClient);
+};
+
 /**
  * Setup the environment
  */
@@ -61,11 +68,13 @@ const setup = async (playwrightConfig) => {
 
         process.env.WEBHOOK_SECRET = await getWebhookSecret();
 
+        // Stub out NodeMailer
+        stubMailgun();
+
         await startGhost({
             frontend: true,
             server: true,
-            backend: true,
-            mockMailgun: true
+            backend: true
         });
     }
 

--- a/ghost/core/test/e2e-browser/utils/global-setup.js
+++ b/ghost/core/test/e2e-browser/utils/global-setup.js
@@ -2,7 +2,7 @@ const config = require('../../../core/shared/config');
 const {promisify} = require('util');
 const {spawn, exec} = require('child_process');
 const {knex} = require('../../../core/server/data/db');
-const {setupGhost, setupStripe} = require('./e2e-browser-utils');
+const {setupGhost, setupStripe, setupMailgun} = require('./e2e-browser-utils');
 const {chromium} = require('@playwright/test');
 const {startGhost} = require('../../utils/e2e-framework');
 const {stopGhost} = require('../../utils/e2e-utils');
@@ -77,6 +77,7 @@ const setup = async (playwrightConfig) => {
     await setupGhost(page);
     if (!usingRemoteServer) {
         await setupStripe(page, stripeConnectIntegrationToken);
+        await setupMailgun(page);
     }
     await page.context().storageState({path: storageState});
     await browser.close();

--- a/ghost/core/test/e2e-browser/utils/global-setup.js
+++ b/ghost/core/test/e2e-browser/utils/global-setup.js
@@ -64,7 +64,8 @@ const setup = async (playwrightConfig) => {
         await startGhost({
             frontend: true,
             server: true,
-            backend: true
+            backend: true,
+            mockMailgun: true
         });
     }
 

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -40,7 +40,6 @@ const supertest = require('supertest');
  * @param {Boolean} [options.backend] Boot the backend
  * @param {Boolean} [options.frontend] Boot the frontend
  * @param {Boolean} [options.server] Start a server
- * @param {Boolean} [options.mockMailgun] Mock mailgun client module
  * @returns {Promise<Express.Application>} ghost
  */
 const startGhost = async (options = {}) => {
@@ -57,20 +56,13 @@ const startGhost = async (options = {}) => {
     const defaults = {
         backend: true,
         frontend: false,
-        server: false,
-        mockMailgun: false
+        server: false
     };
 
     // Ensure the state of all data, including DB and caches
     await resetData();
 
     const bootOptions = Object.assign({}, defaults, options);
-    if (bootOptions.mockMailgun) {
-        const rewire = require('rewire');
-        const bulkEmail = rewire('../../core/server/services/bulk-email');
-        let mockMailgunClient = require('./mocks/MailgunClientMock');
-        bulkEmail.__set__('_mailgunClient', mockMailgunClient);
-    }
 
     const ghostServer = await boot(bootOptions);
 

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -40,6 +40,7 @@ const supertest = require('supertest');
  * @param {Boolean} [options.backend] Boot the backend
  * @param {Boolean} [options.frontend] Boot the frontend
  * @param {Boolean} [options.server] Start a server
+ * @param {Boolean} [options.mockMailgun] Mock mailgun client module
  * @returns {Promise<Express.Application>} ghost
  */
 const startGhost = async (options = {}) => {
@@ -56,13 +57,20 @@ const startGhost = async (options = {}) => {
     const defaults = {
         backend: true,
         frontend: false,
-        server: false
+        server: false,
+        mockMailgun: false
     };
 
     // Ensure the state of all data, including DB and caches
     await resetData();
 
     const bootOptions = Object.assign({}, defaults, options);
+    if (bootOptions.mockMailgun) {
+        const rewire = require('rewire');
+        const bulkEmail = rewire('../../core/server/services/bulk-email');
+        let mockMailgunClient = require('./mocks/MailgunClientMock');
+        bulkEmail.__set__('_mailgunClient', mockMailgunClient);
+    }
 
     const ghostServer = await boot(bootOptions);
 

--- a/ghost/core/test/utils/mocks/MailgunClientMock.js
+++ b/ghost/core/test/utils/mocks/MailgunClientMock.js
@@ -1,0 +1,27 @@
+const ObjectID = require('bson-objectid').default;
+
+class MockMailgunClient {
+    getInstance() {
+        return {};
+    }
+
+    /**
+     *
+     * @param {Promise<{id}>}
+     */
+    async send() {
+        return {
+            id: `mailgun-mock-id-${ObjectID().toHexString()}`
+        };
+    }
+
+    /**
+     * Act as if always configured on test environment
+     * @returns true
+     */
+    isConfigured() {
+        return true;
+    }
+}
+
+module.exports = new MockMailgunClient();

--- a/ghost/core/test/utils/mocks/MailgunClientMock.js
+++ b/ghost/core/test/utils/mocks/MailgunClientMock.js
@@ -7,7 +7,7 @@ class MockMailgunClient {
 
     /**
      *
-     * @param {Promise<{id}>}
+     * @returns {Promise<{id: string}>}
      */
     async send() {
         return {


### PR DESCRIPTION
Working minimal mock Mailgun, created so that tests which try to send emails succeed - even though no mail is sent or recorded.

TODO: Ensure this also works for transactional email, and record received emails to test against their content.