### PR TITLE
Cleaned up member attribution flag

### DIFF
--- a/ghost/admin/app/components/dashboard/charts/recents.hbs
+++ b/ghost/admin/app/components/dashboard/charts/recents.hbs
@@ -99,7 +99,7 @@
                                             <div class="gh-dashboard-list-item-sub">
                                                 {{svg-jar parsedEvent.icon }}
                                                 <span class="gh-dashboard-list-subtext">
-                                                    <span class="gh-members-activity-description {{if (feature "memberAttribution") 'feature-memberAttribution'}}">
+                                                    <span class="gh-members-activity-description feature-memberAttribution">
                                                         <span class="gh-members-activity-event-text">{{capitalize-first-letter parsedEvent.action}}</span>
                                                         {{#if parsedEvent.info}}
                                                             <span class="highlight">({{parsedEvent.info}})</span>

--- a/ghost/admin/app/components/member/activity-feed.hbs
+++ b/ghost/admin/app/components/member/activity-feed.hbs
@@ -24,7 +24,7 @@
                                             <div class="gh-member-feed-detail">
                                                 <div class="gh-member-feed-event">
                                                     <span class="gh-member-feed-event-inner">
-                                                        <span class="gh-members-activity-description {{if (feature "memberAttribution") 'feature-memberAttribution'}}">
+                                                        <span class="gh-members-activity-description feature-memberAttribution">
                                                             <span class="gh-members-activity-event-text">{{capitalize-first-letter event.action}}</span>
                                                             {{#if event.info}}
                                                                 <span class="highlight">({{event.info}})</span>
@@ -41,7 +41,7 @@
                                                             {{/if}}
                                                         </span>
                                                         {{#if event.description}}
-                                                            <div class="ghost-members-activity-event-description {{if (feature "memberAttribution") 'feature-memberAttribution'}}">
+                                                            <div class="ghost-members-activity-event-description feature-memberAttribution">
                                                                 <div class="ghost-members-activity-event-url" {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
                                                                     <span>{{event.description}}</span>
                                                                 </div>

--- a/ghost/admin/app/components/members-activity/table-row.hbs
+++ b/ghost/admin/app/components/members-activity/table-row.hbs
@@ -19,7 +19,7 @@
             <div class="gh-members-activity-container">
                 <div class="gh-members-activity-icon">{{svg-jar event.icon}}</div>
                 <div class="gh-members-activity-event">
-                    <span class="gh-members-activity-description {{if (feature "memberAttribution") 'feature-memberAttribution'}}">
+                    <span class="gh-members-activity-description feature-memberAttribution">
                         <span class="gh-members-activity-event-text">{{capitalize-first-letter event.action}}</span>
                         {{#if event.info}}
                             <span class="highlight">({{event.info}})</span>
@@ -36,7 +36,7 @@
                         {{/if}}
                     </span>
                     {{#if event.description}}
-                        <div class="ghost-members-activity-event-description {{if (feature "memberAttribution") 'feature-memberAttribution'}}">
+                        <div class="ghost-members-activity-event-description feature-memberAttribution">
                             <div class="ghost-members-activity-event-url" {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
                                 <span>{{event.description}}</span>
                             </div>

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -60,7 +60,6 @@ export default class FeatureService extends Service {
 
     // labs flags
     @feature('urlCache') urlCache;
-    @feature('memberAttribution') memberAttribution;
     @feature('lexicalEditor') lexicalEditor;
     @feature('lexicalMultiplayer') lexicalMultiplayer;
     @feature('audienceFeedback') audienceFeedback;

--- a/ghost/admin/app/templates/members-activity.hbs
+++ b/ghost/admin/app/templates/members-activity.hbs
@@ -1,4 +1,4 @@
-<section class="gh-canvas gh-members-activity {{if this.memberRecord "gh-members-activity-single"}} {{if (feature "memberAttribution") "feature-memberAttribution"}}">
+<section class="gh-canvas gh-members-activity {{if this.memberRecord "gh-members-activity-single"}} feature-memberAttribution">
     <GhCanvasHeader class="gh-canvas-header">
         {{#if this.memberRecord}}
             <div class="flex flex-column">

--- a/ghost/admin/app/templates/pages.hbs
+++ b/ghost/admin/app/templates/pages.hbs
@@ -27,7 +27,7 @@
     </GhCanvasHeader>
 
     <section class="view-container content-list">
-        <div class="{{if this.feature.memberAttribution 'gh-list-sticky'}}">
+        <div class="gh-list-sticky">
             <PostsList::List
                 @model={{this.postsInfinityModel}}
                 @list={{this.selectionList}}

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -15,7 +15,6 @@ const messages = {
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
-    'memberAttribution',
     'audienceFeedback',
     'themeErrorsNotification',
     'emailErrors',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -718,7 +718,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4041",
+  "content-length": "4014",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -216,9 +216,6 @@ describe('Members API - member attribution', function () {
     beforeEach(function () {
         mockManager.mockStripe();
         mockManager.mockMail();
-
-        // For some reason it is enabled by default?
-        mockManager.mockLabsEnabled('memberAttribution');
     });
 
     afterEach(function () {

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -1645,7 +1645,6 @@ describe('Members API', function () {
         });
 
         beforeEach(function () {
-            mockManager.mockLabsEnabled('memberAttribution');
             mockManager.mockMail();
         });
 

--- a/ghost/members-api/lib/services/member-bread.js
+++ b/ghost/members-api/lib/services/member-bread.js
@@ -238,10 +238,7 @@ module.exports = class MemberBREADService {
         member.subscriptions = member.subscriptions.filter(sub => !!sub.price);
         this.attachSubscriptionsToMember(member);
         this.attachOffersToSubscriptions(member, await this.fetchSubscriptionOffers(model.related('stripeSubscriptions')));
-
-        if (this.labsService.isSet('memberAttribution')) {
-            await this.attachAttributionsToMember(member, subscriptionIdMap);
-        }
+        await this.attachAttributionsToMember(member, subscriptionIdMap);
 
         const suppressionData = await this.emailSuppressionList.getSuppressionData(member.email);
         member.email_suppression = {


### PR DESCRIPTION
no issue

This commit removes the `memberAttribution` feature flag from the codebase. Some CSS classes are not removed as removing them and updating the associated CSS files have side effects sadly.