### PR TITLE
🐛 Fixed slug saving in editor

### DIFF
--- a/ghost/admin/app/controllers/editor.js
+++ b/ghost/admin/app/controllers/editor.js
@@ -788,6 +788,14 @@ export default class EditorController extends Controller {
             this._koenig.cleanup();
         }
 
+        // user can enter the slug name and then leave the post page,
+        // in such case we should wait until the slug would be saved on backend
+        if (this.updateSlugTask.isRunning) {
+            transition.abort();
+            await this.updateSlugTask.last;
+            return transition.retry();
+        }
+
         let hasDirtyAttributes = this.hasDirtyAttributes;
         let state = post.getProperties('isDeleted', 'isSaving', 'hasDirtyAttributes', 'isNew');
 

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -791,6 +791,14 @@ export default class LexicalEditorController extends Controller {
         //     this._koenig.cleanup();
         // }
 
+        // user can enter the slug name and then leave the post page,
+        // in such case we should wait until the slug would be saved on backend
+        if (this.updateSlugTask.isRunning) {
+            transition.abort();
+            await this.updateSlugTask.last;
+            return transition.retry();
+        }
+
         let hasDirtyAttributes = this.hasDirtyAttributes;
         let state = post.getProperties('isDeleted', 'isSaving', 'hasDirtyAttributes', 'isNew');
 


### PR DESCRIPTION
refs TryGhost/Team#2294
- If user enter the slug name and then leave the post page, we should wait until the slug would be saved on backend. The problem can be reproduced with slow internet connection.
