### PR TITLE
Optimized products queries

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/email-posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/email-posts.js
@@ -5,7 +5,7 @@ const membersService = require('../../../../../services/members');
 module.exports = {
     async read(model, apiConfig, frame) {
         const tiersModels = await membersService.api.productRepository.list({
-            withRelated: ['monthlyPrice', 'yearlyPrice']
+            limit: 'all'
         });
         const tiers = tiersModels.data && tiersModels.data.map(tierModel => tierModel.toJSON());
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/pages.js
@@ -13,7 +13,7 @@ module.exports = {
         let pages = [];
 
         const tiersModels = await membersService.api.productRepository.list({
-            withRelated: ['monthlyPrice', 'yearlyPrice']
+            limit: 'all'
         });
         const tiers = tiersModels.data ? tiersModels.data.map(tierModel => tierModel.toJSON()) : [];
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
@@ -13,7 +13,7 @@ module.exports = {
         let posts = [];
 
         const tiersModels = await membersService.api.productRepository.list({
-            withRelated: ['monthlyPrice', 'yearlyPrice']
+            limit: 'all'
         });
         const tiers = tiersModels.data ? tiersModels.data.map(tierModel => tierModel.toJSON()) : [];
         if (models.meta) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/previews.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/previews.js
@@ -4,7 +4,7 @@ const membersService = require('../../../../../services/members');
 module.exports = {
     async all(model, apiConfig, frame) {
         const tiersModels = await membersService.api.productRepository.list({
-            withRelated: ['monthlyPrice', 'yearlyPrice']
+            limit: 'all'
         });
         const tiers = tiersModels.data ? tiersModels.data.map(tierModel => tierModel.toJSON()) : [];
 

--- a/ghost/members-api/lib/repositories/product.js
+++ b/ghost/members-api/lib/repositories/product.js
@@ -650,14 +650,6 @@ class ProductRepository {
      * @returns {Promise<{data: ProductModel[], meta: object}>}
      **/
     async list(options = {}) {
-        if (!options.transacting) {
-            return this._Product.transaction((transacting) => {
-                return this.list({
-                    ...options,
-                    transacting
-                });
-            });
-        }
         return this._Product.findPage(options);
     }
 


### PR DESCRIPTION
- The `productRepository.list` call produced 5 db queries and a transaction wrapping this call.
- Transaction is not needed in this situation as there are no possible writes in the meantime (transaction wrapping code was put in there through refed commit to guard against failing Stripe API calls, which are no longer involved when calling the list method)
-  The `limit: 'all'` makes sure all product entries are fetched AND removes an extra aggregation query called over stripe_prices join
- The 'monthlyPrice' and 'yearlyPrice' relations are not needed because this data is not used in downstream code - only slug and type are used for visiblity/content gating  (ref. 1 https://github.com/TryGhost/Ghost/blob/3b6759ca6d4d282aa4c7d0e91b961b6d5384d39a/ghost/core/core/server/services/members/content-gating.js#L44-L55, ref. 2 https://github.com/TryGhost/Ghost/blob/3b6759ca6d4d282aa4c7d0e91b961b6d5384d39a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js#L39-L54)

The `limit: 'all'` optimization effect:
![image](https://user-images.githubusercontent.com/675397/217512619-1937845c-4f91-486f-9ba8-af1d56e2318e.png)

Final query result from the `list` method call:
```
knex:client acquired connection from pool: __knexUid8
knex:query select `products`.* from `products` left join `stripe_prices` on `products`.`monthly_price_id` = `stripe_prices`.`id` order by monthly_price ASC undefined
knex:bindings [] undefined
knex:client releasing connection to pool: __knexUid8
```

It's `1` select instead of `5`selects + transaction on every post/page/email render.