### PR TITLE
Added migration for Self-Serve Integration permissions 

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-18-43-add-self-serve-migration-and-permissions.js
+++ b/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-18-43-add-self-serve-migration-and-permissions.js
@@ -1,0 +1,25 @@
+const {combineTransactionalMigrations, addPermissionWithRoles} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Import database',
+        action: 'importContent',
+        object: 'db'
+    }, [
+        'Self-Serve Migration Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add Members',
+        action: 'add',
+        object: 'member'
+    }, [
+        'Self-Serve Migration Integration'
+    ]),
+    addPermissionWithRoles({
+        name: 'Read tags',
+        action: 'read',
+        object: 'tag'
+    }, [
+        'Self-Serve Migration Integration'
+    ])
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -796,6 +796,11 @@
                 "Ghost Explore Integration": {
                     "explore": "read"
                 },
+                "Self-Serve Migration Integration": {
+                    "db": "importContent",
+                    "member": "add",
+                    "tag": "read"
+                },
                 "Admin Integration": {
                     "mail": "all",
                     "notification": "all",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/integrations.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/integrations.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integrations API As Administrator Can't see Self-Serve or any other integration 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "You do not have permission to browse integrations",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Permission error, cannot list integrations.",
+      "property": null,
+      "type": "NoPermissionError",
+    },
+  ],
+}
+`;
+
+exports[`Integrations API As Administrator Can't see Self-Serve or any other integration 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "280",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -48,7 +48,7 @@ describe('Database Migration (special functions)', function () {
             permissions.length.should.eql(110);
 
             permissions.should.havePermission('Export database', ['Administrator', 'DB Backup Integration']);
-            permissions.should.havePermission('Import database', ['Administrator', 'DB Backup Integration']);
+            permissions.should.havePermission('Import database', ['Administrator', 'Self-Serve Migration Integration', 'DB Backup Integration']);
             permissions.should.havePermission('Delete all content', ['Administrator', 'DB Backup Integration']);
             permissions.should.havePermission('Backup database', ['Administrator', 'DB Backup Integration']);
 
@@ -72,7 +72,7 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Generate slugs', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
 
             permissions.should.havePermission('Browse tags', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
-            permissions.should.havePermission('Read tags', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Read tags', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Self-Serve Migration Integration']);
             permissions.should.havePermission('Edit tags', ['Administrator', 'Editor', 'Admin Integration']);
             permissions.should.havePermission('Add tags', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
             permissions.should.havePermission('Delete tags', ['Administrator', 'Editor', 'Admin Integration']);
@@ -145,7 +145,7 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Browse Members');
             permissions.should.havePermission('Read Members');
             permissions.should.havePermission('Edit Members');
-            permissions.should.havePermission('Add Members');
+            permissions.should.havePermission('Add Members', ['Administrator', 'Admin Integration', 'Self-Serve Migration Integration']);
             permissions.should.havePermission('Delete Members');
 
             permissions.should.havePermission('Browse offers');

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -191,7 +191,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
-                const FIXTURE_COUNT = 98;
+                const FIXTURE_COUNT = 101;
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', FIXTURE_COUNT);
@@ -201,7 +201,7 @@ describe('Migration Fixture Utils', function () {
                 permsAllStub.calledOnce.should.be.true();
                 rolesAllStub.calledOnce.should.be.true();
                 dataMethodStub.filter.callCount.should.eql(FIXTURE_COUNT);
-                dataMethodStub.find.callCount.should.eql(8);
+                dataMethodStub.find.callCount.should.eql(9);
                 baseUtilAttachStub.callCount.should.eql(FIXTURE_COUNT);
 
                 fromItem.related.callCount.should.eql(FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '67a16bde6f7dd46c5e07d7fca1005a53';
-    const currentFixturesHash = 'dc2d5430edd212bf579e3533bdbfe806';
+    const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
     const currentSettingsHash = '7b567742b9667d38191d8455c422c5d5';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -976,6 +976,11 @@
                 "Ghost Explore Integration": {
                     "explore": "read"
                 },
+                "Self-Serve Migration Integration": {
+                    "db": "importContent",
+                    "member": "add",
+                    "tag": "read"
+                },
                 "Admin Integration": {
                     "mail": "all",
                     "notification": "all",


### PR DESCRIPTION
⚠️  this branch is a rebase over https://github.com/TryGhost/Ghost/pull/16461 cleanup the commits before merging.

refs https://github.com/TryGhost/Team/issues/2790
needs https://github.com/TryGhost/Ghost/pull/16461

This migration adds permissions for Self-Serve Migration Integration to have access to Admin APIs:

POST /ghost/api/admin/db
POST /ghost/api/admin/db/media/inline
POST /ghost/api/admin/members/upload

🚨 Note on the order of the migration. I've copied [the order of explore-related migrations](https://github.com/TryGhost/Ghost/tree/3623a652ba7b91d59c6f1183cf91a667357178a9/ghost/core/core/server/data/migrations/versions/5.3) as they were doing very similar thing. 
<img width="568" alt="image" src="https://user-images.githubusercontent.com/675397/227306562-69992e7a-e4f5-44bf-8515-087637a4383d.png">
