### PR TITLE
Removed feature action from context menu for email-only posts

### DIFF
--- a/ghost/admin/app/components/posts-list/context-menu.hbs
+++ b/ghost/admin/app/components/posts-list/context-menu.hbs
@@ -11,18 +11,20 @@
             <span>Unpublish</span>
         </button>
     </li>
-    {{#if this.shouldFeatureSelection }}
-        <li>
-            <button class="mr2" type="button" {{on "click" this.featurePosts}}>
-                <span>Feature</span>
-            </button>
-        </li>
-    {{else}}
+    {{#if this.canFeatureSelection}}
+        {{#if this.shouldFeatureSelection }}
             <li>
-            <button class="mr2" type="button" {{on "click" this.unfeaturePosts}}>
-                <span>Unfeature</span>
-            </button>
-        </li>
+                <button class="mr2" type="button" {{on "click" this.featurePosts}}>
+                    <span>Feature</span>
+                </button>
+            </li>
+        {{else}}
+                <li>
+                <button class="mr2" type="button" {{on "click" this.unfeaturePosts}}>
+                    <span>Unfeature</span>
+                </button>
+            </li>
+        {{/if}}
     {{/if}}
     <li>
         <button class="mr2" type="button" disabled {{on "click" @menu.close}}>

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -42,6 +42,13 @@ export default class PostsContextMenu extends Component {
         return !firstPost.featured;
     }
 
+    get canFeatureSelection() {
+        if (!this.selectionList.isSingle) {
+            return true;
+        }
+        return this.selectionList.availableModels[0].get('status') !== 'sent';
+    }
+
     @action
     async featurePosts() {
         const updatedModels = this.selectionList.availableModels;


### PR DESCRIPTION
These posts make no sense to be featured, so we are removing the option from the context menu when there is only a single email-only post under selection.

We still allowing featuring these posts in the PSM and when they are part of a larger selection, but fixing all places for this is out of scope.
