### PR TITLE
Fixed broken empty state in mentions admin url

### DIFF
--- a/ghost/admin/app/services/mention-utils.js
+++ b/ghost/admin/app/services/mention-utils.js
@@ -6,7 +6,12 @@ export default class MentionUtilsService extends Service {
     async loadGroupedMentions(mentions) {
         // Fetch mentions with the same source
         const sources = mentions.mapBy('source').uniq();
-        const sourceMentions = await this.store.query('mention', {filter: `source:[${sources.map(s => `'${s}'`).join(',')}]`});
+        let filter;
+        if (sources.length > 0) {
+            filter = `source:[${sources.map(s => `'${s}'`).join(',')}]`;
+        }
+
+        const sourceMentions = await this.store.query('mention', {filter});
         mentions.forEach((mention) => {
             mention.set('mentions', sourceMentions.filterBy('source', mention.source));
         });


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2734

With WebMentions flag on, navigating to `/ghost/#/mentions` on Admin when there are no mentions gives a 400 error page instead of the intended empty state.