### PR TITLE
Milestones creation events

### DIFF
--- a/ghost/core/core/server/services/milestones/service.js
+++ b/ghost/core/core/server/services/milestones/service.js
@@ -1,3 +1,5 @@
+const DomainEvents = require('@tryghost/domain-events');
+
 const getStripeLiveEnabled = () => {
     const settingsCache = require('../../../shared/settings-cache');
     const stripeConnect = settingsCache.get('stripe_connect_publishable_key');
@@ -35,7 +37,7 @@ module.exports = {
             const {GhostMailer} = require('../mail');
 
             const mailer = new GhostMailer();
-            const repository = new InMemoryMilestoneRepository();
+            const repository = new InMemoryMilestoneRepository({DomainEvents});
             const queries = new MilestoneQueries({db});
 
             this.api = new MilestonesService({

--- a/ghost/core/core/server/services/milestones/service.js
+++ b/ghost/core/core/server/services/milestones/service.js
@@ -34,14 +34,11 @@ module.exports = {
             } = require('@tryghost/milestones');
             const config = require('../../../shared/config');
             const milestonesConfig = config.get('milestones');
-            const {GhostMailer} = require('../mail');
 
-            const mailer = new GhostMailer();
             const repository = new InMemoryMilestoneRepository({DomainEvents});
             const queries = new MilestoneQueries({db});
 
             this.api = new MilestonesService({
-                mailer,
                 repository,
                 milestonesConfig, // avoid using getters and pass as JSON
                 queries

--- a/ghost/milestones/lib/InMemoryMilestoneRepository.js
+++ b/ghost/milestones/lib/InMemoryMilestoneRepository.js
@@ -13,6 +13,17 @@ module.exports = class InMemoryMilestoneRepository {
     /** @type {Object.<string, true>} */
     #ids = {};
 
+    /** @type {import('@tryghost/domain-events')} */
+    #DomainEvents;
+
+    /**
+     * @param {object} deps
+     * @param {import('@tryghost/domain-events')} deps.DomainEvents
+     */
+    constructor(deps) {
+        this.#DomainEvents = deps.DomainEvents;
+    }
+
     /**
      * @param {Milestone} milestone
      *
@@ -27,6 +38,10 @@ module.exports = class InMemoryMilestoneRepository {
         } else {
             this.#store.push(milestone);
             this.#ids[milestone.id.toHexString()] = true;
+
+            for (const event of milestone.events) {
+                this.#DomainEvents.dispatch(event);
+            }
         }
     }
 

--- a/ghost/milestones/lib/InMemoryMilestoneRepository.js
+++ b/ghost/milestones/lib/InMemoryMilestoneRepository.js
@@ -38,10 +38,10 @@ module.exports = class InMemoryMilestoneRepository {
         } else {
             this.#store.push(milestone);
             this.#ids[milestone.id.toHexString()] = true;
+        }
 
-            for (const event of milestone.events) {
-                this.#DomainEvents.dispatch(event);
-            }
+        for (const event of milestone.events) {
+            this.#DomainEvents.dispatch(event);
         }
     }
 

--- a/ghost/milestones/lib/MilestoneCreatedEvent.js
+++ b/ghost/milestones/lib/MilestoneCreatedEvent.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {object} MilestoneCreatedEventData
+ */
+
+module.exports = class MilestoneCreatedEvent {
+    /**
+     * @param {MilestoneCreatedEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {MilestoneCreatedEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new MilestoneCreatedEvent(data, timestamp ?? new Date);
+    }
+};

--- a/ghost/milestones/lib/MilestonesService.js
+++ b/ghost/milestones/lib/MilestonesService.js
@@ -18,11 +18,6 @@ const Milestone = require('./Milestone');
  */
 
 /**
- * @typedef {object} ghostMailer
- * @property {Function} send
- */
-
-/**
  * @typedef {object} milestonesConfig
  * @prop {Array<object>} milestonesConfig.arr
  * @prop {string} milestonesConfig.arr.currency
@@ -35,10 +30,6 @@ module.exports = class MilestonesService {
     #repository;
 
     /**
-     * @type {ghostMailer} */
-    #mailer;
-
-    /**
      * @type {milestonesConfig} */
     #milestonesConfig;
 
@@ -47,13 +38,11 @@ module.exports = class MilestonesService {
 
     /**
      * @param {object} deps
-     * @param {ghostMailer} deps.mailer
      * @param {IMilestoneRepository} deps.repository
      * @param {milestonesConfig} deps.milestonesConfig
      * @param {IQueries} deps.queries
      */
     constructor(deps) {
-        this.#mailer = deps.mailer;
         this.#milestonesConfig = deps.milestonesConfig;
         this.#queries = deps.queries;
         this.#repository = deps.repository;
@@ -147,13 +136,6 @@ module.exports = class MilestonesService {
         const shouldSendEmail = await this.#shouldSendEmail();
 
         if (shouldSendEmail) {
-            // TODO: hook up Ghostmailer or use StaffService and trigger event to send email
-            // await this.#mailer.send({
-            //     subject: 'Test',
-            //     html: '<div>Milestone achieved</div>',
-            //     to: 'test@example.com'
-            // });
-
             milestone.emailSentAt = new Date();
         }
 

--- a/ghost/milestones/lib/milestones.js
+++ b/ghost/milestones/lib/milestones.js
@@ -1,2 +1,3 @@
 module.exports.InMemoryMilestoneRepository = require('./InMemoryMilestoneRepository');
 module.exports.MilestonesService = require('./MilestonesService');
+module.exports.MilestoneCreatedEvent = require('./MilestoneCreatedEvent');

--- a/ghost/milestones/test/Milestone.test.js
+++ b/ghost/milestones/test/Milestone.test.js
@@ -33,7 +33,8 @@ describe('Milestone', function () {
     describe('create', function () {
         it('Will error with invalid inputs', async function () {
             const invalidInputs = [
-                {id: 'Not valid ID'},
+                {id: 'Invalid ID provided for Milestone'},
+                {id: 124},
                 {value: 'Invalid Value'},
                 {createdAt: 'Invalid Date'},
                 {emailSentAt: 'Invalid Date'}
@@ -63,7 +64,8 @@ describe('Milestone', function () {
         it('Will not error with valid inputs', async function () {
             const validInputs = [
                 {id: new ObjectID()},
-                {id: 123},
+                {id: new ObjectID().toString()},
+                {id: null},
                 {type: 'something'},
                 {name: 'testing'},
                 {name: 'members-10000000'},
@@ -109,6 +111,16 @@ describe('Milestone', function () {
             });
 
             assert(milestone.name === 'members-100');
+        });
+
+        it('Will create event for new milestone', async function () {
+            const milestone = await Milestone.create({
+                ...validInputMembers,
+                value: 500,
+                type: 'members'
+            });
+
+            assert.ok(milestone.events);
         });
     });
 });

--- a/ghost/milestones/test/Milestone.test.js
+++ b/ghost/milestones/test/Milestone.test.js
@@ -113,14 +113,25 @@ describe('Milestone', function () {
             assert(milestone.name === 'members-100');
         });
 
-        it('Will create event for new milestone', async function () {
-            const milestone = await Milestone.create({
+        it('Will create event for new milestone but not for existing one', async function () {
+            const milestoneOne = await Milestone.create({
                 ...validInputMembers,
                 value: 500,
                 type: 'members'
             });
 
-            assert.ok(milestone.events);
+            assert(milestoneOne.events.length >= 1);
+
+            // simulate creating an existing milestone
+            const id = new ObjectID();
+            const milestoneTwo = await Milestone.create({
+                ...validInputMembers,
+                id,
+                value: 500,
+                type: 'members'
+            });
+
+            assert(milestoneTwo.events.length === 0);
         });
     });
 });

--- a/ghost/milestones/test/MilestonesService.test.js
+++ b/ghost/milestones/test/MilestonesService.test.js
@@ -48,10 +48,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getARR() {
@@ -108,10 +104,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getARR() {
@@ -141,10 +133,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                // TODO: make this a stub
-                mailer: {
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getARR() {
@@ -179,10 +167,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getARR() {
@@ -207,10 +191,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getARR() {
@@ -251,10 +231,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getARR() {
@@ -284,10 +260,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getMembersCount() {
@@ -341,10 +313,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getMembersCount() {
@@ -382,10 +350,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getMembersCount() {
@@ -419,10 +383,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getMembersCount() {
@@ -462,10 +422,6 @@ describe('MilestonesService', function () {
 
             const milestoneEmailService = new MilestonesService({
                 repository,
-                mailer: {
-                    // TODO: make this a stub
-                    send: async () => {}
-                },
                 milestonesConfig,
                 queries: {
                     async getMembersCount() {


### PR DESCRIPTION
no issue

- In preparation of using event emitting for Milestone achievements, we needed to add a dedicated `MilestoneCreatedEvent` to the `Milestone` entity.
- The event will be emitted using `DomainEvents` when a new milestone is saved, which will allow us to listen to these events.
- With the switch of using a `MilestoneCreatedEvent` we'll be decoupling the mailing functionality and not need `GhostMailer` as dependency in the package anymore