### PR TITLE
Fixed post editor items getting cut off on iOS

### DIFF
--- a/ghost/admin/app/components/gh-koenig-editor.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor.hbs
@@ -1,4 +1,4 @@
-<div class="gh-koenig-editor relative w-100 vh-100 overflow-x-hidden overflow-y-auto z-0" {{did-insert this.registerElement}} ...attributes>
+<div class="gh-koenig-editor relative w-100 overflow-x-hidden z-0" {{did-insert this.registerElement}} ...attributes>
     {{!-- full height content pane --}}
     {{!-- template-lint-disable no-invalid-interactive no-passed-in-event-handlers --}}
     <div

--- a/ghost/admin/app/styles/components/settings-menu.css
+++ b/ghost/admin/app/styles/components/settings-menu.css
@@ -5,7 +5,7 @@
 /* ---------------------------------------------------------- */
 
 .settings-menu-toggle {
-    position: absolute;
+    position: fixed;
     top: 30px;
     right: 24px;
     z-index: 9999;
@@ -76,6 +76,13 @@
     }
 }
 
+@media (max-width: 500px) {
+    .settings-menu-container {
+        width: 100vw;
+        min-width: 100vw;
+    }
+}
+
 .settings-menu-container .settings-menu-pane {
     position: absolute;
     top: 0;
@@ -100,6 +107,13 @@
     right: auto;
     bottom: auto;
     height: 100vh;
+}
+
+@media (max-width: 500px) {
+    .settings-menu-container .settings-menu-pane {
+        width: 100vw;
+        min-width: 100vw;
+    }
 }
 
 /* Header

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -305,7 +305,7 @@
 }
 
 .gh-editor-header {
-    position: absolute;
+    position: fixed;
     top: 0;
     right: 0;
     left: 0;
@@ -361,7 +361,7 @@
 }
 
 .gh-editor-wordcount-container {
-    position: absolute;
+    position: fixed;
     right: 30px;
     bottom: 30px;
     display: flex;


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

Under the current behavior, there are two scrollable areas on the main post editor, the base page and the editor itself. Both are supposed to be the same size, but on Safari iOS they somehow show at different sizes, so each gets its own scroll bar. That causes either the word counter or the toolbar to be cut off in the editor.

This changes the scrolling so only the top-level area is scrollable. The toolbar and word count are set to "position: fixed" to exempt them from scrolling.

This also fixes an issue where the left side of the post settings menu can be cut off for small screen sizes.

Tested on Safari iOS (as well as Firefox desktop to make sure I didn't break anything).

Video comparison: 
* [Old behavior](https://github.com/TryGhost/Ghost/assets/12983479/73cbd344-3298-4744-aa34-13d43c921f58)
* [New behavior](https://github.com/TryGhost/Ghost/assets/12983479/0b4c0d65-7e21-4d50-a856-2fc533d4a0a2)

