### PR TITLE
Grouped mentions from same source in email report

### DIFF
--- a/ghost/core/core/server/services/mentions-email-report/service.js
+++ b/ghost/core/core/server/services/mentions-email-report/service.js
@@ -63,23 +63,13 @@ module.exports = {
              * @returns {Promise<string>}
              */
             async renderHTML(report, recipient) {
-                const unqiueMentions = {};
-
-                report?.mentions?.forEach((mention) => {
-                    if (unqiueMentions[mention.source]) {
-                        unqiueMentions[mention.source].count += 1;
-                        unqiueMentions[mention.source].hasMultiple = true;
-                    } else {
-                        unqiueMentions[mention.source] = {
-                            ...mention,
-                            count: 1
-                        };
-                    }
+                // Filter out mentions with duplicate source url from the report
+                const uniqueMentions = report.mentions.filter((mention, index, self) => {
+                    return self.findIndex(m => m.sourceUrl.href === mention.sourceUrl.href) === index;
                 });
 
                 return staffService.api.emails.renderHTML('mention-report', {
-                    mentions: Object.values(unqiueMentions),
-                    report: report,
+                    mentions: uniqueMentions,
                     recipient: recipient,
                     hasMoreMentions: report.mentions.length > 5
                 });

--- a/ghost/core/core/server/services/mentions-email-report/service.js
+++ b/ghost/core/core/server/services/mentions-email-report/service.js
@@ -63,7 +63,22 @@ module.exports = {
              * @returns {Promise<string>}
              */
             async renderHTML(report, recipient) {
+                const unqiueMentions = {};
+
+                report?.mentions?.forEach((mention) => {
+                    if (unqiueMentions[mention.source]) {
+                        unqiueMentions[mention.source].count += 1;
+                        unqiueMentions[mention.source].hasMultiple = true;
+                    } else {
+                        unqiueMentions[mention.source] = {
+                            ...mention,
+                            count: 1
+                        };
+                    }
+                });
+
                 return staffService.api.emails.renderHTML('mention-report', {
+                    mentions: Object.values(unqiueMentions),
                     report: report,
                     recipient: recipient,
                     hasMoreMentions: report.mentions.length > 5

--- a/ghost/staff-service/lib/email-templates/mention-report.hbs
+++ b/ghost/staff-service/lib/email-templates/mention-report.hbs
@@ -31,10 +31,7 @@
                         <figure style="margin:0 0 1.5em;padding:0;width:100%;">
                           <a style="display:flex;min-height:148px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none" href="{{mention.sourceUrl}}">
                             <div style="display:inline-block; width:100%; padding:20px">
-                              <div style="color:#15212a;font-size:16px;line-height:1.3em;font-weight:600">
-                                {{mention.sourceTitle}}
-                                {{#if mention.hasMultiple}}<span>{{mention.count}} links</span>{{/if}}
-                              </div>
+                              <div style="color:#15212a;font-size:16px;line-height:1.3em;font-weight:600">{{mention.sourceTitle}}</div>
                               <div style="display:-webkit-box;overflow-y:hidden;margin-top:12px;max-height:40px;color:#738a94;font-size:13px;line-height:1.5em;font-weight:400">{{mention.sourceExcerpt}}</div>
                               <div style="display:flex;margin-top:14px;color:#15212a;font-size:13px;font-weight:400">
                                 {{#if mention.sourceFavicon}}<img style="border:none;max-width:100%;margin-right:8px;width:22px;height:22px" src="{{mention.sourceFavicon}}" alt="">{{/if}}

--- a/ghost/staff-service/lib/email-templates/mention-report.hbs
+++ b/ghost/staff-service/lib/email-templates/mention-report.hbs
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>💌 New mention{{#eq report.mentions.length 1}}{{else}}{{report.mentions.length}}s{{/eq}}</title>
+    <title>💌 New mention{{#eq mentions.length 1}}{{else}}{{mentions.length}}s{{/eq}}</title>
     {{> styles}}
   </head>
   <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
@@ -24,14 +24,17 @@
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;">
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 20px; color: #15212A; font-weight: bold; line-height: 25px; margin: 0; margin-bottom: 15px;">Hey there,</p>
-                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 16px;">{{siteTitle}} was mentioned{{#eq report.mentions.length 1}} in:{{else}} <strong>{{report.mentions.length}} times</strong> recently. Here's where:{{/eq}}</p>
+                        <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 16px;">{{siteTitle}} was mentioned{{#eq mentions.length 1}} in:{{else}} <strong>{{mentions.length}} times</strong> recently. Here's where:{{/eq}}</p>
 
-                        {{#each (limit report.mentions 5) as |mention|}}
+                        {{#each (limit mentions 5) as |mention|}}
                         <!--[if !mso !vml]-->
                         <figure style="margin:0 0 1.5em;padding:0;width:100%;">
                           <a style="display:flex;min-height:148px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none" href="{{mention.sourceUrl}}">
                             <div style="display:inline-block; width:100%; padding:20px">
-                              <div style="color:#15212a;font-size:16px;line-height:1.3em;font-weight:600">{{mention.sourceTitle}}</div>
+                              <div style="color:#15212a;font-size:16px;line-height:1.3em;font-weight:600">
+                                {{mention.sourceTitle}}
+                                {{#if mention.hasMultiple}}<span>{{mention.count}} links</span>{{/if}}
+                              </div>
                               <div style="display:-webkit-box;overflow-y:hidden;margin-top:12px;max-height:40px;color:#738a94;font-size:13px;line-height:1.5em;font-weight:400">{{mention.sourceExcerpt}}</div>
                               <div style="display:flex;margin-top:14px;color:#15212a;font-size:13px;font-weight:400">
                                 {{#if mention.sourceFavicon}}<img style="border:none;max-width:100%;margin-right:8px;width:22px;height:22px" src="{{mention.sourceFavicon}}" alt="">{{/if}}
@@ -91,7 +94,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
                                   <tbody>
                                     <tr>
-                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{siteUrl}}ghost/#/mentions" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View all {{#if hasMoreMentions}}{{report.mentions.length}}{{/if}} mentions</a></td>
+                                      <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top; background-color: {{accentColor}}; border-radius: 5px; text-align: center;"> <a href="{{siteUrl}}ghost/#/mentions" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: {{accentColor}};">View all {{#if hasMoreMentions}}{{mentions.length}}{{/if}} mentions</a></td>
                                     </tr>
                                   </tbody>
                                 </table>


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2754

Mentions from same source are already grouped together in Admin UI, with number of links for each source shown in the grouped mention. Similarly this change adds the grouping to email reports, combining multiple mentions of same source into single mention with number of links.