### PR TITLE
Switch to using X-Real-IP when set as the real IP address

### DIFF
--- a/ghost/core/core/shared/express.js
+++ b/ghost/core/core/shared/express.js
@@ -14,6 +14,14 @@ module.exports = (name) => {
     // (X-Forwarded-Proto header will be checked, if present)
     app.enable('trust proxy');
 
+    app.use((req, _res, next) => {
+        if (req.headers['x-real-ip']) {
+            // Use X-Real-IP as the real IP where set
+            req.headers['x-forwarded-for'] = req.headers['x-real-ip'];
+        }
+        next();
+    });
+
     // Sentry must be our first error handler. Mounting it here means all custom error handlers will come after
     app.use(sentry.errorHandler);
 


### PR DESCRIPTION
refs: https://github.com/TryGhost/DevOps/issues/1

The default setup for Express' `trust proxy` option uses X-Forwarded-For to set the remote address. Because Ghost is behind a proxy by default (when setup with Ghost CLI), this should be correct. The issue is that the typical way to setup X-Forwarded-For is to append to what the client has sent, which means that X-Forwarded-For can be set entirely by the client, which we do not trust.

Our options are:

* Make Nginx send only $remote_addr instead of $proxy_add_x_forwarded_for (fine for normal cases, wrong for proxies!)
* Have Ghost use an alternative header (implemented by this PR!)

Our configuration of Nginx already sets X-Real-IP to $remote_addr by default, which is correct when there are no further proxies.

Users with proxy setups can modify the Nginx config to use [ngx_http_realip_module](https://nginx.org/en/docs/http/ngx_http_realip_module.html) to set the X-Real-IP header to the value passed by a remote server, if that remote server has a trusted IP address. As an example, here is the configuration suggested for using Cloudflare as a proxy ([source](https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs#JUxJSMn3Ht5c5yq)):

```nginx
# Get list of CIDR entries from https://www.cloudflare.com/en-gb/ips/
# Example:
set_real_ip_from 192.0.2.1;

real_ip_header CF-Connecting-IP;
```

For self-hosted proxies it should be easy to know which IP address(es) they will use, making it easy to use the `set_real_ip_from` directive. For cloud proxies this is harder - not all services publish their IP ranges, and public cloud services may mean that the selection is far too broad. There are some workarounds for some services, e.g. Netlify can sign requests with JWS - so you could conceivably use the Lua module for Nginx to confirm that the request came from Netlify before setting X-Real-IP to the value of X-Nf-Client-Connection-Ip.