### PR TITLE
Issue-16603 Changed Kiev to Kyiv (2nd try)

### DIFF
--- a/ghost/admin/mirage/fixtures/timezones.js
+++ b/ghost/admin/mirage/fixtures/timezones.js
@@ -132,8 +132,8 @@ export default [
         label: '(GMT +2:00) Harare'
     },
     {
-        name: 'Europe/Kiev',
-        label: '(GMT +2:00) Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius'
+        name: 'Europe/Kyiv',
+        label: '(GMT +2:00) Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius'
     },
     {
         name: 'Asia/Jerusalem',

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -53,7 +53,7 @@
     "@tryghost/nql": "0.11.0",
     "@tryghost/nql-lang": "0.5.0",
     "@tryghost/string": "0.2.4",
-    "@tryghost/timezone-data": "0.2.76",
+    "@tryghost/timezone-data": "0.3.0",
     "autoprefixer": "9.8.6",
     "babel-eslint": "10.1.0",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6085,10 +6085,10 @@
   dependencies:
     unidecode "^0.1.8"
 
-"@tryghost/timezone-data@0.2.76":
-  version "0.2.76"
-  resolved "https://registry.yarnpkg.com/@tryghost/timezone-data/-/timezone-data-0.2.76.tgz#1dc3d5be5c4e356480fc82d0a1d5838a795fe1d8"
-  integrity sha512-7HkGE+bWsKORhMw5kE1Tjp4WxWA3JZ1RVZ6FVWDmje2MD5WrbUrP1RBJ9dWneTCpO4DvQJDWx7AQkYBrYgc+uA==
+"@tryghost/timezone-data@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/timezone-data/-/timezone-data-0.3.0.tgz#5b0940a370a22a0fa3bdf506850dabbc6af574fa"
+  integrity sha512-3vdaEugCY7cTOlo8TuEYTXnXJa1CeNKJ34EU9uJPxWfUsd0BwaSN0hNcXLHhKxnPQnnJkSjradkXSvTfUsYZiA==
 
 "@tryghost/tpl@0.1.24", "@tryghost/tpl@^0.1.24":
   version "0.1.24"


### PR DESCRIPTION
2nd try for a proper commit @naz 

This should contribute to fix [Issue-16603](https://github.com/TryGhost/Ghost/issues/16603)

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1db2c5b</samp>

This pull request updates the timezone data used by Ghost to the latest version, which fixes the spelling of Kyiv and other minor corrections. It affects the `@tryghost/timezone-data` dependency and the `timezones.js` fixture file.
