### PR TITLE
🐛 Fixed site setup hanging when mail isn't configured

### DIFF
--- a/ghost/core/core/server/api/endpoints/authentication.js
+++ b/ghost/core/core/server/api/endpoints/authentication.js
@@ -3,6 +3,7 @@ const api = require('./index');
 const config = require('../../../shared/config');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
 const web = require('../../web');
 const models = require('../../models');
 const auth = require('../../services/auth');
@@ -70,8 +71,11 @@ module.exports = {
                     return auth.setup.doSettings(data, api.settings);
                 })
                 .then((user) => {
-                    return auth.setup.sendWelcomeEmail(user.get('email'), api.mail)
-                        .then(() => user);
+                    auth.setup.sendWelcomeEmail(user.get('email'), api.mail)
+                        .catch((err) => {
+                            logging.error(err);
+                        });
+                    return user;
                 });
         }
     },

--- a/ghost/core/test/regression/api/admin/authentication.test.js
+++ b/ghost/core/test/regression/api/admin/authentication.test.js
@@ -7,6 +7,20 @@ const {tokens} = require('@tryghost/security');
 const models = require('../../../../core/server/models');
 const settingsCache = require('../../../../core/shared/settings-cache');
 
+async function waitForEmailSent(emailMockReceiver, number = 1) {
+    let sentEmailCount = 0;
+    while (sentEmailCount === 0) {
+        try {
+            emailMockReceiver.assertSentEmailCount(number);
+            sentEmailCount = number;
+        } catch (e) {
+            await new Promise((resolve) => {
+                setTimeout(resolve, 100);
+            });
+        }
+    }
+}
+
 describe('Authentication API', function () {
     let emailMockReceiver;
     let agent;
@@ -70,6 +84,8 @@ describe('Authentication API', function () {
                     'content-version': anyContentVersion,
                     etag: anyEtag
                 });
+
+            await waitForEmailSent(emailMockReceiver);
 
             // Test our side effects
             emailMockReceiver.matchHTMLSnapshot();
@@ -207,6 +223,8 @@ describe('Authentication API', function () {
                     'content-version': anyContentVersion,
                     etag: anyEtag
                 });
+
+            await waitForEmailSent(emailMockReceiver);
 
             // Test our side effects
             emailMockReceiver.matchHTMLSnapshot();


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3176

We were waiting for the welcome email to send before responding to the client that setup is complete, this was causing the client to hang when running `ghost install local` as mail isn't configured by default.
