### PR TITLE
Added default email to send import reports to

### DIFF
--- a/ghost/core/core/server/api/endpoints/db.js
+++ b/ghost/core/core/server/api/endpoints/db.js
@@ -82,12 +82,20 @@ module.exports = {
             cacheInvalidate: true
         },
         permissions: true,
-        query(frame) {
+        async query(frame) {
             const siteTimezone = settingsCache.get('timezone');
             const importTag = `#Import ${moment().tz(siteTimezone).format('YYYY-MM-DD HH:mm')}`;
+
+            let email;
+            if (frame.user) {
+                email = frame.user.get('email');
+            } else {
+                email = await models.User.getOwnerUser().get('email');
+            }
+
             return importer.importFromFile(frame.file, {
                 user: {
-                    email: frame.user.get('email')
+                    email: email
                 },
                 importTag
             });

--- a/ghost/core/core/server/api/endpoints/members.js
+++ b/ghost/core/core/server/api/endpoints/members.js
@@ -367,6 +367,13 @@ module.exports = {
             const pathToCSV = frame.file.path;
             const headerMapping = frame.data.mapping;
 
+            let email;
+            if (frame.user) {
+                email = frame.user.get('email');
+            } else {
+                email = await models.User.getOwnerUser().get('email');
+            }
+
             return membersService.processImport({
                 pathToCSV,
                 headerMapping,
@@ -374,7 +381,7 @@ module.exports = {
                 importLabel,
                 LabelModel: models.Label,
                 user: {
-                    email: frame.user.get('email')
+                    email: email
                 }
             });
         }


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2790

- When a Self-Serve integration does content/members import it failed because there was no "user" to get the email from - needed to send the import report
- The fix defaults to the instance's owner email when an integration does the request