### PR TITLE
🐛 Fixed emoji causing page jump in safari

### DIFF
--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-callout.hbs
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-callout.hbs
@@ -24,7 +24,9 @@
 
         <div class="kg-card kg-callout-card kg-callout-card-{{@payload.backgroundColor}}">
             {{#if @payload.calloutEmoji}}
-            <button type="button" class="kg-callout-emoji {{if this.isPickerVisible "kg-emoji-picker-active"}}" {{on "click" this.changeEmoji}}>{{@payload.calloutEmoji}}</button>
+            <div tabindex="-1">
+                <button type="button" class="kg-callout-emoji {{if this.isPickerVisible "kg-emoji-picker-active"}}" {{on "click" this.changeEmoji}}>{{@payload.calloutEmoji}}</button>
+            </div>
             {{/if}}
             <KoenigBasicHtmlInput
                 @html={{@payload.calloutText}}


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/15295

- By design Safari [does not support focus on a button element](https://bugs.webkit.org/show_bug.cgi?id=22261). We have to keep the focus somehow otherwise we cause page jump in Safari when changing the emoji. Tabindex -1 is a good choice because it does not mess with a tab sequence if we have one.
