### PR TITLE
Corrected announcement_visibility setting type

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/validators/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/settings.js
@@ -22,7 +22,8 @@ module.exports = {
             const arrayTypeSettings = [
                 'notifications',
                 'navigation',
-                'secondary_navigation'
+                'secondary_navigation',
+                'announcement_visibility'
             ];
 
             const emailTypeSettings = [
@@ -64,14 +65,26 @@ module.exports = {
             }
 
             if (setting.key === 'announcement_visibility') {
-                const visibilityValue = setting.value;
+                // NOTE: safe to parse because of array validation up top
+                const visibilityValues = JSON.parse(setting.value);
 
-                if (!['public', 'visitors', 'members', 'paid'].includes(visibilityValue)) {
-                    const visibilityError = new ValidationError({
-                        message: tpl(messages.invalidAnnouncementVisibilityValueReceived),
-                        property: setting.key
+                // NOTE: combination of 'free_members' & 'paid_members' makes just a 'members' filter
+                const validVisibilityValues = [
+                    'visitors', // Logged out visitors
+                    'free_members', // Free members
+                    'paid_members' // Paid members
+                ];
+
+                if (visibilityValues.length) {
+                    visibilityValues.forEach((visibilityValue) => {
+                        if (!validVisibilityValues.includes(visibilityValue)) {
+                            const visibilityError = new ValidationError({
+                                message: tpl(messages.invalidAnnouncementVisibilityValueReceived),
+                                property: setting.key
+                            });
+                            errors.push(visibilityError);
+                        }
                     });
-                    errors.push(visibilityError);
                 }
             }
 

--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-18-12-56-add-announcement-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-18-12-56-add-announcement-settings.js
@@ -9,12 +9,6 @@ module.exports = combineTransactionalMigrations(
         group: 'announcement'
     }),
     addSetting({
-        key: 'announcement_visibility',
-        value: 'public',
-        type: 'string',
-        group: 'announcement'
-    }),
-    addSetting({
         key: 'announcement_background',
         value: 'dark',
         type: 'string',

--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-20-14-19-add-announcement-visibility-setting.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-20-14-19-add-announcement-visibility-setting.js
@@ -1,0 +1,32 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration, combineTransactionalMigrations, addSetting} = require('../../utils');
+
+const visibilitySettingCleanup = createTransactionalMigration(
+    async function up(knex) {
+        const existingSetting = await knex('settings')
+            .where('key', '=', 'announcement_visibility');
+
+        if (existingSetting.length) {
+            logging.info(`Deleting setting: "announcement_visibility"`);
+
+            await knex('settings')
+                .where('key', '=', 'announcement_visibility')
+                .del();
+        } else {
+            logging.info(`Setting: "announcement_visibility", was not found in the database. Skipping removal`);
+        }
+    },
+    async function down() {
+        // no-op: we don't want to recreate "announcement_visibility" setting
+    }
+);
+
+module.exports = combineTransactionalMigrations(
+    visibilitySettingCleanup,
+    addSetting({
+        key: 'announcement_visibility',
+        value: '[]',
+        type: 'array',
+        group: 'announcement'
+    })
+);

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -490,14 +490,8 @@
             "flags": "PUBLIC"
         },
         "announcement_visibility": {
-            "defaultValue": "public",
-            "type": "string",
-            "isIn": [[
-                "public",
-                "visitors",
-                "members",
-                "paid"
-            ]]
+            "defaultValue": "[]",
+            "type": "array"
         },
         "announcement_background": {
             "defaultValue": "dark",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -278,7 +278,7 @@ Object {
     },
     Object {
       "key": "announcement_visibility",
-      "value": "public",
+      "value": "[]",
     },
     Object {
       "key": "announcement_background",
@@ -668,7 +668,7 @@ Object {
     },
     Object {
       "key": "announcement_visibility",
-      "value": "public",
+      "value": "[\\"visitors\\",\\"free_members\\"]",
     },
     Object {
       "key": "announcement_background",
@@ -718,7 +718,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4043",
+  "content-length": "4068",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1006,7 +1006,7 @@ Object {
     },
     Object {
       "key": "announcement_visibility",
-      "value": "public",
+      "value": "[\\"visitors\\",\\"free_members\\"]",
     },
     Object {
       "key": "announcement_background",
@@ -1343,7 +1343,7 @@ Object {
     },
     Object {
       "key": "announcement_visibility",
-      "value": "public",
+      "value": "[\\"visitors\\",\\"free_members\\"]",
     },
     Object {
       "key": "announcement_background",
@@ -1685,7 +1685,7 @@ Object {
     },
     Object {
       "key": "announcement_visibility",
-      "value": "public",
+      "value": "[\\"visitors\\",\\"free_members\\"]",
     },
     Object {
       "key": "announcement_background",
@@ -2115,7 +2115,7 @@ Object {
     },
     Object {
       "key": "announcement_visibility",
-      "value": "public",
+      "value": "[\\"visitors\\",\\"free_members\\"]",
     },
     Object {
       "key": "announcement_background",
@@ -2517,7 +2517,7 @@ Object {
     },
     Object {
       "key": "announcement_visibility",
-      "value": "public",
+      "value": "[\\"visitors\\",\\"free_members\\"]",
     },
     Object {
       "key": "announcement_background",

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -113,6 +113,10 @@ describe('Settings API', function () {
                     value: '<p>Great news coming soon!</p>'
                 },
                 {
+                    key: 'announcement_visibility',
+                    value: JSON.stringify(['visitors', 'free_members'])
+                },
+                {
                     key: 'navigation',
                     value: JSON.stringify([{
                         label: 'label1'
@@ -315,7 +319,7 @@ describe('Settings API', function () {
             const settingsToChange = [
                 {
                     key: 'announcement_visibility',
-                    value: 'invalid value'
+                    value: JSON.stringify(['invalid value'])
                 }
             ];
 

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '00c8616470de50a6716369511a39eca9';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
-    const currentSettingsHash = 'e417c8e87e736f9421358117eb94af02';
+    const currentSettingsHash = 'f9db81a9d2fe2fed5e9cfda1ccd2b3cc';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -498,14 +498,8 @@
             "flags": "PUBLIC"
         },
         "announcement_visibility": {
-            "defaultValue": "public",
-            "type": "string",
-            "isIn": [[
-                "public",
-                "visitors",
-                "members",
-                "paid"
-            ]]
+            "defaultValue": "[]",
+            "type": "array"
         },
         "announcement_background": {
             "defaultValue": "dark",


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/14264

- With a requirement change we need to transform `announcement_visibility` setting to be an "array" instead of a "string". Array structure will allow us to hold multiple filters at once giving more coverage to the audience targeting usecases.
- Example filter variations we'll support are: 
[ ] Logged out visitors
[ ] Members
[ ] Free members
[ ] Paid members