### PR TITLE
Handle blockquotes & empty paragraphs

### DIFF
--- a/ghost/importer-revue/lib/importer-revue.js
+++ b/ghost/importer-revue/lib/importer-revue.js
@@ -54,9 +54,7 @@ const fetchPostsFromData = (revueData) => {
             created_at: postDate,
             published_at: postDate,
             updated_at: postDate,
-            html: postHTML,
-            tags: ['#revue']
-
+            html: postHTML
         });
     });
 

--- a/ghost/importer-revue/lib/importer-revue.js
+++ b/ghost/importer-revue/lib/importer-revue.js
@@ -33,14 +33,14 @@ const fetchPostsFromData = (revueData) => {
         }
 
         const revuePostID = postMeta.id;
-        let postHTML = postMeta.description;
+        let postHTML = JSONToHTML.cleanCsvHTML(postMeta.description);
 
         const postItems = _.filter(itemData, {issue_id: revuePostID});
         const sortedPostItems = _.sortBy(postItems, o => o.order);
 
         if (postItems) {
             const convertedItems = JSONToHTML.itemsToHtml(sortedPostItems);
-            postHTML = `${postMeta.description}${convertedItems}`;
+            postHTML = `${postHTML}${convertedItems}`;
         }
 
         const postDate = JSONToHTML.getPostDate(postMeta);

--- a/ghost/importer-revue/lib/json-to-html.js
+++ b/ghost/importer-revue/lib/json-to-html.js
@@ -88,8 +88,20 @@ const getPostStatus = (data) => {
     return (isPublished) ? 'published' : 'draft';
 };
 
+const cleanCsvHTML = (data) => {
+    // Blockquotes need to have some sort of wrapping elements around all contents
+    // Wrap all content in <p> tags. The HTML to Mobiledoc parse can handle duplicate <p> tags.
+    data = data.replace(/<blockquote.*?>(.*?)<\/blockquote>/gm, '<blockquote><p>$1</p></blockquote>');
+
+    // These exports have a lot of <p><br></p> that we don't want
+    data = data.replace(/<p><br><\/p>/gm, '');
+
+    return data;
+};
+
 module.exports = {
     itemsToHtml,
     getPostDate,
-    getPostStatus
+    getPostStatus,
+    cleanCsvHTML
 };

--- a/ghost/importer-revue/test/importer-revue.test.js
+++ b/ghost/importer-revue/test/importer-revue.test.js
@@ -68,8 +68,7 @@ describe('Revue Importer', function () {
                     created_at: '2022-12-01T01:01:30.000Z',
                     published_at: '2022-12-01T01:01:30.000Z',
                     updated_at: '2022-12-01T01:01:30.000Z',
-                    html: '<p>Hello World!</p>',
-                    tags: ['#revue']
+                    html: '<p>Hello World!</p>'
                 }
             ]);
         });
@@ -88,9 +87,6 @@ describe('Revue Importer', function () {
                     html: '<p>Hello World!</p><p>Goodbye World!</p>',
                     published_at: '2022-12-01T01:01:30.000Z',
                     status: 'published',
-                    tags: [
-                        '#revue'
-                    ],
                     title: 'Hello World - Issue #8',
                     slug: 'hello-world-issue-8',
                     updated_at: '2022-12-01T01:01:30.000Z',
@@ -113,8 +109,7 @@ describe('Revue Importer', function () {
                     created_at: '2022-12-01T01:02:03.123Z',
                     published_at: '2022-12-01T01:02:03.123Z',
                     updated_at: '2022-12-01T01:02:03.123Z',
-                    html: '<p>Hello World!</p><p>Goodbye World!</p>',
-                    tags: ['#revue']
+                    html: '<p>Hello World!</p><p>Goodbye World!</p>'
                 }
             ]);
         });

--- a/ghost/importer-revue/test/importer-revue.test.js
+++ b/ghost/importer-revue/test/importer-revue.test.js
@@ -223,5 +223,19 @@ describe('Revue Importer', function () {
                 assert.deepEqual(result, '<figure class="kg-card kg-embed-card kg-card-hascaption"><iframe src="https://player.vimeo.com/video/789123" width="200" height="113" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe><figcaption>Hello world</figcaption></figure>');
             });
         });
+
+        describe('cleanCsvHTML', function () {
+            it('can wrap blockquote content in p tags', function () {
+                const result = JSONToHTML.cleanCsvHTML('<p>Hello World!</p><blockquote>Try <a href="https://example.com">This</a>!</blockquote>');
+
+                assert.deepEqual(result, '<p>Hello World!</p><blockquote><p>Try <a href="https://example.com">This</a>!</p></blockquote>');
+            });
+
+            it('can remove unwanted blank paragraphs', function () {
+                const result = JSONToHTML.cleanCsvHTML('<p>Hello World!</p><p><br></p><p>Goodbye World!</p>');
+
+                assert.deepEqual(result, '<p>Hello World!</p><p>Goodbye World!</p>');
+            });
+        });
     });
 });


### PR DESCRIPTION
refs: https://github.com/TryGhost/Ghost/commit/5f90baf6fe3bd9b9acdcc418a0e21389084030ee

Blockquotes without any wrapping tag get converted to Mobiledoc weirdly. Wrapping them in `<p>` tags helps solve that

Also removes empty paragraph tags which cause unwanted large blank spaces in content

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)