### PR TITLE
Moved announcement bar data to Members API

### DIFF
--- a/ghost/announcement-bar/src/App.js
+++ b/ghost/announcement-bar/src/App.js
@@ -2,8 +2,8 @@ import React from 'react';
 import {AnnouncementBar} from './components/AnnouncementBar';
 import setupGhostApi from './utils/api';
 
-export function App({apiUrl, apiKey}) {
-    const api = React.useRef(setupGhostApi({apiKey, apiUrl}));
+export function App({apiUrl}) {
+    const api = React.useRef(setupGhostApi({apiUrl}));
     const [siteSettings, setSiteSettings] = React.useState();
 
     React.useEffect(() => {
@@ -11,8 +11,9 @@ export function App({apiUrl, apiKey}) {
             return;
         }
         const getSiteSettings = async () => {
-            const {settingsData} = await api.current.init();
-            setSiteSettings(settingsData.settings);
+            const announcement = await api.current.init();
+
+            setSiteSettings(announcement);
         };
 
         getSiteSettings();

--- a/ghost/announcement-bar/src/index.js
+++ b/ghost/announcement-bar/src/index.js
@@ -21,10 +21,8 @@ function getSiteData() {
      */
     const scriptTag = document.querySelector('script[data-announcement-bar]');
     if (scriptTag) {
-        const adminUrl = scriptTag.dataset.announcementBar;
-        const apiKey = scriptTag.dataset.key;
-        const apiUrl = scriptTag.dataset.api;
-        return {adminUrl, apiKey, apiUrl};
+        const apiUrl = scriptTag.dataset.apiUrl;
+        return {apiUrl};
     }
     return {};
 }
@@ -34,14 +32,11 @@ function setup() {
 }
 
 function init() {
-    const {adminUrl, apiKey, apiUrl} = getSiteData();
-    const adminBaseUrl = (adminUrl || window.location.origin)?.replace(/\/+$/, '');
+    const {apiUrl} = getSiteData();
     setup();
     ReactDOM.render(
         <React.StrictMode>
             <App
-                adminUrl={adminBaseUrl}
-                apiKey={apiKey}
                 apiUrl={apiUrl}
             />
         </React.StrictMode>,

--- a/ghost/announcement-bar/src/utils/api.js
+++ b/ghost/announcement-bar/src/utils/api.js
@@ -1,11 +1,4 @@
-function setupGhostApi({apiUrl, apiKey}) {
-    function contentEndpointFor({resource, keys, params = ''}) {
-        if (apiUrl && apiKey) {
-            return `${apiUrl.replace(/\/$/, '')}/${resource}/?key=${apiKey}&keys=${keys.join(',')}${params}`;
-        }
-        return '';
-    }
-
+function setupGhostApi({apiUrl}) {
     function makeRequest({url, method = 'GET', headers = {}, credentials = undefined, body = undefined}) {
         const options = {
             method,
@@ -17,12 +10,9 @@ function setupGhostApi({apiUrl, apiKey}) {
     }
     const api = {};
 
-    api.site = {
-        settings() {
-            const url = contentEndpointFor({
-                resource: 'settings',
-                keys: ['announcement', 'announcement_background']
-            });
+    api.announcementSettings = {
+        browse() {
+            const url = apiUrl;
             return makeRequest({
                 url,
                 method: 'GET',
@@ -40,11 +30,8 @@ function setupGhostApi({apiUrl, apiKey}) {
     };
 
     api.init = async () => {
-        let [settingsData] = await Promise.all([
-            api.site.settings()
-        ]);
-
-        return {settingsData};
+        let {announcement} = await api.announcementSettings.browse();
+        return announcement[0];
     };
 
     return api;

--- a/ghost/announcement-bar/src/utils/api.test.js
+++ b/ghost/announcement-bar/src/utils/api.test.js
@@ -4,16 +4,21 @@ test('should call settings endpoint on init', () => {
     jest.spyOn(window, 'fetch');
     window.fetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({success: true})
+        json: async () => ({
+            announcement: [{
+                announcement_content: '<p>Test announcement</p>',
+                announcement_background: 'dark'
+            }]
+        })
     });
 
-    const api = setupGhostApi({apiKey: 'key', apiUrl: 'http://localhost'});
+    const api = setupGhostApi({apiKey: 'key', apiUrl: 'http://localhost/members/api/announcement/'});
 
     api.init();
 
     expect(window.fetch).toHaveBeenCalledTimes(1);
     expect(window.fetch).toHaveBeenCalledWith(
-        'http://localhost/settings/?key=key&keys=announcement,announcement_background',
+        'http://localhost/members/api/announcement/',
         expect.objectContaining({
             method: 'GET',
             headers: {'Content-Type': 'application/json'},

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -87,17 +87,19 @@ function getSearchHelper(frontendKey) {
     return helper;
 }
 
-function getAnnouncementBarHelper(frontendKey) {
+function getAnnouncementBarHelper() {
     if (!settingsCache.get('announcement_content')) {
         return '';
     }
-    const adminUrl = urlUtils.getAdminUrl() || urlUtils.getSiteUrl();
+
     const {scriptUrl} = getFrontendAppConfig('announcementBar');
+    const siteUrl = urlUtils.getSiteUrl();
+    const announcementUrl = new URL('members/api/announcement/', siteUrl);
     const attrs = {
-        key: frontendKey,
-        'announcement-bar': adminUrl,
-        api: urlUtils.urlFor('api', {type: 'content'}, true)
+        'announcement-bar': siteUrl,
+        'api-url': announcementUrl
     };
+
     const dataAttrs = getDataAttributes(attrs);
     let helper = `<script defer src="${scriptUrl}" ${dataAttrs} crossorigin="anonymous"></script>`;
 
@@ -247,7 +249,7 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
         if (!_.includes(context, 'amp')) {
             head.push(getMembersHelper(options.data, frontendKey));
             head.push(getSearchHelper(frontendKey));
-            head.push(getAnnouncementBarHelper(frontendKey));
+            head.push(getAnnouncementBarHelper());
             try {
                 head.push(getWebmentionDiscoveryLink());
             } catch (err) {

--- a/ghost/core/core/server/api/endpoints/announcements.js
+++ b/ghost/core/core/server/api/endpoints/announcements.js
@@ -1,0 +1,12 @@
+const announcementBarSettings = require('../../services/announcement-bar-service');
+
+module.exports = {
+    docName: 'announcement',
+
+    browse: {
+        permissions: true,
+        query(frame) {
+            return announcementBarSettings.getAnnouncementSettings(frame.options.context?.member);
+        }
+    }
+};

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -77,6 +77,10 @@ module.exports = {
         return apiFramework.pipeline(require('./settings'), localUtils);
     },
 
+    get announcements() {
+        return apiFramework.pipeline(require('./announcements'), localUtils);
+    },
+
     get membersStripeConnect() {
         return apiFramework.pipeline(require('./members-stripe-connect'), localUtils);
     },
@@ -239,5 +243,5 @@ module.exports = {
 
     get feedbackMembers() {
         return apiFramework.pipeline(require('./feedback-members'), localUtils, 'members');
-    }   
+    }
 };

--- a/ghost/core/core/server/api/endpoints/settings-public.js
+++ b/ghost/core/core/server/api/endpoints/settings-public.js
@@ -1,25 +1,17 @@
 const settingsCache = require('../../../shared/settings-cache');
 const urlUtils = require('../../../shared/url-utils');
 const ghostVersion = require('@tryghost/version');
-const announcementBarSettings = require('../../services/announcement-bar-service');
-const labs = require('../../../shared/labs');
 
 module.exports = {
     docName: 'settings',
 
     browse: {
         permissions: true,
-        query(frame) {
-            let announcementSettings;
-            if (labs.isSet('announcementBar')) {
-                announcementSettings = announcementBarSettings.getAnnouncementSettings(frame.options.context?.member);
-            }
-
+        query() {
             // @TODO: decouple settings cache from API knowledge
             // The controller fetches models (or cached models) and the API frame for the target API version formats the response.
             return Object.assign({},
-                settingsCache.getPublic(),
-                announcementSettings, {
+                settingsCache.getPublic(), {
                     url: urlUtils.urlFor('home', true),
                     version: ghostVersion.safe
                 }

--- a/ghost/core/core/server/web/announcement/index.js
+++ b/ghost/core/core/server/web/announcement/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./routes');

--- a/ghost/core/core/server/web/announcement/routes.js
+++ b/ghost/core/core/server/web/announcement/routes.js
@@ -1,0 +1,15 @@
+const express = require('../../../shared/express');
+const api = require('../../api').endpoints;
+const {http} = require('@tryghost/api-framework');
+const shared = require('../shared');
+
+module.exports = function apiRoutes() {
+    const router = express.Router('announcements');
+
+    // shouldn't be cached as it depends on member's context
+    router.use(shared.middleware.cacheControl('private'));
+
+    router.get('/', http(api.announcements.browse));
+
+    return router;
+};

--- a/ghost/core/core/server/web/members/app.js
+++ b/ghost/core/core/server/web/members/app.js
@@ -14,6 +14,7 @@ const {http} = require('@tryghost/api-framework');
 const api = require('../../api').endpoints;
 
 const commentRouter = require('../comments');
+const announcementRouter = require('../announcement');
 
 module.exports = function setupMembersApp() {
     debug('Members App setup start');
@@ -77,6 +78,14 @@ module.exports = function setupMembersApp() {
         middleware.loadMemberSession,
         middleware.authMemberByUuid,
         http(api.feedbackMembers.add)
+    );
+
+    // Announcement
+    membersApp.use(
+        '/api/announcement',
+        labs.enabledMiddleware('announcementBar'),
+        middleware.loadMemberSession,
+        announcementRouter()
     );
 
     // API error handling

--- a/ghost/core/test/e2e-api/members/__snapshots__/announcement.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/announcement.test.js.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Announcement Can read announcement data 1: [body] 1`] = `
+Object {
+  "announcement": Array [
+    Object {},
+  ],
+}
+`;
+
+exports[`Announcement Can read announcement data 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "21",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Announcement Can read announcement endpoint 1: [body] 1`] = `
+Object {
+  "announcement": Array [
+    Object {},
+  ],
+}
+`;
+
+exports[`Announcement Can read announcement endpoint 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "21",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Announcement Can read announcement when it is present in announcement data 1: [body] 1`] = `
+Object {
+  "announcement": Array [
+    Object {
+      "announcement": "<p>Test announcement</p>",
+      "announcement_background": "dark",
+    },
+  ],
+}
+`;
+
+exports[`Announcement Can read announcement when it is present in announcement data 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "95",
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/members/announcement.test.js
+++ b/ghost/core/test/e2e-api/members/announcement.test.js
@@ -1,0 +1,41 @@
+const {agentProvider, mockManager, fixtureManager, matchers, configUtils} = require('../../utils/e2e-framework');
+const {anyEtag} = matchers;
+const settingsCache = require('../../../core/shared/settings-cache');
+
+describe('Announcement', function () {
+    let membersAgent;
+
+    before(async function () {
+        membersAgent = await agentProvider.getMembersAPIAgent();
+
+        await fixtureManager.init('members');
+    });
+
+    afterEach(async function () {
+        await configUtils.restore();
+        mockManager.restore();
+    });
+
+    it('Can read announcement endpoint', async function () {
+        await membersAgent
+            .get(`/api/announcement/`)
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            })
+            .matchBodySnapshot();
+    });
+
+    it('Can read announcement when it is present in announcement data', async function () {
+        settingsCache.set('announcement_content', {value: '<p>Test announcement</p>'});
+        settingsCache.set('announcement_visibility', {value: ['visitors']});
+
+        await membersAgent
+            .get(`/api/announcement/`)
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                etag: anyEtag
+            })
+            .matchBodySnapshot();
+    });
+});


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f11d897</samp>

This pull request updates the announcement bar feature to use a new `announcement` API endpoint, which simplifies the code and removes the need for an API key. It also adds web routes for serving announcement pages to members, and tests for the new endpoint. It modifies the `App.js`, `index.js`, and `api.js` files in the `ghost/announcement-bar` repository, and the `ghost_head.js`, `endpoints/index.js`, `endpoints/settings-public.js`, `endpoints/announcements.js`, `web/members/app.js`, `web/announcement/index.js`, `web/announcement/routes.js`, and `test/e2e-api/members/announcement.test.js` files in the `ghost/core` repository.
