### PR TITLE
Fixed random timeouts in milestone service e2e test

### DIFF
--- a/ghost/core/test/e2e-server/services/milestones.test.js
+++ b/ghost/core/test/e2e-server/services/milestones.test.js
@@ -158,7 +158,10 @@ describe('Milestones Service', function () {
         loggingStub = sinon.stub(logging, 'info');
         const threeMonthsAgo = new Date();
         threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
-        clock = sinon.useFakeTimers(threeMonthsAgo.getTime());
+        clock = sinon.useFakeTimers({
+            now: threeMonthsAgo.getTime(),
+            toFake: ['setTimeout']
+        });
         sinon.createSandbox();
         configUtils.set('milestones', milestonesConfig);
         mockManager.mockLabsEnabled('milestoneEmails');


### PR DESCRIPTION
no issue

- Passed specific config to `useFakeTimers` so the test only fakes the `setTimeout` call