### PR TITLE
Removed Bluebird `mapSeries` usage

### DIFF
--- a/ghost/core/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/ghost/core/core/server/adapters/scheduling/post-scheduling/index.js
@@ -1,4 +1,4 @@
-const Promise = require('bluebird');
+const {sequence} = require('@tryghost/promise');
 const events = require('../../../lib/common/events');
 const localUtils = require('../utils');
 const PostScheduler = require('./post-scheduler');
@@ -13,7 +13,8 @@ const loadScheduledResources = async function () {
     const SCHEDULED_RESOURCES = ['post', 'page'];
 
     // Fetches all scheduled resources(posts/pages) with default API
-    const results = await Promise.mapSeries(SCHEDULED_RESOURCES, async (resourceType) => {
+
+    const results = await sequence(SCHEDULED_RESOURCES.map(resourceType => async () => {
         const result = await api.schedules.getScheduled.query({
             options: {
                 resource: resourceType
@@ -21,7 +22,7 @@ const loadScheduledResources = async function () {
         });
 
         return result[resourceType] || [];
-    });
+    }));
 
     return SCHEDULED_RESOURCES.reduce(function (obj, entry, index) {
         return Object.assign(obj, {

--- a/ghost/core/core/server/data/migrations/init/1-create-tables.js
+++ b/ghost/core/core/server/data/migrations/init/1-create-tables.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const commands = require('../../schema').commands;
 const schema = require('../../schema').tables;
 const logging = require('@tryghost/logging');
@@ -10,10 +9,10 @@ module.exports.up = async (options) => {
     const existingTables = await commands.getTables(connection);
     const missingTables = schemaTables.filter(t => !existingTables.includes(t));
 
-    await Promise.mapSeries(missingTables, async (table) => {
+    for (const table of missingTables) {
         logging.info('Creating table: ' + table);
         await commands.createTable(table, connection);
-    });
+    }
 };
 
 /**
@@ -24,9 +23,10 @@ module.exports.up = async (options) => {
 
         // Reference between tables!
         schemaTables.reverse();
-        await Promise.mapSeries(schemaTables, async (table) => {
+
+        for (const table of schemaTables) {
             logging.info('Drop table: ' + table);
             await commands.deleteTable(table, connection);
-        });
+        }
     };
  */

--- a/ghost/core/core/server/models/base/listeners.js
+++ b/ghost/core/core/server/models/base/listeners.js
@@ -3,7 +3,6 @@ const _ = require('lodash');
 const models = require('../../models');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
-const Promise = require('bluebird');
 
 // Listen to settings.timezone.edited and settings.notifications.edited to bind extra logic to settings, similar to the bridge and member service
 const events = require('../../lib/common/events');
@@ -46,7 +45,7 @@ events.on('settings.timezone.edited', function (settingModel, options) {
                 return;
             }
 
-            await Promise.mapSeries(results, async (post) => {
+            for (const post of results) {
                 const newPublishedAtMoment = moment(post.get('published_at')).add(timezoneOffsetDiff, 'minutes');
 
                 /**
@@ -73,7 +72,7 @@ events.on('settings.timezone.edited', function (settingModel, options) {
                         err
                     }));
                 }
-            });
+            }
         } catch (err) {
             logging.error(new errors.InternalServerError({
                 err: err,

--- a/ghost/core/test/regression/api/admin/schedules.test.js
+++ b/ghost/core/test/regression/api/admin/schedules.test.js
@@ -1,9 +1,10 @@
 const _ = require('lodash');
 const should = require('should');
 const supertest = require('supertest');
-const Promise = require('bluebird');
 const sinon = require('sinon');
 const moment = require('moment-timezone');
+const {sequence} = require('@tryghost/promise');
+
 const SchedulingDefault = require('../../../../core/server/adapters/scheduling/SchedulingDefault');
 const models = require('../../../../core/server/models');
 const config = require('../../../../core/shared/config');
@@ -86,9 +87,9 @@ describe('Schedules API', function () {
             }]
         }));
 
-        const result = await Promise.mapSeries(resources, function (post) {
+        const result = await sequence(resources.map(post => () => {
             return models.Post.add(post, {context: {internal: true}});
-        });
+        }));
 
         result.length.should.eql(5);
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/14882

- we're working on removing Bluebird and there are a few places where we can switch it to native for-loops (if we don't need the result), or the `sequence` function from `@tryghost/promise`
