### PR TITLE
Added theme docs link to the admin

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/design.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/design.hbs
@@ -44,13 +44,14 @@
 
         <div class="gh-nav-bottom">
             <div class="gh-change-theme">
-                <LinkTo class="gh-nav-design-tab" @route="settings.design.change-theme" {{on "click" this.closeAllSections}} data-test-nav="change-theme">
+                <div class="gh-nav-design-tab">
+                    <LinkTo @route="settings.design.change-theme" {{on "click" this.closeAllSections}} data-test-nav="change-theme"></LinkTo>
                     <div>
                         <span>Change theme</span>
-                        <span class="active-theme" data-test-text="current-theme">Current: {{this.activeTheme.name}}{{#if this.activeTheme.package.version}} - v{{this.activeTheme.package.version}}{{/if}}</span>
+                        <span class="active-theme" data-test-text="current-theme">Current: {{this.activeTheme.name}}{{#if this.activeTheme.package.version}} - v{{this.activeTheme.package.version}}{{/if}}{{#if this.activeTheme.package.docs}}<a class="gh-theme-docs" href="{{this.activeTheme.package.docs}}" target="_blank">{{svg-jar "book-open" width="12" height="12"}}</a>{{/if}}</span>
                     </div>
                     <div class="gh-nav-design-tabicon">{{svg-jar "sync"}}</div>
-                </LinkTo>
+                </div>
             </div>
         </div>
     </section>

--- a/ghost/admin/app/components/gh-nav-menu/design.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/design.hbs
@@ -45,10 +45,10 @@
         <div class="gh-nav-bottom">
             <div class="gh-change-theme">
                 <div class="gh-nav-design-tab">
-                    <LinkTo @route="settings.design.change-theme" {{on "click" this.closeAllSections}} data-test-nav="change-theme"></LinkTo>
+                    <LinkTo @route="settings.design.change-theme" {{on "click" this.closeAllSections}} aria-label="Change theme" data-test-nav="change-theme"></LinkTo>
                     <div>
                         <span>Change theme</span>
-                        <span class="active-theme" data-test-text="current-theme">Current: {{this.activeTheme.name}}{{#if this.activeTheme.package.version}} - v{{this.activeTheme.package.version}}{{/if}}{{#if this.activeTheme.package.docs}}<a class="gh-theme-docs" href="{{this.activeTheme.package.docs}}" target="_blank">{{svg-jar "book-open" width="12" height="12"}}</a>{{/if}}</span>
+                        <span class="active-theme" data-test-text="current-theme">Current: {{this.activeTheme.name}}{{#if this.activeTheme.package.version}} - v{{this.activeTheme.package.version}}{{/if}}{{#if this.activeTheme.package.docs}}<a class="gh-theme-docs" href="{{this.activeTheme.package.docs}}" target="_blank" rel="noopener noreferrer">{{svg-jar "book-open" width="12" height="12"}}</a>{{/if}}</span>
                     </div>
                     <div class="gh-nav-design-tabicon">{{svg-jar "sync"}}</div>
                 </div>

--- a/ghost/admin/app/styles/layouts/settings.css
+++ b/ghost/admin/app/styles/layouts/settings.css
@@ -1893,6 +1893,11 @@ p.theme-validation-details {
     background: var(--mainmenu-color-hover-bg);
 }
 
+.gh-nav-bottom .gh-nav-design-tab > a {
+    position: absolute;
+    inset: 0;
+}
+
 .gh-nav-bottom .gh-nav-design-tab .active-theme {
     color: var(--midgrey);
     font-size: 1.3rem;
@@ -1960,6 +1965,24 @@ p.theme-validation-details {
     height: 96px;
     margin-bottom: -24px;
     background: var(--white);
+}
+
+.gh-theme-docs {
+    position: relative;
+    z-index: 10;
+    padding: 4px 8px;
+    line-height: 0;
+    color: var(--midgrey);
+}
+
+.gh-theme-docs:hover {
+    color: #15171a;
+}
+
+.gh-theme-docs svg {
+    width: 12px;
+    height: 12px;
+    fill: currentColor;
 }
 
 .gh-nav-design-tabicon {


### PR DESCRIPTION
no refs

This adds a theme documentation link that's set in the package.json to the design settings footer. An example of the package.json property:

`"docs": "https://example.com"`
