### PR TITLE
Added error handling for ENAMETOOLONG import error

### DIFF
--- a/ghost/admin/app/components/modal-import-content.js
+++ b/ghost/admin/app/components/modal-import-content.js
@@ -2,6 +2,7 @@ import ModalComponent from 'ghost-admin/components/modal-base';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {GENERIC_ERROR_MESSAGE} from 'ghost-admin/services/notifications';
 import {computed} from '@ember/object';
+import {getErrorCode, getErrorMessage} from '../services/ajax';
 import {inject} from 'ghost-admin/decorators/inject';
 import {
     isRequestEntityTooLargeError,
@@ -90,7 +91,10 @@ export default ModalComponent.extend({
             this.notifications.showAPIError(error);
         }
 
-        if (isUnsupportedMediaTypeError(error)) {
+        // First handle safe error messages, then default to more generic error messages
+        if (getErrorCode(error) === 'INVALID_ZIP_FILE_NAME_ENCODING') {
+            message = getErrorMessage(error);
+        } else if (isUnsupportedMediaTypeError(error)) {
             message = 'The file type you uploaded is not supported.';
         } else if (isRequestEntityTooLargeError(error)) {
             message = 'The file you uploaded was larger than the maximum file size your server allows.';

--- a/ghost/admin/app/components/modal-import-content.js
+++ b/ghost/admin/app/components/modal-import-content.js
@@ -2,7 +2,7 @@ import ModalComponent from 'ghost-admin/components/modal-base';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {GENERIC_ERROR_MESSAGE} from 'ghost-admin/services/notifications';
 import {computed} from '@ember/object';
-import {getErrorCode, getErrorMessage} from '../services/ajax';
+import {getErrorCode} from '../services/ajax';
 import {inject} from 'ghost-admin/decorators/inject';
 import {
     isRequestEntityTooLargeError,
@@ -91,9 +91,8 @@ export default ModalComponent.extend({
             this.notifications.showAPIError(error);
         }
 
-        // First handle safe error messages, then default to more generic error messages
         if (getErrorCode(error) === 'INVALID_ZIP_FILE_NAME_ENCODING') {
-            message = getErrorMessage(error);
+            message = 'The uploaded zip could not be read due to a long or invalid file name. Please remove any special characters from the file name, or alternatively try another archiving tool if using MacOS Archive Utility.';
         } else if (isUnsupportedMediaTypeError(error)) {
             message = 'The file type you uploaded is not supported.';
         } else if (isRequestEntityTooLargeError(error)) {

--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -112,17 +112,6 @@ export function getErrorCode(errorOrStatus) {
     return null;
 }
 
-/**
- * Returns the message (from the payload) from an error object.
- * @returns {string|null} error message
- */
-export function getErrorMessage(errorOrStatus) {
-    if (isAjaxError(errorOrStatus) && errorOrStatus.payload && errorOrStatus.payload.errors && Array.isArray(errorOrStatus.payload.errors) && errorOrStatus.payload.errors.length > 0) {
-        return errorOrStatus.payload.errors[0].message ?? '';
-    }
-    return null;
-}
-
 /* Maintenance error */
 
 export class MaintenanceError extends AjaxError {

--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -101,6 +101,28 @@ export function isUnsupportedMediaTypeError(errorOrStatus) {
     }
 }
 
+/**
+ * Returns the code (from the payload) from an error object.
+ * @returns {string|null} error code
+ */
+export function getErrorCode(errorOrStatus) {
+    if (isAjaxError(errorOrStatus) && errorOrStatus.payload && errorOrStatus.payload.errors && Array.isArray(errorOrStatus.payload.errors) && errorOrStatus.payload.errors.length > 0) {
+        return errorOrStatus.payload.errors[0].code || null;
+    }
+    return null;
+}
+
+/**
+ * Returns the message (from the payload) from an error object.
+ * @returns {string|null} error message
+ */
+export function getErrorMessage(errorOrStatus) {
+    if (isAjaxError(errorOrStatus) && errorOrStatus.payload && errorOrStatus.payload.errors && Array.isArray(errorOrStatus.payload.errors) && errorOrStatus.payload.errors.length > 0) {
+        return errorOrStatus.payload.errors[0].message ?? '';
+    }
+    return null;
+}
+
 /* Maintenance error */
 
 export class MaintenanceError extends AjaxError {

--- a/ghost/core/core/server/data/importer/import-manager.js
+++ b/ghost/core/core/server/data/importer/import-manager.js
@@ -33,8 +33,9 @@ const messages = {
     invalidZipStructure: 'Invalid zip file structure.',
     invalidZipFileBaseDirectory: 'Invalid zip file: base directory read failed',
     zipContainsMultipleDataFormats: 'Zip file contains multiple data formats. Please split up and import separately.',
-    // The following error is whitelisted and shown in the frontend. It should be carefully worded.
-    invalidZipFileNameEncoding: 'The uploaded zip is not readable. Try re-zipping the zip with a different archiving tool (not MacOS Archive Utility) or remove the special characters from the file names.'
+    invalidZipFileNameEncoding: 'The uploaded zip could not be read',
+    invalidZipFileNameEncodingContext: 'The filename was too long or contained invalid characters',
+    invalidZipFileNameEncodingHelp: 'Remove any special characters from the file name, or alternatively try another archiving tool if using MacOS Archive Utility',
 };
 
 // Glob levels
@@ -184,7 +185,8 @@ class ImportManager {
                 // This causes ENAMETOOLONG error on Linux, because the resulting filename length is too long when decoded using the default string encoder.
                 throw new errors.UnsupportedMediaTypeError({
                     message: tpl(messages.invalidZipFileNameEncoding),
-                    context: err.message,
+                    context: tpl(messages.invalidZipFileNameEncodingContext),
+                    help: tpl(messages.invalidZipFileNameEncodingHelp),
                     code: 'INVALID_ZIP_FILE_NAME_ENCODING'
                 });
             }

--- a/ghost/core/core/server/data/importer/import-manager.js
+++ b/ghost/core/core/server/data/importer/import-manager.js
@@ -35,7 +35,7 @@ const messages = {
     zipContainsMultipleDataFormats: 'Zip file contains multiple data formats. Please split up and import separately.',
     invalidZipFileNameEncoding: 'The uploaded zip could not be read',
     invalidZipFileNameEncodingContext: 'The filename was too long or contained invalid characters',
-    invalidZipFileNameEncodingHelp: 'Remove any special characters from the file name, or alternatively try another archiving tool if using MacOS Archive Utility',
+    invalidZipFileNameEncodingHelp: 'Remove any special characters from the file name, or alternatively try another archiving tool if using MacOS Archive Utility'
 };
 
 // Glob levels


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2200

When zipping a folder that contains files with UTF-8 characters in the filename, using the MacOS Archive Utility, the resulting zip will be missing some UTF-8 configuration bit. This breaks the unzipper, causing it to decode the filenames using the wrong encodign.

When the file names are long, and become longer than the length allowed by the OS, an ENAMETOOLONG error is thrown. This error is not handled by the importer, and causes the import to fail.

This adds a specific check for this error so we can show a clear error message to the user, that helps them to resolve the issue. We are currently unable to fix the issue on our side, because of a lack of well supported zip libraries for node.