### PR TITLE
✨ Improved FirstPromoter integration to run on all subdomains

### DIFF
--- a/ghost/portal/src/App.js
+++ b/ghost/portal/src/App.js
@@ -534,7 +534,12 @@ export default class App extends React.Component {
             return null;
         }
         const firstPromoterId = getFirstpromoterId({site});
-        const siteDomain = getSiteDomain({site});
+        let siteDomain = getSiteDomain({site});
+        // Replace any leading subdomain and prefix the siteDomain with
+        // a `.` to allow the FPROM cookie to be accessible across all subdomains
+        // or the root.
+        siteDomain = siteDomain?.replace(/^(\S*\.)?(\S*\.\S*)$/i, '.$2');
+
         if (firstPromoterId && siteDomain) {
             const t = document.createElement('script');
             t.type = 'text/javascript';


### PR DESCRIPTION
closes https://www.notion.so/ghost/Update-FirstPromoter-implementation-to-allow-subdomains-d108aee94aaa417eb552db7e825f1e44?pvs=4

- Allow the FirstPromoter script to run on all subdomains of the root site domain by removing any subdomain from the used domain and prefixing the root with a `.`.