### PR TITLE
Improved resilience of `adapter-cache-memory-ttl` tests

### DIFF
--- a/ghost/adapter-cache-memory-ttl/package.json
+++ b/ghost/adapter-cache-memory-ttl/package.json
@@ -19,8 +19,8 @@
     ],
     "devDependencies": {
         "c8": "7.13.0",
-        "mocha": "10.2.0",
-        "sinon": "15.0.1"
+        "clock-mock": "1.0.6",
+        "mocha": "10.2.0"
     },
     "dependencies": {
         "@isaacs/ttlcache": "1.2.1"

--- a/ghost/adapter-cache-memory-ttl/test/adapter-cache-memory-ttl.test.js
+++ b/ghost/adapter-cache-memory-ttl/test/adapter-cache-memory-ttl.test.js
@@ -1,13 +1,21 @@
 const assert = require('assert');
+const Clock = require('clock-mock');
+
 const MemoryTTLCache = require('../index');
 
-const sleep = ms => (
-    new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    })
-);
-
 describe('Cache Adapter In Memory with Time To Live', function () {
+    /** @type {Clock} */
+    let clock;
+
+    beforeEach(function () {
+        clock = new Clock();
+        clock.enter();
+    });
+
+    afterEach(function () {
+        clock.exit();
+    });
+
     it('Can initialize a cache instance', function () {
         const cache = new MemoryTTLCache();
         assert.ok(cache);
@@ -19,54 +27,54 @@ describe('Cache Adapter In Memory with Time To Live', function () {
             cache.set('a', 'b');
             assert.equal(cache.get('a'), 'b', 'should get the value from the cache');
 
-            await sleep(100);
+            clock.advance(100);
 
             assert.equal(cache.get('a'), 'b', 'should get the value from the cache after some time');
         });
 
-        it.skip('Can get a value from the cache before TTL kicks in', async function () {
+        it('Can get a value from the cache before TTL kicks in', async function () {
             const cache = new MemoryTTLCache({ttl: 50});
             cache.set('a', 'b');
             assert.equal(cache.get('a'), 'b', 'should get the value from the cache');
 
-            await sleep(20);
+            clock.advance(20);
 
             assert.equal(cache.get('a'), 'b', 'should get the value from the cache before TTL time');
 
             // NOTE: 20 + 200 = 220, which is more than 50 TTL
-            await sleep(200);
+            clock.advance(200);
 
             assert.equal(cache.get('a'), undefined, 'should NOT get the value from the cache after TTL time');
         });
     });
 
     describe('set', function () {
-        it.skip('Can set a value in the cache', async function () {
+        it('Can set a value in the cache', async function () {
             const cache = new MemoryTTLCache({ttl: 50});
 
             cache.set('a', 'b');
 
             assert.equal(cache.get('a'), 'b', 'should get the value from the cache');
 
-            await sleep(20);
+            clock.advance(20);
 
             assert.equal(cache.get('a'), 'b', 'should get the value from the cache after time < TTL');
 
-            await sleep(200);
+            clock.advance(200);
 
             assert.equal(cache.get('a'), undefined, 'should NOT get the value from the cache after TTL time');
         });
 
-        it.skip('Can override TTL time', async function () {
+        it('Can override TTL time', async function () {
             const cache = new MemoryTTLCache({ttl: 20});
 
             cache.set('a', 'b', {ttl: 50});
 
-            await sleep(21);
+            clock.advance(21);
 
             assert.equal(cache.get('a'), 'b', 'should get the value from the cache');
 
-            await sleep(200);
+            clock.advance(200);
 
             assert.equal(cache.get('a'), undefined, 'should NOT get the value from the cache after TTL time');
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9375,6 +9375,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clock-mock@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/clock-mock/-/clock-mock-1.0.6.tgz#7c0753f786e169c97a883f84756fa6234c42c659"
+  integrity sha512-mPXwJHSN8pWm5H8l42taxldL+LA5dTHd/S7TldqvJy7RkMM3+HwsvLt3g1mQTFcu1oK9nV+9+laKf1hSM9EiVQ==
+
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"


### PR DESCRIPTION
- when CI is slow, these tests can erroneously fail
- we should prefer to use `sinon.useFakeTimers` over awaiting a Promise with a timeout for better resilience against slow machines