### PR TITLE
Fixed self-serve api key type

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-19-02-add-self-serve-integration-api-key.js
+++ b/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-19-02-add-self-serve-integration-api-key.js
@@ -37,7 +37,7 @@ module.exports = createTransactionalMigration(
 
         await knex('api_keys').insert({
             id: (new ObjectID()).toHexString(),
-            type: 'core',
+            type: 'admin',
             secret: security.secret.create('admin'),
             role_id: role.id,
             integration_id: integration.id,

--- a/ghost/core/core/server/data/migrations/versions/5.41/2023-03-27-17-51-fix-self-serve-integration-api-key-type.js
+++ b/ghost/core/core/server/data/migrations/versions/5.41/2023-03-27-17-51-fix-self-serve-integration-api-key-type.js
@@ -1,0 +1,36 @@
+const {InternalServerError} = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Updating Admin API key for "Self-Serve Migration Integration"');
+
+        const integration = await knex('integrations').where({
+            slug: 'self-serve-migration',
+            name: 'Self-Serve Migration Integration'
+        }).first();
+
+        if (!integration) {
+            throw new InternalServerError('Could not find "Self-Serve Migration Integration"');
+        }
+
+        const existingKey = await knex('api_keys').where({
+            integration_id: integration.id,
+            type: 'core'
+        }).first();
+
+        if (!existingKey) {
+            logging.warn('Admin API key for "Self-Serve Migration Integration" with type "core" does not exists');
+            return;
+        }
+
+        logging.info(`Updating API key type to "admin" for "Self-Serve Migration Integration" ${existingKey.id}`);
+        await knex('api_keys')
+            .update('type', 'admin')
+            .where('id', existingKey.id);
+    },
+    async function down() {
+        // noop as previous state was incorrect
+    }
+);

--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -179,6 +179,17 @@ describe('Integrations API', function () {
 
         body.integrations.forEach((integration) => {
             should.exist(integration.api_keys);
+            if (integration.api_keys.length) {
+                integration.api_keys.forEach((apiKey) => {
+                    should.exist(apiKey.secret);
+
+                    if (apiKey.type === 'content') {
+                        should.equal(apiKey.secret.split(':').length, 1, `${integration.name} api key secret should have correct key format without ":"`);
+                    } else if (apiKey.type === 'admin') {
+                        should.equal(apiKey.secret.split(':').length, 2, `${integration.name} api key secret should have correct key format with ":"`);
+                    }
+                });
+            }
         });
     });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/16461

- The referenced migration had an incorrect 'type' assigned to the self-serve integration's api key. Should have been "admin" instead of "core"