### PR TITLE
Added columns to store feature image metadata for revision

### DIFF
--- a/ghost/admin/app/models/post-revision.js
+++ b/ghost/admin/app/models/post-revision.js
@@ -5,6 +5,8 @@ export default class PostRevisionModel extends Model {
   @attr('string') lexical;
   @attr('string') title;
   @attr('string') featureImage;
+  @attr('string') featureImageAlt;
+  @attr('string') featureImageCaption;
   @attr('string') reason;
   @attr('moment-utc') createdAt;
   @belongsTo('user') author;

--- a/ghost/admin/app/serializers/post-revision.js
+++ b/ghost/admin/app/serializers/post-revision.js
@@ -9,9 +9,11 @@ export default class PostRevisionSerializer extends ApplicationSerializer.extend
         lexical: {key: 'lexical'},
         title: {key: 'title'},
         createdAt: {key: 'created_at'},
-        postIdLocal: {key: 'post_id'},
         postStatus: {key: 'post_status'},
         reason: {key: 'reason'},
-        featureImage: {key: 'feature_image'}
+        featureImage: {key: 'feature_image'},
+        featureImageAlt: {key: 'feature_image_alt'},
+        featureImageCaption: {key: 'feature_image_caption'},
+        postIdLocal: {key: 'post_id'}
     };
 }

--- a/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-13-01-add-feature-image-meta-to-post-revisions.js
+++ b/ghost/core/core/server/data/migrations/versions/5.45/2023-04-21-13-01-add-feature-image-meta-to-post-revisions.js
@@ -1,0 +1,14 @@
+const {combineNonTransactionalMigrations,createAddColumnMigration} = require('../../utils');
+
+module.exports = combineNonTransactionalMigrations(
+    createAddColumnMigration('post_revisions', 'feature_image_caption', {
+        type: 'string',
+        maxlength: 65535,
+        nullable: true
+    }),
+    createAddColumnMigration('post_revisions', 'feature_image_alt', {
+        type: 'string',
+        maxlength: 191,
+        nullable: true
+    })
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -407,7 +407,9 @@ module.exports = {
         title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 255}}},
         post_status: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['draft', 'published', 'scheduled', 'sent']]}},
         reason: {type: 'string', maxlength: 50, nullable: true},
-        feature_image: {type: 'string', maxlength: 2000, nullable: true}
+        feature_image: {type: 'string', maxlength: 2000, nullable: true},
+        feature_image_alt: {type: 'string', maxlength: 191, nullable: true, validations: {isLength: {max: 125}}},
+        feature_image_caption: {type: 'text', maxlength: 65535, nullable: true}
     },
     members: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -917,21 +917,15 @@ Post = ghostBookshelf.Model.extend({
                         }, _.pick(options, 'transacting')));
 
                     const revisions = revisionModels.toJSON();
-                    const previous = {
-                        id: model.id,
-                        lexical: model.previous('lexical'),
-                        html: model.previous('html'),
-                        author_id: model.previous('updated_by'),
-                        feature_image: model.previous('feature_image'),
-                        title: model.previous('title'),
-                        post_status: model.previous('status')
-                    };
+
                     const current = {
                         id: model.id,
                         lexical: model.get('lexical'),
                         html: model.get('html'),
                         author_id: authorId,
                         feature_image: model.get('feature_image'),
+                        feature_image_alt: model.get('posts_meta')?.feature_image_alt,
+                        feature_image_caption: model.get('posts_meta')?.feature_image_caption,
                         title: model.get('title'),
                         post_status: model.get('status')
                     };
@@ -941,7 +935,7 @@ Post = ghostBookshelf.Model.extend({
                         forceRevision: options.save_revision,
                         isPublished: newStatus === 'published'
                     };
-                    const newRevisions = await postRevisions.getRevisions(previous, current, revisions, revisionOptions);
+                    const newRevisions = await postRevisions.getRevisions(current, revisions, revisionOptions);
                     model.set('post_revisions', newRevisions);
                 });
             }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -831,7 +831,7 @@ exports[`Posts API Create Can create a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5312",
+  "content-length": "5363",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1371,7 +1371,7 @@ exports[`Posts API Update Can update a post with lexical 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "6517",
+  "content-length": "6619",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c3b0d8e83f681893057906495ac051e1';
+    const currentSchemaHash = '2445c734ffb514d11b56e74591bcde4e';
     const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
     const currentSettingsHash = 'f9db81a9d2fe2fed5e9cfda1ccd2b3cc';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/post-revisions/lib/post-revisions.js
+++ b/ghost/post-revisions/lib/post-revisions.js
@@ -5,6 +5,8 @@
  * @property {string} html
  * @property {string} author_id
  * @property {string} feature_image
+ * @property {string} feature_image_alt
+ * @property {string} feature_image_caption
  * @property {string} title
  * @property {string} reason
  * @property {string} post_status
@@ -17,6 +19,8 @@
  * @property {number} created_at_ts
  * @property {string} author_id
  * @property {string} feature_image
+ * @property {string} feature_image_alt
+ * @property {string} feature_image_caption
  * @property {string} title
  * @property {string} reason
  * @property {string} post_status
@@ -41,11 +45,8 @@ class PostRevisions {
      * @param {object} options
      * @returns {object}
      */
-    shouldGenerateRevision(previous, current, revisions, options) {
+    shouldGenerateRevision(current, revisions, options) {
         const latestRevision = revisions[revisions.length - 1];
-        if (!previous) {
-            return {value: false};
-        }
         // If there's no revisions for this post, we should always save a revision
         if (revisions.length === 0) {
             return {value: true, reason: 'initial_revision'};
@@ -57,8 +58,9 @@ class PostRevisions {
 
         const forceRevision = options && options.forceRevision;
         const lexicalHasChangedSinceLatestRevision = latestRevision.lexical !== current.lexical;
-        const titleHasChanged = previous.title !== current.title;
-        if ((lexicalHasChangedSinceLatestRevision || titleHasChanged) && forceRevision) {
+        const titleHasChanged = latestRevision.title !== current.title;
+        const featuredImagedHasChanged = latestRevision.feature_image !== current.feature_image;
+        if ((lexicalHasChangedSinceLatestRevision || titleHasChanged || featuredImagedHasChanged) && forceRevision) {
             return {value: true, reason: 'explicit_save'};
         }
         return {value: false};
@@ -71,8 +73,8 @@ class PostRevisions {
      * @param {object} options
      * @returns {Promise<Revision[]>}
      */
-    async getRevisions(previous, current, revisions, options) {
-        const shouldGenerateRevision = this.shouldGenerateRevision(previous, current, revisions, options);
+    async getRevisions(current, revisions, options) {
+        const shouldGenerateRevision = this.shouldGenerateRevision(current, revisions, options);
         if (!shouldGenerateRevision.value) {
             return revisions;
         }
@@ -106,6 +108,8 @@ class PostRevisions {
             created_at_ts: Date.now() - offset,
             author_id: input.author_id,
             feature_image: input.feature_image,
+            feature_image_alt: input.feature_image_alt,
+            feature_image_caption: input.feature_image_caption,
             title: input.title,
             post_status: input.post_status
         };

--- a/ghost/post-revisions/test/hello.test.js
+++ b/ghost/post-revisions/test/hello.test.js
@@ -8,20 +8,11 @@ const config = {
 
 describe('PostRevisions', function () {
     describe('shouldGenerateRevision', function () {
-        it('should return false if there is no previous', function () {
-            const postRevisions = new PostRevisions({config});
-
-            const expected = {value: false};
-            const actual = postRevisions.shouldGenerateRevision(null, {}, []);
-
-            assert.deepEqual(actual, expected);
-        });
-
         it('should return true if there are no revisions', function () {
             const postRevisions = new PostRevisions({config});
 
             const expected = {value: true, reason: 'initial_revision'};
-            const actual = postRevisions.shouldGenerateRevision({}, {}, []);
+            const actual = postRevisions.shouldGenerateRevision({}, []);
 
             assert.deepEqual(actual, expected);
         });
@@ -31,9 +22,6 @@ describe('PostRevisions', function () {
 
             const expected = {value: false};
             const actual = postRevisions.shouldGenerateRevision({
-                lexical: 'previous',
-                html: 'blah'
-            }, {
                 lexical: 'current',
                 html: 'blah'
             }, [{
@@ -48,9 +36,6 @@ describe('PostRevisions', function () {
 
             const expected = {value: true, reason: 'explicit_save'};
             const actual = postRevisions.shouldGenerateRevision({
-                lexical: 'blah',
-                html: 'blah'
-            }, {
                 lexical: 'blah',
                 html: 'blah2'
             }, [{
@@ -71,13 +56,30 @@ describe('PostRevisions', function () {
             const actual = postRevisions.shouldGenerateRevision({
                 lexical: 'blah',
                 html: 'blah',
-                title: 'blah'
-            }, {
-                lexical: 'blah',
-                html: 'blah',
                 title: 'blah2'
             }, [{
                 lexical: 'blah'
+            }], {
+                forceRevision: true
+            });
+
+            assert.deepEqual(actual, expected);
+        });
+
+        it('should return true if the current and previous feature_image values are different and forceRevision is true', function () {
+            const postRevisions = new PostRevisions({config});
+
+            const expected = {value: true, reason: 'explicit_save'};
+            const actual = postRevisions.shouldGenerateRevision({
+                lexical: 'blah',
+                html: 'blah',
+                title: 'blah',
+                feature_image: 'new'
+            }, [{
+                lexical: 'blah',
+                html: 'blah',
+                title: 'blah',
+                feature_image: null
             }], {
                 forceRevision: true
             });
@@ -90,10 +92,6 @@ describe('PostRevisions', function () {
 
             const expected = {value: true, reason: 'published'};
             const actual = postRevisions.shouldGenerateRevision({
-                lexical: 'blah',
-                html: 'blah',
-                title: 'blah'
-            }, {
                 lexical: 'blah',
                 html: 'blah',
                 title: 'blah2'
@@ -114,7 +112,7 @@ describe('PostRevisions', function () {
             const expected = [{
                 lexical: 'blah'
             }];
-            const actual = await postRevisions.getRevisions(null, {}, [{
+            const actual = await postRevisions.getRevisions({}, [{
                 lexical: 'blah'
             }]);
 
@@ -130,9 +128,6 @@ describe('PostRevisions', function () {
             const actual = await postRevisions.getRevisions({
                 lexical: 'blah',
                 html: 'blah'
-            }, {
-                lexical: 'blah',
-                html: 'blah'
             }, [{
                 lexical: 'revision'
             }]);
@@ -144,12 +139,6 @@ describe('PostRevisions', function () {
             const postRevisions = new PostRevisions({config});
 
             const actual = await postRevisions.getRevisions({
-                id: '1',
-                lexical: 'previous',
-                html: 'previous',
-                author_id: '123',
-                title: 'foo bar baz'
-            }, {
                 id: '1',
                 lexical: 'current',
                 html: 'current',
@@ -172,19 +161,11 @@ describe('PostRevisions', function () {
 
             const revisions = await postRevisions.getRevisions({
                 id: '1',
-                lexical: 'previous',
-                html: 'previous'
-            }, {
-                id: '1',
                 lexical: 'current',
                 html: 'current'
             }, []);
 
             const actual = await postRevisions.getRevisions({
-                id: '1',
-                lexical: 'old',
-                html: 'old'
-            }, {
                 id: '1',
                 lexical: 'new',
                 html: 'new'
@@ -204,19 +185,11 @@ describe('PostRevisions', function () {
 
             const revisions = await postRevisions.getRevisions({
                 id: '1',
-                lexical: 'previous',
-                html: 'previous'
-            }, {
-                id: '1',
                 lexical: 'current',
                 html: 'current'
             }, []);
 
             const actual = await postRevisions.getRevisions({
-                id: '1',
-                lexical: 'old',
-                html: 'old'
-            }, {
                 id: '1',
                 lexical: 'new',
                 html: 'new'


### PR DESCRIPTION
We need this to correctly display the difference with feature images and to restore them.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43d68c7</samp>

This pull request adds two new columns to the `post_revisions` table to store the feature image caption and alternative text for each post revision. It also updates the schema definition file, the migration file, and the integrity test file accordingly.
