### PR TITLE
[WIP] Redis Cache Adapter Upgrades

### DIFF
--- a/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
+++ b/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
@@ -83,6 +83,14 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         });
     }
 
+    async #getKeys() {
+        const primaryNode = this.#getPrimaryRedisNode();
+        if (primaryNode === null) {
+            return [];
+        }
+        return await this.#scanNodeForKeys(primaryNode);
+    }
+
     /**
      * This is a recommended way to build cache key prefixes from
      * the cache-manager package. Might be a good contribution to make
@@ -144,12 +152,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      */
     async keys() {
         try {
-            const primaryNode = this.#getPrimaryRedisNode();
-            if (primaryNode === null) {
-                return [];
-            }
-            const rawKeys = await this.#scanNodeForKeys(primaryNode);
-            return rawKeys.map((key) => {
+            return (await this.#getKeys()).map((key) => {
                 return this._removeKeyPrefix(key);
             });
         } catch (err) {

--- a/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
+++ b/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
@@ -144,9 +144,13 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      * Reset the cache by deleting everything from redis
      */
     async reset() {
-        const keys = await this.#getKeys();
-        for (const key of keys) {
-            await this.cache.del(key);
+        try {
+            const keys = await this.#getKeys();
+            for (const key of keys) {
+                await this.cache.del(key);
+            }
+        } catch (err) {
+            logging.error(err);
         }
     }
 

--- a/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
+++ b/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
@@ -140,10 +140,14 @@ class AdapterCacheRedis extends BaseCacheAdapter {
         }
     }
 
+    /**
+     * Reset the cache by deleting everything from redis
+     */
     async reset() {
-        // NOTE: dangerous in shared environment, and not used in production code anyway!
-        // return await this.cache.reset();
-        logging.error('Cache reset has not been implemented with shared cache environment in mind');
+        const keys = await this.#getKeys();
+        for (const key of keys) {
+            await this.cache.del(key);
+        }
     }
 
     /**

--- a/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
+++ b/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
@@ -54,6 +54,9 @@ class AdapterCacheRedis extends BaseCacheAdapter {
     }
 
     #getPrimaryRedisNode() {
+        if (this.redisClient.constructor.name !== 'Cluster') {
+            return this.redisClient;
+        }
         const slot = calculateSlot(this.keyPrefix);
         const [ip, port] = this.redisClient.slots[slot][0].split(':');
         for (const node of this.redisClient.nodes()) {

--- a/ghost/adapter-cache-redis/test/adapter-cache-redis.test.js
+++ b/ghost/adapter-cache-redis/test/adapter-cache-redis.test.js
@@ -1,8 +1,13 @@
 const assert = require('assert/strict');
 const sinon = require('sinon');
+const logging = require('@tryghost/logging');
 const RedisCache = require('../index');
 
 describe('Adapter Cache Redis', function () {
+    beforeEach(function () {
+        sinon.stub(logging, 'error');
+    });
+
     afterEach(function () {
         sinon.restore();
     });
@@ -80,6 +85,26 @@ describe('Adapter Cache Redis', function () {
 
             assert.equal(value, 'new value');
             assert.equal(redisCacheInstanceStub.set.args[0][0], 'testing-prefix:key-here');
+        });
+    });
+
+    describe('reset', function () {
+        it('catches an error when thrown during the reset', async function () {
+            const redisCacheInstanceStub = {
+                get: sinon.stub().resolves('value from cache'),
+                store: {
+                    getClient: sinon.stub().returns({
+                        on: sinon.stub()
+                    })
+                }
+            };
+            const cache = new RedisCache({
+                cache: redisCacheInstanceStub
+            });
+
+            await cache.reset();
+
+            assert.ok(logging.error.calledOnce, 'error was logged');
         });
     });
 });


### PR DESCRIPTION
# Additions

# #Added Non Redis Cluster Support

If the constructor of the redis client isn't a cluster then it will now fall back to returning the full client when requesting the primary node.

##  Added a reset method

The reset method first gets all keys stored for the cache and then one by one deletes them from redis. I tried to get it working with a single delete command but had issues. I am not sure if that was due to the length and complexity of the keys or something else but this way seems safer.

# Known Issues

I see one main issue with the cache adapter right now and that is that the `keyPrefix` is not required. I agree that it should be an optional field in config however it causes problems when it comes to getting all keys (this includes when deleting). The problem is that without a key prefix right now we generate the `_keysPattern` as empty. This means that it will return no keys. However, if we switched it to `*` then it would return all keys on that redis instance, then causing errors when resetting if there are any keys that they don't have permission to delete. Also, every time a reset occurred it would reset all cache and not just that specific cache.

I think the solution is to make the constructor of the cache pass in a name for that cache; for example `tags-public`, `posts-public` or `image-sizes` and not have that as something that has to be passed in as config. Then, in config, we can pass the key prefix and it would all get combined into the prefix. For example `[Config Defined Key Prefix][Cache Constructor Name]:[Key]`. So, in key prefix we would define `site:[site id]:` and the constructor would be given the name `posts-public` so that would combine into `site:[site id]:posts-public`.