### PR TITLE
Updated to use proper members importer for Revue

### DIFF
--- a/ghost/core/core/server/data/importer/importers/data/revue-subscriber.js
+++ b/ghost/core/core/server/data/importer/importers/data/revue-subscriber.js
@@ -6,7 +6,6 @@ const path = require('path');
 const fs = require('fs-extra');
 
 const config = require('../../../../../shared/config');
-const membersService = require('../../../../services/members');
 const models = require('../../../../models');
 
 class RevueSubscriberImporter extends BaseImporter {
@@ -29,6 +28,9 @@ class RevueSubscriberImporter extends BaseImporter {
         if (this.dataToImport.length === 0) {
             return Promise.resolve();
         }
+
+        // required here rather than top-level to avoid pulling in before it's initialized during boot
+        const membersService = require('../../../../services/members');
 
         const importLabel = importOptions.importTag ? importOptions.importTag.replace(/^#/, '') : null;
 

--- a/ghost/core/core/server/data/importer/importers/data/revue-subscriber.js
+++ b/ghost/core/core/server/data/importer/importers/data/revue-subscriber.js
@@ -25,6 +25,11 @@ class RevueSubscriberImporter extends BaseImporter {
     async doImport(options, importOptions) {
         debug('doImport', this.modelName, this.dataToImport.length);
 
+        // Don't do anything if there is no data to import
+        if (this.dataToImport.length === 0) {
+            return Promise.resolve();
+        }
+
         const importLabel = importOptions.importTag ? importOptions.importTag.replace(/^#/, '') : null;
 
         const outputFileName = `Converted ${importLabel}.csv`;

--- a/ghost/importer-revue/lib/importer-revue.js
+++ b/ghost/importer-revue/lib/importer-revue.js
@@ -79,8 +79,8 @@ const buildSubscriberList = (revueData) => {
         subscribers.push({
             email: subscriber.email,
             name: `${subscriber.first_name} ${subscriber.last_name}`.trim(),
-            created_at: subscriber.created_at
-
+            created_at: subscriber.created_at,
+            subscribed: true
         });
     });
 

--- a/ghost/importer-revue/test/importer-revue.test.js
+++ b/ghost/importer-revue/test/importer-revue.test.js
@@ -124,19 +124,19 @@ describe('Revue Importer', function () {
         it('can process a subscriber with only first name', function () {
             const result = RevueImporter.importSubscribers({subscribers: 'email,first_name,last_name,created_at\njoe@bloggs.me,Joe,"",2022-12-01 01:02:03.123457'});
 
-            assert.deepEqual(result, [{email: 'joe@bloggs.me', name: 'Joe', created_at: '2022-12-01 01:02:03.123457'}]);
+            assert.deepEqual(result, [{email: 'joe@bloggs.me', name: 'Joe', created_at: '2022-12-01 01:02:03.123457', subscribed: true}]);
         });
 
         it('can process a subscriber with first and last name', function () {
             const result = RevueImporter.importSubscribers({subscribers: 'email,first_name,last_name,created_at\njoe@bloggs.me,Joe,Bloggs,2022-12-01 01:02:03.123457'});
 
-            assert.deepEqual(result, [{email: 'joe@bloggs.me', name: 'Joe Bloggs', created_at: '2022-12-01 01:02:03.123457'}]);
+            assert.deepEqual(result, [{email: 'joe@bloggs.me', name: 'Joe Bloggs', created_at: '2022-12-01 01:02:03.123457', subscribed: true}]);
         });
 
         it('can process multiple subscribers', function () {
             const result = RevueImporter.importSubscribers({subscribers: 'email,first_name,last_name,created_at\njoe@bloggs.me,Joe,Bloggs,2022-12-01 01:02:03.123457\njo@bloggs.me,Jo,Bloggs,2022-12-01 01:02:04.123457'});
 
-            assert.deepEqual(result, [{email: 'joe@bloggs.me', name: 'Joe Bloggs', created_at: '2022-12-01 01:02:03.123457'},{email: 'jo@bloggs.me', name: 'Jo Bloggs', created_at: '2022-12-01 01:02:04.123457'}]);
+            assert.deepEqual(result, [{email: 'joe@bloggs.me', name: 'Joe Bloggs', created_at: '2022-12-01 01:02:03.123457', subscribed: true},{email: 'jo@bloggs.me', name: 'Jo Bloggs', created_at: '2022-12-01 01:02:04.123457', subscribed: true}]);
         });
     });
 


### PR DESCRIPTION
refs: https://github.com/TryGhost/Ghost/commit/5f90baf6fe3bd9b9acdcc418a0e21389084030ee

- The OG implementation of importing revue subscribers was very naive
- This sures it up to use our proper member importer, which makes sure everything works perfectly:
  - adds an import label
  - ensures members are subscribed to newsletters


