### PR TITLE
Fixed hidden free tier in Portal settings

### DIFF
--- a/ghost/admin/app/components/modal-portal-settings.hbs
+++ b/ghost/admin/app/components/modal-portal-settings.hbs
@@ -39,33 +39,30 @@
                                             </div>
                                         </div>
                                     </GhFormGroup>
-                                    {{#if this.membersUtils.isStripeEnabled}}
-                                        <div {{did-insert this.refreshAfterStripeConnected}} data-test-tiers-at-signup>
-                                            <div class="mb3 mt5">
-                                                <h4 class="gh-portal-setting-title">Tiers available at signup</h4>
-                                            </div>
-                                            <div class="form-group mb0 for-checkbox">
-                                                <label
-                                                    class="checkbox"
-                                                    for="free-plan"
+                                    <div {{did-insert this.refreshAfterStripeConnected}} data-test-tiers-at-signup>
+                                        <div class="mb3 mt5">
+                                            <h4 class="gh-portal-setting-title">Tiers available at signup</h4>
+                                        </div>
+                                        <div class="form-group mb0 for-checkbox" data-test-free-tier-at-signup>
+                                            <label
+                                                class="checkbox"
+                                                for="free-plan"
+                                            >
+                                                <input
+                                                    type="checkbox"
+                                                    checked={{this.membersUtils.isFreeChecked}}
+                                                    id="free-plan"
+                                                    name="free-plan"
+                                                    data-test-settings-tier-input="Free"
+                                                    disabled={{(not-eq this.settings.membersSignupAccess "all")}}
+                                                    class="gh-input post-settings-featured"
+                                                    {{on "click" (action "togglePlan" "free")}}
                                                 >
-                                                    <input
-                                                        type="checkbox"
-                                                        checked={{this.membersUtils.isFreeChecked}}
-                                                        id="free-plan"
-                                                        name="free-plan"
-                                                        disabled={{or
-                                                            (not this.membersUtils.isStripeEnabled)
-                                                            (not-eq this.settings.membersSignupAccess "all")
-                                                        }}
-                                                        class="gh-input post-settings-featured"
-                                                        data-test-settings-tier-input="Free"
-                                                        {{on "click" (action "togglePlan" "free")}}
-                                                    >
-                                                    <span class="input-toggle-component"></span>
-                                                    <p data-test-settings-tier-label="Free">Free</p>
-                                                </label>
-                                            </div>
+                                                <span class="input-toggle-component"></span>
+                                                <p data-test-settings-tier-label="Free">Free</p>
+                                            </label>
+                                        </div>
+                                        {{#if this.membersUtils.isStripeEnabled}}
                                             {{#each this.tiers as |tier|}}
                                                 <div class="form-group mb0 for-checkbox" data-test-tier-at-signup>
                                                     <label
@@ -139,8 +136,8 @@
                                                     </label>
                                                 </div>
                                             {{/if}}
-                                        </div>
-                                    {{/if}}
+                                        {{/if}}
+                                    </div>
                                 </div>
                             {{/liquid-if}}
                         {{/let}}

--- a/ghost/admin/app/components/modal-portal-settings.hbs
+++ b/ghost/admin/app/components/modal-portal-settings.hbs
@@ -54,7 +54,7 @@
                                                     id="free-plan"
                                                     name="free-plan"
                                                     data-test-settings-tier-input="Free"
-                                                    disabled={{(not-eq this.settings.membersSignupAccess "all")}}
+                                                    disabled={{not-eq this.settings.membersSignupAccess "all"}}
                                                     class="gh-input post-settings-featured"
                                                     {{on "click" (action "togglePlan" "free")}}
                                                 >

--- a/ghost/core/test/e2e-browser/admin/membership-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/membership-settings.spec.js
@@ -1,0 +1,19 @@
+const {expect, test} = require('@playwright/test');
+const {disconnectStripe, setupStripe, generateStripeIntegrationToken} = require('../utils');
+
+test.describe('Membership Settings', () => {
+    test.describe('Portal settings', () => {
+        test('Shows free tier when stripe is disconnected', async ({page}) => {
+            await page.goto('/ghost');
+            await disconnectStripe(page);
+            await page.goto('/ghost');
+            await page.locator('.gh-nav a[href="#/settings/"]').click();
+            await page.locator('.gh-setting-group').filter({hasText: 'Membership'}).click();
+            await page.locator('[data-test-toggle="portal-settings"]').click();
+            await expect(page.locator('label').filter({hasText: 'Free'}).first()).toBeVisible();
+            await page.goto('/ghost');
+            const stripeToken = await generateStripeIntegrationToken();
+            await setupStripe(page, stripeToken);
+        });
+    });
+});

--- a/ghost/core/test/e2e-browser/admin/membership-settings.spec.js
+++ b/ghost/core/test/e2e-browser/admin/membership-settings.spec.js
@@ -3,16 +3,22 @@ const {disconnectStripe, setupStripe, generateStripeIntegrationToken} = require(
 
 test.describe('Membership Settings', () => {
     test.describe('Portal settings', () => {
-        test('Shows free tier when stripe is disconnected', async ({page}) => {
+        test('Shows free tier toggle when stripe is disconnected', async ({page}) => {
             await page.goto('/ghost');
+            // Disconnect stripe
             await disconnectStripe(page);
+
+            // Open Portal settings
             await page.goto('/ghost');
             await page.locator('.gh-nav a[href="#/settings/"]').click();
             await page.locator('.gh-setting-group').filter({hasText: 'Membership'}).click();
             await page.locator('[data-test-toggle="portal-settings"]').click();
+            // Check free tier toggle is visible
             await expect(page.locator('label').filter({hasText: 'Free'}).first()).toBeVisible();
-            await page.goto('/ghost');
+
+            // Reconnect Stripe for other tests
             const stripeToken = await generateStripeIntegrationToken();
+            await page.goto('/ghost');
             await setupStripe(page, stripeToken);
         });
     });

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -2,6 +2,7 @@ const DataGenerator = require('../../utils/fixtures/data-generator');
 const {test} = require('@playwright/test');
 const ObjectID = require('bson-objectid').default;
 const {promisify} = require('util');
+const {exec} = require('child_process');
 
 /**
  * Tier


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2338

If a site has the Free tier hidden from the Portal, and subsequently the Stripe connection is disconnected, this produces a dead-end state where no new members can sign up and the Free tier cannot be reactivated again in Portal settings as its hidden. This change -

- enables free tier toggle to be always shown on site irrespective of Stripe connection