### PR TITLE
Fixed UI bug when selecting specific recipients by label

### DIFF
--- a/ghost/admin/app/components/gh-members-recipient-select.hbs
+++ b/ghost/admin/app/components/gh-members-recipient-select.hbs
@@ -67,7 +67,7 @@
                         disabled={{@disabled}}
                         aria-label="Specific people toggle"
                         {{on "change" this.toggleSpecificFilter}}
-                        data-test-checkbox="paid-members"
+                        data-test-checkbox="specific-members"
                     >
                     <div class="flex">
                         <span class="input-toggle-component"></span>
@@ -79,20 +79,22 @@
     {{/if}}
 </div>
 {{#if this.isSpecificChecked}}
-    <label class="gh-main-section-header small bn">Selection</label>
-    <GhTokenInput
-        @class="select-members select-members-recipient"
-        @dropdownClass={{@dropdownClass}}
-        @options={{this.specificOptions}}
-        @selected={{this.selectedSpecificOptions}}
-        @disabled={{@disabled}}
-        @searchMessage="All labels selected"
-        @optionsComponent={{component "power-select/options"}}
-        @allowCreation={{false}}
-        @renderInPlace={{this.renderInPlace}}
-        @onChange={{this.selectSpecificOptions}}
-        as |option|
-    >
-        {{option.name}}
-    </GhTokenInput>
+    <div data-test-select="specific-members">
+        <label class="gh-main-section-header small bn">Selection</label>
+        <GhTokenInput
+            @class="select-members select-members-recipient"
+            @dropdownClass={{@dropdownClass}}
+            @options={{this.specificOptions}}
+            @selected={{this.selectedSpecificOptions}}
+            @disabled={{@disabled}}
+            @searchMessage="All labels selected"
+            @optionsComponent={{component "power-select/options"}}
+            @allowCreation={{false}}
+            @renderInPlace={{this.renderInPlace}}
+            @onChange={{this.selectSpecificOptions}}
+            as |option|
+        >
+            {{option.name}}
+        </GhTokenInput>
+    </div>
 {{/if}}

--- a/ghost/admin/app/components/gh-members-recipient-select.js
+++ b/ghost/admin/app/components/gh-members-recipient-select.js
@@ -108,6 +108,15 @@ export default class GhMembersRecipientSelect extends Component {
         }
 
         const newSpecificFilters = new Set(selectedOptions.map(o => o.segment));
+
+        // If the user has deselected all options, clear the _previousSpecificFilters
+        // and force the specific filter to be checked so that the user can still see the options select
+        // Refs https://github.com/TryGhost/Team/issues/2859
+        if (newSpecificFilters.size === 0) {
+            this._previousSpecificFilters = undefined;
+            this.forceSpecificChecked = true;
+        }
+
         this.updateFilter({newSpecificFilters});
     }
 

--- a/ghost/admin/tests/acceptance/editor/publish-flow-test.js
+++ b/ghost/admin/tests/acceptance/editor/publish-flow-test.js
@@ -1,7 +1,7 @@
 import loginAsRole from '../../helpers/login-as-role';
 import moment from 'moment-timezone';
 import {blur, click, fillIn, find, findAll} from '@ember/test-helpers';
-import {clickTrigger, selectChoose} from 'ember-power-select/test-support/helpers';
+import {clickTrigger, removeMultipleOption, selectChoose} from 'ember-power-select/test-support/helpers';
 import {disableMailgun, enableMailgun} from '../../helpers/mailgun';
 import {disableMembers, enableMembers} from '../../helpers/members';
 import {disableNewsletters, enableNewsletters} from '../../helpers/newsletters';
@@ -155,7 +155,8 @@ describe('Acceptance: Publish flow', function () {
             enableStripe(this.server);
 
             // at least one member is required for publish+send to be available
-            this.server.createList('member', 3, {status: 'free'});
+            const label = this.server.create('label');
+            this.server.createList('member', 3, {status: 'free', labels: [label]});
             this.server.createList('member', 4, {status: 'paid'});
         });
 
@@ -203,7 +204,38 @@ describe('Acceptance: Publish flow', function () {
             // check them both again
             await click(freeCheckbox);
             await click(paidCheckbox);
-            
+
+            // check that specific filters work
+            // refs https://github.com/TryGhost/Team/issues/2859
+
+            // select the Specific people checkbox
+            const specificCheckbox = find('[data-test-checkbox="specific-members"]');
+            await click(specificCheckbox);
+            expect(specificCheckbox.checked, 'specific people checkbox checked').to.be.true;
+
+            // check that the select box is displayed
+            const specificSelect = find('.select-members-recipient');
+            expect(specificSelect, 'specific members select').to.exist;
+
+            // select a specific label to send the newsletter to
+            await clickTrigger('[data-test-select="specific-members"]');
+            await selectChoose('[data-test-select="specific-members"]', 'Label 0');
+
+            // uncheck everything, then recheck specific members
+            await click(freeCheckbox);
+            await click(paidCheckbox);
+            await click(specificCheckbox);
+            await click(specificCheckbox);
+
+            // Remove selected option and check that the select box is still visible
+            await removeMultipleOption('[data-test-select="specific-members"]', 'Label 0');
+            expect(specificCheckbox.checked, 'specific people checkbox checked').to.be.true;
+
+            // Uncheck specific and recheck free + paid
+            await click(freeCheckbox);
+            await click(paidCheckbox);
+            await click(specificCheckbox);
+
             expect(freeCheckbox.checked, 'free members checkbox checked').to.be.true;
             expect(paidCheckbox.checked, 'paid members checkbox checked').to.be.true;
 


### PR DESCRIPTION
closes TryGhost/Team#2859

- when removing all selected labels/newsletters, the UI would uncheck the Specific People checkbox and hide the label/newsletter selection
- this change forces the Specific People checkbox to be checked even if no labels/newsletters are selected
- test enhanced to cover this specific edge case