### PR TITLE
🐛 Fixed editor crashing with unknown cards in mobiledoc

### DIFF
--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-editor.js
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-editor.js
@@ -189,7 +189,12 @@ export default class KoenigEditor extends Component {
             spellcheck: this.spellcheck,
             autofocus: this.autofocus,
             atoms,
-            cards
+            cards,
+            unknownCardHandler: ({env}) => {
+                console.warn(`Unknown card encountered: ${env.name}`); //eslint-disable-line
+                
+                env.remove();
+            }
         }, options);
     }
 
@@ -807,7 +812,7 @@ export default class KoenigEditor extends Component {
         // refresh drag/drop
         // TODO: can be made more performant by only refreshing when droppable
         // order changes or when sections are added/removed
-        this._cardDragDropContainer.refresh();
+        this._cardDragDropContainer?.refresh();
     }
 
     cursorDidChange(editor) {


### PR DESCRIPTION
refs TryGhost/Team#2702

- adds a default handler for unknown cards: 
- logs a warning message to the console 
- removes the card from the mobiledoc