### PR TITLE
Updated limit service to only request a single member

### DIFF
--- a/ghost/admin/app/services/limit.js
+++ b/ghost/admin/app/services/limit.js
@@ -93,7 +93,7 @@ export default class LimitsService extends Service {
     }
 
     async getMembersCount() {
-        const members = await this.store.query('member', {limit: 'all'});
+        const members = await this.store.query('member', {limit: 1});
         const total = members.meta.pagination.total;
 
         return total;


### PR DESCRIPTION
When we request all members, what happens is that the amount of data is so great that Ghost is completely overwhelmemed. Database connections are hanging open, spanners are thrown in the works, half the team are staying up half the night.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c1d8366</samp>

Refactored the `limit` service to use a more efficient query for getting the members count. This improves the performance of the members screen in the admin app.
