### PR TITLE
🐛 Fixed broken editor breadcrumbs when opening a new post from analytics

### DIFF
--- a/ghost/admin/app/routes/editor.js
+++ b/ghost/admin/app/routes/editor.js
@@ -16,7 +16,7 @@ export default AuthenticatedRoute.extend({
     },
 
     setupController(controller, model, transition) {
-        if (transition.from?.name === 'posts.analytics') {
+        if (transition.from?.name === 'posts.analytics' && transition.to?.name !== 'editor.new') {
             controller.fromAnalytics = true;
         }
     },

--- a/ghost/admin/app/templates/editor.hbs
+++ b/ghost/admin/app/templates/editor.hbs
@@ -18,14 +18,14 @@
                     <div class="flex items-center pe-auto h-100">
                         {{#if this.ui.isFullScreen}}
                             {{#if this.fromAnalytics }}
-                                <LinkTo @route="posts.analytics" @model={{this.post.id}} class="gh-btn-editor gh-editor-back-button">
+                                <LinkTo @route="posts.analytics" @model={{this.post.id}} class="gh-btn-editor gh-editor-back-button" data-test-breadcrumb>
                                     <span>
                                         {{svg-jar "arrow-left"}}
                                         Analytics
                                     </span>
                                 </LinkTo>
                             {{else}}
-                                <LinkTo @route={{pluralize this.post.displayName }} class="gh-btn-editor gh-editor-back-button" data-test-link={{pluralize this.post.displayName}}>
+                                <LinkTo @route={{pluralize this.post.displayName }} class="gh-btn-editor gh-editor-back-button" data-test-link={{pluralize this.post.displayName}} data-test-breadcrumb>
                                     <span>
                                         {{svg-jar "arrow-left"}}
                                         {{capitalize (pluralize this.post.displayName)}}

--- a/ghost/admin/tests/acceptance/editor-test.js
+++ b/ghost/admin/tests/acceptance/editor-test.js
@@ -702,5 +702,45 @@ describe('Acceptance: Editor', function () {
                 ],
                 ghostVersion: '4.0'}));
         });
+
+        it('renders a breadcrumb back to the post list', async function () {
+            let post = this.server.create('post', {authors: [author]});
+
+            await visit(`/editor/post/${post.id}`);
+
+            expect(
+                find('[data-test-breadcrumb]').textContent.trim(),
+                'breadcrumb text'
+            ).to.contain('Posts');
+
+            expect(
+                find('[data-test-breadcrumb]').getAttribute('href'),
+                'breadcrumb link'
+            ).to.equal('/ghost/posts');
+        });
+
+        it('renders a breadcrumb back to the analytics list if that\'s where we came from ', async function () {
+            let post = this.server.create('post', {
+                authors: [author],
+                status: 'published',
+                title: 'Published Post'
+            });
+
+            // visit the analytics page for the post
+            await visit(`/posts/analytics/${post.id}`);
+            // now visit the editor for the same post
+            await visit(`/editor/post/${post.id}`);
+
+            // Breadcrumbs should point back to Analytics page
+            expect(
+                find('[data-test-breadcrumb]').textContent.trim(),
+                'breadcrumb text'
+            ).to.contain('Analytics');
+
+            expect(
+                find('[data-test-breadcrumb]').getAttribute('href'),
+                'breadcrumb link'
+            ).to.equal(`/ghost/posts/analytics/${post.id}`);
+        });
     });
 });


### PR DESCRIPTION
refs TryGhost/Team#2401

- Previously, if you opened a new post using the plus button on the sidebar
while on a different post's analytics page, the breadcrumbs would point
back to Analytics instead of the Posts list view. Going back to Analytics
brought you back to the analytics page for the post you just created,
which wasn't populating since it likely hadn't been published yet.
- This commit fixes the issue by setting fromAnalytics = false if transitioning
to a new Post, even if the previous route was the analytics page.
