### PR TITLE
Fixed member count for limit checks when publishing sometimes being incorrect

### DIFF
--- a/ghost/admin/app/services/limit.js
+++ b/ghost/admin/app/services/limit.js
@@ -93,9 +93,10 @@ export default class LimitsService extends Service {
     }
 
     async getMembersCount() {
-        const counts = await this.membersStats.fetchCounts();
+        const members = await this.store.query('member', {limit: 'all'});
+        const total = members.meta.pagination.total;
 
-        return counts.total;
+        return total;
     }
 
     async getNewslettersCount() {


### PR DESCRIPTION
no issue

- the members stats service was being used for the total member count when checking member limits for publishing but the stats service is not always correct which could result in publishing being blocked unexpectedly
- switched to using the total count from a `/members/` query which should always be correct/match other counts within the UI
