### PR TITLE
Highlighted successful in the theme activation modal

### DIFF
--- a/ghost/admin/app/components/modals/design/theme-errors.hbs
+++ b/ghost/admin/app/components/modals/design/theme-errors.hbs
@@ -3,7 +3,7 @@
         <header class="modal-header">
             <h1 data-test-theme-warnings-title>
                 {{#if @data.canActivate}}
-                    {{@data.title}} with {{#if @data.errors}}errors{{else}}warnings{{/if}}
+                    {{{@data.title}}} with {{#if @data.errors}}errors{{else}}warnings{{/if}}
                 {{else}}
                     {{@data.title}}
                 {{/if}}

--- a/ghost/admin/app/services/theme-management.js
+++ b/ghost/admin/app/services/theme-management.js
@@ -122,7 +122,7 @@ export default class ThemeManagementService extends Service {
 
                     if (!isEmpty(warnings) || !isEmpty(errors)) {
                         resultModal = this.modals.open('modals/design/theme-errors', {
-                            title: 'Activation successful',
+                            title: 'Activation <span class="green">successful</span>',
                             canActivate: true,
                             warnings,
                             errors


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2713

- currently, it's not clear enough that if the theme activation was successful
- highlighting "successful" makes it easier to know the main action was successful even though there are errors to fix

Before:
<img width="589" alt="CleanShot 2023-03-21 at 2 48 16@2x" src="https://user-images.githubusercontent.com/1418797/226535575-7171dcc6-e752-49c5-bfea-ee68454b6b99.png">

After:
<img width="580" alt="CleanShot 2023-03-21 at 2 48 06@2x" src="https://user-images.githubusercontent.com/1418797/226535587-6aad4a6f-3fba-43d9-b598-f7c99dcf4850.png">
