### PR TITLE
Fixed random test failure due to member newsletter ordering

### DIFF
--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -50,7 +50,7 @@ const Member = ghostBookshelf.Model.extend({
             replacement: 'emails.post_id',
             // Currently we cannot expand on values such as null or a string in mongo-knex
             // But the line below is essentially the same as: `email_recipients.opened_at:-null`
-            expansion: 'email_recipients.opened_at:>=0' 
+            expansion: 'email_recipients.opened_at:>=0'
         }];
     },
 
@@ -165,6 +165,7 @@ const Member = ghostBookshelf.Model.extend({
 
     newsletters() {
         return this.belongsToMany('Newsletter', 'members_newsletters', 'member_id', 'newsletter_id')
+            .query('orderBy', 'newsletters.sort_order', 'ASC')
             .query((qb) => {
                 // avoids bookshelf adding a `DISTINCT` to the query
                 // we know the result set will already be unique and DISTINCT hurts query performance


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2365

The newsletters relation of a member was not sorted. This is fixed now, so we have consistent results in the test snapshots.