### PR TITLE
Improved error message when embedding a Youtube video with embedding disabled

### DIFF
--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -1138,3 +1138,6 @@ remove|ember-template-lint|no-triple-curlies|72|16|72|16|9197e9050977ef47965e1b6
 remove|ember-template-lint|no-invalid-interactive|93|36|93|36|fc4eb64cc0ad0cc9c500c7ef026e44649bc4778b|1662681600000|1673053200000|1678237200000|app/templates/offers.hbs
 remove|ember-template-lint|no-action|143|50|143|50|91a3281547c8446529685240c77aaccb5c7d69bd|1662681600000|1673053200000|1678237200000|app/components/gh-post-settings-menu.hbs
 remove|ember-template-lint|no-action|411|168|411|168|0145b67f0faef0aad141c6a4269c35c6ef8f0a47|1662681600000|1673053200000|1678237200000|app/components/gh-post-settings-menu.hbs
+add|ember-template-lint|no-action|55|71|55|71|76726a13a086d82dab219df12e86db1773a9de32|1673481600000|1683846000000|1689030000000|lib/koenig-editor/addon/components/koenig-card-embed.hbs
+add|ember-template-lint|no-action|56|85|56|85|bb78ad59bc384ea0de5e9459da9d85f1735ce141|1673481600000|1683846000000|1689030000000|lib/koenig-editor/addon/components/koenig-card-embed.hbs
+add|ember-template-lint|no-action|57|38|57|38|3ad187464ff78253a0ea4dd17dcfcf0423f66864|1673481600000|1683846000000|1689030000000|lib/koenig-editor/addon/components/koenig-card-embed.hbs

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-embed.hbs
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-embed.hbs
@@ -40,6 +40,15 @@
             <div class="miw-100 pa2 ba br2 b--lightgrey-d1 flex items-center justify-center bg-whitegrey-l2 f6 lh-title h10">
                 &nbsp;<div class="ghost-spinner spinner-blue"></div>&nbsp;
             </div>
+        {{else if this.isUnauthorized}}
+            <div class="miw-100 flex flex-row pa2 pl3 ba br2 b--red-l3 red bg-error-red f7 fw4 lh-title h10 items-center">
+                <span class="mr3">The owner of this URL has disabled embedding.</span>
+                <button type="button" class="red-d2 mr3 fw6 hover-red" {{action "retry"}}><span class="underline">Retry</span></button>
+                <button type="button" class="red-d2 mr-auto fw6 underline hover-red" {{action "insertAsLink"}}><span class="underline">Paste URL as link</span></button>
+                <button type="button" {{action this.deleteCard}} class="nudge-right--2">
+                    {{svg-jar "close" class="w3 stroke-red-l3"}}
+                </button>
+            </div>
         {{else if this.hasError}}
             <div class="miw-100 flex flex-row pa2 pl3 ba br2 b--red-l3 red bg-error-red f7 fw4 lh-title h10 items-center">
                 <span class="mr3">There was an error when parsing the URL.</span>

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-embed.js
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-embed.js
@@ -6,6 +6,7 @@ import {NO_CURSOR_MOVEMENT} from './koenig-editor';
 import {action, computed, set} from '@ember/object';
 import {utils as ghostHelperUtils} from '@tryghost/helpers';
 import {isBlank} from '@ember/utils';
+import {isUnauthorizedError} from 'ember-ajax/errors';
 import {run} from '@ember/runloop';
 import {task} from 'ember-concurrency';
 
@@ -23,6 +24,7 @@ export default class KoenigCardEmbed extends Component {
 
     // internal properties
     hasError = false;
+    isUnauthorized = false;
 
     // closure actions
     selectCard() {}
@@ -114,6 +116,7 @@ export default class KoenigCardEmbed extends Component {
     @action
     retry() {
         this.set('hasError', false);
+        this.set('isUnauthorized', false);
     }
 
     @action
@@ -208,6 +211,9 @@ export default class KoenigCardEmbed extends Component {
                 return;
             }
             this.set('hasError', true);
+            if (isUnauthorizedError(err)) {
+                this.set('isUnauthorized', true);
+            }
         }
     }).drop())
         convertUrl;

--- a/ghost/core/core/server/services/twitter-embed.js
+++ b/ghost/core/core/server/services/twitter-embed.js
@@ -1,4 +1,4 @@
-const {extract} = require('oembed-parser');
+const {extract} = require('@extractus/oembed-extractor');
 const logging = require('@tryghost/logging');
 
 /**

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -56,6 +56,7 @@
     "cli": "^1.17.0"
   },
   "dependencies": {
+    "@extractus/oembed-extractor": "^3.1.8",
     "@sentry/node": "7.11.1",
     "@tryghost/adapter-base-cache": "0.1.3",
     "@tryghost/adapter-manager": "0.0.0",
@@ -184,7 +185,6 @@
     "mysql2": "2.3.3",
     "nconf": "0.12.0",
     "node-jose": "2.1.1",
-    "oembed-parser": "1.4.9",
     "path-match": "1.2.4",
     "probe-image-size": "7.2.3",
     "rss": "1.2.2",

--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -60,6 +60,37 @@ describe('Oembed API', function () {
         should.exist(res.body.html);
     });
 
+    it('errors with a useful message when embedding is disabled', async function () {
+        const requestMock = nock('https://www.youtube.com')
+            .get('/oembed')
+            .query(true)
+            .reply(401, {
+                errors: [
+                    {
+                        message: 'Authorisation error, cannot read oembed.',
+                        context: 'URL contains a private resource.',
+                        type: 'UnauthorizedError',
+                        details: null,
+                        property: null,
+                        help: null,
+                        code: null,
+                        id: 'c51228a0-921a-11ed-8abe-6babfda4d18a',
+                        ghostErrorCode: null
+                    }
+                ]
+            });
+
+        const res = await request.get(localUtils.API.getApiQuery('oembed/?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DE5yFcdPAGv0'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(401);
+
+        requestMock.isDone().should.be.true();
+        should.exist(res.body.errors);
+        res.body.errors[0].context.should.match(/URL contains a private resource/i);
+    });
+
     describe('type: bookmark', function () {
         it('can fetch a bookmark with ?type=bookmark', async function () {
             const pageMock = nock('http://example.com')

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
       "intl-messageformat",
       "moment",
       "moment-timezone",
-      "oembed-parser",
       "simple-dom",
       "ember-drag-drop",
       "normalize.css",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,6 +2496,13 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@extractus/oembed-extractor@^3.1.8":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@extractus/oembed-extractor/-/oembed-extractor-3.1.8.tgz#79ea7ed65c7688bdf9ee673a0ac5aa122cef5e4e"
+  integrity sha512-k6p8des8ISJY2fuuQDyiUOTlcuPOzWETM2ewF1aywFNSS3EvgGWRwoMsvBKhCrLuvb8NyEKDAJB0SWgt0L793w==
+  dependencies:
+    cross-fetch "^3.1.5"
+
 "@faker-js/faker@7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
@@ -9817,7 +9824,7 @@ cron-validate@1.4.5, cron-validate@^1.4.1:
   dependencies:
     yup "0.32.9"
 
-cross-fetch@^3.1.4:
+cross-fetch@^3.1.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==


### PR DESCRIPTION
fixes TryGhost/Ghost#16048

- When attempting to embed a Youtube video that has had embedding disabled by its owner/author, Ghost displayed a generic error message that didn't indicate the reason for the failed embed.

- This change updated the error message when Youtube (or any provider) returns 401: Unauthorized to indicate that the owner of the resource has explicity disabled embedding.