### PR TITLE
🐛 Fixed newsletter resending showing incorrect recipient data

### DIFF
--- a/ghost/admin/app/utils/publish-options.js
+++ b/ghost/admin/app/utils/publish-options.js
@@ -168,7 +168,7 @@ export default class PublishOptions {
     }
 
     get recipientFilter() {
-        return this.selectedRecipientFilter === undefined ? this.defaultRecipientFilter : this.selectedRecipientFilter;
+        return this.selectedRecipientFilter || this.post.emailSegment || this.defaultRecipientFilter;
     }
 
     get defaultRecipientFilter() {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/16125

We weren't taking into account any existing email segment set on the post. This is usually not an issue because during the publishing flow the post.emailSegment and the selectedRecipientFilter are kept in sync, but it becomes and issue when the email fails to send and is later retried - we now have an inconsistency between the two values.
