### PR TITLE
Added post revision anonymous author label

### DIFF
--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -47,7 +47,7 @@
                                     <span class="gh-post-history-version-tag published">Publised</span>
                                 {{/if}}
                             </div>
-                            <span class="gh-post-history-version-meta">{{revision.author.name}}</span>
+                            <span class="gh-post-history-version-meta {{if (eq revision.author.name "Anonymous") "anonymous-author"}}">{{revision.author.name}}</span>
                         </button>
                         {{#if (and revision.selected (not revision.latest))}}
                             <button

--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -60,7 +60,7 @@ export default class ModalPostHistory extends Component {
               createdAt: revision.get('createdAt'),
               title: revision.get('title'),
               author: {
-                  name: revision.get('author.name')
+                  name: revision.get('author.name') || 'Anonymous'
               }
           };
       });

--- a/ghost/admin/app/styles/layouts/post-history.css
+++ b/ghost/admin/app/styles/layouts/post-history.css
@@ -36,6 +36,10 @@
     font-weight: 400;
 }
 
+.nav-list-item .gh-post-history-version-meta.anonymous-author {
+    color: var(--lightgrey);
+}
+
 .nav-list-item .gh-post-history-version-tag {
     margin-left: .8rem;
     padding: 0 5px;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3104

When a post revision author has been deleted, or there is no author associated with a post revision, the label "Anonymous" is used for the revision author