### PR TITLE
Implemented bulk editing post access

### DIFF
--- a/ghost/admin/app/components/posts-list/context-menu.hbs
+++ b/ghost/admin/app/components/posts-list/context-menu.hbs
@@ -25,7 +25,7 @@
         </button>
     </li>
     <li>
-        <button class="mr2" type="button" disabled {{on "click" @menu.close}}>
+        <button class="mr2" type="button" {{on "click" this.editPostsAccess}}>
             <span>Post access...</span>
         </button>
     </li>

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -3,6 +3,7 @@ import DeletePostsModal from './modals/delete-posts';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
+import EditPostsAccessModal from './modals/edit-posts-access';
 
 export default class PostsContextMenu extends Component {
     @service ajax;
@@ -10,6 +11,7 @@ export default class PostsContextMenu extends Component {
     @service session;
     @service infinity;
     @service modals;
+    @service store;
 
     get menu() {
         return this.args.menu;
@@ -29,6 +31,16 @@ export default class PostsContextMenu extends Component {
         });
     }
 
+    @action
+    async editPostsAccess() {
+        this.menu.close();
+        await this.modals.open(EditPostsAccessModal, {
+            isSingle: this.selectionList.isSingle,
+            count: this.selectionList.count,
+            confirm: this.editPostsAccessTask
+        });
+    }
+
     @task
     *deletePostsTask(close) {
         const deletedModels = this.selectionList.availableModels;
@@ -39,6 +51,35 @@ export default class PostsContextMenu extends Component {
         // Deleteobjects method from infintiymodel is broken for all models except the first page, so we cannot use this
         this.infinity.replace(this.selectionList.infinityModel, remainingModels);
         this.selectionList.clearSelection();
+        close();
+
+        return true;
+    }
+
+    @task
+    *editPostsAccessTask(close, {visibility, tiers}) {
+        const updatedModels = this.selectionList.availableModels;
+        yield this.performBulkEdit('access', {visibility, tiers});
+
+        // Update the models on the client side
+        for (const post of updatedModels) {
+            // We need to do it this way to prevent marking the model as dirty
+            this.store.push({
+                data: {
+                    id: post.id,
+                    type: 'post',
+                    attributes: {
+                        visibility
+                    },
+                    relationships: {
+                        links: {
+                            data: tiers
+                        }
+                    }
+                }
+            });
+        }
+
         close();
 
         return true;
@@ -85,7 +126,16 @@ export default class PostsContextMenu extends Component {
 
         // Update the models on the client side
         for (const post of updatedModels) {
-            post.set('featured', true);
+            // We need to do it this way to prevent marking the model as dirty
+            this.store.push({
+                data: {
+                    id: post.id,
+                    type: 'post',
+                    attributes: {
+                        featured: true
+                    }
+                }
+            });
         }
 
         // Close the menu
@@ -99,7 +149,16 @@ export default class PostsContextMenu extends Component {
 
         // Update the models on the client side
         for (const post of updatedModels) {
-            post.set('featured', false);
+            // We need to do it this way to prevent marking the model as dirty
+            this.store.push({
+                data: {
+                    id: post.id,
+                    type: 'post',
+                    attributes: {
+                        featured: false
+                    }
+                }
+            });
         }
 
         // Close the menu

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -1,9 +1,9 @@
 import Component from '@glimmer/component';
 import DeletePostsModal from './modals/delete-posts';
+import EditPostsAccessModal from './modals/edit-posts-access';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
-import EditPostsAccessModal from './modals/edit-posts-access';
 
 export default class PostsContextMenu extends Component {
     @service ajax;

--- a/ghost/admin/app/components/posts-list/modals/edit-posts-access.hbs
+++ b/ghost/admin/app/components/posts-list/modals/edit-posts-access.hbs
@@ -1,0 +1,40 @@
+<div class="modal-content" data-test-modal="edit-posts-access">
+    <header class="modal-header">
+        <h1>Modify access for {{if @data.isSingle 'this post' (concat @data.count ' posts')}}</h1>
+    </header>
+    <button type="button" class="close" title="Close" {{on "click" (fn @close false)}} data-test-button="close">{{svg-jar "close"}}<span class="hidden">Close</span></button>
+
+    <div class="modal-body">
+        <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="visibility">
+            <label for="visibility-input">{{capitalize this.post.displayName}} access</label>
+            <GhPsmVisibilityInput @post={{this.post}} @triggerId="visibility-input" />
+        </GhFormGroup>
+
+        {{#if (eq this.post.visibility "tiers")}}
+            <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="tiers" class="nt3" data-test-visibility-segment-select>
+                <GhPostSettingsMenu::VisibilitySegmentSelect
+                    @tiers={{this.post.tiers}}
+                    @onChange={{action "setVisibility"}}
+                    @renderInPlace={{true}}
+                    @hideOptionsWhenAllSelected={{true}}
+                />
+                <GhErrorMessage @errors={{this.post.errors}} @property="tiers" data-test-error="tiers" />
+            </GhFormGroup>
+        {{/if}}
+
+    </div>
+
+    <div class="modal-footer">
+        <button class="gh-btn" data-test-button="cancel" type="button" {{on "click" (fn @close false)}}><span>Cancel</span></button>
+
+         <GhTaskButton
+            @buttonText="Save"
+            @runningText="Saving"
+            @showSuccess={{false}}
+            @task={{this.save}}
+            @class="gh-btn gh-btn-icon gh-btn-black"
+            data-test-button="confirm"
+        />
+
+    </div>
+</div>

--- a/ghost/admin/app/components/posts-list/modals/edit-posts-access.hbs
+++ b/ghost/admin/app/components/posts-list/modals/edit-posts-access.hbs
@@ -14,7 +14,7 @@
             <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="tiers" class="nt3" data-test-visibility-segment-select>
                 <GhPostSettingsMenu::VisibilitySegmentSelect
                     @tiers={{this.post.tiers}}
-                    @onChange={{action "setVisibility"}}
+                    @onChange={{this.setVisibility}}
                     @renderInPlace={{true}}
                     @hideOptionsWhenAllSelected={{true}}
                 />
@@ -27,7 +27,7 @@
     <div class="modal-footer">
         <button class="gh-btn" data-test-button="cancel" type="button" {{on "click" (fn @close false)}}><span>Cancel</span></button>
 
-         <GhTaskButton
+        <GhTaskButton
             @buttonText="Save"
             @runningText="Saving"
             @showSuccess={{false}}
@@ -35,6 +35,5 @@
             @class="gh-btn gh-btn-icon gh-btn-black"
             data-test-button="confirm"
         />
-
     </div>
 </div>

--- a/ghost/admin/app/components/posts-list/modals/edit-posts-access.js
+++ b/ghost/admin/app/components/posts-list/modals/edit-posts-access.js
@@ -47,7 +47,7 @@ export default class EditPostsAccessModal extends Component {
             }
             throw e;
         }
-        yield this.args.data.confirm.perform(this.args.close, {
+        return yield this.args.data.confirm.perform(this.args.close, {
             visibility: this.post.visibility,
             tiers: this.post.tiers
         });

--- a/ghost/admin/app/components/posts-list/modals/edit-posts-access.js
+++ b/ghost/admin/app/components/posts-list/modals/edit-posts-access.js
@@ -1,0 +1,55 @@
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
+
+export default class EditPostsAccessModal extends Component {
+    @service store;
+
+    // We createa new post model to use the same validations as the post model
+    @tracked post = this.store.createRecord('post', {
+        visibility: 'public',
+        tiers: []
+    });
+
+    async validate() {
+        // Mark as not new
+        this.post.set('currentState.parentState.isNew', false);
+        await this.post.validate({property: 'visibility'});
+        await this.post.validate({property: 'tiers'});
+    }
+
+    @action
+    async setVisibility(segment) {
+        this.post.set('tiers', segment);
+        try {
+            await this.validate();
+        } catch (e) {
+            if (!e) {
+                // validation error
+                return;
+            }
+
+            throw e;
+        }
+    }
+
+    @task
+    *save() {
+        // First validate
+        try {
+            yield this.validate();
+        } catch (e) {
+            if (!e) {
+                // validation error
+                return;
+            }
+            throw e;
+        }
+        yield this.args.data.confirm.perform(this.args.close, {
+            visibility: this.post.visibility,
+            tiers: this.post.tiers
+        });
+    }
+}

--- a/ghost/core/core/server/models/base/plugins/bulk-operations.js
+++ b/ghost/core/core/server/models/base/plugins/bulk-operations.js
@@ -39,20 +39,36 @@ function createBulkOperation(singular, multiple) {
     };
 }
 
-async function insertSingle(knex, table, record) {
-    await knex(table).insert(record);
+async function insertSingle(knex, table, record, options) {
+    let k = knex(table);
+    if (options.transacting) {
+        k = k.transacting(options.transacting);
+    }
+    await k.insert(record);
 }
 
-async function insertMultiple(knex, table, chunk) {
-    await knex(table).insert(chunk);
+async function insertMultiple(knex, table, chunk, options) {
+    let k = knex(table);
+    if (options.transacting) {
+        k = k.transacting(options.transacting);
+    }
+    await k.insert(chunk);
 }
 
 async function editSingle(knex, table, id, options) {
-    await knex(table).where('id', id).update(options.data);
+    let k = knex(table);
+    if (options.transacting) {
+        k = k.transacting(options.transacting);
+    }
+    await k.where('id', id).update(options.data);
 }
 
 async function editMultiple(knex, table, chunk, options) {
-    await knex(table).whereIn('id', chunk).update(options.data);
+    let k = knex(table);
+    if (options.transacting) {
+        k = k.transacting(options.transacting);
+    }
+    await k.whereIn('id', chunk).update(options.data);
 }
 
 async function delSingle(knex, table, id, options) {
@@ -90,13 +106,13 @@ const del = createBulkOperation(delSingle, delMultiple);
  */
 module.exports = function (Bookshelf) {
     Bookshelf.Model = Bookshelf.Model.extend({}, {
-        bulkAdd: function bulkAdd(data, tableName) {
+        bulkAdd: function bulkAdd(data, tableName, options = {}) {
             tableName = tableName || this.prototype.tableName;
 
-            return insert(Bookshelf.knex, tableName, data);
+            return insert(Bookshelf.knex, tableName, data, options);
         },
 
-        bulkEdit: async function bulkEdit(data, tableName, options) {
+        bulkEdit: async function bulkEdit(data, tableName, options = {}) {
             tableName = tableName || this.prototype.tableName;
 
             return await edit(Bookshelf.knex, tableName, data, options);

--- a/ghost/posts-service/package.json
+++ b/ghost/posts-service/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@tryghost/errors": "1.2.24",
     "@tryghost/nql": "0.11.0",
-    "@tryghost/tpl": "0.1.24"
+    "@tryghost/tpl": "0.1.24",
+    "bson-objectid": "2.0.4"
   }
 }


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2924

This change adds a new bulk edit action for posts to update their visibility. It also implements a modal to change the post access level for multiple posts at once using this new API.

It also fixes a pattern that was used when modifying the Ember models in memory. They previously were marked as dirty, this is fixed now. So when going to the editor after modifying posts, you won't get a confirmation dialog any longer.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea24adb</samp>

This pull request adds a new feature to the Ghost admin app that allows users to edit the access settings of multiple posts at once using a modal component. It also adds the necessary logic and database operations to the posts service and the Bookshelf models to support bulk editing of posts. It introduces a new dependency on `bson-objectid` for the posts service. The affected files are `ghost/admin/app/components/posts-list/context-menu.js`, `ghost/admin/app/components/posts-list/context-menu.hbs`, `ghost/admin/app/components/posts-list/modals/edit-posts-access.js`, `ghost/admin/app/components/posts-list/modals/edit-posts-access.hbs`, `ghost/core/core/server/models/base/plugins/bulk-operations.js`, `ghost/posts-service/lib/PostsService.js`, and `ghost/posts-service/package.json`.
