### PR TITLE
Added page resource type to Mentions

### DIFF
--- a/ghost/core/core/server/services/mentions/BookshelfMentionRepository.js
+++ b/ghost/core/core/server/services/mentions/BookshelfMentionRepository.js
@@ -49,6 +49,7 @@ module.exports = class BookshelfMentionRepository {
             timestamp: model.get('created_at'),
             payload,
             resourceId: model.get('resource_id'),
+            resourceType: model.get('resource_type'),
             sourceTitle: model.get('source_title'),
             sourceSiteTitle: model.get('source_site_title'),
             sourceAuthor: model.get('source_author'),
@@ -106,7 +107,7 @@ module.exports = class BookshelfMentionRepository {
             source_favicon: mention.sourceFavicon?.href,
             target: mention.target.href,
             resource_id: mention.resourceId?.toHexString(),
-            resource_type: mention.resourceId ? 'post' : null,
+            resource_type: mention.resourceType,
             payload: mention.payload ? JSON.stringify(mention.payload) : null,
             deleted: Mention.isDeleted(mention),
             verified: mention.verified

--- a/ghost/core/core/server/services/mentions/ResourceService.js
+++ b/ghost/core/core/server/services/mentions/ResourceService.js
@@ -31,9 +31,16 @@ module.exports = class ResourceService {
     async getByURL(url) {
         const path = this.#urlUtils.absoluteToRelative(url.href, {withoutSubdirectory: true});
         const resource = this.#urlService.getResource(path);
+        console.log(resource.config);
         if (resource?.config?.type === 'posts') {
             return {
                 type: 'post',
+                id: ObjectID.createFromHexString(resource.data.id)
+            };
+        }
+        if (resource?.config?.type === 'pages') {
+            return {
+                type: 'page',
                 id: ObjectID.createFromHexString(resource.data.id)
             };
         }

--- a/ghost/core/core/server/services/mentions/ResourceService.js
+++ b/ghost/core/core/server/services/mentions/ResourceService.js
@@ -31,7 +31,6 @@ module.exports = class ResourceService {
     async getByURL(url) {
         const path = this.#urlUtils.absoluteToRelative(url.href, {withoutSubdirectory: true});
         const resource = this.#urlService.getResource(path);
-        console.log(resource.config);
         if (resource?.config?.type === 'posts') {
             return {
                 type: 'post',

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -70,13 +70,12 @@ module.exports = {
                     if (!id) {
                         return null;
                     }
-
+                    
                     const post = await models.Post.findOne({id: id.toHexString()});
 
                     if (!post) {
                         return null;
                     }
-                    
                     return {
                         id: id,
                         name: post.get('title'),

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -70,7 +70,6 @@ module.exports = {
                     if (!id) {
                         return null;
                     }
-                    
                     const post = await models.Post.findOne({id: id.toHexString()});
 
                     if (!post) {

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -76,11 +76,11 @@ module.exports = {
                     if (!post) {
                         return null;
                     }
-
+                    
                     return {
                         id: id,
                         name: post.get('title'),
-                        type: 'post'
+                        type: post.get('type')
                     };
                 }
             }

--- a/ghost/webmentions/lib/Mention.js
+++ b/ghost/webmentions/lib/Mention.js
@@ -58,6 +58,12 @@ module.exports = class Mention {
         return this.#resourceId;
     }
 
+    /** @type {string | null} */
+    #resourceType;
+    get resourceType() {
+        return this.#resourceType;
+    }
+
     /** @type {string} */
     #sourceTitle;
     get sourceTitle() {
@@ -147,6 +153,7 @@ module.exports = class Mention {
             timestamp: this.timestamp,
             payload: this.payload,
             resourceId: this.resourceId,
+            resourceType: this.resourceType,
             sourceTitle: this.sourceTitle,
             sourceSiteTitle: this.sourceSiteTitle,
             sourceAuthor: this.sourceAuthor,
@@ -165,6 +172,7 @@ module.exports = class Mention {
         this.#timestamp = data.timestamp;
         this.#payload = data.payload;
         this.#resourceId = data.resourceId;
+        this.#resourceType = data.resourceType;
         this.#verified = data.verified;
     }
 
@@ -237,6 +245,12 @@ module.exports = class Mention {
             }
         }
 
+        /** @type {string | null} */
+        let resourceType = null;
+        if (data.resourceType) {
+            resourceType = data.resourceType;
+        }
+
         const mention = new Mention({
             id,
             source,
@@ -244,6 +258,7 @@ module.exports = class Mention {
             timestamp,
             payload,
             resourceId,
+            resourceType,
             verified
         });
 

--- a/ghost/webmentions/lib/MentionsAPI.js
+++ b/ghost/webmentions/lib/MentionsAPI.js
@@ -160,7 +160,7 @@ module.exports = class MentionsAPI {
         }
 
         const resourceInfo = await this.#resourceService.getByURL(webmention.target);
-
+        console.log('resource info', resourceInfo.type);
         let metadata;
         try {
             metadata = await this.#webmentionMetadata.fetch(webmention.source);
@@ -187,7 +187,8 @@ module.exports = class MentionsAPI {
                 target: webmention.target,
                 timestamp: new Date(),
                 payload: webmention.payload,
-                resourceId: resourceInfo.type === 'post' ? resourceInfo.id : null,
+                resourceId: resourceInfo.id ? resourceInfo.id.toHexString() : null,
+                resourceType: resourceInfo.type,
                 sourceTitle: metadata.title,
                 sourceSiteTitle: metadata.siteTitle,
                 sourceAuthor: metadata.author,

--- a/ghost/webmentions/lib/MentionsAPI.js
+++ b/ghost/webmentions/lib/MentionsAPI.js
@@ -160,7 +160,6 @@ module.exports = class MentionsAPI {
         }
 
         const resourceInfo = await this.#resourceService.getByURL(webmention.target);
-        console.log('resource info', resourceInfo.type);
         let metadata;
         try {
             metadata = await this.#webmentionMetadata.fetch(webmention.source);

--- a/ghost/webmentions/test/Mention.test.js
+++ b/ghost/webmentions/test/Mention.test.js
@@ -21,6 +21,7 @@ describe('Mention', function () {
                 'timestamp',
                 'payload',
                 'resourceId',
+                'resourceType',
                 'sourceTitle',
                 'sourceSiteTitle',
                 'sourceAuthor',


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2572

The mentions browse output previously only showed resource info if the mentioned resource type was a `post`.
Additionally, the `resource_type` column basically defaulted to `post` regardless whether it was a page or in fact a post.

With this change we now have `resource_type` wired in to correctly determine if the mentioned url was a page or a post.