### PR TITLE
Added Post History modal to the editor behind postHistory flag

### DIFF
--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -566,3 +566,4 @@ add|ember-template-lint|no-invalid-interactive|1|103|1|103|f5a46b2538fbf79a40f26
 add|ember-template-lint|no-invalid-interactive|5|53|5|53|9647ef6afba919b2af04fe551b0fdf0fb63be849|1680652800000|1691020800000|1696204800000|app/components/gh-context-menu.hbs
 remove|ember-template-lint|no-invalid-interactive|1|103|1|103|f5a46b2538fbf79a40f2683ff1151ca60e0fa0ca|1680652800000|1691020800000|1696204800000|app/components/gh-context-menu.hbs
 add|ember-template-lint|no-invalid-interactive|1|103|1|103|534029ab0ba1b74eff4a2f31c8b4dd9f1460316a|1681430400000|1691798400000|1696982400000|app/components/gh-context-menu.hbs
+add|ember-template-lint|no-action|7|49|7|49|141d456b03124abca146e58e4ae15825fdd040bb|1681689600000|1692057600000|1697241600000|app/components/modal-post-history.hbs

--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -1,0 +1,18 @@
+{{!-- template-lint-disable no-invalid-interactive --}}
+<div class="modal-body gh-ps-modal-body modal-fullsettings modal-fullsettings-body ">
+    <div class="flex pa0 flex-grow-1 gh-post-history">
+        <div class=" modal-fullsettings-sidebar-labs">
+            <h2 class="modal-fullsettings-heading-labs">Post History</h2>
+            <button
+                class="gh-btn mr3" type="button" {{action "closeModal"}}
+                {{!-- disable mouseDown so it doesn't trigger focus-out validations --}}
+                {{on "mousedown" (optional this.noop)}}
+            >
+                        <span>Exit</span>
+            </button>
+        </div>
+        <div class="gh-post-history-main">
+
+        </div>
+    </div>
+</div>

--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -1,0 +1,5 @@
+import ModalComponent from 'ghost-admin/components/modal-base';
+
+export default ModalComponent.extend({
+    
+});

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -23,6 +23,7 @@ import {isArray as isEmberArray} from '@ember/array';
 import {isHostLimitError, isServerUnreachableError, isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {isInvalidError} from 'ember-ajax/errors';
 import {inject as service} from '@ember/service';
+import {tracked} from '@glimmer/tracking';
 
 const DEFAULT_TITLE = '(Untitled)';
 
@@ -115,6 +116,7 @@ export default class LexicalEditorController extends Controller {
 
     shouldFocusTitle = false;
     showSettingsMenu = false;
+    @tracked showPostHistory = false;
 
     /**
      * Flag used to determine if we should return to the analytics page or to the posts/pages overview
@@ -395,6 +397,16 @@ export default class LexicalEditorController extends Controller {
         await this.modals.open(DeleteSnippetModal, {
             snippet
         });
+    }
+
+    @action
+    openPostHistory() {
+        this.showPostHistory = true;
+    }
+
+    @action
+    closePostHistory() {
+        this.showPostHistory = false;
     }
 
     /* Public tasks ----------------------------------------------------------*/

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -52,7 +52,9 @@
                             <Editor::PublishButtons @publishManagement={{publishManagement}} />
 
                             {{#if (feature 'postHistory')}}
-                                {{svg-jar "clock" class="w4 ml3"}}
+                                <button type="button" {{on "click" this.openPostHistory}} data-test-toggle="post-history">
+                                    {{svg-jar "clock" class="w4 ml3"}}
+                                </button>
                             {{/if}}
 
                             {{#unless this.showSettingsMenu}}
@@ -129,6 +131,15 @@
         <GhFullscreenModal @modal="re-authenticate"
             @close={{this.toggleReAuthenticateModal}}
             @modifier="action wide" />
+    {{/if}}
+
+    {{#if (feature 'postHistory')}}
+        {{#if this.showPostHistory}}
+            <GhFullscreenModal
+                @modal="post-history"
+                @close={{this.closePostHistory}}
+                @modifier="full-overlay post-history" />
+        {{/if}}
     {{/if}}
 {{/if}}
 

--- a/ghost/admin/tests/integration/components/modal-post-history-test.js
+++ b/ghost/admin/tests/integration/components/modal-post-history-test.js
@@ -1,0 +1,27 @@
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {find, render} from '@ember/test-helpers';
+import {hbs} from 'ember-cli-htmlbars';
+import {setupRenderingTest} from 'ember-mocha';
+
+describe('Integration | Component | modal-post-history', function () {
+    setupRenderingTest();
+
+    it('renders', async function () {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+        await render(hbs`<ModalPostHistory />`);
+
+        expect(find('h2').textContent.trim()).to.equal('Post History');
+
+        // Template block usage:
+        await render(hbs`
+      <ModalPostHistory>
+        template block text
+      </ModalPostHistory>
+    `);
+
+        expect(find('h2').textContent.trim()).to.equal('Post History');
+    });
+});


### PR DESCRIPTION
no issue

- added modal-post-history component and wired it up to the lexical-editor

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b726dd5</samp>

> _`Post history` is the key to the past_
> _Unveil the changes in a modal so vast_
> _But beware of the doom that lurks in the edits_
> _The lexical-editor is a portal to the abyss_
