### PR TITLE
Post export improvements

### DIFF
--- a/ghost/admin/app/components/settings/analytics.hbs
+++ b/ghost/admin/app/components/settings/analytics.hbs
@@ -107,7 +107,7 @@
                 <div>
                     <h4 class="gh-expandable-title">Export post analytics</h4>
                     <p class="gh-expandable-description">
-                        Download a CSV file of all your post data for easy analysis in one place
+                        Download a CSV file of your last 1000 posts data for easy analysis in one place
                     </p>
                 </div>
                 <GhTaskButton @buttonText="Export" @successText="Exported" @task={{this.exportPostsTask}} @class="gh-btn gh-btn-icon"/>

--- a/ghost/admin/app/components/settings/analytics.hbs
+++ b/ghost/admin/app/components/settings/analytics.hbs
@@ -110,9 +110,7 @@
                         Download a CSV file of all your post data for easy analysis in one place
                     </p>
                 </div>
-                <button type="button" class="gh-btn" {{on "click" this.exportData}}>
-                    <span>Export</span>
-                </button>
+                <GhTaskButton @buttonText="Export" @successText="Exported" @task={{this.exportPostsTask}} @class="gh-btn gh-btn-icon"/>
             </div>
         </div>
     </section>

--- a/ghost/admin/app/components/settings/analytics.js
+++ b/ghost/admin/app/components/settings/analytics.js
@@ -21,7 +21,7 @@ export default class Analytics extends Component {
     *exportPostsTask() {
         let exportUrl = ghostPaths().url.api('posts/export');
         let downloadParams = new URLSearchParams();
-        downloadParams.set('limit', 'all');
+        downloadParams.set('limit', 1000);
 
         yield this.utils.fetchAndDownloadFile(`${exportUrl}?${downloadParams.toString()}`);
 

--- a/ghost/admin/app/components/settings/analytics.js
+++ b/ghost/admin/app/components/settings/analytics.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
 
 export default class Analytics extends Component {
     @service settings;
@@ -16,13 +17,15 @@ export default class Analytics extends Component {
         this.settings.emailTrackOpens = !this.settings.emailTrackOpens;
     }
 
-    @action
-    exportData() {
+    @task
+    *exportPostsTask() {
         let exportUrl = ghostPaths().url.api('posts/export');
         let downloadParams = new URLSearchParams();
         downloadParams.set('limit', 'all');
 
-        this.utils.downloadFile(`${exportUrl}?${downloadParams.toString()}`);
+        yield this.utils.fetchAndDownloadFile(`${exportUrl}?${downloadParams.toString()}`);
+
+        return true;
     }
 
     @action

--- a/ghost/admin/app/services/utils.js
+++ b/ghost/admin/app/services/utils.js
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+import fetch from 'fetch';
 
 export default class UtilsService extends Service {
     downloadFile(url) {
@@ -12,6 +13,29 @@ export default class UtilsService extends Service {
         }
 
         iframe.setAttribute('src', url);
+    }
+
+    /**
+     * This method will fetch a file from the server and then download it, resolving
+     * once the initial fetch is complete, allowing it to be used with loading spinners.
+     *
+     * @param {string} url - The URL of the file to download
+     * @returns {Promise<void>}
+     */
+    async fetchAndDownloadFile(url) {
+        const response = await fetch(url);
+        const blob = await response.blob();
+
+        const anchor = document.createElement('a');
+
+        anchor.href = window.URL.createObjectURL(blob);
+        anchor.download = /filename="(.*)"/.exec(response.headers.get('Content-Disposition'))[1];
+
+        document.body.append(anchor);
+
+        anchor.click();
+
+        document.body.removeChild(anchor);
     }
 
     /**


### PR DESCRIPTION

**[Updated the posts export button to be a GhTaskButton](https://github.com/TryGhost/Ghost/commit/5833a435e2ce96037ab987e0ffbcb35e3e0c6730)**

refs https://github.com/TryGhost/Team/issues/2935

This allows us to track the state with a loading spinner and a
success/error message on completion. This is expecially important for
larger sites where the download can take a long time, and users are
unsure if something is happening.

---

**[Limited post export size to 1000 posts](https://github.com/TryGhost/Ghost/commit/23519fa0c456049b4f50091f0fcb9cb4f2a10111)**

refs https://github.com/TryGhost/Team/issues/2936

We want to make sure that downloads complete in a reasonable number of
time, and the simplest way to do that is to cap the size of the file.