### PR TITLE
Added `unpublished` reason to post revisions

### DIFF
--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -66,7 +66,7 @@
                                 {{#if revision.new_publish}}
                                     <span class="gh-post-history-version-tag published">Published</span>
                                 {{/if}}
-                                {{#if revision.new_unpublish}}
+                                {{#if (eq revision.reason "unpublished")}}
                                     <span class="gh-post-history-version-tag unpublished">Unpublished</span>
                                 {{/if}}
                                 

--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -71,8 +71,7 @@ export default class ModalPostHistory extends Component {
                 },
                 postStatus: revision.get('postStatus'),
                 reason: revision.get('reason'),
-                new_publish: revision.get('postStatus') === 'published' && revisions[index + 1]?.get('postStatus') === 'draft',
-                new_unpublish: revision.get('postStatus') === 'draft' && revisions[index + 1]?.get('postStatus') === 'published'
+                new_publish: revision.get('postStatus') === 'published' && revisions[index + 1]?.get('postStatus') === 'draft'
             };
         });
     }

--- a/ghost/admin/app/components/modal-post-history.js
+++ b/ghost/admin/app/components/modal-post-history.js
@@ -68,8 +68,7 @@ export default class ModalPostHistory extends Component {
               },
               postStatus: revision.get('postStatus'),
               reason: revision.get('reason'),
-              new_publish: revision.get('postStatus') === 'published' && revisions[index + 1]?.get('postStatus') === 'draft',
-              new_unpublish: revision.get('postStatus') === 'draft' && revisions[index + 1]?.get('postStatus') === 'published'
+              new_publish: revision.get('postStatus') === 'published' && revisions[index + 1]?.get('postStatus') === 'draft'
           };
       });
   }

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -935,7 +935,9 @@ Post = ghostBookshelf.Model.extend({
                     // This can be refactored once we have the status stored in each revision
                     const revisionOptions = {
                         forceRevision: options.save_revision,
-                        isPublished: newStatus === 'published'
+                        isPublished: newStatus === 'published',
+                        newStatus,
+                        olderStatus
                     };
                     const newRevisions = await postRevisions.getRevisions(current, revisions, revisionOptions);
                     model.set('post_revisions', newRevisions);

--- a/ghost/post-revisions/lib/post-revisions.js
+++ b/ghost/post-revisions/lib/post-revisions.js
@@ -52,6 +52,12 @@ class PostRevisions {
         if (revisions.length === 0) {
             return {value: true, reason: 'initial_revision'};
         }
+        // check if the post has been unpublished
+        const isUnpublished = options && options.newStatus === 'draft' && options.olderStatus === 'published';
+        if (isUnpublished) {
+            return {value: true, reason: 'unpublished'};
+        }
+        // check if the post has been published
         const isPublished = options && options.isPublished;
         if (isPublished) {
             return {value: true, reason: 'published'};

--- a/ghost/post-revisions/test/hello.test.js
+++ b/ghost/post-revisions/test/hello.test.js
@@ -89,6 +89,27 @@ describe('PostRevisions', function () {
             assert.deepEqual(actual, expected);
         });
 
+        it('should return true if post is unpublished and forceRevision is true', function () {
+            const postRevisions = new PostRevisions({config});
+
+            const expected = {value: true, reason: 'unpublished'};
+
+            const actual = postRevisions.shouldGenerateRevision({
+                lexical: 'blah',
+                html: 'blah',
+                title: 'blah2'
+            }, [{
+                lexical: 'blah'
+            }], {
+                isPublished: false,
+                forceRevision: true,
+                newStatus: 'draft',
+                olderStatus: 'published'
+            });
+
+            assert.deepEqual(actual, expected);
+        });
+
         it('should always return true if isPublished is true', function () {
             const postRevisions = new PostRevisions({config});
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3137

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c49b478</samp>

This pull request fixes a bug in the revision history modal that prevented the "Unpublished" tag from showing up for posts that were unpublished by a user action. It also adds a new condition and a new test case to the revision generation logic to handle posts that are unpublished by a user action and set the reason accordingly.
