### PR TITLE
Mentions email report

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -315,6 +315,7 @@ async function initServices({config}) {
     const emailService = require('./server/services/email-service');
     const emailAnalytics = require('./server/services/email-analytics');
     const mentionsService = require('./server/services/mentions');
+    const mentionsEmailReport = require('./server/services/mentions-email-report');
     const tagsPublic = require('./server/services/tags-public');
     const postsPublic = require('./server/services/posts-public');
     const slackNotifications = require('./server/services/slack-notifications');
@@ -333,6 +334,7 @@ async function initServices({config}) {
     await Promise.all([
         memberAttribution.init(),
         mentionsService.init(),
+        mentionsEmailReport.init(),
         staffService.init(),
         members.init(),
         tiers.init(),

--- a/ghost/core/core/server/services/mentions-email-report/StartMentionEmailReportJob.js
+++ b/ghost/core/core/server/services/mentions-email-report/StartMentionEmailReportJob.js
@@ -1,0 +1,16 @@
+module.exports = class StartMentionEmailReportJob {
+    /**
+     * @param {Date} timestamp
+     */
+    constructor(timestamp) {
+        this.data = null;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new StartMentionEmailReportJob(timestamp ?? new Date);
+    }
+};

--- a/ghost/core/core/server/services/mentions-email-report/index.js
+++ b/ghost/core/core/server/services/mentions-email-report/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./service');

--- a/ghost/core/core/server/services/mentions-email-report/job.js
+++ b/ghost/core/core/server/services/mentions-email-report/job.js
@@ -1,0 +1,11 @@
+const {parentPort} = require('worker_threads');
+const StartMentionEmailReportJob = require('./StartMentionEmailReportJob');
+
+if (parentPort) {
+    parentPort.postMessage({
+        event: {
+            type: StartMentionEmailReportJob.name
+        }
+    });
+    parentPort.postMessage('done');
+}

--- a/ghost/core/core/server/services/mentions-email-report/service.js
+++ b/ghost/core/core/server/services/mentions-email-report/service.js
@@ -1,0 +1,142 @@
+const MentionEmailReportJob = require('@tryghost/mentions-email-report');
+
+/**
+ * @typedef {import('@tryghost/mentions-email-report/lib/mentions-email-report').MentionReport} MentionReport
+ * @typedef {import('@tryghost/mentions-email-report/lib/mentions-email-report').MentionReportRecipient} MentionReportRecipient
+ */
+
+let initialised = false;
+
+module.exports = {
+    async init() {
+        if (initialised) {
+            return;
+        }
+
+        const mentions = require('../mentions');
+        const mentionReportGenerator = {
+            getMentionReport(startDate, endDate) {
+                return mentions.api.getMentionReport(startDate, endDate);
+            }
+        };
+
+        const models = require('../../models');
+        const mentionReportRecipientRepository = {
+            async getMentionReportRecipients() {
+                const users = await models.User.getEmailAlertUsers('mention-received');
+                return users.map((model) => {
+                    return {
+                        email: model.email,
+                        slug: model.slug
+                    };
+                });
+            }
+        };
+
+        const staffService = require('../staff');
+        const mentionReportEmailView = {
+            /**
+             * @returns {Promise<string>}
+             */
+            async renderSubject() {
+                return 'Mention Report';
+            },
+
+            /**
+             * @param {MentionReport} report
+             * @param {MentionReportRecipient} recipient
+             * @returns {Promise<string>}
+             */
+            async renderHTML(report, recipient) {
+                return staffService.api.emails.renderHTML('mention-report', {
+                    report: report,
+                    recipient: recipient,
+                    hasMoreMentions: report.mentions.length > 5
+                });
+            },
+
+            /**
+             * @param {MentionReport} report
+             * @param {MentionReportRecipient} recipient
+             * @returns {Promise<string>}
+             */
+            async renderText(report, recipient) {
+                return staffService.api.emails.renderText('mention-report', {
+                    report: report,
+                    recipient: recipient
+                });
+            }
+        };
+
+        const settingsCache = require('../../../shared/settings-cache');
+        const mentionReportHistoryService = {
+            async getLatestReportDate() {
+                const setting = settingsCache.get('lastMentionsReportEmailTimestamp');
+                const parsedDate = Date.parse(setting);
+
+                // Protect against missing/bad data
+                if (Number.isNaN(parsedDate)) {
+                    const date = new Date();
+                    date.setDate(date.getDate() - 1);
+                    return date;
+                }
+
+                return new Date(parsedDate);
+            },
+            async setLatestReportDate(date) {
+                await models.Settings.edit({
+                    key: 'lastMentionsReportEmailTimestamp',
+                    value: date
+                });
+            }
+        };
+
+        const mail = require('../mail');
+        const mailer = new mail.GhostMailer();
+        const emailService = {
+            async send(to, subject, html, text) {
+                return mailer.send({
+                    to,
+                    subject,
+                    html,
+                    text
+                });
+            }
+        };
+
+        const job = new MentionEmailReportJob({
+            mentionReportGenerator,
+            mentionReportRecipientRepository,
+            mentionReportEmailView,
+            mentionReportHistoryService,
+            emailService
+        });
+
+        const mentionsJobs = require('../mentions-jobs');
+
+        const DomainEvents = require('@tryghost/domain-events');
+        const StartMentionEmailReportJob = require('./StartMentionEmailReportJob');
+
+        const labs = require('../../../shared/labs');
+        DomainEvents.subscribe(StartMentionEmailReportJob, () => {
+            if (labs.isSet('webmentionEmails')) {
+                job.sendLatestReport();
+            }
+        });
+
+        // Kick off the job on boot, this will make sure that we send a missing report if needed
+        DomainEvents.dispatch(StartMentionEmailReportJob.create());
+
+        const s = Math.floor(Math.random() * 60); // 0-59
+        const m = Math.floor(Math.random() * 60); // 0-59
+
+        // Schedules a job every hour at a random minute and second to send the latest report
+        mentionsJobs.addJob({
+            name: 'mentions-email-report',
+            job: require('path').resolve(__dirname, './job.js'),
+            at: `${s} ${m} * * * *`
+        });
+
+        initialised = true;
+    }
+};

--- a/ghost/core/core/server/services/mentions-email-report/service.js
+++ b/ghost/core/core/server/services/mentions-email-report/service.js
@@ -72,21 +72,21 @@ module.exports = {
         const mentionReportHistoryService = {
             async getLatestReportDate() {
                 const setting = settingsCache.get('lastMentionsReportEmailTimestamp');
-                const parsedDate = Date.parse(setting);
+                const parsedInt = parseInt(setting);
 
                 // Protect against missing/bad data
-                if (Number.isNaN(parsedDate)) {
+                if (Number.isNaN(parsedInt) || !parsedInt) {
                     const date = new Date();
                     date.setDate(date.getDate() - 1);
                     return date;
                 }
 
-                return new Date(parsedDate);
+                return new Date(parsedInt);
             },
             async setLatestReportDate(date) {
                 await models.Settings.edit({
                     key: 'lastMentionsReportEmailTimestamp',
-                    value: date
+                    value: date.getTime()
                 });
             }
         };

--- a/ghost/core/core/server/services/mentions/BookshelfMentionRepository.js
+++ b/ghost/core/core/server/services/mentions/BookshelfMentionRepository.js
@@ -12,6 +12,7 @@ const logging = require('@tryghost/logging');
 
 /**
  * @typedef {import('@tryghost/webmentions/lib/MentionsAPI').GetPageOptions} GetPageOptions
+ * @typedef {import('@tryghost/webmentions/lib/MentionsAPI').GetAllOptions} GetAllOptions
  */
 
 /**
@@ -82,6 +83,16 @@ module.exports = class BookshelfMentionRepository {
             data: await Promise.all(page.data.map(model => this.#modelToMention(model))),
             meta: page.meta
         };
+    }
+
+    /**
+     * @param {GetAllOptions} options
+     * @returns {Promise<import('@tryghost/webmentions/lib/Mention')[]>}
+     */
+    async getAll(options) {
+        const models = await this.#MentionModel.findAll(options);
+
+        return await Promise.all(models.map(model => this.#modelToMention(model)));
     }
 
     /**

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -25,6 +25,8 @@ function getPostUrl(post) {
 }
 
 module.exports = {
+    /** @type {import('@tryghost/webmentions/lib/MentionsAPI')} */
+    api: null,
     controller: new MentionController(),
     didInit: false,
     async init() {
@@ -55,6 +57,8 @@ module.exports = {
             resourceService,
             routingService
         });
+
+        this.api = api;
 
         this.controller.init({
             api,

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -114,6 +114,7 @@
     "@tryghost/members-offers": "0.0.0",
     "@tryghost/members-ssr": "0.0.0",
     "@tryghost/members-stripe-service": "0.0.0",
+    "@tryghost/mentions-email-report": "0.0.0",
     "@tryghost/metrics": "1.0.22",
     "@tryghost/milestones": "0.0.0",
     "@tryghost/minifier": "0.0.0",

--- a/ghost/mentions-email-report/.eslintrc.js
+++ b/ghost/mentions-email-report/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node'
+    ]
+};

--- a/ghost/mentions-email-report/README.md
+++ b/ghost/mentions-email-report/README.md
@@ -1,0 +1,21 @@
+# Mentions Email Report
+
+
+## Usage
+
+
+## Develop
+
+This is a monorepo package.
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+

--- a/ghost/mentions-email-report/index.js
+++ b/ghost/mentions-email-report/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/MentionEmailReportJob');

--- a/ghost/mentions-email-report/lib/MentionEmailReportJob.js
+++ b/ghost/mentions-email-report/lib/MentionEmailReportJob.js
@@ -1,0 +1,117 @@
+module.exports = class MentionEmailReportJob {
+    /** @type {IMentionReportGenerator} */
+    #mentionReportGenerator;
+
+    /** @type {IMentionReportRecipientRepository} */
+    #mentionReportRecipientRepository;
+
+    /** @type {IMentionReportEmailView} */
+    #mentionReportEmailView;
+
+    /** @type {IMentionReportHistoryService} */
+    #mentionReportHistoryService;
+
+    /** @type {IEmailService} */
+    #emailService;
+
+    /**
+     * @param {object} deps
+     * @param {IMentionReportGenerator} deps.mentionReportGenerator
+     * @param {IMentionReportRecipientRepository} deps.mentionReportRecipientRepository
+     * @param {IMentionReportEmailView} deps.mentionReportEmailView
+     * @param {IMentionReportHistoryService} deps.mentionReportHistoryService
+     * @param {IEmailService} deps.emailService
+     */
+    constructor(deps) {
+        this.#mentionReportGenerator = deps.mentionReportGenerator;
+        this.#mentionReportRecipientRepository = deps.mentionReportRecipientRepository;
+        this.#mentionReportEmailView = deps.mentionReportEmailView;
+        this.#mentionReportHistoryService = deps.mentionReportHistoryService;
+        this.#emailService = deps.emailService;
+    }
+
+    /**
+     * Checks for new mentions since the last report and sends an email to the recipients.
+     *
+     * @returns {Promise<number>} - A promise that resolves with the number of mentions found.
+     */
+    async sendLatestReport() {
+        const lastReport = await this.#mentionReportHistoryService.getLatestReportDate();
+        const now = new Date();
+
+        if (now.valueOf() - lastReport.valueOf() < 24 * 60 * 60 * 1000) {
+            return 0;
+        }
+
+        const report = await this.#mentionReportGenerator.getMentionReport(lastReport, now);
+
+        report.mentions = report.mentions.map((mention) => {
+            return {
+                targetUrl: mention.target,
+                sourceUrl: mention.source,
+                sourceTitle: mention.sourceTitle,
+                sourceExcerpt: mention.sourceExcerpt,
+                sourceSiteTitle: mention.sourceSiteTitle,
+                sourceFavicon: mention.sourceFavicon,
+                sourceAuthor: mention.sourceAuthor,
+                sourceFeaturedImage: mention.sourceFeaturedImage
+            };
+        });
+
+        if (!report?.mentions?.length) {
+            return 0;
+        }
+
+        const recipients = await this.#mentionReportRecipientRepository.getMentionReportRecipients();
+
+        for (const recipient of recipients) {
+            const subject = await this.#mentionReportEmailView.renderSubject(report, recipient);
+            const html = await this.#mentionReportEmailView.renderHTML(report, recipient);
+            const text = await this.#mentionReportEmailView.renderText(report, recipient);
+
+            await this.#emailService.send(recipient.email, subject, html, text);
+        }
+
+        await this.#mentionReportHistoryService.setLatestReportDate(now);
+
+        return report.mentions.length;
+    }
+};
+
+/**
+ * @typedef {object} MentionReportRecipient
+ * @prop {string} email
+ * @prop {string} slug
+ */
+
+/**
+ * @typedef {object} IMentionReportRecipientRepository
+ * @prop {() => Promise<MentionReportRecipient[]>} getMentionReportRecipients
+ */
+
+/**
+ * @typedef {import('@tryghost/webmentions/lib/MentionsAPI').MentionReport} MentionReport
+ */
+
+/**
+ * @typedef {object} IMentionReportGenerator
+ * @prop {(startDate: Date, endDate: Date) => Promise<MentionReport>} getMentionReport
+ */
+
+/**
+ * @typedef {object} IMentionReportEmailView
+ * @prop {(report: MentionReport, recipient: MentionReportRecipient) => Promise<string>} renderHTML
+ * @prop {(report: MentionReport, recipient: MentionReportRecipient) => Promise<string>} renderText
+ * @prop {(report: MentionReport, recipient: MentionReportRecipient) => Promise<string>} renderSubject
+ */
+
+/**
+ * @typedef {object} IEmailService
+ * @prop {(to: string, subject: string, html: string, text: string) => Promise<void>} send
+ */
+
+/**
+ * @typedef {object} IMentionReportHistoryService
+ * @prop {() => Promise<Date>} getLatestReportDate
+ * @prop {(date: Date) => Promise<void>} setLatestReportDate
+ */

--- a/ghost/mentions-email-report/package.json
+++ b/ghost/mentions-email-report/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@tryghost/mentions-email-report",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/mentions-email-report",
+  "author": "Ghost Foundation",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "dev": "echo \"Implement me!\"",
+    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --100  --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+    "test": "yarn test:unit",
+    "lint:code": "eslint *.js lib/ --ext .js --cache",
+    "lint": "yarn lint:code && yarn lint:test",
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .js --cache"
+  },
+  "files": [
+    "index.js",
+    "lib"
+  ],
+  "devDependencies": {
+    "c8": "7.13.0",
+    "mocha": "10.2.0",
+    "sinon": "15.0.1"
+  },
+  "dependencies": {}
+}

--- a/ghost/mentions-email-report/test/.eslintrc.js
+++ b/ghost/mentions-email-report/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/ghost/mentions-email-report/test/hello.test.js
+++ b/ghost/mentions-email-report/test/hello.test.js
@@ -1,0 +1,164 @@
+const sinon = require('sinon');
+const MentionEmailReportJob = require('../');
+
+class MockMentionReportRecipientRepository {
+    #recipients = [{
+        email: 'fake@email.address',
+        slug: 'user-slug'
+    }];
+
+    constructor(recipients) {
+        if (recipients) {
+            this.#recipients = recipients;
+        }
+    }
+
+    async getMentionReportRecipients() {
+        return this.#recipients;
+    }
+}
+
+class MockMentionReportEmailView {
+    async renderSubject() {
+        return 'Mention Report';
+    }
+
+    async renderHTML() {
+        return '<h1>Mention Report</h1>';
+    }
+
+    async renderText() {
+        return 'Mention Report';
+    }
+}
+
+class MockEmailService {
+    async send() {
+        return;
+    }
+}
+
+class MockMentionReportHistoryService {
+    #date = null;
+
+    constructor(date) {
+        if (!date) {
+            throw new Error('Missing date');
+        }
+        this.#date = date;
+    }
+
+    async getLatestReportDate() {
+        return this.#date;
+    }
+
+    async setLatestReportDate(date) {
+        this.#date = date;
+    }
+}
+
+class MockMentionReportGenerator {
+    #mentions = null;
+
+    constructor(mentions) {
+        if (!mentions) {
+            throw new Error('Missing mentions');
+        }
+        this.#mentions = mentions;
+    }
+
+    async getMentionReport(startDate, endDate) {
+        return {
+            startDate,
+            endDate,
+            mentions: this.#mentions
+        };
+    }
+}
+
+describe('MentionEmailReportJob', function () {
+    describe('sendLatestReport', function () {
+        it('Does not send an email if the report has no mentions', async function () {
+            const emailService = new MockEmailService();
+
+            const mock = sinon.mock(emailService);
+
+            mock.expects('send').never();
+
+            const job = new MentionEmailReportJob({
+                mentionReportGenerator: new MockMentionReportGenerator([]),
+                mentionReportRecipientRepository: new MockMentionReportRecipientRepository(),
+                mentionReportEmailView: new MockMentionReportEmailView(),
+                mentionReportHistoryService: new MockMentionReportHistoryService(new Date(0)),
+                emailService: emailService
+            });
+
+            await job.sendLatestReport();
+
+            mock.verify();
+        });
+
+        it('Does not send an email if the last email was sent within 24 hours', async function () {
+            const emailService = new MockEmailService();
+
+            const mock = sinon.mock(emailService);
+
+            mock.expects('send').never();
+
+            const job = new MentionEmailReportJob({
+                mentionReportGenerator: new MockMentionReportGenerator([{
+                    target: new URL('https://target.com'),
+                    source: new URL('https://source.com'),
+                    sourceTitle: 'Source Title',
+                    sourceExcerpt: 'Source Excerpt',
+                    sourceSiteTitle: 'Source Site Title',
+                    sourceFavicon: new URL('https://source.com/favicon.ico'),
+                    sourceAuthor: 'Source Author',
+                    sourceFeaturedImage: new URL('https://source.com/featured-image.jpg')
+                }]),
+                mentionReportRecipientRepository: new MockMentionReportRecipientRepository(),
+                mentionReportEmailView: new MockMentionReportEmailView(),
+                mentionReportHistoryService: new MockMentionReportHistoryService(new Date()),
+                emailService: emailService
+            });
+
+            await job.sendLatestReport();
+
+            mock.verify();
+        });
+
+        it('Sends an email if the last email was sent more than 24 hours ago', async function () {
+            const emailService = new MockEmailService();
+
+            const mock = sinon.mock(emailService);
+
+            mock.expects('send').once().alwaysCalledWith(
+                'fake@email.address',
+                'Mention Report',
+                '<h1>Mention Report</h1>',
+                'Mention Report'
+            );
+
+            const job = new MentionEmailReportJob({
+                mentionReportGenerator: new MockMentionReportGenerator([{
+                    target: new URL('https://target.com'),
+                    source: new URL('https://source.com'),
+                    sourceTitle: 'Source Title',
+                    sourceExcerpt: 'Source Excerpt',
+                    sourceSiteTitle: 'Source Site Title',
+                    sourceFavicon: new URL('https://source.com/favicon.ico'),
+                    sourceAuthor: 'Source Author',
+                    sourceFeaturedImage: new URL('https://source.com/featured-image.jpg')
+                }]),
+                mentionReportRecipientRepository: new MockMentionReportRecipientRepository(),
+                mentionReportEmailView: new MockMentionReportEmailView(),
+                mentionReportHistoryService: new MockMentionReportHistoryService(new Date(0)),
+                emailService
+            });
+
+            await job.sendLatestReport();
+
+            mock.verify();
+        });
+    });
+});

--- a/ghost/staff-service/lib/email-templates/mention-report.hbs
+++ b/ghost/staff-service/lib/email-templates/mention-report.hbs
@@ -1,0 +1,136 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>💌 New mention{{#eq report.mentions.length 1}}{{else}}{{report.mentions.length}}s{{/eq}}</title>
+    {{> styles}}
+  </head>
+  <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+      <tr>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; padding: 10px;">
+          <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED CONTAINER -->
+            <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                    <tr>
+                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: bold; line-height: 25px; margin: 0; margin-bottom: 15px;">Hey there,</p>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 16px;">{{siteTitle}} was mentioned{{#eq report.mentions.length 1}} in:{{else}} <strong>{{report.mentions.length}} times</strong> recently. Here's where:{{/eq}}</p>
+
+                        {{#each (limit report.mentions 5) as |mention|}}
+                        <!--[if !mso !vml]-->
+                        <figure style="margin:0 0 1.5em;padding:0;width:100%;">
+                          <a style="display:flex;min-height:148px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none" href="{{mention.sourceUrl}}">
+                            <div style="display:inline-block; width:100%; padding:20px">
+                              <div style="color:#15212a;font-size:16px;line-height:1.3em;font-weight:600">{{mention.sourceTitle}}</div>
+                              <div style="display:-webkit-box;overflow-y:hidden;margin-top:12px;max-height:40px;color:#738a94;font-size:13px;line-height:1.5em;font-weight:400">{{mention.sourceExcerpt}}</div>
+                              <div style="display:flex;margin-top:14px;color:#15212a;font-size:13px;font-weight:400">
+                                {{#if mention.sourceFavicon}}<img style="border:none;max-width:100%;margin-right:8px;width:22px;height:22px" src="{{mention.sourceFavicon}}" alt="">{{/if}}
+                                {{#if mention.sourceSiteTitle}}<span style="font-size:13px;line-height:1.5em">{{mention.sourceSiteTitle}}</span>{{/if}}
+                              </div>
+                            </div>
+                            {{#if mention.sourceFeaturedImage}}
+                              <div style="min-width: 140px; max-width: 180px; background-repeat: no-repeat; background-size: cover; background-position: center; border-radius: 0 2px 2px 0;background-image: url('{{mention.sourceFeaturedImage}}')" class="new-mention-thumbnail">
+                                <img src="{{mention.sourceFeaturedImage}}" style="border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: none;"/>
+                              </div>
+                            {{/if}}
+                          </a>
+                        </figure>
+                        <!--[endif]-->
+
+                        <!--[if vml]>
+                        <table style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; border: 1px solid #f9f9fa; background: #f9f9fa; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;">
+                            <tr>
+                                <td width="100%" style="padding: 20px;">
+                                    <table style="margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;">
+                                        <tr>
+                                            <td><a style="color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600; text-decoration: none;" href="{{sourceUrl}}">{{sourceTitle}}</a></td>
+                                        </tr>
+                                        <tr>
+                                            <td><div><a href="{{sourceUrl}}" style="margin-top: 12px; color: #738a94; font-size: 13px; line-height: 1.5em; font-weight: 400;text-decoration: none;">{{sourceExcerpt}}</a></div></td>
+                                        </tr>
+                                        <tr>
+                                            <td style="padding-top: 14px; color: #15212A; font-size: 13px; font-weight: 400; line-height: 1.5em;">
+                                                <table style="margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;">
+                                                    <tr>
+                                                        {{#if sourceFavicon}}
+                                                            <td valign="middle" style="padding-right: 8px; font-size: 0; line-height: 1.5em">
+                                                                <a href="{{sourceUrl}}" style="color: #15212A; text-decoration: none;"><img src="{{sourceFavicon}}" width="22" height="22" alt=" "></a>
+                                                            </td>
+                                                        {{/if}}
+                                                        <td valign="middle">
+                                                            <a href="{{sourceUrl}}" style="color: #15212A; text-decoration: none;">
+                                                                {{sourceSiteTitle}}
+                                                            </a>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                        <![endif]-->
+
+                        {{/each}}
+
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; padding-top: 32px; padding-bottom: 12px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{siteUrl}}ghost/#/mentions" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View all {{#if hasMoreMentions}}{{report.mentions.length}}{{/if}} mentions</a></td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <hr/>
+                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 5px;">You can also copy & paste this URL into your browser:</p>
+                        <p class="text-link" style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;">{{siteUrl}}ghost/#/mentions</p>
+                      </td>
+                    </tr>
+
+                    <!-- START FOOTER -->
+                    <tr>
+                        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 80px;">
+                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;">This message was sent from <a class="small" href="{{siteUrl}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">{{siteDomain}}</a> to <a class="small" href="mailto:{{toEmail}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">{{toEmail}}</a></p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 2px">
+                        <p class="small" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;">Don’t want to receive these emails? Manage your preferences <a class="small" href="{{staffUrl}}" style="text-decoration: underline; color: #738A94; font-size: 11px;">here</a>.</p>
+                      </td>
+                    </tr>
+
+                    <!-- END FOOTER -->
+                  </table>
+                </td>
+              </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+
+          <!-- END CENTERED CONTAINER -->
+          </div>
+        </td>
+        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/ghost/staff-service/lib/email-templates/mention-report.txt.js
+++ b/ghost/staff-service/lib/email-templates/mention-report.txt.js
@@ -1,0 +1,11 @@
+module.exports = function (data) {
+    // Be careful when you indent the email, because whitespaces are visible in emails!
+    return `
+    You have been mentioned by ${data.sourceUrl}.
+
+---
+
+Sent to ${data.toEmail} from ${data.siteDomain}.
+If you would no longer like to receive these notifications you can adjust your settings at ${data.staffUrl}.
+    `;
+};

--- a/ghost/webmentions/lib/InMemoryMentionRepository.js
+++ b/ghost/webmentions/lib/InMemoryMentionRepository.js
@@ -115,4 +115,15 @@ module.exports = class InMemoryMentionRepository {
             }
         };
     }
+
+    async getAll(options) {
+        const page = await this.getPage({
+            filter: options.filter,
+            order: options.order,
+            page: null,
+            limit: 'all'
+        });
+
+        return page.data;
+    }
 };

--- a/ghost/webmentions/lib/MentionsAPI.js
+++ b/ghost/webmentions/lib/MentionsAPI.js
@@ -38,9 +38,15 @@ const Mention = require('./Mention');
  */
 
 /**
+ * @typedef {object} GetAllOptions
+ * @prop {string} [filter] A valid NQL string
+ */
+
+/**
  * @typedef {object} IMentionRepository
  * @prop {(mention: Mention) => Promise<void>} save
  * @prop {(options: GetPageOptions) => Promise<Page<Mention>>} getPage
+ * @prop {(options: GetAllOptions) => Promise<Mention[]>} getAll
  * @prop {(source: URL, target: URL) => Promise<Mention>} getBySourceAndTarget
  */
 
@@ -72,6 +78,13 @@ const Mention = require('./Mention');
  */
 
 /**
+ * @typedef {object} MentionReport
+ * @prop {Date} startDate
+ * @prop {Date} endDate
+ * @prop {Mention[]} mentions
+ */
+
+/**
  * @typedef {object} IWebmentionMetadata
  * @prop {(url: URL) => Promise<WebmentionMetadata>} fetch
  */
@@ -98,6 +111,25 @@ module.exports = class MentionsAPI {
         this.#resourceService = deps.resourceService;
         this.#routingService = deps.routingService;
         this.#webmentionMetadata = deps.webmentionMetadata;
+    }
+
+    /**
+     * @param {Date} startDate
+     * @param {Date} endDate
+     * @returns {Promise<MentionReport>}
+     */
+    async getMentionReport(startDate, endDate) {
+        const mentions = await this.#repository.getAll({
+            filter: `created_at:>${startDate.toISOString()}+created_at:<${endDate.toISOString()}`
+        });
+
+        const report = {
+            startDate: new Date(startDate),
+            endDate: new Date(endDate),
+            mentions
+        };
+
+        return report;
     }
 
     /**

--- a/ghost/webmentions/test/MentionsAPI.test.js
+++ b/ghost/webmentions/test/MentionsAPI.test.js
@@ -44,6 +44,31 @@ describe('MentionsAPI', function () {
         sinon.restore();
     });
 
+    it('Can generate a mentions report', async function () {
+        const repository = new InMemoryMentionRepository();
+        const api = new MentionsAPI({
+            repository,
+            routingService: mockRoutingService,
+            resourceService: mockResourceService,
+            webmentionMetadata: mockWebmentionMetadata
+        });
+
+        const mention = await api.processWebmention({
+            source: new URL('https://source.com'),
+            target: new URL('https://target.com'),
+            payload: {}
+        });
+
+        assert(mention instanceof Mention);
+
+        const now = new Date();
+
+        const report = await api.getMentionReport(new Date(0), new Date());
+
+        assert.deepEqual(report.startDate, new Date(0));
+        assert.deepEqual(report.endDate, now);
+    });
+
     it('Can list paginated mentions', async function () {
         const repository = new InMemoryMentionRepository();
         const api = new MentionsAPI({


### PR DESCRIPTION
This will attempt to send a mentions report email on boot and also every hour (at a random minute and second), but not doing so if either:

1. There are no new mentions since the last report
2. The last report was sent within 24 hours

All of this is behind the mentions emails labs flag, which means it can be released/tested independently of the rest of the mentions feature.

The scheduler doesn't support local timezones at the moment, so sending every day at around 4pm was difficult, and would end up error prone unless we add proper support for timezones - I've done the best I can to make sure that we send something every day if possible! 