### PR TITLE
Added announcement data to settings

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-18-12-56-add-announcement-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-18-12-56-add-announcement-settings.js
@@ -1,0 +1,24 @@
+const {combineTransactionalMigrations, addSetting} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addSetting({
+        key: 'announcement_content',
+        value: null,
+        type: 'string',
+        flags: 'PUBLIC',
+        group: 'announcement'
+    }),
+    addSetting({
+        key: 'announcement_visibility',
+        value: 'public',
+        type: 'string',
+        group: 'announcement'
+    }),
+    addSetting({
+        key: 'announcement_background',
+        value: 'dark',
+        type: 'string',
+        flags: 'PUBLIC',
+        group: 'announcement'
+    })
+);

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -483,6 +483,33 @@
             "type": "string"
         }
     },
+    "announcement": {
+        "announcement_content": {
+            "defaultValue": null,
+            "type": "string",
+            "flags": "PUBLIC"
+        },
+        "announcement_visibility": {
+            "defaultValue": "public",
+            "type": "string",
+            "isIn": [[
+                "public",
+                "visitors",
+                "members",
+                "paid"
+            ]]
+        },
+        "announcement_background": {
+            "defaultValue": "dark",
+            "type": "string",
+            "isIn": [[
+                "accent",
+                "dark",
+                "light"
+            ]],
+            "flags": "PUBLIC"
+        }
+    },
     "comments": {
         "comments_enabled": {
             "type": "string",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -273,6 +273,18 @@ Object {
       "value": "all",
     },
     Object {
+      "key": "announcement_content",
+      "value": null,
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
+    },
+    Object {
       "key": "comments_enabled",
       "value": "off",
     },
@@ -639,6 +651,18 @@ Object {
       "value": "all",
     },
     Object {
+      "key": "announcement_content",
+      "value": null,
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
+    },
+    Object {
       "key": "comments_enabled",
       "value": "off",
     },
@@ -670,7 +694,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3762",
+  "content-length": "3906",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -951,6 +975,18 @@ Object {
     Object {
       "key": "editor_default_email_recipients_filter",
       "value": "all",
+    },
+    Object {
+      "key": "announcement_content",
+      "value": null,
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
     },
     Object {
       "key": "comments_enabled",
@@ -1264,6 +1300,18 @@ Object {
     Object {
       "key": "editor_default_email_recipients_filter",
       "value": "all",
+    },
+    Object {
+      "key": "announcement_content",
+      "value": null,
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
     },
     Object {
       "key": "comments_enabled",
@@ -1584,6 +1632,18 @@ Object {
       "value": "all",
     },
     Object {
+      "key": "announcement_content",
+      "value": null,
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
+    },
+    Object {
       "key": "comments_enabled",
       "value": "off",
     },
@@ -1895,6 +1955,18 @@ Object {
     Object {
       "key": "editor_default_email_recipients_filter",
       "value": "all",
+    },
+    Object {
+      "key": "announcement_content",
+      "value": null,
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
     },
     Object {
       "key": "comments_enabled",
@@ -2273,6 +2345,18 @@ Object {
     Object {
       "key": "editor_default_email_recipients_filter",
       "value": "all",
+    },
+    Object {
+      "key": "announcement_content",
+      "value": null,
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
     },
     Object {
       "key": "comments_enabled",

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -6,7 +6,7 @@ const {stringMatching, anyEtag, anyUuid, anyContentLength, anyContentVersion} = 
 const models = require('../../../core/server/models');
 const {anyErrorId} = matchers;
 
-const CURRENT_SETTINGS_COUNT = 73;
+const CURRENT_SETTINGS_COUNT = 76;
 
 const settingsMatcher = {};
 

--- a/ghost/core/test/regression/models/model_settings.test.js
+++ b/ghost/core/test/regression/models/model_settings.test.js
@@ -5,7 +5,7 @@ const db = require('../../../core/server/data/db');
 // Stuff we are testing
 const models = require('../../../core/server/models');
 
-const SETTINGS_LENGTH = 84;
+const SETTINGS_LENGTH = 87;
 
 describe('Settings Model', function () {
     before(models.init);

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 76;
+            const allowedKeysLength = 79;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '00c8616470de50a6716369511a39eca9';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
-    const currentSettingsHash = 'e2fc04c37fe89e972b063ee8fd1d4bec';
+    const currentSettingsHash = '7b80d26ccced791da70ca5c753959689';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -491,6 +491,33 @@
             "type": "string"
         }
     },
+    "announcement": {
+        "announcement_content": {
+            "defaultValue": null,
+            "type": "string",
+            "flags": "PUBLIC"
+        },
+        "announcement_visibility": {
+            "defaultValue": "public",
+            "type": "string",
+            "isIn": [[
+                "public",
+                "visitors",
+                "members",
+                "paid"
+            ]]
+        },
+        "announcement_background": {
+            "defaultValue": "dark",
+            "type": "string",
+            "isIn": [[
+                "accent",
+                "dark",
+                "light"
+            ]],
+            "flags": "PUBLIC"
+        }
+    },
     "comments": {
         "comments_enabled": {
             "type": "string",


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3011


- This is a data structure needed to support Announcement Bar feature - allows to create custom site-wide announcements tailored to the audience.
- The `announcement_content` is meant to hold displayed HTML content of the announcement and will be exposed through unauthenticated Content Site API

- The `announcement_visibility` sets the target audience to display the Announcement Bart to:
  - `public` - Everyone
  - `visitors` - Logged out visitors only
  - `members` - Members only
  - `paid` - Paid members only

- The `announcement_background` sets the CSS class that should be applied to the Announcement Bar. and will be exposed through unauthenticated Content Site API. Three styles are available:
  - `accent` - matches the color of the site accent
  - `dark` - dark style
  - `light` - light style