### PR TITLE
Fixed `Theme.errors` clash with Ember Data Model's `errors` property

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -31,12 +31,12 @@ export default class Footer extends Component {
             canActivate: false,
             // Warnings will only be set for developers, otherwise it will always be empty
             warnings: this.themeManagement.activeTheme.warnings,
-            errors: this.themeManagement.activeTheme.errors
+            errors: this.themeManagement.activeTheme.gscanErrors
         });
     }
 
     get hasThemeErrors() {
-        return this.themeManagement.activeTheme && this.themeManagement.activeTheme.errors.length;
+        return this.themeManagement.activeTheme && this.themeManagement.activeTheme.gscanErrors.length;
     }
 
     // equivalent to "left: auto; right: -20px"

--- a/ghost/admin/app/components/modals/design/install-theme.js
+++ b/ghost/admin/app/components/modals/design/install-theme.js
@@ -91,7 +91,7 @@ export default class InstallThemeModal extends Component {
                 this.installedTheme = this.store.peekRecord('theme', result.themes[0].name);
 
                 this.validationWarnings = this.installedTheme.warnings || [];
-                this.validationErrors = this.installedTheme.errors || [];
+                this.validationErrors = this.installedTheme.gscanErrors || [];
                 this.fatalValidationErrors = [];
 
                 // activate but prevent additional error modal from showing

--- a/ghost/admin/app/components/modals/design/upload-theme.js
+++ b/ghost/admin/app/components/modals/design/upload-theme.js
@@ -129,8 +129,8 @@ export default class UploadThemeModal extends Component {
 
         // Ghost differentiates between errors and fatal errors
         // You can't activate a theme with fatal errors, but with errors.
-        if (theme.errors?.length > 0) {
-            this.validationErrors = theme.errors;
+        if (theme.gscanErrors?.length > 0) {
+            this.validationErrors = theme.gscanErrors;
         }
     }
 

--- a/ghost/admin/app/models/theme.js
+++ b/ghost/admin/app/models/theme.js
@@ -4,7 +4,7 @@ import {isBlank} from '@ember/utils';
 
 export default Model.extend({
     active: attr('boolean'),
-    errors: attr('raw', {defaultValue: () => []}),
+    gscanErrors: attr('raw', {defaultValue: () => []}), // renamed from 'errors' to avoid clash with Ember Data Model's `errors` property
     name: attr('string'),
     package: attr('raw'),
     templates: attr('raw', {defaultValue: () => []}),

--- a/ghost/admin/app/serializers/theme.js
+++ b/ghost/admin/app/serializers/theme.js
@@ -1,5 +1,11 @@
 import ApplicationSerializer from './application';
+import classic from 'ember-classic-decorator';
 
+@classic
 export default class Theme extends ApplicationSerializer {
     primaryKey = 'name';
+
+    attrs = {
+        gscanErrors: {key: 'errors'}
+    };
 }


### PR DESCRIPTION
no issue

- the Ember Data `Model` class has an `errors` property by default that is set to a `DS.Errors` instance but the Theme model was overriding that with an `errors` attr
- it hasn't been an issue so far but causes problems in Ember/Ember Data 3.28.x because that tries to use the `DS.Errors` interface on the overridden attr property which then throws errors because the `errors` attr doesn't have the right methods
