### PR TITLE
feat: configurable mailgun bulk email batch size #15725

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview/email.js
+++ b/ghost/admin/app/components/editor/modals/preview/email.js
@@ -57,8 +57,15 @@ export default class ModalPostPreviewEmailComponent extends Component {
     }
 
     get mailgunIsEnabled() {
-        return this.config.mailgunIsConfigured ||
-            !!(this.settings.mailgunApiKey && this.settings.mailgunDomain && this.settings.mailgunBaseUrl);
+        return (
+            this.config.mailgunIsConfigured ||
+            !!(
+                this.settings.mailgunApiKey &&
+                this.settings.mailgunDomain &&
+                this.settings.mailgunBaseUrl &&
+                this.settings.mailgunBatchSize
+            )
+        );
     }
 
     get paidMembersEnabled() {

--- a/ghost/admin/app/components/settings/newsletters.hbs
+++ b/ghost/admin/app/components/settings/newsletters.hbs
@@ -115,6 +115,16 @@
                                                 data-test-mailgun-domain-input
                                             />
                                         </GhFormGroup>
+                                        <GhFormGroup class="no-margin">
+                                            <label class="fw6 f8" for="mailgun-batch-size">Mailgun batch size</label>
+                                            <input
+                                                id="mailgun-batch-size"
+                                                type="text"
+                                                class="gh-input mt1"
+                                                value={{this.mailgunSettings.batchSize}}
+                                                {{on "input" this.setMailgunBatchSize}}
+                                            />
+                                        </GhFormGroup>
                                     </div>
                                     <p>Find your Mailgun region and domain
                                         <a href="https://app.mailgun.com/app/sending/domains" target="_blank" class="fw5" rel="noopener noreferrer">here</a>

--- a/ghost/admin/app/components/settings/newsletters.js
+++ b/ghost/admin/app/components/settings/newsletters.js
@@ -6,6 +6,7 @@ import {tracked} from '@glimmer/tracking';
 
 const US = {flag: '🇺🇸', name: 'US', baseUrl: 'https://api.mailgun.net/v3'};
 const EU = {flag: '🇪🇺', name: 'EU', baseUrl: 'https://api.eu.mailgun.net/v3'};
+const DEFAULT_MAILGUN_BATCH_SIZE = 1000;
 
 export default class Newsletters extends Component {
     @service settings;
@@ -39,7 +40,8 @@ export default class Newsletters extends Component {
         return {
             apiKey: this.settings.mailgunApiKey || '',
             domain: this.settings.mailgunDomain || '',
-            baseUrl: this.settings.mailgunBaseUrl || ''
+            baseUrl: this.settings.mailgunBaseUrl,
+            batchSize: this.settings.mailgunBatchSize || DEFAULT_MAILGUN_BATCH_SIZE
         };
     }
 
@@ -62,6 +64,14 @@ export default class Newsletters extends Component {
     @action
     setMailgunRegion(region) {
         this.settings.mailgunBaseUrl = region.baseUrl;
+    }
+
+    @action
+    setMailgunBatchSize(event) {
+        this.settings.mailgunBatchSize = Math.abs(parseInt(event.target.value)) || DEFAULT_MAILGUN_BATCH_SIZE;
+        if (!this.settings.mailgunBaseUrl) {
+            this.settings.mailgunBaseUrl = this.mailgunRegion.baseUrl;
+        }
     }
 
     @action

--- a/ghost/admin/app/models/setting.js
+++ b/ghost/admin/app/models/setting.js
@@ -40,6 +40,7 @@ export default Model.extend(ValidationEngine, {
     mailgunApiKey: attr('string'),
     mailgunDomain: attr('string'),
     mailgunBaseUrl: attr('string'),
+    mailgunBatchSize: attr('number'),
     portalButton: attr('boolean'),
     portalName: attr('boolean'),
     portalPlans: attr('json-string'),

--- a/ghost/admin/app/services/settings.js
+++ b/ghost/admin/app/services/settings.js
@@ -46,7 +46,7 @@ export default class SettingsService extends Service.extend(ValidationEngine) {
     }
 
     get mailgunIsConfigured() {
-        return this.mailgunApiKey && this.mailgunDomain && this.mailgunBaseUrl;
+        return this.mailgunApiKey && this.mailgunDomain && this.mailgunBaseUrl && this.mailgunBatchSize;
     }
 
     // the settings API endpoint is a little weird as it's singular and we have

--- a/ghost/admin/mirage/fixtures/settings.js
+++ b/ghost/admin/mirage/fixtures/settings.js
@@ -86,6 +86,7 @@ export default [
     setting('email', 'mailgun_domain', null),
     setting('email', 'mailgun_api_key', null),
     setting('email', 'mailgun_base_url', null),
+    setting('email', 'mailgun_batch_size', null),
     setting('email', 'email_track_opens', 'true'),
     setting('email', 'email_track_clicks', 'true'),
     setting('email', 'email_verification_required', 'false'),

--- a/ghost/admin/tests/acceptance/settings/labs-test.js
+++ b/ghost/admin/tests/acceptance/settings/labs-test.js
@@ -337,5 +337,20 @@ describe('Acceptance: Settings - Labs', function () {
 
             expect(params.settings.findBy('key', 'mailgun_base_url').value).not.to.equal(null);
         });
+
+        it.skip('sets the mailgunBatchSize to the default', async function () {
+            await visit('/settings/members');
+
+            await fillIn('[data-test-mailgun-api-key-input]', 'i_am_an_api_key');
+            await fillIn('[data-test-mailgun-domain-input]', 'https://domain.tld');
+
+            await click('[data-test-button="save-members-settings"]');
+
+            const [lastRequest] = this.server.pretender.handledRequests.slice(-1);
+            const params = JSON.parse(lastRequest.requestBody);
+
+            expect(params.settings.findBy('key', 'mailgun_batch_size').value).not.to.equal(null);
+            expect(typeof params.settings.findBy('key', 'mailgun_batch_size').value).to.equal('number');
+        });
     });
 });

--- a/ghost/admin/tests/helpers/mailgun.js
+++ b/ghost/admin/tests/helpers/mailgun.js
@@ -10,6 +10,10 @@ export function enableMailgun(server, enabled = true) {
     server.db.settings.find({key: 'mailgun_base_url'})
         ? server.db.settings.update({key: 'mailgun_base_url'}, {value: (enabled ? 'MAILGUN_BASE_URL' : null)})
         : server.create('setting', {key: 'mailgun_base_url', value: (enabled ? 'MAILGUN_BASE_URL' : null), group: 'email'});
+
+    server.db.settings.find({key: 'mailgun_batch_size'})
+        ? server.db.settings.update({key: 'mailgun_batch_size'}, {value: (enabled ? 'mailgun_batch_size' : null)})
+        : server.create('setting', {key: 'mailgun_batch_size', value: (enabled ? 'mailgun_batch_size' : null), group: 'email'});
 }
 
 export function disableMailgun(server) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -46,6 +46,7 @@ const EDITABLE_SETTINGS = [
     'mailgun_api_key',
     'mailgun_domain',
     'mailgun_base_url',
+    'mailgun_batch_size',
     'email_track_opens',
     'email_track_clicks',
     'members_track_sources',

--- a/ghost/core/core/server/data/migrations/versions/5.36/2023-02-22-23-10-email-batch-size.js
+++ b/ghost/core/core/server/data/migrations/versions/5.36/2023-02-22-23-10-email-batch-size.js
@@ -1,0 +1,6 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('setting', 'mailgun_batch_size', {
+    type: 'number',
+    nullable: true,
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -360,6 +360,10 @@
             "defaultValue": null,
             "type": "string"
         },
+        "mailgun_batch_size": {
+            "defaultValue": null,
+            "type": "number"
+        },
         "email_track_opens": {
             "defaultValue": "true",
             "validations": {

--- a/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
+++ b/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
@@ -71,7 +71,7 @@ class FailedBatch extends BatchResultBase {
  */
 
 module.exports = {
-    BATCH_SIZE: MailgunClient.BATCH_SIZE,
+    BATCH_SIZE: mailgunClient.getBatchSize(),
     SuccessfulBatch,
     FailedBatch,
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -209,6 +209,10 @@ Object {
       "value": null,
     },
     Object {
+      "key": "mailgun_batch_size",
+      "value": null,
+    },
+    Object {
       "key": "email_track_opens",
       "value": true,
     },
@@ -567,6 +571,10 @@ Object {
       "value": null,
     },
     Object {
+      "key": "mailgun_batch_size",
+      "value": null,
+    },
+    Object {
       "key": "email_track_opens",
       "value": true,
     },
@@ -873,6 +881,10 @@ Object {
       "value": null,
     },
     Object {
+      "key": "mailgun_batch_size",
+      "value": null,
+    },
+    Object {
       "key": "email_track_opens",
       "value": true,
     },
@@ -1175,6 +1187,10 @@ Object {
     },
     Object {
       "key": "mailgun_base_url",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_batch_size",
       "value": null,
     },
     Object {
@@ -1488,6 +1504,10 @@ Object {
       "value": null,
     },
     Object {
+      "key": "mailgun_batch_size",
+      "value": null,
+    },
+    Object {
       "key": "email_track_opens",
       "value": true,
     },
@@ -1790,6 +1810,10 @@ Object {
     },
     Object {
       "key": "mailgun_base_url",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_batch_size",
       "value": null,
     },
     Object {
@@ -2160,6 +2184,10 @@ Object {
     },
     Object {
       "key": "mailgun_base_url",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_batch_size",
       "value": null,
     },
     Object {

--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -177,7 +177,7 @@ describe('Batch sending tests', function () {
     let ghostServer;
 
     beforeEach(function () {
-        MailgunEmailProvider.BATCH_SIZE = 100;
+        mockManager.mockSetting('mailgun_batch_size', 100);
         stubbedSend = sinon.fake.resolves({
             id: 'stubbed-email-id'
         });
@@ -195,6 +195,7 @@ describe('Batch sending tests', function () {
         mockManager.mockSetting('mailgun_api_key', 'test');
         mockManager.mockSetting('mailgun_domain', 'example.com');
         mockManager.mockSetting('mailgun_base_url', 'test');
+        mockManager.mockSetting('mailgun_batch_size', 1000);
         mockManager.mockMail();
 
         // We need to stub the Mailgun client before starting Ghost
@@ -447,7 +448,7 @@ describe('Batch sending tests', function () {
     });
 
     it('Splits up in batches according to email provider batch size', async function () {
-        MailgunEmailProvider.BATCH_SIZE = 1;
+        mockManager.mockSetting('mailgun_batch_size', 1);
         await testEmailBatches({
             mobiledoc: mobileDocExample
         }, null, [
@@ -460,7 +461,7 @@ describe('Batch sending tests', function () {
     });
 
     it('Splits up in batches according to email provider batch size with paid and free segments', async function () {
-        MailgunEmailProvider.BATCH_SIZE = 1;
+        mockManager.mockSetting('mailgun_batch_size', 1);
         await testEmailBatches({
             mobiledoc: mobileDocWithPaidMemberOnly
         }, null, [
@@ -476,7 +477,7 @@ describe('Batch sending tests', function () {
     });
 
     it('One failed batch marks the email as failed and allows for a retry', async function () {
-        MailgunEmailProvider.BATCH_SIZE = 1;
+        mockManager.mockSetting('mailgun_batch_size', 1);
         let counter = 0;
         stubbedSend = async function () {
             counter += 1;

--- a/ghost/core/test/utils/fixtures/default-settings-browser.json
+++ b/ghost/core/test/utils/fixtures/default-settings-browser.json
@@ -360,6 +360,10 @@
             "defaultValue": null,
             "type": "string"
         },
+        "mailgun_batch_size": {
+            "defaultValue": null,
+            "type": "number"
+        },
         "email_track_opens": {
             "defaultValue": "true",
             "validations": {

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -368,6 +368,10 @@
             "defaultValue": null,
             "type": "string"
         },
+        "mailgun_batch_size": {
+            "defaultValue": null,
+            "type": "number"
+        },
         "email_track_opens": {
             "defaultValue": "true",
             "validations": {

--- a/ghost/core/test/utils/fixtures/export/v4_export.json
+++ b/ghost/core/test/utils/fixtures/export/v4_export.json
@@ -4076,6 +4076,16 @@
             "updated_at": "2021-03-24T17:34:10.000Z"
           },
           {
+            "id": "aa26ce065f12aa4df0b1159a",
+            "group": "email",
+            "key": "mailgun_batch_size",
+            "value": null,
+            "type": "number",
+            "flags": null,
+            "created_at": "2021-03-24T17:34:10.000Z",
+            "updated_at": "2021-03-24T17:34:10.000Z"
+          },
+          {
             "id": "605ac142a2d5a6aa9e101ffc",
             "group": "email",
             "key": "email_track_opens",

--- a/ghost/email-analytics-provider-mailgun/test/provider-mailgun.test.js
+++ b/ghost/email-analytics-provider-mailgun/test/provider-mailgun.test.js
@@ -56,7 +56,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -75,7 +76,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -96,7 +98,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -117,7 +120,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -138,7 +142,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
             configStub.withArgs('bulkEmail:mailgun:tag').returns('custom-tag');

--- a/ghost/email-service/lib/mailgun-email-provider.js
+++ b/ghost/email-service/lib/mailgun-email-provider.js
@@ -30,8 +30,6 @@ class MailgunEmailProvider {
     #mailgunClient;
     #errorHandler;
 
-    static BATCH_SIZE = 1000;
-
     /**
      * @param {object} dependencies
      * @param {import('@tryghost/mailgun-client/lib/mailgun-client')} dependencies.mailgunClient - mailgun client to send emails
@@ -172,7 +170,7 @@ class MailgunEmailProvider {
     }
 
     getMaximumRecipients() {
-        return MailgunEmailProvider.BATCH_SIZE;
+        return this.#mailgunClient.getBatchSize();
     }
 }
 

--- a/ghost/mailgun-client/lib/mailgun-client.js
+++ b/ghost/mailgun-client/lib/mailgun-client.js
@@ -4,11 +4,11 @@ const logging = require('@tryghost/logging');
 const metrics = require('@tryghost/metrics');
 const errors = require('@tryghost/errors');
 
+const DEFAULT_MAILGUN_BATCH_SIZE = 1000;
+
 module.exports = class MailgunClient {
     #config;
     #settings;
-
-    static BATCH_SIZE = 1000;
 
     constructor({config, settings}) {
         this.#config = config;
@@ -38,9 +38,11 @@ module.exports = class MailgunClient {
             return null;
         }
 
-        if (Object.keys(recipientData).length > MailgunClient.BATCH_SIZE) {
+        const batchSize = this.getBatchSize();
+
+        if (Object.keys(recipientData).length > batchSize) {
             throw new errors.IncorrectUsageError({
-                message: `Mailgun only supports sending to ${MailgunClient.BATCH_SIZE} recipients at a time`
+                message: `Mailgun only supports sending to ${batchSize} recipients at a time`
             });
         }
 
@@ -233,6 +235,20 @@ module.exports = class MailgunClient {
                 enhancedCode: event['delivery-status']['enhanced-code']?.toString()?.substring(0, 50) ?? null
             } : null
         };
+    }
+
+    getBatchSize() {
+        const bulkEmailConfig = this.#config.get('bulkEmail');
+        const batchSizeSetting = this.#settings.get('mailgun_batch_size');
+        const batchSizeConfig = bulkEmailConfig?.mailgun?.batchSize;
+
+        if (!batchSizeConfig && !batchSizeSetting) {
+            return null;
+        }
+
+        const batchSize = batchSizeConfig || batchSizeSetting;
+
+        return Math.abs(parseInt(batchSize)) || DEFAULT_MAILGUN_BATCH_SIZE;
     }
 
     #getConfig() {

--- a/ghost/mailgun-client/test/mailgun-client.test.js
+++ b/ghost/mailgun-client/test/mailgun-client.test.js
@@ -43,17 +43,14 @@ describe('MailgunClient', function () {
         sinon.restore();
     });
 
-    it('exports a number for BATCH_SIZE', function () {
-        assert(typeof MailgunClient.BATCH_SIZE === 'number');
-    });
-
     it('can connect via config', function () {
         const configStub = sinon.stub(config, 'get');
         configStub.withArgs('bulkEmail').returns({
             mailgun: {
                 apiKey: 'apiKey',
                 domain: 'domain.com',
-                baseUrl: 'https://api.mailgun.net/v3'
+                baseUrl: 'https://api.mailgun.net/v3',
+                batchSize: 1000
             }
         });
 
@@ -66,6 +63,7 @@ describe('MailgunClient', function () {
         settingsStub.withArgs('mailgun_api_key').returns('settingsApiKey');
         settingsStub.withArgs('mailgun_domain').returns('settingsdomain.com');
         settingsStub.withArgs('mailgun_base_url').returns('https://example.com/v3');
+        settingsStub.withArgs('mailgun_batch_size').returns(1000);
 
         const mailgunClient = new MailgunClient({config, settings});
         assert.equal(mailgunClient.isConfigured(), true);
@@ -81,6 +79,7 @@ describe('MailgunClient', function () {
         settingsStub.withArgs('mailgun_api_key').returns('settingsApiKey');
         settingsStub.withArgs('mailgun_domain').returns('settingsdomain.com');
         settingsStub.withArgs('mailgun_base_url').returns('https://api.mailgun.net');
+        settingsStub.withArgs('mailgun_batch_size').returns(1000);
 
         const eventsMock1 = nock('https://api.mailgun.net')
             .get('/v3/settingsdomain.com/events')
@@ -95,6 +94,7 @@ describe('MailgunClient', function () {
         settingsStub.withArgs('mailgun_api_key').returns('settingsApiKey2');
         settingsStub.withArgs('mailgun_domain').returns('settingsdomain2.com');
         settingsStub.withArgs('mailgun_base_url').returns('https://api.mailgun.net');
+        settingsStub.withArgs('mailgun_batch_size').returns(1000);
 
         const eventsMock2 = nock('https://api.mailgun.net')
             .get('/v3/settingsdomain2.com/events')
@@ -115,7 +115,8 @@ describe('MailgunClient', function () {
             mailgun: {
                 apiKey: 'apiKey',
                 domain: 'configdomain.com',
-                baseUrl: 'https://api.mailgun.net'
+                baseUrl: 'https://api.mailgun.net',
+                batchSize: 1000
             }
         });
 
@@ -123,6 +124,7 @@ describe('MailgunClient', function () {
         settingsStub.withArgs('mailgun_api_key').returns('settingsApiKey');
         settingsStub.withArgs('mailgun_domain').returns('settingsdomain.com');
         settingsStub.withArgs('mailgun_base_url').returns('https://api.mailgun.net');
+        settingsStub.withArgs('mailgun_batch_size').returns(1000);
 
         const configApiMock = nock('https://api.mailgun.net')
             .get('/v3/configdomain.com/events')
@@ -169,7 +171,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -213,7 +216,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -258,7 +262,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -303,7 +308,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -348,7 +354,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.eu.mailgun.net/v3'
+                    baseUrl: 'https://api.eu.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 


### PR DESCRIPTION
Makes the `BATCH_SIZE` parameter configurable. Closes #15725.

- [x] There's a clear use-case for this code change, explained above
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)
