### PR TITLE
✨ Handled Mailgun email suppressions internally in Ghost

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.30/2023-01-13-04-25-unsubscribe-suppressed-emails.js
+++ b/ghost/core/core/server/data/migrations/versions/5.30/2023-01-13-04-25-unsubscribe-suppressed-emails.js
@@ -1,0 +1,21 @@
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const membersWithSuppressedEmails = await knex.select('members.id').from('members').innerJoin('suppressions', 'members.email', 'suppressions.email');
+
+        if (membersWithSuppressedEmails.length === 0) {
+            logging.info('No emails suppressions found');
+            return;
+        } else {
+            logging.info(`Unsubscribing ${membersWithSuppressedEmails.length} members from newsletters due to email suppressions`);
+        }
+
+        await knex('members_newsletters').whereIn('member_id', membersWithSuppressedEmails.map(member => member.id)).del();
+    },
+    async function down() {
+        logging.info('Not repopulating members_newsletters');
+    }
+);

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -15,6 +15,7 @@ const messages = {
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
+    'suppressionList',
     'sourceAttribution',
     'memberAttribution',
     'audienceFeedback',
@@ -31,7 +32,6 @@ const ALPHA_FEATURES = [
     'urlCache',
     'beforeAfterCard',
     'lexicalEditor',
-    'suppressionList',
     'emailStability'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -635,7 +635,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3497",
+  "content-length": "3522",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",


### PR DESCRIPTION
This introduces the new suppressions feature will automatically unsubscribe members from newsletters when their email is added to the suppression list in Mailgun, this is usually due to either emails permanently bouncing to the address, or the user making a spam complaint.

Both Members and Admins are able to see that the email has been added to the list, and Members are be able to request their email be removed from the list via Portal.

Overall this feature should improve deliverability rates of newsletters and improve the rating of the domain you're sending from.