### PR TITLE
Added post_revisions to posts endpoint as an include option

### DIFF
--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -105,7 +105,7 @@ module.exports = {
         validation: {
             options: {
                 include: {
-                    values: allowedIncludes
+                    values: [...allowedIncludes, 'post_revisions']
                 },
                 formats: {
                     values: models.Post.allowedFormats

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -1004,9 +1004,8 @@ Post = ghostBookshelf.Model.extend({
 
         attrs = this.formatsToJSON(attrs, options);
 
-        // CASE: never expose the revisions
+        // CASE: never expose the mobiledoc revisions
         delete attrs.mobiledoc_revisions;
-        delete attrs.post_revisions;
 
         // If the current column settings allow it...
         if (!options.columns || (options.columns && options.columns.indexOf('primary_tag') > -1)) {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -551,6 +551,180 @@ Building your audience with subscriber signups,http://127.0.0.1:2369/portal/,Gho
 }
 `;
 
+exports[`Posts API Can read with post_revisions included 1: [body] 1`] = `
+Object {
+  "posts": Array [
+    Object {
+      "authors": Any<Array>,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "comment_id": Any<String>,
+      "count": Object {
+        "clicks": 0,
+        "negative_feedback": 0,
+        "positive_feedback": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "custom_excerpt": null,
+      "custom_template": null,
+      "email": null,
+      "email_only": false,
+      "email_segment": "all",
+      "email_subject": null,
+      "excerpt": "Testing post creation with lexical",
+      "feature_image": null,
+      "feature_image_alt": null,
+      "feature_image_caption": null,
+      "featured": false,
+      "frontmatter": null,
+      "html": "<p>Testing post creation with lexical</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "lexical": "{\\"root\\":{\\"children\\":[{\\"children\\":[{\\"detail\\":0,\\"format\\":0,\\"mode\\":\\"normal\\",\\"style\\":\\"\\",\\"text\\":\\"Testing post creation with lexical\\",\\"type\\":\\"text\\",\\"version\\":1}],\\"direction\\":\\"ltr\\",\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"paragraph\\",\\"version\\":1}],\\"direction\\":\\"ltr\\",\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"root\\",\\"version\\":1}}",
+      "meta_description": null,
+      "meta_title": null,
+      "mobiledoc": null,
+      "newsletter": null,
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "primary_author": Any<Object>,
+      "primary_tag": Any<Object>,
+      "published_at": null,
+      "reading_time": 0,
+      "slug": "post-revisions-test",
+      "status": "draft",
+      "tags": Any<Array>,
+      "tiers": Array [
+        Object {
+          "active": true,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "currency": null,
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "monthly_price": null,
+          "monthly_price_id": null,
+          "name": "Free",
+          "slug": "free",
+          "trial_days": 0,
+          "type": "free",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "public",
+          "welcome_page_url": null,
+          "yearly_price": null,
+          "yearly_price_id": null,
+        },
+        Object {
+          "active": true,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "currency": "usd",
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "monthly_price": 500,
+          "monthly_price_id": null,
+          "name": "Default Product",
+          "slug": "default-product",
+          "trial_days": 0,
+          "type": "paid",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "public",
+          "welcome_page_url": null,
+          "yearly_price": 5000,
+          "yearly_price_id": null,
+        },
+      ],
+      "title": "Post Revisions Test",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "url": Any<String>,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "visibility": "public",
+    },
+  ],
+}
+`;
+
+exports[`Posts API Can read with post_revisions included 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "4018",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/posts\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Posts API Can read with post_revisions included 3: [body] 1`] = `
+Object {
+  "posts": Array [
+    Object {
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "comment_id": Any<String>,
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "custom_excerpt": null,
+      "custom_template": null,
+      "email_only": false,
+      "email_segment": "all",
+      "email_subject": null,
+      "excerpt": "Testing post creation with lexical",
+      "feature_image": null,
+      "feature_image_alt": null,
+      "feature_image_caption": null,
+      "featured": false,
+      "frontmatter": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "meta_description": null,
+      "meta_title": null,
+      "mobiledoc": null,
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "post_revisions": Array [
+        Object {
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "created_at_ts": Any<Number>,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "lexical": "{\\"root\\":{\\"children\\":[{\\"children\\":[{\\"detail\\":0,\\"format\\":0,\\"mode\\":\\"normal\\",\\"style\\":\\"\\",\\"text\\":\\"Testing post creation with lexical\\",\\"type\\":\\"text\\",\\"version\\":1}],\\"direction\\":\\"ltr\\",\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"paragraph\\",\\"version\\":1}],\\"direction\\":\\"ltr\\",\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"root\\",\\"version\\":1}}",
+          "post_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+        },
+      ],
+      "published_at": null,
+      "slug": "post-revisions-test",
+      "status": "draft",
+      "title": "Post Revisions Test",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "url": Any<String>,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "visibility": "public",
+    },
+  ],
+}
+`;
+
+exports[`Posts API Can read with post_revisions included 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "1450",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Posts API Create Can create a post with lexical 1: [body] 1`] = `
 Object {
   "posts": Array [

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -251,7 +251,7 @@ describe('Unit: models/post', function () {
             should.exist(json.mobiledoc);
         });
 
-        it('ensure post revisions are never exposed', function () {
+        it('ensure post revisions are exposed', function () {
             const post = {
                 lexical: '{}',
                 post_revisions: []
@@ -259,7 +259,7 @@ describe('Unit: models/post', function () {
 
             const json = toJSON(post, {formats: ['lexical']});
 
-            should.not.exist(json.post_revisions);
+            should.exist(json.post_revisions);
             should.exist(json.lexical);
         });
     });


### PR DESCRIPTION
no issue

- with this change, you can access a post's lexical revisions via the api (e.g. `/posts/:id/?include=post_revisions`)

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f25592d</samp>

> _We are the post revisions, we won't be erased_
> _We rise from the ashes of the mobiledoc waste_
> _We join the API response, we claim our rightful place_
> _We are the post revisions, we show the truth of your face_
