### PR TITLE
Fixed broken link tracking in newsletters

### DIFF
--- a/ghost/email-service/lib/email-renderer.js
+++ b/ghost/email-service/lib/email-renderer.js
@@ -8,6 +8,7 @@ const {textColorForBackgroundColor, darkenToContrastThreshold} = require('@trygh
 const {DateTime} = require('luxon');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
 const tpl = require('@tryghost/tpl');
+const entities = require('entities');
 
 const messages = {
     subscriptionStatus: {
@@ -283,6 +284,8 @@ class EmailRenderer {
         // Link tracking
         if (options.clickTrackingEnabled) {
             html = await this.#linkReplacer.replace(html, async (url) => {
+                // Decode any escaped entities in the url
+                url = new URL(entities.decode(url.toString()));
                 // We ignore all links that contain %%{uuid}%%
                 // because otherwise we would add tracking to links that need to be replaced first
                 if (url.toString().indexOf('%%{uuid}%%') !== -1) {

--- a/ghost/email-service/package.json
+++ b/ghost/email-service/package.json
@@ -19,10 +19,10 @@
   ],
   "devDependencies": {
     "c8": "7.13.0",
+    "html-validate": "7.13.3",
     "mocha": "10.2.0",
     "should": "13.2.3",
-    "sinon": "15.0.2",
-    "html-validate": "7.13.3"
+    "sinon": "15.0.2"
   },
   "dependencies": {
     "@tryghost/color-utils": "0.1.23",
@@ -35,6 +35,7 @@
     "@tryghost/validator": "^0.2.0",
     "bson-objectid": "2.0.4",
     "cheerio": "0.22.0",
+    "entities": "^4.4.0",
     "handlebars": "4.7.7",
     "juice": "8.1.0",
     "moment-timezone": "0.5.23"

--- a/ghost/email-service/package.json
+++ b/ghost/email-service/package.json
@@ -35,7 +35,7 @@
     "@tryghost/validator": "^0.2.0",
     "bson-objectid": "2.0.4",
     "cheerio": "0.22.0",
-    "entities": "^4.4.0",
+    "entities": "4.4.0",
     "handlebars": "4.7.7",
     "juice": "8.1.0",
     "moment-timezone": "0.5.23"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13784,6 +13784,11 @@ ensure-posix-path@^1.0.0, ensure-posix-path@^1.0.1, ensure-posix-path@^1.0.2, en
   resolved "https://registry.yarnpkg.com/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz#3c62bdb19fa4681544289edb2b382adc029179ce"
   integrity sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==
 
+entities@4.4.0, entities@^4.2.0, entities@^4.3.0, entities@^4.4.0, entities@~4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
+  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
+
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
@@ -13793,11 +13798,6 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
-
-entities@^4.2.0, entities@^4.3.0, entities@^4.4.0, entities@~4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
-  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 entities@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2805

When we render mobiledoc to HTML, it automatically escapes HTML entities in the process, so a button or directly pasted link with href="https://example.com?code=test" will be rendered as href="https://example.com?code&#x3Dtest" as the url is encoded in the rendered HTML. Our link tracking was using the encoded URL as the redirect URL in newsletters, causing certain links to break. 

This change updates the link tracking to decode the URL with `entities.decode(url)` so we store the correct redirect URL in our DB and ensure link tracking redirects to the correct url from newsletters.