### PR TITLE
 🐛 Fixed meta is missing error with revue imports

### DIFF
--- a/ghost/core/core/server/data/importer/handlers/revue.js
+++ b/ghost/core/core/server/data/importer/handlers/revue.js
@@ -2,9 +2,10 @@ const _ = require('lodash');
 const fs = require('fs-extra');
 const debug = require('@tryghost/debug')('importer:handler:revue');
 
-const hasIssuesCSV = (files) => {
+const hasIssuesCSV = (files, startDirRegex) => {
     return _.some(files, (file) => {
-        return file.name.match(/^issues.*?\.csv/);
+        const name = file.name.replace(startDirRegex, '');
+        return name.match(/^issues.*?\.csv/);
     });
 };
 
@@ -21,7 +22,8 @@ const RevueHandler = {
         const ops = [];
         const revue = {};
 
-        if (!hasIssuesCSV(files)) {
+        if (!hasIssuesCSV(files, startDirRegex)) {
+            debug('No issue CSV');
             return Promise.resolve();
         }
 


### PR DESCRIPTION
refs: https://github.com/TryGhost/Ghost/commit/5f90baf6fe3bd9b9acdcc418a0e21389084030ee

- The check for hasIssuesCSV didn't normalize the filename first, meaning the importer is super sensitive to zip structure
- This allows for zips that contain a directory, so that it will still be processed as a revue import, not a Ghost import

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

Also, if you'd be interested in writing code like this for us more regularly, we're hiring:
https://careers.ghost.org
