### PR TITLE
Added email content snapshots to version tests

### DIFF
--- a/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
+++ b/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
@@ -356,7 +356,235 @@ Object {
 }
 `;
 
+exports[`API Versioning Admin API responds with error and sends email ONCE when requested version is BEHIND and CANNOT respond multiple times 3: [html 1] 1`] = `
+"<!doctype html>
+<html>
+<head>
+<meta name=\\"viewport\\" content=\\"width=device-width\\">
+<meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\">
+<title>Integration error</title>
+<style>
+/* -------------------------------------
+    RESPONSIVE AND MOBILE FRIENDLY STYLES
+------------------------------------- */
+@media only screen and (max-width: 620px) {
+    table[class=body] h1 {
+    font-size: 28px !important;
+    margin-bottom: 10px !important;
+    }
+    table[class=body] p,
+        table[class=body] ul,
+        table[class=body] ol,
+        table[class=body] td,
+        table[class=body] span,
+        table[class=body] a {
+    font-size: 16px !important;
+    }
+    table[class=body] .title {
+    font-size: 22px !important;
+    }
+    table[class=body] .wrapper,
+        table[class=body] .article {
+    padding: 10px !important;
+    }
+    table[class=body] .content {
+    padding: 0 !important;
+    }
+    table[class=body] .container {
+    padding: 0 !important;
+    width: 100% !important;
+    }
+    table[class=body] .main {
+    border-left-width: 0 !important;
+    border-radius: 0 !important;
+    border-right-width: 0 !important;
+    }
+    table[class=body] .btn table {
+    width: 100% !important;
+    }
+    table[class=body] .btn a {
+    width: 100% !important;
+    }
+    table[class=body] .img-responsive {
+    height: auto !important;
+    max-width: 100% !important;
+    width: auto !important;
+    }
+    table[class=body] p[class=small],
+    table[class=body] a[class=small] {
+    font-size: 12x !important;
+    }
+}
+/* -------------------------------------
+    PRESERVE THESE STYLES IN THE HEAD
+------------------------------------- */
+@media all {
+    .ExternalClass {
+    width: 100%;
+    }
+    .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+    line-height: 100%;
+    }
+    .recipient-link a {
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: none !important;
+    }
+    #MessageViewBody a {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    }
+}
+hr {
+    border-width: 0;
+    height: 0;
+    margin-top: 34px;
+    margin-bottom: 34px;
+    border-bottom-width: 1px;
+    border-bottom-color: #EEF5F8;
+}
+a {
+    color: #3A464C;
+}
+</style>
+</head>
+<body style=\\"background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;\\">
+
+<table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"body\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+    <tr>
+        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
+        <td class=\\"container\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;\\">
+
+            <div class=\\"content\\" style=\\"box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;\\">
+
+            <!-- START CENTERED CONTAINER -->
+            <table class=\\"main\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;\\">
+
+                <!-- START MAIN CONTENT AREA -->
+                <tr>
+                <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;\\">
+                    <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                        <tr>
+                            <td align=\\"center\\" style=\\"padding-top: 20px; padding-bottom: 12px;\\"><img src=\\"https://static.ghost.org/v4.50.0/images/ghost-orb-1.png\\" width=\\"60\\" height=\\"60\\" style=\\"width: 60px; height: 60px;\\" /></td>
+                        </tr>
+                        <tr>
+                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top;\\">
+                            <p class=\\"title\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 21px; color: #3A464C; font-weight: normal; line-height: 25px; margin-bottom: 0px; margin-top: 50px; font-weight: 600; color: #15212A;\\">Uh-oh!</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 24px; padding-bottom: 10px;\\">
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 30px;\\">
+                                Your <strong style=\\"font-weight: 600;\\">Zapier</strong> integration is no longer working as expected. This integration must be updated by its developer to work with your version of Ghost.
+                                </p>
+
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 30px;\\">
+                                  To help you get things fixed as quickly as possible, Ghost has automatically generated some helpful information about the error that you can share with the creator of the Zapier integration below:
+                                </p>
+
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;background-color:#f6f6f6; padding:20px; border-radius:2px;\\">
+                                    <strong style=\\"font-weight: 600;\\">Integration expected Ghost version:</strong>&nbsp; v4.50
+                                    <br>
+                                    <strong style=\\"font-weight: 600;\\">Current Ghost version:</strong>&nbsp; v4.50
+                                    <br>
+                                    <strong style=\\"font-weight: 600;\\">Failed request URL:</strong>&nbsp; /ghost/api/admin/removed_endpoint/
+                                </p>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; vertical-align: top; padding-top: 80px; padding-bottom: 10px;\\">
+                    <div class=\\"footer\\">
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; color: #738A94; font-weight: normal; margin: 0; line-height: 18px; margin-bottom: 0px; font-size: 11px;\\">This email was sent from <a href=\\"http://127.0.0.1:2369/\\" style=\\"color: #738A94;\\">http://127.0.0.1:2369/</a> to <a href=\\"mailto:jbloggs@example.com\\" style=\\"color: #738A94;\\">jbloggs@example.com</a></p>
+                    </div>
+                </td>
+            </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+            <!-- END CENTERED CONTAINER -->
+            </div>
+        </td>
+        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>
+"
+`;
+
 exports[`API Versioning Admin API responds with error and sends email ONCE when requested version is BEHIND and CANNOT respond multiple times 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`API Versioning Admin API responds with error and sends email ONCE when requested version is BEHIND and CANNOT respond multiple times 4: [text 1] 1`] = `
+" [https://static.ghost.org/v4.50.0/images/ghost-orb-1.png] Uh-oh!
+
+Your Zapier integration is no longer working as expected. This integration must
+be updated by its developer to work with your version of Ghost. 
+
+To help you get things fixed as quickly as possible, Ghost has automatically
+generated some helpful information about the error that you can share with the
+creator of the Zapier integration below: 
+
+ Integration expected Ghost version:v4.50 
+Current Ghost version:v4.50 
+Failed request URL:/ghost/api/admin/removed_endpoint/ 
+
+This email was sent from http://127.0.0.1:2369/ [http://127.0.0.1:2369/] to 
+jbloggs@example.com [jbloggs@example.com]"
+`;
+
+exports[`API Versioning Admin API responds with error and sends email ONCE when requested version is BEHIND and CANNOT respond multiple times 5: [metadata 1] 1`] = `
+Object {
+  "subject": "Attention required: Your Zapier integration has failed",
+  "to": "jbloggs@example.com",
+}
+`;
+
+exports[`API Versioning Admin API responds with error and sends email ONCE when requested version is BEHIND and CANNOT respond multiple times 6: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": "UPDATE_CLIENT",
+      "context": StringMatching /Provided client accept-version v3\\.5 is behind current Ghost version v\\\\d\\+\\\\\\.\\\\d\\+/,
+      "details": null,
+      "ghostErrorCode": null,
+      "help": "Try upgrading your Ghost API client.",
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Request could not be served, the endpoint was not found.",
+      "property": null,
+      "type": "RequestNotAcceptableError",
+    },
+  ],
+}
+`;
+
+exports[`API Versioning Admin API responds with error and sends email ONCE when requested version is BEHIND and CANNOT respond multiple times 7: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -428,6 +656,203 @@ Object {
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-powered-by": "Express",
+}
+`;
+
+exports[`API Versioning Admin API responds with error when requested version is BEHIND and CANNOT respond 3: [html 1] 1`] = `
+"<!doctype html>
+<html>
+<head>
+<meta name=\\"viewport\\" content=\\"width=device-width\\">
+<meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\">
+<title>Integration error</title>
+<style>
+/* -------------------------------------
+    RESPONSIVE AND MOBILE FRIENDLY STYLES
+------------------------------------- */
+@media only screen and (max-width: 620px) {
+    table[class=body] h1 {
+    font-size: 28px !important;
+    margin-bottom: 10px !important;
+    }
+    table[class=body] p,
+        table[class=body] ul,
+        table[class=body] ol,
+        table[class=body] td,
+        table[class=body] span,
+        table[class=body] a {
+    font-size: 16px !important;
+    }
+    table[class=body] .title {
+    font-size: 22px !important;
+    }
+    table[class=body] .wrapper,
+        table[class=body] .article {
+    padding: 10px !important;
+    }
+    table[class=body] .content {
+    padding: 0 !important;
+    }
+    table[class=body] .container {
+    padding: 0 !important;
+    width: 100% !important;
+    }
+    table[class=body] .main {
+    border-left-width: 0 !important;
+    border-radius: 0 !important;
+    border-right-width: 0 !important;
+    }
+    table[class=body] .btn table {
+    width: 100% !important;
+    }
+    table[class=body] .btn a {
+    width: 100% !important;
+    }
+    table[class=body] .img-responsive {
+    height: auto !important;
+    max-width: 100% !important;
+    width: auto !important;
+    }
+    table[class=body] p[class=small],
+    table[class=body] a[class=small] {
+    font-size: 12x !important;
+    }
+}
+/* -------------------------------------
+    PRESERVE THESE STYLES IN THE HEAD
+------------------------------------- */
+@media all {
+    .ExternalClass {
+    width: 100%;
+    }
+    .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+    line-height: 100%;
+    }
+    .recipient-link a {
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: none !important;
+    }
+    #MessageViewBody a {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    }
+}
+hr {
+    border-width: 0;
+    height: 0;
+    margin-top: 34px;
+    margin-bottom: 34px;
+    border-bottom-width: 1px;
+    border-bottom-color: #EEF5F8;
+}
+a {
+    color: #3A464C;
+}
+</style>
+</head>
+<body style=\\"background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;\\">
+
+<table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"body\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+    <tr>
+        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
+        <td class=\\"container\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;\\">
+
+            <div class=\\"content\\" style=\\"box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;\\">
+
+            <!-- START CENTERED CONTAINER -->
+            <table class=\\"main\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;\\">
+
+                <!-- START MAIN CONTENT AREA -->
+                <tr>
+                <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; box-sizing: border-box;\\">
+                    <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                        <tr>
+                            <td align=\\"center\\" style=\\"padding-top: 20px; padding-bottom: 12px;\\"><img src=\\"https://static.ghost.org/v4.50.0/images/ghost-orb-1.png\\" width=\\"60\\" height=\\"60\\" style=\\"width: 60px; height: 60px;\\" /></td>
+                        </tr>
+                        <tr>
+                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top;\\">
+                            <p class=\\"title\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 21px; color: #3A464C; font-weight: normal; line-height: 25px; margin-bottom: 0px; margin-top: 50px; font-weight: 600; color: #15212A;\\">Uh-oh!</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 24px; padding-bottom: 10px;\\">
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 30px;\\">
+                                Your <strong style=\\"font-weight: 600;\\">Zapier</strong> integration is no longer working as expected. This integration must be updated by its developer to work with your version of Ghost.
+                                </p>
+
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 30px;\\">
+                                  To help you get things fixed as quickly as possible, Ghost has automatically generated some helpful information about the error that you can share with the creator of the Zapier integration below:
+                                </p>
+
+                                <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 20px;background-color:#f6f6f6; padding:20px; border-radius:2px;\\">
+                                    <strong style=\\"font-weight: 600;\\">Integration expected Ghost version:</strong>&nbsp; v4.50
+                                    <br>
+                                    <strong style=\\"font-weight: 600;\\">Current Ghost version:</strong>&nbsp; v4.50
+                                    <br>
+                                    <strong style=\\"font-weight: 600;\\">Failed request URL:</strong>&nbsp; /ghost/api/admin/removed_endpoint/
+                                </p>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; vertical-align: top; padding-top: 80px; padding-bottom: 10px;\\">
+                    <div class=\\"footer\\">
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; color: #738A94; font-weight: normal; margin: 0; line-height: 18px; margin-bottom: 0px; font-size: 11px;\\">This email was sent from <a href=\\"http://127.0.0.1:2369/\\" style=\\"color: #738A94;\\">http://127.0.0.1:2369/</a> to <a href=\\"mailto:jbloggs@example.com\\" style=\\"color: #738A94;\\">jbloggs@example.com</a></p>
+                    </div>
+                </td>
+            </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+            <!-- END CENTERED CONTAINER -->
+            </div>
+        </td>
+        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top;\\">&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>
+"
+`;
+
+exports[`API Versioning Admin API responds with error when requested version is BEHIND and CANNOT respond 4: [text 1] 1`] = `
+" [https://static.ghost.org/v4.50.0/images/ghost-orb-1.png] Uh-oh!
+
+Your Zapier integration is no longer working as expected. This integration must
+be updated by its developer to work with your version of Ghost. 
+
+To help you get things fixed as quickly as possible, Ghost has automatically
+generated some helpful information about the error that you can share with the
+creator of the Zapier integration below: 
+
+ Integration expected Ghost version:v4.50 
+Current Ghost version:v4.50 
+Failed request URL:/ghost/api/admin/removed_endpoint/ 
+
+This email was sent from http://127.0.0.1:2369/ [http://127.0.0.1:2369/] to 
+jbloggs@example.com [jbloggs@example.com]"
+`;
+
+exports[`API Versioning Admin API responds with error when requested version is BEHIND and CANNOT respond 5: [metadata 1] 1`] = `
+Object {
+  "subject": "Attention required: Your Zapier integration has failed",
+  "to": "jbloggs@example.com",
 }
 `;
 

--- a/ghost/core/test/e2e-api/shared/version.test.js
+++ b/ghost/core/test/e2e-api/shared/version.test.js
@@ -1,5 +1,6 @@
-const {agentProvider, fixtureManager, matchers, mockManager} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers, regexes, mockManager} = require('../../utils/e2e-framework');
 const {anyErrorId, stringMatching, anyObjectId, anyLocationFor, anyISODateTime, anyEtag, anyString, anyContentLength, anyContentVersion} = matchers;
+const {anyMajorMinorVersion} = regexes;
 
 const settingsMatcher = {
     settings: {
@@ -10,6 +11,7 @@ const settingsMatcher = {
 describe('API Versioning', function () {
     describe('Admin API', function () {
         let agentAdminAPI;
+        let emailMockReceiver;
 
         before(async function () {
             agentAdminAPI = await agentProvider.getAdminAPIAgent();
@@ -18,7 +20,7 @@ describe('API Versioning', function () {
         });
 
         beforeEach(function () {
-            mockManager.mockMail();
+            emailMockReceiver = mockManager.mockMail();
         });
 
         afterEach(function () {
@@ -130,11 +132,17 @@ describe('API Versioning', function () {
                     }]
                 });
 
-            mockManager.assert.sentEmailCount(1);
-            mockManager.assert.sentEmail({
-                subject: 'Attention required: Your Zapier integration has failed',
-                to: 'jbloggs@example.com'
-            });
+            emailMockReceiver
+                .assertSentEmailCount(1)
+                .matchMetadataSnapshot()
+                .matchHTMLSnapshot([{
+                    pattern: anyMajorMinorVersion,
+                    replacement: 'v4.50'
+                }])
+                .matchPlaintextSnapshot([{
+                    pattern: anyMajorMinorVersion,
+                    replacement: 'v4.50'
+                }]);
         });
 
         it('responds with error and sends email ONCE when requested version is BEHIND and CANNOT respond multiple times', async function () {
@@ -155,11 +163,17 @@ describe('API Versioning', function () {
                     }]
                 });
 
-            mockManager.assert.sentEmailCount(1);
-            mockManager.assert.sentEmail({
-                subject: 'Attention required: Your Zapier integration has failed',
-                to: 'jbloggs@example.com'
-            });
+            emailMockReceiver
+                .assertSentEmailCount(1)
+                .matchMetadataSnapshot()
+                .matchHTMLSnapshot([{
+                    pattern: anyMajorMinorVersion,
+                    replacement: 'v4.50'
+                }])
+                .matchPlaintextSnapshot([{
+                    pattern: anyMajorMinorVersion,
+                    replacement: 'v4.50'
+                }]);
 
             await agentAdminAPI
                 .get('removed_endpoint')
@@ -178,7 +192,7 @@ describe('API Versioning', function () {
                     }]
                 });
 
-            mockManager.assert.sentEmailCount(1);
+            emailMockReceiver.assertSentEmailCount(1);
         });
 
         it('responds with 404 error when the resource cannot be found', async function () {
@@ -197,7 +211,7 @@ describe('API Versioning', function () {
                     }]
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
 
         it('Does an internal rewrite for canary URLs with accept version set', async function () {
@@ -271,9 +285,10 @@ describe('API Versioning', function () {
 
     describe('Content API', function () {
         let agentContentAPI;
+        let emailMockReceiver;
 
         beforeEach(function () {
-            mockManager.mockMail();
+            emailMockReceiver = mockManager.mockMail();
         });
 
         afterEach(function () {
@@ -341,7 +356,7 @@ describe('API Versioning', function () {
                     }]
                 });
 
-            mockManager.assert.sentEmailCount(0);
+            emailMockReceiver.assertSentEmailCount(0);
         });
     });
 });

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -451,6 +451,9 @@ module.exports = {
             return path.join(__dirname, 'fixtures', fixturePath);
         }
     },
+    regexes: {
+        anyMajorMinorVersion: /v\d+\.\d+/gi
+    },
     matchers: {
         anyBoolean: any(Boolean),
         anyString: any(String),


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2691
refs https://github.com/TryGhost/Ghost/commit/939f25a987d26b385978609bac29d27ba8881326

- Resurrected refed commit that was adding tests for versioning API, this time it's using dynamic replacements to match dynamic content of the email using matchHTMLSnapshot / matchPlaintextSnapshot with dynamic content replacements.