### PR TITLE
Prevented post history from being viewed for emailed posts

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -149,7 +149,7 @@
                                 </div>
                             </li>
                         {{/unless}}
-                        {{#if (and (feature 'postHistory') this.post.lexical)}}
+                        {{#if this.canViewPostHistory}}
                             <li class="nav-list-item">
                                 <button type="button" {{on "click" this.openPostHistory}} data-test-toggle="post-history">
                                     <span>{{svg-jar "history" class="history"}} Post history</span>

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -144,6 +144,18 @@ export default class GhPostSettingsMenu extends Component {
         return urlParts.join(' › ');
     }
 
+    get canViewPostHistory() {
+        let showPostHistory = this.feature.postHistory === true
+            && this.post.lexical !== null
+            && this.post.emailOnly === false;
+
+        if (this.post.isPublished === true) {
+            showPostHistory = this.post.hasEmail === false;
+        }
+
+        return showPostHistory;
+    }
+
     willDestroyElement() {
         super.willDestroyElement(...arguments);
 


### PR DESCRIPTION
refs https://github.com/orgs/TryGhost/projects/88/views/2?pane=issue&itemId=26198422

Prevented post history from being viewed in the following scenarios:

- When a post is sent as and email only
- When a post is published and sent as an email