### PR TITLE
Added user notification toggle for Milestone emails

### DIFF
--- a/ghost/admin/app/controllers/settings/staff/user.js
+++ b/ghost/admin/app/controllers/settings/staff/user.js
@@ -217,6 +217,11 @@ export default class UserController extends Controller {
     }
 
     @action
+    toggleMilestoneNotifications(event) {
+        this.user.milestoneNotifications = event.target.checked;
+    }
+
+    @action
     toggleMemberEmailAlerts(type, event) {
         if (type === 'free-signup') {
             this.user.freeMemberSignupNotification = event.target.checked;

--- a/ghost/admin/app/models/user.js
+++ b/ghost/admin/app/models/user.js
@@ -41,6 +41,7 @@ export default BaseModel.extend(ValidationEngine, {
     paidSubscriptionStartedNotification: attr(),
     paidSubscriptionCanceledNotification: attr(),
     mentionNotifications: attr(),
+    milestoneNotifications: attr(),
     ghostPaths: service(),
     ajax: service(),
     session: service(),

--- a/ghost/admin/app/templates/settings/staff/user.hbs
+++ b/ghost/admin/app/templates/settings/staff/user.hbs
@@ -346,6 +346,27 @@
                                         </div>
                                     </div>
                                     {{/if}}
+                                    {{#if (feature 'milestoneEmails') }}
+                                    <div class="user-setting-toggle">
+                                        <div>
+                                            <label for="user-email">Milestones</label>
+                                            <p>Occasional summaries of your audience & revenue growth</p>
+                                        </div>
+                                        <div class="for-switch small">
+                                            <label class="switch" for="milestone-notifications" data-test-label="milestone-notifications">
+                                                <input
+                                                    id="milestone-notifications"
+                                                    type="checkbox"
+                                                    checked={{this.user.milestoneNotifications}}
+                                                    class="gh-input"
+                                                    {{on "change" this.toggleMilestoneNotifications}}
+                                                    data-test-checkbox="milestone-notifications"
+                                                >
+                                                <span class="input-toggle-component"></span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                {{/if}}
                                 {{/if}}
                                 {{/if}}
                             </GhFormGroup>

--- a/ghost/admin/tests/acceptance/staff-test.js
+++ b/ghost/admin/tests/acceptance/staff-test.js
@@ -82,6 +82,7 @@ describe('Acceptance: Staff', function () {
             enableStripe(this.server);
             enableLabsFlag(this.server, 'webmentions');
             enableLabsFlag(this.server, 'webmentionEmails');
+            enableLabsFlag(this.server, 'milestoneEmails');
 
             admin = this.server.create('user', {email: 'admin@example.com', roles: [adminRole]});
 
@@ -873,11 +874,13 @@ describe('Acceptance: Staff', function () {
                 expect(find('[data-test-checkbox="paid-started-notifications"]')).to.not.be.checked;
                 expect(find('[data-test-checkbox="paid-canceled-notifications"]')).to.not.be.checked;
                 expect(find('[data-test-checkbox="mention-notifications"]')).to.not.be.checked;
+                expect(find('[data-test-checkbox="milestone-notifications"]')).to.not.be.checked;
 
                 await click('[data-test-label="free-signup-notifications"]');
                 await click('[data-test-label="paid-started-notifications"]');
                 await click('[data-test-label="paid-canceled-notifications"]');
                 await click('[data-test-label="mention-notifications"]');
+                await click('[data-test-label="milestone-notifications"]');
                 await click('[data-test-save-button]');
 
                 await visit(`/settings/staff/${admin.slug}`);
@@ -886,6 +889,7 @@ describe('Acceptance: Staff', function () {
                 expect(find('[data-test-checkbox="paid-started-notifications"]')).to.be.checked;
                 expect(find('[data-test-checkbox="paid-canceled-notifications"]')).to.be.checked;
                 expect(find('[data-test-checkbox="mention-notifications"]')).to.be.checked;
+                expect(find('[data-test-checkbox="milestone-notifications"]')).to.be.checked;
             });
         });
 


### PR DESCRIPTION
refs https://www.notion.so/ghost/Marketing-Milestone-email-campaigns-1d2c9dee3cfa4029863edb16092ad5c4?pvs=4
needs https://github.com/TryGhost/Ghost/pull/16318

- Added a toggle to disable and enable receiving Milestone emails behind a feature flag