### PR TITLE
Improved email verification required checks

### DIFF
--- a/ghost/core/core/server/services/email-service/wrapper.js
+++ b/ghost/core/core/server/services/email-service/wrapper.js
@@ -101,7 +101,8 @@ class EmailServiceWrapper {
             emailRenderer,
             emailSegmenter,
             limitService,
-            membersRepository
+            membersRepository,
+            verificationTrigger: membersService.verificationTrigger
         });
 
         this.controller = new EmailController(this.service, {

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -67,11 +67,11 @@ const processImport = async (options) => {
     return await membersImporter.process({...options, verificationTrigger});
 };
 
-const updateVerificationTrigger = () => {
-    verificationTrigger = new VerificationTrigger({
-        apiTriggerThreshold: _.get(config.get('hostSettings'), 'emailVerification.apiThreshold'),
-        adminTriggerThreshold: _.get(config.get('hostSettings'), 'emailVerification.adminThreshold'),
-        importTriggerThreshold: _.get(config.get('hostSettings'), 'emailVerification.importThreshold'),
+const initVerificationTrigger = () => {
+    return new VerificationTrigger({
+        getApiTriggerThreshold: () => _.get(config.get('hostSettings'), 'emailVerification.apiThreshold'),
+        getAdminTriggerThreshold: () => _.get(config.get('hostSettings'), 'emailVerification.adminThreshold'),
+        getImportTriggerThreshold: () => _.get(config.get('hostSettings'), 'emailVerification.importThreshold'),
         isVerified: () => config.get('hostSettings:emailVerification:verified') === true,
         isVerificationRequired: () => settingsCache.get('email_verification_required') === true,
         sendVerificationEmail: async ({subject, message, amountTriggered}) => {
@@ -133,7 +133,8 @@ module.exports = {
             getMembersApi: () => module.exports.api
         });
 
-        updateVerificationTrigger();
+        verificationTrigger = initVerificationTrigger();
+        module.exports.verificationTrigger = verificationTrigger;
 
         (async () => {
             try {
@@ -169,16 +170,14 @@ module.exports = {
     },
 
     ssr: null,
+    verificationTrigger: null,
 
     stripeConnect: require('./stripe-connect'),
 
     processImport: processImport,
 
     stats: membersStats,
-    export: require('./exporter/query'),
-
-    // Only for tests
-    _updateVerificationTrigger: updateVerificationTrigger
+    export: require('./exporter/query')
 };
 
 module.exports.middleware = require('./middleware');

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -16,7 +16,6 @@ const membersService = require('../../../core/server/services/members');
 const memberAttributionService = require('../../../core/server/services/member-attribution');
 const urlService = require('../../../core/server/services/url');
 const urlUtils = require('../../../core/shared/url-utils');
-const {_updateVerificationTrigger} = require('../../../core/server/services/members');
 const settingsCache = require('../../../core/shared/settings-cache');
 
 /**
@@ -712,7 +711,6 @@ describe('Members API', function () {
             verified: false,
             escalationAddress: 'test@example.com'
         });
-        _updateVerificationTrigger();
 
         assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
 
@@ -766,7 +764,6 @@ describe('Members API', function () {
         await agent.delete(`/members/${memberFailVerification.id}`);
 
         configUtils.restore();
-        _updateVerificationTrigger();
     });
 
     it('Can add and send a signup confirmation email', async function () {

--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -9,7 +9,6 @@ const jobManager = require('../../../../core/server/services/jobs/job-service');
 let agent;
 const _ = require('lodash');
 const {MailgunEmailProvider} = require('@tryghost/email-service');
-const members = require('../../../../core/server/services/members');
 const mobileDocWithPaywall = '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["paywall",{}]],"sections":[[1,"p",[[0,[],0,"Free content"]]],[10,0],[1,"p",[[0,[],0,"Members content"]]]]}';
 const configUtils = require('../../../utils/configUtils');
 const {settingsCache} = require('../../../../core/server/services/settings-helpers');
@@ -479,6 +478,7 @@ describe('Batch sending tests', function () {
 
         // We stub a lot of imported members to mimic a large import that is in progress but is not yet finished
         // the current verification required value is off. But when creating an email, we need to update that check to avoid this issue.
+        const members = require('../../../../core/server/services/members');
         const events = members.api.events;
         const getSignupEvents = sinon.stub(events, 'getSignupEvents').resolves({
             meta: {
@@ -518,6 +518,8 @@ describe('Batch sending tests', function () {
             .expectStatus(403);
         sinon.assert.calledOnce(getSignupEvents);
         assert.equal(settingsCache.get('email_verification_required'), true);
+
+        configUtils.restore();
     });
 
     // TODO: Link tracking

--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -9,8 +9,10 @@ const jobManager = require('../../../../core/server/services/jobs/job-service');
 let agent;
 const _ = require('lodash');
 const {MailgunEmailProvider} = require('@tryghost/email-service');
-
+const members = require('../../../../core/server/services/members');
 const mobileDocWithPaywall = '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["paywall",{}]],"sections":[[1,"p",[[0,[],0,"Free content"]]],[10,0],[1,"p",[[0,[],0,"Members content"]]]]}';
+const configUtils = require('../../../utils/configUtils');
+const {settingsCache} = require('../../../../core/server/services/settings-helpers');
 
 function sortBatches(a, b) {
     const aId = a.get('provider_id');
@@ -81,6 +83,7 @@ describe('Batch sending tests', function () {
         mockManager.mockSetting('mailgun_api_key', 'test');
         mockManager.mockSetting('mailgun_domain', 'example.com');
         mockManager.mockSetting('mailgun_base_url', 'test');
+        mockManager.mockMail();
 
         // We need to stub the Mailgun client before starting Ghost
         sinon.stub(MailgunClient.prototype, 'getInstance').returns({
@@ -145,6 +148,57 @@ describe('Batch sending tests', function () {
         assert.equal(memberIds.length, _.uniq(memberIds).length);
     });
 
+    it('Doesn\'t include members created after the email in the batches', async function () {
+        // If we create a new member (e.g. a member that was imported) after the email was created, they should not be included in the email
+
+        // Prepare a post and email model
+        const completedPromise = jobManager.awaitCompletion('batch-sending-service-job');
+        const emailModel = await createPublishedPostEmail();
+
+        // Create a new member that is subscribed
+        const laterMember = await models.Member.add({
+            name: 'Member that is added later',
+            email: 'member-that-is-added-later@example.com',
+            status: 'free',
+            newsletters: [{
+                id: fixtureManager.get('newsletters', 0).id
+            }]
+        });
+
+        // Check the batches are not yet generated
+        const earlyBatches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
+        assert.equal(earlyBatches.models.length, 0);
+
+        // Await sending job
+        await completedPromise;
+
+        await emailModel.refresh();
+        assert.equal(emailModel.get('status'), 'submitted');
+        assert.equal(emailModel.get('email_count'), 4);
+
+        // Did we create batches?
+        const batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
+        assert.equal(batches.models.length, 1);
+
+        // Did we create recipients?
+        const emailRecipients = await models.EmailRecipient.findAll({filter: `email_id:${emailModel.id}`});
+        assert.equal(emailRecipients.models.length, 4);
+
+        for (const recipient of emailRecipients.models) {
+            assert.equal(recipient.get('batch_id'), batches.models[0].id);
+            assert.notEqual(recipient.get('member_id'), laterMember.id);
+        }
+
+        // Create a new email and see if it is included now
+        const completedPromise2 = jobManager.awaitCompletion('batch-sending-service-job');
+        const emailModel2 = await createPublishedPostEmail();
+        await completedPromise2;
+        await emailModel2.refresh();
+        assert.equal(emailModel2.get('email_count'), 5);
+        const emailRecipients2 = await models.EmailRecipient.findAll({filter: `email_id:${emailModel2.id}`});
+        assert.equal(emailRecipients2.models.length, emailRecipients.models.length + 1);
+    });
+
     it('Splits recipients in free and paid batch', async function () {
         // Prepare a post and email model
         const completedPromise = jobManager.awaitCompletion('batch-sending-service-job');
@@ -164,7 +218,7 @@ describe('Batch sending tests', function () {
 
         await emailModel.refresh();
         assert(emailModel.get('status'), 'submitted');
-        assert.equal(emailModel.get('email_count'), 4);
+        assert.equal(emailModel.get('email_count'), 5);
 
         // Did we create batches?
         const batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
@@ -189,7 +243,7 @@ describe('Batch sending tests', function () {
 
         // Did we create recipients?
         const emailRecipientsFirstBatch = await models.EmailRecipient.findAll({filter: `email_id:${emailModel.id}+batch_id:${firstBatch.id}`});
-        assert.equal(emailRecipientsFirstBatch.models.length, 2);
+        assert.equal(emailRecipientsFirstBatch.models.length, 3);
 
         const emailRecipientsSecondBatch = await models.EmailRecipient.findAll({filter: `email_id:${emailModel.id}+batch_id:${secondBatch.id}`});
         assert.equal(emailRecipientsSecondBatch.models.length, 2);
@@ -258,11 +312,11 @@ describe('Batch sending tests', function () {
 
         await emailModel.refresh();
         assert.equal(emailModel.get('status'), 'submitted');
-        assert.equal(emailModel.get('email_count'), 4);
+        assert.equal(emailModel.get('email_count'), 5);
 
         // Did we create batches?
         const batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
-        assert.equal(batches.models.length, 4);
+        assert.equal(batches.models.length, 5);
 
         const emailRecipients = [];
 
@@ -318,13 +372,13 @@ describe('Batch sending tests', function () {
 
         await emailModel.refresh();
         assert.equal(emailModel.get('status'), 'failed');
-        assert.equal(emailModel.get('email_count'), 4);
+        assert.equal(emailModel.get('email_count'), 5);
 
         // Did we create batches?
         let batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
-        assert.equal(batches.models.length, 4);
+        assert.equal(batches.models.length, 5);
 
-        // sort batches by provider_id (nullable) because findAll doesn't have order option
+        // sort batches by id because findAll doesn't have order option
         batches.models.sort(sortBatches);
 
         let emailRecipients = [];
@@ -334,7 +388,7 @@ describe('Batch sending tests', function () {
         for (const batch of batches.models) {
             count += 1;
 
-            if (count === 4) {
+            if (count === 5) {
                 assert.equal(batch.get('provider_id'), null);
                 assert.equal(batch.get('status'), 'failed');
                 assert.equal(batch.get('error_status_code'), 500);
@@ -343,7 +397,13 @@ describe('Batch sending tests', function () {
                 assert.equal(errorData.error.status, 500);
                 assert.deepEqual(errorData.messageData.to.length, 1);
             } else {
-                assert.equal(batch.get('provider_id'), 'stubbed-email-id-' + count);
+                if (count === 4) {
+                    // We sorted on provider_id so the count is slightly off
+                    assert.equal(batch.get('provider_id'), 'stubbed-email-id-5');
+                } else {
+                    assert.equal(batch.get('provider_id'), 'stubbed-email-id-' + count);
+                }
+
                 assert.equal(batch.get('status'), 'submitted');
                 assert.equal(batch.get('error_status_code'), null);
                 assert.equal(batch.get('error_message'), null);
@@ -374,14 +434,14 @@ describe('Batch sending tests', function () {
         batches.models.sort(sortBatches);
 
         assert.equal(emailModel.get('status'), 'submitted');
-        assert.equal(emailModel.get('email_count'), 4);
+        assert.equal(emailModel.get('email_count'), 5);
 
         // Did we keep the batches?
         batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
 
         // sort batches by provider_id (nullable) because findAll doesn't have order option
         batches.models.sort(sortBatches);
-        assert.equal(batches.models.length, 4);
+        assert.equal(batches.models.length, 5);
 
         emailRecipients = [];
 
@@ -405,6 +465,59 @@ describe('Batch sending tests', function () {
         // Check members are unique
         memberIds = emailRecipients.map(recipient => recipient.get('member_id'));
         assert.equal(memberIds.length, _.uniq(memberIds).length);
+    });
+
+    it('Cannot send an email if verification is required', async function () {
+        // First enable import thresholds
+        configUtils.set('hostSettings:emailVerification', {
+            apiThreshold: 100,
+            adminThreshold: 100,
+            importThreshold: 100,
+            verified: false,
+            escalationAddress: 'test@example.com'
+        });
+
+        // We stub a lot of imported members to mimic a large import that is in progress but is not yet finished
+        // the current verification required value is off. But when creating an email, we need to update that check to avoid this issue.
+        const events = members.api.events;
+        const getSignupEvents = sinon.stub(events, 'getSignupEvents').resolves({
+            meta: {
+                pagination: {
+                    total: 100000
+                }
+            }
+        });
+
+        assert.equal(settingsCache.get('email_verification_required'), false, 'This test requires email verification to be disabled initially');
+
+        const post = {
+            title: 'A random test post',
+            status: 'draft',
+            feature_image_alt: 'Testing sending',
+            feature_image_caption: 'Testing <b>feature image caption</b>',
+            created_at: moment().subtract(2, 'days').toISOString(),
+            updated_at: moment().subtract(2, 'days').toISOString(),
+            created_by: ObjectId().toHexString(),
+            updated_by: ObjectId().toHexString()
+        };
+
+        const res = await agent.post('posts/')
+            .body({posts: [post]})
+            .expectStatus(201);
+
+        const id = res.body.posts[0].id;
+
+        const updatedPost = {
+            status: 'published',
+            updated_at: res.body.posts[0].updated_at
+        };
+
+        const newsletterSlug = fixtureManager.get('newsletters', 0).slug;
+        await agent.put(`posts/${id}/?newsletter=${newsletterSlug}`)
+            .body({posts: [updatedPost]})
+            .expectStatus(403);
+        sinon.assert.calledOnce(getSignupEvents);
+        assert.equal(settingsCache.get('email_verification_required'), true);
     });
 
     // TODO: Link tracking

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -81,7 +81,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(100);
+        await sleep(400);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -135,7 +135,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(100);
+        await sleep(400);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -186,7 +186,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(100);
+        await sleep(400);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -271,7 +271,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(200);
+        await sleep(400);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -371,7 +371,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(200);
+        await sleep(400);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -490,7 +490,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(200);
+        await sleep(400);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -597,7 +597,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(200);
+        await sleep(400);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -776,7 +776,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(200);
+        await sleep(400);
 
         // Check if event exists
         const {body: {events: eventsAfter}} = await agent.get(eventsURI);
@@ -834,7 +834,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(200);
+        await sleep(400);
 
         // Check if unsubscribed
         const member = await membersService.api.members.get({id: memberId}, {withRelated: ['newsletters']});

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -81,7 +81,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(400);
+        await sleep(200);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -135,7 +135,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(400);
+        await sleep(200);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -186,7 +186,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(400);
+        await sleep(200);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -271,7 +271,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(400);
+        await sleep(200);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -371,7 +371,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(400);
+        await sleep(200);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -490,7 +490,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(400);
+        await sleep(200);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -597,7 +597,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(400);
+        await sleep(200);
 
         // Check if status has changed to delivered, with correct timestamp
         const updatedEmailRecipient = await models.EmailRecipient.findOne({
@@ -776,7 +776,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(400);
+        await sleep(200);
 
         // Check if event exists
         const {body: {events: eventsAfter}} = await agent.get(eventsURI);
@@ -834,7 +834,7 @@ describe('EmailEventStorage', function () {
         assert.deepEqual(result.memberIds, [memberId]);
 
         // Now wait for events processed
-        await sleep(400);
+        await sleep(200);
 
         // Check if unsubscribed
         const member = await membersService.api.members.get({id: memberId}, {withRelated: ['newsletters']});

--- a/ghost/core/test/unit/server/services/mega/mega.test.js
+++ b/ghost/core/test/unit/server/services/mega/mega.test.js
@@ -8,6 +8,12 @@ const membersService = require('../../../../../core/server/services/members');
 
 describe('MEGA', function () {
     describe('addEmail', function () {
+        before(function () {
+            membersService.verificationTrigger = {
+                checkVerificationRequired: sinon.stub().resolves(false)
+            };
+        });
+
         afterEach(function () {
             sinon.restore();
         });

--- a/ghost/core/test/unit/server/services/mega/mega.test.js
+++ b/ghost/core/test/unit/server/services/mega/mega.test.js
@@ -14,6 +14,10 @@ describe('MEGA', function () {
             };
         });
 
+        after(function () {
+            membersService.verificationTrigger = null;
+        });
+
         afterEach(function () {
             sinon.restore();
         });

--- a/ghost/email-service/lib/email-service.js
+++ b/ghost/email-service/lib/email-service.js
@@ -4,6 +4,7 @@
  * @typedef {object} Post
  * @typedef {object} Email
  * @typedef {object} LimitService
+ * @typedef {{checkVerificationRequired(): Promise<boolean>}} VerificationTrigger
  */
 
 const BatchSendingService = require('./batch-sending-service');
@@ -15,7 +16,8 @@ const SendingService = require('./sending-service');
 
 const messages = {
     archivedNewsletterError: 'Cannot send email to archived newsletters',
-    missingNewsletterError: 'The post does not have a newsletter relation'
+    missingNewsletterError: 'The post does not have a newsletter relation',
+    emailSendingDisabled: `Email sending is temporarily disabled because your account is currently in review. You should have an email about this from us already, but you can also reach us any time at support@ghost.org`
 };
 
 class EmailService {
@@ -27,6 +29,7 @@ class EmailService {
     #emailSegmenter;
     #limitService;
     #membersRepository;
+    #verificationTrigger;
 
     /**
      *
@@ -40,6 +43,7 @@ class EmailService {
      * @param {EmailSegmenter} dependencies.emailSegmenter
      * @param {LimitService} dependencies.limitService
      * @param {object} dependencies.membersRepository
+     * @param {VerificationTrigger} dependencies.verificationTrigger
      */
     constructor({
         batchSendingService,
@@ -49,7 +53,8 @@ class EmailService {
         emailRenderer,
         emailSegmenter,
         limitService,
-        membersRepository
+        membersRepository,
+        verificationTrigger
     }) {
         this.#batchSendingService = batchSendingService;
         this.#models = models;
@@ -59,12 +64,13 @@ class EmailService {
         this.#limitService = limitService;
         this.#membersRepository = membersRepository;
         this.#sendingService = sendingService;
+        this.#verificationTrigger = verificationTrigger;
     }
 
     /**
      * @private
      */
-    async checkLimits() {
+    async checkLimits(addedCount = 0) {
         // Check host limit for allowed member count and throw error if over limit
         // - do this even if it's a retry so that there's no way around the limit
         if (this.#limitService.isLimited('members')) {
@@ -73,7 +79,15 @@ class EmailService {
 
         // Check host limit for disabled emails or going over emails limit
         if (this.#limitService.isLimited('emails')) {
-            await this.#limitService.errorIfWouldGoOverLimit('emails');
+            await this.#limitService.errorIfWouldGoOverLimit('emails', {addedCount});
+        }
+
+        // Check email verification required
+        // We need to check this inside the job again
+        if (await this.#verificationTrigger.checkVerificationRequired()) {
+            throw new errors.HostLimitError({
+                message: tpl(messages.emailSendingDisabled)
+            });
         }
     }
 
@@ -99,6 +113,8 @@ class EmailService {
         }
 
         const emailRecipientFilter = post.get('email_recipient_filter');
+        const emailCount = await this.#emailSegmenter.getMembersCount(newsletter, emailRecipientFilter);
+        await this.checkLimits(emailCount);
 
         const email = await this.#models.Email.add({
             post_id: post.id,
@@ -112,13 +128,12 @@ class EmailService {
             subject: this.#emailRenderer.getSubject(post),
             from: this.#emailRenderer.getFromAddress(post, newsletter),
             replyTo: this.#emailRenderer.getReplyToAddress(post, newsletter),
-            email_count: await this.#emailSegmenter.getMembersCount(newsletter, emailRecipientFilter),
+            email_count: emailCount,
             source: post.get('lexical') || post.get('mobiledoc'),
             source_type: post.get('lexical') ? 'lexical' : 'mobiledoc'
         });
 
         try {
-            await this.checkLimits();
             this.#batchSendingService.scheduleEmail(email);
         } catch (e) {
             await email.save({

--- a/ghost/email-service/lib/email-service.js
+++ b/ghost/email-service/lib/email-service.js
@@ -82,8 +82,7 @@ class EmailService {
             await this.#limitService.errorIfWouldGoOverLimit('emails', {addedCount});
         }
 
-        // Check email verification required
-        // We need to check this inside the job again
+        // Check if email verification is required
         if (await this.#verificationTrigger.checkVerificationRequired()) {
             throw new errors.HostLimitError({
                 message: tpl(messages.emailSendingDisabled)

--- a/ghost/job-manager/lib/job-manager.js
+++ b/ghost/job-manager/lib/job-manager.js
@@ -39,7 +39,7 @@ class JobManager {
      * @param {Object} [options.domainEvents] - domain events emitter
      */
     constructor({errorHandler, workerMessageHandler, JobModel, domainEvents}) {
-        this.queue = fastq(this, worker, 1);
+        this.queue = fastq(this, worker, 3);
         this._jobMessageHandler = this._jobMessageHandler.bind(this);
         this._jobErrorHandler = this._jobErrorHandler.bind(this);
         this.#domainEvents = domainEvents;

--- a/ghost/members-importer/lib/importer.js
+++ b/ghost/members-importer/lib/importer.js
@@ -11,7 +11,7 @@ const messages = {
     filenameCollision: 'Filename already exists, please try again.'
 };
 
-// The key should correspond to a member model field (unless it's a special purpose field like 'complimentary_plan') 
+// The key should correspond to a member model field (unless it's a special purpose field like 'complimentary_plan')
 // the value should represent an allowed field name coming from user input
 const DEFAULT_CSV_HEADER_MAPPING = {
     email: 'email',
@@ -33,7 +33,7 @@ module.exports = class MembersCSVImporter {
      * @param {() => Promise<import('@tryghost/tiers/lib/Tier')>} options.getDefaultTier - async function returning default Member Tier
      * @param {Function} options.sendEmail - function sending an email
      * @param {(string) => boolean} options.isSet - Method checking if specific feature is enabled
-     * @param {({job, offloaded}) => void} options.addJob - Method registering an async job
+     * @param {({job, offloaded, name}) => void} options.addJob - Method registering an async job
      * @param {Object} options.knex - An instance of the Ghost Database connection
      * @param {Function} options.urlFor - function generating urls
      * @param {Object} options.context
@@ -334,7 +334,8 @@ module.exports = class MembersCSVImporter {
                         logging.error(e);
                     }
                 },
-                offloaded: false
+                offloaded: false,
+                name: 'members-import'
             });
 
             return {

--- a/ghost/verification-trigger/package.json
+++ b/ghost/verification-trigger/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --100 --reporter text --reporter cobertura mocha './test/**/*.test.js'",
     "test": "yarn test:unit",
     "lint": "eslint . --ext .js --cache"
   },


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2366
refs https://ghost.slack.com/archives/C02G9E68C/p1670232405014209

Probem described in issue.

In the old MEGA flow:
- The `email_verification_required` check is now repeated inside the job

In the new email service flow:
- The `email_verification_required` is now checked (didn't happen before)
- When generating the email batch recipients, we only include members that were created before the email was created. That way it is impossible to avoid limit checks by inserting new members between creating an email and sending an email.
- We don't need to repeat the check inside the job because of the above changes

Improved handling of large imports:
- When checking `email_verification_required`, we now also check if the import threshold is reached (a new method is introduced in vertificationTrigger specifically for this usage). If it is, we start the verification progress. This is required for long running imports that only check the verification threshold at the very end.
- This change increases the concurrency of fastq to 3 (refs https://ghost.slack.com/archives/C02G9E68C/p1670232405014209). So when running a long import, it is now possible to send emails without having to wait for the import. Above change makes sure it is not possible to get around the verification limits.

Refactoring:
- Removed the need to use `updateVerificationTrigger` by making thresholds getters instead of fixed variables.
- Improved awaiting of members import job in regression test