### PR TITLE
🐛 Fixed blank email previews when opening from member activity feeds

### DIFF
--- a/ghost/admin/app/components/modals/email-preview.js
+++ b/ghost/admin/app/components/modals/email-preview.js
@@ -79,9 +79,10 @@ export default class EmailPreviewModal extends Component {
         } else if (this.args.data.email) {
             html = this.args.data.email.html;
             subject = this.args.data.email.subject;
-        // data is a post? try fetching email preview
+        // data is a post or has no html, try fetching email preview
         } else {
-            let url = this.ghostPaths.url.api('/email_previews/posts', this.args.data.id);
+            const id = this.args.data.post_id || this.args.data.id;
+            let url = this.ghostPaths.url.api('/email_previews/posts', id);
             let response = await this.ajax.request(url);
             let [emailPreview] = response.email_previews;
             html = emailPreview.html;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2506

`email` objects no longer contain a `html` field and the fallback logic in the email preview modal was failing resulting in a 404 from trying to fetch an email preview using the email id rather than a post id.

- added quick-fix to the preview modal logic to use `data.post_id || data.id` for generating the preview URL (previous logic never expected to reach the fallback when working with an email record)
