### PR TITLE
Added background save every 10 minutes to the post editor

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -30,6 +30,8 @@ const DEFAULT_TITLE = '(Untitled)';
 const AUTOSAVE_TIMEOUT = 3000;
 // time in ms to force a save if the user is continuously typing
 const TIMEDSAVE_TIMEOUT = 60000;
+// time in ms to force a save even if the post is already saved so we trigger a new revision on the server
+const REVISIONSAVE_TIMEOUT = 1000 * 60 * 10; // 10 minutes
 
 // this array will hold properties we need to watch for this.hasDirtyAttributes
 let watchedProps = [
@@ -190,12 +192,13 @@ export default class LexicalEditorController extends Controller {
         return false;
     }
 
-    @computed('_autosaveTask.isRunning', '_timedSaveTask.isRunning')
+    @computed('_autosaveTask.isRunning', '_timedSaveTask.isRunning', '_revisionSaveTask.isRunning')
     get _autosaveRunning() {
         let autosave = this.get('_autosaveTask.isRunning');
         let timedsave = this.get('_timedSaveTask.isRunning');
+        let revisionsave = this.get('_revisionSaveTask.isRunning');
 
-        return autosave || timedsave;
+        return autosave || timedsave || revisionsave;
     }
 
     @computed('post.isDraft')
@@ -211,6 +214,8 @@ export default class LexicalEditorController extends Controller {
         this._autosaveTask.perform();
         // force save at 60 seconds
         this._timedSaveTask.perform();
+        // force save at 10 minutes to trigger revision
+        this._revisionSaveTask.perform();
     }
 
     @action
@@ -245,6 +250,7 @@ export default class LexicalEditorController extends Controller {
     cancelAutosave() {
         this._autosaveTask.cancelAll();
         this._timedSaveTask.cancelAll();
+        this._revisionSaveTask.cancelAll();
     }
 
     // called by the "are you sure?" modal
@@ -427,7 +433,7 @@ export default class LexicalEditorController extends Controller {
 
         this.cancelAutosave();
 
-        if (options.backgroundSave && !this.hasDirtyAttributes && !options.leavingEditor) {
+        if (options.backgroundSave && !this.hasDirtyAttributes && !options.leavingEditor && !options.saveRevision) {
             return;
         }
 
@@ -480,6 +486,9 @@ export default class LexicalEditorController extends Controller {
                 }
                 return true;
             }
+
+            // Even if we've just saved and nothing else has changed, we want to save in 10 minutes to force a revision
+            this._revisionSaveTask.perform();
 
             return post;
         } catch (error) {
@@ -967,6 +976,19 @@ export default class LexicalEditorController extends Controller {
         }
     }).drop())
         _timedSaveTask;
+
+    // save at 10 minutes even if the post is already saved
+    @(task(function* () {
+        if (!this._canAutosave) {
+            return;
+        }
+
+        while (config.environment !== 'test' && true) {
+            yield timeout(REVISIONSAVE_TIMEOUT);
+            this.autosaveTask.perform({saveRevision: true});
+        }
+    }).drop())
+        _revisionSaveTask;
 
     /* Private methods -------------------------------------------------------*/
 

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -915,7 +915,7 @@ Post = ghostBookshelf.Model.extend({
                     const revisionModels = await ghostBookshelf.model('PostRevision')
                         .findAll(Object.assign({
                             filter: `post_id:${model.id}`,
-                            columns: ['id', 'lexical', 'created_at', 'author_id', 'title', 'reason', 'post_status', 'created_at_ts']
+                            columns: ['id', 'lexical', 'created_at', 'author_id', 'title', 'reason', 'post_status', 'created_at_ts', 'feature_image']
                         }, _.pick(options, 'transacting')));
 
                     const revisions = revisionModels.toJSON();

--- a/yarn.lock
+++ b/yarn.lock
@@ -22288,9 +22288,9 @@ moment@2.24.0, moment@2.27.0, moment@2.29.1, moment@2.29.3, moment@2.29.4, "mome
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
-monobundle@TryGhost/monobundle#3f1cb946d41d2650d657817c7088574e7c964ac5:
+monobundle@TryGhost/monobundle#2aca618f8880250fb99ad48d61f0ca7251f1e648:
   version "0.1.0"
-  resolved "https://codeload.github.com/TryGhost/monobundle/tar.gz/3f1cb946d41d2650d657817c7088574e7c964ac5"
+  resolved "https://codeload.github.com/TryGhost/monobundle/tar.gz/2aca618f8880250fb99ad48d61f0ca7251f1e648"
   dependencies:
     detect-indent "6.1.0"
     detect-newline "3.1.0"


### PR DESCRIPTION
refs TryGhost/Team#3133

- the backend previously had logic to save a revision if more than 10 mins had elapsed since the last revision
- however, the frontend would autosave after 3 seconds of inactivity (which doesn't trigger a revision), and never send another save request at 10 minutes, so the backend logic to save a revision was never triggered
- this change will save the current contents of the editor every 10 minutes, even if nothing has changed since the last save
