### PR TITLE
Renamed foreign key constraint in migration v5.45

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-17-11-05-add-post-revision-author.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-17-11-05-add-post-revision-author.js
@@ -6,7 +6,8 @@ module.exports = combineNonTransactionalMigrations(
         maxlength: 2000,
         nullable: true,
         references: 'users.id',
-        cascadeDelete: false
+        cascadeDelete: false,
+        constraintName: 'post_revs_author_id_foreign'
     }),
     createAddColumnMigration('post_revisions', 'title', {
         type: 'string',

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -403,7 +403,7 @@ module.exports = {
         lexical: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         created_at_ts: {type: 'bigInteger', nullable: false},
         created_at: {type: 'dateTime', nullable: false},
-        author_id: {type: 'string', maxlength: 24, nullable: true, references: 'users.id', cascadeDelete: false},
+        author_id: {type: 'string', maxlength: 24, nullable: true, references: 'users.id', cascadeDelete: false, constraintName: 'post_revs_author_id_foreign'},
         title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 255}}}
     },
     members: {

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '67f4d03c5b49faccb9aceb127311c5c6';
+    const currentSchemaHash = '00c8616470de50a6716369511a39eca9';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
     const currentSettingsHash = 'e2fc04c37fe89e972b063ee8fd1d4bec';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
- the autogenerated constraint name was too long for MySQL, yielding the error below
- this change adds an explicit, shorthand name for the constraint to stay under the limit on MySQL8

Error: alter table `post_revisions` add constraint `post_revisions_author_id_foreign` foreign key (`author_id`) references `users` (`id`), algorithm=copy - Specified key was too long; max key length is 3072 bytes
