### PR TITLE
Prevented Explore iframe to be loading before needed

### DIFF
--- a/ghost/admin/app/components/gh-explore-iframe.hbs
+++ b/ghost/admin/app/components/gh-explore-iframe.hbs
@@ -3,8 +3,6 @@
     class="explore-frame"
     frameborder="0"
     title="Explore"
-    {{did-insert this.setup}}
     {{did-update this.handleDarkModeChange this.feature.nightShift}}
-    {{did-insert this.attachMessageListener}}
     ...attributes
 ></iframe>

--- a/ghost/admin/app/components/gh-explore-iframe.hbs
+++ b/ghost/admin/app/components/gh-explore-iframe.hbs
@@ -3,7 +3,7 @@
     class="explore-frame"
     frameborder="0"
     title="Explore"
-    {{did-update this.handleDarkModeChange this.feature.nightShift}}
     {{did-insert this.setup}}
+    {{did-update this.handleDarkModeChange this.feature.nightShift}}
     ...attributes
 ></iframe>

--- a/ghost/admin/app/components/gh-explore-iframe.hbs
+++ b/ghost/admin/app/components/gh-explore-iframe.hbs
@@ -5,6 +5,6 @@
     title="Explore"
     {{did-insert this.setup}}
     {{did-update this.handleDarkModeChange this.feature.nightShift}}
+    {{did-insert this.attachMessageListener}}
     ...attributes
->
-</iframe>
+></iframe>

--- a/ghost/admin/app/components/gh-explore-iframe.hbs
+++ b/ghost/admin/app/components/gh-explore-iframe.hbs
@@ -4,5 +4,6 @@
     frameborder="0"
     title="Explore"
     {{did-update this.handleDarkModeChange this.feature.nightShift}}
+    {{did-insert this.setup}}
     ...attributes
 ></iframe>

--- a/ghost/admin/app/components/gh-explore-iframe.js
+++ b/ghost/admin/app/components/gh-explore-iframe.js
@@ -22,8 +22,7 @@ export default class GhExploreIframe extends Component {
         // Only begin setup when Explore window is toggled open
         // to avoid unnecessary loading of assets
         if (this.explore.exploreWindowOpen) {
-            console.log('Rebuild');
-            this.explore.getExploreIframe().src = this.explore.getIframeURL();
+            this.explore.getExploreIframe().src = this.explore.iframeURL;
         }
     }
 
@@ -34,7 +33,7 @@ export default class GhExploreIframe extends Component {
         }
 
         // only process messages coming from the explore iframe
-        if (event?.data && this.explore.getIframeURL().includes(event?.origin)) {
+        if (event?.data && this.explore.iframeURL.includes(event?.origin)) {
             if (event.data?.request === 'apiUrl') {
                 this._handleUrlRequest();
             }

--- a/ghost/admin/app/components/gh-explore-iframe.js
+++ b/ghost/admin/app/components/gh-explore-iframe.js
@@ -14,8 +14,11 @@ export default class GhExploreIframe extends Component {
 
     @action
     setup() {
-        this.explore.getExploreIframe().src = this.explore.getIframeURL();
-        window.addEventListener('message', this.handleIframeMessage);
+        // Only begin setup when Explore window is toggled open
+        // to avoid unnecessary loading of assets
+        if (this.explore.exploreWindowOpen) {
+            this.explore.getExploreIframe().src = this.explore.getIframeURL();
+        }
     }
 
     @action
@@ -45,6 +48,11 @@ export default class GhExploreIframe extends Component {
         if (this.explore.exploreWindowOpen) {
             this.explore.sendUIUpdate({darkMode: this.feature.nightShift});
         }
+    }
+
+    @action
+    attachMessageListener() {
+        window.addEventListener('message', this.handleIframeMessage);
     }
 
     // The iframe can send route updates to navigate to within Admin, as some routes

--- a/ghost/admin/app/components/gh-explore-iframe.js
+++ b/ghost/admin/app/components/gh-explore-iframe.js
@@ -7,18 +7,14 @@ export default class GhExploreIframe extends Component {
     @service router;
     @service feature;
 
+    constructor() {
+        super(...arguments);
+        window.addEventListener('message', this.handleIframeMessage);
+    }
+
     willDestroy() {
         super.willDestroy(...arguments);
         window.removeEventListener('message', this.handleIframeMessage);
-    }
-
-    @action
-    setup() {
-        // Only begin setup when Explore window is toggled open
-        // to avoid unnecessary loading of assets
-        if (this.explore.exploreWindowOpen) {
-            this.explore.getExploreIframe().src = this.explore.getIframeURL();
-        }
     }
 
     @action
@@ -48,11 +44,6 @@ export default class GhExploreIframe extends Component {
         if (this.explore.exploreWindowOpen) {
             this.explore.sendUIUpdate({darkMode: this.feature.nightShift});
         }
-    }
-
-    @action
-    attachMessageListener() {
-        window.addEventListener('message', this.handleIframeMessage);
     }
 
     // The iframe can send route updates to navigate to within Admin, as some routes

--- a/ghost/admin/app/components/gh-explore-iframe.js
+++ b/ghost/admin/app/components/gh-explore-iframe.js
@@ -18,6 +18,16 @@ export default class GhExploreIframe extends Component {
     }
 
     @action
+    setup() {
+        // Only begin setup when Explore window is toggled open
+        // to avoid unnecessary loading of assets
+        if (this.explore.exploreWindowOpen) {
+            console.log('Rebuild');
+            this.explore.getExploreIframe().src = this.explore.getIframeURL();
+        }
+    }
+
+    @action
     async handleIframeMessage(event) {
         if (this.isDestroyed || this.isDestroying) {
             return;

--- a/ghost/admin/app/components/gh-explore-modal.hbs
+++ b/ghost/admin/app/components/gh-explore-modal.hbs
@@ -1,5 +1,5 @@
 <div class="{{this.visibilityClass}}">
     <div class="gh-explore-container">
-        <GhExploreIframe></GhExploreIframe>
+        <GhExploreIframe src={{this.explore.iframeUrl}}></GhExploreIframe>
     </div>
 </div>

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -34,7 +34,9 @@
                     </li>
                     {{#if (gh-user-can-admin this.session.user)}}
                     <li class="relative">
-                        <LinkTo @route="explore" title="Ghost Explore" data-test-nav="explore">{{svg-jar "globe-simple"}} Explore</LinkTo>
+                        <a href="javascript:void(0)" class={{if this.explore.exploreWindowOpen "active"}} {{action "toggleExploreWindow" }} data-test-nav="explore">
+                            {{svg-jar "globe-simple"}} Explore
+                        </a>
                     </li>
                     {{/if}}
                 </ul>

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -34,7 +34,7 @@
                     </li>
                     {{#if (gh-user-can-admin this.session.user)}}
                     <li class="relative">
-                        <a href="javascript:void(0)" class={{if this.explore.exploreWindowOpen "active"}} {{action "toggleExploreWindow" }} data-test-nav="explore">
+                        <a href="javascript:void(0)" class={{if this.explore.exploreWindowOpen "active"}} {{on "click" (fn this.toggleExploreWindow "")}} data-test-nav="explore">
                             {{svg-jar "globe-simple"}} Explore
                         </a>
                     </li>

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -27,6 +27,7 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     @service whatsNew;
     @service membersStats;
     @service settings;
+    @service explore;
 
     @inject config;
 
@@ -106,6 +107,11 @@ export default class Main extends Component.extend(ShortcutsMixin) {
     @action
     toggleBillingModal() {
         this.billing.openBillingWindow(this.router.currentURL);
+    }
+
+    @action
+    toggleExploreWindow() {
+        this.explore.openExploreWindow(this.router.currentURL);
     }
 
     @task(function* () {

--- a/ghost/admin/app/components/gh-nav-menu/main.js
+++ b/ghost/admin/app/components/gh-nav-menu/main.js
@@ -111,7 +111,7 @@ export default class Main extends Component.extend(ShortcutsMixin) {
 
     @action
     toggleExploreWindow() {
-        this.explore.openExploreWindow(this.router.currentURL);
+        this.explore.openExploreWindow();
     }
 
     @task(function* () {

--- a/ghost/admin/app/routes/explore/index.js
+++ b/ghost/admin/app/routes/explore/index.js
@@ -23,7 +23,7 @@ export default class ExploreIndexRoute extends AuthenticatedRoute {
         // Ensure the explore window is set to open
         if (transition.to?.localName === 'index') {
             this.explore.isIframeTransition = true;
-            this.explore.openExploreWindow(this.router.currentURL);
+            this.explore.openExploreWindow();
         }
     }
 

--- a/ghost/admin/app/routes/explore/index.js
+++ b/ghost/admin/app/routes/explore/index.js
@@ -21,7 +21,8 @@ export default class ExploreIndexRoute extends AuthenticatedRoute {
         }
 
         // Ensure the explore window is set to open
-        if (transition.to?.localName === 'index' && !this.explore.exploreWindowOpen) {
+        if (transition.to?.localName === 'index') {
+            this.explore.isIframeTransition = true;
             this.explore.openExploreWindow(this.router.currentURL);
         }
     }

--- a/ghost/admin/app/services/explore.js
+++ b/ghost/admin/app/services/explore.js
@@ -6,14 +6,12 @@ export default class ExploreService extends Service {
     @service feature;
     @service ghostPaths;
 
-    // TODO: make this a config value
     exploreUrl = 'https://ghost.org/explore/';
     exploreRouteRoot = '#/explore';
     submitRoute = 'submit';
 
     @tracked exploreWindowOpen = false;
     @tracked siteData = null;
-    @tracked previousRoute = null;
     @tracked isIframeTransition = false;
 
     get apiUrl() {
@@ -97,34 +95,27 @@ export default class ExploreService extends Service {
         this.exploreWindowOpen = value;
     }
 
-    // Controls navigation to explore window modal which is triggered from the application UI.
-    // For example: pressing "View explore" link in navigation menu. It's main side effect is
-    // remembering the route from which the action has been triggered - "previousRoute" so it
-    // could be reused when closing the explore window
-    openExploreWindow(currentRoute, childRoute) {
+    openExploreWindow() {
         if (this.exploreWindowOpen) {
             // don't attempt to open again
             return;
         }
 
-        this.previousRoute = currentRoute;
-
         // Begin loading the iframe and setting the src if it's not already set
-        if (this.getExploreIframe() && !this.getExploreIframe()?.src) {
-            this.getExploreIframe().src = this.getIframeURL();
-        }
-
-        // Begin loading the iframe and setting the src if it's not already set
-        if (this.getExploreIframe() && !this.getExploreIframe()?.src) {
-            this.getExploreIframe().src = this.getIframeURL();
-        }
+        this.ensureIframeIsLoaded();
 
         // Ensures correct "getIframeURL" calculation when syncing iframe location
         // in toggleExploreWindow
-        window.location.hash = childRoute || '/explore';
+        window.location.hash = '/explore';
 
-        this.router.transitionTo(childRoute || '/explore');
+        this.router.transitionTo('/explore');
         this.toggleExploreWindow(true);
+    }
+
+    ensureIframeIsLoaded() {
+        if (this.getExploreIframe() && !this.getExploreIframe()?.src) {
+            this.getExploreIframe().src = this.getIframeURL();
+        }
     }
 
     getExploreIframe() {

--- a/ghost/admin/app/services/explore.js
+++ b/ghost/admin/app/services/explore.js
@@ -109,6 +109,16 @@ export default class ExploreService extends Service {
 
         this.previousRoute = currentRoute;
 
+        // Begin loading the iframe and setting the src if it's not already set
+        if (this.getExploreIframe() && !this.getExploreIframe()?.src) {
+            this.getExploreIframe().src = this.getIframeURL();
+        }
+
+        // Begin loading the iframe and setting the src if it's not already set
+        if (this.getExploreIframe() && !this.getExploreIframe()?.src) {
+            this.getExploreIframe().src = this.getIframeURL();
+        }
+
         // Ensures correct "getIframeURL" calculation when syncing iframe location
         // in toggleExploreWindow
         window.location.hash = childRoute || '/explore';

--- a/ghost/admin/app/services/explore.js
+++ b/ghost/admin/app/services/explore.js
@@ -23,6 +23,21 @@ export default class ExploreService extends Service {
         return url.replace(/\/$/, '');
     }
 
+    get iframeURL() {
+        let url = this.exploreUrl;
+
+        if (window.location.hash && window.location.hash.includes(this.exploreRouteRoot)) {
+            let destinationRoute = window.location.hash.replace(this.exploreRouteRoot, '');
+
+            // Connect is an Ember route, do not use it as iframe src
+            if (destinationRoute && !destinationRoute.includes('connect')) {
+                url += destinationRoute.replace(/^\//, '');
+            }
+        }
+
+        return url;
+    }
+
     constructor() {
         super(...arguments);
 
@@ -51,21 +66,6 @@ export default class ExploreService extends Service {
                 window.history.replaceState(window.history.state, '', exploreRoute);
             }
         }
-    }
-
-    getIframeURL() {
-        let url = this.exploreUrl;
-
-        if (window.location.hash && window.location.hash.includes(this.exploreRouteRoot)) {
-            let destinationRoute = window.location.hash.replace(this.exploreRouteRoot, '');
-
-            // Connect is an Ember route, do not use it as iframe src
-            if (destinationRoute && !destinationRoute.includes('connect')) {
-                url += destinationRoute.replace(/^\//, '');
-            }
-        }
-
-        return url;
     }
 
     // Sends a route update to a child route in the BMA, because we can't control
@@ -104,7 +104,7 @@ export default class ExploreService extends Service {
         // Begin loading the iframe and setting the src if it's not already set
         this.ensureIframeIsLoaded();
 
-        // Ensures correct "getIframeURL" calculation when syncing iframe location
+        // Ensures correct iframe URL calculation when syncing iframe location
         // in toggleExploreWindow
         window.location.hash = '/explore';
 
@@ -114,7 +114,7 @@ export default class ExploreService extends Service {
 
     ensureIframeIsLoaded() {
         if (this.getExploreIframe() && !this.getExploreIframe()?.src) {
-            this.getExploreIframe().src = this.getIframeURL();
+            this.getExploreIframe().src = this.iframeURL;
         }
     }
 


### PR DESCRIPTION
no issue

- We were loading the Explore iframe together with all assets in Admin
- This change will avoid that and only start loading and rendering Explore, once it's clicked