### PR TITLE
Merged mentions UI and email lab flags

### DIFF
--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -66,7 +66,6 @@ export default class FeatureService extends Service {
     @feature('audienceFeedback') audienceFeedback;
     @feature('suppressionList') suppressionList;
     @feature('webmentions') webmentions;
-    @feature('webmentionEmails') webmentionEmails;
     @feature('emailErrors') emailErrors;
     @feature('websockets') websockets;
     @feature('stripeAutomaticTax') stripeAutomaticTax;

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -203,19 +203,6 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
-                            <h4 class="gh-expandable-title">Webmention notification emails</h4>
-                            <p class="gh-expandable-description">
-                                Send a notification email to staff when a webmention is received.
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                            <GhFeatureFlag @flag="webmentionEmails" />
-                        </div>
-                    </div>
-                </div>
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
                             <h4 class="gh-expandable-title">Show email errors</h4>
                             <p class="gh-expandable-description">
                                 This makes email errors visible in the UI.

--- a/ghost/admin/app/templates/settings/staff/user.hbs
+++ b/ghost/admin/app/templates/settings/staff/user.hbs
@@ -265,7 +265,7 @@
                                     </div>
                                 </div>
                                 {{#if this.user.isAdmin}}
-                                {{#if (and (feature 'webmentions') (feature 'webmentionEmails')) }}
+                                {{#if (feature 'webmentions')}}
                                     <div class="user-setting-toggle">
                                         <div>
                                             <label for="user-email">Mentions</label>

--- a/ghost/admin/tests/acceptance/staff-test.js
+++ b/ghost/admin/tests/acceptance/staff-test.js
@@ -81,7 +81,6 @@ describe('Acceptance: Staff', function () {
             enableMembers(this.server);
             enableStripe(this.server);
             enableLabsFlag(this.server, 'webmentions');
-            enableLabsFlag(this.server, 'webmentionEmails');
 
             admin = this.server.create('user', {email: 'admin@example.com', roles: [adminRole]});
 

--- a/ghost/core/core/server/services/mentions-email-report/service.js
+++ b/ghost/core/core/server/services/mentions-email-report/service.js
@@ -139,7 +139,7 @@ module.exports = {
 
         const labs = require('../../../shared/labs');
         DomainEvents.subscribe(StartMentionEmailReportJob, () => {
-            if (labs.isSet('webmentionEmails')) {
+            if (labs.isSet('webmentions')) {
                 job.sendLatestReport();
             }
         });

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -35,7 +35,6 @@ const ALPHA_FEATURES = [
     'urlCache',
     'lexicalEditor',
     'websockets',
-    'webmentionEmails',
     'stripeAutomaticTax',
     'makingItRain'
 ];

--- a/ghost/core/test/e2e-api/webmentions/webmentions.test.js
+++ b/ghost/core/test/e2e-api/webmentions/webmentions.test.js
@@ -29,7 +29,6 @@ describe('Webmentions (receiving)', function () {
         await allSettled();
         mockManager.disableNetwork();
         mockManager.mockLabsEnabled('webmentions');
-        mockManager.mockLabsEnabled('webmentionEmails');
     });
 
     afterEach(async function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/2851

We had two separate flags to manage the Mentions beta, one for showing UI and other for sending emails. This change combines them both under the single `webmentions` flag that was previously only used to show the UI.