### PR TITLE
🐛 Reverted Sentry to v7.11.1 to fix unhandled promise rejection crashes

### DIFF
--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -77,7 +77,10 @@ const deleteSession = async function (req, res) {
         res.writeHead(204);
         res.end();
     } catch (err) {
-        res.writeHead(err.statusCode, {
+        if (!err.statusCode) {
+            logging.error(err);
+        }
+        res.writeHead(err.statusCode ?? 500, {
             'Content-Type': 'text/plain;charset=UTF-8'
         });
         res.end(err.message);
@@ -105,7 +108,10 @@ const deleteSuppression = async function (req, res) {
         res.writeHead(204);
         res.end();
     } catch (err) {
-        res.writeHead(err.statusCode, {
+        if (!err.statusCode) {
+            logging.error(err);
+        }
+        res.writeHead(err.statusCode ?? 500, {
             'Content-Type': 'text/plain;charset=UTF-8'
         });
         res.end(err.message);
@@ -188,7 +194,10 @@ const updateMemberData = async function (req, res) {
             res.json(null);
         }
     } catch (err) {
-        res.writeHead(err.statusCode, {
+        if (!err.statusCode) {
+            logging.error(err);
+        }
+        res.writeHead(err.statusCode ?? 500, {
             'Content-Type': 'text/plain;charset=UTF-8'
         });
         res.end(err.message);

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -56,7 +56,7 @@
     "cli": "^1.17.0"
   },
   "dependencies": {
-    "@sentry/node": "7.23.0",
+    "@sentry/node": "7.11.1",
     "@tryghost/adapter-base-cache": "0.1.2",
     "@tryghost/adapter-manager": "0.0.0",
     "@tryghost/admin-api-schema": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
       "normalize.css",
       "validator",
       "codemirror",
-      "faker"
+      "faker",
+      "@sentry/node"
     ],
     "ignorePaths": [
       "test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,6 +3378,16 @@
     "@sentry/utils" "7.23.0"
     tslib "^1.9.3"
 
+"@sentry/core@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.11.1.tgz#d68e796f3b6428aefd6086a1db00118df7a9a9e4"
+  integrity sha512-kaDSZ6VNuO4ZZdqUOOX6XM6x+kjo2bMnDQ3IJG51FPvVjr8lXYhXj1Ccxcot3pBYAIWPPby2+vNDOXllmXqoBA==
+  dependencies:
+    "@sentry/hub" "7.11.1"
+    "@sentry/types" "7.11.1"
+    "@sentry/utils" "7.11.1"
+    tslib "^1.9.3"
+
 "@sentry/core@7.23.0":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.23.0.tgz#d320b2b6e5620b41f345bc01d69b547cdf28f78d"
@@ -3412,6 +3422,15 @@
     ember-cli-htmlbars "^6.1.1"
     ember-cli-typescript "^5.1.1"
 
+"@sentry/hub@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.11.1.tgz#1749b2b102ea1892ff388d65d66d3b402b393958"
+  integrity sha512-M6ClgdXdptS0lUBKB5KpXXe2qMQhsoiEN2pEGRI6+auqhfHCUQB1ZXsfjiOYexKC9fwx7TyFyZ9Jcaf2DTxEhw==
+  dependencies:
+    "@sentry/types" "7.11.1"
+    "@sentry/utils" "7.11.1"
+    tslib "^1.9.3"
+
 "@sentry/hub@7.8.1":
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.8.1.tgz#bc255c6b8e99a3333e737f189c984c715df504aa"
@@ -3421,14 +3440,15 @@
     "@sentry/utils" "7.8.1"
     tslib "^1.9.3"
 
-"@sentry/node@7.23.0":
-  version "7.23.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.23.0.tgz#a9573a1a93994b6dc7ed3539c27cb8faf7bacfb2"
-  integrity sha512-w6J+5YRsQEn55508yQYT43ahMP5IHruxq8XnFqYMFZvRohVxrZ1qTz7AMoSgc8fDcHr+LKhs1PxJIqqNwkWrFA==
+"@sentry/node@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.11.1.tgz#97fd26de26e8203a3c34e26b38f3c2a5ba46828b"
+  integrity sha512-EAAHou/eHSzwRK0Z5qnQiwXNbkpnjWjloaG979gftA+MS/kM0AxQHdOrSJQbOEaqRf3F7/eC4Hj+1tfglAuaLQ==
   dependencies:
-    "@sentry/core" "7.23.0"
-    "@sentry/types" "7.23.0"
-    "@sentry/utils" "7.23.0"
+    "@sentry/core" "7.11.1"
+    "@sentry/hub" "7.11.1"
+    "@sentry/types" "7.11.1"
+    "@sentry/utils" "7.11.1"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
@@ -3469,6 +3489,11 @@
     "@sentry/utils" "7.23.0"
     tslib "^1.9.3"
 
+"@sentry/types@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.11.1.tgz#06e2827f6ba37159c33644208a0453b86d25e232"
+  integrity sha512-gIEhOPxC2cjrxQ0+K2SFJ1P6e/an5osSxVc9OOtekN28eHtVsXFCLB8XVWeNQnS7N2VkrVrkqORMBz1kvIcvVQ==
+
 "@sentry/types@7.23.0":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.23.0.tgz#5d2ce94d81d7c1fad702645306f3c0932708cad5"
@@ -3478,6 +3503,14 @@
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.8.1.tgz#c00a1ed02ad8f69d3b94fcda91e2d24e0bb3492a"
   integrity sha512-LOoaeBXVI23Kh5SpIbxSRiJ6+eYZXVOFyPFH1T1mGBj95LPwRMqOdg0lUTmFJGBKbDGDB/YNjNnu1kQ7GrXBXw==
+
+"@sentry/utils@7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.11.1.tgz#1635c5b223369d9428bc83c9b8908c9c3287ee10"
+  integrity sha512-tRVXNT5O9ilkV31pyHeTqA1PcPQfMV/2OR6yUYM4ah+QVISovC0f0ybhByuH5nYg6x/Gsnx1o7pc8L1GE3+O7A==
+  dependencies:
+    "@sentry/types" "7.11.1"
+    tslib "^1.9.3"
 
 "@sentry/utils@7.23.0":
   version "7.23.0"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2370

Due to a possible bug in either `@sentry/node` (mainly the Express middlewares and the usage of deprectated Domain) and Node v16+, unhandled promise rejections are transformed into uncaught exceptions and cause Ghost to crash in unexpected situations.

Reverting to `v7.11.1` fixes this (but definitely not ideal at all) because errors are caught in the Express middleware.

Reproduction repo: https://github.com/SimonBackx/sentry-node-unhandled-rejection-crash