### PR TITLE
Added logging to webmention endpoint

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -86,7 +86,7 @@ function getSearchHelper(frontendKey) {
 function getWebmentionDiscoveryLink() {
     try {
         const siteUrl = urlUtils.getSiteUrl();
-        const webmentionUrl = new URL('webmention', siteUrl);
+        const webmentionUrl = new URL('webmentions/receive', siteUrl);
         return `<link href="${webmentionUrl.href}" rel="webmention" />`;
     } catch (err) {
         logging.warn(err);

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -86,7 +86,7 @@ function getSearchHelper(frontendKey) {
 function getWebmentionDiscoveryLink() {
     try {
         const siteUrl = urlUtils.getSiteUrl();
-        const webmentionUrl = new URL('webmentions/receive', siteUrl);
+        const webmentionUrl = new URL('webmentions/receive/', siteUrl);
         return `<link href="${webmentionUrl.href}" rel="webmention" />`;
     } catch (err) {
         logging.warn(err);

--- a/ghost/core/core/server/api/endpoints/mentions.js
+++ b/ghost/core/core/server/api/endpoints/mentions.js
@@ -1,3 +1,4 @@
+const logging = require('@tryghost/logging');
 const mentions = require('../../services/mentions');
 
 module.exports = {
@@ -14,6 +15,20 @@ module.exports = {
         permissions: false,
         query(frame) {
             return mentions.controller.browse(frame);
+        }
+    },
+
+    receive: {
+        statusCode: 202, // Required for the spec because we don't have a status page
+        headers: {},
+        options: [],
+        permissions: false,
+        response: {
+            format: 'plain'
+        },
+        query(frame) {
+            logging.info('[Webmention] ' + JSON.stringify(frame.data));
+            return null;
         }
     }
 };

--- a/ghost/core/core/server/web/parent/frontend.js
+++ b/ghost/core/core/server/web/parent/frontend.js
@@ -18,6 +18,7 @@ module.exports = (routerConfig) => {
     frontendApp.use(shared.middleware.urlRedirects.frontendSSLRedirect);
 
     frontendApp.lazyUse('/members', require('../members'));
+    frontendApp.lazyUse('/webmentions', require('../webmentions'));
     frontendApp.use('/', require('../../../frontend/web')(routerConfig));
 
     return frontendApp;

--- a/ghost/core/core/server/web/webmentions/index.js
+++ b/ghost/core/core/server/web/webmentions/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./routes');

--- a/ghost/core/core/server/web/webmentions/routes.js
+++ b/ghost/core/core/server/web/webmentions/routes.js
@@ -1,0 +1,18 @@
+const express = require('../../../shared/express');
+const api = require('../../api').endpoints;
+const {http} = require('@tryghost/api-framework');
+const shared = require('../shared');
+
+const bodyParser = require('body-parser');
+
+module.exports = function apiRoutes() {
+    const router = express.Router('webmentions');
+
+    // shouldn't be cached
+    router.use(shared.middleware.cacheControl('private'));
+
+    // Webmentions
+    router.post('/receive', bodyParser.urlencoded({extended: true, limit: '5mb'}), http(api.mentions.receive));
+
+    return router;
+};

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -135,7 +135,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script><style>:root {--ghost-accent-color: #123456;}</style>",
 }
 `;
@@ -284,7 +284,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -294,7 +294,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -370,7 +370,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -445,7 +445,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -840,7 +840,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -956,7 +956,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1071,7 +1071,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -1187,7 +1187,7 @@ Object {
     opacity: 0.92;
 }</style><script async src=\\"https://js.stripe.com/v3/\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -1240,7 +1240,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1355,7 +1355,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -1408,7 +1408,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1421,7 +1421,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/site/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/site/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/site/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1434,7 +1434,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
     <style>body {background: red;}</style>",
 }
 `;
@@ -1448,7 +1448,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
     <style>body {background: red;}</style>",
 }
 `;
@@ -1462,7 +1462,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
     <style>body {background: red;}</style>
     post-codeinjection",
 }
@@ -1477,7 +1477,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
     <style>body {background: red;}</style>",
 }
 `;
@@ -1564,7 +1564,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/site/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/site/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1579,7 +1579,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1604,7 +1604,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1656,7 +1656,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1668,7 +1668,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1680,7 +1680,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1742,7 +1742,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/comment-counts.min.js?v=asset-hash\\" data-ghost-comments-counts-api=\\"http://localhost:65530/members/api/comments/counts/\\"></script>",
 }
 `;
@@ -1795,7 +1795,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/comment-counts.min.js?v=asset-hash\\" data-ghost-comments-counts-api=\\"http://localhost:65530/members/api/comments/counts/\\"></script>",
 }
 `;
@@ -1817,7 +1817,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1884,7 +1884,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1936,7 +1936,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1957,7 +1957,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1969,7 +1969,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1983,7 +1983,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1997,7 +1997,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2051,7 +2051,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2103,7 +2103,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2186,7 +2186,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2317,7 +2317,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2400,7 +2400,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2483,7 +2483,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2554,7 +2554,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2629,7 +2629,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2704,7 +2704,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2779,7 +2779,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2855,7 +2855,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2923,7 +2923,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2973,7 +2973,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -3027,6 +3027,6 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmention\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
 }
 `;

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -135,7 +135,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script><style>:root {--ghost-accent-color: #123456;}</style>",
 }
 `;
@@ -284,7 +284,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -294,7 +294,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -370,7 +370,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -445,7 +445,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -840,7 +840,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -956,7 +956,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1071,7 +1071,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -1187,7 +1187,7 @@ Object {
     opacity: 0.92;
 }</style><script async src=\\"https://js.stripe.com/v3/\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -1240,7 +1240,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1355,7 +1355,7 @@ Object {
     opacity: 0.92;
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -1408,7 +1408,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1421,7 +1421,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/site/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/site/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/site/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1434,7 +1434,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
     <style>body {background: red;}</style>",
 }
 `;
@@ -1448,7 +1448,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
     <style>body {background: red;}</style>",
 }
 `;
@@ -1462,7 +1462,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
     <style>body {background: red;}</style>
     post-codeinjection",
 }
@@ -1477,7 +1477,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
     <style>body {background: red;}</style>",
 }
 `;
@@ -1564,7 +1564,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/site/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/site/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1579,7 +1579,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1604,7 +1604,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1656,7 +1656,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1668,7 +1668,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1680,7 +1680,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1742,7 +1742,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/comment-counts.min.js?v=asset-hash\\" data-ghost-comments-counts-api=\\"http://localhost:65530/members/api/comments/counts/\\"></script>",
 }
 `;
@@ -1795,7 +1795,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
     <script defer src=\\"/public/comment-counts.min.js?v=asset-hash\\" data-ghost-comments-counts-api=\\"http://localhost:65530/members/api/comments/counts/\\"></script>",
 }
 `;
@@ -1817,7 +1817,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1884,7 +1884,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1936,7 +1936,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1957,7 +1957,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1969,7 +1969,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1983,7 +1983,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -1997,7 +1997,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2051,7 +2051,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2103,7 +2103,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2186,7 +2186,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2317,7 +2317,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2400,7 +2400,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2483,7 +2483,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2554,7 +2554,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2629,7 +2629,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2704,7 +2704,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2779,7 +2779,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2855,7 +2855,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2923,7 +2923,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -2973,7 +2973,7 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;
 
@@ -3027,6 +3027,6 @@ Object {
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
-    <link href=\\"http://localhost:65530/webmentions/receive\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
 }
 `;


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2424

Adds the new webmention endpoint, responds with the correct statuscode and empty body at `https://site.ghost/webmentions/receive`.

Also updates the head link tag to the new endpoint location. We don't use /webmention because that could conflict with post slugs.