### PR TITLE
Fixed not providing a `boolean` value or slack-notifications service

### DIFF
--- a/ghost/core/core/server/services/slack-notifications/service.js
+++ b/ghost/core/core/server/services/slack-notifications/service.js
@@ -48,7 +48,7 @@ class SlackNotificationsServiceWrapper {
         const hostSettings = config.get('hostSettings');
         const urlUtils = require('../../../shared/url-utils');
         const siteUrl = urlUtils.getSiteUrl();
-        const isEnabled = labs.isSet('milestoneEmails') && hostSettings?.milestones?.enabled && hostSettings?.milestones?.url;
+        const isEnabled = (labs.isSet('milestoneEmails') && hostSettings?.milestones?.enabled && hostSettings?.milestones?.url) ? true : false;
         const webhookUrl = hostSettings?.milestones?.url;
 
         this.#api = SlackNotificationsServiceWrapper.create({siteUrl, isEnabled, webhookUrl});


### PR DESCRIPTION
no issue

The logic was incorrect and provided a URL instead of the expected `boolean` value for `isEnabled`