### PR TITLE
Removed bluebird dependency from unit tests in core

### DIFF
--- a/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
@@ -2,7 +2,6 @@ const errors = require('@tryghost/errors');
 const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
 const models = require('../../../../../../../core/server/models');
 

--- a/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
@@ -2,7 +2,6 @@ const errors = require('@tryghost/errors');
 const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
 const models = require('../../../../../../../core/server/models');
 

--- a/ghost/core/test/unit/api/canary/utils/validators/input/tags.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/tags.test.js
@@ -2,7 +2,6 @@ const errors = require('@tryghost/errors');
 const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
 
 describe('Unit: endpoints/utils/validators/input/tags', function () {

--- a/ghost/core/test/unit/api/canary/utils/validators/input/webhooks.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/webhooks.test.js
@@ -2,7 +2,6 @@ const errors = require('@tryghost/errors');
 const _ = require('lodash');
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
 
 describe('Unit: endpoints/utils/validators/input/webhooks', function () {

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const {SafeString} = require('../../../../core/frontend/services/handlebars');
 const configUtils = require('../../../utils/configUtils');
 const logging = require('@tryghost/logging');

--- a/ghost/core/test/unit/frontend/helpers/next_post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/next_post.test.js
@@ -1,6 +1,5 @@
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc;
 const next_post = require('../../../../core/frontend/helpers/prev_post');
 const api = require('../../../../core/frontend/services/proxy').api;

--- a/ghost/core/test/unit/frontend/helpers/prev_post.test.js
+++ b/ghost/core/test/unit/frontend/helpers/prev_post.test.js
@@ -1,6 +1,5 @@
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc;
 const prev_post = require('../../../../core/frontend/helpers/prev_post');
 const api = require('../../../../core/frontend/services/proxy').api;

--- a/ghost/core/test/unit/frontend/helpers/url.test.js
+++ b/ghost/core/test/unit/frontend/helpers/url.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const testUtils = require('../../../utils');
 
 const configUtils = require('../../../utils/configUtils');

--- a/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const testUtils = require('../../../../../utils');
 const configUtils = require('../../../../../utils/configUtils');
 const api = require('../../../../../../core/frontend/services/proxy').api;

--- a/ghost/core/test/unit/frontend/services/rss/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/renderer.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const rssCache = require('../../../../../core/frontend/services/rss/cache');
 const renderer = require('../../../../../core/frontend/services/rss/renderer');
 
@@ -26,7 +25,7 @@ describe('RSS: Renderer', function () {
     });
 
     it('calls the cache and attempts to render, even without data', function (done) {
-        rssCacheStub.returns(new Promise.resolve('dummyxml'));
+        rssCacheStub.returns(Promise.resolve('dummyxml'));
 
         renderer.render(res, baseUrl).then(function () {
             rssCacheStub.calledOnce.should.be.true();
@@ -43,7 +42,7 @@ describe('RSS: Renderer', function () {
     });
 
     it('correctly merges locals into empty data before rendering', function (done) {
-        rssCacheStub.returns(new Promise.resolve('dummyxml'));
+        rssCacheStub.returns(Promise.resolve('dummyxml'));
 
         res.locals = {foo: 'bar'};
 
@@ -62,7 +61,7 @@ describe('RSS: Renderer', function () {
     });
 
     it('correctly merges locals into non-empty data before rendering', function (done) {
-        rssCacheStub.returns(new Promise.resolve('dummyxml'));
+        rssCacheStub.returns(Promise.resolve('dummyxml'));
 
         res.locals = {foo: 'bar'};
         const data = {foo: 'baz', fizz: 'buzz'};
@@ -82,7 +81,7 @@ describe('RSS: Renderer', function () {
     });
 
     it('does nothing if it gets an error', function (done) {
-        rssCacheStub.returns(new Promise.reject(new Error('Fake Error')));
+        rssCacheStub.returns(Promise.reject(new Error('Fake Error')));
 
         renderer.render(res, baseUrl).then(function () {
             done('This should have errored');

--- a/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
@@ -57,7 +57,7 @@ describe('Scheduling: Post Scheduler', function () {
                 events.emit('post.scheduled', post);
 
                 // let the events bubble up
-                await Promise.delay(100);
+                await new Promise(resolve => setTimeout(resolve, 100));
 
                 adapter.schedule.called.should.eql(true);
 

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const errors = require('@tryghost/errors');
 const db = require('../../../../../core/server/data/db');
 const exporter = require('../../../../../core/server/data/exporter');
@@ -157,7 +156,7 @@ describe('Exporter', function () {
     describe('exportFileName', function () {
         it('should return a correctly structured filename', function (done) {
             const settingsStub = sinon.stub(models.Settings, 'findOne').returns(
-                new Promise.resolve({
+                Promise.resolve({
                     get: function () {
                         return 'testblog';
                     }
@@ -175,7 +174,7 @@ describe('Exporter', function () {
 
         it('should return a correctly structured filename if settings is empty', function (done) {
             const settingsStub = sinon.stub(models.Settings, 'findOne').returns(
-                new Promise.resolve()
+                Promise.resolve()
             );
 
             exporter.fileName().then(function (result) {
@@ -189,7 +188,7 @@ describe('Exporter', function () {
 
         it('should return a correctly structured filename if settings errors', function (done) {
             const settingsStub = sinon.stub(models.Settings, 'findOne').returns(
-                new Promise.reject()
+                Promise.reject()
             );
 
             exporter.fileName().then(function (result) {

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 
 const models = require('../../../../../../core/server/models');
 const baseUtils = require('../../../../../../core/server/models/base/utils');

--- a/ghost/core/test/unit/server/models/base/index.test.js
+++ b/ghost/core/test/unit/server/models/base/index.test.js
@@ -2,7 +2,6 @@ const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
 const _ = require('lodash');
-const Promise = require('bluebird');
 const security = require('@tryghost/security');
 const models = require('../../../../../core/server/models');
 const urlUtils = require('../../../../../core/shared/url-utils');

--- a/ghost/core/test/unit/server/models/invite.test.js
+++ b/ghost/core/test/unit/server/models/invite.test.js
@@ -1,6 +1,5 @@
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const models = require('../../../../core/server/models');
 const settingsCache = require('../../../../core/shared/settings-cache');
 

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');
 const permissions = require('../../../../core/server/services/permissions');

--- a/ghost/core/test/unit/server/services/mail/GhostMailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/GhostMailer.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const mail = require('../../../../../core/server/services/mail');
 const settingsCache = require('../../../../../core/shared/settings-cache');
 const configUtils = require('../../../../utils/configUtils');

--- a/ghost/core/test/unit/server/services/permissions/can-this.test.js
+++ b/ghost/core/test/unit/server/services/permissions/can-this.test.js
@@ -1,7 +1,6 @@
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
-const Promise = require('bluebird');
 const _ = require('lodash');
 const models = require('../../../../../core/server/models');
 const permissions = require('../../../../../core/server/services/permissions');

--- a/ghost/core/test/unit/server/services/permissions/index.test.js
+++ b/ghost/core/test/unit/server/services/permissions/index.test.js
@@ -1,7 +1,6 @@
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
-const Promise = require('bluebird');
 const _ = require('lodash');
 const models = require('../../../../../core/server/models');
 const actionsMap = require('../../../../../core/server/services/permissions/actions-map-cache');

--- a/ghost/core/test/unit/server/services/permissions/providers.test.js
+++ b/ghost/core/test/unit/server/services/permissions/providers.test.js
@@ -1,7 +1,6 @@
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../../../utils');
-const Promise = require('bluebird');
 const models = require('../../../../../core/server/models');
 const providers = require('../../../../../core/server/services/permissions/providers');
 
@@ -206,7 +205,7 @@ describe('Permission Providers', function () {
     describe('API Key', function () {
         it('errors if api_key cannot be found', function (done) {
             let findApiKeySpy = sinon.stub(models.ApiKey, 'findOne');
-            findApiKeySpy.returns(new Promise.resolve());
+            findApiKeySpy.returns(Promise.resolve());
             providers.apiKey(1)
                 .then(() => {
                     done(new Error('Should have thrown an api key not found error'));


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/14882

- Replaced `new Promise.reject()` / `new Promise.resolve()` with the static methods `Promise.reject` / `Promise/resolve` from native promises
- Replaced `Promise.delay()` with a promisified `setTimeout()`

