### PR TITLE
Added `MilestoneCreatedEvent` to staff service notifications

### DIFF
--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -508,6 +508,8 @@ User = ghostBookshelf.Model.extend({
             filter += '+paid_subscription_canceled_notification:true';
         } else if (type === 'mention-received') {
             filter += '+mention_notifications:true';
+        } else if (type === 'milestone-received') {
+            filter += '+milestone_notifications:true';
         }
         const updatedOptions = _.merge({}, options, {filter, withRelated: ['roles']});
         return this.findAll(updatedOptions).then((users) => {

--- a/ghost/staff-service/lib/emails.js
+++ b/ghost/staff-service/lib/emails.js
@@ -194,6 +194,36 @@ class StaffServiceEmails {
         }
     }
 
+    async notifyMilestoneReceived({milestone}) {
+        const users = await this.models.User.getEmailAlertUsers('milestone-received');
+        for (const user of users) {
+            const to = user.email;
+            const milestoneTypePretty = milestone.type === 'arr' ? 'ARR' : 'Members';
+            const subject = `🏆 New ${milestoneTypePretty} Milestone achieved!`;
+
+            const templateData = {
+                siteTitle: this.settingsCache.get('title'),
+                siteUrl: this.urlUtils.getSiteUrl(),
+                siteDomain: this.siteDomain,
+                accentColor: this.settingsCache.get('accent_color'),
+                fromEmail: this.fromEmailAddress,
+                toEmail: to,
+                staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`)
+            };
+
+            const emailTemplate = milestone.type === 'arr' ? 'new-arr-milestone-received' : 'new-members-milestone-received';
+
+            const {html, text} = await this.renderEmailTemplate(emailTemplate, templateData);
+
+            await this.sendMail({
+                to,
+                subject,
+                html,
+                text
+            });
+        }
+    }
+
     // Utils
 
     /** @private */

--- a/ghost/staff-service/lib/emails.js
+++ b/ghost/staff-service/lib/emails.js
@@ -194,33 +194,21 @@ class StaffServiceEmails {
         }
     }
 
+    /**
+     *
+     * @param {object} eventData
+     * @param {object} eventData.milestone
+     *
+     * @returns {Promise<void>}
+     */
     async notifyMilestoneReceived({milestone}) {
         const users = await this.models.User.getEmailAlertUsers('milestone-received');
+
+        // TODO: send email with correct templates
         for (const user of users) {
             const to = user.email;
-            const milestoneTypePretty = milestone.type === 'arr' ? 'ARR' : 'Members';
-            const subject = `🏆 New ${milestoneTypePretty} Milestone achieved!`;
 
-            const templateData = {
-                siteTitle: this.settingsCache.get('title'),
-                siteUrl: this.urlUtils.getSiteUrl(),
-                siteDomain: this.siteDomain,
-                accentColor: this.settingsCache.get('accent_color'),
-                fromEmail: this.fromEmailAddress,
-                toEmail: to,
-                staffUrl: this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`)
-            };
-
-            const emailTemplate = milestone.type === 'arr' ? 'new-arr-milestone-received' : 'new-members-milestone-received';
-
-            const {html, text} = await this.renderEmailTemplate(emailTemplate, templateData);
-
-            await this.sendMail({
-                to,
-                subject,
-                html,
-                text
-            });
+            this.logging.info(`Will send email to ${to} for ${milestone.type} / ${milestone.value} milestone.`);
         }
     }
 
@@ -257,7 +245,7 @@ class StaffServiceEmails {
     /** @private */
     getFormattedAmount({amount = 0, currency}) {
         if (!currency) {
-            return '';
+            return amount > 0 ? Intl.NumberFormat().format(amount) : '';
         }
 
         return Intl.NumberFormat('en', {

--- a/ghost/staff-service/lib/staff-service.js
+++ b/ghost/staff-service/lib/staff-service.js
@@ -81,12 +81,13 @@ class StaffService {
         if (type === MentionCreatedEvent && event.data.mention && this.labs.isSet('webmentions')) {
             await this.emails.notifyMentionReceived(event.data);
         }
-        if (!['api', 'member'].includes(event.data.source)) {
-            return;
-        }
 
         if (type === MilestoneCreatedEvent && event.data.milestone && this.labs.isSet('milestoneEmails')) {
             await this.emails.notifyMilestoneReceived(event.data);
+        }
+
+        if (!['api', 'member'].includes(event.data.source)) {
+            return;
         }
 
         const {member, tier, subscription, offer} = await this.getDataFromIds({

--- a/ghost/staff-service/lib/staff-service.js
+++ b/ghost/staff-service/lib/staff-service.js
@@ -1,5 +1,6 @@
 const {MemberCreatedEvent, SubscriptionCancelledEvent, SubscriptionActivatedEvent} = require('@tryghost/member-events');
 const {MentionCreatedEvent} = require('@tryghost/webmentions');
+const {MilestoneCreatedEvent} = require('@tryghost/milestones');
 
 // @NOTE: 'StaffService' is a vague name that does not describe what it's actually doing.
 //         Possibly, "StaffNotificationService" or "StaffEventNotificationService" would be a more accurate name
@@ -84,6 +85,10 @@ class StaffService {
             return;
         }
 
+        if (type === MilestoneCreatedEvent && event.data.milestone && this.labs.isSet('milestoneEmails')) {
+            await this.emails.notifyMilestoneReceived(event.data);
+        }
+
         const {member, tier, subscription, offer} = await this.getDataFromIds({
             memberId: event.data.memberId,
             tierId: event.data.tierId,
@@ -144,6 +149,15 @@ class StaffService {
                 await this.handleEvent(MentionCreatedEvent, event);
             } catch (e) {
                 this.logging.error(e, `Failed to notify webmention`);
+            }
+        });
+
+        // Trigger email when a new milestone is reached
+        this.DomainEvents.subscribe(MilestoneCreatedEvent, async (event) => {
+            try {
+                await this.handleEvent(MilestoneCreatedEvent, event);
+            } catch (e) {
+                this.logging.error(e, `Failed to notify milestone`);
             }
         });
     }

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon');
 const {MemberCreatedEvent, SubscriptionCancelledEvent, SubscriptionActivatedEvent} = require('@tryghost/member-events');
 const {MentionCreatedEvent} = require('@tryghost/webmentions');
+const {MilestoneCreatedEvent} = require('@tryghost/milestones');
 
 require('./utils');
 const StaffService = require('../lib/staff-service');
@@ -108,6 +109,7 @@ describe('StaffService', function () {
 
     describe('email notifications:', function () {
         let mailStub;
+        let loggingInfoStub;
         let subscribeStub;
         let getEmailAlertUsersStub;
         let service;
@@ -147,6 +149,7 @@ describe('StaffService', function () {
         };
 
         beforeEach(function () {
+            loggingInfoStub = sinon.stub().resolves();
             mailStub = sinon.stub().resolves();
             subscribeStub = sinon.stub().resolves();
             getEmailAlertUsersStub = sinon.stub().resolves([{
@@ -155,6 +158,7 @@ describe('StaffService', function () {
             }]);
             service = new StaffService({
                 logging: {
+                    info: loggingInfoStub,
                     warn: () => {},
                     error: () => {}
                 },
@@ -182,16 +186,19 @@ describe('StaffService', function () {
         describe('subscribeEvents', function () {
             it('subscribes to events', async function () {
                 service.subscribeEvents();
-                subscribeStub.callCount.should.eql(4);
+                subscribeStub.callCount.should.eql(5);
                 subscribeStub.calledWith(SubscriptionActivatedEvent).should.be.true();
                 subscribeStub.calledWith(SubscriptionCancelledEvent).should.be.true();
                 subscribeStub.calledWith(MemberCreatedEvent).should.be.true();
                 subscribeStub.calledWith(MentionCreatedEvent).should.be.true();
+                subscribeStub.calledWith(MilestoneCreatedEvent).should.be.true();
             });
         });
 
         describe('handleEvent', function () {
             beforeEach(function () {
+                loggingInfoStub = sinon.stub().resolves();
+
                 const models = {
                     User: {
                         getEmailAlertUsers: sinon.stub().resolves([{
@@ -255,6 +262,7 @@ describe('StaffService', function () {
 
                 service = new StaffService({
                     logging: {
+                        info: loggingInfoStub,
                         warn: () => {},
                         error: () => {}
                     },
@@ -269,7 +277,15 @@ describe('StaffService', function () {
                     urlUtils,
                     settingsHelpers,
                     labs: {
-                        isSet: () => 'webmentions'
+                        isSet: (flag) => {
+                            if (flag === 'webmentions') {
+                                return true;
+                            }
+                            if (flag === 'milestoneEmails') {
+                                return true;
+                            }
+                            return false;
+                        }
                     }
                 });
             });
@@ -330,6 +346,21 @@ describe('StaffService', function () {
                 mailStub.calledWith(
                     sinon.match({subject: `💌 New mention from: Exmaple`})
                 ).should.be.true();
+            });
+
+            it('handles milestone created event', async function () {
+                await service.handleEvent(MilestoneCreatedEvent, {
+                    data: {
+                        milestone: {
+                            type: 'arr',
+                            value: '100',
+                            currency: 'usd'
+                        }
+                    }
+                });
+                mailStub.called.should.be.false();
+                loggingInfoStub.calledOnce.should.be.true();
+                loggingInfoStub.calledWith('Will send email to owner@ghost.org for arr / 100 milestone.').should.be.true();
             });
         });
 
@@ -633,6 +664,20 @@ describe('StaffService', function () {
                 mailStub.calledWith(
                     sinon.match.has('html', sinon.match('A paid member has just canceled their subscription.'))
                 ).should.be.true();
+            });
+        });
+
+        describe('notifyMilestoneReceived', function () {
+            it('prepares to send email when user setting available', async function () {
+                const milestone = {
+                    type: 'members',
+                    value: 25000
+                };
+
+                await service.emails.notifyMilestoneReceived({milestone});
+
+                mailStub.called.should.be.false();
+                getEmailAlertUsersStub.calledWith('milestone-received').should.be.true();
             });
         });
     });

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -6,7 +6,7 @@ const {MentionCreatedEvent} = require('@tryghost/webmentions');
 const {MilestoneCreatedEvent} = require('@tryghost/milestones');
 
 require('./utils');
-const StaffService = require('../lib/staff-service');
+const StaffService = require('../index');
 
 function testCommonMailData({mailStub, getEmailAlertUsersStub}) {
     getEmailAlertUsersStub.calledWith(


### PR DESCRIPTION
refs https://www.notion.so/ghost/Marketing-Milestone-email-campaigns-1d2c9dee3cfa4029863edb16092ad5c4?pvs=4

- Added MilestoneCreatedEvent subscription to staff-service incl. first handling
- Logs information for now instead of actually sending an email