### PR TITLE
Use default email sender for setting change confirmations

### DIFF
--- a/ghost/core/core/server/services/mail/GhostMailer.js
+++ b/ghost/core/core/server/services/mail/GhostMailer.js
@@ -6,7 +6,7 @@ const config = require('../../../shared/config');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const settingsCache = require('../../../shared/settings-cache');
-const urlUtils = require('../../../shared/url-utils');
+const {getDomain,getDefaultFromEmail} = require('./default-from-email');
 const metrics = require('@tryghost/metrics');
 const messages = {
     title: 'Ghost at {domain}',
@@ -17,19 +17,13 @@ const messages = {
     messageSent: 'Message sent. Double check inbox and spam folder!'
 };
 
-function getDomain() {
-    const domain = urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
-    return domain && domain[1];
-}
-
 function getFromAddress(requestedFromAddress) {
     const configAddress = config.get('mail') && config.get('mail').from;
 
     const address = requestedFromAddress || configAddress;
     // If we don't have a from address at all
     if (!address) {
-        // Default to noreply@[blog.url]
-        return getFromAddress(`noreply@${getDomain()}`);
+        return getFromAddress(getDefaultFromEmail());
     }
 
     // If we do have a from address, and it's just an email

--- a/ghost/core/core/server/services/mail/default-from-email.js
+++ b/ghost/core/core/server/services/mail/default-from-email.js
@@ -1,0 +1,13 @@
+const urlUtils = require('../../../shared/url-utils');
+
+function getDomain() {
+    const domain = urlUtils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
+    return domain && domain[1];
+}
+
+function getDefaultFromEmail(prefix = 'noreply') {
+    // Default to noreply@[blog.url]
+    return `${prefix}@${getDomain()}`;
+}
+
+module.exports = {getDomain,getDefaultFromEmail};

--- a/ghost/core/core/server/services/mail/index.js
+++ b/ghost/core/core/server/services/mail/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const urlUtils = require('../../../shared/url-utils');
 const settingsCache = require('../../../shared/settings-cache');
 const EmailContentGenerator = require('@tryghost/email-content-generator');
+const {getDefaultFromEmail} = require('./default-from-email');
 
 const emailContentGenerator = new EmailContentGenerator({
     getSiteUrl: () => urlUtils.urlFor('home', true),
@@ -11,5 +12,6 @@ const emailContentGenerator = new EmailContentGenerator({
 
 exports.GhostMailer = require('./GhostMailer');
 exports.utils = {
-    generateContent: emailContentGenerator.getContent.bind(emailContentGenerator)
+    generateContent: emailContentGenerator.getContent.bind(emailContentGenerator),
+    getDefaultFromEmail: getDefaultFromEmail
 };

--- a/ghost/core/core/server/services/newsletters/NewslettersService.js
+++ b/ghost/core/core/server/services/newsletters/NewslettersService.js
@@ -35,6 +35,7 @@ class NewslettersService {
         /* email verification setup */
 
         this.ghostMailer = new mail.GhostMailer();
+        this.getDefaultFromEmail = mail.utils.getDefaultFromEmail;
 
         const {transporter, getSubject, getText, getHTML, getSigninURL} = {
             transporter: {
@@ -297,6 +298,12 @@ class NewslettersService {
      * @private
      */
     async sendEmailVerificationMagicLink({id, email, property = 'sender_from'}) {
+        let fromEmail = this.getDefaultFromEmail('noreply');
+        if (fromEmail === email) {
+            // If the from and to email are the same, mail clients often mark the email as spam
+            fromEmail = this.getDefaultFromEmail('no-reply');
+        }
+
         const {ghostMailer} = this;
 
         this.magicLinkService.transporter = {
@@ -305,6 +312,7 @@ class NewslettersService {
                     logging.warn(message.text);
                 }
                 let msg = Object.assign({
+                    from: fromEmail,
                     subject: 'Verify email address',
                     forceTextContent: true
                 }, message);

--- a/ghost/core/core/server/services/newsletters/NewslettersService.js
+++ b/ghost/core/core/server/services/newsletters/NewslettersService.js
@@ -199,7 +199,7 @@ class NewslettersService {
         }
 
         let updatedNewsletter;
-        
+
         try {
             updatedNewsletter = await this.NewsletterModel.edit(cleanedAttrs, options);
         } catch (error) {
@@ -215,7 +215,7 @@ class NewslettersService {
 
         // Load relations correctly in the response
         updatedNewsletter = await this.NewsletterModel.findOne({id: updatedNewsletter.id}, {...options, require: true});
-        
+
         await this.respondWithEmailVerification(updatedNewsletter, emailsToVerify);
         return updatedNewsletter;
     }
@@ -297,13 +297,6 @@ class NewslettersService {
      * @private
      */
     async sendEmailVerificationMagicLink({id, email, property = 'sender_from'}) {
-        const [,toDomain] = email.split('@');
-
-        let fromEmail = `noreply@${toDomain}`;
-        if (fromEmail === email) {
-            fromEmail = `no-reply@${toDomain}`;
-        }
-
         const {ghostMailer} = this;
 
         this.magicLinkService.transporter = {
@@ -312,7 +305,6 @@ class NewslettersService {
                     logging.warn(message.text);
                 }
                 let msg = Object.assign({
-                    from: fromEmail,
                     subject: 'Verify email address',
                     forceTextContent: true
                 }, message);

--- a/ghost/core/core/server/services/settings/SettingsBREADService.js
+++ b/ghost/core/core/server/services/settings/SettingsBREADService.js
@@ -31,6 +31,7 @@ class SettingsBREADService {
         /* email verification setup */
 
         this.ghostMailer = new mail.GhostMailer();
+        this.getDefaultFromEmail = mail.utils.getDefaultFromEmail;
 
         const {transporter, getSubject, getText, getHTML, getSigninURL} = {
             transporter: {
@@ -360,6 +361,12 @@ class SettingsBREADService {
      * @private
      */
     async sendEmailVerificationMagicLink({email, key}) {
+        let fromEmail = this.getDefaultFromEmail('noreply');
+        if (fromEmail === email) {
+            // If the from and to email are the same, mail clients often mark the email as spam
+            fromEmail = this.getDefaultFromEmail('no-reply');
+        }
+
         const {ghostMailer} = this;
 
         this.magicLinkService.transporter = {
@@ -368,6 +375,7 @@ class SettingsBREADService {
                     logging.warn(message.text);
                 }
                 let msg = Object.assign({
+                    from: fromEmail,
                     subject: 'Verify email address',
                     forceTextContent: true
                 }, message);

--- a/ghost/core/core/server/services/settings/SettingsBREADService.js
+++ b/ghost/core/core/server/services/settings/SettingsBREADService.js
@@ -360,13 +360,6 @@ class SettingsBREADService {
      * @private
      */
     async sendEmailVerificationMagicLink({email, key}) {
-        const [,toDomain] = email.split('@');
-
-        let fromEmail = `noreply@${toDomain}`;
-        if (fromEmail === email) {
-            fromEmail = `no-reply@${toDomain}`;
-        }
-
         const {ghostMailer} = this;
 
         this.magicLinkService.transporter = {
@@ -375,7 +368,6 @@ class SettingsBREADService {
                     logging.warn(message.text);
                 }
                 let msg = Object.assign({
-                    from: fromEmail,
                     subject: 'Verify email address',
                     forceTextContent: true
                 }, message);

--- a/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
@@ -123,7 +123,6 @@ Object {
 exports[`Newsletters API Can add a newsletter - with custom sender_email 3: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
-  "from": "noreply@example.com",
   "subject": "Verify email address",
   "to": "test@example.com",
 }
@@ -549,7 +548,6 @@ exports[`Newsletters API Can add a newsletter - with custom sender_email and sub
 exports[`Newsletters API Can add a newsletter - with custom sender_email and subscribe existing members 3: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
-  "from": "noreply@example.com",
   "subject": "Verify email address",
   "to": "test@example.com",
 }
@@ -1155,7 +1153,6 @@ Object {
 exports[`Newsletters API Can edit a newsletters and update the sender_email when already set 3: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
-  "from": "noreply@example.com",
   "subject": "Verify email address",
   "to": "updated@example.com",
 }
@@ -1859,7 +1856,6 @@ Object {
 exports[`Newsletters API Can verify property updates 1: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
-  "from": "noreply@example.com",
   "subject": "Verify email address",
   "to": "verify@example.com",
 }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
@@ -123,6 +123,7 @@ Object {
 exports[`Newsletters API Can add a newsletter - with custom sender_email 3: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
+  "from": "noreply@127.0.0.1",
   "subject": "Verify email address",
   "to": "test@example.com",
 }
@@ -548,6 +549,7 @@ exports[`Newsletters API Can add a newsletter - with custom sender_email and sub
 exports[`Newsletters API Can add a newsletter - with custom sender_email and subscribe existing members 3: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
+  "from": "noreply@127.0.0.1",
   "subject": "Verify email address",
   "to": "test@example.com",
 }
@@ -1153,6 +1155,7 @@ Object {
 exports[`Newsletters API Can edit a newsletters and update the sender_email when already set 3: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
+  "from": "noreply@127.0.0.1",
   "subject": "Verify email address",
   "to": "updated@example.com",
 }
@@ -1856,6 +1859,7 @@ Object {
 exports[`Newsletters API Can verify property updates 1: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
+  "from": "noreply@127.0.0.1",
   "subject": "Verify email address",
   "to": "verify@example.com",
 }

--- a/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
+++ b/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
@@ -189,6 +189,7 @@ exports[`UNIT > Settings BREAD Service: edit setting members_support_address tri
 exports[`UNIT > Settings BREAD Service: edit setting members_support_address triggers email verification 3: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
+  "from": "noreply@127.0.0.1",
   "subject": "Verify email address",
   "to": "support@example.com",
 }

--- a/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
+++ b/ghost/core/test/unit/server/services/settings/__snapshots__/settings-bread-service.test.js.snap
@@ -189,7 +189,6 @@ exports[`UNIT > Settings BREAD Service: edit setting members_support_address tri
 exports[`UNIT > Settings BREAD Service: edit setting members_support_address triggers email verification 3: [metadata 1] 1`] = `
 Object {
   "forceTextContent": true,
-  "from": "noreply@example.com",
   "subject": "Verify email address",
   "to": "support@example.com",
 }

--- a/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-bread-service.test.js
@@ -200,6 +200,40 @@ describe('UNIT > Settings BREAD Service:', function () {
             emailMockReceiver.matchPlaintextSnapshot();
             emailMockReceiver.matchMetadataSnapshot();
         });
+
+        it('uses a different from email for verification when the to email is the same', async function () {
+            const defaultSettingsManager = new SettingsBreadService({
+                SettingsModel: {
+                    edit: async changes => changes
+                },
+                settingsCache: {
+                    get: () => ({})
+                },
+                mail: {
+                    ...mail,
+                    utils: {
+                        ...mail.utils,
+                        getDefaultFromEmail: prefix => `${prefix}@example.com`
+                    }
+                },
+                urlUtils,
+                singleUseTokenProvider: {
+                    create: () => 'test'
+                },
+                labsService: {}
+            });
+
+            const settings = await defaultSettingsManager.edit([
+                {
+                    key: 'members_support_address',
+                    value: 'noreply@example.com'
+                }
+            ], {}, null);
+
+            assert.deepEqual(settings.meta.sent_email_verification, ['members_support_address']);
+
+            assert.equal(emailMockReceiver.getSentEmail().from, 'no-reply@example.com');
+        });
     });
 
     describe('verifyKeyUpdate', function () {


### PR DESCRIPTION
refs: https://github.com/TryGhost/Team/issues/2527

I looked through the history of these services but couldn't see a particular reason why they override the sender domain. So just removed the custom handling, which will make them use the default `noreply@<site>` or `mail.from` config

Changed emails
* Support address change confirmation
* Newsletter from address change confirmation (had the same problem)