### PR TITLE
Added support for viewing different revisions

### DIFF
--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -18,11 +18,11 @@
             {{/if}}
             <div class="gh-post-history-hidden-lexical previous">
                 <div class="gh-editor-title">{{this.previousTitle}}</div>
-                <KoenigLexicalEditor @lexical={{this.previousLexical}} @cardConfig={{this.cardConfig}} />
+                <KoenigLexicalEditor @lexical={{this.comparisonRevision.lexical}} @cardConfig={{this.cardConfig}} @registerAPI={{action "registerComparisonEditorApi"}}/>
             </div>
             <div class="gh-post-history-hidden-lexical current">
                 <div class="gh-editor-title">{{this.currentTitle}}</div>
-                <KoenigLexicalEditor @lexical={{this.currentLexical}} @cardConfig={{this.cardConfig}}/>
+                <KoenigLexicalEditor @lexical={{this.selectedRevision.lexical}} @cardConfig={{this.cardConfig}} @registerAPI={{action "registerSelectedEditorApi"}}/>
             </div>
         </div>
     </div>
@@ -43,9 +43,9 @@
             </div>
             <div class="settings-menu-content">
                 <ul class="nav-list">
-                    {{#each this.revisionList as |revision|}}
-                    <li class="nav-list-item">
-                        <button type="button">
+                    {{#each this.revisionList as |revision index|}}
+                    <li class="nav-list-item {{if revision.selected "selected" ""}}">
+                        <button type="button" {{action "handleClick" index}}>
                             <div class="flex items-center">
                                 <span class="gh-post-history-version">{{capitalize-first-letter (moment-from-now revision.createdAt)}}</span>
                                 {{!-- <span class="gh-post-history-version-wordcount">


### PR DESCRIPTION
The Lexical editor isn't passed the editor state it's passed the _initial_ editor state, which means that subsequent renders will not use an updated state. To work around this we store a reference to the editor api and manually set the state ourselves when the selected revision is changed.

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44a0108</samp>

This pull request enhances the `modal-post-history` component to allow users to select and compare different versions of a post. It updates the template and the logic of the component to use editor APIs and diff views to show the changes between revisions. It also modifies the `KoenigLexicalEditor` and the `nav-list-item` elements to support the new functionality.
