### PR TITLE
🐛 Fixed post links being marked as edited when they were not

### DIFF
--- a/ghost/core/core/server/models/redirect.js
+++ b/ghost/core/core/server/models/redirect.js
@@ -36,7 +36,8 @@ const Redirect = ghostBookshelf.Model.extend({
     permittedOptions(methodName) {
         let options = ghostBookshelf.Model.permittedOptions.call(this, methodName);
         const validOptions = {
-            findAll: ['filter', 'columns', 'withRelated']
+            findAll: ['filter', 'columns', 'withRelated'],
+            edit: ['importing']
         };
 
         if (validOptions[methodName]) {

--- a/ghost/core/core/server/services/link-redirection/LinkRedirectRepository.js
+++ b/ghost/core/core/server/services/link-redirection/LinkRedirectRepository.js
@@ -37,7 +37,8 @@ module.exports = class LinkRedirectRepository {
 
     fromModel(model) {
         // Store if link has been edited
-        const edited = model.get('created_at')?.getTime() !== model.get('updated_at')?.getTime();
+        // Note: in some edge cases updated_at is set directly after created_at, sometimes with a second difference, so we need to check for that
+        const edited = model.get('updated_at')?.getTime() > (model.get('created_at')?.getTime() + 1000);
 
         return new LinkRedirect({
             id: model.id,

--- a/ghost/core/core/server/services/link-tracking/PostLinkRepository.js
+++ b/ghost/core/core/server/services/link-tracking/PostLinkRepository.js
@@ -80,7 +80,8 @@ module.exports = class PostLinkRepository {
         await this.#LinkRedirect.edit({
             post_id: postLink.post_id.toHexString()
         }, {
-            id: postLink.link_id.toHexString()
+            id: postLink.link_id.toHexString(),
+            importing: true // skip setting updated_at when linking a post to a link
         });
     }
 };

--- a/ghost/core/test/e2e-api/admin/links.test.js
+++ b/ghost/core/test/e2e-api/admin/links.test.js
@@ -1,5 +1,6 @@
-const {agentProvider, fixtureManager, matchers, sleep} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyObjectId, anyString, anyEtag, anyNumber} = matchers;
+const sinon = require('sinon');
 
 const matchLink = {
     post_id: anyObjectId,
@@ -16,10 +17,17 @@ const matchLink = {
 
 describe('Links API', function () {
     let agent;
+    let clock;
+
     beforeEach(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('posts', 'links');
         await agent.loginAsOwner();
+        clock = sinon.useFakeTimers(new Date());
+    });
+
+    afterEach(async function () {
+        clock.restore();
     });
 
     it('Can browse all links', async function () {
@@ -43,8 +51,10 @@ describe('Links API', function () {
         const postId = siteLink.post_id;
         const originalTo = siteLink.link.to;
         const filter = `post_id:${postId}+to:'${originalTo}'`;
-        // Sleep ensures the updated time of the link is different than created
-        await sleep(1000);
+
+        // Wait minimum 2 seconds
+        clock.tick(2 * 1000);
+
         await agent
             .put(`links/bulk/?filter=${encodeURIComponent(filter)}`)
             .body({
@@ -113,7 +123,10 @@ describe('Links API', function () {
         const postId = siteLink.post_id;
         const originalTo = siteLink.link.to;
         const filter = `post_id:${postId}+to:'${originalTo}'`;
-        await sleep(1000);
+
+        // Wait minimum 2 seconds
+        clock.tick(2 * 1000);
+
         await agent
             .put(`links/bulk/?filter=${encodeURIComponent(filter)}`)
             .body({


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2461

- Ignores 'edited' links when there is only one second differences.
- Make sure we don't set updatedAt when linking a post to a redirect