### PR TITLE
🐛 Fixed unsupported link filter params

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -123,7 +123,7 @@
 
     {{!-- Opened / Signups column --}}
     {{#if (and @post.showEmailOpenAnalytics @post.showEmailClickAnalytics) }}
-        <LinkTo @route="members" @query={{hash filterParam=(concat "opened_emails.post_id:[" @post.id "]") }} class="permalink gh-list-data gh-post-list-metrics">
+        <LinkTo @route="members" @query={{hash filterParam=(concat "opened_emails.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
             <span class="gh-content-email-stats-value">
                 {{#if this.isHovered}}
                     {{format-number @post.email.openedCount}}
@@ -143,7 +143,7 @@
     
     {{!-- Clicked / Conversions column --}}
     {{#if @post.showEmailClickAnalytics }}
-        <LinkTo @route="members" @query={{hash filterParam=(concat "clicked_links.post_id:[" @post.id "]") }} class="permalink gh-list-data gh-post-list-metrics">
+        <LinkTo @route="members" @query={{hash filterParam=(concat "clicked_links.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
             <span class="gh-content-email-stats-value">
                 {{#if this.isHovered}}
                     {{format-number @post.count.clicks}}
@@ -157,7 +157,7 @@
         </LinkTo>
     {{else}}
         {{#if @post.showEmailOpenAnalytics }}
-            <LinkTo @route="members" @query={{hash filterParam=(concat "opened_emails.post_id:[" @post.id "]") }} class="permalink gh-list-data gh-post-list-metrics">
+            <LinkTo @route="members" @query={{hash filterParam=(concat "opened_emails.post_id:" @post.id) }} class="permalink gh-list-data gh-post-list-metrics">
                 <span class="gh-content-email-stats-value">
                     {{#if this.isHovered}}
                         {{format-number @post.email.openedCount}}


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2403

- the `list-item.hbs` rendered the the url filter params with brackets eg `['postid']` where the filter UI requires the filter params not to have brackets to allow it to render with the filter pre-selected.