### PR TITLE
🐛 Removed horizontal scroll for long author's name

### DIFF
--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -355,15 +355,19 @@ figure blockquote p {
 .post-meta,
 .view-online {
     padding-bottom: 50px;
-    white-space: nowrap;
     color: #738a94;
     font-size: 13px;
     letter-spacing: 0.2px;
     text-transform: uppercase;
     text-align: center;
 }
+
 .post-meta-left {
     text-align: left;
+}
+
+.post-meta-date {
+    white-space: nowrap;
 }
 
 .view-online {

--- a/ghost/email-service/lib/email-templates/template.hbs
+++ b/ghost/email-service/lib/email-templates/template.hbs
@@ -31,9 +31,9 @@
                                         {{#if headerImage}}
                                             <tr>
                                                 <td class="header-image" width="100%" align="center">
-                                                    <img 
-                                                        src="{{headerImage}}" 
-                                                        {{#if headerImageWidth}} 
+                                                    <img
+                                                        src="{{headerImage}}"
+                                                        {{#if headerImageWidth}}
                                                             width="{{headerImageWidth}}"
                                                         {{/if}}
                                                     >
@@ -81,7 +81,7 @@
                                                 <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
                                                     <tr>
                                                         <td class="{{classes.meta}}">
-                                                            By {{post.authors}} – {{post.publishedAt}} – <a href="{{post.url}}" class="view-online-link">View online →</a>
+                                                            By {{post.authors}} – <span class="post-meta-date">{{post.publishedAt}} – </span><a href="{{post.url}}" class="view-online-link">View online →</a>
                                                         </td>
                                                     </tr>
                                                 </table>
@@ -90,10 +90,10 @@
                                         {{#if showFeatureImage }}
                                             <tr>
                                                 <td class="feature-image
-                                                    {{#if post.feature_image_caption }} 
+                                                    {{#if post.feature_image_caption }}
                                                         feature-image-with-caption
                                                     {{/if}}
-                                                "><img 
+                                                "><img
                                                     src="{{post.feature_image}}"
                                                     {{#if post.feature_image_width }}
                                                         width="{{post.feature_image_width}}"


### PR DESCRIPTION
closes TryGhost/Team#2272
- Show all name's text due to poor support `text-overflow: ellipsis` in email clients
