### PR TITLE
Removed non-recommended Node version DB tests for SQLite3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,10 +180,13 @@ jobs:
       matrix:
         node: [ '14.18.0', '16.13.0', '18.12.1' ]
         env:
-          - DB: sqlite3
-            NODE_ENV: testing
           - DB: mysql8
             NODE_ENV: testing-mysql
+        include:
+          - node: 16.13.0
+            env:
+              DB: sqlite3
+              NODE_ENV: testing
     env:
       DB: ${{ matrix.env.DB }}
       NODE_ENV: ${{ matrix.env.NODE_ENV }}


### PR DESCRIPTION
- given SQLite3 is only supported for development, we don't really care about running tests on Node versions which aren't the recommended version
- this saves 2 jobs per CI run, which helps improve the health of CI in general