### PR TITLE
Added `oembed` Admin API endpoint to allow list

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -36,7 +36,8 @@ const notImplemented = function (req, res, next) {
         files: ['POST'],
         media: ['POST'],
         db: ['POST'],
-        settings: ['GET']
+        settings: ['GET'],
+        oembed: ['GET']
     };
 
     const match = req.url.match(/^\/(\w+)\/?/);


### PR DESCRIPTION
no issue

- Some services require the `oembed` API endpoint to be reachable via Admin API
- Adding the endpoint to the allowed list resolves this

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b1b9e2</samp>

Added `oembed` endpoint to `notImplemented` object in `middleware.js`. This prevents the API from handling oEmbed requests until they are supported.
