### PR TITLE
Added error handling for email analytics unsubscribe event

### DIFF
--- a/ghost/email-service/lib/email-event-storage.js
+++ b/ghost/email-service/lib/email-event-storage.js
@@ -129,7 +129,11 @@ class EmailEventStorage {
     }
 
     async unsubscribeFromNewsletters(event) {
-        await this.#membersRepository.update({newsletters: []}, {id: event.memberId});
+        try {
+            await this.#membersRepository.update({newsletters: []}, {id: event.memberId});
+        } catch (err) {
+            logging.error(err);
+        }
     }
 }
 

--- a/ghost/email-service/test/email-event-storage.test.js
+++ b/ghost/email-service/test/email-event-storage.test.js
@@ -466,6 +466,27 @@ describe('Email Event Storage', function () {
         assert(update.firstCall.args[0].newsletters.length === 0);
     });
 
+    it('Handles unsubscribe with a non-existent member', async function () {
+        const event = EmailUnsubscribedEvent.create({
+            email: 'example@example.com',
+            memberId: '123',
+            emailId: '456',
+            timestamp: new Date(0)
+        });
+
+        const error = new Error('Member not found');
+        const update = sinon.stub().throws(error);
+
+        const eventHandler = new EmailEventStorage({
+            membersRepository: {
+                update
+            }
+        });
+        await eventHandler.handleUnsubscribed(event);
+        assert(update.calledOnce);
+        assert(update.firstCall.args[0].newsletters.length === 0);
+    });
+
     it('Handles complaints', async function () {
         const event = SpamComplaintEvent.create({
             email: 'example@example.com',


### PR DESCRIPTION
refs TryGhost/Team#2974

- currently the unsubscribeFromNewsletters event is failing with 'member not found' in elastic
- this change catches the error and logs it, which should allow the rest of the event(s) to be processed
