### PR TITLE
🐛 Fixed storing email failures with an empty message

### DIFF
--- a/ghost/core/core/server/services/email-analytics/wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/wrapper.js
@@ -55,6 +55,24 @@ class EmailAnalyticsServiceWrapper {
         });
     }
 
+    async fetchLatest() {
+        const fetchStartDate = new Date();
+        debug('Starting email analytics fetch of latest events');
+        const eventStats = await this.service.fetchLatest();
+        const fetchEndDate = new Date();
+        debug(`Finished fetching ${eventStats.totalEvents} analytics events in ${fetchEndDate.getTime() - fetchStartDate.getTime()}ms`);
+
+        const aggregateStartDate = new Date();
+        debug(`Starting email analytics aggregation for ${eventStats.emailIds.length} emails`);
+        await this.service.aggregateStats(eventStats);
+        const aggregateEndDate = new Date();
+        debug(`Finished aggregating email analytics in ${aggregateEndDate.getTime() - aggregateStartDate.getTime()}ms`);
+
+        logging.info(`Fetched ${eventStats.totalEvents} events and aggregated stats for ${eventStats.emailIds.length} emails in ${aggregateEndDate.getTime() - fetchStartDate.getTime()}ms`);
+
+        return eventStats;
+    }
+
     async startFetch() {
         if (this.fetching) {
             logging.info('Email analytics fetch already running, skipping');
@@ -64,19 +82,7 @@ class EmailAnalyticsServiceWrapper {
 
         logging.info('Email analytics fetch started');
         try {
-            const fetchStartDate = new Date();
-            debug('Starting email analytics fetch of latest events');
-            const eventStats = await this.service.fetchLatest();
-            const fetchEndDate = new Date();
-            debug(`Finished fetching ${eventStats.totalEvents} analytics events in ${fetchEndDate.getTime() - fetchStartDate.getTime()}ms`);
-
-            const aggregateStartDate = new Date();
-            debug(`Starting email analytics aggregation for ${eventStats.emailIds.length} emails`);
-            await this.service.aggregateStats(eventStats);
-            const aggregateEndDate = new Date();
-            debug(`Finished aggregating email analytics in ${aggregateEndDate.getTime() - aggregateStartDate.getTime()}ms`);
-
-            logging.info(`Fetched ${eventStats.totalEvents} events and aggregated stats for ${eventStats.emailIds.length} emails in ${aggregateEndDate.getTime() - fetchStartDate.getTime()}ms`);
+            const eventStats = await this.fetchLatest();
 
             this.fetching = false;
             return eventStats;

--- a/ghost/core/core/server/services/email-analytics/wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/wrapper.js
@@ -82,6 +82,9 @@ class EmailAnalyticsServiceWrapper {
             return eventStats;
         } catch (e) {
             logging.error(e, 'Error while fetching email analytics');
+
+            // Log again only the error, otherwise we lose the stack trace
+            logging.error(e);
         }
         this.fetching = false;
     }

--- a/ghost/email-analytics-service/lib/email-analytics-service.js
+++ b/ghost/email-analytics-service/lib/email-analytics-service.js
@@ -1,5 +1,6 @@
 const EventProcessingResult = require('./event-processing-result');
 const debug = require('@tryghost/debug')('services:email-analytics');
+const logging = require('@tryghost/logging');
 
 /**
  * @typedef {import('@tryghost/email-service').EmailEventProcessor} EmailEventProcessor
@@ -176,9 +177,12 @@ module.exports = class EmailAnalyticsService {
     }
 
     async aggregateStats({emailIds = [], memberIds = []}) {
+        logging.info(`Aggregating email analytics for ${emailIds.length} emails`);
         for (const emailId of emailIds) {
             await this.aggregateEmailStats(emailId);
         }
+
+        logging.info(`Aggregating email analytics for ${memberIds.length} members`);
         for (const memberId of memberIds) {
             await this.aggregateMemberStats(memberId);
         }

--- a/ghost/email-service/lib/email-event-storage.js
+++ b/ghost/email-service/lib/email-event-storage.js
@@ -17,8 +17,9 @@ class EmailEventStorage {
         // only set if delivered_at is null
         await this.#db.knex('email_recipients')
             .where('id', '=', event.emailRecipientId)
+            .whereNull('delivered_at')
             .update({
-                delivered_at: this.#db.knex.raw('COALESCE(delivered_at, ?)', [moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss')])
+                delivered_at: moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss')
             });
     }
 
@@ -27,8 +28,9 @@ class EmailEventStorage {
         // only set if opened_at is null
         await this.#db.knex('email_recipients')
             .where('id', '=', event.emailRecipientId)
+            .whereNull('opened_at')
             .update({
-                opened_at: this.#db.knex.raw('COALESCE(opened_at, ?)', [moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss')])
+                opened_at: moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss')
             });
     }
 
@@ -37,8 +39,9 @@ class EmailEventStorage {
         // only set if failed_at is null
         await this.#db.knex('email_recipients')
             .where('id', '=', event.emailRecipientId)
+            .whereNull('failed_at')
             .update({
-                failed_at: this.#db.knex.raw('COALESCE(failed_at, ?)', [moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss')])
+                failed_at: moment.utc(event.timestamp).format('YYYY-MM-DD HH:mm:ss')
             });
         await this.saveFailure('permanent', event);
     }
@@ -78,7 +81,7 @@ class EmailEventStorage {
                 member_id: event.memberId,
                 email_recipient_id: event.emailRecipientId,
                 severity,
-                message: event.error.message,
+                message: event.error.message || `Error ${event.error.enhancedCode ?? event.error.code}`,
                 code: event.error.code,
                 enhanced_code: event.error.enhancedCode,
                 failed_at: event.timestamp,
@@ -98,7 +101,7 @@ class EmailEventStorage {
             // Update the existing failure
             await existing.save({
                 severity,
-                message: event.error.message,
+                message: event.error.message || `Error ${event.error.enhancedCode ?? event.error.code}`,
                 code: event.error.code,
                 enhanced_code: event.error.enhancedCode ?? null,
                 failed_at: event.timestamp,

--- a/ghost/email-service/test/email-event-storage.test.js
+++ b/ghost/email-service/test/email-event-storage.test.js
@@ -101,6 +101,97 @@ describe('Email Event Storage', function () {
         assert(existing.save.calledOnce);
     });
 
+    it('Handles email permanent bounce events with update and empty message', async function () {
+        const event = EmailBouncedEvent.create({
+            email: 'example@example.com',
+            memberId: '123',
+            emailId: '456',
+            emailRecipientId: '789',
+            error: {
+                message: '',
+                code: 500,
+                enhancedCode: '5.5.5'
+            },
+            timestamp: new Date(0)
+        });
+
+        const db = createDb();
+        const existing = {
+            id: 1,
+            get: (key) => {
+                if (key === 'severity') {
+                    return 'temporary';
+                }
+                if (key === 'failed_at') {
+                    return new Date(-5);
+                }
+            },
+            save: sinon.stub().resolves()
+        };
+        const EmailRecipientFailure = {
+            transaction: async function (callback) {
+                return await callback(1);
+            },
+            findOne: sinon.stub().resolves(existing)
+        };
+
+        const eventHandler = new EmailEventStorage({
+            db,
+            models: {
+                EmailRecipientFailure
+            }
+        });
+        await eventHandler.handlePermanentFailed(event);
+        sinon.assert.calledOnce(db.update);
+        assert(!!db.update.firstCall.args[0].failed_at);
+        assert(existing.save.calledOnce);
+    });
+
+    it('Handles email permanent bounce events with update and empty message and without enhanced code', async function () {
+        const event = EmailBouncedEvent.create({
+            email: 'example@example.com',
+            memberId: '123',
+            emailId: '456',
+            emailRecipientId: '789',
+            error: {
+                message: '',
+                code: 500
+            },
+            timestamp: new Date(0)
+        });
+
+        const db = createDb();
+        const existing = {
+            id: 1,
+            get: (key) => {
+                if (key === 'severity') {
+                    return 'temporary';
+                }
+                if (key === 'failed_at') {
+                    return new Date(-5);
+                }
+            },
+            save: sinon.stub().resolves()
+        };
+        const EmailRecipientFailure = {
+            transaction: async function (callback) {
+                return await callback(1);
+            },
+            findOne: sinon.stub().resolves(existing)
+        };
+
+        const eventHandler = new EmailEventStorage({
+            db,
+            models: {
+                EmailRecipientFailure
+            }
+        });
+        await eventHandler.handlePermanentFailed(event);
+        sinon.assert.calledOnce(db.update);
+        assert(!!db.update.firstCall.args[0].failed_at);
+        assert(existing.save.calledOnce);
+    });
+
     it('Handles email permanent bounce events with insert', async function () {
         const event = EmailBouncedEvent.create({
             email: 'example@example.com',
@@ -111,6 +202,75 @@ describe('Email Event Storage', function () {
                 message: 'test',
                 code: 500,
                 enhancedCode: '5.5.5'
+            },
+            timestamp: new Date(0)
+        });
+
+        const db = createDb();
+        const EmailRecipientFailure = {
+            transaction: async function (callback) {
+                return await callback(1);
+            },
+            findOne: sinon.stub().resolves(undefined),
+            add: sinon.stub().resolves()
+        };
+
+        const eventHandler = new EmailEventStorage({
+            db,
+            models: {
+                EmailRecipientFailure
+            }
+        });
+        await eventHandler.handlePermanentFailed(event);
+        sinon.assert.calledOnce(db.update);
+        assert(!!db.update.firstCall.args[0].failed_at);
+        assert(EmailRecipientFailure.add.calledOnce);
+    });
+
+    it('Handles email permanent bounce events with insert and empty message', async function () {
+        const event = EmailBouncedEvent.create({
+            email: 'example@example.com',
+            memberId: '123',
+            emailId: '456',
+            emailRecipientId: '789',
+            error: {
+                message: '',
+                code: 500,
+                enhancedCode: '5.5.5'
+            },
+            timestamp: new Date(0)
+        });
+
+        const db = createDb();
+        const EmailRecipientFailure = {
+            transaction: async function (callback) {
+                return await callback(1);
+            },
+            findOne: sinon.stub().resolves(undefined),
+            add: sinon.stub().resolves()
+        };
+
+        const eventHandler = new EmailEventStorage({
+            db,
+            models: {
+                EmailRecipientFailure
+            }
+        });
+        await eventHandler.handlePermanentFailed(event);
+        sinon.assert.calledOnce(db.update);
+        assert(!!db.update.firstCall.args[0].failed_at);
+        assert(EmailRecipientFailure.add.calledOnce);
+    });
+
+    it('Handles email permanent bounce events with insert and empty message and without enhanced code', async function () {
+        const event = EmailBouncedEvent.create({
+            email: 'example@example.com',
+            memberId: '123',
+            emailId: '456',
+            emailRecipientId: '789',
+            error: {
+                message: '',
+                code: 500
             },
             timestamp: new Date(0)
         });


### PR DESCRIPTION
no issue

- When we receive an email failure with an empty message, the saving of the model would fail because of schema validation that requires strings to be non-empty.
- This adds more logging to the email analytics service to help debug future issues
- Performance improvement to storing delivered, opened and failed emails by replacing COALESCE with WHERE X IS NULL (tested and should give a decent performance boost locally).