### PR TITLE
Added email content testing capabilities

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -201,8 +201,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.29.2",
-    "@tryghost/express-test": "0.11.8",
-    "@tryghost/jest-snapshot": "0.5.0",
+    "@tryghost/express-test": "0.12.0",
     "@tryghost/webhook-mock-receiver": "0.2.3",
     "@types/common-tags": "1.8.1",
     "c8": "7.12.0",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -76,6 +76,7 @@
     "@tryghost/email-analytics-provider-mailgun": "0.0.0",
     "@tryghost/email-analytics-service": "0.0.0",
     "@tryghost/email-content-generator": "0.0.0",
+    "@tryghost/email-mock-receiver": "0.1.0",
     "@tryghost/email-service": "0.0.0",
     "@tryghost/email-suppression-list": "0.0.0",
     "@tryghost/errors": "1.2.20",
@@ -201,7 +202,7 @@
   "devDependencies": {
     "@playwright/test": "1.29.2",
     "@tryghost/express-test": "0.11.8",
-    "@tryghost/jest-snapshot": "0.4.8",
+    "@tryghost/jest-snapshot": "0.5.0",
     "@tryghost/webhook-mock-receiver": "0.2.3",
     "@types/common-tags": "1.8.1",
     "c8": "7.12.0",

--- a/ghost/core/test/e2e-api/admin/newsletters.test.js
+++ b/ghost/core/test/e2e-api/admin/newsletters.test.js
@@ -341,8 +341,8 @@ describe('Newsletters API', function () {
             })
             .expectStatus(200);
 
-        const mailHtml = mailMocks.getCall(0).args[0].html;
-        const $mailHtml = cheerio.load(mailHtml);
+        const mail = mockManager.assert.sentEmail([]);
+        const $mailHtml = cheerio.load(mail.html);
 
         const verifyUrl = new URL($mailHtml('[data-test-verify-link]').attr('href'));
         // convert Admin URL hash to native URL for easier token param extraction
@@ -362,7 +362,7 @@ describe('Newsletters API', function () {
         after(function () {
             configUtils.set('hostSettings:limits', undefined);
         });
-        
+
         it('Request fails when newsletter limit is in place', async function () {
             configUtils.set('hostSettings:limits', {
                 newsletters: {
@@ -398,7 +398,7 @@ describe('Newsletters API', function () {
                         error: 'Your plan supports up to {{max}} newsletters. Please upgrade to add more.'
                     }
                 });
-    
+
                 agent = await agentProvider.getAdminAPIAgent();
                 await fixtureManager.init('newsletters', 'members:newsletters');
                 await agent.loginAsOwner();
@@ -408,11 +408,11 @@ describe('Newsletters API', function () {
                 const allNewsletters = await models.Newsletter.findAll();
                 const newsletterCount = allNewsletters.filter(n => n.get('status') === 'active').length;
                 assert.equal(newsletterCount, 3, 'This test expects to have 3 current active newsletters');
-    
+
                 const newsletter = {
                     name: 'Naughty newsletter'
                 };
-    
+
                 await agent
                     .post(`newsletters/?opt_in_existing=true`)
                     .body({newsletters: [newsletter]})
@@ -431,11 +431,11 @@ describe('Newsletters API', function () {
                 const allNewsletters = await models.Newsletter.findAll();
                 const newsletterCount = allNewsletters.filter(n => n.get('status') === 'active').length;
                 assert.equal(newsletterCount, 3, 'This test expects to have 3 current active newsletters');
-    
+
                 const newsletter = {
                     name: 'Naughty newsletter'
                 };
-    
+
                 // Note that ?opt_in_existing=true will trigger a transaction, so we explicitly test here without a
                 // transaction
                 await agent
@@ -456,12 +456,12 @@ describe('Newsletters API', function () {
                 const allNewsletters = await models.Newsletter.findAll();
                 const newsletterCount = allNewsletters.filter(n => n.get('status') === 'active').length;
                 assert.equal(newsletterCount, 3, 'This test expects to have 3 current active newsletters');
-    
+
                 const newsletter = {
                     name: 'Archived newsletter',
                     status: 'archived'
                 };
-    
+
                 await agent
                     .post(`newsletters/?opt_in_existing=true`)
                     .body({newsletters: [newsletter]})
@@ -479,10 +479,10 @@ describe('Newsletters API', function () {
                 const allNewsletters = await models.Newsletter.findAll();
                 const newsletterCount = allNewsletters.filter(n => n.get('status') === 'active').length;
                 assert.equal(newsletterCount, 3, 'This test expects to have 3 current active newsletters');
-    
+
                 const activeNewsletter = allNewsletters.find(n => n.get('status') !== 'active');
                 assert.ok(activeNewsletter, 'This test expects to have an active newsletter in the test fixtures');
-    
+
                 const id = activeNewsletter.id;
                 await agent.put(`newsletters/${id}`)
                     .body({
@@ -498,15 +498,15 @@ describe('Newsletters API', function () {
                         etag: anyEtag
                     });
             });
-    
+
             it('Editing an archived newsletter doesn\'t fail', async function () {
                 const allNewsletters = await models.Newsletter.findAll();
                 const newsletterCount = allNewsletters.filter(n => n.get('status') === 'active').length;
                 assert.equal(newsletterCount, 3, 'This test expects to have 3 current active newsletters');
-    
+
                 const archivedNewsletter = allNewsletters.find(n => n.get('status') !== 'active');
                 assert.ok(archivedNewsletter, 'This test expects to have an archived newsletter in the test fixtures');
-    
+
                 const id = archivedNewsletter.id;
                 await agent.put(`newsletters/${id}`)
                     .body({
@@ -522,15 +522,15 @@ describe('Newsletters API', function () {
                         etag: anyEtag
                     });
             });
-    
+
             it('Unarchiving a newsletter fails', async function () {
                 const allNewsletters = await models.Newsletter.findAll();
                 const newsletterCount = allNewsletters.filter(n => n.get('status') === 'active').length;
                 assert.equal(newsletterCount, 3, 'This test expects to have 3 current active newsletters');
-    
+
                 const archivedNewsletter = allNewsletters.find(n => n.get('status') !== 'active');
                 assert.ok(archivedNewsletter, 'This test expects to have an archived newsletter in the test fixtures');
-    
+
                 const id = archivedNewsletter.id;
                 await agent.put(`newsletters/${id}`)
                     .body({
@@ -553,9 +553,9 @@ describe('Newsletters API', function () {
                 const allNewsletters = await models.Newsletter.findAll();
                 const newsletterCount = allNewsletters.filter(n => n.get('status') === 'active').length;
                 assert.equal(newsletterCount, 3, 'This test expects to have 3 current active newsletters');
-    
+
                 const activeNewsletter = allNewsletters.find(n => n.get('status') === 'active');
-    
+
                 const id = activeNewsletter.id;
                 await agent.put(`newsletters/${id}`)
                     .body({
@@ -576,7 +576,7 @@ describe('Newsletters API', function () {
                 const allNewsletters = await models.Newsletter.findAll();
                 const newsletterCount = allNewsletters.filter(n => n.get('status') === 'active').length;
                 assert.equal(newsletterCount, 2, 'This test expects to have 2 current active newsletters');
-        
+
                 const newsletter = {
                     name: 'Naughty newsletter'
                 };

--- a/ghost/core/test/regression/api/admin/__snapshots__/authentication.test.js.snap
+++ b/ghost/core/test/regression/api/admin/__snapshots__/authentication.test.js.snap
@@ -46,6 +46,196 @@ Object {
 }
 `;
 
+exports[`Authentication API Blog setup complete setup 3: [html 1] 1`] = `
+"<!doctype html>
+<html>
+<head>
+<meta name=\\"viewport\\" content=\\"width=device-width\\">
+<meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\">
+<title>Welcome to Ghost</title>
+<style>
+/* -------------------------------------
+    RESPONSIVE AND MOBILE FRIENDLY STYLES
+------------------------------------- */
+@media only screen and (max-width: 620px) {
+    table[class=body] h1 {
+    font-size: 28px !important;
+    margin-bottom: 10px !important;
+    }
+    table[class=body] p,
+        table[class=body] ul,
+        table[class=body] ol,
+        table[class=body] td,
+        table[class=body] span,
+        table[class=body] a {
+    font-size: 16px !important;
+    }
+    table[class=body] .title {
+    font-size: 22px !important;
+    }
+    table[class=body] .wrapper,
+        table[class=body] .article {
+    padding: 10px !important;
+    }
+    table[class=body] .content {
+    padding: 0 !important;
+    }
+    table[class=body] .container {
+    padding: 0 !important;
+    width: 100% !important;
+    }
+    table[class=body] .main {
+    border-left-width: 0 !important;
+    border-radius: 0 !important;
+    border-right-width: 0 !important;
+    }
+    table[class=body] .btn table {
+    width: 100% !important;
+    }
+    table[class=body] .btn a {
+    width: 100% !important;
+    }
+    table[class=body] .img-responsive {
+    height: auto !important;
+    max-width: 100% !important;
+    width: auto !important;
+    }
+    table[class=body] p[class=small],
+    table[class=body] a[class=small] {
+    font-size: 12x !important;
+    }
+}
+/* -------------------------------------
+    PRESERVE THESE STYLES IN THE HEAD
+------------------------------------- */
+@media all {
+    .ExternalClass {
+    width: 100%;
+    }
+    .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+    line-height: 100%;
+    }
+    .recipient-link a {
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: none !important;
+    }
+    #MessageViewBody a {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    }
+}
+hr {
+    border-width: 0;
+    height: 0;
+    margin-top: 34px;
+    margin-bottom: 34px;
+    border-bottom-width: 1px;
+    border-bottom-color: #EEF5F8;
+}
+a {
+    color: #3A464C;
+}
+</style>
+</head>
+<body style=\\"background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;\\">
+
+<table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"body\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+    <tr>
+        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
+        <td class=\\"container\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;\\">
+
+            <div class=\\"content\\" style=\\"box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;\\">
+
+            <!-- START CENTERED CONTAINER -->
+            <table class=\\"main\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;\\">
+
+                <!-- START MAIN CONTENT AREA -->
+                <tr>
+                <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;\\">
+                    <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                        <tr>
+                            <td align=\\"center\\" style=\\"padding-top: 20px; padding-bottom: 12px;\\"><img src=\\"https://static.ghost.org/v4.0.0/images/ghost-orb-3.png\\" width=\\"60\\" height=\\"60\\" style=\\"width: 60px; height: 60px;\\" /></td>
+                        </tr>
+                        <tr>
+                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top;\\">
+                            <p class=\\"title\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 21px; color: #3A464C; font-weight: normal; line-height: 25px; margin-bottom: 0px; margin-top: 50px; font-weight: 600; color: #15212A;\\">Hello!</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 24px; padding-bottom: 10px;\\">
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;\\">Good news! You've successfully created a brand new Ghost publication over on  <a href=\\"http://127.0.0.1:2369/\\" style=\\"color: #15212A;\\">http://127.0.0.1:2369/</a></p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;\\">You can log in to your admin account with the following details:</p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;\\"><strong style=\\"font-weight: 600;\\">Email Address:</strong> <a href=\\"mailto:test@example.com\\" style=\\"color: #15212A;\\">test@example.com</a></p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;\\"><strong style=\\"font-weight: 600;\\">Password:</strong> The password you chose when you signed up</p>
+
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;\\">Keep this email somewhere safe for future reference, and have fun!</p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;\\">xoxo</p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;\\">Team Ghost – <a href=\\"https://ghost.org\\" style=\\"color: #15212A;\\">https://ghost.org</a></p>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; vertical-align: top; padding-top: 80px; padding-bottom: 10px;\\">
+                    <div class=\\"footer\\">
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; color: #738A94; font-weight: normal; margin: 0; line-height: 18px; margin-bottom: 0px; font-size: 11px;\\">This email was sent from <a href=\\"http://127.0.0.1:2369/\\" style=\\"color: #738A94;\\">http://127.0.0.1:2369/</a> to <a href=\\"mailto:test@example.com\\" style=\\"color: #738A94;\\">test@example.com</a></p>
+                    </div>
+                </td>
+            </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+            <!-- END CENTERED CONTAINER -->
+            </div>
+        </td>
+        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>"
+`;
+
+exports[`Authentication API Blog setup complete setup 4: [metadata 1] 1`] = `
+Object {
+  "subject": "Your New Ghost Site",
+  "text": " [https://static.ghost.org/v4.0.0/images/ghost-orb-3.png] Hello!
+
+Good news! You've successfully created a brand new Ghost publication over on 
+http://127.0.0.1:2369/ [http://127.0.0.1:2369/]
+
+You can log in to your admin account with the following details:
+
+Email Address: test@example.com [test@example.com]
+
+Password: The password you chose when you signed up
+
+Keep this email somewhere safe for future reference, and have fun!
+
+xoxo
+
+Team Ghost – https://ghost.org [https://ghost.org]
+
+This email was sent from http://127.0.0.1:2369/ [http://127.0.0.1:2369/] to 
+test@example.com [test@example.com]",
+  "to": "test@example.com",
+}
+`;
+
 exports[`Authentication API Blog setup complete setup again 1: [body] 1`] = `
 Object {
   "errors": Array [
@@ -119,6 +309,196 @@ Object {
   "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-cache-invalidate": "/*",
   "x-powered-by": "Express",
+}
+`;
+
+exports[`Authentication API Blog setup complete setup with default theme 3: [html 1] 1`] = `
+"<!doctype html>
+<html>
+<head>
+<meta name=\\"viewport\\" content=\\"width=device-width\\">
+<meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\">
+<title>Welcome to Ghost</title>
+<style>
+/* -------------------------------------
+    RESPONSIVE AND MOBILE FRIENDLY STYLES
+------------------------------------- */
+@media only screen and (max-width: 620px) {
+    table[class=body] h1 {
+    font-size: 28px !important;
+    margin-bottom: 10px !important;
+    }
+    table[class=body] p,
+        table[class=body] ul,
+        table[class=body] ol,
+        table[class=body] td,
+        table[class=body] span,
+        table[class=body] a {
+    font-size: 16px !important;
+    }
+    table[class=body] .title {
+    font-size: 22px !important;
+    }
+    table[class=body] .wrapper,
+        table[class=body] .article {
+    padding: 10px !important;
+    }
+    table[class=body] .content {
+    padding: 0 !important;
+    }
+    table[class=body] .container {
+    padding: 0 !important;
+    width: 100% !important;
+    }
+    table[class=body] .main {
+    border-left-width: 0 !important;
+    border-radius: 0 !important;
+    border-right-width: 0 !important;
+    }
+    table[class=body] .btn table {
+    width: 100% !important;
+    }
+    table[class=body] .btn a {
+    width: 100% !important;
+    }
+    table[class=body] .img-responsive {
+    height: auto !important;
+    max-width: 100% !important;
+    width: auto !important;
+    }
+    table[class=body] p[class=small],
+    table[class=body] a[class=small] {
+    font-size: 12x !important;
+    }
+}
+/* -------------------------------------
+    PRESERVE THESE STYLES IN THE HEAD
+------------------------------------- */
+@media all {
+    .ExternalClass {
+    width: 100%;
+    }
+    .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+    line-height: 100%;
+    }
+    .recipient-link a {
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: none !important;
+    }
+    #MessageViewBody a {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    }
+}
+hr {
+    border-width: 0;
+    height: 0;
+    margin-top: 34px;
+    margin-bottom: 34px;
+    border-bottom-width: 1px;
+    border-bottom-color: #EEF5F8;
+}
+a {
+    color: #3A464C;
+}
+</style>
+</head>
+<body style=\\"background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;\\">
+
+<table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"body\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+    <tr>
+        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
+        <td class=\\"container\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;\\">
+
+            <div class=\\"content\\" style=\\"box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;\\">
+
+            <!-- START CENTERED CONTAINER -->
+            <table class=\\"main\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;\\">
+
+                <!-- START MAIN CONTENT AREA -->
+                <tr>
+                <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;\\">
+                    <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                        <tr>
+                            <td align=\\"center\\" style=\\"padding-top: 20px; padding-bottom: 12px;\\"><img src=\\"https://static.ghost.org/v4.0.0/images/ghost-orb-3.png\\" width=\\"60\\" height=\\"60\\" style=\\"width: 60px; height: 60px;\\" /></td>
+                        </tr>
+                        <tr>
+                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top;\\">
+                            <p class=\\"title\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 21px; color: #3A464C; font-weight: normal; line-height: 25px; margin-bottom: 0px; margin-top: 50px; font-weight: 600; color: #15212A;\\">Hello!</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 24px; padding-bottom: 10px;\\">
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;\\">Good news! You've successfully created a brand new Ghost publication over on  <a href=\\"http://127.0.0.1:2369/\\" style=\\"color: #15212A;\\">http://127.0.0.1:2369/</a></p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;\\">You can log in to your admin account with the following details:</p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;\\"><strong style=\\"font-weight: 600;\\">Email Address:</strong> <a href=\\"mailto:test@example.com\\" style=\\"color: #15212A;\\">test@example.com</a></p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;\\"><strong style=\\"font-weight: 600;\\">Password:</strong> The password you chose when you signed up</p>
+
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;\\">Keep this email somewhere safe for future reference, and have fun!</p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;\\">xoxo</p>
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;\\">Team Ghost – <a href=\\"https://ghost.org\\" style=\\"color: #15212A;\\">https://ghost.org</a></p>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; vertical-align: top; padding-top: 80px; padding-bottom: 10px;\\">
+                    <div class=\\"footer\\">
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; color: #738A94; font-weight: normal; margin: 0; line-height: 18px; margin-bottom: 0px; font-size: 11px;\\">This email was sent from <a href=\\"http://127.0.0.1:2369/\\" style=\\"color: #738A94;\\">http://127.0.0.1:2369/</a> to <a href=\\"mailto:test@example.com\\" style=\\"color: #738A94;\\">test@example.com</a></p>
+                    </div>
+                </td>
+            </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+            <!-- END CENTERED CONTAINER -->
+            </div>
+        </td>
+        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>"
+`;
+
+exports[`Authentication API Blog setup complete setup with default theme 4: [metadata 1] 1`] = `
+Object {
+  "subject": "Your New Ghost Site",
+  "text": " [https://static.ghost.org/v4.0.0/images/ghost-orb-3.png] Hello!
+
+Good news! You've successfully created a brand new Ghost publication over on 
+http://127.0.0.1:2369/ [http://127.0.0.1:2369/]
+
+You can log in to your admin account with the following details:
+
+Email Address: test@example.com [test@example.com]
+
+Password: The password you chose when you signed up
+
+Keep this email somewhere safe for future reference, and have fun!
+
+xoxo
+
+Team Ghost – https://ghost.org [https://ghost.org]
+
+This email was sent from http://127.0.0.1:2369/ [http://127.0.0.1:2369/] to 
+test@example.com [test@example.com]",
+  "to": "test@example.com",
 }
 `;
 

--- a/ghost/core/test/regression/api/admin/authentication.test.js
+++ b/ghost/core/test/regression/api/admin/authentication.test.js
@@ -8,6 +8,7 @@ const models = require('../../../../core/server/models');
 const settingsCache = require('../../../../core/shared/settings-cache');
 
 describe('Authentication API', function () {
+    let emailMockReceiver;
     let agent;
 
     describe('Blog setup', function () {
@@ -17,7 +18,7 @@ describe('Authentication API', function () {
 
         beforeEach(async function () {
             await mockManager.disableStripe();
-            mockManager.mockMail();
+            emailMockReceiver = mockManager.mockMail();
         });
 
         afterEach(function () {
@@ -69,10 +70,9 @@ describe('Authentication API', function () {
                 });
 
             // Test our side effects
-            mockManager.assert.sentEmail({
-                subject: 'Your New Ghost Site',
-                to: email
-            });
+            emailMockReceiver.matchHTMLSnapshot();
+            emailMockReceiver.matchMetadataSnapshot();
+
             assert.equal(requestMock.isDone(), true, 'The dawn github URL should have been used');
 
             const activeTheme = await settingsCache.get('active_theme');
@@ -202,10 +202,9 @@ describe('Authentication API', function () {
                 });
 
             // Test our side effects
-            mockManager.assert.sentEmail({
-                subject: 'Your New Ghost Site',
-                to: email
-            });
+            emailMockReceiver.matchHTMLSnapshot();
+            emailMockReceiver.matchMetadataSnapshot();
+
             assert.equal(requestMock.isDone(), false, 'The ghost github URL should not have been used');
 
             const activeTheme = await settingsCache.get('active_theme');
@@ -471,7 +470,7 @@ describe('Authentication API', function () {
         });
 
         beforeEach(function () {
-            mockManager.mockMail();
+            emailMockReceiver = mockManager.mockMail();
         });
 
         afterEach(function () {

--- a/ghost/core/test/utils/assertions.js
+++ b/ghost/core/test/utils/assertions.js
@@ -1,6 +1,6 @@
 const should = require('should');
 const errorProps = ['message', 'errorType'];
-const {matchSnapshotAssertion} = require('@tryghost/jest-snapshot');
+const {matchSnapshotAssertion} = require('@tryghost/express-test').snapshot;
 
 should.Assertion.add('JSONErrorObject', function () {
     this.params = {operator: 'to be a valid JSON Error Object'};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4337,6 +4337,11 @@
     "@tryghost/debug" "^0.1.21"
     split2 "4.1.0"
 
+"@tryghost/email-mock-receiver@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/email-mock-receiver/-/email-mock-receiver-0.1.0.tgz#2a792f41ca76795c8547cb644185778fdaa557ee"
+  integrity sha512-pvik+ClT2yML5Q67Iw5uxWiEKsQ8muzIkab9emwf0C5zOoFQTbJiXO+fIqI0umKQBzzavwm0ITlrmcoMY/3J/w==
+
 "@tryghost/ember-promise-modals@2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@tryghost/ember-promise-modals/-/ember-promise-modals-2.0.1.tgz#b06b52eb4750b8d7b39470a238f0ebcbbff0c05f"
@@ -4411,7 +4416,17 @@
   optionalDependencies:
     sharp "^0.30.0"
 
-"@tryghost/jest-snapshot@0.4.8", "@tryghost/jest-snapshot@^0.4.8":
+"@tryghost/jest-snapshot@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/jest-snapshot/-/jest-snapshot-0.5.0.tgz#1250a64ecadfecf3f2ab45d5077a9778f2c4ec25"
+  integrity sha512-vw8bEYtIdui1+j4XrR+4HsD6bu2B8MdzImVvawAnxAoPO5fODYe/wWXKNKvraPdpe9pgNQOClQxm9QAF6y8jSw==
+  dependencies:
+    "@jest/expect" "^28.0.1"
+    "@jest/expect-utils" "^28.0.1"
+    "@tryghost/errors" "^1.2.20"
+    jest-snapshot "^29.0.0"
+
+"@tryghost/jest-snapshot@^0.4.8":
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/@tryghost/jest-snapshot/-/jest-snapshot-0.4.8.tgz#434ce54774334af78e6654b2f7be0bb3c87d7af5"
   integrity sha512-bLF0QIE60+ilHi51BHvR8en5gGBnC4VU2jmksIdhQZywlRTLCvYQpxyraSjsUeq5ou5gGHPRChpA/TyvmWLWzg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4367,12 +4367,12 @@
     lodash "^4.17.21"
     uuid "^9.0.0"
 
-"@tryghost/express-test@0.11.8":
-  version "0.11.8"
-  resolved "https://registry.yarnpkg.com/@tryghost/express-test/-/express-test-0.11.8.tgz#96cd84e2746670bdc848c806137327d9a5ed1bcb"
-  integrity sha512-KyiaZc9/+cZCrSl6Ryc9Lt8MnPxbM0WX0kQ9W70LWZikJOX+Ae10FV1/JHa074kHne4dmXaW8vnl+uTO4zDLjw==
+"@tryghost/express-test@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/express-test/-/express-test-0.12.0.tgz#0b96201cadffa615a32e13d225c4cb6871292f0c"
+  integrity sha512-hLtPj/GrjYo52mQpWhkPa386cEKZ2RrzwsHQmE3zfOu3PEqNlLB+4hf0J7SW4gpiHhBtEneytYvj20q2c75qIg==
   dependencies:
-    "@tryghost/jest-snapshot" "^0.4.8"
+    "@tryghost/jest-snapshot" "^0.5.0"
     cookiejar "^2.1.3"
     reqresnext "^1.7.0"
 
@@ -4416,20 +4416,10 @@
   optionalDependencies:
     sharp "^0.30.0"
 
-"@tryghost/jest-snapshot@0.5.0":
+"@tryghost/jest-snapshot@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@tryghost/jest-snapshot/-/jest-snapshot-0.5.0.tgz#1250a64ecadfecf3f2ab45d5077a9778f2c4ec25"
   integrity sha512-vw8bEYtIdui1+j4XrR+4HsD6bu2B8MdzImVvawAnxAoPO5fODYe/wWXKNKvraPdpe9pgNQOClQxm9QAF6y8jSw==
-  dependencies:
-    "@jest/expect" "^28.0.1"
-    "@jest/expect-utils" "^28.0.1"
-    "@tryghost/errors" "^1.2.20"
-    jest-snapshot "^29.0.0"
-
-"@tryghost/jest-snapshot@^0.4.8":
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/@tryghost/jest-snapshot/-/jest-snapshot-0.4.8.tgz#434ce54774334af78e6654b2f7be0bb3c87d7af5"
-  integrity sha512-bLF0QIE60+ilHi51BHvR8en5gGBnC4VU2jmksIdhQZywlRTLCvYQpxyraSjsUeq5ou5gGHPRChpA/TyvmWLWzg==
   dependencies:
     "@jest/expect" "^28.0.1"
     "@jest/expect-utils" "^28.0.1"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2691

- Outgoing emails have been a weak point of Ghost's stability recently. The concept of "emailMockReceiver" similarly to "webhookMockReceiver", allows to test side-effects like outgoing emails.
- This is a first iteration which should lay groundwork for testing all outgoing emails in the future
- The change adds a new concept of "email mock receiver" which is very similar to how the "webhook mock receiver" works. The email mock receiver exposes two methods to record and verify snapshots:
- matchHTMLSnapshot - records and verifies only the HTML content of the outgoint email
- matchMetadataSnapshot - records and verifies all the non-HTML properties sent along an email content, e.g.: to address, plaintext, subject, etc.
- What's missing is matching content based on dynamic content like dates, links with JWT tokens, etc.