### PR TITLE
Added bulk destroy posts api

### DIFF
--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -1,11 +1,15 @@
 import Component from '@glimmer/component';
+import DeletePostsModal from './modals/delete-posts';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
 
 export default class PostsContextMenu extends Component {
     @service ajax;
     @service ghostPaths;
     @service session;
+    @service infinity;
+    @service modals;
 
     get menu() {
         return this.args.menu;
@@ -16,10 +20,36 @@ export default class PostsContextMenu extends Component {
     }
 
     @action
-    deletePosts() {
-        // Use filter in menu.selectionList.filter
-        alert('Deleting posts not yet supported.');
+    async deletePosts() {
         this.menu.close();
+        const confirmedDelete = await this.modals.open(DeletePostsModal, {
+            isSingle: this.selectionList.isSingle,
+            confirm: this.deletePostsTask
+        });
+        if (!confirmedDelete) {
+            return;
+        }
+    }
+
+    @task
+    *deletePostsTask(close) {
+        const deletedModels = this.selectionList.availableModels;
+        yield this.performBulkDestroy();
+        const remainingModels = this.selectionList.infinityModel.content.filter((model) => {
+            return !deletedModels.includes(model);
+        });
+        // Deleteobjects method from infintiymodel is broken for all models except the first page, so we cannot use this
+        this.infinity.replace(this.selectionList.infinityModel, remainingModels);
+        this.selectionList.clearSelection();
+        close();
+
+        return true;
+    }
+
+    async performBulkDestroy() {
+        const filter = this.selectionList.filter;
+        let bulkUpdateUrl = this.ghostPaths.url.api(`posts`) + `?filter=${encodeURIComponent(filter)}`;
+        return await this.ajax.delete(bulkUpdateUrl);
     }
 
     async performBulkEdit(_action, meta = {}) {

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -24,6 +24,7 @@ export default class PostsContextMenu extends Component {
         this.menu.close();
         await this.modals.open(DeletePostsModal, {
             isSingle: this.selectionList.isSingle,
+            count: this.selectionList.count,
             confirm: this.deletePostsTask
         });
     }

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -22,13 +22,10 @@ export default class PostsContextMenu extends Component {
     @action
     async deletePosts() {
         this.menu.close();
-        const confirmedDelete = await this.modals.open(DeletePostsModal, {
+        await this.modals.open(DeletePostsModal, {
             isSingle: this.selectionList.isSingle,
             confirm: this.deletePostsTask
         });
-        if (!confirmedDelete) {
-            return;
-        }
     }
 
     @task

--- a/ghost/admin/app/components/posts-list/modals/delete-posts.hbs
+++ b/ghost/admin/app/components/posts-list/modals/delete-posts.hbs
@@ -1,0 +1,28 @@
+<div class="modal-content" data-test-modal="delete-posts">
+    <header class="modal-header">
+        <h1>Are you sure you want to delete {{if @data.isSingle 'this post' 'these posts'}}?</h1>
+    </header>
+    <button type="button" class="close" title="Close" {{on "click" (fn @close false)}} data-test-button="close">{{svg-jar "close"}}<span class="hidden">Close</span></button>
+
+    <div class="modal-body">
+        <p>
+            You're about to delete {{if @data.isSingle 'this post' 'these posts'}}.
+            This is irreversible.
+        </p>
+    </div>
+
+    <div class="modal-footer">
+        <button class="gh-btn" data-test-button="cancel" type="button" {{on "click" (fn @close false)}}><span>Cancel</span></button>
+
+         <GhTaskButton
+            @buttonText="Delete"
+            @runningText="Deleting"
+            @showSuccess={{false}}
+            @task={{@data.confirm}}
+            @taskArgs={{@close}}
+            @class="gh-btn gh-btn-red gh-btn-icon"
+            data-test-button="confirm"
+        />
+
+    </div>
+</div>

--- a/ghost/admin/app/components/posts-list/modals/delete-posts.hbs
+++ b/ghost/admin/app/components/posts-list/modals/delete-posts.hbs
@@ -1,12 +1,12 @@
 <div class="modal-content" data-test-modal="delete-posts">
     <header class="modal-header">
-        <h1>Are you sure you want to delete {{if @data.isSingle 'this post' 'these posts'}}?</h1>
+        <h1>Are you sure you want to delete {{if @data.isSingle 'this post' (concat @data.count ' posts')}}?</h1>
     </header>
     <button type="button" class="close" title="Close" {{on "click" (fn @close false)}} data-test-button="close">{{svg-jar "close"}}<span class="hidden">Close</span></button>
 
     <div class="modal-body">
         <p>
-            You're about to delete {{if @data.isSingle 'this post' 'these posts'}}.
+            You're about to delete {{if @data.isSingle 'this post' (concat @data.count ' posts')}}.
             This is irreversible.
         </p>
     </div>

--- a/ghost/admin/app/utils/selection-list.js
+++ b/ghost/admin/app/utils/selection-list.js
@@ -71,6 +71,13 @@ export default class SelectionList {
         return this.selectedIds.size === 1 && !this.inverted;
     }
 
+    get count() {
+        if (!this.inverted) {
+            return this.selectedIds.size;
+        }
+        return Math.max((this.infinityModel.meta?.pagination?.total ?? 0) - this.selectedIds.size, 1);
+    }
+
     isSelected(id) {
         if (this.inverted) {
             return !this.selectedIds.has(id);

--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -234,6 +234,20 @@ module.exports = {
         }
     },
 
+    bulkDestroy: {
+        statusCode: 200,
+        headers: {},
+        options: [
+            'filter'
+        ],
+        permissions: {
+            method: 'destroy'
+        },
+        async query(frame) {
+            return await postsService.bulkDestroy(frame.options);
+        }
+    },
+
     destroy: {
         statusCode: 204,
         headers: {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
@@ -53,5 +53,9 @@ module.exports = {
                 }
             }
         };
+    },
+
+    bulkDestroy(bulkActionResult, _apiConfig, frame) {
+        frame.response = bulkActionResult;
     }
 };

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -29,6 +29,7 @@ module.exports = function apiRoutes() {
     router.get('/posts/export', mw.authAdminApi, http(api.posts.exportCSV));
 
     router.post('/posts', mw.authAdminApi, http(api.posts.add));
+    router.del('/posts', mw.authAdminApi, http(api.posts.bulkDestroy));
     router.put('/posts/bulk', mw.authAdminApi, http(api.posts.bulkEdit));
     router.get('/posts/:id', mw.authAdminApi, http(api.posts.read));
     router.get('/posts/slug/:slug', mw.authAdminApi, http(api.posts.read));


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2921

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b7bc87b</samp>

### Summary
🗑️🚀🛠️

<!--
1.  🗑️ - This emoji represents the deletion of posts, which is the main feature of this pull request. It also conveys the idea of removing unwanted or unnecessary data, which is the goal of the bulkDestroy endpoint and the DeletePostsModal component.
2.  🚀 - This emoji represents the improvement of the user experience and reliability of deleting posts, which is achieved by using the modals service, the ember-concurrency addon, the `infinity` service, and the error handling and transaction support in the models layer. It also conveys the idea of speed, efficiency, and performance, which are desirable qualities for bulk operations.
3.  🛠️ - This emoji represents the addition of options and keywords to the bulk operations in the models layer, which enhance the flexibility and robustness of the deletion logic. It also conveys the idea of fixing, building, and modifying, which are relevant actions for the bulkDestroy method and the bulkDestroy serializer.
-->
This pull request adds a new feature to the admin interface and the API that allows users to delete multiple posts at once using a filter option. It introduces a new DeletePostsModal component that shows a confirmation dialog and handles the deletion logic using a deletePostsTask. It also updates the posts route, controller, and model to use the `infinity` service for loading and deleting posts. It adds a new bulkDestroy endpoint, serializer, and route to the posts API, and a new bulkDestroy method to the PostsService class that uses the models layer to perform the deletion operations. It also improves the error handling and transaction support of the bulk operations in the models layer.

> _We're deleting posts in bulk, me hearties, yo ho ho_
> _We're using `bulkDestroy` and `filter` options, yo ho ho_
> _We're opening modals and running tasks, me hearties, yo ho ho_
> _And we're handling errors and transactions on the count of three_

### Walkthrough
*  Add a bulkDestroy endpoint to the posts API that allows deleting posts by filter ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-d10face21279923c54e21a5080b4ba8b5be3bd85aca8fab638e99c2bab07eaa1R237-R250), [link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-943cfe5a8b02de38893677e218265527a2dcfb0cb96f88cf251903ca2966448dR56-R59), [link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-b5bb63987e9c81019de85c59df424b58bdac6e4e2a83fe7401d53d0c135540caR32))
   * Use the postsService.bulkDestroy method to perform the deletion logic using the models layer ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-d10face21279923c54e21a5080b4ba8b5be3bd85aca8fab638e99c2bab07eaa1R237-R250), [link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-768c1fd7956f1d1fc3c8b40fe00a234b30fc78f21e56a9b56ff7bcf0077f118fR75-R143))
   * Use the models.Post.getFilteredCollectionQuery method to fetch the posts that match the filter and their related emails ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-768c1fd7956f1d1fc3c8b40fe00a234b30fc78f21e56a9b56ff7bcf0077f118fR75-R143))
   * Use the models.Post.bulkDestroy and models.Post.bulkEdit methods to delete the posts and their related data from various tables, and set the email_id column to null for some tables that reference the emails ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-768c1fd7956f1d1fc3c8b40fe00a234b30fc78f21e56a9b56ff7bcf0077f118fR75-R143), [link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-e6394039d9f95e078d397acc1914258c202be2362453d30e4665b4fe6beb9104L88-R115))
   * Use the createBulkOperation function to create a generic bulk operation with a throwErrors option that determines whether to throw or ignore errors ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-e6394039d9f95e078d397acc1914258c202be2362453d30e4665b4fe6beb9104R21-R23), [link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-e6394039d9f95e078d397acc1914258c202be2362453d30e4665b4fe6beb9104L88-R115))
   * Use the delSingle and delMultiple functions to delete single or multiple rows from a table using knex, with a transacting option that allows using a transaction object ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-e6394039d9f95e078d397acc1914258c202be2362453d30e4665b4fe6beb9104L57-R64), [link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-e6394039d9f95e078d397acc1914258c202be2362453d30e4665b4fe6beb9104L70-R81))
   * Use the bulkDestroy serializer to format the response with the number of deleted posts ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-943cfe5a8b02de38893677e218265527a2dcfb0cb96f88cf251903ca2966448dR56-R59))
   * Use the authAdminApi middleware and the http helper to handle the authentication, authorization, response formatting, and error handling of the request ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-b5bb63987e9c81019de85c59df424b58bdac6e4e2a83fe7401d53d0c135540caR32))
* Add a DeletePostsModal component that displays a confirmation dialog when deleting posts from the posts list ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-67af0fc7493c7b7441164e31ee1a9b63744b7974c85e28e5ef4ddf76c978c4bfR1-R28))
   * Use the modals service to open the modal and pass the isSingle and confirm properties as data ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-50969db447e7ad84650a2005c59a569e2767d62b2a047c0f864e138a8c4fb84aL18-R53), [link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-67af0fc7493c7b7441164e31ee1a9b63744b7974c85e28e5ef4ddf76c978c4bfR1-R28))
   * Use the isSingle property to display the appropriate warning message for deleting a single post or multiple posts ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-67af0fc7493c7b7441164e31ee1a9b63744b7974c85e28e5ef4ddf76c978c4bfR1-R28))
   * Use the confirm property to bind the confirm button to the deletePostsTask that performs the actual deletion ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-67af0fc7493c7b7441164e31ee1a9b63744b7974c85e28e5ef4ddf76c978c4bfR1-R28))
   * Use the GhTaskButton component to show a loading state while the task is running ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-67af0fc7493c7b7441164e31ee1a9b63744b7974c85e28e5ef4ddf76c978c4bfR1-R28))
   * Use the svg-jar helper to render an icon for the close button ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-67af0fc7493c7b7441164e31ee1a9b63744b7974c85e28e5ef4ddf76c978c4bfR1-R28))
* Add a deletePostsTask to the PostsContextMenu component that handles the deletion of posts using the posts API ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-50969db447e7ad84650a2005c59a569e2767d62b2a047c0f864e138a8c4fb84aL2-R11), [link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-50969db447e7ad84650a2005c59a569e2767d62b2a047c0f864e138a8c4fb84aL18-R53))
   * Use the task decorator to define an asynchronous task that can be canceled or retried ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-50969db447e7ad84650a2005c59a569e2767d62b2a047c0f864e138a8c4fb84aL2-R11))
   * Use the infinity service to update the posts list after deletion ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-50969db447e7ad84650a2005c59a569e2767d62b2a047c0f864e138a8c4fb84aL2-R11))
   * Use the modals service to open the DeletePostsModal component and await the user confirmation ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-50969db447e7ad84650a2005c59a569e2767d62b2a047c0f864e138a8c4fb84aL18-R53))
   * Use the HTTP DELETE method and the /posts path to send a request to the bulkDestroy endpoint with the filter option ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-50969db447e7ad84650a2005c59a569e2767d62b2a047c0f864e138a8c4fb84aL2-R11))
* Add a selectionList property to the posts controller that tracks the selected posts and the available posts for deletion ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-9fb4df9fa2a8b0bae2d44e90e55c301122fef3c8a2c88b6c2f3c56d0176d1930L82-R82), [link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-9fb4df9fa2a8b0bae2d44e90e55c301122fef3c8a2c88b6c2f3c56d0176d1930R96-R97))
   * Use the model parameter to pass the infinity model to the controller ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-9fb4df9fa2a8b0bae2d44e90e55c301122fef3c8a2c88b6c2f3c56d0176d1930L82-R82))
   * Use the SelectionList class to handle the logic for selecting and deselecting posts, as well as filtering and sorting them ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-9fb4df9fa2a8b0bae2d44e90e55c301122fef3c8a2c88b6c2f3c56d0176d1930R96-R97))
   * Use the infinity model to access the posts and update them after deletion ([link](https://github.com/TryGhost/Ghost/pull/16587/files?diff=unified&w=0#diff-9fb4df9fa2a8b0bae2d44e90e55c301122fef3c8a2c88b6c2f3c56d0176d1930R96-R97))


