### PR TITLE
Implemented email analytics retrying

### DIFF
--- a/ghost/admin/app/components/posts/debug.hbs
+++ b/ghost/admin/app/components/posts/debug.hbs
@@ -401,10 +401,17 @@
                             <td>Last event time:</td>
                             <td>{{ this.analyticsStatus.scheduled.lastEventTimestamp }}</td>
                         </tr>
+                        {{#if (not this.analyticsStatus.scheduled.canceled)}}
+                            <tr>
+                                <td colspan="2">
+                                    <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.cancelScheduleAnalytics }}>{{svg-jar "trash"}}Cancel scheduled refetch</button>
+                                </td>
+                            </tr>
+                        {{/if}}
                     {{else}}
                         <tr>
                             <td colspan="2">
-                                <button type="button" class="gh-email-debug-schedule-analytics" onclick={{action scheduleAnalytics }}>{{svg-jar "reload"}}Refetch Analytics</button>
+                                <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.scheduleAnalytics }}>{{svg-jar "reload"}}Refetch Analytics</button>
                             </td>
                         </tr>
                     {{/if}}

--- a/ghost/admin/app/components/posts/debug.hbs
+++ b/ghost/admin/app/components/posts/debug.hbs
@@ -278,15 +278,19 @@
                     </tr>
                     <tr>
                         <td>Emails sent:</td>
-                        <td>{{this.emailSettings.emailsSent}}</td>
+                        <td class="gh-type-number">{{ format-number this.emailSettings.emailsSent}}</td>
                     </tr>
                     <tr>
                         <td>Delivered:</td>
-                        <td>{{this.emailSettings.emailsDelivered}}</td>
+                        <td class="gh-type-number">{{ format-number this.emailSettings.emailsDelivered}}</td>
+                    </tr>
+                    <tr>
+                        <td>Opened:</td>
+                        <td class="gh-type-number">{{ format-number this.emailSettings.emailsOpened}}</td>
                     </tr>
                     <tr>
                         <td>Failed:</td>
-                        <td>{{this.emailSettings.emailsFailed}}</td>
+                        <td class="gh-type-number">{{ format-number this.emailSettings.emailsFailed}}</td>
                     </tr>
                     <tr>
                         <td colspan="2"><hr></td>
@@ -321,8 +325,93 @@
                             {{/if}}
                         </td>
                     </tr>
+                    <tr>
+                        <td colspan="2"><hr></td>
+                    </tr>
+                    <tr>
+                        <td>Analytics Latest running:</td>
+                        <td class="gh-email-debug-settings-icon">
+                            {{#if (and this.analyticsStatus this.analyticsStatus.latest this.analyticsStatus.latest.running) }}
+                                <span class="check">{{svg-jar "check-2"}}</span>
+                            {{else}}
+                                <span class="x">{{svg-jar "close"}}</span>
+                            {{/if}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Last started:</td>
+                        <td>{{ this.analyticsStatus.latest.lastStarted }}</td>
+                    </tr>
+                    <tr>
+                        <td>Fetching from:</td>
+                        <td>{{ this.analyticsStatus.latest.lastBegin }}</td>
+                    </tr>
+                    <tr>
+                        <td>Last event time:</td>
+                        <td>{{ this.analyticsStatus.latest.lastEventTimestamp }}</td>
+                    </tr>
+                    <tr>
+                        <td colspan="2"><hr></td>
+                    </tr>
+                    <tr>
+                        <td>Analytics Missing running:</td>
+                        <td class="gh-email-debug-settings-icon">
+                            {{#if (and this.analyticsStatus this.analyticsStatus.missing this.analyticsStatus.missing.running) }}
+                                <span class="check">{{svg-jar "check-2"}}</span>
+                            {{else}}
+                                <span class="x">{{svg-jar "close"}}</span>
+                            {{/if}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Last started:</td>
+                        <td>{{ this.analyticsStatus.missing.lastStarted }}</td>
+                    </tr>
+                    <tr>
+                        <td>Fetching from:</td>
+                        <td>{{ this.analyticsStatus.missing.lastBegin }}</td>
+                    </tr>
+                    <tr>
+                        <td>Last event time:</td>
+                        <td>{{ this.analyticsStatus.missing.lastEventTimestamp }}</td>
+                    </tr>
+                    {{#if (and this.analyticsStatus this.analyticsStatus.scheduled this.analyticsStatus.scheduled.schedule) }}
+                        <tr>
+                            <td colspan="2"><hr></td>
+                        </tr>
+                        <tr>
+                            <td>Analytics Scheduled running:</td>
+                            <td class="gh-email-debug-settings-icon">
+                                {{#if this.analyticsStatus.scheduled.running }}
+                                    <span class="check">{{svg-jar "check-2"}}</span>
+                                {{else}}
+                                    <span class="x">{{svg-jar "close"}}</span>
+                                {{/if}}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Schedule:</td>
+                            <td>{{ this.analyticsStatus.scheduled.schedule.begin }} - {{ this.analyticsStatus.scheduled.schedule.end }}</td>
+                        </tr>
+                        <tr>
+                            <td>Last started:</td>
+                            <td>{{ this.analyticsStatus.scheduled.lastStarted }}</td>
+                        </tr>
+                        <tr>
+                            <td>Last event time:</td>
+                            <td>{{ this.analyticsStatus.scheduled.lastEventTimestamp }}</td>
+                        </tr>
+                    {{/if}}
+                    {{#unless startedRefetch}}
+                        <tr>
+                            <td colspan="2">
+                                <button type="button" class="gh-email-debug-schedule-analytics" onclick={{action scheduleAnalytics }}>{{svg-jar "reload"}}Refetch Analytics</button>
+                            </td>
+                        </tr>
+                    {{/unless}}
                 </tbody>
             </table>
+
         </tabs.tabPanel>
 
     </Tabs::Tabs>

--- a/ghost/admin/app/components/posts/debug.hbs
+++ b/ghost/admin/app/components/posts/debug.hbs
@@ -401,14 +401,13 @@
                             <td>Last event time:</td>
                             <td>{{ this.analyticsStatus.scheduled.lastEventTimestamp }}</td>
                         </tr>
-                    {{/if}}
-                    {{#unless startedRefetch}}
+                    {{else}}
                         <tr>
                             <td colspan="2">
                                 <button type="button" class="gh-email-debug-schedule-analytics" onclick={{action scheduleAnalytics }}>{{svg-jar "reload"}}Refetch Analytics</button>
                             </td>
                         </tr>
-                    {{/unless}}
+                    {{/if}}
                 </tbody>
             </table>
 

--- a/ghost/admin/app/components/posts/debug.hbs
+++ b/ghost/admin/app/components/posts/debug.hbs
@@ -401,13 +401,13 @@
                             <td>Last event time:</td>
                             <td>{{ this.analyticsStatus.scheduled.lastEventTimestamp }}</td>
                         </tr>
-                        {{#if (not this.analyticsStatus.scheduled.canceled)}}
+                        {{#unless this.analyticsStatus.scheduled.canceled}}
                             <tr>
                                 <td colspan="2">
                                     <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.cancelScheduleAnalytics }}>{{svg-jar "trash"}}Cancel scheduled refetch</button>
                                 </td>
                             </tr>
-                        {{/if}}
+                        {{/unless}}
                     {{else}}
                         <tr>
                             <td colspan="2">

--- a/ghost/admin/app/components/posts/debug.js
+++ b/ghost/admin/app/components/posts/debug.js
@@ -18,7 +18,6 @@ export default class Debug extends Component {
     @tracked emailBatches = null;
     @tracked recipientFailures = null;
     @tracked loading = true;
-    @tracked startedschedule = false;
     @tracked analyticsStatus = null;
     @tracked latestEmail = null;
 
@@ -31,7 +30,11 @@ export default class Debug extends Component {
     }
 
     async updateEmail() {
-        this.latestEmail = await this.store.findRecord('email', this.post.email.id, {reload: true});
+        try {
+            this.latestEmail = await this.store.findRecord('email', this.post.email.id, {reload: true});
+        } catch (e) {
+            // Skip
+        }
     }
 
     get emailError() {
@@ -242,10 +245,7 @@ export default class Debug extends Component {
             }
             return this._fetchAnalyticsStatus.perform();
         } catch (e) {
-            if (!didCancel(e)) {
-                // re-throw the non-cancelation error
-                throw e;
-            }
+            // Skip
         }
     }
 
@@ -312,6 +312,5 @@ export default class Debug extends Component {
         let statsUrl = this.ghostPaths.url.api(`/emails/${this.post.email.id}/analytics`);
         yield this.ajax.put(statsUrl, {});
         yield this.fetchAnalyticsStatus();
-        this.startedschedule = true;
     }
 }

--- a/ghost/admin/app/components/posts/debug.js
+++ b/ghost/admin/app/components/posts/debug.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import moment from 'moment-timezone';
 import {action} from '@ember/object';
-import {didCancel, task} from 'ember-concurrency';
+import {didCancel, task, timeout} from 'ember-concurrency';
 import {formatNumber} from 'ghost-admin/helpers/format-number';
 import {ghPluralize} from 'ghost-admin/helpers/gh-pluralize';
 import {inject as service} from '@ember/service';
@@ -13,13 +13,25 @@ export default class Debug extends Component {
     @service membersUtils;
     @service utils;
     @service feature;
+    @service store;
 
     @tracked emailBatches = null;
     @tracked recipientFailures = null;
     @tracked loading = true;
+    @tracked startedschedule = false;
+    @tracked analyticsStatus = null;
+    @tracked latestEmail = null;
 
     get post() {
         return this.args.post;
+    }
+
+    get email() {
+        return this.latestEmail ?? this.post.email;
+    }
+
+    async updateEmail() {
+        this.latestEmail = await this.store.findRecord('email', this.post.email.id, {reload: true});
     }
 
     get emailError() {
@@ -39,17 +51,18 @@ export default class Debug extends Component {
 
     get emailSettings() {
         return {
-            statusClass: this.post.email?.status,
-            status: this.getStatusLabel(this.post.email?.status),
-            recipientFilter: this.post.email?.recipientFilter,
-            createdAt: this.post.email?.createdAtUTC ? moment(this.post.email.createdAtUTC).format('DD MMM, YYYY, HH:mm:ss') : '',
-            submittedAt: this.post.email?.submittedAtUTC ? moment(this.post.email.submittedAtUTC).format('DD MMM, YYYY, HH:mm:ss') : '',
-            emailsSent: this.post.email?.emailCount,
-            emailsDelivered: this.post.email?.deliveredCount,
-            emailsFailed: this.post.email?.failedCount,
-            trackOpens: this.post.email?.trackOpens,
-            trackClicks: this.post.email?.trackClicks,
-            feedbackEnabled: this.post.email?.feedbackEnabled
+            statusClass: this.email?.status,
+            status: this.getStatusLabel(this.email?.status),
+            recipientFilter: this.email?.recipientFilter,
+            createdAt: this.email?.createdAtUTC ? moment(this.email.createdAtUTC).format('DD MMM, YYYY, HH:mm:ss') : '',
+            submittedAt: this.email?.submittedAtUTC ? moment(this.email.submittedAtUTC).format('DD MMM, YYYY, HH:mm:ss') : '',
+            emailsSent: this.email?.emailCount,
+            emailsDelivered: this.email?.deliveredCount,
+            emailsOpened: this.email?.openedCount,
+            emailsFailed: this.email?.failedCount,
+            trackOpens: this.email?.trackOpens,
+            trackClicks: this.email?.trackClicks,
+            feedbackEnabled: this.email?.feedbackEnabled
         };
     }
 
@@ -159,6 +172,8 @@ export default class Debug extends Component {
         if (this.post.email) {
             this.fetchEmailBatches();
             this.fetchRecipientFailures();
+            this.pollAnalyticsStatus.perform();
+            this.pollEmail.perform();
         }
     }
 
@@ -205,6 +220,36 @@ export default class Debug extends Component {
     }
 
     @task
+    *pollAnalyticsStatus() {
+        while (true) {
+            yield this.fetchAnalyticsStatus();
+            yield timeout(5 * 1000);
+        }
+    }
+
+    @task
+    *pollEmail() {
+        while (true) {
+            yield timeout(10 * 1000);
+            yield this.updateEmail();
+        }
+    }
+
+    async fetchAnalyticsStatus() {
+        try {
+            if (this._fetchAnalyticsStatus.isRunning) {
+                return this._fetchAnalyticsStatus.last;
+            }
+            return this._fetchAnalyticsStatus.perform();
+        } catch (e) {
+            if (!didCancel(e)) {
+                // re-throw the non-cancelation error
+                throw e;
+            }
+        }
+    }
+
+    @task
     *_fetchRecipientFailures() {
         const data = {
             include: 'member,email_recipient',
@@ -213,5 +258,60 @@ export default class Debug extends Component {
         let statsUrl = this.ghostPaths.url.api(`/emails/${this.post.email.id}/recipient-failures`);
         let result = yield this.ajax.request(statsUrl, {data});
         this.recipientFailures = result.failures;
+    }
+
+    @task
+    *_fetchAnalyticsStatus() {
+        let statsUrl = this.ghostPaths.url.api(`/emails/${this.post.email.id}/analytics`);
+        let result = yield this.ajax.request(statsUrl);
+        this.analyticsStatus = result;
+
+        // Parse dates
+        for (const type of Object.keys(result)) {
+            if (!result[type]) {
+                result[type] = {};
+            }
+            let object = result[type];
+            for (const key of ['lastStarted', 'lastBegin', 'lastEventTimestamp']) {
+                if (object[key]) {
+                    object[key] = moment(object[key]).format('DD MMM, YYYY, HH:mm:ss.SSS');
+                } else {
+                    object[key] = 'N/A';
+                }
+            }
+
+            if (object.schedule) {
+                object = object.schedule;
+                for (const key of ['begin', 'end']) {
+                    if (object[key]) {
+                        object[key] = moment(object[key]).format('DD MMM, YYYY, HH:mm:ss.SSS');
+                    } else {
+                        object[key] = 'N/A';
+                    }
+                }
+            }
+        }
+    }
+
+    @action scheduleAnalytics() {
+        try {
+            if (this._scheduleAnalytics.isRunning) {
+                return this._scheduleAnalytics.last;
+            }
+            return this._scheduleAnalytics.perform();
+        } catch (e) {
+            if (!didCancel(e)) {
+                // re-throw the non-cancelation error
+                throw e;
+            }
+        }
+    }
+
+    @task
+    *_scheduleAnalytics() {
+        let statsUrl = this.ghostPaths.url.api(`/emails/${this.post.email.id}/analytics`);
+        yield this.ajax.put(statsUrl, {});
+        yield this.fetchAnalyticsStatus();
+        this.startedschedule = true;
     }
 }

--- a/ghost/admin/app/components/posts/debug.js
+++ b/ghost/admin/app/components/posts/debug.js
@@ -293,7 +293,8 @@ export default class Debug extends Component {
         }
     }
 
-    @action scheduleAnalytics() {
+    @action
+    scheduleAnalytics() {
         try {
             if (this._scheduleAnalytics.isRunning) {
                 return this._scheduleAnalytics.last;
@@ -311,6 +312,28 @@ export default class Debug extends Component {
     *_scheduleAnalytics() {
         let statsUrl = this.ghostPaths.url.api(`/emails/${this.post.email.id}/analytics`);
         yield this.ajax.put(statsUrl, {});
+        yield this.fetchAnalyticsStatus();
+    }
+
+    @action
+    cancelScheduleAnalytics() {
+        try {
+            if (this._cancelScheduleAnalytics.isRunning) {
+                return this._cancelScheduleAnalytics.last;
+            }
+            return this._cancelScheduleAnalytics.perform();
+        } catch (e) {
+            if (!didCancel(e)) {
+                // re-throw the non-cancelation error
+                throw e;
+            }
+        }
+    }
+
+    @task
+    *_cancelScheduleAnalytics() {
+        let statsUrl = this.ghostPaths.url.api(`/emails/analytics`);
+        yield this.ajax.delete(statsUrl, {});
         yield this.fetchAnalyticsStatus();
     }
 }

--- a/ghost/admin/app/styles/layouts/settings.css
+++ b/ghost/admin/app/styles/layouts/settings.css
@@ -3585,6 +3585,10 @@ p.theme-validation-details {
     margin: 12px 0 20px;
 }
 
+.gh-email-debug-settings .gh-type-number {
+    font-variant-numeric: tabular-nums;
+}
+
 .gh-email-debug-settings hr {
     margin: 8px 0;
     border-top-color: var(--whitegrey);
@@ -3596,7 +3600,7 @@ p.theme-validation-details {
 }
 
 .gh-email-debug-settings tr td:first-of-type {
-    width: 20%;
+    width: 30%;
     white-space: nowrap;
     color: var(--midgrey);
 }
@@ -3618,6 +3622,25 @@ p.theme-validation-details {
 
 .gh-email-debug-settings-icon .x path {
     stroke: var(--midgrey);
+}
+
+.gh-email-debug-schedule-analytics {
+    display: flex;
+    align-items: center;
+    width: max-content;
+    margin: .8rem 0 0;
+    color: var(--green-d1);
+}
+
+.gh-email-debug-schedule-analytics svg {
+    width: 1rem;
+    height: 1rem;
+    margin-right: 6px;
+}
+
+.gh-email-debug-schedule-analytics svg g {
+    stroke: var(--green-d1);
+    stroke-width: 3px;
 }
 
 .gh-email-debug-empty-list {

--- a/ghost/core/core/server/api/endpoints/emails.js
+++ b/ghost/core/core/server/api/endpoints/emails.js
@@ -166,5 +166,14 @@ module.exports = {
                 end: new Date(Math.min(Date.now() - 60 * 60 * 1000, model.get('created_at').getTime() + 24 * 60 * 60 * 1000 * 7))
             });
         }
+    },
+
+    cancelScheduledAnalytics: {
+        permissions: {
+            method: 'browse'
+        },
+        async query() {
+            return emailAnalytics.service.cancelScheduled();
+        }
     }
 };

--- a/ghost/core/core/server/api/endpoints/emails.js
+++ b/ghost/core/core/server/api/endpoints/emails.js
@@ -4,6 +4,7 @@ const errors = require('@tryghost/errors');
 const megaService = require('../../services/mega');
 const emailService = require('../../services/email-service');
 const labs = require('../../../shared/labs');
+const emailAnalytics = require('../../services/email-analytics');
 
 const messages = {
     emailNotFound: 'Email not found.',
@@ -139,6 +140,31 @@ module.exports = {
         async query(frame) {
             const filter = `email_id:'${frame.data.id}'` + (frame.options.filter ? `+(${frame.options.filter})` : '');
             return await models.EmailRecipientFailure.findPage({...frame.options, filter});
+        }
+    },
+
+    analyticsStatus: {
+        permissions: {
+            method: 'browse'
+        },
+        async query() {
+            return emailAnalytics.service.getStatus();
+        }
+    },
+
+    scheduleAnalytics: {
+        permissions: {
+            method: 'browse'
+        },
+        data: [
+            'id'
+        ],
+        async query(frame) {
+            const model = await models.Email.findOne(frame.data, frame.options);
+            return emailAnalytics.service.schedule({
+                begin: model.get('created_at'),
+                end: new Date(Math.min(Date.now() - 60 * 60 * 1000, model.get('created_at').getTime() + 24 * 60 * 60 * 1000 * 7))
+            });
         }
     }
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/emails.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/emails.js
@@ -28,5 +28,9 @@ module.exports = {
         if (response.meta) {
             frame.response.meta = response.meta;
         }
+    },
+
+    analyticsStatus(response, apiConfig, frame) {
+        frame.response = response;
     }
 };

--- a/ghost/core/core/server/services/email-analytics/jobs/index.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/index.js
@@ -29,7 +29,7 @@ module.exports = {
                 const m = Math.floor(Math.random() * 5); // 0-4
 
                 jobsService.addJob({
-                    at: `0/15 * * * * *`,
+                    at: `${s} ${m}/5 * * * *`,
                     job: path.resolve(__dirname, 'fetch-latest/index.js'),
                     name: 'email-analytics-fetch-latest'
                 });

--- a/ghost/core/core/server/services/email-analytics/jobs/index.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/index.js
@@ -29,7 +29,7 @@ module.exports = {
                 const m = Math.floor(Math.random() * 5); // 0-4
 
                 jobsService.addJob({
-                    at: `${s} ${m}/5 * * * *`,
+                    at: `0/15 * * * * *`,
                     job: path.resolve(__dirname, 'fetch-latest/index.js'),
                     name: 'email-analytics-fetch-latest'
                 });

--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -15,9 +15,24 @@ module.exports = {
         const startDate = new Date();
 
         // three separate queries is much faster than using max/greatest (with coalesce to handle nulls) across columns
-        const {maxDeliveredAt} = await db.knex('email_recipients').select(db.knex.raw('MAX(delivered_at) as maxDeliveredAt')).first() || {};
-        const {maxOpenedAt} = await db.knex('email_recipients').select(db.knex.raw('MAX(opened_at) as maxOpenedAt')).first() || {};
-        const {maxFailedAt} = await db.knex('email_recipients').select(db.knex.raw('MAX(failed_at) as maxFailedAt')).first() || {};
+        let {maxDeliveredAt} = await db.knex('email_recipients').select(db.knex.raw('MAX(delivered_at) as maxDeliveredAt')).first() || {};
+        let {maxOpenedAt} = await db.knex('email_recipients').select(db.knex.raw('MAX(opened_at) as maxOpenedAt')).first() || {};
+        let {maxFailedAt} = await db.knex('email_recipients').select(db.knex.raw('MAX(failed_at) as maxFailedAt')).first() || {};
+
+        if (maxDeliveredAt && !(maxDeliveredAt instanceof Date)) {
+            // SQLite returns a string instead of a Date
+            maxDeliveredAt = new Date(maxDeliveredAt);
+        }
+
+        if (maxOpenedAt && !(maxOpenedAt instanceof Date)) {
+            // SQLite returns a string instead of a Date
+            maxOpenedAt = new Date(maxOpenedAt);
+        }
+
+        if (maxFailedAt && !(maxFailedAt instanceof Date)) {
+            // SQLite returns a string instead of a Date
+            maxFailedAt = new Date(maxFailedAt);
+        }
 
         const lastSeenEventTimestamp = _.max([maxDeliveredAt, maxOpenedAt, maxFailedAt]);
         debug(`getLastSeenEventTimestamp: finished in ${Date.now() - startDate}ms`);

--- a/ghost/core/core/server/services/email-analytics/wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/wrapper.js
@@ -54,7 +54,7 @@ class EmailAnalyticsServiceWrapper {
         });
     }
 
-    async fetchLatest({maxEvents}) {
+    async fetchLatest({maxEvents} = {maxEvents: Infinity}) {
         logging.info('[EmailAnalytics] Fetch latest started');
 
         const fetchStartDate = new Date();
@@ -65,7 +65,7 @@ class EmailAnalyticsServiceWrapper {
         return totalEvents;
     }
 
-    async fetchMissing({maxEvents}) {
+    async fetchMissing({maxEvents} = {maxEvents: Infinity}) {
         logging.info('[EmailAnalytics] Fetch missing started');
 
         const fetchStartDate = new Date();

--- a/ghost/core/core/server/services/email-analytics/wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/wrapper.js
@@ -56,17 +56,48 @@ class EmailAnalyticsServiceWrapper {
     }
 
     async fetchLatest() {
-        const fetchStartDate = new Date();
-        debug('Starting email analytics fetch of latest events');
-        const eventStats = await this.service.fetchLatest();
-        const fetchEndDate = new Date();
-        debug(`Finished fetching ${eventStats.totalEvents} analytics events in ${fetchEndDate.getTime() - fetchStartDate.getTime()}ms`);
+        // Instead of processing all events directy, we do a little loop
+        // Because otherwise we could be fetching for 30 minutes without updating the aggrage stats
+        // Instead, we fetch ±1000 at a time and stop if we reached a time limit or 0 new events
 
-        const aggregateStartDate = new Date();
-        debug(`Starting email analytics aggregation for ${eventStats.emailIds.length} emails`);
+        const loopStartDate = new Date();
+        let fetchCount = 0;
+
+        for (let index = 0; index < 100; index++) {
+            const fetchStartDate = new Date();
+            debug('Starting email analytics fetch of latest events');
+            const eventStats = await this.service.fetchLatest({maxEvents: 5100});
+            fetchCount += eventStats.totalEvents;
+
+            const fetchEndDate = new Date();
+            debug(`Finished fetching ${eventStats.totalEvents} analytics events in ${fetchEndDate.getTime() - fetchStartDate.getTime()}ms`);
+
+            const aggregateStartDate = new Date();
+            debug(`Starting email analytics aggregation for ${eventStats.emailIds.length} emails`);
+            await this.service.aggregateStats(eventStats);
+            const aggregateEndDate = new Date();
+            debug(`Finished aggregating email analytics in ${aggregateEndDate.getTime() - aggregateStartDate.getTime()}ms`);
+            logging.info(`[EmailAnalytics] Fetched ${eventStats.totalEvents} events and aggregated stats for ${eventStats.emailIds.length} emails in ${aggregateEndDate.getTime() - fetchStartDate.getTime()}ms (iteration ${index + 1})`);
+
+            // Stop if more than 5 minutes working
+            if (eventStats.totalEvents < 5100 || aggregateEndDate.getTime() - loopStartDate.getTime() > 5 * 60 * 1000) {
+                break;
+            }
+        }
+
+        const loopEndTime = new Date();
+        logging.info(`[EmailAnalytics] Total: ${fetchCount} events in ${loopEndTime.getTime() - loopStartDate.getTime()}ms`);
+
+        return fetchCount;
+    }
+
+    async fetchMissing() {
+        const fetchStartDate = new Date();
+
+        const eventStats = await this.service.fetchMissing({maxEvents: 1000});
         await this.service.aggregateStats(eventStats);
+
         const aggregateEndDate = new Date();
-        debug(`Finished aggregating email analytics in ${aggregateEndDate.getTime() - aggregateStartDate.getTime()}ms`);
 
         logging.info(`Fetched ${eventStats.totalEvents} events and aggregated stats for ${eventStats.emailIds.length} emails in ${aggregateEndDate.getTime() - fetchStartDate.getTime()}ms`);
 
@@ -80,12 +111,14 @@ class EmailAnalyticsServiceWrapper {
         }
         this.fetching = true;
 
-        logging.info('Email analytics fetch started');
         try {
-            const eventStats = await this.fetchLatest();
+            logging.info('[EmailAnalytics] Fetch latest started');
+            await this.fetchLatest();
+
+            logging.info('[EmailAnalytics] Fetch missing started');
+            await this.fetchMissing();
 
             this.fetching = false;
-            return eventStats;
         } catch (e) {
             logging.error(e, 'Error while fetching email analytics');
 

--- a/ghost/core/core/server/services/email-analytics/wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/wrapper.js
@@ -77,6 +77,17 @@ class EmailAnalyticsServiceWrapper {
         return totalEvents;
     }
 
+    async fetchScheduled() {
+        logging.info('[EmailAnalytics] Fetch scheduled started');
+
+        const fetchStartDate = new Date();
+        const totalEvents = await this.service.fetchScheduled({maxEvents: 5100}); // Maximum so we don't delay fetchLatest too much
+        const fetchEndDate = new Date();
+
+        logging.info(`[EmailAnalytics] Fetched ${totalEvents} events and aggregated stats in ${fetchEndDate.getTime() - fetchStartDate.getTime()}ms`);
+        return totalEvents;
+    }
+
     async startFetch() {
         if (this.fetching) {
             logging.info('Email analytics fetch already running, skipping');
@@ -87,6 +98,7 @@ class EmailAnalyticsServiceWrapper {
         try {
             await this.fetchLatest();
             await this.fetchMissing();
+            await this.fetchScheduled();
 
             this.fetching = false;
         } catch (e) {

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -302,6 +302,7 @@ module.exports = function apiRoutes() {
     router.get('/emails/:id/recipient-failures', mw.authAdminApi, http(api.emails.browseFailures));
     router.get('/emails/:id/analytics', mw.authAdminApi, http(api.emails.analyticsStatus));
     router.put('/emails/:id/analytics', mw.authAdminApi, http(api.emails.scheduleAnalytics));
+    router.delete('/emails/analytics', mw.authAdminApi, http(api.emails.cancelScheduledAnalytics));
 
     // ## Snippets
     router.get('/snippets', mw.authAdminApi, http(api.snippets.browse));

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -300,6 +300,8 @@ module.exports = function apiRoutes() {
     router.put('/emails/:id/retry', mw.authAdminApi, http(api.emails.retry));
     router.get('/emails/:id/batches', mw.authAdminApi, http(api.emails.browseBatches));
     router.get('/emails/:id/recipient-failures', mw.authAdminApi, http(api.emails.browseFailures));
+    router.get('/emails/:id/analytics', mw.authAdminApi, http(api.emails.analyticsStatus));
+    router.put('/emails/:id/analytics', mw.authAdminApi, http(api.emails.scheduleAnalytics));
 
     // ## Snippets
     router.get('/snippets', mw.authAdminApi, http(api.snippets.browse));

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -66,7 +66,7 @@ describe('EmailEventStorage', function () {
                 }
             },
             // unix timestamp
-            timestamp: Math.round(timestamp.getTime() / 1000)
+            timestamp: timestamp.getTime() / 1000
         }];
 
         const initialModel = await models.EmailRecipient.findOne({
@@ -78,9 +78,7 @@ describe('EmailEventStorage', function () {
         // Fire event processing
         // We use offloading to have correct coverage and usage of worker thread
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.delivered, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -129,9 +127,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.delivered, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -177,9 +173,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.opened, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -259,9 +253,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.permanentFailed, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -357,9 +349,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.permanentFailed, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -454,9 +444,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.permanentFailed, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -546,9 +534,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.permanentFailed, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -664,9 +650,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.temporaryFailed, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -768,9 +752,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.temporaryFailed, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -872,9 +854,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.temporaryFailed, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -976,9 +956,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.permanentFailed, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -1042,9 +1020,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.complained, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -1093,9 +1069,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.unsubscribed, 1);
-        assert.deepEqual(result.emailIds, [emailId]);
-        assert.deepEqual(result.memberIds, [memberId]);
+        assert.equal(result, 1);
 
         // Since this is all event based we should wait for all dispatched events to be completed.
         await DomainEvents.allSettled();
@@ -1132,9 +1106,7 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.unhandled, 1);
-        assert.deepEqual(result.emailIds, []);
-        assert.deepEqual(result.memberIds, []);
+        assert.equal(result, 1);
     });
 
     it('Ignores invalid events', async function () {
@@ -1148,8 +1120,6 @@ describe('EmailEventStorage', function () {
 
         // Fire event processing
         const result = await emailAnalytics.fetchLatest();
-        assert.equal(result.unhandled, 0);
-        assert.deepEqual(result.emailIds, []);
-        assert.deepEqual(result.memberIds, []);
+        assert.equal(result, 0);
     });
 });

--- a/ghost/core/test/integration/services/mailgun-email-suppression-list.test.js
+++ b/ghost/core/test/integration/services/mailgun-email-suppression-list.test.js
@@ -44,7 +44,7 @@ describe('MailgunEmailSuppressionList', function () {
             recipient
         })];
 
-        await emailAnalytics.startFetch();
+        await emailAnalytics.fetchLatest();
         await DomainEvents.allSettled();
 
         const {body: {members: [memberAfter]}} = await agent.get(`/members/${memberId}`);
@@ -72,7 +72,7 @@ describe('MailgunEmailSuppressionList', function () {
             recipient
         })];
 
-        await emailAnalytics.startFetch();
+        await emailAnalytics.fetchLatest();
         await DomainEvents.allSettled();
 
         const {body: {members: [memberAfter]}} = await agent.get(`/members/${memberId}`);
@@ -100,7 +100,7 @@ describe('MailgunEmailSuppressionList', function () {
             recipient
         })];
 
-        await emailAnalytics.startFetch();
+        await emailAnalytics.fetchLatest();
         await DomainEvents.allSettled();
 
         const {body: {members: [memberAfter]}} = await agent.get(`/members/${memberId}`);
@@ -128,7 +128,7 @@ describe('MailgunEmailSuppressionList', function () {
             recipient
         })];
 
-        await emailAnalytics.startFetch();
+        await emailAnalytics.fetchLatest();
         await DomainEvents.allSettled();
 
         const {body: {members: [memberAfter]}} = await agent.get(`/members/${memberId}`);
@@ -163,7 +163,7 @@ describe('MailgunEmailSuppressionList', function () {
             timestamp: Math.round(timestamp.getTime() / 1000)
         }];
 
-        await emailAnalytics.startFetch();
+        await emailAnalytics.fetchLatest();
         await DomainEvents.allSettled();
 
         const {body: {members: [memberAfter]}} = await agent.get(`/members/${memberId}`);

--- a/ghost/email-analytics-provider-mailgun/lib/provider-mailgun.js
+++ b/ghost/email-analytics-provider-mailgun/lib/provider-mailgun.js
@@ -1,10 +1,7 @@
 const MailgunClient = require('@tryghost/mailgun-client');
-const moment = require('moment');
-const {EventProcessingResult} = require('@tryghost/email-analytics-service');
 
 const EVENT_FILTER = 'delivered OR opened OR failed OR unsubscribed OR complained';
 const PAGE_LIMIT = 300;
-const TRUST_THRESHOLD_S = 30 * 60; // 30 minutes
 const DEFAULT_TAGS = ['bulk-email'];
 
 class EmailAnalyticsProviderMailgun {
@@ -20,39 +17,23 @@ class EmailAnalyticsProviderMailgun {
     }
 
     /**
-     * Do not start from a particular time, grab latest then work back through
-     * pages until we get a blank response
-     *
-     * @param {Function} batchHandler
-     * @param {Object} [options]
-     */
-    fetchAll(batchHandler, options) {
-        const mailgunOptions = {
-            event: EVENT_FILTER,
-            limit: PAGE_LIMIT,
-            tags: this.tags.join(' AND ')
-        };
-
-        return this.#fetchAnalytics(mailgunOptions, batchHandler, options);
-    }
-
-    /**
      * Fetch from the last known timestamp-TRUST_THRESHOLD then work forwards
      * through pages until we get a blank response. This lets us get events
      * quicker than the TRUST_THRESHOLD
      *
-     * @param {Date} latestTimestamp
      * @param {Function} batchHandler
      * @param {Object} [options]
+     * @param {Number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
+     * @param {Date} [options.begin]
+     * @param {Date} [options.end]
      */
-    fetchLatest(latestTimestamp, batchHandler, options) {
-        const beginDate = moment(latestTimestamp).subtract(TRUST_THRESHOLD_S, 's').toDate();
-
+    fetchLatest(batchHandler, options) {
         const mailgunOptions = {
             limit: PAGE_LIMIT,
             event: EVENT_FILTER,
             tags: this.tags.join(' AND '),
-            begin: beginDate.toUTCString(),
+            begin: options.begin?.toUTCString(),
+            end: options.end?.toUTCString(),
             ascending: 'yes'
         };
 
@@ -70,15 +51,7 @@ class EmailAnalyticsProviderMailgun {
      * @param {Object} [options]
      */
     async #fetchAnalytics(mailgunOptions, batchHandler, options) {
-        const events = await this.mailgunClient.fetchEvents(mailgunOptions, batchHandler, options);
-
-        const processingResult = new EventProcessingResult();
-
-        for (const event of events) {
-            processingResult.merge(event);
-        }
-
-        return processingResult;
+        return await this.mailgunClient.fetchEvents(mailgunOptions, batchHandler, options);
     }
 }
 

--- a/ghost/email-analytics-provider-mailgun/lib/provider-mailgun.js
+++ b/ghost/email-analytics-provider-mailgun/lib/provider-mailgun.js
@@ -32,8 +32,8 @@ class EmailAnalyticsProviderMailgun {
             limit: PAGE_LIMIT,
             event: EVENT_FILTER,
             tags: this.tags.join(' AND '),
-            begin: options.begin?.toUTCString(),
-            end: options.end?.toUTCString(),
+            begin: options.begin ? options.begin.getTime() / 1000 : undefined,
+            end: options.end ? options.end.getTime() / 1000 : undefined,
             ascending: 'yes'
         };
 

--- a/ghost/email-analytics-provider-mailgun/lib/provider-mailgun.js
+++ b/ghost/email-analytics-provider-mailgun/lib/provider-mailgun.js
@@ -37,7 +37,9 @@ class EmailAnalyticsProviderMailgun {
             ascending: 'yes'
         };
 
-        return this.#fetchAnalytics(mailgunOptions, batchHandler, options);
+        return this.#fetchAnalytics(mailgunOptions, batchHandler, {
+            maxEvents: options.maxEvents
+        });
     }
 
     /**
@@ -49,6 +51,7 @@ class EmailAnalyticsProviderMailgun {
      * @param {String} [mailgunOptions.ascending]
      * @param {Function} batchHandler
      * @param {Object} [options]
+     * @param {Number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
      */
     async #fetchAnalytics(mailgunOptions, batchHandler, options) {
         return await this.mailgunClient.fetchEvents(mailgunOptions, batchHandler, options);

--- a/ghost/email-analytics-provider-mailgun/package.json
+++ b/ghost/email-analytics-provider-mailgun/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing c8 --all --reporter text --reporter cobertura --check-coverage mocha './test/**/*.test.js'",
+    "test:unit": "NODE_ENV=testing c8 --all --reporter text --reporter cobertura --check-coverage --100 mocha './test/**/*.test.js'",
     "test": "yarn test:unit",
     "lint": "eslint . --ext .js --cache"
   },

--- a/ghost/email-analytics-service/lib/email-analytics-service.js
+++ b/ghost/email-analytics-service/lib/email-analytics-service.js
@@ -222,7 +222,8 @@ module.exports = class EmailAnalytics {
             await this.processEventBatch(events, processingResult, fetchData);
             eventCount += events.length;
 
-            // Every 5 minutes we do an aggregation and clear the processingResult
+            // Every 5 minutes or 5000 members we do an aggregation and clear the processingResult
+            // Otherwise we need to loop a lot of members afterwards, and this takes too long without updating the stat counts in between
             if (Date.now() - lastAggregation > 5 * 60 * 1000 || processingResult.memberIds.length > 5000) {
                 // Aggregate and clear the processingResult
                 // We do this here because otherwise it could take a long time before the new events are visible in the stats

--- a/ghost/email-analytics-service/lib/email-analytics-service.js
+++ b/ghost/email-analytics-service/lib/email-analytics-service.js
@@ -1,17 +1,36 @@
 const EventProcessingResult = require('./event-processing-result');
-const debug = require('@tryghost/debug')('services:email-analytics');
 const logging = require('@tryghost/logging');
 
 /**
  * @typedef {import('@tryghost/email-service').EmailEventProcessor} EmailEventProcessor
  */
 
-module.exports = class EmailAnalyticsService {
+/**
+ * @typedef {object} FetchData
+ * @property {boolean} running
+ * @property {Date} [lastStarted] Date the last fetch started on
+ * @property {Date} [lastBegin] The begin time used during the last fetch
+ * @property {Date} [lastEventTimestamp]
+ */
+
+const TRUST_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+
+module.exports = class EmailAnalytics {
     config;
     settings;
     queries;
     eventProcessor;
     providers;
+
+    /**
+     * @type {FetchData}
+     */
+    #fetchLatestData = null;
+
+    /**
+     * @type {FetchData}
+     */
+    #fetchMissingData = null;
 
     /**
      * @param {object} dependencies
@@ -25,62 +44,123 @@ module.exports = class EmailAnalyticsService {
         this.providers = providers;
     }
 
-    async fetchAll() {
-        const result = new EventProcessingResult();
-
-        const shouldFetchStats = await this.queries.shouldFetchStats();
-        if (!shouldFetchStats) {
-            debug('fetchAll: skipping - fetch requirements not met');
-            return result;
-        }
-
-        const startFetch = new Date();
-        debug('fetchAll: starting');
-        for (const [, provider] of Object.entries(this.providers)) {
-            const providerResults = await provider.fetchAll(this.processEventBatch.bind(this));
-            result.merge(providerResults);
-        }
-        debug(`fetchAll: finished (${Date.now() - startFetch}ms)`);
-
-        return result;
+    /**
+     * Returns the timestamp of the last event we processed. Defaults to now minus 30 minutes if we have no data yet.
+     */
+    async getLastEventTimestamp() {
+        return this.#fetchLatestData?.lastEventTimestamp ?? (await this.queries.getLastSeenEventTimestamp()) ?? new Date(Date.now() - TRUST_THRESHOLD_MS);
     }
 
     async fetchLatest({maxEvents = Infinity} = {}) {
-        const result = new EventProcessingResult();
+        // Start where we left of, or the last stored event in the database, or start 30 minutes ago if we have nothing available
+        const begin = await this.getLastEventTimestamp();
+        const end = new Date();
 
-        const shouldFetchStats = await this.queries.shouldFetchStats();
-        if (!shouldFetchStats) {
-            debug('fetchLatest: skipping - fetch requirements not met');
-            return result;
+        // Create the fetch data object if it doesn't exist yet
+        if (!this.#fetchLatestData) {
+            this.#fetchLatestData = {
+                running: false
+            };
         }
 
-        const lastTimestamp = await this.queries.getLastSeenEventTimestamp();
-
-        const startFetch = new Date();
-        debug('fetchLatest: starting');
-        providersLoop:
-        for (const [, provider] of Object.entries(this.providers)) {
-            const providerResults = await provider.fetchLatest(lastTimestamp, this.processEventBatch.bind(this), {maxEvents});
-            result.merge(providerResults);
-
-            if (result.totalEvents >= maxEvents) {
-                break providersLoop;
-            }
-        }
-        debug(`fetchLatest: finished in ${Date.now() - startFetch}ms. Fetched ${result.totalEvents} events`);
-
-        return result;
+        return await this.#fetchEvents(this.#fetchLatestData, {begin, end, maxEvents});
     }
 
-    async processEventBatch(events) {
-        const result = new EventProcessingResult();
+    /**
+     * Fetches events that are older than 30 minutes, because then the 'storage' of the Mailgun API is stable. And we are sure we don't miss any events.
+     * @param {object} options
+     * @param {number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
+     */
+    async fetchMissing({maxEvents = Infinity} = {}) {
+        // We start where we left of, or 30 minutes before the last event we received
+        const begin = this.#fetchMissingData?.lastEventTimestamp ?? new Date((await this.getLastEventTimestamp()).getTime() - TRUST_THRESHOLD_MS);
 
-        for (const event of events) {
-            const batchResult = await this.processEvent(event);
-            result.merge(batchResult);
+        // Always stop at the time the fetchLatest started fetching on, or maximum 30 minutes ago
+        const end = new Date(
+            Math.min(
+                Date.now() - TRUST_THRESHOLD_MS,
+                this.#fetchLatestData?.lastBegin?.getTime()
+            )
+        );
+
+        if (end <= begin) {
+            // Skip for now
+            logging.info('[EmailAnalytics] Skipping fetchMissing because end is before begin');
+            return new EventProcessingResult();
         }
 
-        return result;
+        // Create the fetch data object if it doesn't exist yet
+        if (!this.#fetchMissingData) {
+            this.#fetchMissingData = {
+                running: false
+            };
+        }
+
+        return await this.#fetchEvents(this.#fetchMissingData, {begin, end, maxEvents});
+    }
+
+    /**
+     * Start fetching analytics and store the data of the progress inside fetchData
+     * @param {FetchData} fetchData
+     * @param {object} options
+     * @param {Date} options.begin
+     * @param {Date} options.end
+     * @param {number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
+     */
+    async #fetchEvents(fetchData, {begin, end, maxEvents = Infinity}) {
+        // Start where we left of, or the last stored event in the database, or start 30 minutes ago if we have nothing available
+        logging.info('[EmailAnalytics] Fetching from ' + begin.toISOString() + ' until ' + end.toISOString() + ' (maxEvents: ' + maxEvents + ')');
+
+        // Store that we started fetching
+        fetchData.running = true;
+        fetchData.lastStarted = new Date();
+        fetchData.lastBegin = begin;
+
+        // We keep the processing result here, so we also have a result in case of failures
+        const processingResult = new EventProcessingResult();
+
+        const processBatch = async (events) => {
+            // Even if the fetching is interrupted because of an error, we still store the last event timestamp
+            return this.processEventBatch(events, processingResult, fetchData);
+        };
+
+        try {
+            for (const provider of this.providers) {
+                await provider.fetchLatest(processBatch, {begin, end, maxEvents});
+            }
+
+            logging.info('[EmailAnalytics] Fetching finshed');
+        } catch (err) {
+            logging.error('[EmailAnalytics] Error while fetching');
+            logging.error(err);
+        }
+
+        fetchData.running = false;
+        return processingResult;
+    }
+
+    /**
+     * @param {any[]} events
+     * @param {FetchData} fetchData
+     */
+    async processEventBatch(events, result, fetchData) {
+        const processStart = Date.now();
+        for (const event of events) {
+            const batchResult = await this.processEvent(event);
+
+            // Save last event timestamp
+            if (event.timestamp && event.timestamp > fetchData.lastEventTimestamp) {
+                fetchData.lastEventTimestamp = event.timestamp;
+            }
+
+            result.merge(batchResult);
+        }
+        const processEnd = Date.now();
+        const time = processEnd - processStart;
+        if (time > 1000) {
+            // This is a means to show in the logs that the analytics job is still alive.
+            logging.warn(`[EmailAnalytics] Processing event batch took ${(time / 1000).toFixed(1)}s`);
+        }
     }
 
     /**

--- a/ghost/email-analytics-service/lib/email-analytics-service.js
+++ b/ghost/email-analytics-service/lib/email-analytics-service.js
@@ -20,7 +20,7 @@ const errors = require('@tryghost/errors');
  */
 
 const TRUST_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
-const FETCH_LATEST_END_MARGIN_MS = 5 * 60 * 1000; // Do not fetch events newer than 5 minutes (yet)
+const FETCH_LATEST_END_MARGIN_MS = 1 * 60 * 1000; // Do not fetch events newer than 1 minute (yet). Reduces the chance of having missed events in fetchLatest.
 
 module.exports = class EmailAnalytics {
     config;
@@ -131,7 +131,7 @@ module.exports = class EmailAnalytics {
     schedule({begin, end}) {
         if (this.#fetchScheduledData && this.#fetchScheduledData.running) {
             throw new errors.ValidationError({
-                message: 'Already fetching scheduled events. Wait for it to finish before scheduling a new one.',
+                message: 'Already fetching scheduled events. Wait for it to finish before scheduling a new one.'
             });
         }
         logging.info('[EmailAnalytics] Scheduling fetch from ' + begin.toISOString() + ' until ' + end.toISOString());
@@ -314,12 +314,12 @@ module.exports = class EmailAnalytics {
 
     /**
      *
-     * @param {{id: string, type: any; severity: any; recipientEmail: any; emailId?: string; providerId: string; batchId?: string, timestamp: Date; error: {code: number; message: string; enhandedCode: string|number} | null}} event
+     * @param {{id: string, type: any; severity: any; recipientEmail: any; emailId?: string; providerId: string; timestamp: Date; error: {code: number; message: string; enhandedCode: string|number} | null}} event
      * @returns {Promise<EventProcessingResult>}
      */
     async processEvent(event) {
         if (event.type === 'delivered') {
-            const recipient = await this.eventProcessor.handleDelivered({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail, batchId: event.batchId}, event.timestamp);
+            const recipient = await this.eventProcessor.handleDelivered({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail}, event.timestamp);
 
             if (recipient) {
                 return new EventProcessingResult({
@@ -333,7 +333,7 @@ module.exports = class EmailAnalytics {
         }
 
         if (event.type === 'opened') {
-            const recipient = await this.eventProcessor.handleOpened({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail, batchId: event.batchId}, event.timestamp);
+            const recipient = await this.eventProcessor.handleOpened({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail}, event.timestamp);
 
             if (recipient) {
                 return new EventProcessingResult({
@@ -348,7 +348,7 @@ module.exports = class EmailAnalytics {
 
         if (event.type === 'failed') {
             if (event.severity === 'permanent') {
-                const recipient = await this.eventProcessor.handlePermanentFailed({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail, batchId: event.batchId}, {id: event.id, timestamp: event.timestamp, error: event.error});
+                const recipient = await this.eventProcessor.handlePermanentFailed({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail}, {id: event.id, timestamp: event.timestamp, error: event.error});
 
                 if (recipient) {
                     return new EventProcessingResult({
@@ -360,7 +360,7 @@ module.exports = class EmailAnalytics {
 
                 return new EventProcessingResult({unprocessable: 1});
             } else {
-                const recipient = await this.eventProcessor.handleTemporaryFailed({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail, batchId: event.batchId}, {id: event.id, timestamp: event.timestamp, error: event.error});
+                const recipient = await this.eventProcessor.handleTemporaryFailed({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail}, {id: event.id, timestamp: event.timestamp, error: event.error});
 
                 if (recipient) {
                     return new EventProcessingResult({
@@ -375,7 +375,7 @@ module.exports = class EmailAnalytics {
         }
 
         if (event.type === 'unsubscribed') {
-            const recipient = await this.eventProcessor.handleUnsubscribed({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail, batchId: event.batchId}, event.timestamp);
+            const recipient = await this.eventProcessor.handleUnsubscribed({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail}, event.timestamp);
 
             if (recipient) {
                 return new EventProcessingResult({
@@ -389,7 +389,7 @@ module.exports = class EmailAnalytics {
         }
 
         if (event.type === 'complained') {
-            const recipient = await this.eventProcessor.handleComplained({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail, batchId: event.batchId}, event.timestamp);
+            const recipient = await this.eventProcessor.handleComplained({emailId: event.emailId, providerId: event.providerId, email: event.recipientEmail}, event.timestamp);
 
             if (recipient) {
                 return new EventProcessingResult({

--- a/ghost/email-analytics-service/lib/email-analytics-service.js
+++ b/ghost/email-analytics-service/lib/email-analytics-service.js
@@ -79,7 +79,7 @@ module.exports = class EmailAnalytics {
         if (end < begin) {
             // Skip for now
             logging.info('[EmailAnalytics] Skipping fetchLatest because end (' + end + ') is before begin (' + begin + ')');
-            return 0;
+            //return 0;
         }
 
         // Create the fetch data object if it doesn't exist yet

--- a/ghost/email-analytics-service/lib/email-analytics-service.js
+++ b/ghost/email-analytics-service/lib/email-analytics-service.js
@@ -22,7 +22,7 @@ const errors = require('@tryghost/errors');
 const TRUST_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
 const FETCH_LATEST_END_MARGIN_MS = 1 * 60 * 1000; // Do not fetch events newer than 1 minute (yet). Reduces the chance of having missed events in fetchLatest.
 
-module.exports = class EmailAnalytics {
+module.exports = class EmailAnalyticsService {
     config;
     settings;
     queries;
@@ -98,8 +98,8 @@ module.exports = class EmailAnalytics {
      * @param {number} [options.maxEvents] Not a strict maximum. We stop fetching after we reached the maximum AND received at least one event after begin (not equal) to prevent deadlocks.
      */
     async fetchMissing({maxEvents = Infinity} = {}) {
-        // We start where we left of, or 30 minutes before the last event we received
-        const begin = this.#fetchMissingData?.lastEventTimestamp ?? new Date(Date.now() - TRUST_THRESHOLD_MS * 2);
+        // We start where we left of, or 1,5h ago after a server restart
+        const begin = this.#fetchMissingData?.lastEventTimestamp ?? this.#fetchMissingData?.lastBegin ?? new Date(Date.now() - TRUST_THRESHOLD_MS * 3);
 
         // Always stop at the time the fetchLatest started fetching on, or maximum 30 minutes ago
         const end = new Date(

--- a/ghost/email-analytics-service/lib/email-analytics-service.js
+++ b/ghost/email-analytics-service/lib/email-analytics-service.js
@@ -145,8 +145,13 @@ module.exports = class EmailAnalytics {
             return;
         }
 
-        const begin = this.#fetchScheduledData.schedule.begin;
+        let begin = this.#fetchScheduledData.schedule.begin;
         const end = this.#fetchScheduledData.schedule.end;
+
+        if (this.#fetchScheduledData.lastEventTimestamp && this.#fetchScheduledData.lastEventTimestamp > begin) {
+            // Continue where we left of
+            begin = this.#fetchScheduledData.lastEventTimestamp;
+        }
 
         if (end <= begin) {
             // Skip for now

--- a/ghost/email-analytics-service/lib/email-analytics-service.js
+++ b/ghost/email-analytics-service/lib/email-analytics-service.js
@@ -74,7 +74,7 @@ module.exports = class EmailAnalytics {
     async fetchLatest({maxEvents = Infinity} = {}) {
         // Start where we left of, or the last stored event in the database, or start 30 minutes ago if we have nothing available
         const begin = await this.getLastEventTimestamp();
-        const end = new Date(Date.now() - FETCH_LATEST_END_MARGIN_MS); // ALways stop at 5 minutes ago to give Mailgun a bit more time to stabilize storage
+        const end = new Date(Date.now() - FETCH_LATEST_END_MARGIN_MS); // ALways stop at x minutes ago to give Mailgun a bit more time to stabilize storage
 
         if (end < begin) {
             // Skip for now

--- a/ghost/email-analytics-service/test/email-analytics-service.test.js
+++ b/ghost/email-analytics-service/test/email-analytics-service.test.js
@@ -29,86 +29,6 @@ describe('EmailAnalyticsService', function () {
         });
     });
 
-    describe('fetchAll', function () {
-        let providers;
-        let queries;
-
-        beforeEach(function () {
-            providers = {
-                testing: {
-                    async fetchAll(batchHandler) {
-                        const result = new EventProcessingResult();
-
-                        // first page
-                        result.merge(await batchHandler([{
-                            type: 'delivered',
-                            emailId: 1,
-                            memberId: 1
-                        }, {
-                            type: 'delivered',
-                            emailId: 1,
-                            memberId: 1
-                        }]));
-
-                        // second page
-                        result.merge(await batchHandler([{
-                            type: 'opened',
-                            emailId: 1,
-                            memberId: 1
-                        }, {
-                            type: 'opened',
-                            emailId: 1,
-                            memberId: 1
-                        }]));
-
-                        return result;
-                    }
-                }
-            };
-
-            queries = {
-                shouldFetchStats: sinon.fake.resolves(true)
-            };
-        });
-
-        it('uses passed-in providers', async function () {
-            const service = new EmailAnalyticsService({
-                queries,
-                eventProcessor,
-                providers
-            });
-
-            const result = await service.fetchAll();
-
-            queries.shouldFetchStats.calledOnce.should.be.true();
-            eventProcessor.handleDelivered.calledTwice.should.be.true();
-
-            result.should.deepEqual(new EventProcessingResult({
-                delivered: 2,
-                opened: 2,
-                emailIds: [1],
-                memberIds: [1]
-            }));
-        });
-
-        it('skips if queries.shouldFetchStats is falsy', async function () {
-            queries.shouldFetchStats = sinon.fake.resolves(false);
-
-            const service = new EmailAnalyticsService({
-                queries,
-                eventProcessor,
-                providers
-            });
-
-            const result = await service.fetchAll();
-
-            queries.shouldFetchStats.calledOnce.should.be.true();
-            eventProcessor.handleDelivered.called.should.be.false();
-
-            result.should.deepEqual(new EventProcessingResult());
-        });
-    });
-
     describe('fetchLatest', function () {
 
     });
@@ -119,16 +39,23 @@ describe('EmailAnalyticsService', function () {
                 eventProcessor
             });
 
-            const result = await service.processEventBatch([{
+            const result = new EventProcessingResult();
+            const fetchData = {
+
+            };
+            await service.processEventBatch([{
                 type: 'delivered',
-                emailId: 1
+                emailId: 1,
+                timestamp: new Date(1)
             }, {
                 type: 'delivered',
-                emailId: 2
+                emailId: 2,
+                timestamp: new Date(2)
             }, {
                 type: 'opened',
-                emailId: 1
-            }]);
+                emailId: 1,
+                timestamp: new Date(3)
+            }], result, fetchData);
 
             eventProcessor.handleDelivered.callCount.should.eql(2);
 
@@ -139,6 +66,10 @@ describe('EmailAnalyticsService', function () {
                 emailIds: [1, 2],
                 memberIds: [1]
             }));
+
+            fetchData.should.deepEqual({
+                lastEventTimestamp: new Date(3)
+            });
         });
     });
 

--- a/ghost/email-service/lib/email-event-processor.js
+++ b/ghost/email-service/lib/email-event-processor.js
@@ -82,10 +82,8 @@ class EmailEventProcessor {
                 emailId: recipient.emailId,
                 timestamp
             });
-            await this.#eventStorage.handleOpened(event);
-
             this.#domainEvents.dispatch(event);
-            await waitForEvent(); // Avoids knex connection pool to run dry
+            await this.#eventStorage.handleOpened(event);
         }
         return recipient;
     }

--- a/ghost/mailgun-client/test/fixtures/all-1-timestamp.json
+++ b/ghost/mailgun-client/test/fixtures/all-1-timestamp.json
@@ -11,7 +11,7 @@
           "message-id": "0201125133533.1.C55897076DBD42F2@domain.com"
         }
       },
-      "timestamp": 1606399301.266
+      "timestamp": 1606399301.266528
     },
     {
       "event": "failed",
@@ -25,7 +25,7 @@
           "message-id": "0201125133533.1.C55897076DBD42F2@domain.com"
         }
       },
-      "timestamp": 1606399301.266
+      "timestamp": 1606399301.266528
     },
     {
       "event": "failed",
@@ -39,7 +39,7 @@
           "message-id": "0201125133533.1.C55897076DBD42F2@domain.com"
         }
       },
-      "timestamp": 1606399301.266
+      "timestamp": 1606399301.266528
     },
     {
       "event": "unsubscribed",
@@ -52,7 +52,7 @@
           "message-id": "0201125133533.1.C55897076DBD42F2@domain.com"
         }
       },
-      "timestamp": 1606399301.266
+      "timestamp": 1606399301.366528
     }
   ],
   "paging": {

--- a/ghost/mailgun-client/test/fixtures/all-2.json
+++ b/ghost/mailgun-client/test/fixtures/all-2.json
@@ -11,7 +11,7 @@
           "message-id": "0201125133533.1.C55897076DBD42F2@domain.com"
         }
       },
-      "timestamp": 1606399301.266528
+      "timestamp": 1606399301.266
     },
     {
       "event": "failed",
@@ -25,7 +25,7 @@
           "message-id": "0201125133533.1.C55897076DBD42F2@domain.com"
         }
       },
-      "timestamp": 1606399301.266528
+      "timestamp": 1606399301.266
     }
   ],
   "paging": {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2562

New event fetching loops:
- Reworked the analytics fetching algorithm. Instead of starting again where we stopped during the last fetching minus 30 minutes, we now just continue where we stopped. But with ms precision (because no longer database dependent after first fetch), and we stop at NOW - 1 minute to reduce chance of missing events.
- Apart from that, a missing fetching loop is introduced. This fetches events that are older than 30 minutes, and just processes all events a second time to make sure we didn't skip any because of storage delays in the Mailgun API.
- A new scheduled fetching loop, that allows us to schedule between a given start/end date (currently only persisted in memory, so stops after a reboot)

UI and endpoint changes:
- New UI to show the state of the analytics 'loops'
- New endpoint to request the analytics loop status
- New endpoint to schedule analytics
- New endpoint to cancel scheduled analytics
- Some number formatting improvements, and introduction of 'opened' count in debug screen
- Live reload of data in the debug screen

Other changes:
- This also improves the support for maxEvents. We can now stop a fetching loop after x events without worrying about lost events. This is used to reduce the fetched events in the missing and scheduled event loop (e.g. when the main one is fetching lots of events, we skip the other loops).
- Prevents fetching the same events over and over again if no new events come in (because we always started at the same begin timestamp). The code increases the begin timestamp with 1 second if it is safe to do so, to prevent the API from returning the same events over and over again.
- Some optimisations in handing the processing results (less merges to reduce CPU usage in cases we have lots of events).

Testing:
- You can test with lots of events using the new mailgun mocking server (Toolbox repo `scripts/mailgun-mock-server`). This can also simulate events that are only returned after x minutes because of storage delays.
