### PR TITLE
Fixed Stripe connection modal button visibility

### DIFF
--- a/ghost/admin/app/components/modal-stripe-connect.hbs
+++ b/ghost/admin/app/components/modal-stripe-connect.hbs
@@ -9,6 +9,7 @@
 <div class="modal-body" {{did-insert this.updateSuccessModifier}}>
     <Settings::Members::StripeSettingsForm
         @setStripeConnectIntegrationTokenSetting={{this.setStripeConnectIntegrationTokenSetting}}
+        @reset={{this.reset}}
         @onConnected={{this.updateSuccessModifier}}
         @onDisconnected={{this.updateSuccessModifier}}
     />

--- a/ghost/admin/app/components/settings/members/stripe-settings-form.js
+++ b/ghost/admin/app/components/settings/members/stripe-settings-form.js
@@ -259,6 +259,7 @@ export default class StripeSettingsForm extends Component {
         yield this.ajax.delete(url);
         yield this.settings.reload();
 
+        this.args.reset();
         this.args.onDisconnected?.();
     }
 

--- a/ghost/admin/app/components/settings/members/stripe-settings-form.js
+++ b/ghost/admin/app/components/settings/members/stripe-settings-form.js
@@ -259,7 +259,7 @@ export default class StripeSettingsForm extends Component {
         yield this.ajax.delete(url);
         yield this.settings.reload();
 
-        this.args.reset();
+        this.args.reset?.();
         this.args.onDisconnected?.();
     }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2483

- the button is toggled depending on `stripeConnectIntegrationToken` which is a calculated value
- however, this calculated value isn't reset when Stripe is disconnected right away without closing the modal
- the reset action was already available and it's now passed to `StripeSettingsForm`, so that it can be called when Stripe is disconnected