### PR TITLE
Updated post links in member event feeds to point to post analytics screen

### DIFF
--- a/ghost/admin/app/components/dashboard/charts/recents.hbs
+++ b/ghost/admin/app/components/dashboard/charts/recents.hbs
@@ -104,7 +104,10 @@
                                                         {{#if parsedEvent.info}}
                                                             <span class="highlight">({{parsedEvent.info}})</span>
                                                         {{/if}}
-                                                        {{#if parsedEvent.url}}
+                                                        {{#if parsedEvent.route}}
+                                                            <span class="gh-members-activity-event-join">{{parsedEvent.join}}</span>
+                                                            <LinkTo class="gh-members-activity-object-link" @route={{parsedEvent.route.name}} @model={{parsedEvent.route.model}}>{{parsedEvent.object}}</LinkTo>
+                                                        {{else if parsedEvent.url}}
                                                             <span class="gh-members-activity-event-join">{{parsedEvent.join}}</span>
                                                             <a class="ghost-members-activity-object-link" href="{{parsedEvent.url}}" target="_blank" rel="noopener noreferrer">{{parsedEvent.object}}</a>
                                                         {{else if parsedEvent.email}}

--- a/ghost/admin/app/components/member/activity-feed.hbs
+++ b/ghost/admin/app/components/member/activity-feed.hbs
@@ -29,7 +29,10 @@
                                                             {{#if event.info}}
                                                                 <span class="highlight">({{event.info}})</span>
                                                             {{/if}}
-                                                            {{#if event.url}}
+                                                            {{#if event.route}}
+                                                                <span class="gh-members-activity-event-join">{{event.join}}</span>
+                                                                <LinkTo class="gh-members-activity-object-link" @route={{event.route.name}} @model={{event.route.model}}>{{event.object}}</LinkTo>
+                                                            {{else if event.url}}
                                                                 <span class="gh-members-activity-event-join">{{event.join}}</span>
                                                                 <a class="ghost-members-activity-object-link" href="{{event.url}}" target="_blank" rel="noopener noreferrer">{{event.object}}</a>
                                                             {{else if event.email}}

--- a/ghost/admin/app/components/members-activity/table-row.hbs
+++ b/ghost/admin/app/components/members-activity/table-row.hbs
@@ -1,5 +1,5 @@
 {{#let (parse-member-event @event @hasMultipleNewsletters) as |event|}}
-    <tr>  
+    <tr>
         {{#unless @hideMemberColumn}}
             <div class="gh-list-data">
                 <LinkTo @route="members-activity" @query={{hash member=event.member.id}}>
@@ -24,7 +24,10 @@
                         {{#if event.info}}
                             <span class="highlight">({{event.info}})</span>
                         {{/if}}
-                        {{#if event.url}}
+                        {{#if event.route}}
+                            <span class="gh-members-activity-event-join">{{event.join}}</span>
+                            <LinkTo class="gh-members-activity-object-link" @route={{event.route.name}} @model={{event.route.model}}>{{event.object}}</LinkTo>
+                        {{else if event.url}}
                             <span class="gh-members-activity-event-join">{{event.join}}</span>
                             <a class="ghost-members-activity-object-link" href="{{event.url}}" target="_blank" rel="noopener noreferrer">{{event.object}}</a>
                         {{else if event.email}}

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -19,6 +19,7 @@ export default class ParseMemberEventHelper extends Helper {
         const join = this.getJoin(event);
         const object = this.getObject(event);
         const url = this.getURL(event);
+        const route = this.getRoute(event);
         const timestamp = moment(event.data.created_at);
         const source = this.getSource(event);
 
@@ -36,6 +37,7 @@ export default class ParseMemberEventHelper extends Helper {
             info,
             description,
             url,
+            route,
             timestamp
         };
     }
@@ -308,15 +310,39 @@ export default class ParseMemberEventHelper extends Helper {
      * Make the object clickable
      */
     getURL(event) {
-        if (event.type === 'comment_event' || event.type === 'click_event' || event.type === 'feedback_event') {
+        if (['comment_event', 'click_event', 'feedback_event'].includes(event.type)) {
             if (event.data.post) {
                 return event.data.post.url;
             }
         }
 
-        if (event.type === 'signup_event' || event.type === 'subscription_event') {
+        if (['signup_event', 'subscription_event'].includes(event.type)) {
             if (event.data.attribution && event.data.attribution.url) {
                 return event.data.attribution.url;
+            }
+        }
+        return;
+    }
+
+    /**
+     * Get internal route props for a clickable object
+     */
+    getRoute(event) {
+        if (['comment_event', 'click_event', 'feedback_event'].includes(event.type)) {
+            if (event.data.post) {
+                return {
+                    name: 'posts.analytics',
+                    model: event.data.post.id
+                };
+            }
+        }
+
+        if (['signup_event', 'subscription_event'].includes(event.type)) {
+            if (event.data.attribution_type === 'post') {
+                return {
+                    name: 'posts.analytics',
+                    model: event.data.attribution_id
+                };
             }
         }
         return;


### PR DESCRIPTION
no issue

- member event feeds previously had links to posts that opened the front-end post URL in a new tab
- now that we have an analytics screen for each post it makes sense to link to that screen where possible because it allows drill-down into site performance
