### PR TITLE
Fixed email preview text with new stability flow

### DIFF
--- a/ghost/email-service/lib/email-renderer.js
+++ b/ghost/email-service/lib/email-renderer.js
@@ -476,6 +476,21 @@ class EmailRenderer {
         return this.#renderTemplate(data);
     }
 
+    #getPostExcerpt(postModel) {
+        let plaintext = postModel.get('plaintext');
+        let customExcerpt = postModel.get('custom_excerpt');
+
+        if (customExcerpt !== null){
+            return customExcerpt;
+        } else {
+            if (plaintext) {
+                return plaintext.substring(0, 500);
+            } else {
+                return null;
+            }
+        }
+    }
+
     /**
      * @private
      */
@@ -526,6 +541,7 @@ class EmailRenderer {
             0
         ).href.replace('--uuid--', '%%{uuid}%%');
 
+        const postExcerpt = this.#getPostExcerpt(post);
         const data = {
             site: {
                 title: this.#settingsCache.get('title'),
@@ -535,7 +551,7 @@ class EmailRenderer {
                         image: this.#settingsCache.get('icon')
                     }, true) : null
             },
-            preheader: post.get('excerpt') ? post.get('excerpt') : `${post.get('title')} – `,
+            preheader: postExcerpt ? postExcerpt : `${post.get('title')} – `,
             html,
 
             post: {

--- a/ghost/email-service/lib/email-renderer.js
+++ b/ghost/email-service/lib/email-renderer.js
@@ -484,7 +484,7 @@ class EmailRenderer {
     #getEmailPreheader(postModel) {
         let plaintext = postModel.get('plaintext');
         let customExcerpt = postModel.get('custom_excerpt');
-        if (customExcerpt !== null){
+        if (customExcerpt) {
             return customExcerpt;
         } else {
             if (plaintext) {

--- a/ghost/email-service/lib/email-renderer.js
+++ b/ghost/email-service/lib/email-renderer.js
@@ -476,17 +476,21 @@ class EmailRenderer {
         return this.#renderTemplate(data);
     }
 
-    #getPostExcerpt(postModel) {
+    /**
+     * Get email preheader text from post model
+     * @param {object} postModel
+     * @returns
+     */
+    #getEmailPreheader(postModel) {
         let plaintext = postModel.get('plaintext');
         let customExcerpt = postModel.get('custom_excerpt');
-
         if (customExcerpt !== null){
             return customExcerpt;
         } else {
             if (plaintext) {
                 return plaintext.substring(0, 500);
             } else {
-                return null;
+                return `${postModel.get('title')} – `;
             }
         }
     }
@@ -541,7 +545,6 @@ class EmailRenderer {
             0
         ).href.replace('--uuid--', '%%{uuid}%%');
 
-        const postExcerpt = this.#getPostExcerpt(post);
         const data = {
             site: {
                 title: this.#settingsCache.get('title'),
@@ -551,7 +554,7 @@ class EmailRenderer {
                         image: this.#settingsCache.get('icon')
                     }, true) : null
             },
-            preheader: postExcerpt ? postExcerpt : `${post.get('title')} – `,
+            preheader: this.#getEmailPreheader(post),
             html,
 
             post: {

--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -1,5 +1,6 @@
 const EmailRenderer = require('../lib/email-renderer');
 const assert = require('assert');
+const cheerio = require('cheerio');
 
 describe('Email renderer', function () {
     describe('buildReplacementDefinitions', function () {
@@ -367,6 +368,14 @@ describe('Email renderer', function () {
                     if (key === 'title') {
                         return 'Test Post';
                     }
+
+                    if (key === 'plaintext') {
+                        return 'Test plaintext for post';
+                    }
+
+                    if (key === 'custom_excerpt') {
+                        return null;
+                    }
                 },
                 getLazyRelation: () => {
                     return {
@@ -410,9 +419,12 @@ describe('Email renderer', function () {
                 options
             );
 
+            const $ = cheerio.load(response.html);
+
             response.plaintext.should.containEql('Test Post');
             response.plaintext.should.containEql('Unsubscribe [%%{unsubscribe_url}%%]');
             response.plaintext.should.containEql('http://example.com');
+            should($('.preheader').text()).eql('Test plaintext for post');
             response.html.should.containEql('Test Post');
             response.html.should.containEql('Unsubscribe');
             response.html.should.containEql('http://example.com');


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2382

The preview text is getting set to subject line in the new email flow so it repeats multiple times in the inbox(subject+preview+title). This was because the new flow doesn't use the post serialisation that the old system did, causing excerpt to be empty in the email rendering.

Old system was using post serialisation here - https://github.com/TryGhost/Ghost/blob/a721e4f2d7428e59f153bbd0e06d19d0c7ef9e63/ghost/core/core/server/services/mega/post-email-serializer.js#L136-L139. 

This change adds explicit method to calculate the preview text for email in email renderer service using same logic as used in old system.