### PR TITLE
Handled empty content when attempting to send webmentions

### DIFF
--- a/ghost/core/test/e2e-server/services/mentions.test.js
+++ b/ghost/core/test/e2e-server/services/mentions.test.js
@@ -77,6 +77,17 @@ describe('Mentions Service', function () {
                 assert.equal(mentionMock.isDone(), false);
                 assert.equal(endpointMock.isDone(), false);
             });
+
+            it('Post without content', async function () {
+                let publishedPost = {status: 'published', mobiledoc: markdownToMobiledoc(''), title: 'empty post'};
+                await agent
+                    .post('posts/')
+                    .body({posts: [publishedPost]})
+                    .expectStatus(201);
+
+                assert.equal(mentionMock.isDone(), false);
+                assert.equal(endpointMock.isDone(), false);
+            });
         });
 
         describe(`does send when we expect it to send`, function () {

--- a/ghost/webmentions/test/MentionSendingService.test.js
+++ b/ghost/webmentions/test/MentionSendingService.test.js
@@ -188,6 +188,24 @@ describe('MentionSendingService', function () {
             }));
             assert(errorLogStub.calledTwice);
         });
+
+        it('Sends no mentions for posts without html and previous html', async function () {
+            const service = new MentionSendingService({
+                isEnabled: () => true,
+                getPostUrl: () => 'https://site.com/post/',
+                jobService: jobService
+            });
+            const stub = sinon.stub(service, 'sendAll');
+            await service.sendForPost(createModel({
+                status: 'published',
+                html: '',
+                previous: {
+                    status: 'draft',
+                    html: ''
+                }
+            }));
+            assert(stub.notCalled);
+        });
     });
 
     describe('sendAll', function () {
@@ -282,6 +300,16 @@ describe('MentionSendingService', function () {
                 previousHtml: `<a href="https://typo.com">Example</a>`});
             assert.strictEqual(scope.isDone(), true);
             assert.equal(counter, 2);
+        });
+
+        // cheerio must be served a string
+        it('Does not evaluate links for an empty post', async function () {
+            const service = new MentionSendingService({
+                isEnabled: () => true
+            });
+            const linksStub = sinon.stub(service, 'getLinks');
+            await service.sendAll({html: ``,previousHtml: ``});
+            sinon.assert.notCalled(linksStub);
         });
     });
 


### PR DESCRIPTION
no refs

- cheerio would error when trying to parse `null`