### PR TITLE
Added short lived caching to email batch body

### DIFF
--- a/ghost/email-service/lib/email-body-cache.js
+++ b/ghost/email-service/lib/email-body-cache.js
@@ -1,0 +1,20 @@
+/**
+ * This is a cache provider that lives very short in memory, there is no need for persistence.
+ * It is created when scheduling an email in the batch sending service, and is then passed to the sending service. The sending service
+ * can optionally use a passed cache provider to reuse the email body for each batch with the same segment.
+ */
+class EmailBodyCache {
+    constructor() {
+        this.cache = new Map();
+    }
+
+    get(key) {
+        return this.cache.get(key) ?? null;
+    }
+
+    set(key, value) {
+        this.cache.set(key, value);
+    }
+}
+
+module.exports = EmailBodyCache;

--- a/ghost/email-service/lib/sending-service.js
+++ b/ghost/email-service/lib/sending-service.js
@@ -22,12 +22,14 @@ const logging = require('@tryghost/logging');
 
 /**
  * @typedef {import("./email-renderer")} EmailRenderer
+ * @typedef {import("./email-renderer").EmailBody} EmailBody
  */
 
 /**
  * @typedef {object} EmailSendingOptions
  * @prop {boolean} clickTrackingEnabled
  * @prop {boolean} openTrackingEnabled
+ * @prop {{get(id: string): EmailBody | null, set(id: string, body: EmailBody): void}} [emailBodyCache]
  */
 
 /**
@@ -85,12 +87,30 @@ class SendingService {
      * @returns {Promise<EmailProviderSuccessResponse>}
     */
     async send({post, newsletter, segment, members, emailId}, options) {
-        const emailBody = await this.#emailRenderer.renderBody(
-            post,
-            newsletter,
-            segment,
-            options
-        );
+        const cacheId = emailId + '-' + post.id + '-' + newsletter.id + '-' + (segment ?? 'null');
+
+        /**
+         * @type {EmailBody | null}
+         */
+        let emailBody = null;
+
+        if (options.emailBodyCache) {
+            emailBody = options.emailBodyCache.get(cacheId);
+        }
+
+        if (!emailBody) {
+            emailBody = await this.#emailRenderer.renderBody(
+                post,
+                newsletter,
+                segment,
+                {
+                    clickTrackingEnabled: !!options.clickTrackingEnabled,
+                }
+            );
+            if (options.emailBodyCache) {
+                options.emailBodyCache.set(cacheId, emailBody);
+            }
+        }
 
         const recipients = this.buildRecipients(members, emailBody.replacements);
         return await this.#emailProvider.send({
@@ -102,7 +122,10 @@ class SendingService {
             recipients,
             emailId: emailId,
             replacementDefinitions: emailBody.replacements
-        }, options);
+        }, {
+            clickTrackingEnabled: !!options.clickTrackingEnabled,
+            openTrackingEnabled: !!options.openTrackingEnabled
+        });
     }
 
     /**

--- a/ghost/email-service/lib/sending-service.js
+++ b/ghost/email-service/lib/sending-service.js
@@ -87,7 +87,7 @@ class SendingService {
      * @returns {Promise<EmailProviderSuccessResponse>}
     */
     async send({post, newsletter, segment, members, emailId}, options) {
-        const cacheId = emailId + '-' + post.id + '-' + newsletter.id + '-' + (segment ?? 'null');
+        const cacheId = emailId + '-' + (segment ?? 'null');
 
         /**
          * @type {EmailBody | null}

--- a/ghost/email-service/lib/sending-service.js
+++ b/ghost/email-service/lib/sending-service.js
@@ -104,7 +104,7 @@ class SendingService {
                 newsletter,
                 segment,
                 {
-                    clickTrackingEnabled: !!options.clickTrackingEnabled,
+                    clickTrackingEnabled: !!options.clickTrackingEnabled
                 }
             );
             if (options.emailBodyCache) {

--- a/ghost/email-service/test/sending-service.test.js
+++ b/ghost/email-service/test/sending-service.test.js
@@ -181,6 +181,37 @@ describe('Sending service', function () {
             });
             assert.equal(response2.id, 'provider-123');
             sinon.assert.calledTwice(sendStub);
+            assert(sendStub.getCall(1).calledWith(
+                {
+                    subject: 'Hi',
+                    from: 'ghost@example.com',
+                    replyTo: 'ghost+reply@example.com',
+                    html: '<html><body>Hi {{name}}</body></html>',
+                    plaintext: 'Hi',
+                    emailId: '123',
+                    replacementDefinitions: [
+                        {
+                            id: 'name',
+                            token: '{{name}}',
+                            getValue: sinon.match.func
+                        }
+                    ],
+                    recipients: [
+                        {
+                            email: 'member@example.com',
+                            replacements: [{
+                                id: 'name',
+                                token: '{{name}}',
+                                value: 'John'
+                            }]
+                        }
+                    ]
+                },
+                {
+                    clickTrackingEnabled: true,
+                    openTrackingEnabled: true
+                }
+            ));
 
             // Didn't call renderBody again
             sinon.assert.calledOnce(emailRenderer.renderBody);

--- a/ghost/email-service/test/sending-service.test.js
+++ b/ghost/email-service/test/sending-service.test.js
@@ -103,7 +103,6 @@ describe('Sending service', function () {
             ));
         });
 
-
         it('supports cache', async function () {
             const emailBodyCache = new EmailBodyCache();
             const sendingService = new SendingService({

--- a/ghost/email-service/test/sending-service.test.js
+++ b/ghost/email-service/test/sending-service.test.js
@@ -1,6 +1,7 @@
 const SendingService = require('../lib/sending-service');
 const sinon = require('sinon');
 const assert = require('assert');
+const EmailBodyCache = require('../lib/email-body-cache');
 
 describe('Sending service', function () {
     describe('send', function () {
@@ -100,6 +101,89 @@ describe('Sending service', function () {
                     openTrackingEnabled: true
                 }
             ));
+        });
+
+
+        it('supports cache', async function () {
+            const emailBodyCache = new EmailBodyCache();
+            const sendingService = new SendingService({
+                emailRenderer,
+                emailProvider
+            });
+
+            const response = await sendingService.send({
+                post: {},
+                newsletter: {},
+                segment: null,
+                emailId: '123',
+                members: [
+                    {
+                        email: 'member@example.com',
+                        name: 'John'
+                    }
+                ]
+            }, {
+                clickTrackingEnabled: true,
+                openTrackingEnabled: true,
+                emailBodyCache
+            });
+            assert.equal(response.id, 'provider-123');
+            sinon.assert.calledOnce(sendStub);
+            sinon.assert.calledOnce(emailRenderer.renderBody);
+            assert(sendStub.calledWith(
+                {
+                    subject: 'Hi',
+                    from: 'ghost@example.com',
+                    replyTo: 'ghost+reply@example.com',
+                    html: '<html><body>Hi {{name}}</body></html>',
+                    plaintext: 'Hi',
+                    emailId: '123',
+                    replacementDefinitions: [
+                        {
+                            id: 'name',
+                            token: '{{name}}',
+                            getValue: sinon.match.func
+                        }
+                    ],
+                    recipients: [
+                        {
+                            email: 'member@example.com',
+                            replacements: [{
+                                id: 'name',
+                                token: '{{name}}',
+                                value: 'John'
+                            }]
+                        }
+                    ]
+                },
+                {
+                    clickTrackingEnabled: true,
+                    openTrackingEnabled: true
+                }
+            ));
+
+            // Do again and see if cache is used
+            const response2 = await sendingService.send({
+                post: {},
+                newsletter: {},
+                segment: null,
+                emailId: '123',
+                members: [
+                    {
+                        email: 'member@example.com',
+                        name: 'John'
+                    }
+                ]
+            }, {
+                clickTrackingEnabled: true,
+                openTrackingEnabled: true,
+                emailBodyCache
+            });
+            assert.equal(response2.id, 'provider-123');
+            sinon.assert.calledTwice(sendStub);
+
+            // Didn't call renderBody again
+            sinon.assert.calledOnce(emailRenderer.renderBody);
         });
 
         it('removes invalid recipients before sending', async function () {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2522

When sending an email for multiple batches at the same time, we now reuse the same email body for each batch in the same segment. This reduces the amount of database queries and makes the sending more reliable in case of database failures.

The cache is short lived. After sending the email it is automatically garbage collected.