### PR TITLE
Added `post-status` and `reason` col to `post_revisions`

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
@@ -6,11 +6,8 @@ module.exports = combineNonTransactionalMigrations(
     createAddColumnMigration('post_revisions', 'post_status', {
         type: 'string',
         maxlength: 50,
-        nullable: true
-        defaultTo: 'draft',
-        validations: {
-            isIn: [['published', 'draft', 'scheduled', 'sent']]
-        }
+        nullable: true,
+        defaultTo: 'draft'
     }),
     createAddColumnMigration('post_revisions', 'reason', {
         type: 'string',

--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
@@ -1,0 +1,15 @@
+// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
+
+const {createAddColumnMigration} = require('../../utils');
+
+// status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'draft', validations: {isIn: [['published', 'draft', 'scheduled', 'sent']]}},
+
+module.exports = createAddColumnMigration('post_revisions', 'post_status', {
+    type: 'string',
+    maxlength: 50,
+    nullable: false,
+    defaultTo: 'draft',
+    validations: {
+        isIn: [['published', 'draft', 'scheduled', 'sent']]
+    }
+});

--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
@@ -1,15 +1,34 @@
 // For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
 
 const {createAddColumnMigration} = require('../../utils');
+const {combineNonTransactionalMigrations,createAddColumnMigration} = require('../../utils');
 
 // status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'draft', validations: {isIn: [['published', 'draft', 'scheduled', 'sent']]}},
 
-module.exports = createAddColumnMigration('post_revisions', 'post_status', {
-    type: 'string',
-    maxlength: 50,
-    nullable: false,
-    defaultTo: 'draft',
-    validations: {
-        isIn: [['published', 'draft', 'scheduled', 'sent']]
-    }
-});
+// module.exports = createAddColumnMigration('post_revisions', 'post_status', {
+//     type: 'string',
+//     maxlength: 50,
+//     nullable: false,
+//     defaultTo: 'draft',
+//     validations: {
+//         isIn: [['published', 'draft', 'scheduled', 'sent']]
+//     }
+// });
+
+
+module.exports = combineNonTransactionalMigrations(
+    createAddColumnMigration('post_revisions', 'post_status', {
+        type: 'string',
+        maxlength: 50,
+        nullable: false,
+        defaultTo: 'draft',
+        validations: {
+            isIn: [['published', 'draft', 'scheduled', 'sent']]
+        }
+    }),
+    createAddColumnMigration('post_revisions', 'reason', {
+        type: 'string',
+        maxlength: 50,
+        nullable: true,
+    })
+);

--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
@@ -6,7 +6,7 @@ module.exports = combineNonTransactionalMigrations(
     createAddColumnMigration('post_revisions', 'post_status', {
         type: 'string',
         maxlength: 50,
-        nullable: false,
+        nullable: true
         defaultTo: 'draft',
         validations: {
             isIn: [['published', 'draft', 'scheduled', 'sent']]

--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-08-54-add-post-revision-status.js
@@ -1,20 +1,6 @@
 // For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
 
-const {createAddColumnMigration} = require('../../utils');
 const {combineNonTransactionalMigrations,createAddColumnMigration} = require('../../utils');
-
-// status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'draft', validations: {isIn: [['published', 'draft', 'scheduled', 'sent']]}},
-
-// module.exports = createAddColumnMigration('post_revisions', 'post_status', {
-//     type: 'string',
-//     maxlength: 50,
-//     nullable: false,
-//     defaultTo: 'draft',
-//     validations: {
-//         isIn: [['published', 'draft', 'scheduled', 'sent']]
-//     }
-// });
-
 
 module.exports = combineNonTransactionalMigrations(
     createAddColumnMigration('post_revisions', 'post_status', {
@@ -29,6 +15,6 @@ module.exports = combineNonTransactionalMigrations(
     createAddColumnMigration('post_revisions', 'reason', {
         type: 'string',
         maxlength: 50,
-        nullable: true,
+        nullable: true
     })
 );

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -404,7 +404,8 @@ module.exports = {
         created_at_ts: {type: 'bigInteger', nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         author_id: {type: 'string', maxlength: 24, nullable: true, references: 'users.id', cascadeDelete: false, constraintName: 'post_revs_author_id_foreign'},
-        title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 255}}}
+        title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 255}}},
+        post_status: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['draft', 'published', 'scheduled']]}}
     },
     members: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -405,7 +405,7 @@ module.exports = {
         created_at: {type: 'dateTime', nullable: false},
         author_id: {type: 'string', maxlength: 24, nullable: true, references: 'users.id', cascadeDelete: false, constraintName: 'post_revs_author_id_foreign'},
         title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 255}}},
-        post_status: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['draft', 'published', 'scheduled']]}},
+        post_status: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['draft', 'published', 'scheduled', 'sent']]}},
         reason: {type: 'string', maxlength: 50, nullable: true}
     },
     members: {

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -405,7 +405,8 @@ module.exports = {
         created_at: {type: 'dateTime', nullable: false},
         author_id: {type: 'string', maxlength: 24, nullable: true, references: 'users.id', cascadeDelete: false, constraintName: 'post_revs_author_id_foreign'},
         title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 255}}},
-        post_status: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['draft', 'published', 'scheduled']]}}
+        post_status: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['draft', 'published', 'scheduled']]}},
+        reason: {type: 'string', maxlength: 50, nullable: true}
     },
     members: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -831,7 +831,7 @@ exports[`Posts API Create Can create a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5241",
+  "content-length": "5274",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1261,7 +1261,7 @@ exports[`Posts API Update Can update a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5178",
+  "content-length": "5211",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1371,7 +1371,7 @@ exports[`Posts API Update Can update a post with lexical 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "6378",
+  "content-length": "6444",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -831,7 +831,7 @@ exports[`Posts API Create Can create a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5274",
+  "content-length": "5295",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1261,7 +1261,7 @@ exports[`Posts API Update Can update a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5211",
+  "content-length": "5232",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1371,7 +1371,7 @@ exports[`Posts API Update Can update a post with lexical 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "6444",
+  "content-length": "6486",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'e823f96e85a2b9b8e2792cbfcee42d3f';
+    const currentSchemaHash = 'c3b0d8e83f681893057906495ac051e1';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
     const currentSettingsHash = 'f9db81a9d2fe2fed5e9cfda1ccd2b3cc';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'af126e9f44bc1d0e8c41f6a3a67ef84e';
+    const currentSchemaHash = 'e823f96e85a2b9b8e2792cbfcee42d3f';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
     const currentSettingsHash = 'f9db81a9d2fe2fed5e9cfda1ccd2b3cc';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '00c8616470de50a6716369511a39eca9';
+    const currentSchemaHash = 'af126e9f44bc1d0e8c41f6a3a67ef84e';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
     const currentSettingsHash = 'f9db81a9d2fe2fed5e9cfda1ccd2b3cc';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3099

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83140b5</samp>

This pull request adds a new column `post_status` to the `post_revisions` table to store the status of the post revision. It also updates the schema definition, the migration file, and the integrity test to reflect the new column.
