### PR TITLE
Wired lexical snippets to Ghost

### DIFF
--- a/ghost/admin/app/adapters/snippet.js
+++ b/ghost/admin/app/adapters/snippet.js
@@ -1,0 +1,20 @@
+import ApplicationAdapter from 'ghost-admin/adapters/application';
+
+export default class Snippet extends ApplicationAdapter {
+    buildURL() {
+        const url = super.buildURL(...arguments);
+
+        try {
+            const parsedUrl = new URL(url);
+            if (!parsedUrl.searchParams.get('formats')) {
+                parsedUrl.searchParams.set('formats', 'mobiledoc,lexical');
+                return parsedUrl.href;
+            }
+        } catch (e) {
+            // noop, just use the original url
+            console.error('Couldn\'t parse URL', e); // eslint-disable-line
+        }
+
+        return url;
+    }
+}

--- a/ghost/admin/app/components/editor/modals/update-snippet.js
+++ b/ghost/admin/app/components/editor/modals/update-snippet.js
@@ -7,10 +7,15 @@ export default class UpdateSnippetModal extends Component {
 
     @task({drop: true})
     *updateSnippetTask() {
-        const {snippet, updatedProperties: {mobiledoc}} = this.args.data;
+        const {snippet, updatedProperties: {mobiledoc, lexical}} = this.args.data;
 
         try {
-            snippet.mobiledoc = mobiledoc;
+            if (mobiledoc) {
+                snippet.mobiledoc = mobiledoc;
+            }
+            if (lexical) {
+                snippet.lexical = lexical;
+            }
 
             yield snippet.save();
 

--- a/ghost/admin/app/controllers/editor.js
+++ b/ghost/admin/app/controllers/editor.js
@@ -172,7 +172,8 @@ export default class EditorController extends Controller {
     get snippets() {
         return this._snippets
             .reject(snippet => snippet.get('isNew'))
-            .sort((a, b) => a.name.localeCompare(b.name));
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .filterBy('lexical', null);
     }
 
     @computed('session.user.{isAdmin,isEditor}')

--- a/ghost/admin/app/models/snippet.js
+++ b/ghost/admin/app/models/snippet.js
@@ -6,6 +6,7 @@ export default Model.extend(ValidationEngine, {
 
     name: attr('string'),
     mobiledoc: attr('json-string'),
+    lexical: attr('json-string'),
     createdAtUTC: attr('moment-utc'),
     updatedAtUTC: attr('moment-utc')
 });

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -77,10 +77,6 @@
                 @scrollOffsetBottomSelector=".gh-mobile-nav-bar"
                 @onEditorCreated={{this.setKoenigEditor}}
                 @onWordCountChange={{this.updateWordCount}}
-                @snippets={{this.snippets}}
-                @saveSnippet={{if this.canManageSnippets this.saveSnippet}}
-                @updateSnippet={{if this.canManageSnippets this.confirmUpdateSnippet}}
-                @deleteSnippet={{if this.canManageSnippets this.confirmDeleteSnippet}}
                 @featureImage={{this.post.featureImage}}
                 @featureImageAlt={{this.post.featureImageAlt}}
                 @featureImageCaption={{this.post.featureImageCaption}}
@@ -91,7 +87,8 @@
                 @cardOptions={{hash
                     post=this.post
                     snippets=this.snippets
-                    deleteSnippet=this.confirmDeleteSnippet
+                    deleteSnippet=(if this.canManageSnippets this.confirmDeleteSnippet)
+                    createSnippet=(if this.canManageSnippets this.createSnippet)
                 }}
                 @postType={{this.post.displayName}}
             />


### PR DESCRIPTION
refs TryGhost/Team#2904

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2ba5e2a</samp>

This pull request adds the lexical editor feature to the Ghost admin app, which allows users to create and edit snippets in a natural language format. It modifies the `snippet` model, adapter, and controller, and the `lexical-editor` template and component to support the new feature.
