### PR TITLE
Added setting to store last mention report email date

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.39/2023-03-14-12-26-add-last-mentions-email-report-timestamp-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.39/2023-03-14-12-26-add-last-mentions-email-report-timestamp-setting.js
@@ -3,6 +3,6 @@ const {addSetting} = require('../../utils');
 module.exports = addSetting({
     key: 'last_mentions_report_email_timestamp',
     value: null,
-    type: 'string',
+    type: 'number',
     group: 'core'
 });

--- a/ghost/core/core/server/data/migrations/versions/5.39/2023-03-14-12-26-add-last-mentions-email-report-timestamp-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.39/2023-03-14-12-26-add-last-mentions-email-report-timestamp-setting.js
@@ -1,0 +1,8 @@
+const {addSetting} = require('../../utils');
+
+module.exports = addSetting({
+    key: 'last_mentions_report_email_timestamp',
+    value: null,
+    type: 'string',
+    group: 'core'
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -1,5 +1,9 @@
 {
     "core": {
+        "last_mentions_report_email_timestamp": {
+            "defaultValue": null,
+            "type": "datetime"
+        },
         "db_hash": {
             "defaultValue": null,
             "type": "string"

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -2,7 +2,7 @@
     "core": {
         "last_mentions_report_email_timestamp": {
             "defaultValue": null,
-            "type": "datetime"
+            "type": "string"
         },
         "db_hash": {
             "defaultValue": null,

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -2,7 +2,7 @@
     "core": {
         "last_mentions_report_email_timestamp": {
             "defaultValue": null,
-            "type": "string"
+            "type": "number"
         },
         "db_hash": {
             "defaultValue": null,

--- a/ghost/core/test/integration/settings/settings.test.js
+++ b/ghost/core/test/integration/settings/settings.test.js
@@ -15,6 +15,7 @@ describe('Settings', function () {
 
     // Allowlist: Only this list needs updating when a core setting is added/removed/renamed
     const coreSettingKeys = [
+        'last_mentions_report_email_timestamp',
         'db_hash',
         'routes_hash',
         'next_update_check',

--- a/ghost/core/test/regression/models/model_settings.test.js
+++ b/ghost/core/test/regression/models/model_settings.test.js
@@ -5,7 +5,7 @@ const db = require('../../../core/server/data/db');
 // Stuff we are testing
 const models = require('../../../core/server/models');
 
-const SETTINGS_LENGTH = 81;
+const SETTINGS_LENGTH = 82;
 
 describe('Settings Model', function () {
     before(models.init);

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 73;
+            const allowedKeysLength = 74;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '82bdc4fbb962f036a30a17ea0f9f0f50';
     const currentFixturesHash = 'd99d3c2891e79b8662ed6a312490d2fd';
-    const currentSettingsHash = 'f6dee4268d973ee9c36c2b764ecf7cd0';
+    const currentSettingsHash = '7b567742b9667d38191d8455c422c5d5';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '82bdc4fbb962f036a30a17ea0f9f0f50';
     const currentFixturesHash = 'd99d3c2891e79b8662ed6a312490d2fd';
-    const currentSettingsHash = 'b0c8359b7482e39112e7c5739d43f11b';
+    const currentSettingsHash = 'c2cc0cd48b45d85c18a6ef28f956f2d8';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '82bdc4fbb962f036a30a17ea0f9f0f50';
     const currentFixturesHash = 'd99d3c2891e79b8662ed6a312490d2fd';
-    const currentSettingsHash = 'c2cc0cd48b45d85c18a6ef28f956f2d8';
+    const currentSettingsHash = 'f6dee4268d973ee9c36c2b764ecf7cd0';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -1,5 +1,9 @@
 {
     "core": {
+        "last_mentions_report_email_timestamp": {
+            "defaultValue": null,
+            "type": "string"
+        },
         "db_hash": {
             "defaultValue": null,
             "type": "string"


### PR DESCRIPTION
Because there is no guarantee about a daily job running exactly once a day, we need to store the last time that the email was sent, so that we can refrain from sending one if it's been less than a day since the last.

A setting has been used for this as we don't currently have a pattern for it, we might want to consider moving this to some kind of cache based solution in future. This has been added as a core setting so that we don't expose it via the API.