### PR TITLE
Added example translation for emails within Ghost

### DIFF
--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -17,6 +17,7 @@ const tiersService = require('../tiers');
 const newslettersService = require('../newsletters');
 const memberAttributionService = require('../member-attribution');
 const emailSuppressionList = require('../email-suppression-list');
+const {t} = require('../i18n');
 
 const MAGIC_LINK_TOKEN_VALIDITY = 24 * 60 * 60 * 1000;
 const MAGIC_LINK_TOKEN_VALIDITY_AFTER_USAGE = 10 * 60 * 1000;
@@ -58,28 +59,28 @@ function createApiInstance(config) {
                 const siteTitle = settingsCache.get('title');
                 switch (type) {
                 case 'subscribe':
-                    return `📫 Confirm your subscription to ${siteTitle}`;
+                    return t(`📫 Confirm your subscription to {{siteTitle}}`, {siteTitle});
                 case 'signup':
-                    return `🙌 Complete your sign up to ${siteTitle}!`;
+                    return t(`🙌 Complete your sign up to {{siteTitle}}!`, {siteTitle});
                 case 'signup-paid':
-                    return `🙌 Thank you for signing up to ${siteTitle}!`;
+                    return t(`🙌 Thank you for signing up to {{siteTitle}}!`, {siteTitle});
                 case 'updateEmail':
-                    return `📫 Confirm your email update for ${siteTitle}!`;
+                    return t(`📫 Confirm your email update for {{siteTitle}}!`, {siteTitle});
                 case 'signin':
                 default:
-                    return `🔑 Secure sign in link for ${siteTitle}`;
+                    return t(`🔑 Secure sign in link for {{siteTitle}}`, {siteTitle});
                 }
             },
             getText(url, type, email) {
                 const siteTitle = settingsCache.get('title');
                 switch (type) {
                 case 'subscribe':
-                    return `
+                    return t(`
                         Hey there,
 
-                        You're one tap away from subscribing to ${siteTitle} — please confirm your email address with this link:
+                        You're one tap away from subscribing to {{siteTitle}} — please confirm your email address with this link:
 
-                        ${url}
+                        {{- url}}
 
                         For your security, the link will expire in 24 hours time.
 
@@ -87,16 +88,16 @@ function createApiInstance(config) {
 
                         ---
 
-                        Sent to ${email}
+                        Sent to {{email}}
                         If you did not make this request, you can simply delete this message. You will not be subscribed.
-                        `;
+                        `, {url, email, siteTitle});
                 case 'signup':
-                    return `
+                    return t(`
                         Hey there!
 
-                        Tap the link below to complete the signup process for ${siteTitle}, and be automatically signed in:
+                        Tap the link below to complete the signup process for {{siteTitle}}, and be automatically signed in:
 
-                        ${url}
+                        {{- url}}
 
                         For your security, the link will expire in 24 hours time.
 
@@ -104,16 +105,16 @@ function createApiInstance(config) {
 
                         ---
 
-                        Sent to ${email}
+                        Sent to {{email}}
                         If you did not make this request, you can simply delete this message. You will not be signed up, and no account will be created for you.
-                        `;
+                        `, {url, email, siteTitle});
                 case 'signup-paid':
-                    return `
+                    return t(`
                         Hey there!
 
-                        Thank you for subscribing to ${siteTitle}. Tap the link below to be automatically signed in:
+                        Thank you for subscribing to {{siteTitle}}. Tap the link below to be automatically signed in:
 
-                        ${url}
+                        {{- url}}
 
                         For your security, the link will expire in 24 hours time.
 
@@ -121,32 +122,32 @@ function createApiInstance(config) {
 
                         ---
 
-                        Sent to ${email}
-                        Thank you for subscribing to ${siteTitle}!
-                        `;
+                        Sent to {{email}}
+                        Thank you for subscribing to {{siteTitle}}!
+                        `, {url, email, siteTitle});
                 case 'updateEmail':
-                    return `
+                    return t(`
                             Hey there,
 
                             Please confirm your email address with this link:
 
-                            ${url}
+                            {{- url}}
 
                             For your security, the link will expire in 24 hours time.
 
                             ---
 
-                            Sent to ${email}
+                            Sent to {{email}}
                             If you did not make this request, you can simply delete this message. This email address will not be used.
-                            `;
+                            `, {url, email});
                 case 'signin':
                 default:
-                    return `
+                    return t(`
                         Hey there,
 
-                        Welcome back! Use this link to securely sign in to your ${siteTitle} account:
+                        Welcome back! Use this link to securely sign in to your {{siteTitle}} account:
 
-                        ${url}
+                        {{- url}}
 
                         For your security, the link will expire in 24 hours time.
 
@@ -154,9 +155,9 @@ function createApiInstance(config) {
 
                         ---
 
-                        Sent to ${email}
+                        Sent to {{email}}
                         If you did not make this request, you can safely ignore this email.
-                        `;
+                        `, {url, email, siteTitle});
                 }
             },
             getHTML(url, type, email) {
@@ -167,16 +168,16 @@ function createApiInstance(config) {
                 const accentColor = settingsCache.get('accent_color');
                 switch (type) {
                 case 'subscribe':
-                    return subscribeEmail({url, email, siteTitle, accentColor, siteDomain, siteUrl});
+                    return subscribeEmail({t, url, email, siteTitle, accentColor, siteDomain, siteUrl});
                 case 'signup':
-                    return signupEmail({url, email, siteTitle, accentColor, siteDomain, siteUrl});
+                    return signupEmail({t, url, email, siteTitle, accentColor, siteDomain, siteUrl});
                 case 'signup-paid':
-                    return signupPaidEmail({url, email, siteTitle, accentColor, siteDomain, siteUrl});
+                    return signupPaidEmail({t, url, email, siteTitle, accentColor, siteDomain, siteUrl});
                 case 'updateEmail':
-                    return updateEmail({url, email, siteTitle, accentColor, siteDomain, siteUrl});
+                    return updateEmail({t, url, email, siteTitle, accentColor, siteDomain, siteUrl});
                 case 'signin':
                 default:
-                    return signinEmail({url, email, siteTitle, accentColor, siteDomain, siteUrl});
+                    return signinEmail({t, url, email, siteTitle, accentColor, siteDomain, siteUrl});
                 }
             }
         },

--- a/ghost/core/core/server/services/members/emails/signin.js
+++ b/ghost/core/core/server/services/members/emails/signin.js
@@ -1,10 +1,10 @@
-module.exports = ({siteTitle, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => `
+module.exports = ({t, siteTitle, email, url, accentColor = '#15212A', siteDomain, siteUrl}) => `
 <!doctype html>
 <html>
   <head>
     <meta name="viewport" content="width=device-width">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>🔑 Secure sign in link for ${siteTitle}</title>
+    <title>${t('🔑 Secure sign in link for {{siteTitle}}', {siteTitle})}</title>
     <style>
     /* -------------------------------------
         RESPONSIVE AND MOBILE FRIENDLY STYLES
@@ -107,7 +107,7 @@ module.exports = ({siteTitle, email, url, accentColor = '#15212A', siteDomain, s
           <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
 
             <!-- START CENTERED CONTAINER -->
-            <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">Welcome back to ${siteTitle}!</span>
+            <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">${t('Welcome back to {{siteTitle}}!', {siteTitle})}</span>
             <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
 
               <!-- START MAIN CONTENT AREA -->
@@ -116,8 +116,8 @@ module.exports = ({siteTitle, email, url, accentColor = '#15212A', siteDomain, s
                   <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
-                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: bold; line-height: 25px; margin: 0; margin-bottom: 15px;">Hey there,</p>
-                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">Welcome back! Use this link to securely sign in to your ${siteTitle} account:</p>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: bold; line-height: 25px; margin: 0; margin-bottom: 15px;">${t('Hey there,')}</p>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 32px;">${t('Welcome back! Use this link to securely sign in to your {{siteTitle}} account:', {siteTitle})}</p>
                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;">
                           <tbody>
                             <tr>
@@ -125,7 +125,7 @@ module.exports = ({siteTitle, email, url, accentColor = '#15212A', siteDomain, s
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${accentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${accentColor};">Sign in to ${siteTitle}</a> </td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: ${accentColor}; border-radius: 5px; text-align: center;"> <a href="${url}" target="_blank" style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: ${accentColor};">${t('Sign in to {{siteTitle}}', {siteTitle})}</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -133,10 +133,10 @@ module.exports = ({siteTitle, email, url, accentColor = '#15212A', siteDomain, s
                             </tr>
                           </tbody>
                         </table>
-                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; line-height: 25px; margin: 0; margin-bottom: 25px;">For your security, the link will expire in 24 hours time.</p>
-                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; line-height: 25px; margin: 0; margin-bottom: 30px;">See you soon!</p>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; line-height: 25px; margin: 0; margin-bottom: 25px;">${t('For your security, the link will expire in 24 hours time.')}</p>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; line-height: 25px; margin: 0; margin-bottom: 30px;">${t('See you soon!')}</p>
                         <hr/>
-                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 5px;">You can also copy & paste this URL into your browser:</p>
+                        <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 5px;">${t('You can also copy & paste this URL into your browser:')}</p>
                         <p style="word-break: break-all; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 15px; line-height: 25px; margin-top:0; color: #3A464C;">${url}</p>
                       </td>
                     </tr>

--- a/ghost/i18n/locales/en/ghost.json
+++ b/ghost/i18n/locales/en/ghost.json
@@ -1,1 +1,19 @@
-{}
+{
+    "\n                            Hey there,\n\n                            Please confirm your email address with this link:\n\n                            {{url}}\n\n                            For your security, the link will expire in 24 hours time.\n\n                            ---\n\n                            Sent to {{email}}\n                            If you did not make this request, you can simply delete this message. This email address will not be used.\n                            ": "",
+    "\n                        Hey there,\n\n                        Welcome back! Use this link to securely sign in to your {{siteTitle}} account:\n\n                        {{url}}\n\n                        For your security, the link will expire in 24 hours time.\n\n                        See you soon!\n\n                        ---\n\n                        Sent to {{email}}\n                        If you did not make this request, you can safely ignore this email.\n                        ": "",
+    "\n                        Hey there,\n\n                        You're one tap away from subscribing to {{siteTitle}} — please confirm your email address with this link:\n\n                        {{url}}\n\n                        For your security, the link will expire in 24 hours time.\n\n                        All the best!\n\n                        ---\n\n                        Sent to {{email}}\n                        If you did not make this request, you can simply delete this message. You will not be subscribed.\n                        ": "",
+    "\n                        Hey there!\n\n                        Tap the link below to complete the signup process for {{siteTitle}}, and be automatically signed in:\n\n                        {{url}}\n\n                        For your security, the link will expire in 24 hours time.\n\n                        See you soon!\n\n                        ---\n\n                        Sent to {{email}}\n                        If you did not make this request, you can simply delete this message. You will not be signed up, and no account will be created for you.\n                        ": "",
+    "\n                        Hey there!\n\n                        Thank you for subscribing to {{siteTitle}}. Tap the link below to be automatically signed in:\n\n                        {{url}}\n\n                        For your security, the link will expire in 24 hours time.\n\n                        See you soon!\n\n                        ---\n\n                        Sent to {{email}}\n                        Thank you for subscribing to {{siteTitle}}!\n                        ": "",
+    "📫 Confirm your email update for {{siteTitle}}!": "",
+    "📫 Confirm your subscription to {{siteTitle}}": "",
+    "🔑 Secure sign in link for {{siteTitle}}": "",
+    "🙌 Complete your sign up to {{siteTitle}}!": "",
+    "🙌 Thank you for signing up to {{siteTitle}}!": "",
+    "For your security, the link will expire in 24 hours time.": "",
+    "Hey there,": "",
+    "See you soon!": "",
+    "Sign in to {{siteTitle}}": "",
+    "Welcome back to {{siteTitle}}!": "",
+    "Welcome back! Use this link to securely sign in to your {{siteTitle}} account:": "",
+    "You can also copy & paste this URL into your browser:": ""
+}

--- a/ghost/i18n/locales/nl/ghost.json
+++ b/ghost/i18n/locales/nl/ghost.json
@@ -1,1 +1,19 @@
-{}
+{
+    "\n                            Hey there,\n\n                            Please confirm your email address with this link:\n\n                            {{url}}\n\n                            For your security, the link will expire in 24 hours time.\n\n                            ---\n\n                            Sent to {{email}}\n                            If you did not make this request, you can simply delete this message. This email address will not be used.\n                            ": "",
+    "\n                        Hey there,\n\n                        Welcome back! Use this link to securely sign in to your {{siteTitle}} account:\n\n                        {{url}}\n\n                        For your security, the link will expire in 24 hours time.\n\n                        See you soon!\n\n                        ---\n\n                        Sent to {{email}}\n                        If you did not make this request, you can safely ignore this email.\n                        ": "",
+    "\n                        Hey there,\n\n                        You're one tap away from subscribing to {{siteTitle}} — please confirm your email address with this link:\n\n                        {{url}}\n\n                        For your security, the link will expire in 24 hours time.\n\n                        All the best!\n\n                        ---\n\n                        Sent to {{email}}\n                        If you did not make this request, you can simply delete this message. You will not be subscribed.\n                        ": "",
+    "\n                        Hey there!\n\n                        Tap the link below to complete the signup process for {{siteTitle}}, and be automatically signed in:\n\n                        {{url}}\n\n                        For your security, the link will expire in 24 hours time.\n\n                        See you soon!\n\n                        ---\n\n                        Sent to {{email}}\n                        If you did not make this request, you can simply delete this message. You will not be signed up, and no account will be created for you.\n                        ": "",
+    "\n                        Hey there!\n\n                        Thank you for subscribing to {{siteTitle}}. Tap the link below to be automatically signed in:\n\n                        {{url}}\n\n                        For your security, the link will expire in 24 hours time.\n\n                        See you soon!\n\n                        ---\n\n                        Sent to {{email}}\n                        Thank you for subscribing to {{siteTitle}}!\n                        ": "",
+    "📫 Confirm your email update for {{siteTitle}}!": "",
+    "📫 Confirm your subscription to {{siteTitle}}": "",
+    "🔑 Secure sign in link for {{siteTitle}}": "",
+    "🙌 Complete your sign up to {{siteTitle}}!": "",
+    "🙌 Thank you for signing up to {{siteTitle}}!": "",
+    "For your security, the link will expire in 24 hours time.": "",
+    "Hey there,": "",
+    "See you soon!": "",
+    "Sign in to {{siteTitle}}": "",
+    "Welcome back to {{siteTitle}}!": "",
+    "Welcome back! Use this link to securely sign in to your {{siteTitle}} account:": "",
+    "You can also copy & paste this URL into your browser:": ""
+}


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/15502

- this adds the i18n translation wrapper to the titles, plaintext versions and one HTML version of the member emails
