### PR TITLE
Fixed issue with restoring post revision

### DIFF
--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import RestoreRevisionModal from '../components/modals/restore-revision';
 import diff from 'node-htmldiff';
-import {action} from '@ember/object';
+import {action, set} from '@ember/object';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
@@ -28,7 +28,7 @@ export default class ModalPostHistory extends Component {
       super(...arguments);
       this.post = this.args.model.post;
       this.editorAPI = this.args.model.editorAPI;
-      this.toggleSettingsMenu = this.args.toggleSettingsMenu;
+      this.toggleSettingsMenu = this.args.model.toggleSettingsMenu;
   }
   @tracked selectedHTML = `<h1>loading...</h1>`;
   @tracked diffHtml = null;
@@ -106,7 +106,7 @@ export default class ModalPostHistory extends Component {
           post: this.post,
           revision,
           updateTitle: () => {
-              this.post.titleScratch = revision.title;
+              set(this.post, 'titleScratch', revision.title);
           },
           updateEditor: () => {
               const state = this.editorAPI.editorInstance.parseEditorState(revision.lexical);


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3102

Post revision restoration was failing due a few failing edge cases that occurred during the refactor of the post history modal
