### PR TITLE
Fixed flaky test: Can generate a mentions report

### DIFF
--- a/ghost/webmentions/test/MentionsAPI.test.js
+++ b/ghost/webmentions/test/MentionsAPI.test.js
@@ -45,7 +45,7 @@ describe('MentionsAPI', function () {
     });
 
     it('Can generate a mentions report', async function () {
-        this.retries(1);
+        // this.retries(1);
         const repository = new InMemoryMentionRepository();
         const api = new MentionsAPI({
             repository,
@@ -64,7 +64,7 @@ describe('MentionsAPI', function () {
 
         const now = new Date();
 
-        const report = await api.getMentionReport(new Date(0), new Date());
+        const report = await api.getMentionReport(new Date(0), now);
 
         assert.deepEqual(report.startDate, new Date(0));
         assert.deepEqual(report.endDate, now);


### PR DESCRIPTION
refs TryGhost/Team#2844

- assertion was comparing a constant `now` with a `new Date()` that was made on the next line — by passing now in as the end date to `getMentionReport`, the end date should always equal the constant
- intent of the test is just to make sure a mentions report can generate, so we can just use the variable now instead of creating new Date() objects