### PR TITLE
Allowed version build info to be shown in Admin

### DIFF
--- a/ghost/admin/app/components/modals/settings/about.js
+++ b/ghost/admin/app/components/modals/settings/about.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import config from 'ghost-admin/config/environment';
-import semver from 'semver';
+import semverParse from 'semver/functions/parse';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 
@@ -24,15 +24,10 @@ export default class AboutModal extends Component {
     get linkToGitHubReleases() {
         if (this.config.version.includes('-pre.')) {
             try {
-                const semverVersion = semver.parse(this.config.version, {includePrerelease: true});
+                const semverVersion = semverParse(this.config.version, {includePrerelease: true});
 
-                // Ensure this follows our prerelease format
-                if (semverVersion
-                    && semverVersion.prerelease?.[0] === 'pre'
-                    && semverVersion.prerelease?.[1]
-                    && Number.isInteger(semverVersion.prerelease?.[2])
-                ) {
-                    return `https://github.com/TryGhost/Ghost/commit/${semverVersion.prerelease[1]}`;
+                if (semverVersion && semverVersion.build?.[0]) {
+                    return `https://github.com/TryGhost/Ghost/commit/${semverVersion.build[0]}`;
                 }
 
                 return false;

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -6,7 +6,7 @@ const ghostVersion = require('@tryghost/version');
 
 module.exports = function getConfigProperties() {
     const configProperties = {
-        version: ghostVersion.full,
+        version: ghostVersion.original,
         environment: config.get('env'),
         database: databaseInfo.getEngine(),
         mail: isPlainObject(config.get('mail')) ? config.get('mail').transport : '',


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1679577089441659

- this allows the full Ghost version through the API so we can extract the build info from it and provide a link to GitHub
