### PR TITLE
Rendering lexical for diffing

### DIFF
--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -7,9 +7,11 @@
             Loading...
         {{/if}}
         <div class="gh-post-history-hidden-lexical previous">
+            <div class="gh-editor-title">{{this.previousTitle}}</div>
             <KoenigLexicalEditor @lexical={{this.previousLexical}} @cardConfig={{this.cardConfig}} />
         </div>
         <div class="gh-post-history-hidden-lexical current">
+            <div class="gh-editor-title">{{this.currentTitle}}</div>
             <KoenigLexicalEditor @lexical={{this.currentLexical}} @cardConfig={{this.cardConfig}}/>
         </div>
     </div>

--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -1,16 +1,25 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 <div class="gh-post-history">
     <div class="gh-post-history-main">
-          <div class="gh-koenig-editor-pane flex flex-column mih-100">
-            <div class="gh-editor-feature-image-container">
-                <div class="gh-editor-feature-image-dropzone"></div>
-                <div class="flex flex-row items-center invisible">
-                    <button type="button" class="gh-editor-feature-image-add-button">{{svg-jar "plus"}}<span>Add feature image</span></button>
-                    <button type="button" class="gh-editor-feature-image-unsplash">{{svg-jar "unsplash"}}</button>
-                </div>
-            </div>
-            <div class="gh-editor-title ember-text-area gh-input ember-view">Old-school excess, star power and spectacle: Royal Opera’s Tosca reviewed</div>
-            {{{this.postDiff}}}
+        {{#if this.diffHtml}}
+            {{{this.diffHtml}}}
+        {{else}}
+            Loading...
+        {{/if}}
+          <div class="gh-post-history-hidden-lexical previous">
+            <KoenigLexicalEditor
+                @hasLoaded={this.hasLoaded}
+                @lexical={{this.previousLexical}}
+                @cardConfig={{this.cardConfig}}
+            />
+          </div>
+          <div class="gh-post-history-hidden-lexical current">
+
+            <KoenigLexicalEditor
+                @lexical={{this.currentLexical}}
+                @cardConfig={{this.cardConfig}}
+            />
+
           </div>
     </div>
     <div class="settings-menu-container">

--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -6,21 +6,12 @@
         {{else}}
             Loading...
         {{/if}}
-          <div class="gh-post-history-hidden-lexical previous">
-            <KoenigLexicalEditor
-                @hasLoaded={this.hasLoaded}
-                @lexical={{this.previousLexical}}
-                @cardConfig={{this.cardConfig}}
-            />
-          </div>
-          <div class="gh-post-history-hidden-lexical current">
-
-            <KoenigLexicalEditor
-                @lexical={{this.currentLexical}}
-                @cardConfig={{this.cardConfig}}
-            />
-
-          </div>
+        <div class="gh-post-history-hidden-lexical previous">
+            <KoenigLexicalEditor @lexical={{this.previousLexical}} @cardConfig={{this.cardConfig}} />
+        </div>
+        <div class="gh-post-history-hidden-lexical current">
+            <KoenigLexicalEditor @lexical={{this.currentLexical}} @cardConfig={{this.cardConfig}}/>
+        </div>
     </div>
     <div class="settings-menu-container">
         <div class="settings-menu settings-menu-pane settings-menu-pane-main">

--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -1,23 +1,75 @@
 import ModalComponent from 'ghost-admin/components/modal-base';
 import diff from 'node-htmldiff';
 
+function checkFinishedRendering(element, done) {
+    let last = element.innerHTML;
+
+    function check() {
+        let html = element.innerHTML;
+        if (html === last) {
+            done();
+        } else {
+            last = html;
+            setTimeout(check, 50);
+        }
+    }
+
+    setTimeout(check, 50);
+}
+
 export default ModalComponent.extend({
+    diffHtml: null,
 
     init() {
         this._super(...arguments);
         this.post = this.model;
     },
 
-    get previous() {
-        return `<div class="koenig-react-editor"><div class="koenig-lexical  "><div data-kg="editor"><div class="kg-prose" contenteditable="true" spellcheck="true" data-lexical-editor="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-koenig-dnd-container="true" role="textbox"><p dir="ltr" data-koenig-dnd-droppable="true"><strong data-lexical-text="true">Lorem Ipsum</strong><span data-lexical-text="true">&nbsp;is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</span></p><p dir="ltr" data-koenig-dnd-droppable="true"><span data-lexical-text="true">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.</span></p><p data-koenig-dnd-droppable="true"><br></p></div></div>   <div id="koenig-drag-drop-ghost-container" style="position: fixed; width: 100%; z-index: 10001;"></div></div></div></div>`;
+    didInsertElement() {
+        this._super(...arguments);
+        let previous = document.querySelector('.gh-post-history-hidden-lexical.previous');
+        let current = document.querySelector('.gh-post-history-hidden-lexical.current');
+
+        let previousDone = false;
+        let currentDone = false;
+
+        let updateIfBothDone = () => {
+            if (previousDone && currentDone) {
+                this.set('diffHtml', diff(previous.innerHTML, current.innerHTML));
+            }
+        };
+
+        checkFinishedRendering(previous, () => {
+            previous.querySelectorAll('[contenteditable]').forEach((el) => {
+                el.setAttribute('contenteditable', false);
+            });
+            previousDone = true;
+            updateIfBothDone();
+        });
+
+        checkFinishedRendering(current, () => {
+            current.querySelectorAll('[contenteditable]').forEach((el) => {
+                el.setAttribute('contenteditable', false);
+            });
+            currentDone = true;
+            updateIfBothDone();
+        });
     },
 
-    get current() {
-        return `<div class="koenig-react-editor"><div class="koenig-lexical  "><div data-kg="editor"><div class="kg-prose" contenteditable="true" spellcheck="true" data-lexical-editor="true" style="user-select: text; white-space: pre-wrap; word-break: break-word;" data-koenig-dnd-container="true" role="textbox"><p dir="ltr" data-koenig-dnd-droppable="true"><strong data-lexical-text="true">Lorem Ipsum</strong><span data-lexical-text="true">&nbsp;is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It is one of the worse things I've ever read. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</span></p><p dir="ltr" data-koenig-dnd-droppable="true"><span data-lexical-text="true">Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.</span></p><p data-koenig-dnd-droppable="true"><br></p></div></div>   <div id="koenig-drag-drop-ghost-container" style="position: fixed; width: 100%; z-index: 10001;"></div></div></div>`;
+    get previousLexical() {
+        let revisions = this.post.get('postRevisions').toArray();
+        // Revisions are in chronological order, and the last revision is the
+        // the current post, so the second to last is the previous revision
+        return revisions[revisions.length - 2].get('lexical');
     },
 
-    get postDiff() {
-        let diffHtml = diff(this.previous, this.current);
-        return diffHtml;
+    get currentLexical() {
+        return this.post.get('lexical');
+    },
+
+    get cardConfig() {
+        return {
+            post: this.model
+        };
     }
 });

--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -56,15 +56,27 @@ export default ModalComponent.extend({
         });
     },
 
-    get previousLexical() {
+    get selectedRevision() {
         let revisions = this.post.get('postRevisions').toArray();
         // Revisions are in chronological order, and the last revision is the
         // the current post, so the second to last is the previous revision
-        return revisions[revisions.length - 2].get('lexical');
+        return revisions[revisions.length - 2];
+    },
+
+    get previousLexical() {
+        return this.selectedRevision.get('lexical');
     },
 
     get currentLexical() {
         return this.post.get('lexical');
+    },
+
+    get previousTitle() {
+        return this.selectedRevision.get('title') || this.post.get('title');
+    },
+
+    get currentTitle() {
+        return this.post.get('title');
     },
 
     get cardConfig() {

--- a/ghost/admin/app/styles/layouts/post-history.css
+++ b/ghost/admin/app/styles/layouts/post-history.css
@@ -68,3 +68,7 @@
 .gh-post-history-main .koenig-lexical del {
     color: var(--red) !important;
 }
+
+.gh-post-history-hidden-lexical {
+    display: none;
+}


### PR DESCRIPTION
no issue

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1167a70</samp>

This pull request introduces a new `KoenigLexicalEditor` component that can render the lexical representation of the post content, and uses it to implement a new post history feature. The post history feature allows users to compare different versions of the post content using a diff algorithm that works on the HTML output of the lexical editor. The pull request also improves the error handling of the existing `gh-koenig-editor-lexical` component.
