### PR TITLE
Fixed timezone issue with email renderer tests

### DIFF
--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -1068,6 +1068,7 @@ describe('Email renderer', function () {
 
         it('uses post published_at', async function () {
             const html = '';
+            settings.timezone = 'Etc/UTC';
             const post = createModel({
                 posts_meta: createModel({}),
                 loaded: ['posts_meta'],
@@ -1283,6 +1284,7 @@ describe('Email renderer', function () {
         it('latestPosts can be enabled', async function () {
             labsEnabled = true;
             const html = '';
+            settings.timezone = 'Etc/UTC';
             const post = createModel({
                 posts_meta: createModel({}),
                 loaded: ['posts_meta'],


### PR DESCRIPTION
no issue

- The tests didn't explicitly set the timezone that the EmailRenderer uses, so it was falling back to just local timezone
- This meant that the tests would pass on CI and for most people who are +- a few hours from UTC, but not for me in PST.
