### PR TITLE
🐛 Reduced concurrency when fetching Mailgun events

### DIFF
--- a/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
+++ b/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
@@ -469,7 +469,7 @@ a {
                                 <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;background-color:#f6f6f6; padding:20px; border-radius:2px;\\">
                                     <strong style=\\"font-weight: 600;\\">Integration expected Ghost version:</strong>&nbsp; v3.5
                                     <br>
-                                    <strong style=\\"font-weight: 600;\\">Current Ghost version:</strong>&nbsp; v5.30
+                                    <strong style=\\"font-weight: 600;\\">Current Ghost version:</strong>&nbsp; v5.31
                                     <br>
                                     <strong style=\\"font-weight: 600;\\">Failed request URL:</strong>&nbsp; /ghost/api/admin/removed_endpoint/
                                 </p>
@@ -526,7 +526,7 @@ generated some helpful information about the error that you can share with the
 creator of the Zapier integration below: 
 
  Integration expected Ghost version:v3.5 
-Current Ghost version:v5.30 
+Current Ghost version:v5.31 
 Failed request URL:/ghost/api/admin/removed_endpoint/ 
 
 This email was sent from http://127.0.0.1:2369/ [http://127.0.0.1:2369/] to 
@@ -769,7 +769,7 @@ a {
                                 <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;background-color:#f6f6f6; padding:20px; border-radius:2px;\\">
                                     <strong style=\\"font-weight: 600;\\">Integration expected Ghost version:</strong>&nbsp; v3.1
                                     <br>
-                                    <strong style=\\"font-weight: 600;\\">Current Ghost version:</strong>&nbsp; v5.30
+                                    <strong style=\\"font-weight: 600;\\">Current Ghost version:</strong>&nbsp; v5.31
                                     <br>
                                     <strong style=\\"font-weight: 600;\\">Failed request URL:</strong>&nbsp; /ghost/api/admin/removed_endpoint/
                                 </p>
@@ -813,7 +813,7 @@ generated some helpful information about the error that you can share with the
 creator of the Zapier integration below: 
 
  Integration expected Ghost version:v3.1 
-Current Ghost version:v5.30 
+Current Ghost version:v5.31 
 Failed request URL:/ghost/api/admin/removed_endpoint/ 
 
 This email was sent from http://127.0.0.1:2369/ [http://127.0.0.1:2369/] to 

--- a/ghost/email-service/lib/batch-sending-service.js
+++ b/ghost/email-service/lib/batch-sending-service.js
@@ -8,6 +8,8 @@ const messages = {
     emailError: 'Email failed to send'
 };
 
+const MAX_SENDING_CONCURRENCY = 2;
+
 /**
  * @typedef {import('./sending-service')} SendingService
  * @typedef {import('./email-segmenter')} EmailSegmenter
@@ -267,8 +269,8 @@ class BatchSendingService {
             }
         };
 
-        // Run maximum 10 at the same time
-        await Promise.all(new Array(10).fill(0).map(() => runNext()));
+        // Run maximum MAX_SENDING_CONCURRENCY at the same time
+        await Promise.all(new Array(MAX_SENDING_CONCURRENCY).fill(0).map(() => runNext()));
 
         if (succeededCount < batches.length) {
             if (succeededCount > 0) {

--- a/ghost/email-service/lib/email-event-processor.js
+++ b/ghost/email-service/lib/email-event-processor.js
@@ -1,5 +1,11 @@
 const {EmailDeliveredEvent, EmailOpenedEvent, EmailBouncedEvent, SpamComplaintEvent, EmailUnsubscribedEvent, EmailTemporaryBouncedEvent} = require('@tryghost/email-events');
 
+async function waitForEvent() {
+    return new Promise((resolve) => {
+        setTimeout(resolve, 100);
+    });
+}
+
 /**
  * @typedef EmailIdentification
  * @property {string} email
@@ -43,6 +49,8 @@ class EmailEventProcessor {
                 emailId: recipient.emailId,
                 timestamp
             }));
+            // We cannot await the dispatched domainEvent, but we need to limit the number of events thare are processed at the same time
+            await waitForEvent();
         }
         return recipient;
     }
@@ -61,6 +69,8 @@ class EmailEventProcessor {
                 emailId: recipient.emailId,
                 timestamp
             }));
+            // We cannot await the dispatched domainEvent, but we need to limit the number of events thare are processed at the same time
+            await waitForEvent();
         }
         return recipient;
     }
@@ -81,6 +91,8 @@ class EmailEventProcessor {
                 emailRecipientId: recipient.emailRecipientId,
                 timestamp
             }));
+            // We cannot await the dispatched domainEvent, but we need to limit the number of events thare are processed at the same time
+            await waitForEvent();
         }
         return recipient;
     }
@@ -101,6 +113,8 @@ class EmailEventProcessor {
                 emailRecipientId: recipient.emailRecipientId,
                 timestamp
             }));
+            // We cannot await the dispatched domainEvent, but we need to limit the number of events thare are processed at the same time
+            await waitForEvent();
         }
         return recipient;
     }
@@ -118,6 +132,8 @@ class EmailEventProcessor {
                 emailId: recipient.emailId,
                 timestamp
             }));
+            // We cannot await the dispatched domainEvent, but we need to limit the number of events thare are processed at the same time
+            await waitForEvent();
         }
         return recipient;
     }
@@ -135,6 +151,8 @@ class EmailEventProcessor {
                 emailId: recipient.emailId,
                 timestamp
             }));
+            // We cannot await the dispatched domainEvent, but we need to limit the number of events thare are processed at the same time
+            await waitForEvent();
         }
         return recipient;
     }

--- a/ghost/email-service/test/batch-sending-service.test.js
+++ b/ghost/email-service/test/batch-sending-service.test.js
@@ -440,7 +440,7 @@ describe('Batch Sending Service', function () {
             assert.equal(arg.batch, batches[0]);
         });
 
-        it('Works for more than 10 batches', async function () {
+        it('Works for more than 2 batches', async function () {
             const service = new BatchSendingService({});
             let runningCount = 0;
             let maxRunningCount = 0;
@@ -461,7 +461,7 @@ describe('Batch Sending Service', function () {
             sinon.assert.callCount(sendBatch, 101);
             const sendBatches = sendBatch.getCalls().map(call => call.args[0].batch);
             assert.deepEqual(sendBatches, batches);
-            assert.equal(maxRunningCount, 10);
+            assert.equal(maxRunningCount, 2);
         });
 
         it('Throws error if all batches fail', async function () {
@@ -485,7 +485,7 @@ describe('Batch Sending Service', function () {
             sinon.assert.callCount(sendBatch, 101);
             const sendBatches = sendBatch.getCalls().map(call => call.args[0].batch);
             assert.deepEqual(sendBatches, batches);
-            assert.equal(maxRunningCount, 10);
+            assert.equal(maxRunningCount, 2);
         });
 
         it('Throws error if a single batch fails', async function () {
@@ -511,7 +511,7 @@ describe('Batch Sending Service', function () {
             sinon.assert.callCount(sendBatch, 101);
             const sendBatches = sendBatch.getCalls().map(call => call.args[0].batch);
             assert.deepEqual(sendBatches, batches);
-            assert.equal(maxRunningCount, 10);
+            assert.equal(maxRunningCount, 2);
         });
     });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2482

This change adds a small sleep in between dispatching events in the worker thread that reads the events from Mailgun. That should reduce the amount of queries we fire parallel to each other and could cause the connection pool to run out of connections.

It also reduces the amount of concurrent sending to 2 from 10. Also to make sure the connection pool doesn't run out of connections while sending emails, and to reduce the chance of new connections falling back on a (delayed) replicated database.