### PR TITLE
Switched around CI machine allocation

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -21,6 +21,8 @@ on:
         description: 'Owner password (override)'
         required: false
         type: string
+concurrency:
+  group: ${{ github.workflow }}
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: linux
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     environment: ${{ github.event.inputs.environment || 'browser-tests-local' }}
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   lint:
-    runs-on: linux
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     name: Lint
     steps:
@@ -36,7 +36,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   admin-tests:
-    runs-on: linux
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     name: Admin - Chrome
     env:
@@ -71,7 +71,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   migrations:
-    runs-on: linux
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ghost/core
@@ -135,7 +135,7 @@ jobs:
       - run: yarn knex-migrator migrate --force
 
   unit-tests:
-    runs-on: linux
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
@@ -167,7 +167,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   database-tests:
-    runs-on: linux
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ghost/core
@@ -278,7 +278,7 @@ jobs:
   ghost-cli:
     name: Ghost-CLI
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
-    runs-on: linux
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -337,7 +337,7 @@ jobs:
   coverage:
     name: Coverage
     needs: [unit-tests, admin-tests]
-    runs-on: linux
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Restore coverage


### PR DESCRIPTION
- now the vast majority of our flaky tests are gone, we don't need the bigger machines
- however, browser tests seem to be a little slow, so we can try giving them more power than the defaults
- this should also help with resource contention when we have multiple jobs running at the same time, as we have double the numbers of runners on the free machines