### PR TITLE
Added image editing feature for publication logo and cover

### DIFF
--- a/ghost/admin/app/components/koenig-image-editor.hbs
+++ b/ghost/admin/app/components/koenig-image-editor.hbs
@@ -1,5 +1,5 @@
 {{#if this.isEditorEnabled}}
-    <button type="button" class="image-action image-edit" title="Edit image" {{on "click" this.handleClick}}>
+    <button type="button" class="{{if @className @className "image-action image-edit"}}" title="Edit image" {{on "click" this.handleClick}}>
         {{svg-jar "pen"}}
     </button>
 {{/if}}

--- a/ghost/admin/app/components/settings/form-fields/publication-cover.hbs
+++ b/ghost/admin/app/components/settings/form-fields/publication-cover.hbs
@@ -24,6 +24,13 @@
                         {{on "click" uploader.triggerFileDialog}}
                         data-test-cover-img
                     >
+                    {{#if (feature 'imageEditor')}}
+                    <KoenigImageEditor
+                        @className="gh-setting-action-largeimg-delete gh-setting-action-largeimg-edit"
+                        @imageSrc={{this.settings.coverImage}}
+                        @saveImage={{fn this.saveImage uploader.setFiles}}
+                    />
+                    {{/if}}
                     <button type="button" class="gh-setting-action-largeimg-delete" {{on "click" (fn this.update null)}} data-test-delete-image="coverImage">
                         {{svg-jar "trash" class="w4 h4"}}
                     </button>

--- a/ghost/admin/app/components/settings/form-fields/publication-cover.js
+++ b/ghost/admin/app/components/settings/form-fields/publication-cover.js
@@ -35,6 +35,11 @@ export default class PublicationCoverFormField extends Component {
     }
 
     @action
+    saveImage(setFiles, imageFile) {
+        setFiles([imageFile]);
+    }
+
+    @action
     setUnsplashImage({src}) {
         this.update(src);
     }

--- a/ghost/admin/app/components/settings/form-fields/publication-logo.hbs
+++ b/ghost/admin/app/components/settings/form-fields/publication-logo.hbs
@@ -24,6 +24,13 @@
                             {{on "click" uploader.triggerFileDialog}}
                             data-test-logo-img
                         >
+                        {{#if (feature 'imageEditor')}}
+                        <KoenigImageEditor
+                            @className="gh-setting-action-smallimg-delete gh-setting-action-smallimg-edit"
+                            @imageSrc={{this.settings.logo}}
+                            @saveImage={{fn this.saveImage uploader.setFiles}}
+                        />
+                        {{/if}}
                         <button type="button" class="gh-setting-action-smallimg-delete" {{on "click" (fn this.update null)}} data-test-delete-image="logo">
                             {{svg-jar "trash" class="w4 h4"}}
                         </button>

--- a/ghost/admin/app/components/settings/form-fields/publication-logo.js
+++ b/ghost/admin/app/components/settings/form-fields/publication-logo.js
@@ -20,6 +20,11 @@ export default class PublicationLogoFormField extends Component {
     }
 
     @action
+    saveImage(setFiles, imageFile) {
+        setFiles([imageFile]);
+    }
+
+    @action
     update(value) {
         this.settings.logo = value;
         this.args.didUpdate('logo', value);

--- a/ghost/admin/app/styles/layouts/settings.css
+++ b/ghost/admin/app/styles/layouts/settings.css
@@ -2053,10 +2053,20 @@ p.theme-validation-details {
     opacity: 0;
 }
 
+.gh-nav-design .gh-setting-action-largeimg-edit,
+.gh-nav-design .gh-setting-action-smallimg-edit {
+    right: 40px;
+}
+
 .gh-nav-design .gh-setting-action-largeimg-delete:hover,
 .gh-nav-design .gh-setting-action-smallimg-delete:hover {
     background: var(--red);
     border-color: transparent;
+}
+
+.gh-nav-design .gh-setting-action-smallimg-edit:hover,
+.gh-nav-design .gh-setting-action-largeimg-edit:hover {
+    background: var(--middarkgrey);
 }
 
 .gh-nav-design .gh-setting-action-largeimg-delete svg,


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3145

- adds image editing functionality(behind flag) using pintura integration to publication logo and cover