### PR TITLE
Fixed MailgunEmailSuppressionList adding non-5xx failures to the list

### DIFF
--- a/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
+++ b/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
@@ -96,12 +96,15 @@ class MailgunEmailSuppressionList extends AbstractEmailSuppressionList {
 
     async init() {
         const handleEvent = reason => async (event) => {
-            if (reason === 'bounce') {
-                if (event.error.code < 500 || event.error.code > 599) {
-                    return;
-                }
-            }
             try {
+                if (reason === 'bounce') {
+                    if (!Number.isInteger(event.error?.code)) {
+                        return;
+                    }
+                    if (event.error.code < 500 || event.error.code > 599) {
+                        return;
+                    }
+                }
                 await this.Suppression.add({
                     email_address: event.email,
                     email_id: event.emailId,

--- a/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
+++ b/ghost/core/core/server/services/email-suppression-list/MailgunEmailSuppressionList.js
@@ -96,6 +96,11 @@ class MailgunEmailSuppressionList extends AbstractEmailSuppressionList {
 
     async init() {
         const handleEvent = reason => async (event) => {
+            if (reason === 'bounce') {
+                if (event.error.code < 500 || event.error.code > 599) {
+                    return;
+                }
+            }
             try {
                 await this.Suppression.add({
                     email_address: event.email,

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -208,6 +208,9 @@ describe('EmailEventStorage', function () {
         const providerId = emailBatch.provider_id;
         const timestamp = new Date(2000, 0, 1);
 
+        const {body: {members: [member]}} = await agent.get(`/members/${memberId}`);
+        assert.equal(member.email_suppression.suppressed, false, 'This test requires a member that does not have a suppressed email');
+
         events = [{
             event: 'failed',
             id: 'pl271FzxTTmGRW8Uj3dUWw',
@@ -297,6 +300,10 @@ describe('EmailEventStorage', function () {
         assert.equal(permanentFailures.models[0].get('event_id'), 'pl271FzxTTmGRW8Uj3dUWw');
         assert.equal(permanentFailures.models[0].get('severity'), 'permanent');
         assert.equal(permanentFailures.models[0].get('failed_at').toUTCString(), timestamp.toUTCString());
+
+        const {body: {members: [memberAfter]}} = await agent.get(`/members/${memberId}`);
+        assert.equal(memberAfter.email_suppression.suppressed, false, 'The member should not have a suppressed email');
+        assert.equal(memberAfter.email_suppression.info, null);
     });
 
     it('Ignores permanent failures if already failed', async function () {


### PR DESCRIPTION
no-issue

The current implementation of the suppression list is incorrectly adding emails to the suppression list for permanent failure events which have an error code outside of the 5xx range.