### PR TITLE
🐛 Added missing history logs for post/page bulk actions

### DIFF
--- a/ghost/admin/app/components/settings/history/table.hbs
+++ b/ghost/admin/app/components/settings/history/table.hbs
@@ -20,32 +20,34 @@
                     <div>
                         <div class="gh-history-description">
                             <span>
-                                {{capitalize-first-letter ev.action}}:
+                                {{capitalize-first-letter ev.action}}{{#unless ev.isBulkAction}}:{{/unless}}
                             </span>
-                            {{#if ev.contextResource}}
-                                <span>
-                                    <span>{{capitalize-first-letter ev.contextResource.first}}</span>
-                                    {{#if (not-eq ev.contextResource.first ev.contextResource.second)}}
-                                        <code>({{ev.contextResource.second}})</code>
-                                    {{/if}}
-                                </span>
-                            {{else if (or ev.original.resource.title ev.original.resource.name ev.original.context.primary_name)}}
-                                {{#if ev.linkTarget}}
-                                    {{#if ev.linkTarget.models}}
-                                        <LinkTo @route={{ev.linkTarget.route}} @models={{ev.linkTarget.models}} class="permalink fw6">
-                                            {{or ev.original.resource.title ev.original.resource.name}}
-                                        </LinkTo>
+                            {{#unless ev.isBulkAction}}
+                                {{#if ev.contextResource}}
+                                    <span>
+                                        <span>{{capitalize-first-letter ev.contextResource.first}}</span>
+                                        {{#if (not-eq ev.contextResource.first ev.contextResource.second)}}
+                                            <code>({{ev.contextResource.second}})</code>
+                                        {{/if}}
+                                    </span>
+                                {{else if (or ev.original.resource.title ev.original.resource.name ev.original.context.primary_name)}}
+                                    {{#if ev.linkTarget}}
+                                        {{#if ev.linkTarget.models}}
+                                            <LinkTo @route={{ev.linkTarget.route}} @models={{ev.linkTarget.models}} class="permalink fw6">
+                                                {{or ev.original.resource.title ev.original.resource.name}}
+                                            </LinkTo>
+                                        {{else}}
+                                            <LinkTo @route={{ev.linkTarget.route}} class="permalink fw6">
+                                                {{or ev.original.resource.title ev.original.resource.name}}
+                                            </LinkTo>
+                                        {{/if}}
                                     {{else}}
-                                        <LinkTo @route={{ev.linkTarget.route}} class="permalink fw6">
-                                            {{or ev.original.resource.title ev.original.resource.name}}
-                                        </LinkTo>
+                                        <span>{{or ev.original.resource.title ev.original.resource.name ev.original.context.primary_name}}</span>
                                     {{/if}}
                                 {{else}}
-                                    <span>{{or ev.original.resource.title ev.original.resource.name ev.original.context.primary_name}}</span>
+                                    <span class="midlightgrey">(unknown)</span>
                                 {{/if}}
-                            {{else}}
-                                <span class="midlightgrey">(unknown)</span>
-                            {{/if}}
+                            {{/unless}}
 
                             <span class="gh-history-name">
                                 <span class="midgrey">&ndash; by </span>

--- a/ghost/admin/app/helpers/parse-history-event.js
+++ b/ghost/admin/app/helpers/parse-history-event.js
@@ -24,7 +24,8 @@ export default class ParseHistoryEvent extends Helper {
             actor,
             actorIcon,
             actorLinkTarget,
-            original: ev
+            original: ev,
+            isBulkAction: !!ev.context.count
         };
     }
 }
@@ -88,7 +89,7 @@ function getLinkTarget(ev) {
         switch (ev.resource_type) {
         case 'page':
         case 'post':
-            if (!ev.resource.id) {
+            if (!ev.resource || !ev.resource.id) {
                 return null;
             }
 
@@ -103,7 +104,7 @@ function getLinkTarget(ev) {
                 models: [resourceType, ev.resource.id]
             };
         case 'integration':
-            if (!ev.resource.id) {
+            if (!ev.resource || !ev.resource.id) {
                 return null;
             }
 
@@ -112,7 +113,7 @@ function getLinkTarget(ev) {
                 models: [ev.resource.id]
             };
         case 'offer':
-            if (!ev.resource.id) {
+            if (!ev.resource || !ev.resource.id) {
                 return null;
             }
 
@@ -121,7 +122,7 @@ function getLinkTarget(ev) {
                 models: [ev.resource.id]
             };
         case 'tag':
-            if (!ev.resource.slug) {
+            if (!ev.resource || !ev.resource.slug) {
                 return null;
             }
 
@@ -135,7 +136,7 @@ function getLinkTarget(ev) {
                 models: null
             };
         case 'user':
-            if (!ev.resource.slug) {
+            if (!ev.resource || !ev.resource.slug) {
                 return null;
             }
 
@@ -181,7 +182,19 @@ function getAction(ev) {
         }
     }
 
-    return `${resourceType} ${ev.event}`;
+    let action = ev.event;
+
+    if (ev.event === 'edited') {
+        if (ev.context.action_name) {
+            action = ev.context.action_name;
+        }
+    }
+
+    if (ev.context.count && ev.context.count > 1) {
+        return `${ev.context.count} ${resourceType}s ${action}`;
+    }
+
+    return `${resourceType} ${action}`;
 }
 
 function getContextResource(ev) {

--- a/ghost/core/core/server/models/base/plugins/actions.js
+++ b/ghost/core/core/server/models/base/plugins/actions.js
@@ -6,6 +6,54 @@ const logging = require('@tryghost/logging');
  * @param {import('bookshelf')} Bookshelf
  */
 module.exports = function (Bookshelf) {
+    const insertAction = async (data, options) => {
+        // CASE: model does not support action for target event
+        if (!data) {
+            return;
+        }
+
+        const insert = (action) => {
+            Bookshelf.model('Action')
+                .add(action, {autoRefresh: false})
+                .catch((err) => {
+                    if (_.isArray(err)) {
+                        err = err[0];
+                    }
+
+                    logging.error(new errors.InternalServerError({
+                        err
+                    }));
+                });
+        };
+
+        if (options.transacting) {
+            options.transacting.once('committed', (committed) => {
+                if (!committed) {
+                    return;
+                }
+
+                insert(data);
+            });
+        } else {
+            insert(data);
+        }
+    };
+
+    // We need this addAction accessible from the static model and instances
+    const addAction = (model, event, options) => {
+        if (!model.wasChanged()) {
+            return;
+        }
+
+        // CASE: model does not support actions at all
+        if (!model.getAction) {
+            return;
+        }
+
+        const existingAction = model.getAction(event, options);
+        insertAction(existingAction, options);
+    };
+
     Bookshelf.Model = Bookshelf.Model.extend({
         /**
          * Constructs data to be stored in the database with info
@@ -33,7 +81,9 @@ module.exports = function (Bookshelf) {
                 return;
             }
 
-            let context = {};
+            let context = {
+                action_name: options.actionName
+            };
 
             if (this.actionsExtraContext && Array.isArray(this.actionsExtraContext)) {
                 for (const c of this.actionsExtraContext) {
@@ -74,48 +124,73 @@ module.exports = function (Bookshelf) {
          *
          * We could embed adding actions more nicely in the future e.g. plugin.
          */
-        addAction: (model, event, options) => {
-            if (!model.wasChanged()) {
+        addAction
+    }, {
+        addAction,
+        async addActions(event, ids, options) {
+            if (ids.length === 1) {
+                // We want to store an event for a single model in the actions table
+                // This is so we can include the name
+                const model = await this.findOne({[options.column ?? 'id']: ids[0]}, {require: true, transacting: options.transacting, context: {internal: true}});
+                this.addAction(model, event, options);
                 return;
             }
 
-            // CASE: model does not support actions at all
-            if (!model.getAction) {
+            const existingAction = this.getBulkAction(event, ids.length, options);
+            insertAction(existingAction, options);
+        },
+
+        /**
+         * Constructs data to be stored in the database with info
+         * on particular actions
+         */
+        getBulkAction(event, count, options) {
+            const actor = this.prototype.getActor(options);
+
+            // @NOTE: we ignore internal updates (`options.context.internal`) for now
+            if (!actor) {
                 return;
             }
 
-            const existingAction = model.getAction(event, options);
-
-            // CASE: model does not support action for target event
-            if (!existingAction) {
+            if (!this.prototype.actionsCollectCRUD) {
                 return;
             }
 
-            const insert = (action) => {
-                Bookshelf.model('Action')
-                    .add(action, {autoRefresh: false})
-                    .catch((err) => {
-                        if (_.isArray(err)) {
-                            err = err[0];
-                        }
+            let resourceType = this.prototype.actionsResourceType;
 
-                        logging.error(new errors.InternalServerError({
-                            err
-                        }));
-                    });
+            if (typeof resourceType === 'function') {
+                resourceType = resourceType.bind(this)();
+            }
+
+            if (!resourceType) {
+                return;
+            }
+
+            let context = {
+                count,
+                action_name: options.actionName
             };
 
-            if (options.transacting) {
-                options.transacting.once('committed', (committed) => {
-                    if (!committed) {
-                        return;
-                    }
-
-                    insert(existingAction);
-                });
-            } else {
-                insert(existingAction);
+            if (this.getBulkActionExtraContext && typeof this.getBulkActionExtraContext === 'function') {
+                context = {
+                    ...context,
+                    ...this.getBulkActionExtraContext.bind(this)(options)
+                };
             }
+
+            const data = {
+                event,
+                resource_id: null,
+                resource_type: resourceType,
+                actor_id: actor.id,
+                actor_type: actor.type
+            };
+
+            if (context && Object.keys(context).length) {
+                data.context = context;
+            }
+
+            return data;
         }
     });
 };

--- a/ghost/core/core/server/models/base/plugins/actions.js
+++ b/ghost/core/core/server/models/base/plugins/actions.js
@@ -6,7 +6,7 @@ const logging = require('@tryghost/logging');
  * @param {import('bookshelf')} Bookshelf
  */
 module.exports = function (Bookshelf) {
-    const insertAction = async (data, options) => {
+    const insertAction = (data, options) => {
         // CASE: model does not support action for target event
         if (!data) {
             return;
@@ -50,8 +50,8 @@ module.exports = function (Bookshelf) {
             return;
         }
 
-        const existingAction = model.getAction(event, options);
-        insertAction(existingAction, options);
+        const data = model.getAction(event, options);
+        insertAction(data, options);
     };
 
     Bookshelf.Model = Bookshelf.Model.extend({

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -1129,6 +1129,16 @@ Post = ghostBookshelf.Model.extend({
         return filter;
     }
 }, {
+    getBulkActionExtraContext: function (options) {
+        if (options && options.filter && options.filter.includes('type:page')) {
+            return {
+                type: 'page'
+            };
+        }
+        return {
+            type: 'post'
+        };
+    },
     allowedFormats: ['mobiledoc', 'lexical', 'html', 'plaintext'],
 
     orderDefaultOptions: function orderDefaultOptions() {
@@ -1236,9 +1246,11 @@ Post = ghostBookshelf.Model.extend({
      * **See:** [ghostBookshelf.Model.findOne](base.js.html#Find%20One)
      */
     findOne: function findOne(data = {}, options = {}) {
-        // @TODO: remove when we drop v0.1
-        if (!options.filter && !data.status) {
-            data.status = 'published';
+        if (!options.context || !options.context.internal) {
+            // @TODO: remove when we drop v0.1
+            if (!options.filter && !data.status) {
+                data.status = 'published';
+            }
         }
 
         if (data.status === 'all') {


### PR DESCRIPTION
no issue

The post/page bulk actions weren't logged in the history log / actions table.

This change adds support for logging bulk actions.
- New `addActions` static method on models. It creates an action log in the database for multiple models at once. If only one model was edited, deleted or added, it will fallback to `addAction`
- `addAction` can also be called statically now
- `actionName` option is now supported when using `addActions`, `addAction`, and as a result also in all bulk manipulation methods, and CRUD methods. This allows you to replace the default '5 posts edited' into something more specific like '5 posts featured'
- Fixed support for null resource_id in the parse-history-event helper
- Removed the default 'published' status requirement when using Post.findOne for internal queries.