### PR TITLE
Added signupCard feature flags

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -251,7 +251,10 @@ export default class KoenigLexicalEditor extends Component {
             },
             tenor: this.config.tenor?.googleApiKey ? this.config.tenor : null,
             fetchEmbed: fetchEmbed,
-            fetchAutocompleteLinks
+            fetchAutocompleteLinks,
+            feature: {
+                signupCard: this.feature.get('signupCard')
+            }
         };
         const cardConfig = Object.assign({}, defaultCardConfig, props.cardConfig, {pinturaConfig: this.pinturaConfig});
 

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -74,6 +74,7 @@ export default class FeatureService extends Service {
     @feature('postDiffing') postDiffing;
     @feature('announcementBar') announcementBar;
     @feature('imageEditor') imageEditor;
+    @feature('signupCard') signupCard;
 
     _user = null;
 

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -346,6 +346,21 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="gh-expandable-block">
+                    <div class="gh-expandable-header">
+                        <div>
+                            <h4 class="gh-expandable-title">Signup Card</h4>
+                            <p class="gh-expandable-description">
+                                Enables the signup card in the Lexical editor
+                            </p>
+                        </div>
+                        <div class="for-switch">
+                            <GhFeatureFlag @flag="signupCard" />
+                        </div>
+                    </div>
+                </div>
+
             </div>
         </div>
         {{/if}}

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -40,7 +40,8 @@ const ALPHA_FEATURES = [
     'makingItRain',
     'postHistory',
     'postDiffing',
-    'imageEditor'
+    'imageEditor',
+    'signupCard'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];


### PR DESCRIPTION
no issue

- Added feature flags for the Lexical Signup Card that's being worked on.

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2897a19</samp>

This pull request adds a new experimental feature flag `signupCard` to the Ghost admin app, which enables a signup card component in the lexical editor. The feature flag can be toggled from the settings/labs UI and is read from the server-side configuration.
