### PR TITLE
Enabled `--prefer-offline` in CI to reduce network requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           path: ghost/**/.eslintcache
           key: eslint-cache
 
-      - run: yarn
+      - run: yarn --prefer-offline
       - run: yarn lint
       - uses: daniellockyer/action-slack-build@master
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -56,7 +56,7 @@ jobs:
         with:
           node-version: "16.13.0"
 
-      - run: yarn
+      - run: yarn --prefer-offline
       - run: yarn workspace ghost-admin run test
         env:
           BROWSER: Chrome
@@ -128,7 +128,7 @@ jobs:
           echo "database__connection__password=root" >> $GITHUB_ENV
           echo "database__connection__database=ghost_testing" >> $GITHUB_ENV
 
-      - run: yarn
+      - run: yarn --prefer-offline
       - run: |
           node index.js &
           sleep 20 && { kill $! && wait $!; } 2>/dev/null
@@ -156,7 +156,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: yarn
 
-      - run: yarn
+      - run: yarn --prefer-offline
       - run: yarn test:unit
 
       - uses: actions/upload-artifact@v3
@@ -214,7 +214,7 @@ jobs:
           mysql database: 'ghost_testing'
           mysql root password: 'root'
 
-      - run: yarn
+      - run: yarn --prefer-offline
 
       - run: date +%s > ${{ runner.temp }}/startTime # Get start time for test suite
 
@@ -300,7 +300,7 @@ jobs:
       - name: Install Ghost-CLI
         run: npm install -g ghost-cli@latest
 
-      - run: yarn
+      - run: yarn --prefer-offline
 
       - run: npm --no-git-tag-version version minor # We need to artificially bump the minor version to get migrations to run
         working-directory: ghost/core


### PR DESCRIPTION
- by default, yarn will try and fetch dependencies from the network, and fallback to local cache if the network is down
- `--prefer-offline` switches that around so we can take advantage of local caches before defaulting to the network
- hopefully this speeds up dependency install steps in CI