### PR TITLE
🐛 Fixed member signup emails being sent with escaped subject line

### DIFF
--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -59,16 +59,16 @@ function createApiInstance(config) {
                 const siteTitle = settingsCache.get('title');
                 switch (type) {
                 case 'subscribe':
-                    return `📫 ${t(`Confirm your subscription to {{siteTitle}}`, {siteTitle})}`;
+                    return `📫 ${t(`Confirm your subscription to {{siteTitle}}`, {siteTitle, interpolation: {escapeValue: false}})}`;
                 case 'signup':
-                    return `🙌 ${t(`Complete your sign up to {{siteTitle}}!`, {siteTitle})}`;
+                    return `🙌 ${t(`Complete your sign up to {{siteTitle}}!`, {siteTitle, interpolation: {escapeValue: false}})}`;
                 case 'signup-paid':
-                    return `🙌 ${t(`Thank you for signing up to {{siteTitle}}!`, {siteTitle})}`;
+                    return `🙌 ${t(`Thank you for signing up to {{siteTitle}}!`, {siteTitle, interpolation: {escapeValue: false}})}`;
                 case 'updateEmail':
-                    return `📫 ${t(`Confirm your email update for {{siteTitle}}!`, {siteTitle})}`;
+                    return `📫 ${t(`Confirm your email update for {{siteTitle}}!`, {siteTitle, interpolation: {escapeValue: false}})}`;
                 case 'signin':
                 default:
-                    return `🔑 ${t(`Secure sign in link for {{siteTitle}}`, {siteTitle})}`;
+                    return `🔑 ${t(`Secure sign in link for {{siteTitle}}`, {siteTitle, interpolation: {escapeValue: false}})}`;
                 }
             },
             getText(url, type, email) {
@@ -78,7 +78,7 @@ function createApiInstance(config) {
                     return `
                         ${t(`Hey there,`)}
 
-                        ${t('You\'re one tap away from subscribing to {{siteTitle}} — please confirm your email address with this link:', {siteTitle})}
+                        ${t('You\'re one tap away from subscribing to {{siteTitle}} — please confirm your email address with this link:', {siteTitle, interpolation: {escapeValue: false}})}
 
                         ${url}
 
@@ -95,7 +95,7 @@ function createApiInstance(config) {
                     return `
                         ${t(`Hey there,`)}
 
-                        ${t('Tap the link below to complete the signup process for {{siteTitle}}, and be automatically signed in:', {siteTitle})}
+                        ${t('Tap the link below to complete the signup process for {{siteTitle}}, and be automatically signed in:', {siteTitle, interpolation: {escapeValue: false}})}
 
                         ${url}
 
@@ -112,7 +112,7 @@ function createApiInstance(config) {
                     return `
                         ${t(`Hey there,`)}
 
-                        ${t('Thank you for subscribing to {{siteTitle}}. Tap the link below to be automatically signed in:', {siteTitle})}
+                        ${t('Thank you for subscribing to {{siteTitle}}. Tap the link below to be automatically signed in:', {siteTitle, interpolation: {escapeValue: false}})}
 
                         ${url}
 
@@ -123,7 +123,7 @@ function createApiInstance(config) {
                         ---
 
                         ${t('Sent to {{email}}', {email})}
-                        ${t('Thank you for subscribing to {{siteTitle}}!', {siteTitle})}
+                        ${t('Thank you for subscribing to {{siteTitle}}!', {siteTitle, interpolation: {escapeValue: false}})}
                         `;
                 case 'updateEmail':
                     return `
@@ -145,7 +145,7 @@ function createApiInstance(config) {
                     return `
                         ${t(`Hey there,`)}
 
-                        ${t('Welcome back! Use this link to securely sign in to your {{siteTitle}} account:', {siteTitle})}
+                        ${t('Welcome back! Use this link to securely sign in to your {{siteTitle}} account:', {siteTitle, interpolation: {escapeValue: false}})}
 
                         ${url}
 

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -846,6 +846,19 @@ describe('Members API', function () {
             ]
         };
 
+        // Set site title to something with a special character to ensure subject line doesn't get escaped
+        // Refs https://github.com/TryGhost/Team/issues/2895
+        await agent.put('/settings/')
+            .body({
+                settings: [
+                    {
+                        key: 'title',
+                        value: 'Ghost\'s Test Site'
+                    }
+                ]
+            })
+            .expectStatus(200);
+
         const {body} = await agent
             .post('/members/?send_email=true&email_type=signup')
             .body({members: [member]})
@@ -866,7 +879,7 @@ describe('Members API', function () {
         const newMember = body.members[0];
 
         mockManager.assert.sentEmail({
-            subject: '🙌 Complete your sign up to Ghost!',
+            subject: '🙌 Complete your sign up to Ghost\'s Test Site!',
             to: 'member_getting_confirmation@test.com'
         });
 
@@ -913,6 +926,18 @@ describe('Members API', function () {
             memberId: newMember.id,
             asserts: []
         });
+
+        // Reset the site title to the default
+        await agent.put('/settings/')
+            .body({
+                settings: [
+                    {
+                        key: 'title',
+                        value: 'Ghost'
+                    }
+                ]
+            })
+            .expectStatus(200);
     });
 
     it('Add should fail when passing incorrect email_type query parameter', async function () {


### PR DESCRIPTION
closes TryGhost/Team#2895

- this was caused by the subject line being passed through the i18n translator, which was escaping the content
- passing in `interpolation: {escapeValue: false}` when retrieving the value prevents the content from being escaped
- modified a test to ensure the subject line is not escaped
