### PR TITLE
🐛 Fixed default email recipients always being "everyone" rather than matching post visibility

### DIFF
--- a/ghost/admin/app/utils/publish-options.js
+++ b/ghost/admin/app/utils/publish-options.js
@@ -168,7 +168,7 @@ export default class PublishOptions {
     }
 
     get recipientFilter() {
-        return this.selectedRecipientFilter || this.post.emailSegment || this.defaultRecipientFilter;
+        return this.selectedRecipientFilter || (this.post.newsletter && this.post.emailSegment) || this.defaultRecipientFilter;
     }
 
     get defaultRecipientFilter() {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/16125

The previous fix for incorrect recipient details being shown when re-sending a failed email introduced another bug that prevented the "Match post visibility" default recipients setting from working.

- the server always sets `post.emailSegment` to `'all'` for new posts so the publish flow recipient filter logic that checked for `post.emailSegment` being present always defaulted to `'all'` rather than falling back to the selected default recipients setting
- when a post has been published but the email failed it will have its `newsletter` value set so we can use that as a check for using the `post.emailSegment` value in place of the default recipients setting
