### PR TITLE
Added feature_image to post_revisions

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-10-30-add-feature-image-to-revisions.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-10-30-add-feature-image-to-revisions.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('post_revisions', 'feature_image', {
+    type: 'string',
+    maxlength: 2000,
+    nullable: true
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -404,7 +404,8 @@ module.exports = {
         created_at_ts: {type: 'bigInteger', nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         author_id: {type: 'string', maxlength: 24, nullable: true, references: 'users.id', cascadeDelete: false, constraintName: 'post_revs_author_id_foreign'},
-        title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 255}}}
+        title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 255}}},
+        feature_image: {type: 'string', maxlength: 2000, nullable: true}
     },
     members: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -922,6 +922,7 @@ Post = ghostBookshelf.Model.extend({
                         lexical: model.previous('lexical'),
                         html: model.previous('html'),
                         author_id: model.previous('updated_by'),
+                        feature_image: model.previous('feature_image'),
                         title: model.previous('title')
                     };
                     const current = {
@@ -929,6 +930,7 @@ Post = ghostBookshelf.Model.extend({
                         lexical: model.get('lexical'),
                         html: model.get('html'),
                         author_id: authorId,
+                        feature_image: model.get('feature_image'),
                         title: model.get('title')
                     };
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -831,7 +831,7 @@ exports[`Posts API Create Can create a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5241",
+  "content-length": "5262",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1261,7 +1261,7 @@ exports[`Posts API Update Can update a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5178",
+  "content-length": "5199",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1371,7 +1371,7 @@ exports[`Posts API Update Can update a post with lexical 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "6378",
+  "content-length": "6420",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '00c8616470de50a6716369511a39eca9';
+    const currentSchemaHash = '05bb5d84875ec3b6ed6aca8228dec986';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
     const currentSettingsHash = 'f9db81a9d2fe2fed5e9cfda1ccd2b3cc';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/post-revisions/lib/post-revisions.js
+++ b/ghost/post-revisions/lib/post-revisions.js
@@ -4,6 +4,7 @@
  * @property {string} lexical
  * @property {string} html
  * @property {string} author_id
+ * @property {string} feature_image
  * @property {string} title
  */
 
@@ -13,6 +14,7 @@
  * @property {string} lexical
  * @property {number} created_at_ts
  * @property {string} author_id
+ * @property {string} feature_image
  * @property {string} title
  */
 
@@ -91,6 +93,7 @@ class PostRevisions {
             lexical: input.lexical,
             created_at_ts: Date.now() - offset,
             author_id: input.author_id,
+            feature_image: input.feature_image,
             title: input.title
         };
     }


### PR DESCRIPTION
This will allow us to store historical data for feature images so we can diff and restore them

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0cd8088</samp>

This pull request adds a new column `feature_image` to the `post_revisions` table to store the feature image URL of a post revision. It also updates the schema definition and the integrity test hash to reflect the database change.
