### PR TITLE
Implemented awaitable DomainEvents

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -2209,7 +2209,7 @@ exports[`Members API Can create a member with an existing complimentary subscrip
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3141",
+  "content-length": "3031",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2313,7 +2313,7 @@ exports[`Members API Can create a member with an existing paid subscription 2: [
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3127",
+  "content-length": "3017",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -2209,7 +2209,7 @@ exports[`Members API Can create a member with an existing complimentary subscrip
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3031",
+  "content-length": "3141",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2313,7 +2313,7 @@ exports[`Members API Can create a member with an existing paid subscription 2: [
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3017",
+  "content-length": "3127",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -746,7 +746,7 @@ describe('Members API', function () {
     it('Can add a member and trigger host email verification limits', async function () {
         configUtils.set('hostSettings:emailVerification', {
             apiThreshold: 0,
-            adminThreshold: 1,
+            adminThreshold: 2,
             importThreshold: 0,
             verified: false,
             escalationAddress: 'test@example.com'

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -662,6 +662,14 @@ describe('Members API', function () {
             assert.equal(member.status, 'paid', 'The member should be "paid"');
             assert.equal(member.subscriptions.length, 1, 'The member should have a single subscription');
 
+            // Wait for the dispatched events (because this happens async)
+            await DomainEvents.allSettled();
+
+            mockManager.assert.sentEmail({
+                subject: '💸 Paid subscription started: checkout-webhook-test@email.com',
+                to: 'jbloggs@example.com'
+            });
+
             mockManager.assert.sentEmail({
                 subject: '🙌 Thank you for signing up to Ghost!',
                 to: 'checkout-webhook-test@email.com'
@@ -705,14 +713,6 @@ describe('Members API', function () {
                         mrr_delta: 500
                     }
                 ]
-            });
-
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
-
-            mockManager.assert.sentEmail({
-                subject: '💸 Paid subscription started: checkout-webhook-test@email.com',
-                to: 'jbloggs@example.com'
             });
         });
 

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -106,11 +106,10 @@ describe('Unit: sitemap/manager', function () {
 
             it('Listens to URLResourceUpdatedEvent event', async function () {
                 sinon.stub(PostGenerator.prototype, 'updateURL').resolves(true);
-                DomainEvents.dispatch(URLResourceUpdatedEvent.create({
+                await DomainEvents.dispatch(URLResourceUpdatedEvent.create({
                     id: 'post_id',
                     resourceType: 'posts'
                 }));
-                await DomainEvents.allSettled();
 
                 assert.ok(PostGenerator.prototype.updateURL.calledOnce);
             });

--- a/ghost/core/test/unit/server/services/staff/index.test.js
+++ b/ghost/core/test/unit/server/services/staff/index.test.js
@@ -75,13 +75,11 @@ describe('Staff Service:', function () {
 
         it('sends email for member source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(MemberCreatedEvent.create({
+            await DomainEvents.dispatch(MemberCreatedEvent.create({
                 source: 'member',
                 ...eventData
             }));
 
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
             mockManager.assert.sentEmail({
                 to: 'owner@ghost.org',
                 subject: /🥳 Free member signup: Jamie/
@@ -91,13 +89,11 @@ describe('Staff Service:', function () {
 
         it('sends email for api source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(MemberCreatedEvent.create({
+            await DomainEvents.dispatch(MemberCreatedEvent.create({
                 source: 'api',
                 ...eventData
             }));
 
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
             mockManager.assert.sentEmail({
                 to: 'owner@ghost.org',
                 subject: /🥳 Free member signup: Jamie/
@@ -107,13 +103,11 @@ describe('Staff Service:', function () {
 
         it('does not send email for importer source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(MemberCreatedEvent.create({
+            await DomainEvents.dispatch(MemberCreatedEvent.create({
                 source: 'import',
                 ...eventData
             }));
 
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
             mockManager.assert.sentEmailCount(0);
         });
     });
@@ -132,13 +126,11 @@ describe('Staff Service:', function () {
 
         it('sends email for member source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(SubscriptionCreatedEvent.create({
+            await DomainEvents.dispatch(SubscriptionCreatedEvent.create({
                 source: 'member',
                 ...eventData
             }));
 
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
             mockManager.assert.sentEmail({
                 to: 'owner@ghost.org',
                 subject: /💸 Paid subscription started: Jamie/
@@ -148,13 +140,11 @@ describe('Staff Service:', function () {
 
         it('sends email for api source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(SubscriptionCreatedEvent.create({
+            await DomainEvents.dispatch(SubscriptionCreatedEvent.create({
                 source: 'api',
                 ...eventData
             }));
 
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
             mockManager.assert.sentEmail({
                 to: 'owner@ghost.org',
                 subject: /💸 Paid subscription started: Jamie/
@@ -164,13 +154,11 @@ describe('Staff Service:', function () {
 
         it('does not send email for importer source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(SubscriptionCreatedEvent.create({
+            await DomainEvents.dispatch(SubscriptionCreatedEvent.create({
                 source: 'import',
                 ...eventData
             }));
 
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
             mockManager.assert.sentEmailCount(0);
         });
     });
@@ -184,13 +172,11 @@ describe('Staff Service:', function () {
 
         it('sends email for member source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(SubscriptionCancelledEvent.create({
+            await DomainEvents.dispatch(SubscriptionCancelledEvent.create({
                 source: 'member',
                 ...eventData
             }, new Date()));
 
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
             mockManager.assert.sentEmail({
                 to: 'owner@ghost.org',
                 subject: /⚠️ Cancellation: Jamie/
@@ -200,13 +186,11 @@ describe('Staff Service:', function () {
 
         it('sends email for api source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(SubscriptionCancelledEvent.create({
+            await DomainEvents.dispatch(SubscriptionCancelledEvent.create({
                 source: 'api',
                 ...eventData
             }));
 
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
             mockManager.assert.sentEmail({
                 to: 'owner@ghost.org',
                 subject: /⚠️ Cancellation: Jamie/
@@ -216,13 +200,11 @@ describe('Staff Service:', function () {
 
         it('does not send email for importer source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(SubscriptionCancelledEvent.create({
+            await DomainEvents.dispatch(SubscriptionCancelledEvent.create({
                 source: 'import',
                 ...eventData
             }));
 
-            // Wait for the dispatched events (because this happens async)
-            await DomainEvents.allSettled();
             mockManager.assert.sentEmailCount(0);
         });
     });

--- a/ghost/domain-events/README.md
+++ b/ghost/domain-events/README.md
@@ -20,5 +20,5 @@ DomainEvents.subscribe(MyEvent, function handler(event) {
 
 const event = new MyEvent('hello world');
 
-DomainEvents.dispatch(event);
+await DomainEvents.dispatch(event);
 ```

--- a/ghost/domain-events/lib/AsyncEventEmitter.js
+++ b/ghost/domain-events/lib/AsyncEventEmitter.js
@@ -1,4 +1,3 @@
-const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 
 class AsyncEventEmitter {
@@ -14,12 +13,12 @@ class AsyncEventEmitter {
      * @param {(data: any) => void | Promise<void>} listener
      */
     on(event, listener) {
-        if (typeof event !== 'string') {
-            throw new errors.IncorrectUsageError({
-                message: 'Cannot add an event listener without a string event name'
-            });
+        const array = this.listeners.get(event);
+        if (!array) {
+            this.listeners.set(event, [listener]);
+        } else {
+            array.push(listener);
         }
-        this.listeners.set(event, (this.listeners.get(event) || []).concat(listener));
     }
 
     /**
@@ -27,6 +26,17 @@ class AsyncEventEmitter {
      */
     listenerCount(event) {
         return this.listeners.get(event)?.length ?? 0;
+    }
+
+    /**
+     * @param {string} [event]
+     */
+    removeAllListeners(event) {
+        if (event === undefined) {
+            this.listeners = new Map();
+        } else {
+            this.listeners.delete(event);
+        }
     }
 
     /**

--- a/ghost/domain-events/lib/AsyncEventEmitter.js
+++ b/ghost/domain-events/lib/AsyncEventEmitter.js
@@ -1,0 +1,55 @@
+const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+
+class AsyncEventEmitter {
+    /**
+     * @private
+     * @type Map<string, ((data: any) => (Promise<void> | void))[]>
+     */
+    listeners = new Map();
+
+    /**
+     *
+     * @param {string} event
+     * @param {(data: any) => void | Promise<void>} listener
+     */
+    on(event, listener) {
+        if (typeof event !== 'string') {
+            throw new errors.IncorrectUsageError({
+                message: 'Cannot add an event listener without a string event name'
+            });
+        }
+        this.listeners.set(event, (this.listeners.get(event) || []).concat(listener));
+    }
+
+    /**
+     * @param {string} event
+     */
+    listenerCount(event) {
+        return this.listeners.get(event)?.length ?? 0;
+    }
+
+    /**
+     * We'll wait on each listener before calling the next one, to avoid too much concurrency
+     * @param {string} name
+     * @param {any} data
+     */
+    async emit(name, data) {
+        try {
+            for (const listener of this.listeners.get(name) || []) {
+                try {
+                    await listener(data);
+                } catch (e) {
+                    logging.error('Unhandled error in event handler for event: ' + name);
+                    logging.error(e);
+                }
+            }
+        } catch (e) {
+            // Avoid unhandled promise rejections in case emit is not awaited
+            logging.error('Unhandled error in AsyncEventEmitter for ' + name);
+            logging.error(e);
+        }
+    }
+}
+
+module.exports = AsyncEventEmitter;

--- a/ghost/domain-events/lib/DomainEvents.js
+++ b/ghost/domain-events/lib/DomainEvents.js
@@ -1,5 +1,5 @@
-const EventEmitter = require('events').EventEmitter;
 const logging = require('@tryghost/logging');
+const AsyncEventEmitter = require('./AsyncEventEmitter');
 
 /**
  * @template T
@@ -18,7 +18,7 @@ class DomainEvents {
      * @private
      * @type EventEmitter
      */
-    static ee = new EventEmitter;
+    static ee = new AsyncEventEmitter;
 
     /**
      * @template Data
@@ -45,10 +45,10 @@ class DomainEvents {
     /**
      * @template Data
      * @param {IEvent<Data>} event
-     * @returns {void}
+     * @returns {Promise<void>}
      */
-    static dispatch(event) {
-        DomainEvents.dispatchRaw(event.constructor.name, event);
+    static async dispatch(event) {
+        return DomainEvents.dispatchRaw(event.constructor.name, event);
     }
 
     /**
@@ -56,13 +56,13 @@ class DomainEvents {
      * @template Data
      * @param {string} name
      * @param {Data} data
-     * @returns {void}
+     * @returns {Promise<void>}
      */
-    static dispatchRaw(name, data) {
+    static async dispatchRaw(name, data) {
         if (this.#trackingEnabled) {
             this.#dispatchCount += DomainEvents.ee.listenerCount(name);
         }
-        DomainEvents.ee.emit(name, data);
+        return DomainEvents.ee.emit(name, data);
     }
 
     // Methods and properties below are only for testing purposes

--- a/ghost/domain-events/test/AsyncEventEmitter.test.js
+++ b/ghost/domain-events/test/AsyncEventEmitter.test.js
@@ -58,7 +58,7 @@ describe('AsyncEventEmitter', function () {
     });
 
     describe('emit', function () {
-        it('catchs errors in listeners', async function () {
+        it('catches errors in listeners', async function () {
             const ee = new AsyncEventEmitter();
             const stub = sinon.stub(logging, 'error').returns();
             let called = 0;
@@ -85,7 +85,7 @@ describe('AsyncEventEmitter', function () {
             assert.equal(stub.callCount, 4);
         });
 
-        it('catchs errors outside listeners', async function () {
+        it('catches errors outside listeners', async function () {
             const ee = new AsyncEventEmitter();
             ee.listeners = null;
             const stub = sinon.stub(logging, 'error').returns();

--- a/ghost/domain-events/test/AsyncEventEmitter.test.js
+++ b/ghost/domain-events/test/AsyncEventEmitter.test.js
@@ -1,0 +1,111 @@
+const assert = require('assert');
+const AsyncEventEmitter = require('../lib/AsyncEventEmitter');
+const sinon = require('sinon');
+const logging = require('@tryghost/logging');
+
+const sleep = ms => new Promise((resolve) => {
+    setTimeout(resolve, ms);
+});
+
+describe('AsyncEventEmitter', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('removeAllListeners', function () {
+        it('works without listeners', function () {
+            const ee = new AsyncEventEmitter();
+            ee.removeAllListeners();
+        });
+
+        it('works without listeners with name', function () {
+            const ee = new AsyncEventEmitter();
+            ee.removeAllListeners('test');
+        });
+
+        it('works with listeners', async function () {
+            const ee = new AsyncEventEmitter();
+            let called = false;
+            ee.on('test', () => {
+                called = true;
+            });
+            ee.removeAllListeners();
+            await ee.emit('test');
+            assert(!called);
+        });
+
+        it('works with listeners with name', async function () {
+            const ee = new AsyncEventEmitter();
+            let called = false;
+            ee.on('test', () => {
+                called = true;
+            });
+            ee.removeAllListeners('test');
+            await ee.emit('test');
+            assert(!called);
+        });
+
+        it('works with listeners with other name', async function () {
+            const ee = new AsyncEventEmitter();
+            let called = false;
+            ee.on('test', () => {
+                called = true;
+            });
+            ee.removeAllListeners('test2');
+            await ee.emit('test');
+            assert(called);
+        });
+    });
+
+    describe('emit', function () {
+        it('catchs errors in listeners', async function () {
+            const ee = new AsyncEventEmitter();
+            const stub = sinon.stub(logging, 'error').returns();
+            let called = 0;
+            ee.on('test', () => {
+                called += 1;
+                throw new Error('Test error');
+            });
+            ee.on('test', async () => {
+                // success
+                await sleep(5);
+                called += 1;
+            });
+            ee.on('test', async () => {
+                await sleep(5);
+                called += 1;
+                throw new Error('Test error');
+            });
+            ee.on('test', () => {
+                called += 1;
+                // success
+            });
+            await ee.emit('test');
+            assert.equal(called, 4);
+            assert.equal(stub.callCount, 4);
+        });
+
+        it('catchs errors outside listeners', async function () {
+            const ee = new AsyncEventEmitter();
+            ee.listeners = null;
+            const stub = sinon.stub(logging, 'error').returns();
+            await ee.emit('test');
+            assert.equal(stub.callCount, 2);
+        });
+    });
+
+    describe('listenerCount', function () {
+        it('works without listeners', async function () {
+            const ee = new AsyncEventEmitter();
+            assert.equal(ee.listenerCount('test'), 0);
+        });
+        it('works with listeners', async function () {
+            const ee = new AsyncEventEmitter();
+            ee.on('test', () => {});
+            ee.on('test', () => {});
+            ee.on('test2', () => {});
+            ee.on('test', () => {});
+            assert.equal(ee.listenerCount('test'), 3);
+        });
+    });
+});

--- a/ghost/domain-events/test/DomainEvents.test.js
+++ b/ghost/domain-events/test/DomainEvents.test.js
@@ -107,8 +107,7 @@ describe('DomainEvents', function () {
         DomainEvents.subscribe(TestEvent, handler1);
         DomainEvents.subscribe(TestEvent, handler2);
 
-        DomainEvents.dispatch(event);
-        await DomainEvents.allSettled();
+        await DomainEvents.dispatch(event);
 
         assert.equal(events.length, 2);
         assert.equal(events[0], event);
@@ -130,8 +129,7 @@ describe('DomainEvents', function () {
 
         DomainEvents.subscribe(TestEvent, handler1);
 
-        DomainEvents.dispatch(event);
-        await DomainEvents.allSettled();
+        await DomainEvents.dispatch(event);
         assert.equal(stub.calledTwice, true);
     });
 

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -852,6 +852,7 @@ module.exports = class MemberRepository {
                     ...options,
                     transacting
                 });
+                // Catch updated executionPromise
                 executionPromise = transacting.executionPromise;
             });
             if (executionPromise) {
@@ -1359,7 +1360,7 @@ module.exports = class MemberRepository {
                     subscriptionId: subscriptionModel.get('id'),
                     tierId: ghostProduct?.get('id')
                 };
-                this.dispatchEvent(SubscriptionCancelledEvent.create(cancelEventData, cancellationTimestamp), options);
+                await this.dispatchEvent(SubscriptionCancelledEvent.create(cancelEventData, cancellationTimestamp), options);
             }
         }
     }

--- a/ghost/members-api/test/unit/lib/repositories/member.test.js
+++ b/ghost/members-api/test/unit/lib/repositories/member.test.js
@@ -254,6 +254,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
+            await DomainEvents.allSettled();
             notifySpy.calledOnce.should.be.true();
         });
 
@@ -284,6 +285,7 @@ describe('MemberRepository', function () {
                 context: {}
             });
 
+            await DomainEvents.allSettled();
             notifySpy.calledOnce.should.be.true();
             notifySpy.calledWith(sinon.match((event) => {
                 if (event.data.offerId === 'offer_123') {

--- a/ghost/members-events-service/test/last-seen-at-updater.test.js
+++ b/ghost/members-events-service/test/last-seen-at-updater.test.js
@@ -32,7 +32,7 @@ describe('LastSeenAtUpdater', function () {
         });
         updater.subscribe(DomainEvents);
         sinon.stub(updater, 'updateLastSeenAt');
-        DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now.toDate()));
+        await DomainEvents.dispatch(MemberPageViewEvent.create({memberId: '1', memberLastSeenAt: previousLastSeen, url: '/'}, now.toDate()));
         assert(updater.updateLastSeenAt.calledOnceWithExactly('1', previousLastSeen, now.toDate()));
     });
 
@@ -65,8 +65,7 @@ describe('LastSeenAtUpdater', function () {
         updater.subscribe(DomainEvents);
         sinon.spy(updater, 'updateLastSeenAt');
         sinon.spy(updater, 'updateLastSeenAtWithoutKnownLastSeen');
-        DomainEvents.dispatch(EmailOpenedEvent.create({memberId: '1', emailRecipientId: '1', emailId: '1', timestamp: now.toDate()}));
-        await DomainEvents.allSettled();
+        await DomainEvents.dispatch(EmailOpenedEvent.create({memberId: '1', emailRecipientId: '1', emailId: '1', timestamp: now.toDate()}));
         assert(updater.updateLastSeenAtWithoutKnownLastSeen.calledOnceWithExactly('1', now.toDate()));
         assert(db.update.calledOnce);
     });
@@ -91,7 +90,7 @@ describe('LastSeenAtUpdater', function () {
         });
         updater.subscribe(DomainEvents);
         sinon.stub(updater, 'updateLastCommentedAt');
-        DomainEvents.dispatch(MemberCommentEvent.create({memberId: '1'}, now.toDate()));
+        await DomainEvents.dispatch(MemberCommentEvent.create({memberId: '1'}, now.toDate()));
         assert(updater.updateLastCommentedAt.calledOnceWithExactly('1', now.toDate()));
     });
 

--- a/ghost/verification-trigger/test/verification-trigger.test.js
+++ b/ghost/verification-trigger/test/verification-trigger.test.js
@@ -180,7 +180,7 @@ describe('Email verification flow', function () {
             }
         });
 
-        DomainEvents.dispatch(MemberCreatedEvent.create({
+        await DomainEvents.dispatch(MemberCreatedEvent.create({
             memberId: 'hello!',
             source: 'api'
         }, new Date()));


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2482

**Main reason for this change:**
We need a way to await DomainEvents, otherwise we risk sending too many events in one go, if we for example send events in a for loop. This is causing **issues in the email event processing**, which sends thousands of events in a loop. This causes the db connection pool to run out of connections and eventually time out. A proper implementation should wait for each event to be processed before sending the next event. With this change that becomes possible.

**Why not native EventEmitter?**
This uses a new AsyncEventEmitter, which follows the same interface as EventEmitter but is awaitable. It also only fires event listeners one after each other instead of parallel (= more predictable outcome + connection pool is limited and we don't need that concurrency). The native EventEmitter doesn't support this functionality, so custom code was required.

**Other advantages:**
- We can write more stable code (and tests!) by awaiting dispatchEvents where needed. E.g. in the members API code, we sometimes dispatch events that affect the result of the same request. (e.g. creating a member -> attribution stored -> attribution not returned in same request randomly sometimes because delay in events) That means that tests are not stable and the responses of those requests are not predictable and could be incorrect.