### PR TITLE
Added new settings for pintura editor integration

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-19-13-45-add-pintura-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-19-13-45-add-pintura-settings.js
@@ -1,0 +1,22 @@
+const {combineTransactionalMigrations, addSetting} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addSetting({
+        key: 'pintura',
+        value: 'false',
+        type: 'boolean',
+        group: 'pintura'
+    }),
+    addSetting({
+        key: 'pintura_js_url',
+        value: null,
+        type: 'string',
+        group: 'pintura'
+    }),
+    addSetting({
+        key: 'pintura_css_url',
+        value: null,
+        type: 'string',
+        group: 'pintura'
+    })
+);

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -533,5 +533,27 @@
             },
             "type": "boolean"
         }
+    },
+    "pintura": {
+        "pintura": {
+            "defaultValue": "false",
+            "validations": {
+                "isIn": [
+                    [
+                        "true",
+                        "false"
+                    ]
+                ]
+            },
+            "type": "boolean"
+        },
+        "pintura_js_url": {
+            "defaultValue": null,
+            "type": "string"
+        },
+        "pintura_css_url": {
+            "defaultValue": null,
+            "type": "string"
+        }
     }
 }

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 79;
+            const allowedKeysLength = 82;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '00c8616470de50a6716369511a39eca9';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
-    const currentSettingsHash = '7b80d26ccced791da70ca5c753959689';
+    const currentSettingsHash = 'e417c8e87e736f9421358117eb94af02';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -518,28 +518,6 @@
             "flags": "PUBLIC"
         }
     },
-    "pintura": {
-        "pintura": {
-            "defaultValue": "false",
-            "validations": {
-                "isIn": [
-                    [
-                        "true",
-                        "false"
-                    ]
-                ]
-            },
-            "type": "boolean"
-        },
-        "pintura_js_url": {
-            "defaultValue": null,
-            "type": "string"
-        },
-        "pintura_css_url": {
-            "defaultValue": null,
-            "type": "string"
-        }
-    },
     "comments": {
         "comments_enabled": {
             "type": "string",

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -518,6 +518,28 @@
             "flags": "PUBLIC"
         }
     },
+    "pintura": {
+        "pintura": {
+            "defaultValue": "false",
+            "validations": {
+                "isIn": [
+                    [
+                        "true",
+                        "false"
+                    ]
+                ]
+            },
+            "type": "boolean"
+        },
+        "pintura_js_url": {
+            "defaultValue": null,
+            "type": "string"
+        },
+        "pintura_css_url": {
+            "defaultValue": null,
+            "type": "string"
+        }
+    },
     "comments": {
         "comments_enabled": {
             "type": "string",


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3034

- adds 3 new settings for managing pintura image editor integration in admin
- `pintura` setting controls the enabling of the feature
- `pintura_css_url` is used to store path to pintura css file uploaded on integration page
- `pintura_js_url` is used to store path to pintura js file uploaded on integration page