### PR TITLE
Bumped email stability flag to beta

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -25,14 +25,14 @@ const GA_FEATURES = [
 // NOTE: this allowlist is meant to be used to filter out any unexpected
 //       input for the "labs" setting value
 const BETA_FEATURES = [
-    'activitypub'
+    'activitypub',
+    'emailStability'
 ];
 
 const ALPHA_FEATURES = [
     'urlCache',
     'beforeAfterCard',
-    'lexicalEditor',
-    'emailStability'
+    'lexicalEditor'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];


### PR DESCRIPTION
- allows email stability to be turned on without developer experiments enabled