### PR TITLE
Optimized dynamic routing url updates

### DIFF
--- a/ghost/core/core/frontend/services/sitemap/base-generator.js
+++ b/ghost/core/core/frontend/services/sitemap/base-generator.js
@@ -63,6 +63,12 @@ class BaseSiteMapGenerator {
         return sitemapXml;
     }
 
+    updateURL(datum) {
+        const url = this.nodeLookup[datum.id].url[0].loc;
+        this.removeUrl(url, datum);
+        this.addUrl(url, datum);
+    }
+
     addUrl(url, datum) {
         const node = this.createUrlNodeFromDatum(url, datum);
 
@@ -100,6 +106,12 @@ class BaseSiteMapGenerator {
         }
     }
 
+    /**
+     *
+     * @param {String} url
+     * @param {Object} datum
+     * @returns
+     */
     createUrlNodeFromDatum(url, datum) {
         let node;
         let imgNode;

--- a/ghost/core/core/frontend/services/sitemap/base-generator.js
+++ b/ghost/core/core/frontend/services/sitemap/base-generator.js
@@ -55,7 +55,7 @@ class BaseSiteMapGenerator {
         // Generate full xml
         let sitemapXml = localUtils.getDeclarations() + xml(data);
 
-        // Perform url transformatons
+        // Perform url transformations
         // - Necessary because sitemap data is supplied by the router which
         //   uses knex directly bypassing model-layer attribute transforms
         sitemapXml = urlUtils.transformReadyToAbsolute(sitemapXml);
@@ -64,9 +64,12 @@ class BaseSiteMapGenerator {
     }
 
     updateURL(datum) {
-        const url = this.nodeLookup[datum.id].url[0].loc;
-        this.removeUrl(url, datum);
-        this.addUrl(url, datum);
+        const url = this.nodeLookup[datum.id]?.url[0].loc;
+
+        if (url) {
+            this.removeUrl(url, datum);
+            this.addUrl(url, datum);
+        }
     }
 
     addUrl(url, datum) {

--- a/ghost/core/core/frontend/services/sitemap/manager.js
+++ b/ghost/core/core/frontend/services/sitemap/manager.js
@@ -1,3 +1,5 @@
+const DomainEvents = require('@tryghost/domain-events');
+const {URLResourceUpdatedEvent} = require('@tryghost/dynamic-routing-events');
 const IndexMapGenerator = require('./index-generator');
 const PagesMapGenerator = require('./page-generator');
 const PostsMapGenerator = require('./post-generator');
@@ -27,6 +29,10 @@ class SiteMapManager {
             if (router.name === 'CollectionRouter') {
                 this.pages.addUrl(router.getRoute({absolute: true}), {id: router.identifier, staticRoute: false});
             }
+        });
+
+        DomainEvents.subscribe(URLResourceUpdatedEvent, (event) => {
+            this[event.data.resourceType].updateURL(event.data);
         });
 
         events.on('url.added', (obj) => {

--- a/ghost/core/core/server/services/url/Urls.js
+++ b/ghost/core/core/server/services/url/Urls.js
@@ -32,6 +32,9 @@ class Urls {
     /**
      * @description Add a url to the system.
      * @param {Object} options
+     * @param {import('./Resource')} options.resource - instance of the Resource class
+     * @param {string} options.generatorId
+     * @param {string} options.url
      */
     add(options) {
         const url = options.url;

--- a/ghost/core/core/server/services/url/config.js
+++ b/ghost/core/core/server/services/url/config.js
@@ -31,7 +31,8 @@ module.exports = [
                 'twitter_title',
                 'twitter_description',
                 'custom_template',
-                'locale'
+                'locale',
+                'tiers'
             ],
             withRelated: ['tags', 'authors'],
             withRelatedPrimary: {
@@ -79,7 +80,8 @@ module.exports = [
                 'tags',
                 'authors',
                 'primary_tag',
-                'primary_author'
+                'primary_author',
+                'tiers'
             ],
             filter: 'status:published+type:page'
         },

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -73,6 +73,7 @@
     "@tryghost/database-info": "0.3.14",
     "@tryghost/debug": "0.1.21",
     "@tryghost/domain-events": "0.0.0",
+    "@tryghost/dynamic-routing-events": "0.0.0",
     "@tryghost/email-analytics-provider-mailgun": "0.0.0",
     "@tryghost/email-analytics-service": "0.0.0",
     "@tryghost/email-content-generator": "0.0.0",

--- a/ghost/core/test/unit/server/services/url/Resources.test.js
+++ b/ghost/core/test/unit/server/services/url/Resources.test.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+
+const Resources = require('../../../../../core/server/services/url/Resources');
+
+describe('Unit: services/url/Resources', function () {
+    describe('_onResourceUpdated', function () {
+        it('does not start the queue when non-routing properties were changed', async function () {
+            const resources = new Resources({
+                resourcesConfig: [{
+                    type: 'post',
+                    modelOptions: {
+                        modelName: 'Post',
+                        exclude: [
+                            'title',
+                            'mobiledoc',
+                            'lexical',
+                            'html',
+                            'plaintext'
+                        ]
+                    }
+                }]
+            });
+
+            const postModelMock = {
+                _changed: {
+                    title: 'New Title',
+                    plaintext: 'New plaintext'
+                }
+            };
+
+            const updated = await resources._onResourceUpdated('post', postModelMock);
+
+            assert.equal(updated, false);
+        });
+    });
+});

--- a/ghost/dynamic-routing-events/.eslintrc.js
+++ b/ghost/dynamic-routing-events/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node'
+    ]
+};

--- a/ghost/dynamic-routing-events/README.md
+++ b/ghost/dynamic-routing-events/README.md
@@ -1,0 +1,23 @@
+# Dynamic Routing Events
+
+Contains Dynamic Routing (URL Service) events
+
+
+## Usage
+
+
+## Develop
+
+This is a monorepo package.
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+

--- a/ghost/dynamic-routing-events/index.js
+++ b/ghost/dynamic-routing-events/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    URLResourceUpdatedEvent: require('./lib/URLResourceUpdatedEvent')
+};

--- a/ghost/dynamic-routing-events/lib/URLResourceUpdatedEvent.js
+++ b/ghost/dynamic-routing-events/lib/URLResourceUpdatedEvent.js
@@ -1,0 +1,33 @@
+module.exports = class URLResourceUpdatedEvent {
+    /**
+     * @readonly
+     * @type {Object}
+     */
+    data;
+
+    /**
+     * @readonly
+     * @type {Date}
+     */
+    timestamp;
+
+    /**
+     * @private
+     */
+    constructor({timestamp, ...data}) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     *
+     * @param {Object} data URL Resource
+     * @returns
+     */
+    static create(data) {
+        return new URLResourceUpdatedEvent({
+            ...data,
+            timestamp: data.timestamp || new Date
+        });
+    }
+};

--- a/ghost/dynamic-routing-events/package.json
+++ b/ghost/dynamic-routing-events/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@tryghost/dynamic-routing-events",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/dynamic-routing-events",
+  "author": "Ghost Foundation",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "dev": "echo \"Implement me!\"",
+    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --100  --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+    "test": "yarn test:unit",
+    "lint:code": "eslint *.js lib/ --ext .js --cache",
+    "lint": "yarn lint:code && yarn lint:test",
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .js --cache"
+  },
+  "files": [
+    "index.js",
+    "lib"
+  ],
+  "devDependencies": {
+    "c8": "7.12.0",
+    "mocha": "10.2.0",
+    "sinon": "15.0.1"
+  },
+  "dependencies": {}
+}

--- a/ghost/dynamic-routing-events/test/.eslintrc.js
+++ b/ghost/dynamic-routing-events/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/ghost/dynamic-routing-events/test/dynamic-routing-events.test.js
+++ b/ghost/dynamic-routing-events/test/dynamic-routing-events.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const events = require('../index');
+
+describe('Dynamic Routing Events', function () {
+    it('exports events', function () {
+        assert(events.URLResourceUpdatedEvent);
+    });
+});

--- a/ghost/dynamic-routing-events/test/lib/URLResourceUpdatedEvent.test.js
+++ b/ghost/dynamic-routing-events/test/lib/URLResourceUpdatedEvent.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const {URLResourceUpdatedEvent} = require('../../index');
+
+describe('URLResourceUpdatedEvent', function () {
+    it('exports a static create method to create instances', function () {
+        const event = URLResourceUpdatedEvent.create({
+            id: 'resource-id'
+        });
+
+        assert(event instanceof URLResourceUpdatedEvent);
+    });
+});


### PR DESCRIPTION
Optimizations around URL recalculation for published post updates.

- Full URL regeneration process was happening even when only unrelated to URL generation fields were updated (e.g. 'plaintext' change in post does not affect the URL of the post). Stopping the  "resource updated" event processing early circumvents full url regeneration inside of DynamicRouting, which can be quite heavy depending on routing configuration
- The URLResourceUpdatedEvent is supposed to be emmited whenever there's an update to the resource already associated with the URL and no url-affecting fields were touched.

The issue left to solve here is sitemaps update with the latest `lastmod` value whenever the post's test is modified.