### PR TITLE
🐛 Fixed 'Invalid status code: undefined' in members api

### DIFF
--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -77,7 +77,10 @@ const deleteSession = async function (req, res) {
         res.writeHead(204);
         res.end();
     } catch (err) {
-        res.writeHead(err.statusCode, {
+        if (!err.statusCode) {
+            logging.error(err);
+        }
+        res.writeHead(err.statusCode ?? 500, {
             'Content-Type': 'text/plain;charset=UTF-8'
         });
         res.end(err.message);
@@ -105,7 +108,10 @@ const deleteSuppression = async function (req, res) {
         res.writeHead(204);
         res.end();
     } catch (err) {
-        res.writeHead(err.statusCode, {
+        if (!err.statusCode) {
+            logging.error(err);
+        }
+        res.writeHead(err.statusCode ?? 500, {
             'Content-Type': 'text/plain;charset=UTF-8'
         });
         res.end(err.message);
@@ -188,7 +194,10 @@ const updateMemberData = async function (req, res) {
             res.json(null);
         }
     } catch (err) {
-        res.writeHead(err.statusCode, {
+        if (!err.statusCode) {
+            logging.error(err);
+        }
+        res.writeHead(err.statusCode ?? 500, {
             'Content-Type': 'text/plain;charset=UTF-8'
         });
         res.end(err.message);


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2377

When there is an error thrown that is not a Ghost error, there is no status code in the error. Calling res.writeHead with an undefined status code, throws an error and crashes Ghost.

This change fixes that and adds logging for those errors.