### PR TITLE
Removed tabbed look for analytics with one metric

### DIFF
--- a/ghost/admin/app/components/posts/analytics.hbs
+++ b/ghost/admin/app/components/posts/analytics.hbs
@@ -41,7 +41,7 @@
         </div>
     </GhCanvasHeader>
 
-    <Tabs::Tabs class="gh-tabs-analytics" @forceRender={{true}} as |tabs|>
+    <Tabs::Tabs class="gh-tabs-analytics {{if (eq this.post.hasBeenEmailed null) "no-tabs"}}" @forceRender={{true}} as |tabs|>
         {{#if this.post.hasBeenEmailed}}
             <tabs.tab>
                 <h3>{{svg-jar "analytics-tab-sent-large"}}{{format-number this.post.email.emailCount}}</h3>

--- a/ghost/admin/app/styles/layouts/content.css
+++ b/ghost/admin/app/styles/layouts/content.css
@@ -1536,12 +1536,23 @@
     border-radius: 5px 5px 0 0;
 }
 
+.gh-tabs-analytics.no-tabs .tab-selected {
+    padding-top: 14px;
+    border: 0;
+    box-shadow: none;
+}
+
 .gh-tabs-analytics .tab-list {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
     padding: 8px 8px 0px;
     background: linear-gradient(360deg, #F7F8F9 -6.38%, rgba(247, 248, 249, 0) 159.57%);
     box-shadow: inset 0 -1px 0 #eceef0;
+}
+
+.gh-tabs-analytics.no-tabs .tab-list {
+    background: none;
+    box-shadow: none;
 }
 
 .gh-tabs-analytics .tab-panel {


### PR DESCRIPTION
When there's only one metric in the Post Analytics page, the tabbed look will be removed from the analytics table.

Before:
<img width="879" alt="CleanShot 2023-03-07 at 1 55 43@2x" src="https://user-images.githubusercontent.com/1418797/223333055-1fd4594d-37bf-46c7-a9a1-0c19b2b670bf.png">

After:
<img width="879" alt="CleanShot 2023-03-07 at 1 55 02@2x" src="https://user-images.githubusercontent.com/1418797/223333040-30587c56-31e4-437e-acc5-bab15771b2c5.png">
