### PR TITLE
Resolved issue where we redundantly created Customer objects in Stripe. Fixes #16057.

### DIFF
--- a/ghost/stripe/lib/StripeAPI.js
+++ b/ghost/stripe/lib/StripeAPI.js
@@ -364,8 +364,9 @@ module.exports = class StripeAPI {
      */
     async createCheckoutSession(priceId, customer, options) {
         const metadata = options.metadata || undefined;
+        const customerId = customer ? customer.id : undefined;
         const customerEmail = customer ? customer.email : options.customerEmail;
-        const customerId = customer ? customer.id : null;
+ 
         await this._rateLimitBucket.throttle();
         let discounts;
         if (options.coupon) {
@@ -387,12 +388,11 @@ module.exports = class StripeAPI {
             delete subscriptionData.trial_from_plan;
             subscriptionData.trial_period_days = options.trialDays;
         }
-        const session = await this._stripe.checkout.sessions.create({
+
+        let stripeSessionOptions = {
             payment_method_types: ['card'],
             success_url: options.successUrl || this._config.checkoutSessionSuccessUrl,
             cancel_url: options.cancelUrl || this._config.checkoutSessionCancelUrl,
-            customer: customerId,
-            customer_email: customerEmail,
             // @ts-ignore - we need to update to latest stripe library to correctly use newer features
             allow_promotion_codes: discounts ? undefined : this._config.enablePromoCodes,
             metadata,
@@ -407,7 +407,17 @@ module.exports = class StripeAPI {
             // however, this would lose the "trial from plan" feature which has also
             // been deprecated by Stripe
             subscription_data: subscriptionData
-        });
+        };
+
+        /* We are only allowed to specify one of these; email will be pulled from
+           customer object on Stripe side if that object already exists. */
+        if (customerId) {
+            stripeSessionOptions.customer = customerId;
+        } else {
+            stripeSessionOptions.customer_email = customerEmail;
+        }
+
+        const session = await this._stripe.checkout.sessions.create(stripeSessionOptions);
 
         return session;
     }

--- a/ghost/stripe/lib/StripeAPI.js
+++ b/ghost/stripe/lib/StripeAPI.js
@@ -365,6 +365,7 @@ module.exports = class StripeAPI {
     async createCheckoutSession(priceId, customer, options) {
         const metadata = options.metadata || undefined;
         const customerEmail = customer ? customer.email : options.customerEmail;
+        const customerId = customer ? customer.id : null;
         await this._rateLimitBucket.throttle();
         let discounts;
         if (options.coupon) {
@@ -390,6 +391,7 @@ module.exports = class StripeAPI {
             payment_method_types: ['card'],
             success_url: options.successUrl || this._config.checkoutSessionSuccessUrl,
             cancel_url: options.cancelUrl || this._config.checkoutSessionCancelUrl,
+            customer: customerId,
             customer_email: customerEmail,
             // @ts-ignore - we need to update to latest stripe library to correctly use newer features
             allow_promotion_codes: discounts ? undefined : this._config.enablePromoCodes,

--- a/ghost/stripe/test/unit/lib/StripeAPI.test.js
+++ b/ghost/stripe/test/unit/lib/StripeAPI.test.js
@@ -80,4 +80,21 @@ describe('StripeAPI', function () {
         should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_from_plan, true);
         should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.subscription_data.trial_period_days);
     });
+
+    it('createCheckoutSession passes customer ID successfully to Stripe', async function (){
+        const mockCustomer = {
+          id: "cust_mock_123456",
+          customer_email: "foo@example.com",
+          name: "Example Customer",
+        };
+
+        await api.createCheckoutSession('priceId', mockCustomer, {
+            trialDays: null
+        });
+
+        should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
+        should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, "cust_mock_123456");
+    });
+
+
 });

--- a/ghost/stripe/test/unit/lib/StripeAPI.test.js
+++ b/ghost/stripe/test/unit/lib/StripeAPI.test.js
@@ -83,9 +83,9 @@ describe('StripeAPI', function () {
 
     it('createCheckoutSession passes customer ID successfully to Stripe', async function (){
         const mockCustomer = {
-          id: "cust_mock_123456",
-          customer_email: "foo@example.com",
-          name: "Example Customer",
+            id: 'cust_mock_123456',
+            customer_email: 'foo@example.com',
+            name: 'Example Customer'
         };
 
         await api.createCheckoutSession('priceId', mockCustomer, {
@@ -93,8 +93,6 @@ describe('StripeAPI', function () {
         });
 
         should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
-        should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, "cust_mock_123456");
+        should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
     });
-
-
 });

--- a/ghost/stripe/test/unit/lib/StripeAPI.test.js
+++ b/ghost/stripe/test/unit/lib/StripeAPI.test.js
@@ -95,4 +95,44 @@ describe('StripeAPI', function () {
         should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
         should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
     });
+
+    it('createCheckoutSession passes email if no customer object provided', async function (){
+        await api.createCheckoutSession('priceId', undefined, {
+            customerEmail: 'foo@example.com',
+            trialDays: null
+        });
+
+        should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+        should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, 'foo@example.com');
+    });
+
+    it('createCheckoutSession passes email if customer object provided w/o ID', async function (){
+        const mockCustomer = {
+            email: 'foo@example.com',
+            name: 'Example Customer'
+        };
+
+        await api.createCheckoutSession('priceId', mockCustomer, {
+            trialDays: null
+        });
+
+        should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+        should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email, 'foo@example.com');
+    });
+
+    it('createCheckoutSession passes only one of customer ID and email', async function (){
+        const mockCustomer = {
+            id: 'cust_mock_123456',
+            email: 'foo@example.com',
+            name: 'Example Customer'
+        };
+
+        await api.createCheckoutSession('priceId', mockCustomer, {
+            trialDays: null
+        });
+
+        should.not.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_email);
+        should.exist(mockStripe.checkout.sessions.create.firstCall.firstArg.customer);
+        should.equal(mockStripe.checkout.sessions.create.firstCall.firstArg.customer, 'cust_mock_123456');
+    });
 });


### PR DESCRIPTION
Fixes #16057 and adds some tests.

Briefly, Ghost created two Customer objects via the Stripe API when an existing subscriber would upgrade to a paid subscription, one in an API call to create the Customer and then a second as a side effect of an API call to create a Checkout session for the user. The fix is passing the reference to the Customer object to the API call to create the Checkout session; Stripe will no long redundantly create a Customer object in this case.

This largely impacts the owner's experience of the Stripe Dashboard; it will correct their new Customer count (going forward) and make searches for users by name or email address return one responsive object which has the actual subscription in it versus returning two and forcing them to look in each to e.g. refund a transaction or similar. 

I've verified this behavior locally against the test version of the API:

<img width="1353" alt="スクリーンショット 2023-01-04 11 44 29" src="https://user-images.githubusercontent.com/32929/210474927-df0d7270-e9c8-4bc6-9101-5d3c89939cec.png">

As you can see, after switching to the branch with the fix, we get the expected single user created; prior to applying the fix we get two users created per checkout.

## Code hygiene and correctness issues

* I have tested manually, as above. 
* I have verified that no files I change have issues with lint.
* I have verified that all tests pass, via yarn test. This includes tests which I added.

I have reasonably strong confidence that I have not broken pre-existing behavior, mostly as a result of adding unit tests which exercise that pre-existing behavior, in the case where we are creating the customer and the checkout session atomically (AFAIK, this happens when a user who is not subscribed to the newsletter elects a paid subscription immediately).
