### PR TITLE
Added logic for saving revisions on explicit saves

### DIFF
--- a/ghost/admin/app/adapters/post.js
+++ b/ghost/admin/app/adapters/post.js
@@ -20,6 +20,10 @@ export default class Post extends ApplicationAdapter {
             }
         }
 
+        if (snapshot?.adapterOptions?.saveRevision) {
+            const saveRevision = snapshot.adapterOptions.saveRevision;
+            parsedUrl.searchParams.append('save_revision', saveRevision);
+        }
         return parsedUrl.toString();
     }
 

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -833,7 +833,7 @@ export default class LexicalEditorController extends Controller {
         let hasDirtyAttributes = this.hasDirtyAttributes;
         let state = post.getProperties('isDeleted', 'isSaving', 'hasDirtyAttributes', 'isNew');
 
-        // Get the postRevisions from the post as an array
+        // Check if anything has changed since the last revision
         let postRevisions = post.get('postRevisions').toArray();
         let latestRevision = postRevisions[postRevisions.length - 1];
         let hasChangedSinceLastRevision = post.get('lexical') !== latestRevision.get('lexical');

--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -176,6 +176,7 @@ module.exports = {
             'email_segment',
             'newsletter',
             'force_rerender',
+            'save_revision',
             // NOTE: only for internal context
             'forUpdate',
             'transacting'

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -932,7 +932,12 @@ Post = ghostBookshelf.Model.extend({
                         title: model.get('title')
                     };
 
-                    const newRevisions = await postRevisions.getRevisions(previous, current, revisions);
+                    // CASE: Always save a new revision when a post is published or 'updated'
+                    if (newStatus === 'published') {
+                        options.save_revision = true;
+                    }
+
+                    const newRevisions = await postRevisions.getRevisions(previous, current, revisions, {forceRevision: options.save_revision});
                     model.set('post_revisions', newRevisions);
                 });
             }
@@ -1170,7 +1175,7 @@ Post = ghostBookshelf.Model.extend({
             findPage: ['status'],
             findAll: ['columns', 'filter'],
             destroy: ['destroyAll', 'destroyBy'],
-            edit: ['filter', 'email_segment', 'force_rerender', 'newsletter']
+            edit: ['filter', 'email_segment', 'force_rerender', 'newsletter', 'save_revision']
         };
 
         // The post model additionally supports having a formats option

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -932,12 +932,12 @@ Post = ghostBookshelf.Model.extend({
                         title: model.get('title')
                     };
 
-                    // CASE: Always save a new revision when a post is published or 'updated'
-                    if (newStatus === 'published') {
-                        options.save_revision = true;
-                    }
-
-                    const newRevisions = await postRevisions.getRevisions(previous, current, revisions, {forceRevision: options.save_revision});
+                    // This can be refactored once we have the status stored in each revision
+                    const revisionOptions = {
+                        forceRevision: options.save_revision,
+                        isPublished: newStatus === 'published'
+                    };
+                    const newRevisions = await postRevisions.getRevisions(previous, current, revisions, revisionOptions);
                     model.set('post_revisions', newRevisions);
                 });
             }

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -913,7 +913,7 @@ Post = ghostBookshelf.Model.extend({
                     const revisionModels = await ghostBookshelf.model('PostRevision')
                         .findAll(Object.assign({
                             filter: `post_id:${model.id}`,
-                            columns: ['id']
+                            columns: ['id', 'lexical', 'created_at', 'author_id', 'title']
                         }, _.pick(options, 'transacting')));
 
                     const revisions = revisionModels.toJSON();

--- a/ghost/core/test/e2e-api/admin/posts.test.js
+++ b/ghost/core/test/e2e-api/admin/posts.test.js
@@ -389,7 +389,7 @@ describe('Posts API', function () {
             const [postResponse] = postBody.posts;
 
             await agent
-                .put(`/posts/${postResponse.id}/?formats=mobiledoc,lexical,html`)
+                .put(`/posts/${postResponse.id}/?formats=mobiledoc,lexical,html&save_revision=true`)
                 .body({posts: [Object.assign({}, postResponse, {lexical: updatedLexical})]})
                 .expectStatus(200)
                 .matchBodySnapshot({

--- a/ghost/post-revisions/lib/post-revisions.js
+++ b/ghost/post-revisions/lib/post-revisions.js
@@ -43,17 +43,18 @@ class PostRevisions {
         if (revisions.length === 0) {
             return true;
         }
-        // If the user has explicitly requested a revision (cmd+s), we should always save a revision
-        if (options.forceRevision) {
+        const isPublished = options && options.isPublished;
+        if (isPublished) {
             return true;
         }
 
+        const forceRevision = options && options.forceRevision;
         const htmlHasChanged = previous.html !== current.html;
         const titleHasChanged = previous.title !== current.title;
-        const forceRevision = options.forceRevision;
         if ((htmlHasChanged || titleHasChanged) && forceRevision) {
             return true;
         }
+        return false;
     }
 
     /**

--- a/ghost/post-revisions/lib/post-revisions.js
+++ b/ghost/post-revisions/lib/post-revisions.js
@@ -36,6 +36,7 @@ class PostRevisions {
      * @returns {boolean}
      */
     shouldGenerateRevision(previous, current, revisions, options) {
+        const latestRevision = revisions[revisions.length - 1];
         if (!previous) {
             return false;
         }
@@ -49,9 +50,9 @@ class PostRevisions {
         }
 
         const forceRevision = options && options.forceRevision;
-        const htmlHasChanged = previous.html !== current.html;
+        const lexicalHasChangedSinceLatestRevision = latestRevision.lexical !== current.lexical;
         const titleHasChanged = previous.title !== current.title;
-        if ((htmlHasChanged || titleHasChanged) && forceRevision) {
+        if ((lexicalHasChangedSinceLatestRevision || titleHasChanged) && forceRevision) {
             return true;
         }
         return false;

--- a/ghost/post-revisions/lib/post-revisions.js
+++ b/ghost/post-revisions/lib/post-revisions.js
@@ -32,26 +32,39 @@ class PostRevisions {
      * @param {PostLike} previous
      * @param {PostLike} current
      * @param {Revision[]} revisions
+     * @param {object} options
      * @returns {boolean}
      */
-    shouldGenerateRevision(previous, current, revisions) {
+    shouldGenerateRevision(previous, current, revisions, options) {
         if (!previous) {
             return false;
         }
+        // If there's no revisions for this post, we should always save a revision
         if (revisions.length === 0) {
             return true;
         }
-        return previous.html !== current.html || previous.title !== current.title;
+        // If the user has explicitly requested a revision (cmd+s), we should always save a revision
+        if (options.forceRevision) {
+            return true;
+        }
+
+        const htmlHasChanged = previous.html !== current.html;
+        const titleHasChanged = previous.title !== current.title;
+        const forceRevision = options.forceRevision;
+        if ((htmlHasChanged || titleHasChanged) && forceRevision) {
+            return true;
+        }
     }
 
     /**
      * @param {PostLike} previous
      * @param {PostLike} current
      * @param {Revision[]} revisions
+     * @param {object} options
      * @returns {Promise<Revision[]>}
      */
-    async getRevisions(previous, current, revisions) {
-        if (!this.shouldGenerateRevision(previous, current, revisions)) {
+    async getRevisions(previous, current, revisions, options) {
+        if (!this.shouldGenerateRevision(previous, current, revisions, options)) {
             return revisions;
         }
 

--- a/ghost/post-revisions/test/hello.test.js
+++ b/ghost/post-revisions/test/hello.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const PostRevisions = require('../');
+const PostRevisions = require('..');
 
 const config = {
     max_revisions: 10
@@ -43,7 +43,7 @@ describe('PostRevisions', function () {
             assert.equal(actual, expected);
         });
 
-        it('should return true if the current and previous html values are different', function () {
+        it('should return true if the current and previous html values are different and forceRevision is true', function () {
             const postRevisions = new PostRevisions({config});
 
             const expected = true;
@@ -55,12 +55,14 @@ describe('PostRevisions', function () {
                 html: 'blah2'
             }, [{
                 lexical: 'blah'
-            }]);
+            }], {
+                forceRevision: true
+            });
 
             assert.equal(actual, expected);
         });
 
-        it('should return true if the current and previous title values are different', function () {
+        it('should return true if the current and previous title values are different and forceRevision is true', function () {
             const postRevisions = new PostRevisions({config});
 
             const expected = true;
@@ -74,7 +76,30 @@ describe('PostRevisions', function () {
                 title: 'blah2'
             }, [{
                 lexical: 'blah'
-            }]);
+            }], {
+                forceRevision: true
+            });
+
+            assert.equal(actual, expected);
+        });
+
+        it('should always return true if isPublished is true', function () {
+            const postRevisions = new PostRevisions({config});
+
+            const expected = true;
+            const actual = postRevisions.shouldGenerateRevision({
+                lexical: 'blah',
+                html: 'blah',
+                title: 'blah'
+            }, {
+                lexical: 'blah',
+                html: 'blah',
+                title: 'blah2'
+            }, [{
+                lexical: 'blah'
+            }], {
+                isPublished: true
+            });
 
             assert.equal(actual, expected);
         });
@@ -161,7 +186,9 @@ describe('PostRevisions', function () {
                 id: '1',
                 lexical: 'new',
                 html: 'new'
-            }, revisions);
+            }, revisions, {
+                forceRevision: true
+            });
 
             assert.equal(actual.length, 2);
         });

--- a/ghost/post-revisions/test/hello.test.js
+++ b/ghost/post-revisions/test/hello.test.js
@@ -43,7 +43,7 @@ describe('PostRevisions', function () {
             assert.equal(actual, expected);
         });
 
-        it('should return true if the current and previous html values are different and forceRevision is true', function () {
+        it('should return true if forceRevision is true and the lexical has changed since the latest revision', function () {
             const postRevisions = new PostRevisions({config});
 
             const expected = true;
@@ -55,6 +55,8 @@ describe('PostRevisions', function () {
                 html: 'blah2'
             }, [{
                 lexical: 'blah'
+            }, {
+                lexical: 'blah2'
             }], {
                 forceRevision: true
             });


### PR DESCRIPTION
refs @TryGhost/Team#3076

- added `save_revision` option to edit post endpoint
- this change covers the following cases:
1. we will not save a `post_revision` on every background autosave that occurs after 3 seconds of inactivity in the editor
2. we will save a `post_revision` when the user hits `cmd+s` in the editor to explicitly save
3. we will save a `post_revision` when the user navigates away from the editor (e.g. by clicking the 'Posts' breadcrumb in the editor)
4. we will save a `post_revision` when the user publishes a post
5. we will save a `post_revision` when a user updates an already published post

