### PR TITLE
Allowed autoRefresh option to edit model method

### DIFF
--- a/ghost/core/core/server/models/base/plugins/sanitize.js
+++ b/ghost/core/core/server/models/base/plugins/sanitize.js
@@ -41,7 +41,7 @@ module.exports = function (Bookshelf) {
             case 'add':
                 return baseOptions.concat(extraOptions, ['autoRefresh']);
             case 'edit':
-                return baseOptions.concat(extraOptions, ['id', 'require']);
+                return baseOptions.concat(extraOptions, ['id', 'require', 'autoRefresh']);
             case 'findOne':
                 return baseOptions.concat(extraOptions, ['columns', 'require', 'mongoTransformer']);
             case 'findAll':

--- a/ghost/core/core/server/services/webhooks/trigger.js
+++ b/ghost/core/core/server/services/webhooks/trigger.js
@@ -31,7 +31,7 @@ class WebhookTrigger {
                 last_triggered_at: Date.now(),
                 last_triggered_status: data.statusCode,
                 last_triggered_error: data.error || null
-            }, {id: webhook.id})
+            }, {id: webhook.id, autoRefresh: false})
             .catch(() => {
                 logging.warn(`Unable to update "last_triggered" for webhook: ${webhook.id}`);
             });


### PR DESCRIPTION
- this allows us to disable auto-refresh in Bookshelf if we don't need
  an updated model, which saves an extra SQL query