### PR TITLE
Added referrals invite notification

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -1,17 +1,12 @@
-<div class="gh-nav-bottom" {{did-insert this.loadCurrentMRR}}>
+<div class="gh-nav-bottom">
     {{#if this.hasThemeErrors}}
     <button type="button" class="gh-footer-toast gh-theme-error-toast" {{on "click" (fn this.openThemeErrors null)}}>
         <span class="gh-footer-toast-title gh-notification-title">Your theme contains errors</span>
         <span class="gh-footer-toast-p">Some functionality on your site may be limited &rarr;</span>
     </button>
-    {{else if this.showReferralInvite}}
-    <a href="https://referrals.ghost.org/?ref=admin" class="gh-referral-toast" target="_blank" rel="noopener noreferrer">
-        <span class="gh-referral-toast-close" {{on "click" (fn this.dismissReferralInvite)}}>&#xd7;</span>
-        <strong>You qualify for our invite-only  referral program.</strong>
-        <p class="gh-footer-toast-p">Refer people to Ghost and earn a <strong>30% share</strong> of the subscription revenue, every single month.</p>
-        <button class="gh-btn gh-btn-black gh-referral-toast-button"><span>Find out more &rarr;</span></button>
-    </a>
     {{/if}}
+
+    <GhReferralInvite @hasThemeErrors={{this.hasThemeErrors}} />
 
     <div class="flex items-center justify-between">
         <div class="pe-all">

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -1,4 +1,4 @@
-<div class="gh-nav-bottom">
+<div class="gh-nav-bottom" {{did-insert this.loadCurrentMRR}}>
     {{#if this.hasThemeErrors}}
     <button type="button" class="gh-footer-toast gh-theme-error-toast" {{on "click" (fn this.openThemeErrors null)}}>
         <span class="gh-footer-toast-title gh-notification-title">Your theme contains errors</span>

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -1,8 +1,13 @@
 <div class="gh-nav-bottom">
     {{#if this.hasThemeErrors}}
-    <button type="button" class="gh-theme-error-toast" {{on "click" (fn this.openThemeErrors null)}}>
-        <span class="gh-notification-title">Your theme contains errors</span>
-        <span class="gh-theme-error-p">Some functionality on your site may be limited &rarr;</span>
+    <button type="button" class="gh-footer-toast gh-theme-error-toast" {{on "click" (fn this.openThemeErrors null)}}>
+        <span class="gh-footer-toast-title gh-notification-title">Your theme contains errors</span>
+        <span class="gh-footer-toast-p">Some functionality on your site may be limited &rarr;</span>
+    </button>
+    {{else if (and this.showReferralInvite (not this.hasThemeErrors))}}
+    <button type="button" class="gh-footer-toast gh-referral-toast" {{on "click" (fn this.openReferralsPage null)}}>
+        <span class="gh-footer-toast-title gh-notification-title">Become a Ghost referral partner</span>
+        <span class="gh-footer-toast-p">Earn 30% of every Ghost(Pro) referral, for life &rarr;</span>
     </button>
     {{/if}}
 

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -5,9 +5,11 @@
         <span class="gh-footer-toast-p">Some functionality on your site may be limited &rarr;</span>
     </button>
     {{else if (and this.showReferralInvite (not this.hasThemeErrors))}}
-    <a href="https://referrals.ghost.org/?ref=admin" class="gh-footer-toast gh-referral-toast" target="_blank" rel="noopener noreferrer">
-        <span class="gh-footer-toast-title gh-notification-title">Become a Ghost referral partner</span>
-        <span class="gh-footer-toast-p">Earn 30% of every Ghost(Pro) referral, for life &rarr;</span>
+    <a href="https://referrals.ghost.org/?ref=admin" class="gh-referral-toast" target="_blank" rel="noopener noreferrer">
+        <span class="gh-referral-toast-close">&#xd7;</span>
+        <strong>You qualify for our invite-only  referral program.</strong>
+        <p class="gh-footer-toast-p">Refer people to Ghost and earn a <strong>30% share</strong> of the subscription revenue, every single month.</p>
+        <button class="gh-btn gh-btn-black gh-referral-toast-button"><span>Find out more &rarr;</span></button>
     </a>
     {{/if}}
 

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -4,7 +4,7 @@
         <span class="gh-footer-toast-title gh-notification-title">Your theme contains errors</span>
         <span class="gh-footer-toast-p">Some functionality on your site may be limited &rarr;</span>
     </button>
-    {{else if (and this.showReferralInvite (not this.hasThemeErrors))}}
+    {{else if this.showReferralInvite}}
     <a href="https://referrals.ghost.org/?ref=admin" class="gh-referral-toast" target="_blank" rel="noopener noreferrer">
         <span class="gh-referral-toast-close" {{on "click" (fn this.dismissReferralInvite)}}>&#xd7;</span>
         <strong>You qualify for our invite-only  referral program.</strong>

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -6,7 +6,7 @@
     </button>
     {{else if (and this.showReferralInvite (not this.hasThemeErrors))}}
     <a href="https://referrals.ghost.org/?ref=admin" class="gh-referral-toast" target="_blank" rel="noopener noreferrer">
-        <span class="gh-referral-toast-close">&#xd7;</span>
+        <span class="gh-referral-toast-close" {{on "click" (fn this.dismissReferralInvite)}}>&#xd7;</span>
         <strong>You qualify for our invite-only  referral program.</strong>
         <p class="gh-footer-toast-p">Refer people to Ghost and earn a <strong>30% share</strong> of the subscription revenue, every single month.</p>
         <button class="gh-btn gh-btn-black gh-referral-toast-button"><span>Find out more &rarr;</span></button>

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -5,10 +5,10 @@
         <span class="gh-footer-toast-p">Some functionality on your site may be limited &rarr;</span>
     </button>
     {{else if (and this.showReferralInvite (not this.hasThemeErrors))}}
-    <button type="button" class="gh-footer-toast gh-referral-toast" {{on "click" (fn this.openReferralsPage null)}}>
+    <a href="https://referrals.ghost.org/?ref=admin" class="gh-footer-toast gh-referral-toast" target="_blank" rel="noopener noreferrer">
         <span class="gh-footer-toast-title gh-notification-title">Become a Ghost referral partner</span>
         <span class="gh-footer-toast-p">Earn 30% of every Ghost(Pro) referral, for life &rarr;</span>
-    </button>
+    </a>
     {{/if}}
 
     <div class="flex items-center justify-between">

--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -54,7 +54,7 @@ export default class Footer extends Component {
     }
 
     get showReferralInvite() {
-        return !this.hasThemeErrors && this.isStripeLiveMode && this.dashboardStats?.currentMRR / 100 >= 1000;
+        return !this.hasThemeErrors && this.isStripeLiveMode && this.dashboardStats?.currentMRR / 100 >= 100;
     }
 
     // equivalent to "left: auto; right: -20px"

--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -49,7 +49,7 @@ export default class Footer extends Component {
         // 2. Stripe is setup and enabled in live mode
         // 3. MRR is > $100
         // 4. Notification has not yet been dismissed by the user
-        return this.isAdminOrOwner && this.isReferralNotificationNotDismissed && this.stripeLiveModeEnabled && (this.dashboardStats?.currentMRR / 100 >= 100);
+        return !this.hasThemeErrors && this.isAdminOrOwner && this.isReferralNotificationNotDismissed && this.stripeLiveModeEnabled && (this.dashboardStats?.currentMRR / 100 >= 100);
     }
 
     @action

--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -72,11 +72,10 @@ export default class Footer extends Component {
     dismissReferralInvite(event) {
         event.preventDefault();
         event.stopPropagation();
-        const key = 'referralInviteDismissed';
-        const value = moment().tz(this.settings.timezone);
-        const options = {user: true};
 
-        return this.feature.update(key, value, options);
+        if (!this.feature.referralInviteDismissed) {
+            this.feature.referralInviteDismissed = moment().tz(this.settings.timezone);
+        }
     }
 
     get hasThemeErrors() {

--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import ThemeErrorsModal from '../modals/design/theme-errors';
 import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 import classic from 'ember-classic-decorator';
-// import envConfig from 'ghost-admin/config/environment';
+import envConfig from 'ghost-admin/config/environment';
 import {action} from '@ember/object';
 import {and, match} from '@ember/object/computed';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -18,7 +18,7 @@ export default class Footer extends Component {
     @service themeManagement;
     @service dashboardStats;
     @service settings;
-    // @service membersUtils;
+    @service membersUtils;
 
     @inject config;
 
@@ -39,19 +39,14 @@ export default class Footer extends Component {
         });
     }
 
-    @action
-    openReferralsPage() {
-        return window.open('https://referrals.ghost.org/?ref=admin', '_blank');
-    }
-
     get isStripeLiveMode() {
-        // if (envConfig.environment !== 'production' && this.membersUtils.isStripeEnabled) {
-        //     return true;
-        // } else if (this.settings.stripeConnectLivemode) {
-        //     return true;
-        // }
-        // return false;
-        return this.settings.stripeConnectLivemode;
+        if (envConfig.environment !== 'production' && this.membersUtils.isStripeEnabled) {
+            return true;
+        } else if (this.settings.stripeConnectLivemode) {
+            return true;
+        }
+        return false;
+        // return this.settings.stripeConnectLivemode;
     }
 
     get hasThemeErrors() {

--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import ThemeErrorsModal from '../modals/design/theme-errors';
 import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 import classic from 'ember-classic-decorator';
+// import envConfig from 'ghost-admin/config/environment';
 import {action} from '@ember/object';
 import {and, match} from '@ember/object/computed';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -15,6 +16,9 @@ export default class Footer extends Component {
     @service feature;
     @service modals;
     @service themeManagement;
+    @service dashboardStats;
+    @service settings;
+    // @service membersUtils;
 
     @inject config;
 
@@ -35,8 +39,27 @@ export default class Footer extends Component {
         });
     }
 
+    @action
+    openReferralsPage() {
+        return window.open('https://referrals.ghost.org/?ref=admin', '_blank');
+    }
+
+    get isStripeLiveMode() {
+        // if (envConfig.environment !== 'production' && this.membersUtils.isStripeEnabled) {
+        //     return true;
+        // } else if (this.settings.stripeConnectLivemode) {
+        //     return true;
+        // }
+        // return false;
+        return this.settings.stripeConnectLivemode;
+    }
+
     get hasThemeErrors() {
         return this.themeManagement.activeTheme && this.themeManagement.activeTheme.errors.length;
+    }
+
+    get showReferralInvite() {
+        return !this.hasThemeErrors && this.isStripeLiveMode && this.dashboardStats?.currentMRR / 100 >= 1000;
     }
 
     // equivalent to "left: auto; right: -20px"

--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -2,10 +2,8 @@ import Component from '@ember/component';
 import ThemeErrorsModal from '../modals/design/theme-errors';
 import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 import classic from 'ember-classic-decorator';
-import envConfig from 'ghost-admin/config/environment';
-import moment from 'moment-timezone';
-import {action, computed} from '@ember/object';
-import {and, empty, match, reads} from '@ember/object/computed';
+import {action} from '@ember/object';
+import {and, match} from '@ember/object/computed';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 
@@ -13,13 +11,8 @@ import {inject as service} from '@ember/service';
 export default class Footer extends Component {
     @service session;
     @service router;
-    @service whatsNew;
-    @service feature;
     @service modals;
     @service themeManagement;
-    @service dashboardStats;
-    @service settings;
-    @service membersUtils;
 
     @inject config;
 
@@ -28,29 +21,6 @@ export default class Footer extends Component {
 
     @match('router.currentRouteName', /^settings/)
         isSettingsRoute;
-
-    @reads('session.user.isAdmin')
-        isAdminOrOwner;
-
-    @empty('feature.accessibility.referralInviteDismissed')
-        isReferralNotificationNotDismissed;
-
-    @computed('envConfig.environment', 'membersUtils.isStripeEnabled', 'settings.stripeConnectLivemode')
-    get stripeLiveModeEnabled() {
-        // allow testing mode when not in a production environment
-        const isDevModeStripeEnabled = envConfig.environment !== 'production' && this.membersUtils.isStripeEnabled;
-        const isLiveEnabled = this.settings.stripeConnectLivemode;
-        return isDevModeStripeEnabled || isLiveEnabled;
-    }
-
-    get showReferralInvite() {
-        // Conditions to see the referral invite
-        // 1. Needs to be Owner or Admin
-        // 2. Stripe is setup and enabled in live mode
-        // 3. MRR is > $100
-        // 4. Notification has not yet been dismissed by the user
-        return !this.hasThemeErrors && this.isAdminOrOwner && this.isReferralNotificationNotDismissed && this.stripeLiveModeEnabled && (this.dashboardStats?.currentMRR / 100 >= 100);
-    }
 
     @action
     openThemeErrors() {
@@ -61,21 +31,6 @@ export default class Footer extends Component {
             warnings: this.themeManagement.activeTheme.warnings,
             errors: this.themeManagement.activeTheme.errors
         });
-    }
-
-    @action
-    loadCurrentMRR() {
-        this.dashboardStats.loadMrrStats();
-    }
-
-    @action
-    dismissReferralInvite(event) {
-        event.preventDefault();
-        event.stopPropagation();
-
-        if (!this.feature.referralInviteDismissed) {
-            this.feature.referralInviteDismissed = moment().tz(this.settings.timezone);
-        }
     }
 
     get hasThemeErrors() {

--- a/ghost/admin/app/components/gh-nav-menu/footer.js
+++ b/ghost/admin/app/components/gh-nav-menu/footer.js
@@ -11,6 +11,8 @@ import {inject as service} from '@ember/service';
 export default class Footer extends Component {
     @service session;
     @service router;
+    @service whatsNew;
+    @service feature;
     @service modals;
     @service themeManagement;
 

--- a/ghost/admin/app/components/gh-referral-invite.hbs
+++ b/ghost/admin/app/components/gh-referral-invite.hbs
@@ -1,0 +1,8 @@
+{{#if this.showReferralInvite}}
+<a href="https://referrals.ghost.org/?ref=admin" class="gh-referral-toast" target="_blank" rel="noopener noreferrer">
+    <span class="gh-referral-toast-close" {{on "click" (fn this.dismissReferralInvite)}}>&#xd7;</span>
+    <strong>You qualify for our invite-only  referral program.</strong>
+    <p class="gh-footer-toast-p">Refer people to Ghost and earn a <strong>30% share</strong> of the subscription revenue, every single month.</p>
+    <button class="gh-btn gh-btn-black gh-referral-toast-button"><span>Find out more &rarr;</span></button>
+</a>
+{{/if}}

--- a/ghost/admin/app/components/gh-referral-invite.hbs
+++ b/ghost/admin/app/components/gh-referral-invite.hbs
@@ -1,8 +1,10 @@
 {{#if this.showReferralInvite}}
-<a href="https://referrals.ghost.org/?ref=admin" class="gh-referral-toast" target="_blank" rel="noopener noreferrer">
-    <span class="gh-referral-toast-close" {{on "click" (fn this.dismissReferralInvite)}}>&#xd7;</span>
-    <strong>You qualify for our invite-only  referral program.</strong>
-    <p class="gh-footer-toast-p">Refer people to Ghost and earn a <strong>30% share</strong> of the subscription revenue, every single month.</p>
-    <button class="gh-btn gh-btn-black gh-referral-toast-button"><span>Find out more &rarr;</span></button>
-</a>
+<div class="gh-referral-toast">
+    <button class="gh-referral-toast-close" type="button" {{on "click" this.dismissReferralInvite}}>&#xd7;</button>
+    <a href="https://referrals.ghost.org/?ref=admin" target="_blank" rel="noopener noreferrer">
+        <strong>You qualify for our invite-only referral program.</strong>
+        <p class="gh-footer-toast-p">Refer people to Ghost and earn a <strong>30% share</strong> of the subscription revenue, every single month.</p>
+        <div class="gh-btn gh-btn-black gh-referral-toast-button" type="button"><span>Find out more &rarr;</span></div>
+    </a>
+</div>
 {{/if}}

--- a/ghost/admin/app/components/gh-referral-invite.js
+++ b/ghost/admin/app/components/gh-referral-invite.js
@@ -47,7 +47,13 @@ export default class GhReferralInvite extends Component {
 
     @task
     *loadCurrentMRR() {
-        yield this.dashboardStats.loadMrrStats();
+        if (this.isAdminOrOwnern) {
+            try {
+                yield this.dashboardStats.loadMrrStats();
+            } catch (error) {
+                // noop
+            }
+        }
     }
 
     @action

--- a/ghost/admin/app/components/gh-referral-invite.js
+++ b/ghost/admin/app/components/gh-referral-invite.js
@@ -1,0 +1,62 @@
+import Component from '@glimmer/component';
+import envConfig from 'ghost-admin/config/environment';
+import moment from 'moment-timezone';
+import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
+
+export default class GhReferralInvite extends Component {
+    @service session;
+    @service dashboardStats;
+    @service feature;
+    @service membersUtils;
+    @service settings;
+
+    constructor() {
+        super(...arguments);
+        this.loadCurrentMRR.perform();
+    }
+
+    get isAdminOrOwner() {
+        return this.session.user.isAdmin;
+    }
+
+    get isReferralNotificationNotDismissed() {
+        return !this.feature.accessibility.referralInviteDismissed;
+    }
+
+    get stripeLiveModeEnabled() {
+        // allow testing mode when not in a production environment
+        const isDevModeStripeEnabled = envConfig.environment !== 'production' && this.membersUtils.isStripeEnabled;
+        const isLiveEnabled = this.settings.stripeConnectLivemode;
+        return isDevModeStripeEnabled || isLiveEnabled;
+    }
+
+    get hasReachedMRR() {
+        return this.dashboardStats.currentMRR / 100 >= 100;
+    }
+
+    get showReferralInvite() {
+        // Conditions to see the referral invite
+        // 1. Needs to be Owner or Admin
+        // 2. Stripe is setup and enabled in live mode
+        // 3. MRR is > $100
+        // 4. Notification has not yet been dismissed by the user
+        return !this.args.hasThemeErrors && this.isAdminOrOwner && this.isReferralNotificationNotDismissed && this.stripeLiveModeEnabled && this.hasReachedMRR;
+    }
+
+    @task
+    *loadCurrentMRR() {
+        yield this.dashboardStats.loadMrrStats();
+    }
+
+    @action
+    dismissReferralInvite(event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (!this.feature.referralInviteDismissed) {
+            this.feature.referralInviteDismissed = moment().tz(this.settings.timezone);
+        }
+    }
+}

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -55,6 +55,9 @@ export default class FeatureService extends Service {
     @feature('nightShift', {user: true, onChange: '_setAdminTheme'})
         nightShift;
 
+    // user-specific referral invitation
+    @feature('referralInviteDismissed', {user: true}) referralInviteDismissed;
+
     // labs flags
     @feature('urlCache') urlCache;
     @feature('beforeAfterCard') beforeAfterCard;

--- a/ghost/admin/app/styles/app-dark.css
+++ b/ghost/admin/app/styles/app-dark.css
@@ -810,6 +810,10 @@ input:focus,
     background: color-mod(var(--dark-main-bg-color) l(+2%));
 }
 
+.gh-referral-toast-close:hover {
+    color: #fff;
+}
+
 .nightshift-toggle {
     background: var(--lightgrey);
 }

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -2199,7 +2199,6 @@ section.gh-ds h2 {
     color: #ddd;
     font-size: 2.2rem;
     line-height: 1;
-    transition: all 0.3s ease;
 }
 
 .gh-referral-toast-close:hover {

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -2173,11 +2173,68 @@ section.gh-ds h2 {
 
 /* Ghost Referrals invite toast */
 .gh-referral-toast {
-    background: var(--white);
+    position: relative;
+    display: block;
+    padding: 25px;
+    margin-bottom: 50px;
     color: var(--black);
-    border: 1px solid var(--darkgrey);
+    text-decoration: none;
+    background: var(--white);
+    border-radius: 10px;
+    box-shadow: rgb(75 225 226 / 28%) -7px -6px 42px 8px, rgb(202 103 255 / 32%) 7px 6px 42px 8px;
+    transition: all 0.6s ease;
 }
 
-.gh-referral-toast .gh-footer-toast-p {
-    color: var(--middarkgrey);
+.gh-referral-toast:hover {
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: rgb(75 225 226 / 38%) -7px -4px 42px 10px, rgb(202 103 255 / 42%) 7px 8px 42px 10px;
+    transition: all 0.3s ease;
+  }
+
+.gh-referral-toast-close {
+    position: absolute;
+    top: 7px;
+    right: 10px;
+    padding: 5px;
+    color: #ddd;
+    font-size: 2.2rem;
+    line-height: 1;
+    transition: all 0.3s ease;
+}
+
+.gh-referral-toast-close:hover {
+    color: #15171A;
+}
+
+.gh-referral-toast > strong {
+    display: block;
+    margin-bottom: 10px;
+    font-size: 1.7rem;
+    line-height: 1.2em;
+}
+
+.gh-referral-toast p {
+    margin: 0;
+    font-size: 1.5rem;
+    line-height: 1.35em;
+    letter-spacing: -0.015em;
+    font-weight: 500;
+    color: #666;
+}
+.gh-referral-toast p strong {
+    color: #ff247d;
+}
+
+.gh-referral-toast-button {
+    margin-top: 20px;
+    border-radius: 5px;
+    width: 100%;
+}
+
+.gh-referral-toast-button span {
+    padding: 0 12px;
+    font-size: 1.4rem;
+    text-align-last: center;
+    height: 40px;
+    line-height: 40px;
 }

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -2183,6 +2183,11 @@ section.gh-ds h2 {
     border-radius: 10px;
     box-shadow: rgb(75 225 226 / 28%) -7px -6px 42px 8px, rgb(202 103 255 / 32%) 7px 6px 42px 8px;
     transition: all 0.6s ease;
+    cursor: pointer;
+}
+
+.gh-referral-toast a {
+    color: var(--black);
 }
 
 .gh-referral-toast:hover {
@@ -2205,14 +2210,14 @@ section.gh-ds h2 {
     color: #15171A;
 }
 
-.gh-referral-toast > strong {
+.gh-referral-toast a > strong {
     display: block;
     margin-bottom: 10px;
     font-size: 1.7rem;
     line-height: 1.2em;
 }
 
-.gh-referral-toast p {
+.gh-referral-toast a > p {
     margin: 0;
     font-size: 1.5rem;
     line-height: 1.35em;
@@ -2220,7 +2225,8 @@ section.gh-ds h2 {
     font-weight: 500;
     color: #666;
 }
-.gh-referral-toast p strong {
+
+.gh-referral-toast a > p strong {
     color: #ff247d;
 }
 

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -2149,8 +2149,8 @@ section.gh-ds h2 {
 }
 
 
-/* Theme error toast and modal */
-.gh-theme-error-toast {
+/* Footer toast in navbar */
+.gh-footer-toast {
     display: flex;
     flex-direction: column;
     font-size: 1.3rem;
@@ -2159,10 +2159,25 @@ section.gh-ds h2 {
     padding: 20px;
     margin-bottom: 32px;
     color: #fff;
-    background: var(--red);
     border-radius: 6px;
 }
 
-.gh-theme-error-toast .gh-notification-title {
+.gh-footer-toast-title.gh-notification-title {
     margin: 0 0 6px 0;
+}
+
+/* Theme error toast and modal */
+.gh-theme-error-toast {
+    background: var(--red);
+}
+
+/* Ghost Referrals invite toast */
+.gh-referral-toast {
+    background: var(--white);
+    color: var(--black);
+    border: 1px solid var(--darkgrey);
+}
+
+.gh-referral-toast .gh-footer-toast-p {
+    color: var(--middarkgrey);
 }


### PR DESCRIPTION
no issue

- Ghost users that make >= $100 MRR will see a dismissible notification that invites them to the Ghost Referral program
- Only Admin and Owner users will see it
- Only applies when Stripe is setup and connected in live mode
- By saving a `referralInviteDismissed` property to the users' `accessibility` JSON object we can determine if the notification has been dismissed and won't show it again
- Added new `gh-referral-invite` component
