### PR TITLE
Fixed pasting links in koenig basic html input

### DIFF
--- a/ghost/admin/app/components/modal-base.js
+++ b/ghost/admin/app/components/modal-base.js
@@ -7,6 +7,7 @@ export default Component.extend({
     classNames: 'modal-content',
 
     _previousKeymasterScope: null,
+    closeOnEnter: true,
 
     // Allowed Actions
     closeModal: () => {},
@@ -38,9 +39,11 @@ export default Component.extend({
 
         this._previousKeymasterScope = key.getScope();
 
-        key('enter', 'modal', () => {
-            this.send('confirm');
-        });
+        if (this.closeOnEnter) {
+            key('enter', 'modal', () => {
+                this.send('confirm');
+            });
+        }
 
         key('escape', 'modal', (event) => {
             if (!event.target.dataset.preventEscapeCloseModal) {

--- a/ghost/admin/app/components/modal-portal-settings.js
+++ b/ghost/admin/app/components/modal-portal-settings.js
@@ -28,6 +28,7 @@ export default ModalComponent.extend({
     changedTiers: null,
     openSection: null,
     portalPreviewGuid: 'modal-portal-settings',
+    closeOnEnter: false,
 
     confirm() {},
 

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-basic-html-input.js
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-basic-html-input.js
@@ -315,10 +315,6 @@ export default class KoenigBasicHtmlInput extends Component {
             return;
         }
 
-        if (!range.isCollapsed) {
-            editor.performDelete();
-        }
-
         if (editor.post.isBlank) {
             editor._insertEmptyMarkupSectionAtCursor();
         }
@@ -335,6 +331,10 @@ export default class KoenigBasicHtmlInput extends Component {
                 editor.selectRange(range.tail);
                 return;
             }
+        }
+
+        if (!range.isCollapsed) {
+            editor.performDelete();
         }
 
         const position = editor.range.head;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/2680

When selecting a portion of text in KoenigBasicHtmlInput (capation input for images, newsletter footer text input, new signup notice), and then pasting a link, some funky things happen:
- Part of the text disappears
- The wrong part of the text is linked

The cause of this is that `KoenigBasicHtmlInput` deletes the selected text range when pasting, even when pasting a link. so moving that part below the code that detected a valid link, fixes the issue.

This also adds an option to not close an old style modal when pressing the enter key (e.g. pressing enter when entering a link causes the modal to close).

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 73d0531</samp>

### Summary
🛠️📝⌨️

<!--
1.  🛠️ - This emoji represents a fix or improvement, and can be used for the first and third changes, which both improve the functionality of the modals and the code block input.
2.  📝 - This emoji represents a form or document, and can be used for the second change, which adds a new option for modals that contain forms or other text inputs that need to use the enter key.
3.  ⌨️ - This emoji represents a keyboard, and can be used for the second and third changes, which both involve the enter key and how it affects the modals and the code block input.
-->
This pull request adds a new option to disable closing modals on enter in the `modal-base` component and applies it to the `modal-portal-settings` component. It also fixes a bug in the `koenig-basic-html-input` component that affected deleting text in code blocks.

> _Some modals need enter to save_
> _But others should close and behave_
> _So `closeOnEnter` was set_
> _To `false` or `true` as met_
> _And `koenig-basic-html-input` was made brave_

### Walkthrough
*  Add `closeOnEnter` property to `modal-base` component to control enter key behavior ([link](https://github.com/TryGhost/Ghost/pull/16584/files?diff=unified&w=0#diff-93abc13aee5433639f75e8564252ef3813e9ff64b7a01eda70b6ea5ad253273bR10))
*  Register `enter` key event handler only if `closeOnEnter` is true in `modal-base` component ([link](https://github.com/TryGhost/Ghost/pull/16584/files?diff=unified&w=0#diff-93abc13aee5433639f75e8564252ef3813e9ff64b7a01eda70b6ea5ad253273bL41-R46))
*  Disable `closeOnEnter` for `modal-portal-settings` component to allow form submission on enter ([link](https://github.com/TryGhost/Ghost/pull/16584/files?diff=unified&w=0#diff-3e90fe8af84f576c57120a3757e4100712f54b36f904417874cc796cb5835d5dR31))
*  Fix bug in `koenig-basic-html-input` component by deleting selected text before inserting new line in code block ([link](https://github.com/TryGhost/Ghost/pull/16584/files?diff=unified&w=0#diff-fd3a588cba60eaf2e3eda5ed531b97989bd63f7f486d0ee5ae0a259b0b257219R336-R339))
*  Remove redundant delete operation in `handleNewline` method of `koenig-basic-html-input` component ([link](https://github.com/TryGhost/Ghost/pull/16584/files?diff=unified&w=0#diff-fd3a588cba60eaf2e3eda5ed531b97989bd63f7f486d0ee5ae0a259b0b257219L318-L321))


