### PR TITLE
Fixed portal comp upgrade playwright tests

### DIFF
--- a/ghost/core/test/e2e-browser/portal/upgrade.spec.js
+++ b/ghost/core/test/e2e-browser/portal/upgrade.spec.js
@@ -116,7 +116,9 @@ test.describe('Portal', () => {
 
             // Give member comped subscription
             await page.locator('[data-test-button="add-complimentary"]').click();
-            await page.locator('[data-test-button="save-comp-tier"]').first().click();
+            await page.locator('[data-test-button="save-comp-tier"]').first().click({
+                delay: 500
+            });
 
             // open member impersonation modal
             await page.locator('[data-test-button="member-actions"]').click();
@@ -134,7 +136,7 @@ test.describe('Portal', () => {
             // open portal, go to plans and click continue to select the first plan(yearly)
             await portalTriggerButton.click();
             await portalFrame.getByRole('button', {name: 'Change'}).click();
-            await portalFrame.getByRole('button', {name: 'Choose'}).first().click();
+            await portalFrame.locator('[data-test-button="select-tier"]').first().click();
 
             // complete stripe checkout
             await completeStripeSubscription(page);


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/f5aae1e2c519b1def31530e1a4a49198784941e0 refs https://github.com/TryGhost/Ghost/commit/0f9ed54a6fff1ebd2d0bbcb886e30e24491e15b9

- changing playwright portal tests to work for single tier setup caused failure for comped upgrade tests as they were relying on button text that changed