### PR TITLE
Update search text highlighting to escape HTML

### DIFF
--- a/ghost/admin/app/helpers/highlighted-text.js
+++ b/ghost/admin/app/helpers/highlighted-text.js
@@ -1,11 +1,28 @@
+import Ember from 'ember';
 import {helper} from '@ember/component/helper';
 import {htmlSafe} from '@ember/template';
+
+const {Handlebars} = Ember;
 
 export function highlightedText([text, termToHighlight]) {
     // replace any non-word character with an escaped character
     let sanitisedTerm = termToHighlight.replace(new RegExp(/\W/ig), '\\$&');
+    let termMatcher = new RegExp(sanitisedTerm, 'ig');
 
-    return htmlSafe(text.replace(new RegExp(sanitisedTerm, 'ig'), '<span class="highlight">$&</span>'));
+    let matches = text.match(termMatcher) || [];
+    let nonMatches = text.split(termMatcher);
+
+    let htmlSafeResult = '';
+
+    nonMatches.forEach((nonMatch, index) => {
+        htmlSafeResult += Handlebars.Utils.escapeExpression(nonMatch);
+
+        if (matches[index]) {
+            htmlSafeResult += `<span class="highlight">${Handlebars.Utils.escapeExpression(matches[index])}</span>`;
+        }
+    });
+
+    return htmlSafe(htmlSafeResult);
 }
 
 export default helper(highlightedText);

--- a/ghost/admin/tests/unit/helpers/highlighted-text-test.js
+++ b/ghost/admin/tests/unit/helpers/highlighted-text-test.js
@@ -13,4 +13,10 @@ describe('Unit: Helper: highlighted-text', function () {
         expect(result).to.be.an('object');
         expect(result.string).to.equal('T<span class="highlight">e</span>st');
     });
+
+    it('escapes html', function () {
+        let result = highlightedText(['<script>alert("oops")</script>', 'oops']);
+        expect(result).to.be.an('object');
+        expect(result.string).to.equal('&lt;script&gt;alert(&quot;<span class="highlight">oops</span>&quot;)&lt;/script&gt;');
+    });
 });


### PR DESCRIPTION
refs: https://github.com/TryGhost/Team/issues/2390

Escapes each matched and non-matched segment of the post title in the admin search field, to make sure they're displayed in plain text but still have matches highlighted.