### PR TITLE
🐛 Fixed UI bug when choosing email recipients

### DIFF
--- a/ghost/admin/app/utils/publish-options.js
+++ b/ghost/admin/app/utils/publish-options.js
@@ -172,7 +172,11 @@ export default class PublishOptions {
     }
 
     get recipientFilter() {
-        return this.selectedRecipientFilter || (this.post.newsletter && this.post.emailSegment) || this.defaultRecipientFilter;
+        if (this.selectedRecipientFilter === undefined) {
+            return (this.post.newsletter && this.post.emailSegment) || this.defaultRecipientFilter;
+        } else {
+            return this.selectedRecipientFilter;
+        }
     }
 
     get defaultRecipientFilter() {

--- a/ghost/admin/tests/acceptance/editor/publish-flow-test.js
+++ b/ghost/admin/tests/acceptance/editor/publish-flow-test.js
@@ -178,6 +178,35 @@ describe('Acceptance: Publish flow', function () {
             await click('[data-test-setting="email-recipients"] [data-test-setting-title]');
             expect(find('[data-test-select="newsletter"]'), 'newsletter select').to.not.exist;
 
+            // check that the Free + Paid members toggle works properly
+            const freeCheckbox = find('[data-test-checkbox="free-members"]');
+            const paidCheckbox = find('[data-test-checkbox="paid-members"]');
+
+            // toggles exist
+            expect(freeCheckbox, 'free members checkbox').to.exist;
+            expect(paidCheckbox, 'paid members checkbox').to.exist;
+
+            // both toggles are checked by default
+            expect(freeCheckbox.checked, 'free members checkbox checked').to.be.true;
+            expect(paidCheckbox.checked, 'paid members checkbox checked').to.be.true;
+
+            // uncheck both and check that the title updates
+            await click(freeCheckbox);
+            await click(paidCheckbox);
+            expect(freeCheckbox.checked, 'free members checkbox checked').to.be.false;
+            expect(paidCheckbox.checked, 'paid members checkbox checked').to.be.false;
+
+            expect(
+                find('[data-test-setting="email-recipients"] [data-test-setting-title]')
+            ).to.have.trimmed.rendered.text('Not sent as newsletter');
+
+            // check them both again
+            await click(freeCheckbox);
+            await click(paidCheckbox);
+            
+            expect(freeCheckbox.checked, 'free members checkbox checked').to.be.true;
+            expect(paidCheckbox.checked, 'paid members checkbox checked').to.be.true;
+
             await click('[data-test-button="continue"]');
 
             // confirm text is correct


### PR DESCRIPTION
- closes https://github.com/TryGhost/Team/issues/2786

- when trying to deselect all recipients, the UI would pass null as the filter to publish-options
- publish-options would then fallback to the default options, which is all recipients, and then the UI wouldn't update which made things even weirder
- we want to fallback to the default recipients when the recipientFilter is undefined (e.g. hasn't been set at all), but not when it is explicitly set to null (e.g. when the user has deselected all recipients)