### PR TITLE
🐛 Fixed archived offers return button not working

### DIFF
--- a/ghost/admin/app/templates/offers.hbs
+++ b/ghost/admin/app/templates/offers.hbs
@@ -125,7 +125,7 @@
                 <div class="no-posts-box">
                     <div class="no-posts">
                         <h4>You have no archived offers.</h4>
-                        <LinkTo @route="offers" @query={{hash type=null author=null tag=null}} class="gh-btn gh-btn-lg">
+                        <LinkTo @route="offers" @query={{hash type="active" author=null tag=null}} class="gh-btn gh-btn-lg">
                             <span>Show active offers</span>
                         </LinkTo>
                     </div>


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2374

When clicking 'Show active offers' in the archived offers view, it would always return to an empty offers list, even when there are active offers.