### PR TITLE
Hide preview select for design/announcement settings

### DIFF
--- a/ghost/admin/app/templates/settings/announcement-bar/index.hbs
+++ b/ghost/admin/app/templates/settings/announcement-bar/index.hbs
@@ -2,17 +2,19 @@
     <GhCanvasHeader class="gh-canvas-header">
         <h2 class="gh-canvas-title">Announcement bar</h2>
         <section class="view-actions">
-            <div class="gh-select gh-preview-page-selector">
-                <OneWaySelect
-                    @value={{this.themeManagement.previewType}}
-                    @options={{this.themeManagement.availablePreviewTypes}}
-                    @optionValuePath="name"
-                    @optionLabelPath="label"
-                    @optionTargetPath="name"
-                    @update={{this.themeManagement.setPreviewType}}
-                />
-                {{svg-jar "arrow-down-small"}}
-            </div>
+            {{#if (gt this.themeManagement.availablePreviewTypes.length 1)}}
+                <div class="gh-select gh-preview-page-selector">
+                    <OneWaySelect
+                        @value={{this.themeManagement.previewType}}
+                        @options={{this.themeManagement.availablePreviewTypes}}
+                        @optionValuePath="name"
+                        @optionLabelPath="label"
+                        @optionTargetPath="name"
+                        @update={{this.themeManagement.setPreviewType}}
+                    />
+                    {{svg-jar "arrow-down-small"}}
+                </div>
+            {{/if}}
 
             <div class="gh-contentfilter gh-btn-group">
                 <button type="button" class="gh-btn gh-design-preview-mode {{if this.isDesktopPreview "gh-btn-group-selected"}}" {{on "click" (fn this.setPreviewSize "desktop")}} data-test-button="desktop-preview"><span>{{svg-jar "desktop"}}</span></button>

--- a/ghost/admin/app/templates/settings/design/index.hbs
+++ b/ghost/admin/app/templates/settings/design/index.hbs
@@ -2,17 +2,19 @@
     <GhCanvasHeader class="gh-canvas-header">
         <h2 class="gh-canvas-title">Site design</h2>
         <section class="view-actions">
-            <div class="gh-select gh-preview-page-selector">
-                <OneWaySelect
-                    @value={{this.themeManagement.previewType}}
-                    @options={{this.themeManagement.availablePreviewTypes}}
-                    @optionValuePath="name"
-                    @optionLabelPath="label"
-                    @optionTargetPath="name"
-                    @update={{this.themeManagement.setPreviewType}}
-                />
-                {{svg-jar "arrow-down-small"}}
-            </div>
+            {{#if (gt this.themeManagement.availablePreviewTypes.length 1)}}
+                <div class="gh-select gh-preview-page-selector">
+                    <OneWaySelect
+                        @value={{this.themeManagement.previewType}}
+                        @options={{this.themeManagement.availablePreviewTypes}}
+                        @optionValuePath="name"
+                        @optionLabelPath="label"
+                        @optionTargetPath="name"
+                        @update={{this.themeManagement.setPreviewType}}
+                    />
+                    {{svg-jar "arrow-down-small"}}
+                </div>
+            {{/if}}
 
             <div class="gh-contentfilter gh-btn-group">
                 <button type="button" class="gh-btn gh-design-preview-mode {{if this.isDesktopPreview "gh-btn-group-selected"}}" {{on "click" (fn this.setPreviewSize "desktop")}} data-test-button="desktop-preview"><span>{{svg-jar "desktop"}}</span></button>


### PR DESCRIPTION
no issue
- Hide post preview select if there is no published posts yet.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
copilot:summary
