### PR TITLE
fixed member import email setting import

### DIFF
--- a/ghost/members-csv/lib/unparse.js
+++ b/ghost/members-csv/lib/unparse.js
@@ -48,7 +48,7 @@ const unparse = (members, columns = DEFAULT_COLUMNS.slice()) => {
             email: member.email,
             name: member.name,
             note: member.note,
-            subscribed_to_emails: member.subscribed,
+            subscribed_to_emails: member.subscribed || member.subscribed_to_emails ? true : false,
             complimentary_plan: member.comped || member.complimentary_plan,
             stripe_customer_id: _.get(member, 'subscriptions[0].customer.id') || member.stripe_customer_id,
             created_at: member.created_at,

--- a/ghost/members-csv/test/unparse.test.js
+++ b/ghost/members-csv/test/unparse.test.js
@@ -13,14 +13,14 @@ describe('unparse', function () {
 
         assert.ok(result);
 
-        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers\r\n,email@example.com,Sam Memberino,Early supporter,,,,,,,`;
+        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers\r\n,email@example.com,Sam Memberino,Early supporter,false,,,,,,`;
         assert.equal(result, expected);
     });
 
     it('maps the subscribed property to subscribed_to_emails', function () {
         const json = [{
             email: 'do-not-email-me@email.com',
-            subscribed: false
+            subscribed_to_emails: false
         }];
 
         const columns = [


### PR DESCRIPTION
refs TryGhost/Team#2605
-updated unparse to look at both subscribed and subscribed_to_emails
-subscribed is for backwards compatibility
-may want to retire subscribed since we can't set from front-end