### PR TITLE
Added mocks mail receiver reset

### DIFF
--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -199,6 +199,10 @@ const restore = () => {
         mocks.webhookMockReceiver.reset();
     }
 
+    if (mocks.mockMailReceiver) {
+        mocks.mockMailReceiver.reset();
+    }
+
     mailService.GhostMailer.prototype.send = originalMailServiceSend;
 };
 


### PR DESCRIPTION
no issue

- opening this as a draft for now to see if it helps the failing tests.
- initiates the mail receiver reset to ensure it clears the mock inbox.
- potential cause for current failing tests, will remove PR if not.
