### PR TITLE
🐛 Fixed Handlebars’ asset helper for SafeString input

### DIFF
--- a/ghost/core/core/frontend/meta/asset-url.js
+++ b/ghost/core/core/frontend/meta/asset-url.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const config = require('../../shared/config');
 const {blogIcon} = require('../../server/lib/image');
 const urlUtils = require('../../shared/url-utils');
+const {SafeString} = require('../services/handlebars');
 
 /**
  * Serve either uploaded favicon or default
@@ -11,7 +12,15 @@ function getFaviconUrl() {
     return blogIcon.getIconUrl();
 }
 
+/**
+ * Prepare URL for an asset
+ * @param {string|SafeString} path — the asset’s path
+ * @param {boolean} hasMinFile — flag for the existence of a minified version for the asset
+ * @returns {string}
+ */
 function getAssetUrl(path, hasMinFile) {
+    path = path instanceof SafeString ? path.string : path;
+
     // CASE: favicon - this is special path with its own functionality
     if (path.match(/\/?favicon\.(ico|png)$/)) {
         // @TODO, resolve this - we should only be resolving subdirectory and extension.

--- a/ghost/core/test/unit/frontend/meta/asset-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/asset-url.test.js
@@ -1,5 +1,6 @@
 const should = require('should');
 const sinon = require('sinon');
+const {SafeString} = require('../../../../core/frontend/services/handlebars');
 const imageLib = require('../../../../core/server/lib/image');
 const settingsCache = require('../../../../core/shared/settings-cache');
 const configUtils = require('../../../utils/configUtils');
@@ -36,6 +37,11 @@ describe('getAssetUrl', function () {
     it('should return hash before #', function () {
         const testUrl = getAssetUrl('myfile.svg#arrow-up');
         testUrl.should.equal(`/assets/myfile.svg?v=${config.get('assetHash')}#arrow-up`);
+    });
+
+    it('should handle Handlebars’ SafeString', function () {
+        const testUrl = getAssetUrl(new SafeString('myfile.js'));
+        testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
     });
 
     describe('favicon', function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/16332

Passing `SafeString` input to `asset` helper was resulting in the exception being thrown. This meant that we couldn’t combine `asset` helper with other helpers which produce `SafeString` e.g. `concat` helper for string concatenation.

- [x] There's a clear use-case for this code change, explained above
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)