### PR TITLE
Updated outbound_link_tagging setting to be based on members_track_sources

### DIFF
--- a/ghost/admin/app/services/settings.js
+++ b/ghost/admin/app/services/settings.js
@@ -55,7 +55,7 @@ export default class SettingsService extends Service.extend(ValidationEngine) {
     _loadSettings() {
         if (!this._loadingPromise) {
             this._loadingPromise = this.store
-                .queryRecord('setting', {group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments'})
+                .queryRecord('setting', {group: 'site,theme,private,members,portal,newsletter,email,amp,labs,slack,unsplash,views,firstpromoter,editor,comments,analytics'})
                 .then((settings) => {
                     this._loadingPromise = null;
                     return settings;

--- a/ghost/core/core/server/data/migrations/versions/5.36/2023-02-23-10-40-set-outbound-link-tagging-based-on-source-tracking.js
+++ b/ghost/core/core/server/data/migrations/versions/5.36/2023-02-23-10-40-set-outbound-link-tagging-based-on-source-tracking.js
@@ -1,0 +1,31 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+// Set outbound_link_tagging to the current value of members_track_sources
+module.exports = createTransactionalMigration(
+    async function up(connection) {
+        const reuseValueOfSetting = await connection('settings')
+            .where('key', '=', 'members_track_sources')
+            .first();
+
+        if (!reuseValueOfSetting) {
+            logging.warn(`Skipped setting outbound_link_tagging to current value of members_track_sources - members_track_sources not found`);
+            return;
+        }
+
+        const affectedRows = await connection('settings')
+            .update({
+                value: reuseValueOfSetting.value
+            })
+            .where('key', '=', 'outbound_link_tagging');
+
+        if (affectedRows === 1) {
+            logging.info(`Set outbound_link_tagging to ${reuseValueOfSetting.value} (current members_track_sources value)`);
+        } else {
+            logging.warn(`Tried setting outbound_link_tagging to ${reuseValueOfSetting.value} — ${affectedRows} changes`);
+        }
+    },
+    async function down() {
+        // no-op: we don't need to change it back
+    }
+);


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2601

Sets the value of outbound_link_tagging to the same value of members_track_sources, so that is disabled by default for privacy sensitive sites.

Also makes sure the `outbound_link_tagging` setting is available in admin (currently excluded because it is in the analytics group)