### PR TITLE
🐛 Fixed invalid email getting saved for members

### DIFF
--- a/ghost/core/test/regression/api/admin/members-importer.test.js
+++ b/ghost/core/test/regression/api/admin/members-importer.test.js
@@ -234,15 +234,16 @@ describe('Members Importer API', function () {
                 should.exist(jsonResponse.meta.stats);
 
                 jsonResponse.meta.stats.imported.should.equal(1);
-                jsonResponse.meta.stats.invalid.length.should.equal(1);
+                jsonResponse.meta.stats.invalid.length.should.equal(2);
 
-                jsonResponse.meta.stats.invalid[0].error.should.match(/Validation \(isEmail\) failed for email/);
+                jsonResponse.meta.stats.invalid[0].error.should.match(/Invalid Email/);
+                jsonResponse.meta.stats.invalid[1].error.should.match(/Invalid Email/);
 
                 should.exist(jsonResponse.meta.import_label);
                 jsonResponse.meta.import_label.slug.should.match(/^import-/);
             });
     });
-    
+
     it('Can import members with host emailVerification limits', async function () {
         // If this test fails, check if the total members that have been created with fixtures has increased a lot, and if required, increase the amount of imported members
         configUtils.set('hostSettings:emailVerification', {

--- a/ghost/core/test/utils/fixtures/csv/members-invalid-values.csv
+++ b/ghost/core/test/utils/fixtures/csv/members-invalid-values.csv
@@ -1,3 +1,4 @@
 email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,labels
 valid2@email.com,"good name",,true,not_boolean,,2019-10-30T14:52:08.000Z,more-labels
 invalid_email_value,"good name",,true,false,,2019-10-30T14:52:08.000Z,more-labels
+invalid2@email.com�,"good name",,true,false,,2019-10-30T14:52:08.000Z,more-labels

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -6,6 +6,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const {MemberCreatedEvent, SubscriptionCreatedEvent, MemberSubscribeEvent, SubscriptionCancelledEvent} = require('@tryghost/member-events');
 const ObjectId = require('bson-objectid').default;
 const {NotFoundError} = require('@tryghost/errors');
+const validator = require('@tryghost/validator');
 
 const messages = {
     noStripeConnection: 'Cannot {action} without a Stripe Connection',
@@ -16,7 +17,8 @@ const messages = {
     subscriptionNotFound: 'Could not find Subscription {id}',
     productNotFound: 'Could not find Product {id}',
     bulkActionRequiresFilter: 'Cannot perform {action} without a filter or all=true',
-    tierArchived: 'Cannot use archived Tiers'
+    tierArchived: 'Cannot use archived Tiers',
+    invalidEmail: 'Invalid Email'
 };
 
 /**
@@ -247,6 +249,14 @@ module.exports = class MemberRepository {
 
         const memberData = _.pick(data, ['email', 'name', 'note', 'subscribed', 'geolocation', 'created_at', 'products', 'newsletters']);
 
+        // Throw error if email is invalid using latest validator
+        if (!validator.isEmail(memberData.email, {latest: true})) {
+            throw new errors.ValidationError({
+                message: tpl(messages.invalidEmail),
+                property: 'email'
+            });
+        }
+
         if (memberData.products && memberData.products.length > 1) {
             throw new errors.BadRequestError({message: tpl(messages.moreThanOneProduct)});
         }
@@ -437,6 +447,17 @@ module.exports = class MemberRepository {
             if (!initialMember) {
                 throw new NotFoundError({message: tpl(messages.memberNotFound, {id: options.id})});
             }
+        }
+
+        // Throw error if email is invalid and it's been changed
+        if (
+            initialMember.get('email') !== memberData.email &&
+            !validator.isEmail(memberData.email, {latest: true})
+        ) {
+            throw new errors.ValidationError({
+                message: tpl(messages.invalidEmail),
+                property: 'email'
+            });
         }
 
         const memberStatusData = {};

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -451,8 +451,9 @@ module.exports = class MemberRepository {
 
         // Throw error if email is invalid and it's been changed
         if (
-            initialMember.get('email') !== memberData.email &&
-            !validator.isEmail(memberData.email, {legacy: false})
+            initialMember?.get('email') && memberData.email
+            && initialMember.get('email') !== memberData.email
+            && !validator.isEmail(memberData.email, {legacy: false})
         ) {
             throw new errors.ValidationError({
                 message: tpl(messages.invalidEmail),

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -250,7 +250,7 @@ module.exports = class MemberRepository {
         const memberData = _.pick(data, ['email', 'name', 'note', 'subscribed', 'geolocation', 'created_at', 'products', 'newsletters']);
 
         // Throw error if email is invalid using latest validator
-        if (!validator.isEmail(memberData.email, {latest: true})) {
+        if (!validator.isEmail(memberData.email, {legacy: false})) {
             throw new errors.ValidationError({
                 message: tpl(messages.invalidEmail),
                 property: 'email'
@@ -452,7 +452,7 @@ module.exports = class MemberRepository {
         // Throw error if email is invalid and it's been changed
         if (
             initialMember.get('email') !== memberData.email &&
-            !validator.isEmail(memberData.email, {latest: true})
+            !validator.isEmail(memberData.email, {legacy: false})
         ) {
             throw new errors.ValidationError({
                 message: tpl(messages.invalidEmail),

--- a/ghost/members-api/package.json
+++ b/ghost/members-api/package.json
@@ -36,7 +36,7 @@
     "@tryghost/members-payments": "0.0.0",
     "@tryghost/nql": "0.11.0",
     "@tryghost/tpl": "0.1.20",
-    "@tryghost/validator": "^0.1.31",
+    "@tryghost/validator": "^0.2.0",
     "@types/jsonwebtoken": "8.5.9",
     "body-parser": "1.20.1",
     "bson-objectid": "2.0.4",

--- a/ghost/members-api/package.json
+++ b/ghost/members-api/package.json
@@ -36,6 +36,7 @@
     "@tryghost/members-payments": "0.0.0",
     "@tryghost/nql": "0.11.0",
     "@tryghost/tpl": "0.1.20",
+    "@tryghost/validator": "^0.1.31",
     "@types/jsonwebtoken": "8.5.9",
     "body-parser": "1.20.1",
     "bson-objectid": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4506,6 +4506,15 @@
     lodash "^4.17.21"
     uuid "^9.0.0"
 
+"@tryghost/errors@^1.2.20":
+  version "1.2.20"
+  resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.2.20.tgz#bd5c96bb815f7b49cacee1bd0ce235c3a5f25e82"
+  integrity sha512-9QGLj3jrslEo4BEByMn/vT65d4fUHSz22p0R5ixiYVtHsuXjdKJm0oDBt8wtKXxdgE/h3CCFI709TW6hLyk+7w==
+  dependencies:
+    "@stdlib/utils" "^0.0.12"
+    lodash "^4.17.21"
+    uuid "^9.0.0"
+
 "@tryghost/express-test@0.11.7":
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/@tryghost/express-test/-/express-test-0.11.7.tgz#586cc0537a944f4e908736dff46617d4b391c52d"
@@ -4837,6 +4846,13 @@
   dependencies:
     lodash.template "^4.5.0"
 
+"@tryghost/tpl@^0.1.21":
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/@tryghost/tpl/-/tpl-0.1.21.tgz#60ba975d0acc7af6911e7b021b2235d6338ab6c7"
+  integrity sha512-ED0SR09+v7SglL+JOD1+q7QaZU4cRa+XemymQomob8hc9PNqE8Gzw0Rd4fqtMD9v91OHvg5rS/MrKvUHn6eTfw==
+  dependencies:
+    lodash.template "^4.5.0"
+
 "@tryghost/url-utils@4.3.0", "@tryghost/url-utils@^4.0.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@tryghost/url-utils/-/url-utils-4.3.0.tgz#f276ea0963f34547dca8f8f8a6c7bd4e6d4bb6e3"
@@ -4856,6 +4872,17 @@
   dependencies:
     "@tryghost/errors" "^1.2.19"
     "@tryghost/tpl" "^0.1.20"
+    lodash "^4.17.21"
+    moment-timezone "^0.5.23"
+    validator "7.2.0"
+
+"@tryghost/validator@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/validator/-/validator-0.2.0.tgz#cfb0b9447cfb50901b2a2fbf8519de4d5b992f12"
+  integrity sha512-sKAcyZwOCdCe7jG6B1UxzOijHjvwqwj9G9l+hQhRScT1gMT4C8zhyq7BrEQmFUvsLUXVBlpph5wn95E34oqCDw==
+  dependencies:
+    "@tryghost/errors" "^1.2.20"
+    "@tryghost/tpl" "^0.1.21"
     lodash "^4.17.21"
     moment-timezone "^0.5.23"
     validator "7.2.0"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2235

We found some cases which can cause a site to have member emails that have invalid characters like `member@example.com�`. This happened due to the `validator` version used by Ghost not able to catch some specific cases as invalid email, allowing members to be created with them either via Admin or Importer or direct signup. Portal UI already blocked these email as invalid. This change

- updates `@tryghost/validator` to include a latest version of email validator that catches these invalid cases
- doesn't allow member creation with invalid email like above
- doesn't allow existing member emails to be edited to invalid