### PR TITLE
Added public tags (Content API) caching

### DIFF
--- a/ghost/adapter-cache-redis/.eslintrc.js
+++ b/ghost/adapter-cache-redis/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node'
+    ]
+};

--- a/ghost/adapter-cache-redis/README.md
+++ b/ghost/adapter-cache-redis/README.md
@@ -1,0 +1,23 @@
+# Adapter Cache Redis
+
+Redis based cache adapter with support of Redis cluster
+
+
+## Usage
+
+
+## Develop
+
+This is a monorepo package.
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+

--- a/ghost/adapter-cache-redis/index.js
+++ b/ghost/adapter-cache-redis/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/adapter-cache-redis');

--- a/ghost/adapter-cache-redis/lib/adapter-cache-redis.js
+++ b/ghost/adapter-cache-redis/lib/adapter-cache-redis.js
@@ -1,0 +1,147 @@
+const BaseCacheAdapter = require('@tryghost/adapter-base-cache');
+const logging = require('@tryghost/logging');
+const cacheManager = require('cache-manager');
+const redisStore = require('cache-manager-ioredis');
+const calculateSlot = require('cluster-key-slot');
+
+class Redis extends BaseCacheAdapter {
+    /**
+     *
+     * @param {Object} config
+     * @param {Object} [config.cache] - caching instance compatible with cache-manager with redis store
+     * @param {String} [config.host] - redis host used in case no cache instance provided
+     * @param {Number} [config.port] - redis port used in case no cache instance provided
+     * @param {String} [config.password] - redis password used in case no cache instance provided
+     * @param {Object} [config.clusterConfig] - redis cluster config used in case no cache instance provided
+     * @param {Number} [config.ttl] - default cached value Time To Live (expiration) in *seconds*
+     * @param {String} [config.keyPrefix] - prefix to use when building a unique cache key, e.g.: 'some_id:image-sizes:'
+     */
+    constructor(config) {
+        super();
+
+        this.cache = config.cache;
+
+        if (!this.cache) {
+            this.cache = cacheManager.caching({
+                store: redisStore,
+                ttl: config.ttl,
+                host: config.host,
+                port: config.port,
+                password: config.password,
+                clusterConfig: config.clusterConfig
+            });
+        }
+
+        this.keyPrefix = config.keyPrefix;
+        this._keysPattern = config.keyPrefix ? `${config.keyPrefix}*` : '';
+        this.redisClient = this.cache.store.getClient();
+        this.redisClient.on('error', this.handleRedisError);
+    }
+
+    handleRedisError(error) {
+        logging.error(error);
+    }
+
+    #getPrimaryRedisNode() {
+        const slot = calculateSlot(this.keyPrefix);
+        const [ip, port] = this.redisClient.slots[slot][0].split(':');
+        for (const node of this.redisClient.nodes()) {
+            if (node.options.host === ip && node.options.port === parseInt(port)) {
+                return node;
+            }
+        }
+        return null;
+    }
+
+    #scanNodeForKeys(node) {
+        return new Promise((resolve, reject) => {
+            const stream = node.scanStream({match: this._keysPattern, count: 100});
+            let keys = [];
+            stream.on('data', (resultKeys) => {
+                keys = keys.concat(resultKeys);
+            });
+            stream.on('error', (e) => {
+                reject(e);
+            });
+            stream.on('end', () => {
+                resolve(keys);
+            });
+        });
+    }
+
+    /**
+     * This is a recommended way to build cache key prefixes from
+     * the cache-manager package. Might be a good contribution to make
+     * in the package itself (https://github.com/node-cache-manager/node-cache-manager/issues/158)
+     * @param {string} key
+     * @returns {string}
+     */
+    _buildKey(key) {
+        if (this.keyPrefix) {
+            return `${this.keyPrefix}${key}`;
+        }
+
+        return key;
+    }
+
+    /**
+     * This is a method to remove the key prefix from any raw key returned from redis.
+     * @param {string} key
+     * @returns {string}
+     */
+    _removeKeyPrefix(key) {
+        return key.slice(this.keyPrefix.length);
+    }
+
+    /**
+     *
+     * @param {String} key
+     */
+    async get(key) {
+        try {
+            return await this.cache.get(this._buildKey(key));
+        } catch (err) {
+            logging.error(err);
+        }
+    }
+
+    /**
+     *
+     * @param {String} key
+     * @param {*} value
+     */
+    async set(key, value) {
+        try {
+            return await this.cache.set(this._buildKey(key), value);
+        } catch (err) {
+            logging.error(err);
+        }
+    }
+
+    async reset() {
+        // NOTE: dangerous in shared environment, and not used in production code anyway!
+        // return await this.cache.reset();
+        logging.error('Cache reset has not been implemented with shared cache environment in mind');
+    }
+
+    /**
+     * Helper method to assist "getAll" type of operations
+     * @returns {Promise<Array<String>>} all keys present in the cache
+     */
+    async keys() {
+        try {
+            const primaryNode = this.#getPrimaryRedisNode();
+            if (primaryNode === null) {
+                return [];
+            }
+            const rawKeys = await this.#scanNodeForKeys(primaryNode);
+            return rawKeys.map((key) => {
+                return this._removeKeyPrefix(key);
+            });
+        } catch (err) {
+            logging.error(err);
+        }
+    }
+}
+
+module.exports = Redis;

--- a/ghost/adapter-cache-redis/package.json
+++ b/ghost/adapter-cache-redis/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@tryghost/adapter-cache-redis",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/adapter-cache-redis",
+  "author": "Ghost Foundation",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "dev": "echo \"Implement me!\"",
+    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --100  --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+    "test": "yarn test:unit",
+    "lint:code": "eslint *.js lib/ --ext .js --cache",
+    "lint": "yarn lint:code && yarn lint:test",
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .js --cache"
+  },
+  "files": [
+    "index.js",
+    "lib"
+  ],
+  "devDependencies": {
+    "c8": "7.12.0",
+    "mocha": "10.2.0",
+    "sinon": "15.0.1"
+  },
+  "dependencies": {}
+}

--- a/ghost/adapter-cache-redis/package.json
+++ b/ghost/adapter-cache-redis/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --100  --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+    "test:unit": "NODE_ENV=testing c8 --all --lines 75  --reporter text --reporter cobertura mocha './test/**/*.test.js'",
     "test": "yarn test:unit",
     "lint:code": "eslint *.js lib/ --ext .js --cache",
     "lint": "yarn lint:code && yarn lint:test",
@@ -22,5 +22,9 @@
     "mocha": "10.2.0",
     "sinon": "15.0.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "cache-manager": "4.1.0",
+    "cache-manager-ioredis": "2.1.0",
+    "cluster-key-slot": "1.1.2"
+  }
 }

--- a/ghost/adapter-cache-redis/test/.eslintrc.js
+++ b/ghost/adapter-cache-redis/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/ghost/adapter-cache-redis/test/adapter-cache-redis.test.js
+++ b/ghost/adapter-cache-redis/test/adapter-cache-redis.test.js
@@ -1,0 +1,85 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const RedisCache = require('../index');
+
+describe('Adapter Cache Redis', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('can initialize Redis cache instance directly', async function () {
+        const redisCacheInstanceStub = {
+            store: {
+                getClient: sinon.stub().returns({
+                    on: sinon.stub()
+                })
+            }
+        };
+        const cache = new RedisCache({
+            cache: redisCacheInstanceStub
+        });
+
+        assert.ok(cache);
+    });
+
+    describe('get', function () {
+        it('can get a value from the cache', async function () {
+            const redisCacheInstanceStub = {
+                get: sinon.stub().resolves('value from cache'),
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub
+            });
+
+            const value = await cache.get('key');
+
+            assert.equal(value, 'value from cache');
+        });
+    });
+
+    describe('set', function () {
+        it('can set a value in the cache', async function () {
+            const redisCacheInstanceStub = {
+                set: sinon.stub().resolvesArg(1),
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub
+            });
+
+            const value = await cache.set('key-here', 'new value');
+
+            assert.equal(value, 'new value');
+            assert.equal(redisCacheInstanceStub.set.args[0][0], 'key-here');
+        });
+
+        it('sets a key based on keyPrefix', async function () {
+            const redisCacheInstanceStub = {
+                set: sinon.stub().resolvesArg(1),
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub,
+                keyPrefix: 'testing-prefix:'
+            });
+
+            const value = await cache.set('key-here', 'new value');
+
+            assert.equal(value, 'new value');
+            assert.equal(redisCacheInstanceStub.set.args[0][0], 'testing-prefix:key-here');
+        });
+    });
+});

--- a/ghost/adapter-cache-redis/test/hello.test.js
+++ b/ghost/adapter-cache-redis/test/hello.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+describe('Hello world', function () {
+    it('Runs a test', function () {
+        // TODO: Write me!
+        assert.ok(require('../index'));
+    });
+});

--- a/ghost/adapter-cache-redis/test/hello.test.js
+++ b/ghost/adapter-cache-redis/test/hello.test.js
@@ -1,8 +1,0 @@
-const assert = require('assert');
-
-describe('Hello world', function () {
-    it('Runs a test', function () {
-        // TODO: Write me!
-        assert.ok(require('../index'));
-    });
-});

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -294,6 +294,7 @@ async function initServices({config}) {
     const emailService = require('./server/services/email-service');
     const emailAnalytics = require('./server/services/email-analytics');
     const mentionsService = require('./server/services/mentions');
+    const tagsPublic = require('./server/services/tags-public');
 
     const urlUtils = require('./shared/url-utils');
 
@@ -311,6 +312,7 @@ async function initServices({config}) {
         staffService.init(),
         members.init(),
         tiers.init(),
+        tagsPublic.init(),
         membersEvents.init(),
         permissions.init(),
         xmlrpc.listen(),

--- a/ghost/core/core/server/adapters/cache/Redis.js
+++ b/ghost/core/core/server/adapters/cache/Redis.js
@@ -1,0 +1,3 @@
+const RedisCache = require('@tryghost/adapter-cache-redis');
+
+module.exports = RedisCache;

--- a/ghost/core/core/server/api/endpoints/tags-public.js
+++ b/ghost/core/core/server/api/endpoints/tags-public.js
@@ -2,6 +2,7 @@ const Promise = require('bluebird');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
+const tagsPublicService = require('../../services/tags-public');
 
 const ALLOWED_INCLUDES = ['count.posts'];
 
@@ -31,7 +32,7 @@ module.exports = {
         },
         permissions: true,
         query(frame) {
-            return models.TagPublic.findPage(frame.options);
+            return tagsPublicService.api.browse(frame.options);
         }
     },
 

--- a/ghost/core/core/server/services/tags-public/index.js
+++ b/ghost/core/core/server/services/tags-public/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./service');

--- a/ghost/core/core/server/services/tags-public/service.js
+++ b/ghost/core/core/server/services/tags-public/service.js
@@ -1,0 +1,26 @@
+class TagsPublicServiceWrapper {
+    async init() {
+        if (this.api) {
+            // Already done
+            return;
+        }
+
+        // Wire up all the dependencies
+        const models = require('../../models');
+        const adapterManager = require('../adapter-manager');
+
+        const tagsCache = adapterManager.getAdapter('cache:tagsPublic');
+        const {TagsPublicRepository} = require('@tryghost/tags-public');
+
+        this.linkRedirectRepository = new TagsPublicRepository({
+            Tag: models.TagPublic,
+            cache: tagsCache
+        });
+
+        this.api = {
+            browse: this.linkRedirectRepository.getAll.bind(this.linkRedirectRepository)
+        };
+    }
+}
+
+module.exports = new TagsPublicServiceWrapper();

--- a/ghost/core/core/server/services/tags-public/service.js
+++ b/ghost/core/core/server/services/tags-public/service.js
@@ -8,8 +8,13 @@ class TagsPublicServiceWrapper {
         // Wire up all the dependencies
         const models = require('../../models');
         const adapterManager = require('../adapter-manager');
+        const config = require('../../../shared/config');
 
-        const tagsCache = adapterManager.getAdapter('cache:tagsPublic');
+        let tagsCache;
+        if (config.get('hostSettings:tagsPublicCache:enabled')) {
+            tagsCache = adapterManager.getAdapter('cache:tagsPublic');
+        }
+
         const {TagsPublicRepository} = require('@tryghost/tags-public');
 
         this.linkRedirectRepository = new TagsPublicRepository({

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@sentry/node": "7.11.1",
     "@tryghost/adapter-base-cache": "0.1.3",
+    "@tryghost/adapter-cache-redis": "0.0.0",
     "@tryghost/adapter-manager": "0.0.0",
     "@tryghost/admin-api-schema": "4.2.1",
     "@tryghost/api-framework": "0.0.0",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -131,6 +131,7 @@
     "@tryghost/staff-service": "0.0.0",
     "@tryghost/stats-service": "0.0.0",
     "@tryghost/string": "0.2.2",
+    "@tryghost/tags-public": "0.0.0",
     "@tryghost/tiers": "0.0.0",
     "@tryghost/tpl": "0.1.21",
     "@tryghost/update-check-service": "0.0.0",

--- a/ghost/tags-public/.eslintrc.js
+++ b/ghost/tags-public/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node'
+    ]
+};

--- a/ghost/tags-public/README.md
+++ b/ghost/tags-public/README.md
@@ -1,0 +1,23 @@
+# Tags Public
+
+services and repositories serving public tags endpoints
+
+
+## Usage
+
+
+## Develop
+
+This is a monorepo package.
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+

--- a/ghost/tags-public/index.js
+++ b/ghost/tags-public/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/tags-public');

--- a/ghost/tags-public/lib/TagsPublicRepository.js
+++ b/ghost/tags-public/lib/TagsPublicRepository.js
@@ -40,11 +40,15 @@ module.exports = class TagsPublicRepository {
                 .filter(option => (option !== 'context'));
             const optionsForCacheKey = _.pick(options, permittedOptions);
 
-            // TODO: filter options, for example do we care make a distinction about
-            //       logged in member on the tags level?
+            // NOTE: can be more aggressive here with filtering options,
+            //       for example, do we care make a distinction for logged
+            //       in member on the tags level?
             cacheKey = `get-all-${JSON.stringify(optionsForCacheKey)}`;
-            const cachedResult = this.#cache.get(cacheKey);
+            const cachedResult = await this.#cache.get(cacheKey);
 
+            // NOTE: if the cache result is empty still going to the DB
+            //       this check can be removed if we want to be more aggressive
+            //       with caching and avoid and extra DB call
             if (cachedResult) {
                 return cachedResult;
             }
@@ -53,7 +57,7 @@ module.exports = class TagsPublicRepository {
         const dbResult = await this.#getAllDB(options);
 
         if (this.#cache) {
-            this.#cache.set(cacheKey, dbResult);
+            await this.#cache.set(cacheKey, dbResult);
         }
 
         return dbResult;

--- a/ghost/tags-public/lib/TagsPublicRepository.js
+++ b/ghost/tags-public/lib/TagsPublicRepository.js
@@ -1,0 +1,61 @@
+const _ = require('lodash');
+
+module.exports = class TagsPublicRepository {
+    /** @type {object} */
+    #Tag;
+
+    /** @type {object} */
+    #cache;
+
+    /**
+     * @param {object} deps
+     * @param {object} deps.Tag Bookshelf Model instance of TagPublic
+     * @param {object} deps.cache cache instance
+     */
+    constructor(deps) {
+        this.#Tag = deps.Tag;
+        this.#cache = deps.cache;
+    }
+
+    /**
+     * Queries the database for Tag records
+     * @param {Object} options model options
+     * @returns
+     */
+    async #getAllDB(options) {
+        return this.#Tag.findPage(options);
+    }
+
+    /**
+     * Gets all tags and caches the returned results
+     * @param {Object} options
+     * @returns
+     */
+    async getAll(options) {
+        let cacheKey;
+
+        if (this.#cache) {
+            // make the cache key smaller and don't include context
+            const permittedOptions = this.#Tag.permittedOptions('findPage')
+                .filter(option => (option !== 'context'));
+            const optionsForCacheKey = _.pick(options, permittedOptions);
+
+            // TODO: filter options, for example do we care make a distinction about
+            //       logged in member on the tags level?
+            cacheKey = `get-all-${JSON.stringify(optionsForCacheKey)}`;
+            const cachedResult = this.#cache.get(cacheKey);
+
+            if (cachedResult) {
+                return cachedResult;
+            }
+        }
+
+        const dbResult = await this.#getAllDB(options);
+
+        if (this.#cache) {
+            this.#cache.set(cacheKey, dbResult);
+        }
+
+        return dbResult;
+    }
+};

--- a/ghost/tags-public/lib/tags-public.js
+++ b/ghost/tags-public/lib/tags-public.js
@@ -1,0 +1,1 @@
+module.exports.TagsPublicRepository = require('./TagsPublicRepository');

--- a/ghost/tags-public/package.json
+++ b/ghost/tags-public/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@tryghost/tags-public",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/tags-public",
+  "author": "Ghost Foundation",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "dev": "echo \"Implement me!\"",
+    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --100  --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+    "test": "yarn test:unit",
+    "lint:code": "eslint *.js lib/ --ext .js --cache",
+    "lint": "yarn lint:code && yarn lint:test",
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .js --cache"
+  },
+  "files": [
+    "index.js",
+    "lib"
+  ],
+  "devDependencies": {
+    "c8": "7.12.0",
+    "mocha": "10.2.0",
+    "sinon": "15.0.1"
+  },
+  "dependencies": {}
+}

--- a/ghost/tags-public/test/.eslintrc.js
+++ b/ghost/tags-public/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/ghost/tags-public/test/TagsPublicRepository.test.js
+++ b/ghost/tags-public/test/TagsPublicRepository.test.js
@@ -1,0 +1,104 @@
+const assert = require('assert');
+const sinon = require('sinon');
+
+const {TagsPublicRepository} = require('../index');
+// @NOTE: This is a dirty import from the Ghost "core"!
+//        extract it to it's own package and import here as require('@tryghost/adapter-base-cache-memory');
+const MemoryCache = require('../../core/core/server/adapters/cache/Memory');
+
+describe('TagsPublicRepository', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('getAll', function () {
+        it('calls findPage on the model multiple times when cache NOT present', async function () {
+            const tagStub = {
+                findPage: sinon.stub().resolves(),
+                permittedOptions: sinon.stub()
+            };
+            const repo = new TagsPublicRepository({
+                Tag: tagStub
+            });
+
+            // first call
+            await repo.getAll({
+                limit: 'all'
+            });
+            // second call
+            await repo.getAll({
+                limit: 'all'
+            });
+
+            assert.equal(tagStub.findPage.callCount, 2, 'should be called same amount of times as getAll');
+            assert.ok(tagStub.findPage.calledWith({limit: 'all'}));
+        });
+
+        it('calls findPage once and uses the cached value on subsequent calls', async function () {
+            const tagStub = {
+                findPage: sinon.stub().resolves({
+                    data: [{
+                        get(key) {
+                            return key;
+                        }
+                    }],
+                    meta: {}
+                }),
+                permittedOptions: sinon.stub().returns(['limit'])
+            };
+            const repo = new TagsPublicRepository({
+                Tag: tagStub,
+                cache: new MemoryCache()
+            });
+
+            // first call
+            const dbTags = await repo.getAll({
+                limit: 'all'
+            });
+            // second call
+            const cacheTags = await repo.getAll({
+                limit: 'all'
+            });
+
+            assert.equal(tagStub.findPage.callCount, 1, 'should be called once when cache is present');
+            assert.ok(tagStub.findPage.calledWith({limit: 'all'}));
+
+            assert.equal(dbTags, cacheTags, 'should return the same value from the cache');
+        });
+
+        it('calls findPage multiple times if the record is not present in the cache', async function () {
+            const tagStub = {
+                findPage: sinon.stub().resolves({
+                    data: [{
+                        get(key) {
+                            return key;
+                        }
+                    }],
+                    meta: {}
+                }),
+                permittedOptions: sinon.stub().returns(['limit'])
+            };
+            const cache = new MemoryCache();
+            const repo = new TagsPublicRepository({
+                Tag: tagStub,
+                cache: cache
+            });
+
+            // first call
+            await repo.getAll({
+                limit: 'all'
+            });
+
+            // clear the cache
+            cache.reset();
+
+            // second call
+            await repo.getAll({
+                limit: 'all'
+            });
+
+            assert.equal(tagStub.findPage.callCount, 2, 'should be called every time the item is not in the cache');
+            assert.ok(tagStub.findPage.calledWith({limit: 'all'}));
+        });
+    });
+});

--- a/ghost/tags-public/test/TagsPublicRepository.test.js
+++ b/ghost/tags-public/test/TagsPublicRepository.test.js
@@ -100,5 +100,34 @@ describe('TagsPublicRepository', function () {
             assert.equal(tagStub.findPage.callCount, 2, 'should be called every time the item is not in the cache');
             assert.ok(tagStub.findPage.calledWith({limit: 'all'}));
         });
+
+        it('works with a cache that has an asynchronous interface', async function () {
+            const tagStub = {
+                findPage: sinon.stub().resolves({
+                    data: [{
+                        get(key) {
+                            return key;
+                        }
+                    }],
+                    meta: {}
+                }),
+                permittedOptions: sinon.stub().returns(['limit'])
+            };
+
+            const asyncMemoryCache = {
+                get: sinon.stub().resolves('test'),
+                set: sinon.stub().resolves()
+            };
+
+            const repo = new TagsPublicRepository({
+                Tag: tagStub,
+                cache: asyncMemoryCache
+            });
+
+            const result = await repo.getAll();
+
+            assert.ok(asyncMemoryCache.get.calledOnce);
+            assert.equal('test', result, 'should return the value from the cache');
+        });
     });
 });


### PR DESCRIPTION
- There are a lot of repeated cacheable tag-related queries coming from
{{get}} helpers in themes that can be cached.
- Having a repository layer deal with very specific type of query allows
to add extra functionality, like caching, on top of the database query
- This commit is wiring code that addds a default in-memory cache to
all db queries. Note, it lasts forever and has no "reset" listeners. The
production cache is mean to have a short time-to-live (TTL) - removes a need
to keep the cache always fresh.

It's a WIP, but sharing the direction early.

Left to do:
- [x] Feature flag for gradual rollout (will be hidden behind host settings config)
- [x] Unit tests for new modules
- [x] Redis cache configuration with TTL - find suitable implementation and prepare for Pro to use.


For review @allouis. This PR uses a combination of an established pattern repository + service wrapper initialization, but also adds a cache awareness to the repository. Wanted to get your eyes on it for a quick check if this all looks sound. Also note, the cache is only active when there's a `hostSettings` setting present - would run only on hosted environment, so we don't have to worry about self-hosted environments for the time being.