### PR TITLE
Updated GhContextMenu to handle freezing the SelectionList

### DIFF
--- a/ghost/admin/app/components/gh-context-menu.js
+++ b/ghost/admin/app/components/gh-context-menu.js
@@ -2,15 +2,67 @@ import Component from '@glimmer/component';
 import SelectionList from '../utils/selection-list';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
+
+const states = [
+    'default', // default state
+    'open', // menu open
+    'modal', // modal open
+    'loading' // performing an action
+];
 
 export default class GhContextMenu extends Component {
     @service dropdown;
+    @service modals;
 
     @tracked isOpen = false;
     @tracked left = 0;
     @tracked top = 0;
     @tracked selectionList = new SelectionList();
+
+    state = states[0];
+
+    #originalConfirm = null;
+    #modal = null;
+
+    setState(state) {
+        switch (state) {
+        case this.state:
+            return;
+        case 'default':
+            this.isOpen = false;
+            this.selectionList.unfreeze();
+            this.#closeModal();
+            this.state = state;
+            return;
+        case 'open':
+            if (this.state !== 'default') {
+                return;
+            }
+            this.isOpen = true;
+            this.selectionList.freeze();
+            this.#closeModal();
+            this.state = state;
+            return;
+        case 'modal':
+            if (this.state !== 'open') {
+                return;
+            }
+            this.isOpen = false;
+            this.selectionList.freeze();
+            this.state = state;
+            return;
+        case 'loading':
+            if (this.state !== 'open' && this.state !== 'modal') {
+                return;
+            }
+            this.isOpen = false;
+            this.selectionList.freeze();
+            this.state = state;
+            return;
+        }
+    }
 
     get name() {
         return this.args.name;
@@ -36,12 +88,14 @@ export default class GhContextMenu extends Component {
 
     @action
     open() {
-        this.isOpen = true;
+        this.setState('open');
     }
 
     @action
     close() {
-        this.isOpen = false;
+        if (this.state === 'open') {
+            this.setState('default');
+        }
     }
 
     @action
@@ -65,7 +119,7 @@ export default class GhContextMenu extends Component {
             }
 
             this.open();
-        } else if (this.isOpen) {
+        } else {
             this.close();
         }
     }
@@ -73,5 +127,37 @@ export default class GhContextMenu extends Component {
     @action
     stopClicks(event) {
         event.stopPropagation();
+    }
+
+    @task
+    *confirmWrapperTask(...args) {
+        this.setState('loading');
+        let result = yield this.#originalConfirm.perform(...args);
+        this.#originalConfirm = null;
+        this.setState('default');
+        return result;
+    }
+
+    openModal(Modal, data) {
+        this.#originalConfirm = data.confirm;
+        data.confirm = this.confirmWrapperTask;
+
+        this.setState('modal');
+
+        this.#modal = this.modals.open(Modal, data);
+        this.#modal.then(() => {
+            this.setState('default');
+        });
+    }
+
+    #closeModal() {
+        this.#modal?.close();
+        this.#modal = null;
+    }
+
+    async performTask(taskObj) {
+        this.setState('loading');
+        await taskObj.perform();
+        this.setState('default');
     }
 }

--- a/ghost/admin/app/components/gh-context-menu.js
+++ b/ghost/admin/app/components/gh-context-menu.js
@@ -5,13 +5,6 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
 
-const states = [
-    'default', // default state
-    'open', // menu open
-    'modal', // modal open
-    'loading' // performing an action
-];
-
 export default class GhContextMenu extends Component {
     @service dropdown;
     @service modals;
@@ -21,6 +14,14 @@ export default class GhContextMenu extends Component {
     @tracked top = 0;
     @tracked selectionList = new SelectionList();
 
+    /**
+     * The current state of the context menu
+     * @type {'default'|'open'|'modal'|'loading'}
+     * default: default state
+     * open: menu open
+     * modal: modal open
+     * loading: performing an action
+     */
     state = states[0];
 
     #originalConfirm = null;

--- a/ghost/admin/app/utils/selection-list.js
+++ b/ghost/admin/app/utils/selection-list.js
@@ -10,8 +10,18 @@ export default class SelectionList {
 
     infinityModel;
 
+    #frozen = false;
+
     constructor(infinityModel) {
         this.infinityModel = infinityModel ?? {content: []};
+    }
+
+    freeze() {
+        this.#frozen = true;
+    }
+
+    unfreeze() {
+        this.#frozen = false;
     }
 
     /**
@@ -90,6 +100,9 @@ export default class SelectionList {
     }
 
     toggleItem(id) {
+        if (this.#frozen) {
+            return;
+        }
         this.lastShiftSelectionGroup = new Set();
 
         if (this.selectedIds.has(id)) {
@@ -123,6 +136,9 @@ export default class SelectionList {
      * Select all items between the last selection or the first one if none
      */
     shiftItem(id) {
+        if (this.#frozen) {
+            return;
+        }
         // Unselect last selected items
         for (const item of this.lastShiftSelectionGroup) {
             if (this.inverted) {
@@ -181,12 +197,18 @@ export default class SelectionList {
     }
 
     selectAll() {
+        if (this.#frozen) {
+            return;
+        }
         this.selectedIds = new Set();
         this.inverted = !this.inverted;
         this.lastSelectedId = null;
     }
 
     clearSelection() {
+        if (this.#frozen) {
+            return;
+        }
         this.selectedIds = new Set();
         this.inverted = false;
         this.lastSelectedId = null;


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d69b45</samp>

Refactored the context menu component and its usage in the posts list to improve the user experience and code quality. Introduced a `state` property and a `setState` method to the `gh-context-menu` component to handle different scenarios. Used the `gh-context-menu` component in the `posts-list/context-menu` component to simplify the modal and loading logic. Added a `#frozen` property and methods to the `selection-list` utility to prevent the selection of posts from changing while the context menu is active.
