### PR TITLE
Added `lexical` column to `snippets` table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.44/2023-04-14-04-17-add-snippets-lexical-column.js
+++ b/ghost/core/core/server/data/migrations/versions/5.44/2023-04-14-04-17-add-snippets-lexical-column.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('snippets', 'lexical', {
+    type: 'text',
+    maxlength: 1000000000,
+    fieldtype: 'long',
+    nullable: true
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -876,6 +876,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         name: {type: 'string', maxlength: 191, nullable: false, unique: true},
         mobiledoc: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: false},
+        lexical: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '395330cb390d669843e4913b63a4cf25';
+    const currentSchemaHash = '8ec1f25b5e9e1dde5b1b8ee04dacf4f9';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
     const currentSettingsHash = 'e2fc04c37fe89e972b063ee8fd1d4bec';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs TryGhost/Team#2904

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04a6b06</samp>

This pull request adds a new `lexical` column to the `snippets` table to store lexical information for snippets. It includes a migration script, a schema update, and a schema hash update.
