### PR TITLE
Milestone emails templates and sending implementation

### DIFF
--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -153,6 +153,19 @@
                     </div>
                     </GhUploader>
                 </div>
+                <div class="gh-expandable-block">
+                    <div class="gh-expandable-header">
+                        <div>
+                            <h4 class="gh-expandable-title">Milestones</h4>
+                            <p class="gh-expandable-description">
+                                Occasional summaries of your audience & revenue growth
+                            </p>
+                        </div>
+                        <div class="for-switch">
+                            <GhFeatureFlag @flag="milestoneEmails" />
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -223,19 +236,6 @@
                         </div>
                         <div class="for-switch">
                             <GhFeatureFlag @flag="emailErrors" />
-                        </div>
-                    </div>
-                </div>
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
-                            <h4 class="gh-expandable-title">Milestone emails</h4>
-                            <p class="gh-expandable-description">
-                                Send emails for reaching specific milestones.
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                            <GhFeatureFlag @flag="milestoneEmails" />
                         </div>
                     </div>
                 </div>

--- a/ghost/core/core/server/services/milestones/service.js
+++ b/ghost/core/core/server/services/milestones/service.js
@@ -10,7 +10,8 @@ const getStripeLiveEnabled = () => {
     const stripeConnect = settingsCache.get('stripe_connect_publishable_key');
     const stripeKey = settingsCache.get('stripe_publishable_key');
 
-    const stripeLiveRegex = /pk_live_/;
+    // Allow Stripe test key when in development mode
+    const stripeLiveRegex = process.env.NODE_ENV === 'development' ? /pk_test_/ : /pk_live_/;
 
     if (stripeConnect && stripeConnect.match(stripeLiveRegex)) {
         return true;
@@ -84,6 +85,11 @@ module.exports = {
      *  @returns {Promise<object>}
      */
     async scheduleRun(customTimeout) {
+        if (process.env.NODE_ENV === 'development') {
+            // Run the job within 5sec after boot when in local development mode
+            customTimeout = 5000;
+        }
+
         const timeOut = customTimeout || JOB_TIMEOUT;
 
         const today = new Date();

--- a/ghost/staff-service/lib/email-templates/new-milestone-received.hbs
+++ b/ghost/staff-service/lib/email-templates/new-milestone-received.hbs
@@ -58,7 +58,7 @@
                                         <tr style="padding:0;text-align:left;vertical-align:top">
                                             <th style="margin:0 auto; padding:0; padding-bottom: 48px; padding-left:0; padding-right:0; width:580px">
                                                 <center data-parsed="" style="min-width:580px;width:100%; padding: 0;">
-                                                <img class="feature-post-image" src="{{imageUrl}}" width="580" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border:0 none;clear:both;display:block;float:none;height:auto!important;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:100%!important;z-index:99;padding:0;"></center>
+                                                <img class="feature-post-image" src="{{image.url}}" width="580"{{#if image.height}} height="{{image.height}}"{{/if}} align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border:0 none;clear:both;display:block;float:none;height:auto!important;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:100%!important;z-index:99;padding:0;"></center>
                                             </th>
                                         </tr>
                                     </tbody>

--- a/ghost/staff-service/lib/email-templates/new-milestone-received.hbs
+++ b/ghost/staff-service/lib/email-templates/new-milestone-received.hbs
@@ -1,0 +1,216 @@
+<!doctype html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>{{subject}}</title>
+
+    {{> styles}}
+
+</head>
+
+<body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+        <tr>
+            <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+                <td class="container" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 660px; padding: 10px; width: 660px;">
+                  <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 620px; padding: 30px 20px;">
+
+                    <!-- START CENTERED CONTAINER -->
+
+                    {{#> preview}}
+                        {{#*inline "content"}}
+                            {{{heading}}}
+                        {{/inline}}
+                    {{/preview}}
+
+                    <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
+
+                        <!-- START MAIN CONTENT AREA -->
+                        <tr>
+                            <td class="wrapper" align="center" valign="top" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;">
+
+                                <!-- START HEADER -->
+                                <!-- START 50PX ROW -->
+                                <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
+                                    <tbody>
+                                        <tr style="padding:0;text-align:left;vertical-align:top">
+                                            <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
+                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
+                                                    <tr style="padding:0;text-align:left;vertical-align:top">
+                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
+                                                            <table class="spacer" style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
+                                                                <tbody>
+                                                                    <tr style="padding:0;text-align:left;vertical-align:top">
+                                                                        <td height="50px" style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;border-collapse:collapse!important;font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:50px;font-weight:400;hyphens:auto;line-height:50px;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">&#xA0;</td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </th>
+                                                    </tr>
+                                                </table>
+                                            </th>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <!-- END 50PX ROW -->
+
+                                <!-- START LOGO -->
+                                <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
+                                    <tbody>
+                                        <tr style="padding:0;text-align:left;vertical-align:top">
+                                            <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
+                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
+                                                    <tr style="padding:0;text-align:left;vertical-align:top">
+                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
+                                                            <center data-parsed="" style="min-width:580px;width:100%">
+                                                                <!-- Ghost icon width and height 70px for best results -->
+                                                                <img class="blog-logo float-center" src="https://static.ghost.org/v4.0.0/images/ghost-orb-1.png" alt="Ghost Icon" width="70" height="70" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border-radius:50%;clear:both;display:block;float:none;height:70px;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:70px!important" align="center">
+                                                            </center>
+                                                        </th>
+                                                    </tr>
+                                                </table>
+                                            </th>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <!-- END LOGO -->
+
+                                <!-- START 50PX ROW -->
+                                <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
+                                    <tbody>
+                                        <tr style="padding:0;text-align:left;vertical-align:top">
+                                            <th style="Margin:0 auto;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
+                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
+                                                    <tr style="padding:0;text-align:left;vertical-align:top">
+                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
+                                                            <table class="spacer" style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
+                                                                <tbody>
+                                                                    <tr style="padding:0;text-align:left;vertical-align:top">
+                                                                        <td height="50px" style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;border-collapse:collapse!important;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:50px;font-weight:400;hyphens:auto;line-height:50px;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">&#xA0;</td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </th>
+                                                    </tr>
+                                                </table>
+                                            </th>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <!-- END 50PX ROW -->
+
+                                <!-- START FEATURE IMAGE -->
+                                <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
+                                    <tbody>
+                                        <tr style="padding:0;text-align:left;vertical-align:top">
+                                            <th style="Margin:0 auto;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
+                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
+                                                    <tr style="padding:0;text-align:left;vertical-align:top">
+                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
+                                                            <center data-parsed="" style="min-width:580px;width:100%">
+                                                                <!-- blog post picture, height 268px und width 580px for best results -->
+                                                                <img class="feature-post-image float-center" src="{{imageUrl}}" alt="Feature Image" width="580" height="368" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border:0 none;border-radius:8px;clear:both;display:block;float:none;height:auto!important;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:100%!important;z-index:99">
+                                                            </center>
+                                                        </th>
+                                                    </tr>
+                                                </table>
+                                            </th>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <!-- END FEATURE IMAGE -->
+
+                                <!-- START 50PX ROW -->
+                                <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
+                                    <tbody>
+                                        <tr style="padding:0;text-align:left;vertical-align:top">
+                                            <th style="Margin:0 auto;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
+                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
+                                                    <tr style="padding:0;text-align:left;vertical-align:top">
+                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
+                                                            <table class="spacer" style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
+                                                                <tbody>
+                                                                    <tr style="padding:0;text-align:left;vertical-align:top">
+                                                                        <td height="50px" style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;border-collapse:collapse!important;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:50px;font-weight:400;hyphens:auto;line-height:50px;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">&#xA0;</td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </th>
+                                                    </tr>
+                                                </table>
+                                            </th>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <!-- END 50PX ROW -->
+
+                                <!-- END HEADER -->
+                                <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; max-width: 580px;">
+                                <tr>
+                                    <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
+
+                                        <!-- BEGIN EMAIL HEADING -->
+                                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 22px; color: #242628!important; font-weight: 700; line-height: 24px; margin: 0; margin-bottom: 25px;"><font>{{{heading}}}</font></p>
+                                        <!-- END EMAIL HEADING -->
+
+                                        <!-- BEGIN EMAIL CONTENT -->
+                                        {{#each content as |contentPart|}}
+                                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 16px;">{{{contentPart}}}</p>
+                                        {{/each}}
+                                        <!-- END EMAIL CONTENT -->
+
+                                        <!-- BEGIN CTA -->
+                                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">
+                                            <tbody>
+                                            <tr>
+                                                <td align="left" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; padding-top: 32px; padding-bottom: 12px;">
+                                                <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                                                    <tbody>
+                                                    <tr>
+                                                        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: #15171A; border-radius: 5px; text-align: center;"><a href="{{adminUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: #15171A; border: solid 1px #15171A; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: #15171A;">{{ctaText}}</a></td>
+                                                    </tr>
+                                                    </tbody>
+                                                </table>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                        <!-- END CTA -->
+
+                                        <hr/>
+
+                                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;"></p>
+                                    </td>
+                                </tr>
+
+                                <!-- START FOOTER -->
+                                <tr>
+                                    <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 80px;">
+                                    <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;">This message was sent from <a class="small" href="{{siteUrl}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">{{siteDomain}}</a> to <a class="small" href="mailto:{{toEmail}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">{{toEmail}}</a></p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 2px">
+                                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;">Don’t want to receive these emails? Manage your preferences <a class="small" href="{{staffUrl}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">here</a>.</p>
+                                    </td>
+                                </tr>
+                                <!-- END FOOTER -->
+
+                            </table>
+
+                            <!-- END MAIN CONTENT AREA -->
+                            </td>
+                        </tr>
+                    </table>
+
+                    <!-- END CENTERED CONTAINER -->
+                    </div>
+                </td>
+            <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+        </tr>
+    </table>
+
+</body>
+</html>

--- a/ghost/staff-service/lib/email-templates/new-milestone-received.hbs
+++ b/ghost/staff-service/lib/email-templates/new-milestone-received.hbs
@@ -6,11 +6,17 @@
     <title>{{subject}}</title>
 
     {{> styles}}
-
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
 </head>
 
-<body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
-
+  <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
     <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
         <tr>
             <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
@@ -31,120 +37,33 @@
                         <tr>
                             <td class="wrapper" align="center" valign="top" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;">
 
-                                <!-- START HEADER -->
-                                <!-- START 50PX ROW -->
-                                <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
-                                    <tbody>
-                                        <tr style="padding:0;text-align:left;vertical-align:top">
-                                            <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
-                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
-                                                    <tr style="padding:0;text-align:left;vertical-align:top">
-                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
-                                                            <table class="spacer" style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
-                                                                <tbody>
-                                                                    <tr style="padding:0;text-align:left;vertical-align:top">
-                                                                        <td height="50px" style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;border-collapse:collapse!important;font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:50px;font-weight:400;hyphens:auto;line-height:50px;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">&#xA0;</td>
-                                                                    </tr>
-                                                                </tbody>
-                                                            </table>
-                                                        </th>
-                                                    </tr>
-                                                </table>
-                                            </th>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                                <!-- END 50PX ROW -->
 
                                 <!-- START LOGO -->
                                 <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
                                     <tbody>
                                         <tr style="padding:0;text-align:left;vertical-align:top">
-                                            <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
-                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
-                                                    <tr style="padding:0;text-align:left;vertical-align:top">
-                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
-                                                            <center data-parsed="" style="min-width:580px;width:100%">
-                                                                <!-- Ghost icon width and height 70px for best results -->
-                                                                <img class="blog-logo float-center" src="https://static.ghost.org/v4.0.0/images/ghost-orb-1.png" alt="Ghost Icon" width="70" height="70" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border-radius:50%;clear:both;display:block;float:none;height:70px;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:70px!important" align="center">
-                                                            </center>
-                                                        </th>
-                                                    </tr>
-                                                </table>
+                                            <th style="margin:0 auto;padding-bottom:48px;padding-left:0;padding-right:0;padding-top:40px;text-align:left;width:580px">
+                                                <center data-parsed="" style="min-width:580px; width:100%">
+                                                    <img class="blog-logo" src="https://static.ghost.org/v4.0.0/images/ghost-orb-1.png" alt="Blog Logo" width="60" height="60" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border-radius:50%;clear:both;display:block;float:none;height:60px!important;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:60px!important" align="center">
+                                                </center>
                                             </th>
                                         </tr>
                                     </tbody>
                                 </table>
                                 <!-- END LOGO -->
 
-                                <!-- START 50PX ROW -->
-                                <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
-                                    <tbody>
-                                        <tr style="padding:0;text-align:left;vertical-align:top">
-                                            <th style="Margin:0 auto;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
-                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
-                                                    <tr style="padding:0;text-align:left;vertical-align:top">
-                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
-                                                            <table class="spacer" style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
-                                                                <tbody>
-                                                                    <tr style="padding:0;text-align:left;vertical-align:top">
-                                                                        <td height="50px" style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;border-collapse:collapse!important;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:50px;font-weight:400;hyphens:auto;line-height:50px;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">&#xA0;</td>
-                                                                    </tr>
-                                                                </tbody>
-                                                            </table>
-                                                        </th>
-                                                    </tr>
-                                                </table>
-                                            </th>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                                <!-- END 50PX ROW -->
-
                                 <!-- START FEATURE IMAGE -->
                                 <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
                                     <tbody>
                                         <tr style="padding:0;text-align:left;vertical-align:top">
-                                            <th style="Margin:0 auto;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
-                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
-                                                    <tr style="padding:0;text-align:left;vertical-align:top">
-                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
-                                                            <center data-parsed="" style="min-width:580px;width:100%">
-                                                                <!-- blog post picture, height 268px und width 580px for best results -->
-                                                                <img class="feature-post-image float-center" src="{{imageUrl}}" alt="Feature Image" width="580" height="368" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border:0 none;border-radius:8px;clear:both;display:block;float:none;height:auto!important;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:100%!important;z-index:99">
-                                                            </center>
-                                                        </th>
-                                                    </tr>
-                                                </table>
+                                            <th style="margin:0 auto; padding:0; padding-bottom: 48px; padding-left:0; padding-right:0; width:580px">
+                                                <center data-parsed="" style="min-width:580px;width:100%; padding: 0;">
+                                                <img class="feature-post-image" src="{{imageUrl}}" width="580" align="center" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border:0 none;clear:both;display:block;float:none;height:auto!important;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:100%!important;z-index:99;padding:0;"></center>
                                             </th>
                                         </tr>
                                     </tbody>
                                 </table>
                                 <!-- END FEATURE IMAGE -->
-
-                                <!-- START 50PX ROW -->
-                                <table class="row" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:100%">
-                                    <tbody>
-                                        <tr style="padding:0;text-align:left;vertical-align:top">
-                                            <th style="Margin:0 auto;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:19px;margin:0 auto;padding:0;padding-bottom:0;padding-left:0;padding-right:0;text-align:left;width:580px">
-                                                <table style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
-                                                    <tr style="padding:0;text-align:left;vertical-align:top">
-                                                        <th style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';font-size:16px;font-weight:400;line-height:19px;margin:0;padding:0;text-align:left">
-                                                            <table class="spacer" style="border-collapse:collapse;border-spacing:0;padding:0;text-align:left;vertical-align:top;width:100%">
-                                                                <tbody>
-                                                                    <tr style="padding:0;text-align:left;vertical-align:top">
-                                                                        <td height="50px" style="-moz-hyphens:auto;-webkit-hyphens:auto;Margin:0;border-collapse:collapse!important;color:#7d878a;font-family:'Helvetica Neue',Helvetica,Helvetica,Arial,sans-serif;font-size:50px;font-weight:400;hyphens:auto;line-height:50px;margin:0;padding:0;text-align:left;vertical-align:top;word-wrap:break-word">&#xA0;</td>
-                                                                    </tr>
-                                                                </tbody>
-                                                            </table>
-                                                        </th>
-                                                    </tr>
-                                                </table>
-                                            </th>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                                <!-- END 50PX ROW -->
 
                                 <!-- END HEADER -->
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; max-width: 580px;">
@@ -152,16 +71,22 @@
                                     <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
 
                                         <!-- BEGIN EMAIL HEADING -->
-                                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 22px; color: #242628!important; font-weight: 700; line-height: 24px; margin: 0; margin-bottom: 25px;"><font>{{{heading}}}</font></p>
+                                        <!--[if mso]>
+                                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 34px; color: #242628!important; font-weight: 800; line-height: 36px; margin: 0; margin-bottom: 25px; letter-spacing: -0.019em;"><font>{{{heading}}}</font></p>
+                                        <![endif]-->
+
+                                        <!--[if !mso !vml]-->
+                                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 34px !important; color: #242628!important; font-weight: 800; line-height: 36px; margin: 0; margin-bottom: 25px; letter-spacing: -0.019em;"><font>{{{heading}}}</font></p>
+                                        <!--[endif]-->
                                         <!-- END EMAIL HEADING -->
 
                                         <!-- BEGIN EMAIL CONTENT -->
                                         {{#each content as |contentPart|}}
-                                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 16px;">{{{contentPart}}}</p>
+                                            <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px !important; color: #3A464C; font-weight: normal; margin: 0; line-height: 23px; margin-bottom: 16px;">{{{contentPart}}}</p>
                                         {{/each}}
                                         <!-- END EMAIL CONTENT -->
 
-                                        <!-- BEGIN CTA -->
+                                        <!-- CTA -->
                                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">
                                             <tbody>
                                             <tr>
@@ -169,7 +94,7 @@
                                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                                     <tbody>
                                                     <tr>
-                                                        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: #15171A; border-radius: 5px; text-align: center;"><a href="{{adminUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: #15171A; border: solid 1px #15171A; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: #15171A;">{{ctaText}}</a></td>
+                                                        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: #15171A; border-radius: 5px; text-align: center;"> <a href="{{adminUrl}}" target="_blank" style="display: inline-block; color: #ffffff; background-color: #15171A; border: solid 1px #15171A; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px !important; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: #15171A;">{{ctaText}}</a></td>
                                                     </tr>
                                                     </tbody>
                                                 </table>
@@ -177,28 +102,25 @@
                                             </tr>
                                             </tbody>
                                         </table>
-                                        <!-- END CTA -->
-
-                                        <hr/>
 
                                         <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;"></p>
-                                    </td>
-                                </tr>
+                            </td>
+                        </tr>
 
-                                <!-- START FOOTER -->
-                                <tr>
-                                    <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 80px;">
-                                    <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;">This message was sent from <a class="small" href="{{siteUrl}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">{{siteDomain}}</a> to <a class="small" href="mailto:{{toEmail}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">{{toEmail}}</a></p>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 2px">
-                                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;">Don’t want to receive these emails? Manage your preferences <a class="small" href="{{staffUrl}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">here</a>.</p>
-                                    </td>
-                                </tr>
-                                <!-- END FOOTER -->
+                        <!-- START FOOTER -->
+                        <tr>
+                            <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 80px;">
+                            <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;">This message was sent from <a class="small" href="{{siteUrl}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">{{siteDomain}}</a> to <a class="small" href="mailto:{{toEmail}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">{{toEmail}}</a></p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 2px">
+                                <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;">Don’t want to receive these emails? Manage your preferences <a class="small" href="{{staffUrl}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">here</a>.</p>
+                            </td>
+                        </tr>
 
-                            </table>
+                    <!-- END FOOTER -->
+                    </table>
 
                             <!-- END MAIN CONTENT AREA -->
                             </td>

--- a/ghost/staff-service/lib/email-templates/new-milestone-received.hbs
+++ b/ghost/staff-service/lib/email-templates/new-milestone-received.hbs
@@ -44,7 +44,11 @@
                                         <tr style="padding:0;text-align:left;vertical-align:top">
                                             <th style="margin:0 auto;padding-bottom:48px;padding-left:0;padding-right:0;padding-top:40px;text-align:left;width:580px">
                                                 <center data-parsed="" style="min-width:580px; width:100%">
-                                                    <img class="blog-logo" src="https://static.ghost.org/v4.0.0/images/ghost-orb-1.png" alt="Blog Logo" width="60" height="60" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border-radius:50%;clear:both;display:block;float:none;height:60px!important;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:60px!important" align="center">
+                                                    <table border="0" cellspacing="0" cellpadding="0" style="border-collapse:collapse;border-spacing:0;display:table;padding:0;position:relative;text-align:left;vertical-align:top;width:60px; height: 60px;">
+                                                        <tr style="padding: 0; margin: 0;">
+                                                            <td background="https://static.ghost.org/v5.0.0/images/orb-email-head-static.png" width="60" height="60" style="width: 60px; height: 60px; padding: 0; margin: 0;"><img class="blog-logo" src="https://static.ghost.org/v5.0.0/images/orb-email-head.gif" alt="Blog Logo" width="60" height="60" style="-ms-interpolation-mode:bicubic;Margin:0 auto;border-radius:50%;clear:both;display:block;float:none;height:60px!important;margin:0 auto;max-width:100%;outline:0;text-align:center;text-decoration:none;width:60px!important" align="center"></td>
+                                                        </tr>
+                                                    </table>
                                                 </center>
                                             </th>
                                         </tr>

--- a/ghost/staff-service/lib/email-templates/new-milestone-received.txt.js
+++ b/ghost/staff-service/lib/email-templates/new-milestone-received.txt.js
@@ -3,7 +3,7 @@ module.exports = function (data) {
     return `
 Congratulations!
 
-${data.subject}"
+${data.subject}
 
 ---
 

--- a/ghost/staff-service/lib/email-templates/new-milestone-received.txt.js
+++ b/ghost/staff-service/lib/email-templates/new-milestone-received.txt.js
@@ -1,0 +1,13 @@
+module.exports = function (data) {
+    // Be careful when you indent the email, because whitespaces are visible in emails!
+    return `
+Congratulations!
+
+${data.subject}"
+
+---
+
+Sent to ${data.toEmail} from ${data.siteDomain}.
+If you would no longer like to receive these notifications you can adjust your settings at ${data.staffUrl}.
+    `;
+};

--- a/ghost/staff-service/lib/emails.js
+++ b/ghost/staff-service/lib/emails.js
@@ -193,12 +193,19 @@ class StaffServiceEmails {
             return;
         }
 
-        const emailPromises = [];
-        const users = await this.models.User.getEmailAlertUsers('milestone-received');
         const formattedValue = this.getFormattedAmount({currency: milestone?.currency, amount: milestone.value, maximumFractionDigits: 0});
         const milestoneEmailConfig = require('./milestone-email-config')(this.settingsCache.get('title'), formattedValue);
 
-        const emailData = milestone.type === 'arr' ? milestoneEmailConfig.arr : milestoneEmailConfig.members?.[milestone.value];
+        const emailData = milestoneEmailConfig?.[milestone.type]?.[milestone.value];
+
+        if (!emailData || Object.keys(emailData).length === 0) {
+            // Do not attempt to send an email with invalid or missing data
+            this.logging.warn('No Milestone email sent. Invalid or missing data.');
+            return;
+        }
+
+        const emailPromises = [];
+        const users = await this.models.User.getEmailAlertUsers('milestone-received');
 
         for (const user of users) {
             const to = user.email;

--- a/ghost/staff-service/lib/emails.js
+++ b/ghost/staff-service/lib/emails.js
@@ -187,7 +187,7 @@ class StaffServiceEmails {
      * @returns {Promise<void>}
      */
     async notifyMilestoneReceived({milestone}) {
-        if (!milestone?.emailSentAt || (milestone?.meta && milestone?.meta?.reason)) {
+        if (!milestone?.emailSentAt || milestone?.meta?.reason) {
             // Do not send an email when no email was set to be sent or a reason
             // not to send provided
             return;

--- a/ghost/staff-service/lib/milestone-email-config.js
+++ b/ghost/staff-service/lib/milestone-email-config.js
@@ -83,7 +83,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} has ${formattedValue} members 🤗`,
                 heading: 'Congrats! You got your first 100 members.',
                 content: [
-                    'All the hard work in getting your publication up and running paid off, and your work has since gone on to inspire more than 100 people to sign up. This is the first major milestone in growing an online audience, and you\'ve made it here!',
+                    'All the hard work in getting your publication up and running paid off, and your work has since gone on to inspire more than <strong>100 people</strong> to sign up. This is the first major milestone in growing an online audience, and you\'ve made it here!',
                     'So what\'s next?',
                     'If you keep up the great work you\'ll be well on your way to growing an even bigger audience. In the meantime, if you\'re looking for some actionable advice about how to reach the next major milestones, check out these tips for <a href="https://ghost.org/resources/first-1000-email-subscribers/">how to grow an audience of 100 to 1,000</a>.',
                     'You got this!'
@@ -97,7 +97,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} now has ${formattedValue} members`,
                 heading: `You have ${formattedValue} true fans`,
                 content: [
-                    `Congrats, <strong>${siteTitle}</strong> has officially reached 1,000 member signups.`,
+                    `Congrats, <strong>${siteTitle}</strong> has officially reached <strong>1,000 member</strong> signups.`,
                     'This is such an impressive milestone and according to Kevin Kelly\'s true fan <a href="https://kk.org/thetechnium/1000-true-fans/">theory</a>, it means you now have a direct relationship with enough people to run a truly independent creator business online.',
                     'Imagine 1,000 people all in one room at the same time. That\'s a lot of people. It\'s also how many people are happy that you show up to create your work. Very cool. Keep up the great work!'
                 ],
@@ -110,7 +110,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} now has 10k members`,
                 heading: `Big news: You reached ${formattedValue} member signups`,
                 content: [
-                    `There are now 10k people who enjoy <strong>${siteTitle}</strong> enough to give you their email addresses and become members.`,
+                    `There are now <strong>10k people</strong> who enjoy <strong>${siteTitle}</strong> enough to give you their email addresses and become members.`,
                     'Building an audience of any size as an independent creator requires dedication, but reaching this incredible milestone is an impressive feat worth celebrating. There\'s no stopping you now, keep up the great work!'
                 ],
                 ctaText: 'Go to your dashboard',
@@ -122,7 +122,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} now has 25k members`,
                 heading: `You have an audience of ${formattedValue} people`,
                 content: [
-                    'Congrats, what an incredible milestone you have reached with 25k members choosing to support and follow your work. That\'s a big enough audience to sell out Madison Square Garden.',
+                    'Congrats, what an incredible milestone you have reached with <strong>25k members</strong> choosing to support and follow your work. That\'s a big enough audience to sell out Madison Square Garden.',
                     'It takes a lot of work and dedication to build an audience as an independent creator, so here\'s to recognizing what you\'ve achieved.',
                     'Keep up the great work. You\'ll be able to sell out Madison Square Garden twice in no time!'
                 ],
@@ -135,7 +135,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} now has 50k members`,
                 heading: `${formattedValue} people love your work`,
                 content: [
-                    `It's time to pop the champagne. <strong>${siteTitle}</strong> has officially reached the 50,000 members milestone. You almost have enough members to fill a Superbowl event 🏈`,
+                    `It's time to pop the champagne. <strong>${siteTitle}</strong> has officially reached the <strong>50,000 members</strong> milestone. You almost have enough members to fill a Superbowl event 🏈`,
                     'Building an audience of this size is an incredible achievement, so hats off to you. Keep up the amazing work.',
                     'See you at the next milestone!'
                 ],
@@ -148,7 +148,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} just hit 100k members!`,
                 heading: `You just reached ${formattedValue} members`,
                 content: [
-                    'Congratulations &mdash; your work has attracted the support of 100,000 people from around the world. Fun fact: This means you have enough people in your audience to fill any of the largest stadiums in the United States.',
+                    'Congratulations &mdash; your work has attracted the support of <strong>100,000 people</strong> from around the world. Fun fact: This means you have enough people in your audience to fill any of the largest stadiums in the United States.',
                     'Whatever you\'re doing, it\'s working. The sky is the limit from here. Keep up the great work (but first, go and celebrate this impressive milestone, you earned it).'
                 ],
                 ctaText: 'Go to your dashboard',
@@ -160,7 +160,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} now has 250k members`,
                 heading: `Your audience has grown to ${formattedValue} people`,
                 content: [
-                    `You're officially in the top 5% of creators using Ghost. One-quarter of a million people like <strong>${siteTitle}</strong> and decided to subscribe. That's the same number of people who make up the crowds at the SXSW festival.`,
+                    `You're officially in the top 5% of creators using Ghost. <strong>One-quarter of a million people</strong> like <strong>${siteTitle}</strong> and decided to subscribe. That's the same number of people who make up the crowds at the SXSW festival.`,
                     'Reaching this milestone is no easy feat, so make sure you take some time to recognize how far you\'ve come.',
                     'Keep up the amazing work!'
                 ],
@@ -173,7 +173,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} has ${formattedValue} members`,
                 heading: `Half a million members, and counting!`,
                 content: [
-                    `Congrats, <strong>${siteTitle}</strong> has officially attracted an audience of more than 500,000 people. That's more people than the national population of Iceland!`,
+                    `Congrats, <strong>${siteTitle}</strong> has officially attracted an audience of more than <strong>500,000 people</strong>. That's more people than the national population of Iceland!`,
                     'You\'re also officially in the top 3% of creators using Ghost.',
                     'It takes a huge amount of hard work and dedication to build an audience of this size. It is a testament to how much value your work is providing to thousands of people all over the world. Keep up the great work, and make sure to take the time to celebrate this incredible milestone.'
                 ],

--- a/ghost/staff-service/lib/milestone-email-config.js
+++ b/ghost/staff-service/lib/milestone-email-config.js
@@ -11,7 +11,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
             subject: `${siteTitle} hit ${formattedValue} ARR`,
             heading: `Congrats! You reached ${formattedValue} ARR`,
             content: [
-                `<strong>${siteTitle}</strong> is now generating ${formattedValue} in annual recurring revenue. Congratulations &mdash; this is a significant milestone.`,
+                `<strong>${siteTitle}</strong> is now generating <strong>${formattedValue}</strong> in annual recurring revenue. Congratulations &mdash; this is a significant milestone.`,
                 'Subscription revenue is predictable and sustainable, meaning you can keep focusing on delivering great content while watching your business grow. Keep up the great work. See you at the next milestone!'
             ],
             ctaText: 'Login to your dashboard',

--- a/ghost/staff-service/lib/milestone-email-config.js
+++ b/ghost/staff-service/lib/milestone-email-config.js
@@ -85,11 +85,11 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
         members: {
             100: {
                 subject: `${siteTitle} has ${formattedValue} members 🤗`,
-                heading: 'Congrats! You got your first 100 members.',
+                heading: `Milestone achieved: ${formattedValue} signups`,
                 content: [
-                    'All the hard work in getting your publication up and running paid off, and your work has since gone on to inspire more than <strong>100 people</strong> to sign up. This is the first major milestone in growing an online audience, and you\'ve made it here!',
-                    'So what\'s next?',
-                    'If you keep up the great work you\'ll be well on your way to growing an even bigger audience. In the meantime, if you\'re looking for some actionable advice about how to reach the next major milestones, check out these tips for <a href="https://ghost.org/resources/first-1000-email-subscribers/">how to grow an audience of 100 to 1,000</a>.',
+                    'All the hard work in getting your publication up and running paid off, and your work has since gone on to inspire more than <strong>100 people</strong> to sign up. This is the first major milestone in growing an online audience, and you’ve made it here!',
+                    'So what’s next?',
+                    'If you keep up the great work you’ll be well on your way to growing an even bigger audience. In the meantime, here’s some actionable advice about <strong><a href="https://ghost.org/resources/first-1000-email-subscribers/">how to reach the next major milestones</a></strong>.',
                     'You got this!'
                 ],
                 ctaText: 'Login to your dashboard',
@@ -101,21 +101,21 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} now has ${formattedValue} members`,
                 heading: `You have ${formattedValue} true fans`,
                 content: [
-                    `Congrats, <strong>${siteTitle}</strong> has officially reached <strong>1,000 member</strong> signups.`,
-                    'This is such an impressive milestone and according to Kevin Kelly\'s true fan <a href="https://kk.org/thetechnium/1000-true-fans/">theory</a>, it means you now have a direct relationship with enough people to run a truly independent creator business online.',
-                    'Imagine 1,000 people all in one room at the same time. That\'s a lot of people. It\'s also how many people are happy that you show up to create your work. Very cool. Keep up the great work!'
+                    `Congrats, <strong>${siteTitle}</strong> has officially reached <strong>${formattedValue} member signups</strong>.`,
+                    'This is such an impressive milestone and according to Kevin Kelly’s true fan <a href="https://kk.org/thetechnium/1000-true-fans/">theory</a>, it means you now have a direct relationship with enough people to run a truly independent creator business online.',
+                    `Imagine ${formattedValue} people all in one room at the same time. That's a lot of people. It's also how many people are happy that you show up to create your work. Very cool. Keep up the great work!`
                 ],
-                ctaText: 'Login to see your member stats',
+                ctaText: 'See your member stats',
                 image: {
                     url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-1000.png'
                 }
             },
             10000: {
                 subject: `${siteTitle} now has 10k members`,
-                heading: `Big news: You reached ${formattedValue} member signups`,
+                heading: 'Huge success: 10k members',
                 content: [
-                    `There are now <strong>10k people</strong> who enjoy <strong>${siteTitle}</strong> enough to give you their email addresses and become members.`,
-                    'Building an audience of any size as an independent creator requires dedication, but reaching this incredible milestone is an impressive feat worth celebrating. There\'s no stopping you now, keep up the great work!'
+                    `There are now <strong>10k people</strong> who enjoy <strong>${siteTitle}</strong> so much they decided to sign up as members.`,
+                    'Building an audience of any size as an independent creator requires dedication, and reaching this incredible milestone is an impressive feat worth celebrating. There’s no stopping you now, keep up the great work!'
                 ],
                 ctaText: 'Go to your dashboard',
                 image: {
@@ -124,11 +124,11 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
             },
             25000: {
                 subject: `${siteTitle} now has 25k members`,
-                heading: `You have an audience of ${formattedValue} people`,
+                heading: `Celebrating ${formattedValue} signups`,
                 content: [
-                    'Congrats, what an incredible milestone you have reached with <strong>25k members</strong> choosing to support and follow your work. That\'s a big enough audience to sell out Madison Square Garden.',
-                    'It takes a lot of work and dedication to build an audience as an independent creator, so here\'s to recognizing what you\'ve achieved.',
-                    'Keep up the great work. You\'ll be able to sell out Madison Square Garden twice in no time!'
+                    'Congrats, <strong>25k people</strong> have chosen to support and follow your work. That’s an audience big enough to sell out Madison Square Garden. What an incredible milestone!',
+                    'It takes a lot of work and dedication to build an audience as an independent creator, so here’s to recognizing what you’ve achieved.',
+                    'Keep up the great work!'
                 ],
                 ctaText: 'View your dashboard',
                 image: {
@@ -139,7 +139,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} now has 50k members`,
                 heading: `${formattedValue} people love your work`,
                 content: [
-                    `It's time to pop the champagne. <strong>${siteTitle}</strong> has officially reached the <strong>50,000 members</strong> milestone. You almost have enough members to fill a Superbowl event 🏈`,
+                    `It's time to pop the champagne because <strong>${siteTitle}</strong> has officially reached <strong>50k members</strong>. At this rate of growth you can almost fill a Superbowl stadium 🏈`,
                     'Building an audience of this size is an incredible achievement, so hats off to you. Keep up the amazing work.',
                     'See you at the next milestone!'
                 ],
@@ -152,8 +152,8 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} just hit 100k members!`,
                 heading: `You just reached ${formattedValue} members`,
                 content: [
-                    'Congratulations &mdash; your work has attracted the support of <strong>100,000 people</strong> from around the world. Fun fact: This means you have enough people in your audience to fill any of the largest stadiums in the United States.',
-                    'Whatever you\'re doing, it\'s working. The sky is the limit from here. Keep up the great work (but first, go and celebrate this impressive milestone, you earned it).'
+                    'Congratulations &mdash; your work has attracted an audience of <strong>100k people</strong> from around the world. Fun fact: Your audience is now big enough to fill any of the largest stadiums in the United States.',
+                    'Whatever you’re doing, it’s working. The sky is the limit from here. Keep up the great work (but first, go and celebrate this impressive milestone, you earned it).'
                 ],
                 ctaText: 'Go to your dashboard',
                 image: {
@@ -162,10 +162,11 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
             },
             250000: {
                 subject: `${siteTitle} now has 250k members`,
-                heading: `Your audience has grown to ${formattedValue} people`,
+                heading: 'Celebrating 250k member signups',
                 content: [
-                    `You're officially in the top 5% of creators using Ghost. <strong>One-quarter of a million people</strong> like <strong>${siteTitle}</strong> and decided to subscribe. That's the same number of people who make up the crowds at the SXSW festival.`,
-                    'Reaching this milestone is no easy feat, so make sure you take some time to recognize how far you\'ve come.',
+                    `One-quarter of a million people enjoy and support <strong>${siteTitle}</strong>. That’s the same number of people who make up the crowds at the SXSW festival.`,
+                    'You’re officially in the top 5% of creators using Ghost 🚀',
+                    'Reaching this milestone is no easy feat, so make sure you take some time to recognize how far you’ve come.',
                     'Keep up the amazing work!'
                 ],
                 ctaText: 'Go to your dashboard',
@@ -175,10 +176,10 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
             },
             500000: {
                 subject: `${siteTitle} has ${formattedValue} members`,
-                heading: `Half a million members, and counting!`,
+                heading: `Half a million members!`,
                 content: [
-                    `Congrats, <strong>${siteTitle}</strong> has officially attracted an audience of more than <strong>500,000 people</strong>. That's more people than the national population of Iceland!`,
-                    'You\'re also officially in the top 3% of creators using Ghost.',
+                    `Congrats, <strong>${siteTitle}</strong> has officially attracted an audience of more than <strong>${formattedValue} people</strong>, and counting.`,
+                    'You’re officially in the top 3% of creators using Ghost. ',
                     'It takes a huge amount of hard work and dedication to build an audience of this size. It is a testament to how much value your work is providing to thousands of people all over the world. Keep up the great work, and make sure to take the time to celebrate this incredible milestone.'
                 ],
                 ctaText: 'Login to your dashboard',
@@ -190,9 +191,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                 subject: `${siteTitle} has 1 million members`,
                 heading: `You did it. 1 million members 🏆`,
                 content: [
-                    `Congratulations! The <strong>${siteTitle}</strong> audience is now officially bigger than the crowds at the Coachella festival, and you're in the top 1% of creators using Ghost. Right now would be a good time to start writing your acceptance speech.`,
-                    'In all seriousness this is an incredible milestone and something to be very proud of. Not many people build an audience of this size as an independent creator, and hopefully you\'ll get the opportunity to celebrate with your community.',
-                    'Keep it up, you\'re creating amazing value in the world!'
+                    `Start writing your acceptance speech! The <strong>${siteTitle}</strong> audience is now officially big enough to headline an event at the Copacabana, with more than <strong>1 million members</strong>. That puts you in the top 1% of creators using Ghost.`,
+                    'In all seriousness, this is an <em>incredible</em> achievement and something to be very proud of. You deserve all the credit as a truly independent creator.',
+                    'Keep it up, you’re creating amazing value in the world!'
                 ],
                 ctaText: 'Go to your dashboard',
                 image: {

--- a/ghost/staff-service/lib/milestone-email-config.js
+++ b/ghost/staff-service/lib/milestone-email-config.js
@@ -6,16 +6,77 @@
  * @returns {Object.<string, object>}
  */
 const milestoneEmailConfig = (siteTitle, formattedValue) => {
+    const arrContent = {
+        subject: `${siteTitle} hit ${formattedValue} ARR`,
+        heading: `Congrats! You reached ${formattedValue} ARR`,
+        content: [
+            `<strong>${siteTitle}</strong> is now generating <strong>${formattedValue}</strong> in annual recurring revenue. Congratulations &mdash; this is a significant milestone.`,
+            'Subscription revenue is predictable and sustainable, meaning you can keep focusing on delivering great content while watching your business grow. Keep up the great work. See you at the next milestone!'
+        ],
+        ctaText: 'Login to your dashboard'
+    };
+
     return {
+        // For ARR we use the same content and only the image changes
+        // Should we start to support different currencies, we'll need
+        // to update the structure for ARR content to reflect that.
         arr: {
-            subject: `${siteTitle} hit ${formattedValue} ARR`,
-            heading: `Congrats! You reached ${formattedValue} ARR`,
-            content: [
-                `<strong>${siteTitle}</strong> is now generating <strong>${formattedValue}</strong> in annual recurring revenue. Congratulations &mdash; this is a significant milestone.`,
-                'Subscription revenue is predictable and sustainable, meaning you can keep focusing on delivering great content while watching your business grow. Keep up the great work. See you at the next milestone!'
-            ],
-            ctaText: 'Login to your dashboard',
-            imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            100: {
+                ...arrContent,
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-100.png',
+                    height: 348
+                }
+            },
+            1000: {
+                ...arrContent,
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-1000.png',
+                    height: 348
+                }
+            },
+            10000: {
+                ...arrContent,
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-10k.png',
+                    height: 348
+                }
+            },
+            50000: {
+                ...arrContent,
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-50k.png',
+                    height: 348
+                }
+            },
+            100000: {
+                ...arrContent,
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-100k.png',
+                    height: 348
+                }
+            },
+            250000: {
+                ...arrContent,
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-250k.png',
+                    height: 348
+                }
+            },
+            500000: {
+                ...arrContent,
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-500k.png',
+                    height: 348
+                }
+            },
+            1000000: {
+                ...arrContent,
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-1m.png',
+                    height: 348
+                }
+            }
         },
         members: {
             100: {
@@ -28,7 +89,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                     'You got this!'
                 ],
                 ctaText: 'Login to your dashboard',
-                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-100.png'
+                }
             },
             1000: {
                 subject: `${siteTitle} now has ${formattedValue} members`,
@@ -39,7 +102,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                     'Imagine 1,000 people all in one room at the same time. That\'s a lot of people. It\'s also how many people are happy that you show up to create your work. Very cool. Keep up the great work!'
                 ],
                 ctaText: 'Login to see your member stats',
-                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-1000.png'
+                }
             },
             10000: {
                 subject: `${siteTitle} now has 10k members`,
@@ -49,7 +114,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                     'Building an audience of any size as an independent creator requires dedication, but reaching this incredible milestone is an impressive feat worth celebrating. There\'s no stopping you now, keep up the great work!'
                 ],
                 ctaText: 'Go to your dashboard',
-                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-10k.png'
+                }
             },
             25000: {
                 subject: `${siteTitle} now has 25k members`,
@@ -60,7 +127,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                     'Keep up the great work. You\'ll be able to sell out Madison Square Garden twice in no time!'
                 ],
                 ctaText: 'View your dashboard',
-                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-25k.png'
+                }
             },
             50000: {
                 subject: `${siteTitle} now has 50k members`,
@@ -71,7 +140,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                     'See you at the next milestone!'
                 ],
                 ctaText: 'Go to your Dashboard',
-                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-50k.png'
+                }
             },
             100000: {
                 subject: `${siteTitle} just hit 100k members!`,
@@ -81,7 +152,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                     'Whatever you\'re doing, it\'s working. The sky is the limit from here. Keep up the great work (but first, go and celebrate this impressive milestone, you earned it).'
                 ],
                 ctaText: 'Go to your dashboard',
-                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-100k.png'
+                }
             },
             250000: {
                 subject: `${siteTitle} now has 250k members`,
@@ -92,7 +165,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                     'Keep up the amazing work!'
                 ],
                 ctaText: 'Go to your dashboard',
-                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-250k.png'
+                }
             },
             500000: {
                 subject: `${siteTitle} has ${formattedValue} members`,
@@ -103,7 +178,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                     'It takes a huge amount of hard work and dedication to build an audience of this size. It is a testament to how much value your work is providing to thousands of people all over the world. Keep up the great work, and make sure to take the time to celebrate this incredible milestone.'
                 ],
                 ctaText: 'Login to your dashboard',
-                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-500k.png'
+                }
             },
             1000000: {
                 subject: `${siteTitle} has 1 million members`,
@@ -114,7 +191,9 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
                     'Keep it up, you\'re creating amazing value in the world!'
                 ],
                 ctaText: 'Go to your dashboard',
-                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+                image: {
+                    url: 'https://static.ghost.org/v5.0.0/images/milestone-email-members-1m.png'
+                }
             }
         }
     };

--- a/ghost/staff-service/lib/milestone-email-config.js
+++ b/ghost/staff-service/lib/milestone-email-config.js
@@ -1,0 +1,123 @@
+/**
+ *
+ * @param {string} siteTitle
+ * @param {string} formattedValue
+ *
+ * @returns {Object.<string, object>}
+ */
+const milestoneEmailConfig = (siteTitle, formattedValue) => {
+    return {
+        arr: {
+            subject: `${siteTitle} hit ${formattedValue} ARR`,
+            heading: `Congrats! You reached ${formattedValue} ARR`,
+            content: [
+                `<strong>${siteTitle}</strong> is now generating ${formattedValue} in annual recurring revenue. Congratulations &mdash; this is a significant milestone.`,
+                'Subscription revenue is predictable and sustainable, meaning you can keep focusing on delivering great content while watching your business grow. Keep up the great work. See you at the next milestone!'
+            ],
+            ctaText: 'Login to your dashboard',
+            imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+        },
+        members: {
+            100: {
+                subject: `${siteTitle} has ${formattedValue} members 🤗`,
+                heading: 'Congrats! You got your first 100 members.',
+                content: [
+                    'All the hard work in getting your publication up and running paid off, and your work has since gone on to inspire more than 100 people to sign up. This is the first major milestone in growing an online audience, and you\'ve made it here!',
+                    'So what\'s next?',
+                    'If you keep up the great work you\'ll be well on your way to growing an even bigger audience. In the meantime, if you\'re looking for some actionable advice about how to reach the next major milestones, check out these tips for <a href="https://ghost.org/resources/first-1000-email-subscribers/">how to grow an audience of 100 to 1,000</a>.',
+                    'You got this!'
+                ],
+                ctaText: 'Login to your dashboard',
+                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            },
+            1000: {
+                subject: `${siteTitle} now has ${formattedValue} members`,
+                heading: `You have ${formattedValue} true fans`,
+                content: [
+                    `Congrats, <strong>${siteTitle}</strong> has officially reached 1,000 member signups.`,
+                    'This is such an impressive milestone and according to Kevin Kelly\'s true fan <a href="https://kk.org/thetechnium/1000-true-fans/">theory</a>, it means you now have a direct relationship with enough people to run a truly independent creator business online.',
+                    'Imagine 1,000 people all in one room at the same time. That\'s a lot of people. It\'s also how many people are happy that you show up to create your work. Very cool. Keep up the great work!'
+                ],
+                ctaText: 'Login to see your member stats',
+                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            },
+            10000: {
+                subject: `${siteTitle} now has 10k members`,
+                heading: `Big news: You reached ${formattedValue} member signups`,
+                content: [
+                    `There are now 10k people who enjoy <strong>${siteTitle}</strong> enough to give you their email addresses and become members.`,
+                    'Building an audience of any size as an independent creator requires dedication, but reaching this incredible milestone is an impressive feat worth celebrating. There\'s no stopping you now, keep up the great work!'
+                ],
+                ctaText: 'Go to your dashboard',
+                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            },
+            25000: {
+                subject: `${siteTitle} now has 25k members`,
+                heading: `You have an audience of ${formattedValue} people`,
+                content: [
+                    'Congrats, what an incredible milestone you have reached with 25k members choosing to support and follow your work. That\'s a big enough audience to sell out Madison Square Garden.',
+                    'It takes a lot of work and dedication to build an audience as an independent creator, so here\'s to recognizing what you\'ve achieved.',
+                    'Keep up the great work. You\'ll be able to sell out Madison Square Garden twice in no time!'
+                ],
+                ctaText: 'View your dashboard',
+                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            },
+            50000: {
+                subject: `${siteTitle} now has 50k members`,
+                heading: `${formattedValue} people love your work`,
+                content: [
+                    `It's time to pop the champagne. <strong>${siteTitle}</strong> has officially reached the 50,000 members milestone. You almost have enough members to fill a Superbowl event 🏈`,
+                    'Building an audience of this size is an incredible achievement, so hats off to you. Keep up the amazing work.',
+                    'See you at the next milestone!'
+                ],
+                ctaText: 'Go to your Dashboard',
+                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            },
+            100000: {
+                subject: `${siteTitle} just hit 100k members!`,
+                heading: `You just reached ${formattedValue} members`,
+                content: [
+                    'Congratulations &mdash; your work has attracted the support of 100,000 people from around the world. Fun fact: This means you have enough people in your audience to fill any of the largest stadiums in the United States.',
+                    'Whatever you\'re doing, it\'s working. The sky is the limit from here. Keep up the great work (but first, go and celebrate this impressive milestone, you earned it).'
+                ],
+                ctaText: 'Go to your dashboard',
+                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            },
+            250000: {
+                subject: `${siteTitle} now has 250k members`,
+                heading: `Your audience has grown to ${formattedValue} people`,
+                content: [
+                    `You're officially in the top 5% of creators using Ghost. One-quarter of a million people like <strong>${siteTitle}</strong> and decided to subscribe. That's the same number of people who make up the crowds at the SXSW festival.`,
+                    'Reaching this milestone is no easy feat, so make sure you take some time to recognize how far you\'ve come.',
+                    'Keep up the amazing work!'
+                ],
+                ctaText: 'Go to your dashboard',
+                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            },
+            500000: {
+                subject: `${siteTitle} has ${formattedValue} members`,
+                heading: `Half a million members, and counting!`,
+                content: [
+                    `Congrats, <strong>${siteTitle}</strong> has officially attracted an audience of more than 500,000 people. That's more people than the national population of Iceland!`,
+                    'You\'re also officially in the top 3% of creators using Ghost.',
+                    'It takes a huge amount of hard work and dedication to build an audience of this size. It is a testament to how much value your work is providing to thousands of people all over the world. Keep up the great work, and make sure to take the time to celebrate this incredible milestone.'
+                ],
+                ctaText: 'Login to your dashboard',
+                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            },
+            1000000: {
+                subject: `${siteTitle} has 1 million members`,
+                heading: `You did it. 1 million members 🏆`,
+                content: [
+                    `Congratulations! The <strong>${siteTitle}</strong> audience is now officially bigger than the crowds at the Coachella festival, and you're in the top 1% of creators using Ghost. Right now would be a good time to start writing your acceptance speech.`,
+                    'In all seriousness this is an incredible milestone and something to be very proud of. Not many people build an audience of this size as an independent creator, and hopefully you\'ll get the opportunity to celebrate with your community.',
+                    'Keep it up, you\'re creating amazing value in the world!'
+                ],
+                ctaText: 'Go to your dashboard',
+                imageUrl: 'https://static.ghost.org/v5.0.0/images/publication-cover.jpg'
+            }
+        }
+    };
+};
+
+module.exports = milestoneEmailConfig;

--- a/ghost/staff-service/lib/milestone-email-config.js
+++ b/ghost/staff-service/lib/milestone-email-config.js
@@ -51,6 +51,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
             },
             100000: {
                 ...arrContent,
+                heading: `Congrats! You reached $100k ARR`,
                 image: {
                     url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-100k.png',
                     height: 348
@@ -58,6 +59,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
             },
             250000: {
                 ...arrContent,
+                heading: `Congrats! You reached $250k ARR`,
                 image: {
                     url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-250k.png',
                     height: 348
@@ -65,6 +67,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
             },
             500000: {
                 ...arrContent,
+                heading: `Congrats! You reached $500k ARR`,
                 image: {
                     url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-500k.png',
                     height: 348
@@ -72,6 +75,7 @@ const milestoneEmailConfig = (siteTitle, formattedValue) => {
             },
             1000000: {
                 ...arrContent,
+                heading: `Congrats! You reached $1m ARR`,
                 image: {
                     url: 'https://static.ghost.org/v5.0.0/images/milestone-email-usd-1m.png',
                     height: 348

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -815,7 +815,7 @@ describe('StaffService', function () {
                 ).should.be.true();
 
                 mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('You have an audience of 25,000 people'))
+                    sinon.match.has('html', sinon.match('Celebrating 25,000 signups'))
                 ).should.be.true();
 
                 // Correct image and NO height for Members milestone
@@ -824,7 +824,7 @@ describe('StaffService', function () {
                 ).should.be.true();
 
                 mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Congrats, what an incredible milestone you have reached with <strong>25k members</strong> choosing to support and follow your work. That\'s a big enough audience to sell out Madison Square Garden.'))
+                    sinon.match.has('html', sinon.match('Congrats, <strong>25k people</strong> have chosen to support and follow your work. That’s an audience big enough to sell out Madison Square Garden. What an incredible milestone!'))
                 ).should.be.true();
 
                 mailStub.calledWith(

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -851,7 +851,7 @@ describe('StaffService', function () {
                 ).should.be.true();
 
                 mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Congrats! You reached $500,000 ARR'))
+                    sinon.match.has('html', sinon.match('Congrats! You reached $500k ARR'))
                 ).should.be.true();
 
                 // Correct image and height for ARR milestone

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -824,7 +824,7 @@ describe('StaffService', function () {
                 ).should.be.true();
 
                 mailStub.calledWith(
-                    sinon.match.has('html', sinon.match('Congrats, what an incredible milestone you have reached with 25k members choosing to support and follow your work. That\'s a big enough audience to sell out Madison Square Garden.'))
+                    sinon.match.has('html', sinon.match('Congrats, what an incredible milestone you have reached with <strong>25k members</strong> choosing to support and follow your work. That\'s a big enough audience to sell out Madison Square Garden.'))
                 ).should.be.true();
 
                 mailStub.calledWith(


### PR DESCRIPTION
refs https://www.notion.so/ghost/Marketing-Milestone-email-campaigns-1d2c9dee3cfa4029863edb16092ad5c4?pvs=4

- Added email template for milestones with using a configuration file for different member milestone values, as we're sending different content for each one
- Implement sending the email to users who have `milestone-notifications` enabled, currently still behind a flag

---
### Todos before merging:
- [x] Finish email template design
- [x] Ship with public beta
