### PR TITLE
🐛 Fixed generating card assets with `include` allowlist

### DIFF
--- a/ghost/core/core/frontend/services/card-assets/CardAssetService.js
+++ b/ghost/core/core/frontend/services/card-assets/CardAssetService.js
@@ -32,8 +32,8 @@ class CardAssetService {
         // Include rules take precedence over exclude rules.
         if (_.has(this.config, 'include')) {
             return {
-                'cards.min.css': `css/(${this.config.include.join('|')}).css`,
-                'cards.min.js': `js/(${this.config.include.join('|')}).js`
+                'cards.min.css': `css/@(${this.config.include.join('|')}).css`,
+                'cards.min.js': `js/@(${this.config.include.join('|')}).js`
             };
         }
 

--- a/ghost/core/test/unit/frontend/services/card-assets.test.js
+++ b/ghost/core/test/unit/frontend/services/card-assets.test.js
@@ -157,8 +157,8 @@ describe('Card Asset Service', function () {
             });
 
             cardAssets.generateGlobs().should.eql({
-                'cards.min.css': 'css/(gallery).css',
-                'cards.min.js': 'js/(gallery).js'
+                'cards.min.css': 'css/@(gallery).css',
+                'cards.min.js': 'js/@(gallery).js'
             });
         });
 
@@ -171,8 +171,8 @@ describe('Card Asset Service', function () {
             });
 
             cardAssets.generateGlobs().should.eql({
-                'cards.min.css': 'css/(gallery).css',
-                'cards.min.js': 'js/(gallery).js'
+                'cards.min.css': 'css/@(gallery).css',
+                'cards.min.js': 'js/@(gallery).js'
             });
         });
     });

--- a/ghost/minifier/test/minifier.test.js
+++ b/ghost/minifier/test/minifier.test.js
@@ -33,6 +33,14 @@ describe('Minifier', function () {
             result[2].should.eql('test/fixtures/basic-cards/css/gallery.css');
         });
 
+        it('match glob range e.g. css/bookmark.css and css/empty.css (css/@(bookmark|empty).css)', async function () {
+            let result = await minifier.getMatchingFiles('css/@(bookmark|empty).css');
+            
+            result.should.be.an.Array().with.lengthOf(2);
+            result[0].should.eql('test/fixtures/basic-cards/css/bookmark.css');
+            result[1].should.eql('test/fixtures/basic-cards/css/empty.css');
+        });
+
         it('reverse match glob e.g. css/!(bookmark).css', async function () {
             let result = await minifier.getMatchingFiles('css/!(bookmark).css');
 


### PR DESCRIPTION
closes - #16652 
How - In the case of include keyword if we need @ keyword before '(' according to the globrex package used in tiny-glob used here. I've changed it and tested it and its working fine now.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)