### PR TITLE
Updated email sending to remove invalid recipient emails

### DIFF
--- a/ghost/email-service/lib/sending-service.js
+++ b/ghost/email-service/lib/sending-service.js
@@ -1,3 +1,6 @@
+const validator = require('@tryghost/validator');
+const logging = require('@tryghost/logging');
+
 /**
  * @typedef {object} EmailData
  * @prop {string} html
@@ -111,7 +114,7 @@ class SendingService {
     buildRecipients(members, replacementDefinitions) {
         return members.map((member) => {
             return {
-                email: member.email,
+                email: member.email?.trim(),
                 replacements: replacementDefinitions.map((def) => {
                     return {
                         id: def.id,
@@ -120,6 +123,13 @@ class SendingService {
                     };
                 })
             };
+        }).filter((recipient) => {
+            // Remove invalid recipient email addresses
+            const isValidRecipient = validator.isEmail(recipient.email, {legacy: false});
+            if (!isValidRecipient) {
+                logging.warn(`Removed recipient ${recipient.email} from list because it is not a valid email address`);
+            }
+            return isValidRecipient;
         });
     }
 }

--- a/ghost/email-service/package.json
+++ b/ghost/email-service/package.json
@@ -32,6 +32,7 @@
     "@tryghost/logging": "2.4.0",
     "@tryghost/tpl": "0.1.21",
     "bson-objectid": "2.0.4",
+    "@tryghost/validator": "^0.2.0",
     "cheerio": "0.22.0",
     "handlebars": "4.7.7",
     "juice": "8.1.0",


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2388

We have seen examples of sites with member emails that have invalid characters that can cause an entire email send to fail, or just cause a failure to those addresses. The issue that allowed members with invalid email address to be saved was patched earlier, but its possible there are still sites that contain some of those invalid email addresses.

This change updates new sending service to filter out the recipients with invalid email address before passing them to mail provider, so these rogue addresses don't affect the whole batch in anyway. We also trim the recipient emails to clear out any spaces first, which is the most likely culprit.

- uses new email validator that detects invalid email addresses with special chars