### PR TITLE
🐛 Fixed subscriptions visible as "Active" within Ghost Admin

### DIFF
--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -153,6 +153,10 @@
                                             <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                         {{else if sub.trialUntil}}
                                             <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
+                                        {{else if (eq sub.status "past_due")}}
+                                            <span class="gh-badge pink" data-test-text="member-subscription-status">Past due</span>
+                                        {{else if (eq sub.status "unpaid")}}
+                                            <span class="gh-badge pink" data-test-text="member-subscription-status">Unpaid</span>
                                         {{else}}
                                             <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                         {{/if}}

--- a/ghost/admin/app/components/gh-member-settings-form.hbs
+++ b/ghost/admin/app/components/gh-member-settings-form.hbs
@@ -153,10 +153,6 @@
                                             <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                         {{else if sub.trialUntil}}
                                             <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
-                                        {{else if (eq sub.status "past_due")}}
-                                            <span class="gh-badge pink" data-test-text="member-subscription-status">Past due</span>
-                                        {{else if (eq sub.status "unpaid")}}
-                                            <span class="gh-badge pink" data-test-text="member-subscription-status">Unpaid</span>
                                         {{else}}
                                             <span class="gh-badge active" data-test-text="member-subscription-status">Active</span>
                                         {{/if}}

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -2298,11 +2298,6 @@ p.gh-members-import-errordetail:first-of-type {
     font-size: 1.2rem;
 }
 
-.gh-membertier-subscription span.pink {
-    color: var(--pink);
-    background: color-mod(var(--pink) a(20%));
-}
-
 .gh-cp-membertier.multiple-subs .gh-membertier-subscription {
     margin-top: 12px;
     padding-top: 12px;

--- a/ghost/admin/app/styles/layouts/members.css
+++ b/ghost/admin/app/styles/layouts/members.css
@@ -2298,6 +2298,11 @@ p.gh-members-import-errordetail:first-of-type {
     font-size: 1.2rem;
 }
 
+.gh-membertier-subscription span.pink {
+    color: var(--pink);
+    background: color-mod(var(--pink) a(20%));
+}
+
 .gh-cp-membertier.multiple-subs .gh-membertier-subscription {
     margin-top: 12px;
     padding-top: 12px;
@@ -2564,9 +2569,10 @@ p.gh-members-import-errordetail:first-of-type {
 .gh-cp-membertier-attribution .gh-tier-card-header {
     display: flex;
     align-items: flex-start;
+    position: relative;
 }
 
-.gh-cp-membertier-attribution .gh-tier-card-header:nth-of-type(2) {
+.gh-cp-membertier-attribution .gh-tier-card-header:not(:first-child) {
     margin-top: 16px;
     border-top: 1px solid var(--whitegrey);
     padding-top: 16px;
@@ -2609,8 +2615,12 @@ p.gh-members-import-errordetail:first-of-type {
 
 .gh-cp-membertier-attribution .action-menu {
     position: absolute;
-    top: 24px;
-    right: 24px;
+    top: 0px;
+    right: 0px;
+}
+
+.gh-cp-membertier-attribution .gh-tier-card-header:not(:first-child) .action-menu {
+    top: 16px;
 }
 
 .gh-cp-membertier-attribution span.archived {

--- a/ghost/core/test/unit/server/services/staff/index.test.js
+++ b/ghost/core/test/unit/server/services/staff/index.test.js
@@ -6,7 +6,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const {mockManager} = require('../../../../utils/e2e-framework');
 const models = require('../../../../../core/server/models');
 
-const {SubscriptionCreatedEvent, SubscriptionCancelledEvent, MemberCreatedEvent} = require('@tryghost/member-events');
+const {SubscriptionCancelledEvent, MemberCreatedEvent, SubscriptionActivatedEvent} = require('@tryghost/member-events');
 
 describe('Staff Service:', function () {
     before(function () {
@@ -132,7 +132,7 @@ describe('Staff Service:', function () {
 
         it('sends email for member source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(SubscriptionCreatedEvent.create({
+            DomainEvents.dispatch(SubscriptionActivatedEvent.create({
                 source: 'member',
                 ...eventData
             }));
@@ -148,7 +148,7 @@ describe('Staff Service:', function () {
 
         it('sends email for api source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(SubscriptionCreatedEvent.create({
+            DomainEvents.dispatch(SubscriptionActivatedEvent.create({
                 source: 'api',
                 ...eventData
             }));
@@ -164,7 +164,7 @@ describe('Staff Service:', function () {
 
         it('does not send email for importer source', async function () {
             await staffService.init();
-            DomainEvents.dispatch(SubscriptionCreatedEvent.create({
+            DomainEvents.dispatch(SubscriptionActivatedEvent.create({
                 source: 'import',
                 ...eventData
             }));

--- a/ghost/member-events/index.js
+++ b/ghost/member-events/index.js
@@ -7,8 +7,9 @@ module.exports = {
     MemberPaidConverstionEvent: require('./lib/MemberPaidConversionEvent'),
     MemberPaidCancellationEvent: require('./lib/MemberPaidCancellationEvent'),
     MemberPageViewEvent: require('./lib/MemberPageViewEvent'),
-    SubscriptionCreatedEvent: require('./lib/SubscriptionCreatedEvent'),
     MemberCommentEvent: require('./lib/MemberCommentEvent'),
+    SubscriptionCreatedEvent: require('./lib/SubscriptionCreatedEvent'),
+    SubscriptionActivatedEvent: require('./lib/SubscriptionActivatedEvent'),
     SubscriptionCancelledEvent: require('./lib/SubscriptionCancelledEvent'),
     MemberLinkClickEvent: require('./lib/MemberLinkClickEvent')
 };

--- a/ghost/member-events/lib/SubscriptionActivatedEvent.js
+++ b/ghost/member-events/lib/SubscriptionActivatedEvent.js
@@ -1,0 +1,30 @@
+/**
+ * Fired when a subscription becomes active.
+ *
+ * @typedef {object} SubscriptionActivatedEventData
+ * @prop {string} source
+ * @prop {string} memberId
+ * @prop {string} batchId
+ * @prop {string} tierId
+ * @prop {string} subscriptionId
+ * @prop {string} offerId
+ */
+
+module.exports = class SubscriptionActivatedEvent {
+    /**
+     * @param {SubscriptionActivatedEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {SubscriptionActivatedEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new SubscriptionActivatedEvent(data, timestamp ?? new Date);
+    }
+};

--- a/ghost/member-events/lib/SubscriptionCreatedEvent.js
+++ b/ghost/member-events/lib/SubscriptionCreatedEvent.js
@@ -1,4 +1,6 @@
 /**
+ * Fired when a subscription is created. This can also happen when inactive subscriptions are created (incomplete, canceled...).
+ *
  * @typedef {object} SubscriptionCreatedEventData
  * @prop {string} source
  * @prop {string} memberId

--- a/ghost/members-api/lib/repositories/member.js
+++ b/ghost/members-api/lib/repositories/member.js
@@ -3,7 +3,7 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 const DomainEvents = require('@tryghost/domain-events');
-const {MemberCreatedEvent, SubscriptionCreatedEvent, MemberSubscribeEvent, SubscriptionCancelledEvent} = require('@tryghost/member-events');
+const {SubscriptionActivatedEvent, MemberCreatedEvent, SubscriptionCreatedEvent, MemberSubscribeEvent, SubscriptionCancelledEvent} = require('@tryghost/member-events');
 const ObjectId = require('bson-objectid').default;
 const {NotFoundError} = require('@tryghost/errors');
 const validator = require('@tryghost/validator');
@@ -970,6 +970,25 @@ module.exports = class MemberRepository {
             offer_id: offerId
         };
 
+        const getStatus = (modelToCheck) => {
+            const status = modelToCheck.get('status');
+            const canceled = modelToCheck.get('cancel_at_period_end');
+
+            if (status === 'canceled') {
+                return 'expired';
+            }
+
+            if (canceled) {
+                return 'canceled';
+            }
+
+            if (this.isActiveSubscriptionStatus(status)) {
+                return 'active';
+            }
+
+            return 'inactive';
+        };
+
         let eventData = {};
         if (model) {
             // CASE: Offer is already mapped against sub, don't overwrite it with NULL
@@ -985,25 +1004,6 @@ module.exports = class MemberRepository {
             if (model.get('mrr') !== updated.get('mrr') || model.get('plan_id') !== updated.get('plan_id') || model.get('status') !== updated.get('status') || model.get('cancel_at_period_end') !== updated.get('cancel_at_period_end')) {
                 const originalMrrDelta = model.get('mrr');
                 const updatedMrrDelta = updated.get('mrr');
-
-                const getStatus = (modelToCheck) => {
-                    const status = modelToCheck.get('status');
-                    const canceled = modelToCheck.get('cancel_at_period_end');
-
-                    if (status === 'canceled') {
-                        return 'expired';
-                    }
-
-                    if (canceled) {
-                        return 'canceled';
-                    }
-
-                    if (this.isActiveSubscriptionStatus(status)) {
-                        return 'active';
-                    }
-
-                    return 'inactive';
-                };
 
                 const getEventName = (originalStatus, updatedStatus) => {
                     if (originalStatus === updatedStatus) {
@@ -1031,6 +1031,24 @@ module.exports = class MemberRepository {
                     currency: subscriptionPriceData.currency,
                     mrr_delta: mrrDelta
                 }, options);
+
+                // Did we activate this subscription?
+                // This happens when an incomplete subscription is completed
+                // This always happens during the 3D secure flow, so it is important to catch
+                if (originalStatus !== 'active' && updatedStatus === 'active') {
+                    const context = options?.context || {};
+                    const source = this._resolveContextSource(context);
+
+                    const event = SubscriptionActivatedEvent.create({
+                        source,
+                        tierId: ghostProduct?.get('id'),
+                        memberId: member.id,
+                        subscriptionId: updated.get('id'),
+                        offerId: offerId,
+                        batchId: options.batch_id
+                    });
+                    this.dispatchEvent(event, options);
+                }
             }
         } else {
             eventData.created_at = new Date(subscription.start_date * 1000);
@@ -1060,6 +1078,18 @@ module.exports = class MemberRepository {
                 batchId: options.batch_id
             });
             this.dispatchEvent(event, options);
+
+            if (getStatus(subscriptionModel) === 'active') {
+                const activatedEvent = SubscriptionActivatedEvent.create({
+                    source,
+                    tierId: ghostProduct?.get('id'),
+                    memberId: member.id,
+                    subscriptionId: subscriptionModel.get('id'),
+                    offerId: offerId,
+                    batchId: options.batch_id
+                });
+                this.dispatchEvent(activatedEvent, options);
+            }
         }
 
         let memberProducts = (await member.related('products').fetch(options)).toJSON();

--- a/ghost/members-api/lib/services/member-bread.js
+++ b/ghost/members-api/lib/services/member-bread.js
@@ -64,8 +64,11 @@ module.exports = class MemberBREADService {
         }
 
         const subscriptionProducts = (member.subscriptions || [])
-            .filter(sub => sub.status !== 'canceled')
+            .filter(sub => this.memberRepository.isActiveSubscriptionStatus(sub.status))
             .map(sub => sub.price.product.product_id);
+
+        // Remove incomplete subscriptions from the API
+        member.subscriptions = member.subscriptions.filter(sub => sub.status !== 'incomplete' && sub.status !== 'incomplete_expired');
 
         for (const product of member.products) {
             if (!subscriptionProducts.includes(product.id)) {

--- a/ghost/staff-service/lib/staff-service.js
+++ b/ghost/staff-service/lib/staff-service.js
@@ -94,7 +94,6 @@ class StaffService {
         if (type === MemberCreatedEvent && member.status === 'free') {
             await this.emails.notifyFreeMemberSignup(member);
         } else if (type === SubscriptionActivatedEvent) {
-            // Only send an email if the subscription has a positive MRR (ignore incomplete subscriptions)
             await this.emails.notifyPaidSubscriptionStarted({
                 member,
                 offer,

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -1,7 +1,7 @@
 // Switch these lines once there are useful utils
 // const testUtils = require('./utils');
 const sinon = require('sinon');
-const {MemberCreatedEvent, SubscriptionCancelledEvent, SubscriptionCreatedEvent} = require('@tryghost/member-events');
+const {MemberCreatedEvent, SubscriptionCancelledEvent, SubscriptionActivatedEvent} = require('@tryghost/member-events');
 const {MentionCreatedEvent} = require('@tryghost/webmentions');
 
 require('./utils');
@@ -183,7 +183,7 @@ describe('StaffService', function () {
             it('subscribes to events', async function () {
                 service.subscribeEvents();
                 subscribeStub.callCount.should.eql(4);
-                subscribeStub.calledWith(SubscriptionCreatedEvent).should.be.true();
+                subscribeStub.calledWith(SubscriptionActivatedEvent).should.be.true();
                 subscribeStub.calledWith(SubscriptionCancelledEvent).should.be.true();
                 subscribeStub.calledWith(MemberCreatedEvent).should.be.true();
                 subscribeStub.calledWith(MentionCreatedEvent).should.be.true();
@@ -287,7 +287,7 @@ describe('StaffService', function () {
             });
 
             it('handles paid member created event', async function () {
-                await service.handleEvent(SubscriptionCreatedEvent, {
+                await service.handleEvent(SubscriptionActivatedEvent, {
                     data: {
                         source: 'member',
                         memberId: 'member-1',
@@ -316,7 +316,7 @@ describe('StaffService', function () {
                     sinon.match({subject: '⚠️ Cancellation: Jamie'})
                 ).should.be.true();
             });
-            
+
             it('handles new mention notification', async function () {
                 await service.handleEvent(MentionCreatedEvent, {
                     data: {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2542 
fixes https://github.com/TryGhost/Team/issues/2543 
fixes https://github.com/TryGhost/Team/issues/2544

- Hides incomplete subscriptions
- Shows Past Due subscriptions
- Fixed UI issues with 3+ subscriptions
- Fixed missing complimentary subscription when one subscription was incomplete/inactive
- Fixed sending a paid subscription started email for incomplete subscriptions. This change also required us to actually send the email when the incomplete subscription eventually becomes active. So the introduction of a new `SubscriptionActivatedEvent` made sense/was required (because sending a SubscriptionCreatedEvent again would cause other issues).