### PR TITLE
updated events that send mentions

### DIFF
--- a/ghost/webmentions/lib/MentionSendingService.js
+++ b/ghost/webmentions/lib/MentionSendingService.js
@@ -25,15 +25,25 @@ module.exports = class MentionSendingService {
     }
 
     /**
-     * Listen for changes in posts and automatically send webmentions.
+     * Listen for new and edited published posts and automatically send webmentions. Unpublished posts should send mentions
+     *  so the receiver can discover a 404 response and remove the mentions.
      * @param {*} events
      */
     listen(events) {
-        // Note: we don't need to listen for post.published (post.edited is also called at that time)
-        events.on('post.edited', this.sendForEditedPost.bind(this));
+        events.on('post.published', this.sendForPost.bind(this));
+        events.on('post.published.edited', this.sendForPost.bind(this));
+        events.on('post.unpublished', this.sendForPost.bind(this));
     }
 
-    async sendForEditedPost(post) {
+    async sendForPost(post, options) {
+        // NOTE: this is not ideal and shouldn't really be handled within the package...
+        // for now we don't want to evaluate mentions when importing data (at least needs queueing set up)
+        // we do not want to evaluate mentions with fixture (internal) data, e.g. generating posts
+        // TODO: real solution is likely suppressing event emission when building fixture data
+        if (options && (options.importing || options.context.internal)) {
+            return;
+        }
+
         try {
             if (!this.#isEnabled()) {
                 return;
@@ -53,7 +63,7 @@ module.exports = class MentionSendingService {
                 previousHtml: post.previous('status') === 'published' ? post.previous('html') : null
             });
         } catch (e) {
-            logging.error('Error in webmention sending service post.added event handler:');
+            logging.error('Error in webmention sending service post update event handler:');
             logging.error(e);
         }
     }

--- a/ghost/webmentions/test/MentionSendingService.test.js
+++ b/ghost/webmentions/test/MentionSendingService.test.js
@@ -29,7 +29,7 @@ describe('MentionSendingService', function () {
     describe('listen', function () {
         it('Calls on post.edited', async function () {
             const service = new MentionSendingService({});
-            const stub = sinon.stub(service, 'sendForEditedPost').resolves();
+            const stub = sinon.stub(service, 'sendForPost').resolves();
             let callback;
             const events = {
                 on: sinon.stub().callsFake((event, c) => {
@@ -43,13 +43,13 @@ describe('MentionSendingService', function () {
         });
     });
 
-    describe('sendForEditedPost', function () {
+    describe('sendForPost', function () {
         it('Ignores if disabled', async function () {
             const service = new MentionSendingService({
                 isEnabled: () => false
             });
             const stub = sinon.stub(service, 'sendAll');
-            await service.sendForEditedPost({});
+            await service.sendForPost({});
             sinon.assert.notCalled(stub);
         });
 
@@ -58,7 +58,7 @@ describe('MentionSendingService', function () {
                 isEnabled: () => true
             });
             const stub = sinon.stub(service, 'sendAll');
-            await service.sendForEditedPost(createModel({
+            await service.sendForPost(createModel({
                 status: 'draft',
                 html: 'changed',
                 previous: {
@@ -74,7 +74,7 @@ describe('MentionSendingService', function () {
                 isEnabled: () => true
             });
             const stub = sinon.stub(service, 'sendAll');
-            await service.sendForEditedPost(createModel({
+            await service.sendForPost(createModel({
                 status: 'published',
                 html: 'same',
                 previous: {
@@ -90,7 +90,7 @@ describe('MentionSendingService', function () {
                 isEnabled: () => true
             });
             const stub = sinon.stub(service, 'sendAll');
-            await service.sendForEditedPost(createModel({
+            await service.sendForPost(createModel({
                 status: 'send',
                 html: 'changed',
                 previous: {
@@ -107,7 +107,7 @@ describe('MentionSendingService', function () {
                 getPostUrl: () => 'https://site.com/post/'
             });
             const stub = sinon.stub(service, 'sendAll');
-            await service.sendForEditedPost(createModel({
+            await service.sendForPost(createModel({
                 status: 'published',
                 html: 'same',
                 previous: {
@@ -128,7 +128,7 @@ describe('MentionSendingService', function () {
                 getPostUrl: () => 'https://site.com/post/'
             });
             const stub = sinon.stub(service, 'sendAll');
-            await service.sendForEditedPost(createModel({
+            await service.sendForPost(createModel({
                 status: 'published',
                 html: 'updated',
                 previous: {
@@ -149,7 +149,7 @@ describe('MentionSendingService', function () {
                 getPostUrl: () => 'https://site.com/post/'
             });
             sinon.stub(service, 'sendAll').rejects(new Error('Internal error test'));
-            await service.sendForEditedPost(createModel({
+            await service.sendForPost(createModel({
                 status: 'published',
                 html: 'same',
                 previous: {


### PR DESCRIPTION
refs TryGhost/Team#2477
-removed post.edited as it was too inclusive
-changed to post.published, post.published.edited, post.unpublished
-blocked import and internal data from triggering mentions