### PR TITLE
Return no tiers in GET content tiers API

### DIFF
--- a/ghost/core/core/server/api/endpoints/tiers-public.js
+++ b/ghost/core/core/server/api/endpoints/tiers-public.js
@@ -1,4 +1,5 @@
 const tiersService = require('../../services/tiers');
+const settingsHelpers = require('../../services/settings-helpers');
 
 module.exports = {
     docName: 'tiers',
@@ -14,7 +15,7 @@ module.exports = {
         ],
         permissions: true,
         async query(frame) {
-            const page = await tiersService.api.browse(frame.options);
+            const page = await tiersService.api.browse(settingsHelpers.isStripeConnected(), frame.options);
 
             return page;
         }

--- a/ghost/core/core/server/api/endpoints/tiers.js
+++ b/ghost/core/core/server/api/endpoints/tiers.js
@@ -1,4 +1,5 @@
 const tiersService = require('../../services/tiers');
+const settingsHelpers = require('../../services/settings-helpers');
 
 module.exports = {
     docName: 'tiers',
@@ -16,7 +17,7 @@ module.exports = {
             docName: 'products'
         },
         async query(frame) {
-            const page = await tiersService.api.browse(frame.options);
+            const page = await tiersService.api.browse(settingsHelpers.isStripeConnected(), frame.options);
             return page;
         }
     },

--- a/ghost/tiers/lib/TiersAPI.js
+++ b/ghost/tiers/lib/TiersAPI.js
@@ -41,13 +41,18 @@ module.exports = class TiersAPI {
     }
 
     /**
+     * @param {boolean} [paidMembershipEnabled] - if payment method is setup for receiving payments
      * @param {object} [options]
      * @param {string} [options.filter] - An NQL filter string
      *
      * @returns {Promise<Page<Tier>>}
      */
-    async browse(options = {}) {
-        const tiers = await this.#repository.getAll(options);
+    async browse(paidMembershipEnabled, options = {}) {
+        let tiers = [];
+
+        if (paidMembershipEnabled) {
+            tiers = await this.#repository.getAll(options);
+        }
 
         return {
             data: tiers,

--- a/ghost/tiers/test/TiersAPI.test.js
+++ b/ghost/tiers/test/TiersAPI.test.js
@@ -82,11 +82,18 @@ describe('TiersAPI', function () {
         assert(updated.status === 'archived');
     });
 
-    it('Can browse tiers', async function () {
-        const page = await api.browse();
+    it('Browse tiers if paid membership is enabled', async function () {
+        const page = await api.browse(true);
 
         assert(page.data.length === 3);
         assert(page.meta.pagination.total === 3);
+    });
+
+    it('Browse 0 tiers if paid membership is not enabled', async function () {
+        const page = await api.browse();
+
+        assert(page.data.length === 0);
+        assert(page.meta.pagination.total === 0);
     });
 
     it('Can read a default tier', async function () {


### PR DESCRIPTION
Fixed GET content tiers api, now returns no tiers if paid membership is not setup.

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

This resolves the #15759 issue, where we shouldn't return any tiers in GET api/content/tiers if paid membership is not setup by owner.

@ErisDS I'm new to this repo, I've very little to no context of your business to code terminologies. 

1. I've used the boolean key if stripe is connected to check if paid membership is enabled or not, let me know if it's correct or needs changes. 
2. I'm looking forward to contribute more to the project and any coding style or architectural docs would be really helpful to know the context and implementation of the features.