### PR TITLE
Update email mock receiver & authentication test to use email snapshots

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -80,7 +80,7 @@
     "@tryghost/email-analytics-provider-mailgun": "0.0.0",
     "@tryghost/email-analytics-service": "0.0.0",
     "@tryghost/email-content-generator": "0.0.0",
-    "@tryghost/email-mock-receiver": "0.1.1",
+    "@tryghost/email-mock-receiver": "0.2.2",
     "@tryghost/email-service": "0.0.0",
     "@tryghost/email-suppression-list": "0.0.0",
     "@tryghost/errors": "1.2.24",

--- a/ghost/core/test/regression/api/admin/__snapshots__/authentication.test.js.snap
+++ b/ghost/core/test/regression/api/admin/__snapshots__/authentication.test.js.snap
@@ -213,10 +213,8 @@ a {
 </html>"
 `;
 
-exports[`Authentication API Blog setup complete setup 4: [metadata 1] 1`] = `
-Object {
-  "subject": "Your New Ghost Site",
-  "text": " [https://static.ghost.org/v4.0.0/images/ghost-orb-3.png] Hello!
+exports[`Authentication API Blog setup complete setup 4: [text 1] 1`] = `
+" [https://static.ghost.org/v4.0.0/images/ghost-orb-3.png] Hello!
 
 Good news! You've successfully created a brand new Ghost publication over on 
 http://127.0.0.1:2369/ [http://127.0.0.1:2369/]
@@ -234,7 +232,12 @@ xoxo
 Team Ghost – https://ghost.org [https://ghost.org]
 
 This email was sent from http://127.0.0.1:2369/ [http://127.0.0.1:2369/] to 
-test@example.com [test@example.com]",
+test@example.com [test@example.com]"
+`;
+
+exports[`Authentication API Blog setup complete setup 5: [metadata 1] 1`] = `
+Object {
+  "subject": "Your New Ghost Site",
   "to": "test@example.com",
 }
 `;
@@ -483,10 +486,8 @@ a {
 </html>"
 `;
 
-exports[`Authentication API Blog setup complete setup with default theme 4: [metadata 1] 1`] = `
-Object {
-  "subject": "Your New Ghost Site",
-  "text": " [https://static.ghost.org/v4.0.0/images/ghost-orb-3.png] Hello!
+exports[`Authentication API Blog setup complete setup with default theme 4: [text 1] 1`] = `
+" [https://static.ghost.org/v4.0.0/images/ghost-orb-3.png] Hello!
 
 Good news! You've successfully created a brand new Ghost publication over on 
 http://127.0.0.1:2369/ [http://127.0.0.1:2369/]
@@ -504,7 +505,12 @@ xoxo
 Team Ghost – https://ghost.org [https://ghost.org]
 
 This email was sent from http://127.0.0.1:2369/ [http://127.0.0.1:2369/] to 
-test@example.com [test@example.com]",
+test@example.com [test@example.com]"
+`;
+
+exports[`Authentication API Blog setup complete setup with default theme 5: [metadata 1] 1`] = `
+Object {
+  "subject": "Your New Ghost Site",
   "to": "test@example.com",
 }
 `;

--- a/ghost/core/test/regression/api/admin/authentication.test.js
+++ b/ghost/core/test/regression/api/admin/authentication.test.js
@@ -73,6 +73,7 @@ describe('Authentication API', function () {
 
             // Test our side effects
             emailMockReceiver.matchHTMLSnapshot();
+            emailMockReceiver.matchPlaintextSnapshot();
             emailMockReceiver.matchMetadataSnapshot();
 
             assert.equal(requestMock.isDone(), true, 'The dawn github URL should have been used');
@@ -209,6 +210,7 @@ describe('Authentication API', function () {
 
             // Test our side effects
             emailMockReceiver.matchHTMLSnapshot();
+            emailMockReceiver.matchPlaintextSnapshot();
             emailMockReceiver.matchMetadataSnapshot();
 
             assert.equal(requestMock.isDone(), false, 'The ghost github URL should not have been used');

--- a/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
+++ b/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
@@ -169,12 +169,8 @@ exports[`UNIT > Settings BREAD Service: edit setting members_support_address tri
 "
 `;
 
-exports[`UNIT > Settings BREAD Service: edit setting members_support_address triggers email verification 2: [metadata 1] 1`] = `
-Object {
-  "forceTextContent": true,
-  "from": "noreply@example.com",
-  "subject": "Verify email address",
-  "text": "
+exports[`UNIT > Settings BREAD Service: edit setting members_support_address triggers email verification 2: [text 1] 1`] = `
+"
                 Hey there,
 
                 Please confirm your email address with this link:
@@ -187,7 +183,14 @@ Object {
 
                 Sent to support@example.com
                 If you did not make this request, you can simply delete this message. This email address will not be used.
-                ",
+                "
+`;
+
+exports[`UNIT > Settings BREAD Service: edit setting members_support_address triggers email verification 3: [metadata 1] 1`] = `
+Object {
+  "forceTextContent": true,
+  "from": "noreply@example.com",
+  "subject": "Verify email address",
   "to": "support@example.com",
 }
 `;

--- a/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
@@ -197,6 +197,7 @@ describe('UNIT > Settings BREAD Service:', function () {
             assert.deepEqual(settings.meta.sent_email_verification, ['members_support_address']);
 
             emailMockReceiver.matchHTMLSnapshot();
+            emailMockReceiver.matchPlaintextSnapshot();
             emailMockReceiver.matchMetadataSnapshot();
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5737,10 +5737,10 @@
     "@tryghost/debug" "^0.1.22"
     split2 "4.1.0"
 
-"@tryghost/email-mock-receiver@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/email-mock-receiver/-/email-mock-receiver-0.1.1.tgz#0c10d57256d0c8e26a4038e7b8cd3d371acf7cf3"
-  integrity sha512-rM4cQa7VHbuIDFxwKSSU28veQq97B6CPQMEktu3mBRgsFeequUU9cfGbSHnc7nriMRFRT8eThDLOJJ27LHcqhA==
+"@tryghost/email-mock-receiver@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@tryghost/email-mock-receiver/-/email-mock-receiver-0.2.2.tgz#214f4424a3d7a51df19e9de397a42ccedba3dcb3"
+  integrity sha512-iYAp1BGpHPthWgwklddewNJOGdB4/uetAZJRadVsZd/Y8jqtSXk4TEH3IVJuTcXQTbVam+ggAgnheFDW/ANBZg==
 
 "@tryghost/ember-promise-modals@2.0.1":
   version "2.0.1"


### PR DESCRIPTION
Updates email-mock-receiver module and migrated `authentication` test suite to use email snapshots.