### PR TITLE
Improved network access and mocking in tests

### DIFF
--- a/ghost/core/test/e2e-api/admin/oembed.test.js
+++ b/ghost/core/test/e2e-api/admin/oembed.test.js
@@ -5,6 +5,7 @@ const supertest = require('supertest');
 const testUtils = require('../../utils/index');
 const config = require('../../../core/shared/config/index');
 const localUtils = require('./utils');
+const {mockManager} = require('../../utils/e2e-framework');
 
 // for sinon stubs
 const dnsPromises = require('dns').promises;
@@ -20,9 +21,7 @@ describe('Oembed API', function () {
 
     beforeEach(function () {
         // ensure sure we're not network dependent
-        sinon.stub(dnsPromises, 'lookup').callsFake(function () {
-            return Promise.resolve({address: '123.123.123.123'});
-        });
+        mockManager.disableNetwork();
     });
 
     afterEach(function () {
@@ -422,7 +421,7 @@ describe('Oembed API', function () {
                     return Promise.resolve({address: '123.123.123.123'});
                 }
             });
-            
+
             const pageMock = nock('http://test.com')
                 .get('/')
                 .reply(200, '<html><head><link rel="alternate" type="application/json+oembed" href="http://[2607:f0d0:1002:51::4]:9999/oembed"></head></html>');

--- a/ghost/core/test/e2e-server/services/mentions.test.js
+++ b/ghost/core/test/e2e-server/services/mentions.test.js
@@ -1,9 +1,7 @@
 const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
-const sinon = require('sinon');
 const nock = require('nock');
 const assert = require('assert');
 const markdownToMobiledoc = require('../../utils/fixtures/data-generator').markdownToMobiledoc;
-const dnsPromises = require('dns').promises;
 const jobsService = require('../../../core/server/services/mentions-jobs');
 
 let agent;
@@ -30,9 +28,7 @@ describe('Mentions Service', function () {
 
     beforeEach(async function () {
         // externalRequest does dns lookup; stub to make sure we don't fail with fake domain names
-        sinon.stub(dnsPromises, 'lookup').callsFake(function () {
-            return Promise.resolve({address: '123.123.123.123'});
-        });
+        mockManager.disableNetwork();
 
         // mock response from website mentioned by post to provide endpoint
         mentionMock = nock(mentionUrl.href)

--- a/ghost/core/test/unit/server/services/oembed/twitter-embed.test.js
+++ b/ghost/core/test/unit/server/services/oembed/twitter-embed.test.js
@@ -3,6 +3,7 @@ const TwitterOEmbedProvider = require('../../../../../core/server/services/oembe
 const externalRequest = require('../../../../../core/server/lib/request-external');
 const nock = require('nock');
 const sinon = require('sinon');
+const {mockManager} = require('../../../../utils/e2e-framework');
 const dnsPromises = require('dns').promises;
 
 describe('TwitterOEmbedProvider', function () {
@@ -12,14 +13,11 @@ describe('TwitterOEmbedProvider', function () {
 
     beforeEach(function () {
         // external requests will attempt dns lookup
-        sinon.stub(dnsPromises, 'lookup').callsFake(function () {
-            return Promise.resolve({address: '123.123.123.123'});
-        });
+        mockManager.disableNetwork();
     });
 
     afterEach(async function () {
-        nock.cleanAll();
-        sinon.restore();
+        mockManager.restore();
     });
 
     after(async function () {
@@ -47,8 +45,8 @@ describe('TwitterOEmbedProvider', function () {
         const tweetURL = new URL(
             'https://twitter.com/Ghost/status/1630581157568839683'
         );
-    
-        // not certain why we hit publish.twitter.com 
+
+        // not certain why we hit publish.twitter.com
         nock('https://publish.twitter.com')
             .get('/oembed')
             .query(true)

--- a/ghost/core/test/unit/server/services/staff/index.test.js
+++ b/ghost/core/test/unit/server/services/staff/index.test.js
@@ -18,6 +18,7 @@ describe('Staff Service:', function () {
 
     beforeEach(function () {
         mockManager.mockMail();
+        mockManager.mockSlack();
         userModelStub = sinon.stub(models.User, 'getEmailAlertUsers').resolves([{
             email: 'owner@ghost.org',
             slug: 'ghost'

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -82,6 +82,9 @@ const startGhost = async (options = {}) => {
         await urlServiceUtils.isFinished();
     }
 
+    // Disable network in tests at the start
+    mockManager.disableNetwork();
+
     return ghostServer;
 };
 

--- a/ghost/core/test/utils/overrides.js
+++ b/ghost/core/test/utils/overrides.js
@@ -5,3 +5,15 @@ require('../../core/server/overrides');
 
 const {mochaHooks} = require('@tryghost/express-test').snapshot;
 exports.mochaHooks = mochaHooks;
+
+const mockManager = require('./e2e-framework-mock-manager');
+
+const originalBeforeAll = mochaHooks.beforeAll;
+mochaHooks.beforeAll = async function () {
+    if (originalBeforeAll) {
+        await originalBeforeAll();
+    }
+
+    // Disable network in tests to prevent any accidental requests
+    mockManager.disableNetwork();
+};


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2667

Some tests still accessed the internet. Now network access is disabled by default. This change also introduces two helper methods related to networking (mocking Slack and Mailgun).

This fixes two unreliable tests:
- Staff service was accessing a Slack test API -> timeout possible
- MentionSendingService was trying to send webmentions for every post publish/change -> possible timeouts and job issues