### PR TITLE
Removed post revision author id on user deletion

### DIFF
--- a/ghost/core/core/server/services/users.js
+++ b/ghost/core/core/server/services/users.js
@@ -2,6 +2,12 @@
 const path = require('path');
 
 /**
+ * @TODO: pass these in as dependencies
+ */
+const PostRevisions = require('@tryghost/post-revisions');
+const labs = require('../../shared/labs');
+
+/**
  * @typedef {Object} IdbBackup
  * @prop {() => Promise<string>} backup
  */
@@ -149,6 +155,16 @@ class Users {
 
         return this.models.Base.transaction(async (t) => {
             frameOptions.transacting = t;
+
+            if (labs.isSet('postHistory')) {
+                const postRevisions = new PostRevisions({
+                    model: this.models.PostRevision
+                });
+
+                await postRevisions.removeAuthorFromRevisions(frameOptions.id, {
+                    transacting: frameOptions.transacting
+                });
+            }
 
             await this.assignTagToUserPosts({
                 id: frameOptions.id,

--- a/ghost/post-revisions/lib/post-revisions.js
+++ b/ghost/post-revisions/lib/post-revisions.js
@@ -93,11 +93,7 @@ class PostRevisions {
         });
 
         const revisionIds = revisions.toJSON()
-            .reduce((acc, value) => {
-                acc.push(value.id);
-
-                return acc;
-            }, []);
+            .map(({id}) => id);
 
         if (revisionIds.length === 0) {
             return;


### PR DESCRIPTION
no issue

When a user is deleted any post revisions created by the user are set to be owned by nobody (null) rather than deleting the post revisions associated with the user