### PR TITLE
Improved handling large amounts of email events

### DIFF
--- a/ghost/mailgun-client/lib/mailgun-client.js
+++ b/ghost/mailgun-client/lib/mailgun-client.js
@@ -126,6 +126,8 @@ module.exports = class MailgunClient {
                 value: Date.now() - startTime,
                 statusCode: 200
             });
+            // By limiting the processed events to ones created before this job started we cancel early ready for the next job run.
+            // Avoids chance of events being missed in long job runs due to mailgun's eventual-consistency creating events outside of our 30min sliding re-check window
             let events = (page?.items?.map(this.normalizeEvent) || []).filter(e => !!e && e.timestamp <= startDate);
             debug(`fetchEvents: finished fetching first page with ${events.length} events`);
 
@@ -153,6 +155,7 @@ module.exports = class MailgunClient {
                     value: Date.now() - startTime,
                     statusCode: 200
                 });
+                // We need to cap events at the time we started fetching them (see comment above)
                 events = (page?.items?.map(this.normalizeEvent) || []).filter(e => !!e && e.timestamp <= startDate);
                 debug(`fetchEvents: finished fetching next page with ${events.length} events`);
             }

--- a/ghost/mailgun-client/lib/mailgun-client.js
+++ b/ghost/mailgun-client/lib/mailgun-client.js
@@ -119,13 +119,14 @@ module.exports = class MailgunClient {
         debug(`fetchEvents: starting fetching first events page`);
         const mailgunConfig = this.#getConfig();
         let startTime = Date.now();
+        const startDate = new Date();
         try {
             let page = await mailgunInstance.events.get(mailgunConfig.domain, mailgunOptions);
             metrics.metric('mailgun-get-events', {
                 value: Date.now() - startTime,
                 statusCode: 200
             });
-            let events = (page?.items?.map(this.normalizeEvent) || []).filter(e => !!e);
+            let events = (page?.items?.map(this.normalizeEvent) || []).filter(e => !!e && e.timestamp <= startDate);
             debug(`fetchEvents: finished fetching first page with ${events.length} events`);
 
             let eventCount = 0;
@@ -152,7 +153,7 @@ module.exports = class MailgunClient {
                     value: Date.now() - startTime,
                     statusCode: 200
                 });
-                events = (page?.items?.map(this.normalizeEvent) || []).filter(e => !!e);
+                events = (page?.items?.map(this.normalizeEvent) || []).filter(e => !!e && e.timestamp <= startDate);
                 debug(`fetchEvents: finished fetching next page with ${events.length} events`);
             }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2486

Stop the event fetching loop as soon as we receive events that were created later then when we started the loop. This ensures that we don't miss events if we receive a giant batch of events that take a long time to process.