### PR TITLE
Added post status saving

### DIFF
--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -913,7 +913,7 @@ Post = ghostBookshelf.Model.extend({
                     const revisionModels = await ghostBookshelf.model('PostRevision')
                         .findAll(Object.assign({
                             filter: `post_id:${model.id}`,
-                            columns: ['id', 'lexical', 'created_at', 'author_id', 'title', 'reason']
+                            columns: ['id', 'lexical', 'created_at', 'author_id', 'title', 'reason', 'post_status']
                         }, _.pick(options, 'transacting')));
 
                     const revisions = revisionModels.toJSON();
@@ -923,7 +923,8 @@ Post = ghostBookshelf.Model.extend({
                         html: model.previous('html'),
                         author_id: model.previous('updated_by'),
                         feature_image: model.previous('feature_image'),
-                        title: model.previous('title')
+                        title: model.previous('title'),
+                        post_status: model.previous('status')
                     };
                     const current = {
                         id: model.id,
@@ -931,7 +932,8 @@ Post = ghostBookshelf.Model.extend({
                         html: model.get('html'),
                         author_id: authorId,
                         feature_image: model.get('feature_image'),
-                        title: model.get('title')
+                        title: model.get('title'),
+                        post_status: model.get('status')
                     };
 
                     // This can be refactored once we have the status stored in each revision

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -831,7 +831,7 @@ exports[`Posts API Create Can create a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5309",
+  "content-length": "5312",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1261,7 +1261,7 @@ exports[`Posts API Update Can update a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5246",
+  "content-length": "5249",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1371,7 +1371,7 @@ exports[`Posts API Update Can update a post with lexical 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "6511",
+  "content-length": "6517",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/post-revisions/lib/post-revisions.js
+++ b/ghost/post-revisions/lib/post-revisions.js
@@ -7,6 +7,7 @@
  * @property {string} feature_image
  * @property {string} title
  * @property {string} reason
+ * @property {string} post_status
  */
 
 /**
@@ -18,6 +19,7 @@
  * @property {string} feature_image
  * @property {string} title
  * @property {string} reason
+ * @property {string} post_status
  */
 
 class PostRevisions {
@@ -104,7 +106,8 @@ class PostRevisions {
             created_at_ts: Date.now() - offset,
             author_id: input.author_id,
             feature_image: input.feature_image,
-            title: input.title
+            title: input.title,
+            post_status: input.post_status
         };
     }
 


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebd1973</samp>

This pull request adds support for storing and tracking the status of posts in revisions. It introduces a new `post_status` column and property in the `post` and `PostRevision` models, and updates the `PostRevisions.formatInput` method to handle it.
