### PR TITLE
Fixed FIFO for post revisions

### DIFF
--- a/ghost/post-revisions/lib/post-revisions.js
+++ b/ghost/post-revisions/lib/post-revisions.js
@@ -78,7 +78,9 @@ class PostRevisions {
             ];
         }
 
-        return [currentRevision, ...revisions].slice(0, this.config.max_revisions);
+        // Grab the most recent revisions, limited by max_revisions
+        const updatedRevisions = [...revisions, currentRevision];
+        return updatedRevisions.slice(updatedRevisions.length - this.config.max_revisions, updatedRevisions.length);
     }
 
     /**


### PR DESCRIPTION
no issue

- with this change, the oldest revision will be deleted and the new revision will be added if the limit is reached
