### PR TITLE
🎨 Improved dark scrollbar support for admin panel

### DIFF
--- a/ghost/admin/app/styles/spirit/_custom-styles-dark.css
+++ b/ghost/admin/app/styles/spirit/_custom-styles-dark.css
@@ -1,3 +1,7 @@
+:root {
+    color-scheme: dark;
+}
+
 .bg-grouped-table {
     background: #191b1f;
 }


### PR DESCRIPTION
fixes #16444

add dark scrollbar support for chrome


<div style="display: flex">
<img src="https://user-images.githubusercontent.com/6430448/229244600-884da4d0-017c-4cbd-abd3-0c492cda143a.png" style="display: block; flex-grow:1" width="45%">
<img src="https://user-images.githubusercontent.com/6430448/229244597-1bca2265-f5b2-4175-bc3d-2fd28e8f9daf.png" style="display: block; flex-grow:1" width="45%">
</div>


maybe it's a bad commit message, as it doesn't tell that's “Dark mode” explicitly 