### PR TITLE
Trim generated post slug length in Revue importer

### DIFF
--- a/ghost/importer-revue/lib/importer-revue.js
+++ b/ghost/importer-revue/lib/importer-revue.js
@@ -44,11 +44,12 @@ const fetchPostsFromData = (revueData) => {
         }
 
         const postDate = JSONToHTML.getPostDate(postMeta);
+        const postSlug = slugify(postMeta.subject).slice(0, 190);
 
         posts.push({
             comment_id: revuePostID,
             title: postMeta.subject,
-            slug: slugify(postMeta.subject),
+            slug: postSlug,
             status: JSONToHTML.getPostStatus(postMeta),
             visibility: 'public',
             created_at: postDate,

--- a/ghost/importer-revue/test/importer-revue.test.js
+++ b/ghost/importer-revue/test/importer-revue.test.js
@@ -113,6 +113,24 @@ describe('Revue Importer', function () {
                 }
             ]);
         });
+
+        it('can trim generated post slug length', function () {
+            const result = RevueImporter.importPosts({items: '[]', issues: 'id,description,sent_at,subject,preheader\n123456,"<p>Hello World!</p>",2022-12-01 01:01:30 UTC,Lorem Ipsum Dolor Sit Amet Consectetur Adipiscing Elit Mauris Convallis Et Metus Eu Blandit Lorem Ipsum Dolor Sit Amet Consectetur Adipiscing Elit Ut Porta Dapibus Massa Condimentum Malesuada Ipsum Scelerisque Nec Vestibulum Sed Placerat Cras,'});
+
+            assert.deepEqual(result, [
+                {
+                    comment_id: 123456,
+                    title: 'Lorem Ipsum Dolor Sit Amet Consectetur Adipiscing Elit Mauris Convallis Et Metus Eu Blandit Lorem Ipsum Dolor Sit Amet Consectetur Adipiscing Elit Ut Porta Dapibus Massa Condimentum Malesuada Ipsum Scelerisque Nec Vestibulum Sed Placerat Cras',
+                    slug: 'lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-mauris-convallis-et-metus-eu-blandit-lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-ut-porta-dapibus-massa-condimentum-malesuad',
+                    status: 'published',
+                    visibility: 'public',
+                    created_at: '2022-12-01T01:01:30.000Z',
+                    published_at: '2022-12-01T01:01:30.000Z',
+                    updated_at: '2022-12-01T01:01:30.000Z',
+                    html: '<p>Hello World!</p>'
+                }
+            ]);
+        });
     });
 
     describe('importSubscribers', function () {


### PR DESCRIPTION
refs: https://github.com/TryGhost/Ghost/commit/5f90baf6fe3bd9b9acdcc418a0e21389084030ee

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

Ghost has a character limit on post slugs of 191 characters, but sometimes, the slug that is generated from the title in Revue content is longer than this, causing the import to fail. This PR trims that generated post slug to 190 characters.