### PR TITLE
Added support for updating Mentions when Webmentions are resent

### DIFF
--- a/ghost/webmentions/lib/Mention.js
+++ b/ghost/webmentions/lib/Mention.js
@@ -78,6 +78,46 @@ module.exports = class Mention {
         return this.#sourceFeaturedImage;
     }
 
+    /**
+     * @param {object} metadata
+     */
+    setSourceMetadata(metadata) {
+        /** @type {string} */
+        let sourceTitle = validateString(metadata.sourceTitle, 2000, 'sourceTitle');
+        if (sourceTitle === null) {
+            sourceTitle = this.#source.host;
+        }
+        /** @type {string | null} */
+        const sourceExcerpt = validateString(metadata.sourceExcerpt, 2000, 'sourceExcerpt');
+        /** @type {string | null} */
+        const sourceSiteTitle = validateString(metadata.sourceSiteTitle, 2000, 'sourceSiteTitle');
+        /** @type {string | null} */
+        const sourceAuthor = validateString(metadata.sourceAuthor, 2000, 'sourceAuthor');
+
+        /** @type {URL | null} */
+        let sourceFavicon = null;
+        if (metadata.sourceFavicon instanceof URL) {
+            sourceFavicon = metadata.sourceFavicon;
+        } else if (metadata.sourceFavicon) {
+            sourceFavicon = new URL(metadata.sourceFavicon);
+        }
+
+        /** @type {URL | null} */
+        let sourceFeaturedImage = null;
+        if (metadata.sourceFeaturedImage instanceof URL) {
+            sourceFeaturedImage = metadata.sourceFeaturedImage;
+        } else if (metadata.sourceFeaturedImage) {
+            sourceFeaturedImage = new URL(metadata.sourceFeaturedImage);
+        }
+
+        this.#sourceTitle = sourceTitle;
+        this.#sourceExcerpt = sourceExcerpt;
+        this.#sourceSiteTitle = sourceSiteTitle;
+        this.#sourceAuthor = sourceAuthor;
+        this.#sourceFavicon = sourceFavicon;
+        this.#sourceFeaturedImage = sourceFeaturedImage;
+    }
+
     #deleted = false;
     delete() {
         this.#deleted = true;
@@ -108,12 +148,6 @@ module.exports = class Mention {
         this.#timestamp = data.timestamp;
         this.#payload = data.payload;
         this.#resourceId = data.resourceId;
-        this.#sourceTitle = data.sourceTitle;
-        this.#sourceSiteTitle = data.sourceSiteTitle;
-        this.#sourceAuthor = data.sourceAuthor;
-        this.#sourceExcerpt = data.sourceExcerpt;
-        this.#sourceFavicon = data.sourceFavicon;
-        this.#sourceFeaturedImage = data.sourceFeaturedImage;
     }
 
     /**
@@ -181,48 +215,16 @@ module.exports = class Mention {
             }
         }
 
-        /** @type {string} */
-        let sourceTitle = validateString(data.sourceTitle, 2000, 'sourceTitle');
-        if (sourceTitle === null) {
-            sourceTitle = source.host;
-        }
-        /** @type {string | null} */
-        const sourceExcerpt = validateString(data.sourceExcerpt, 2000, 'sourceExcerpt');
-        /** @type {string | null} */
-        const sourceSiteTitle = validateString(data.sourceSiteTitle, 2000, 'sourceSiteTitle');
-        /** @type {string | null} */
-        const sourceAuthor = validateString(data.sourceAuthor, 2000, 'sourceAuthor');
-
-        /** @type {URL | null} */
-        let sourceFavicon = null;
-        if (data.sourceFavicon instanceof URL) {
-            sourceFavicon = data.sourceFavicon;
-        } else if (data.sourceFavicon) {
-            sourceFavicon = new URL(data.sourceFavicon);
-        }
-
-        /** @type {URL | null} */
-        let sourceFeaturedImage = null;
-        if (data.sourceFeaturedImage instanceof URL) {
-            sourceFeaturedImage = data.sourceFeaturedImage;
-        } else if (data.sourceFeaturedImage) {
-            sourceFeaturedImage = new URL(data.sourceFeaturedImage);
-        }
-
         const mention = new Mention({
             id,
             source,
             target,
             timestamp,
             payload,
-            resourceId,
-            sourceTitle,
-            sourceSiteTitle,
-            sourceAuthor,
-            sourceExcerpt,
-            sourceFavicon,
-            sourceFeaturedImage
+            resourceId
         });
+
+        mention.setSourceMetadata(data);
 
         if (isNew) {
             mention.events.push(MentionCreatedEvent.create({mention}));

--- a/ghost/webmentions/lib/MentionsAPI.js
+++ b/ghost/webmentions/lib/MentionsAPI.js
@@ -155,6 +155,16 @@ module.exports = class MentionsAPI {
         let metadata;
         try {
             metadata = await this.#webmentionMetadata.fetch(webmention.source);
+            if (mention) {
+                mention.setSourceMetadata({
+                    sourceTitle: metadata.title,
+                    sourceSiteTitle: metadata.siteTitle,
+                    sourceAuthor: metadata.author,
+                    sourceExcerpt: metadata.excerpt,
+                    sourceFavicon: metadata.favicon,
+                    sourceFeaturedImage: metadata.image
+                });
+            }
         } catch (err) {
             if (!mention) {
                 throw err;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2535

**Refactored the assignment of Mention metadata**

Moving this into a separate method allows us to set the metadata externally from
the Mention entity and keep all of the validation, without having duplicate code


**Added support for updating Mentions when Webmentions are resent**

At the moment we only update the metadata of the Webmention source, so
that we can capture update titles, excerpts, etc... when a post is updated.