### PR TITLE
Fixed maxlength for author_id in migration v5.45

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-17-11-05-add-post-revision-author.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-17-11-05-add-post-revision-author.js
@@ -3,7 +3,7 @@ const {combineNonTransactionalMigrations,createAddColumnMigration} = require('..
 module.exports = combineNonTransactionalMigrations(
     createAddColumnMigration('post_revisions', 'author_id', {
         type: 'string',
-        maxlength: 2000,
+        maxlength: 24,
         nullable: true,
         references: 'users.id',
         cascadeDelete: false,


### PR DESCRIPTION
no issue

- maxlength for author_id was errantly set to 2000 instead of 24
- migration was failing with:

ERROR Field length of `author_id` in `post_revisions` is too long!

Field length of `author_id` in `post_revisions` is too long!

"This usually happens if your database encoding is utf8mb4.\nAll unique fields and indexes must be lower than 191 characters.\nPlease correct your field length and reset your database with `yarn knex-migrator reset`.\n" "Read more here: https://github.com/TryGhost/knex-migrator/issues/51\n"
