### PR TITLE
Added awaiting jobs and events by default to all tests

### DIFF
--- a/ghost/core/test/utils/overrides.js
+++ b/ghost/core/test/utils/overrides.js
@@ -17,3 +17,21 @@ mochaHooks.beforeAll = async function () {
     // Disable network in tests to prevent any accidental requests
     mockManager.disableNetwork();
 };
+
+const originalAfterEach = mochaHooks.afterEach;
+mochaHooks.afterEach = async function () {
+    const domainEvents = require('@tryghost/domain-events');
+    const mentionsJobsService = require('../../core/server/services/mentions-jobs');
+    const jobsService = require('../../core/server/services/jobs');
+
+    await domainEvents.allSettled();
+    await mentionsJobsService.allSettled();
+    await jobsService.allSettled();
+
+    // Last time for events emitted during jobs
+    await domainEvents.allSettled();
+
+    if (originalAfterEach) {
+        await originalAfterEach();
+    }
+};


### PR DESCRIPTION
no issue

This change waits for domain events and jobs before continuing with the next test. This prevents issues where background tasks in tests are executed when the next test is running and the configurations have changed, causing random error logs and test failures.

It also includes a change in Stripe mocking in one E2E test to make use of the new StripeMocker instead of custom mocking in each test (also to reduce error logs).