### PR TITLE
Disabled `autoRefresh` when adding an email recipient failure

### DIFF
--- a/ghost/email-service/lib/email-event-storage.js
+++ b/ghost/email-service/lib/email-event-storage.js
@@ -86,7 +86,7 @@ class EmailEventStorage {
                 enhanced_code: event.error.enhancedCode,
                 failed_at: event.timestamp,
                 event_id: event.id
-            }, options);
+            }, {...options, autoRefresh: false});
         } else {
             if (existing.get('severity') === 'permanent') {
                 // Already marked as failed, no need to change anything here


### PR DESCRIPTION
- we don't need the updated model once we've saved it in the DB, so we can disable the auto refresh in Bookshelf to save a query