### PR TITLE
🐛 Fixed staff token can't export DB

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -35,7 +35,7 @@ const notImplemented = function (req, res, next) {
         schedules: ['PUT'],
         files: ['POST'],
         media: ['POST'],
-        db: ['POST'],
+        db: ['GET', 'POST'],
         settings: ['GET']
     };
 


### PR DESCRIPTION
Allows staff tokens to make backups of the DB by issuing a GET request to the `/db` API endpoint. My use case is automatic daily backups (from a GitHub action).

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

p.s. it might be worth noting that `yarn test:all` should be run inside `ghost/core`, it took me a white to figure that out.