### PR TITLE
Fixed email plaintext for webmention reports

### DIFF
--- a/ghost/core/core/server/services/mentions-email-report/service.js
+++ b/ghost/core/core/server/services/mentions-email-report/service.js
@@ -81,8 +81,13 @@ module.exports = {
              * @returns {Promise<string>}
              */
             async renderText(report, recipient) {
+                // Filter out mentions with duplicate source url from the report
+                const uniqueMentions = report.mentions.filter((mention, index, self) => {
+                    return self.findIndex(m => m.sourceUrl.href === mention.sourceUrl.href) === index;
+                });
+
                 return staffService.api.emails.renderText('mention-report', {
-                    report: report,
+                    mentions: uniqueMentions,
                     recipient: recipient
                 });
             }

--- a/ghost/staff-service/lib/email-templates/mention-report.txt.js
+++ b/ghost/staff-service/lib/email-templates/mention-report.txt.js
@@ -1,7 +1,15 @@
 module.exports = function (data) {
+    const {mentions} = data;
+    // Create a list of new mentions with a link to the source
+    const mentionsList = mentions.map((mention) => {
+        return `- ${mention.sourceSiteTitle} (${mention.sourceUrl})`;
+    }).join('\n');
+
     // Be careful when you indent the email, because whitespaces are visible in emails!
     return `
-    You have been mentioned by ${data.sourceUrl}.
+You have been mentioned recently. Here's where:
+
+${mentionsList}
 
 ---
 

--- a/ghost/staff-service/test/staff-service.test.js
+++ b/ghost/staff-service/test/staff-service.test.js
@@ -908,5 +908,28 @@ describe('StaffService', function () {
                 mailStub.called.should.be.false();
             });
         });
+
+        describe('renderText for webmentions', function () {
+            it('renders plaintext report for mentions', async function () {
+                const textTemplate = await service.emails.renderText('mention-report', {
+                    toEmail: 'jamie@example.com',
+                    siteDomain: 'ghost.org',
+                    staffUrl: 'https://admin.example.com/blog/ghost/#/settings/staff/jane.',
+                    mentions: [
+                        {
+                            sourceSiteTitle: 'Webmentions',
+                            sourceUrl: 'https://webmention.io/'
+                        },
+                        {
+                            sourceSiteTitle: 'Ghost Demo',
+                            sourceUrl: 'https://demo.ghost.io/'
+                        }
+                    ]
+                });
+                textTemplate.should.match(/- Webmentions \(https:\/\/webmention.io\/\)/);
+                textTemplate.should.match(/Ghost Demo \(https:\/\/demo.ghost.io\/\)/);
+                textTemplate.should.match(/Sent to jamie@example.com from ghost.org/);
+            });
+        });
     });
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2754

Updates plaintext version for webmention email reports to include all unique mentions in a nice list format