### PR TITLE
Fixed member import with created_at in the future

### DIFF
--- a/ghost/members-importer/lib/importer.js
+++ b/ghost/members-importer/lib/importer.js
@@ -124,12 +124,16 @@ module.exports = class MembersCSVImporter {
             };
 
             try {
+                // If the member is created in the future, set created_at to now
+                // Members created in the future will not appear in admin members list
+                // Refs https://github.com/TryGhost/Team/issues/2793
+                const createdAt = moment(row.created_at).isAfter(moment()) ? moment().toDate() : row.created_at;
                 const memberValues = {
                     email: row.email,
                     name: row.name,
                     note: row.note,
                     subscribed: row.subscribed,
-                    created_at: row.created_at,
+                    created_at: createdAt,
                     labels: row.labels
                 };
                 const existingMember = await membersRepository.get({email: memberValues.email}, {

--- a/ghost/members-importer/test/fixtures/special-cases.csv
+++ b/ghost/members-importer/test/fixtures/special-cases.csv
@@ -1,0 +1,3 @@
+id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers
+634e48e056ef99c6a7af5850,timetraveler@example.com,"From the cuture","a note",true,true,,9999-10-18T06:34:08.000Z,,"user import label",This is a Bronze Tier
+


### PR DESCRIPTION
refs TryGhost/Team#2793

- if a member is imported with a created_at in the future, the member will not appear in the members list in admin
- this commit updates created_at to the current date if it is in the future upon import