### PR TITLE
🐛 Fixed invalid expiry for member tier subscriptions

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-00-fix-invalid-tier-expiry-for-paid-members.js
+++ b/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-00-fix-invalid-tier-expiry-for-paid-members.js
@@ -5,6 +5,8 @@ module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Removing expiry dates for paid members');
         try {
+            // Fetch all members with a paid status that have an expiry date
+            // Paid members should not have an expiry date
             const invalidExpiryIds = await knex('members_products')
                 .select('members_products.id')
                 .leftJoin('members', 'members_products.member_id', 'members.id')

--- a/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-00-fix-invalid-tier-expiry-for-paid-members.js
+++ b/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-00-fix-invalid-tier-expiry-for-paid-members.js
@@ -1,0 +1,42 @@
+const logging = require('@tryghost/logging');
+const {chunk: chunkArray} = require('lodash');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Removing expiry dates for paid members');
+
+        const paidMembersWithExpiry = await knex('members_products')
+            .select('members_products.id')
+            .leftJoin('members', 'members_products.member_id', 'members.id')
+            .where('members.status', '=', 'paid')
+            .whereNotNull('members_products.expiry_at');
+
+        logging.info(`Found ${paidMembersWithExpiry.length} paid members with expiry dates`);
+
+        if (paidMembersWithExpiry.length === 0) {
+            return;
+        }
+
+        logging.info(`Removing expiry dates for ${paidMembersWithExpiry.length} paid members`);
+
+        // SQLite >= 3.32.0 can support 32766 host parameters
+        // We use one for the SET clause, and the rest can be
+        // used to populate the WHERE IN (?... clause.
+        const chunkSize = 32765;
+
+        const paidMembersWithExpiryIds = paidMembersWithExpiry.map(row => row.id);
+
+        const chunks = chunkArray(paidMembersWithExpiryIds, chunkSize);
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const chunk of chunks) {
+            await knex('members_products')
+                .update('expiry_at', null)
+                .whereIn('id', chunk);
+        }
+    },
+    async function down() {
+        // no-op: we don't want to reintroduce the incorrect expiry dates for member tiers
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-00-fix-invalid-tier-expiry-for-paid-members.js
+++ b/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-00-fix-invalid-tier-expiry-for-paid-members.js
@@ -1,39 +1,30 @@
 const logging = require('@tryghost/logging');
-const {chunk: chunkArray} = require('lodash');
 const {createTransactionalMigration} = require('../../utils');
 
 module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Removing expiry dates for paid members');
+        try {
+            const memberIdsWithInvalidExpiry = await knex('members_products')
+                .select('members_products.member_id as id')
+                .leftJoin('members', 'members_products.member_id', 'members.id')
+                .where('members.status', '=', 'paid')
+                .whereNotNull('members_products.expiry_at').pluck('id');
 
-        const paidMembersWithExpiry = await knex('members_products')
-            .select('members_products.id')
-            .leftJoin('members', 'members_products.member_id', 'members.id')
-            .where('members.status', '=', 'paid')
-            .whereNotNull('members_products.expiry_at');
+            logging.info(`Found ${memberIdsWithInvalidExpiry.length} paid members with expiry dates`);
 
-        logging.info(`Found ${paidMembersWithExpiry.length} paid members with expiry dates`);
+            if (memberIdsWithInvalidExpiry.length === 0) {
+                return;
+            }
 
-        if (paidMembersWithExpiry.length === 0) {
-            return;
-        }
+            logging.info(`Removing expiry dates for ${memberIdsWithInvalidExpiry.length} paid members`);
 
-        logging.info(`Removing expiry dates for ${paidMembersWithExpiry.length} paid members`);
-
-        // SQLite >= 3.32.0 can support 32766 host parameters
-        // We use one for the SET clause, and the rest can be
-        // used to populate the WHERE IN (?... clause.
-        const chunkSize = 32765;
-
-        const paidMembersWithExpiryIds = paidMembersWithExpiry.map(row => row.id);
-
-        const chunks = chunkArray(paidMembersWithExpiryIds, chunkSize);
-
-        // eslint-disable-next-line no-restricted-syntax
-        for (const chunk of chunks) {
             await knex('members_products')
                 .update('expiry_at', null)
-                .whereIn('id', chunk);
+                .whereIn('member_id', memberIdsWithInvalidExpiry);
+        } catch (err) {
+            logging.warn('Failed to remove expiry dates for paid members');
+            logging.warn(err);
         }
     },
     async function down() {

--- a/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-09-restore-incorrect-expired-tiers-for-members.js
+++ b/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-09-restore-incorrect-expired-tiers-for-members.js
@@ -7,8 +7,8 @@ module.exports = createTransactionalMigration(
         logging.info('Restoring member<>tier mapping for members with paid status');
         try {
             // fetch all members with a paid status that don't have a members_products record
-        // and have a members_product_events record with an action of "added"
-        // and fetch the product_id from the most recent record for that member
+            // and have a members_product_events record with an action of "added"
+            // and fetch the product_id from the most recent record for that member
             const memberWithTiers = await knex.select('m.id as member_id', 'mpe.product_id as product_id')
                 .from('members as m')
                 .leftJoin('members_products as mp', 'm.id', 'mp.member_id')

--- a/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-09-restore-incorrect-expired-tiers-for-members.js
+++ b/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-09-restore-incorrect-expired-tiers-for-members.js
@@ -1,0 +1,42 @@
+const logging = require('@tryghost/logging');
+const ObjectId = require('bson-objectid').default;
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Restoring member<>tier mapping for members with paid status');
+
+        // fetch all members with a paid status that don't have a members_products record
+        // and have a members_product_events record with an action of "added"
+        // and fetch the product_id from the most recent record for that member
+        const memberWithTiers = await knex.select('m.id as member_id', 'mpe.product_id as product_id')
+            .from('members as m')
+            .leftJoin('members_products as mp', 'm.id', 'mp.member_id')
+            .leftJoin('members_product_events as mpe', function () {
+                this.on('m.id', 'mpe.member_id')
+                    .andOn(knex.raw('mpe.created_at = (SELECT max(created_at) FROM members_product_events WHERE member_id = mpe.member_id and action = "added")'));
+            })
+            .where({'m.status': 'paid', 'mp.member_id': null, 'mpe.action': 'added'});
+
+        // create a new members_products record for each member with id, member_id and product_id
+        const toInsert = memberWithTiers.map((memberTier) => {
+            return {
+                ...memberTier,
+                id: ObjectId().toHexString()
+            };
+        }).filter((memberTier) => {
+            // filter out any members that don't have a product_id for some reason
+            if (!memberTier.product_id) {
+                logging.warn(`Invalid record found - member_id: ${memberTier.member_id} is without product_id`);
+                return false;
+            }
+            return true;
+        });
+
+        logging.info(`Inserting ${toInsert.length} records into members_products`);
+        await knex.batchInsert('members_products', toInsert);
+    },
+    async function down() {
+        // np-op: we don't want to delete the missing records we've just inserted
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-09-restore-incorrect-expired-tiers-for-members.js
+++ b/ghost/core/core/server/data/migrations/versions/5.32/2023-01-24-08-09-restore-incorrect-expired-tiers-for-members.js
@@ -5,36 +5,40 @@ const {createTransactionalMigration} = require('../../utils');
 module.exports = createTransactionalMigration(
     async function up(knex) {
         logging.info('Restoring member<>tier mapping for members with paid status');
-
-        // fetch all members with a paid status that don't have a members_products record
+        try {
+            // fetch all members with a paid status that don't have a members_products record
         // and have a members_product_events record with an action of "added"
         // and fetch the product_id from the most recent record for that member
-        const memberWithTiers = await knex.select('m.id as member_id', 'mpe.product_id as product_id')
-            .from('members as m')
-            .leftJoin('members_products as mp', 'm.id', 'mp.member_id')
-            .leftJoin('members_product_events as mpe', function () {
-                this.on('m.id', 'mpe.member_id')
-                    .andOn(knex.raw('mpe.created_at = (SELECT max(created_at) FROM members_product_events WHERE member_id = mpe.member_id and action = "added")'));
-            })
-            .where({'m.status': 'paid', 'mp.member_id': null, 'mpe.action': 'added'});
+            const memberWithTiers = await knex.select('m.id as member_id', 'mpe.product_id as product_id')
+                .from('members as m')
+                .leftJoin('members_products as mp', 'm.id', 'mp.member_id')
+                .leftJoin('members_product_events as mpe', function () {
+                    this.on('m.id', 'mpe.member_id')
+                        .andOn(knex.raw('mpe.created_at = (SELECT max(created_at) FROM members_product_events WHERE member_id = mpe.member_id and action = "added")'));
+                })
+                .where({'m.status': 'paid', 'mp.member_id': null, 'mpe.action': 'added'});
 
-        // create a new members_products record for each member with id, member_id and product_id
-        const toInsert = memberWithTiers.map((memberTier) => {
-            return {
-                ...memberTier,
-                id: ObjectId().toHexString()
-            };
-        }).filter((memberTier) => {
-            // filter out any members that don't have a product_id for some reason
-            if (!memberTier.product_id) {
-                logging.warn(`Invalid record found - member_id: ${memberTier.member_id} is without product_id`);
-                return false;
-            }
-            return true;
-        });
+            // create a new members_products record for each member with id, member_id and product_id
+            const toInsert = memberWithTiers.map((memberTier) => {
+                return {
+                    ...memberTier,
+                    id: ObjectId().toHexString()
+                };
+            }).filter((memberTier) => {
+                // filter out any members that don't have a product_id for some reason
+                if (!memberTier.product_id) {
+                    logging.warn(`Invalid record found - member_id: ${memberTier.member_id} is without product_id`);
+                    return false;
+                }
+                return true;
+            });
 
-        logging.info(`Inserting ${toInsert.length} records into members_products`);
-        await knex.batchInsert('members_products', toInsert);
+            logging.info(`Inserting ${toInsert.length} records into members_products`);
+            await knex.batchInsert('members_products', toInsert);
+        } catch (err) {
+            logging.warn('Failed to restore member<>tier mapping for members with paid status');
+            logging.warn(err);
+        }
     },
     async function down() {
         // np-op: we don't want to delete the missing records we've just inserted

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -219,11 +219,13 @@ const Member = ghostBookshelf.Model.extend({
 
     async updateTierExpiry(products = [], options = {}) {
         for (const product of products) {
-            const expiry = product.expiry_at ? new Date(product.expiry_at) : null;
-            const queryOptions = _.extend({}, options, {
-                query: {where: {product_id: product.id}}
-            });
-            await this.products().updatePivot({expiry_at: expiry}, queryOptions);
+            if (product?.id) {
+                const expiry = product.expiry_at ? new Date(product.expiry_at) : null;
+                const queryOptions = _.extend({}, options, {
+                    query: {where: {product_id: product.id}}
+                });
+                await this.products().updatePivot({expiry_at: expiry}, queryOptions);
+            }
         }
     },
 

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -219,13 +219,11 @@ const Member = ghostBookshelf.Model.extend({
 
     async updateTierExpiry(products = [], options = {}) {
         for (const product of products) {
-            if (product?.expiry_at) {
-                const expiry = new Date(product.expiry_at);
-                const queryOptions = _.extend({}, options, {
-                    query: {where: {product_id: product.id}}
-                });
-                await this.products().updatePivot({expiry_at: expiry}, queryOptions);
-            }
+            const expiry = product.expiry_at ? new Date(product.expiry_at) : null;
+            const queryOptions = _.extend({}, options, {
+                query: {where: {product_id: product.id}}
+            });
+            await this.products().updatePivot({expiry_at: expiry}, queryOptions);
         }
     },
 

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -77,5 +77,13 @@ describe('Unit: models/member', function () {
 
             updatePivot.calledWith({expiry_at: new Date(expiry)}, {query: {where: {product_id: '1'}}}).should.be.true();
         });
+
+        it('calls updatePivot on member products to remove expiry', function () {
+            memberModel.updateTierExpiry([{
+                id: '1'
+            }]);
+
+            updatePivot.calledWith({expiry_at: null}, {query: {where: {product_id: '1'}}}).should.be.true();
+        });
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2476

When upgrading from a Complimentary subscription with an expiry, to a paid Subscription of the same Tier, the Member was eventually losing access to the Tier when the complimentary subscription expires as the `expiry_at` on the mapping was not removed. This change fixes the code by setting expiry as null when a member upgrades their subscription to paid. Contains 2 migrations

- [Removed invalid expiry tier expiry date for paid members](https://github.com/TryGhost/Ghost/pull/16174/commits/a8fe6c44de09a06699966ca3ce548db487a4f38d)
- [Restored missing tier mapping for paid members](https://github.com/TryGhost/Ghost/pull/16174/commits/63a869845ff465252b049ae0101e76f2e60bc58c)

