### PR TITLE
Fixed typos

### DIFF
--- a/ghost/core/core/frontend/services/routing/StaticPagesRouter.js
+++ b/ghost/core/core/frontend/services/routing/StaticPagesRouter.js
@@ -52,7 +52,7 @@ class StaticPagesRouter extends ParentRouter {
     }
 
     /**
-     * @description Prepare context for futher middleware/controllers.
+     * @description Prepare context for further middleware/controllers.
      * @param {Object} req
      * @param {Object} res
      * @param {Function} next

--- a/ghost/core/core/server/data/migrations/versions/4.9/05-fix-missed-mobiledoc-url-transforms.js
+++ b/ghost/core/core/server/data/migrations/versions/4.9/05-fix-missed-mobiledoc-url-transforms.js
@@ -4,7 +4,7 @@ const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 const mobiledocLib = require('../../../../lib/mobiledoc');
 const {createTransactionalMigration} = require('../../utils');
 
-// in Ghost versions 4.6.1-4.8.4 the 4.0 migration that transfored URLs had a bug
+// in Ghost versions 4.6.1-4.8.4 the 4.0 migration that transformed URLs had a bug
 // that meant urls inside cards in mobiledoc content was not being transformed
 //
 // if the migrations table indicates an upgrade was made from 3.x to 4.6-4.8 then

--- a/ghost/core/core/server/services/link-tracking/LinkClickRepository.js
+++ b/ghost/core/core/server/services/link-tracking/LinkClickRepository.js
@@ -56,7 +56,7 @@ module.exports = class LinkClickRepository {
         }
 
         const model = await this.#MemberLinkClickEventModel.add({
-            // Only store the parthname (no support for variable query strings)
+            // Only store the pathname (no support for variable query strings)
             redirect_id: linkClick.link_id.toHexString(),
             member_id: member.id
         }, {});

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -294,7 +294,7 @@ describe('Members API', function () {
                 status: 'canceled'
             });
 
-            // Send the webhook call to anounce the cancelation
+            // Send the webhook call to announce the cancelation
             const webhookPayload = JSON.stringify({
                 type: 'customer.subscription.updated',
                 data: {
@@ -504,7 +504,7 @@ describe('Members API', function () {
                 status: 'canceled'
             });
 
-            // Send the webhook call to anounce the cancelation
+            // Send the webhook call to announce the cancelation
             const webhookPayload = JSON.stringify({
                 type: 'customer.subscription.updated',
                 data: {
@@ -1047,7 +1047,7 @@ describe('Members API', function () {
                 status: 'canceled'
             });
 
-            // Send the webhook call to anounce the cancelation
+            // Send the webhook call to announce the cancelation
             webhookPayload = JSON.stringify({
                 type: 'customer.subscription.updated',
                 data: {
@@ -1443,7 +1443,7 @@ describe('Members API', function () {
                 discount
             });
 
-            // Send the webhook call to anounce the cancelation
+            // Send the webhook call to announce the cancelation
             webhookPayload = JSON.stringify({
                 type: 'customer.subscription.updated',
                 data: {

--- a/ghost/portal/src/components/Frame.styles.js
+++ b/ghost/portal/src/components/Frame.styles.js
@@ -1,6 +1,6 @@
 /** By default, CRAs webpack bundle combines and appends the main css at root level, so they are not applied inside iframe
  * This uses a hack where we append `<style> </style>` tag with all CSS inside the head of iframe dynamically, thus making it available easily
- * We can create separate variables to keep styles grouped logically, and export them as one appeneded string
+ * We can create separate variables to keep styles grouped logically, and export them as one appended string
 */
 
 import {GlobalStyles} from './Global.styles';


### PR DESCRIPTION
There are small typos in:
- ghost/core/core/frontend/services/routing/StaticPagesRouter.js
- ghost/core/core/server/data/migrations/versions/4.9/05-fix-missed-mobiledoc-url-transforms.js
- ghost/core/core/server/services/link-tracking/LinkClickRepository.js
- ghost/core/test/e2e-api/members/webhooks.test.js
- ghost/portal/src/components/Frame.styles.js

Fixes:
- Should read `announce` rather than `anounce`.
- Should read `transformed` rather than `transfored`.
- Should read `pathname` rather than `parthname`.
- Should read `further` rather than `futher`.
- Should read `appended` rather than `appeneded`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md