### PR TITLE
Add lexical feedback

### DIFF
--- a/ghost/admin/app/components/editor/modals/publish-flow/complete.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete.hbs
@@ -109,6 +109,7 @@
                     <button
                         type="button"
                         class="gh-publish-confirmation-feedback"
+                        {{on "click" this.openFeedbackLexical}}
                     >
                         <span>Beta feedback?</span>
                     </button>
@@ -116,5 +117,11 @@
             </p>
         {{/if}}
     {{/if}}
-
 {{/let}}
+
+{{#if this.showFeedbackLexicalModal}}
+    <GhFullscreenModal
+        @modal="feedback-lexical"
+        @close={{this.closeFeedbackLexical}}
+        @modifier="action wide" />
+{{/if}}

--- a/ghost/admin/app/components/editor/modals/publish-flow/complete.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete.hbs
@@ -118,10 +118,3 @@
         {{/if}}
     {{/if}}
 {{/let}}
-
-{{#if this.showFeedbackLexicalModal}}
-    <GhFullscreenModal
-        @modal="feedback-lexical"
-        @close={{this.closeFeedbackLexical}}
-        @modifier="action wide" />
-{{/if}}

--- a/ghost/admin/app/components/editor/modals/publish-flow/complete.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete.hbs
@@ -110,6 +110,7 @@
                         type="button"
                         class="gh-publish-confirmation-feedback"
                         {{on "click" this.openFeedbackLexical}}
+                        data-test-button="lexical-feedback"
                     >
                         <span>Beta feedback?</span>
                     </button>

--- a/ghost/admin/app/components/editor/modals/publish-flow/complete.hbs
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete.hbs
@@ -96,7 +96,7 @@
                 </button>
             </p>
         {{else}}
-            <p class="gh-publish-confirmation">
+            <p class="gh-publish-confirmation gh-publish-confirmation-with-feedback">
                 <button
                     type="button"
                     class="gh-back-to-editor"
@@ -105,6 +105,14 @@
                 >
                     <span>Back to editor</span>
                 </button>
+                {{#if (feature 'lexicalEditor')}}
+                    <button
+                        type="button"
+                        class="gh-publish-confirmation-feedback"
+                    >
+                        <span>Beta feedback?</span>
+                    </button>
+                {{/if}}
             </p>
         {{/if}}
     {{/if}}

--- a/ghost/admin/app/components/editor/modals/publish-flow/complete.js
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {tracked} from '@glimmer/tracking';
+
+export default class PublishFlowComplete extends Component {
+    @tracked showFeedbackLexicalModal = false;
+
+    @action
+    openFeedbackLexical() {
+        console.log(`open feedback`)
+        this.showFeedbackLexicalModal = true;
+    }
+
+    @action
+    closeFeedbackLexical() {
+        this.showFeedbackLexicalModal = false;
+    }
+}

--- a/ghost/admin/app/components/editor/modals/publish-flow/complete.js
+++ b/ghost/admin/app/components/editor/modals/publish-flow/complete.js
@@ -1,18 +1,16 @@
 import Component from '@glimmer/component';
+import FeedbackLexicalModal from '../../../modal-feedback-lexical';
 import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
 export default class PublishFlowComplete extends Component {
+    @service modals;
+
     @tracked showFeedbackLexicalModal = false;
 
     @action
-    openFeedbackLexical() {
-        console.log(`open feedback`)
-        this.showFeedbackLexicalModal = true;
-    }
-
-    @action
-    closeFeedbackLexical() {
-        this.showFeedbackLexicalModal = false;
+    async openFeedbackLexical() {
+        await this.modals.open(FeedbackLexicalModal, {post: this.args.publishOptions.post});
     }
 }

--- a/ghost/admin/app/components/editor/publish-buttons.hbs
+++ b/ghost/admin/app/components/editor/publish-buttons.hbs
@@ -60,7 +60,8 @@
             <button
                 type="button"
                 class="gh-btn gh-btn-editor darkgrey gh-unpublish-trigger"
-                {{on "click" @publishManagement.openUpdateFlow}}
+                {{!-- {{on "click" @publishManagement.openUpdateFlow}}
+                {{on "click" (toggle-action "showMemberTierModal" this)}} --}}
                 data-test-button="update-flow"
             >
                 <span>

--- a/ghost/admin/app/components/editor/publish-buttons.hbs
+++ b/ghost/admin/app/components/editor/publish-buttons.hbs
@@ -60,8 +60,7 @@
             <button
                 type="button"
                 class="gh-btn gh-btn-editor darkgrey gh-unpublish-trigger"
-                {{!-- {{on "click" @publishManagement.openUpdateFlow}}
-                {{on "click" (toggle-action "showMemberTierModal" this)}} --}}
+                {{on "click" @publishManagement.openUpdateFlow}}
                 data-test-button="update-flow"
             >
                 <span>

--- a/ghost/admin/app/components/modal-feedback-lexical.hbs
+++ b/ghost/admin/app/components/modal-feedback-lexical.hbs
@@ -1,0 +1,44 @@
+{{!-- disable mouseDown so it doesn't trigger focus-out validations --}}
+<a class="close" href role="button" title="Close" {{action "closeModal"}} {{action (optional this.noop) on="mouseDown"}}>
+    {{svg-jar "close"}}<span class="hidden">Close</span>
+</a>
+
+<div class="gh-modal-invite-user">
+    <header class="modal-header" data-test-modal="invite-staff-user">
+        <h1>Editor beta</h1>
+        <p>Have any issues? Feedback? Let us know!</p>
+    </header>
+
+    {{!-- <div class="modal-body">
+        <fieldset>
+            <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="email">
+                <label for="new-user-email">Email address</label>
+                <GhTextArea
+                    @class="email"
+                    @id="new-user-email"
+                    @type="email"
+                    @placeholder="youremail@example.com"
+                    @name="email"
+                    @shouldFocus={{true}}
+                    @autocapitalize="off"
+                    @autocorrect="off"
+                    @value={{readonly this.email}}
+                    @input={{action (mut this.email) value="target.value"}}
+                    @keyEvents={{hash
+                        Enter=(action "confirm")
+                    }}
+                />
+                <GhErrorMessage @errors={{this.errors}} @property="email" />
+            </GhFormGroup>
+        </fieldset>
+    </div>
+    <div class="modal-footer">
+            <GhTaskButton @buttonText="Send feedback &rarr;"
+                @successText="Sent"
+                @task={{this.sendInvitation}}
+                @class="gh-btn gh-btn-black gh-btn-icon"
+                @disabled={{this.fetchRoles.isRunning}}
+                @disableMouseDown="true"
+                data-test-button="send-user-invite" />
+    </div> --}}
+</div>

--- a/ghost/admin/app/components/modal-feedback-lexical.hbs
+++ b/ghost/admin/app/components/modal-feedback-lexical.hbs
@@ -1,4 +1,4 @@
-<div class="modal-content">
+<div class="modal-content" data-test-modal="lexical-feedback">
     <header class="modal-header">
         <h1>Editor beta feedback</h1>
     </header>
@@ -16,6 +16,7 @@
                     @value={{this.feedbackMessage}}
                     @placeholder="I've noticed that..."
                     @shouldFocus={{true}}
+                    data-test-lexical-feedback-textarea
                 />
                 {{!--
                 <GhErrorMessage @errors={{this.member.errors}} @property="note" /> --}}
@@ -27,6 +28,11 @@
 
     <div class="modal-footer">
         <button class="gh-btn" type="button" {{action "closeModal" }}><span>Cancel</span></button>
-        <GhTaskButton @buttonText="Send feedback" @task={{this.submitFeedback}} @class="gh-btn gh-btn-black gh-btn-icon" />
+        <GhTaskButton 
+            @buttonText="Send feedback"
+            @task={{this.submitFeedback}}
+            @class="gh-btn gh-btn-black gh-btn-icon"
+            data-test-button="submit-lexical-feedback"
+        />
     </div>
 </div>

--- a/ghost/admin/app/components/modal-feedback-lexical.hbs
+++ b/ghost/admin/app/components/modal-feedback-lexical.hbs
@@ -18,7 +18,7 @@
                 {{!--
                 <GhErrorMessage @errors={{this.member.errors}} @property="note" /> --}}
                 <p> Maximum: <b>500</b> characters. You’ve used
-                    {{gh-count-down-characters this.feedbackMessage 500}}</p>
+                    {{gh-count-down-characters this.feedbackMessage 2000}}</p>
             </GhFormGroup>
         </form>
     </div>

--- a/ghost/admin/app/components/modal-feedback-lexical.hbs
+++ b/ghost/admin/app/components/modal-feedback-lexical.hbs
@@ -1,26 +1,30 @@
 <div class="modal-content">
     <header class="modal-header">
-        <h1>Lexical Beta Feedback</h1>
+        <h1>Editor beta feedback</h1>
     </header>
-    <a class="close" href="" role="button" title="Close" {{action "closeModal" }}>{{svg-jar "close"}}<span
+    <a class="close" href="" role="button" title="Close" {{action "closeModal"}}>{{svg-jar "close"}}<span
             class="hidden">Close</span></a>
 
-    <div class="modal-body gh-modal-reset-passwords">
-        <p>Have any issues? Feedback? Let us know!</p>
-        <GhFormGroup>
-            <GhTextarea 
-                @id="feedback-lexical"
-                @name="feedback-lexical" 
-                @value={{this.feedbackMessage}}
-            />
-            {{!--
-            <GhErrorMessage @errors={{this.member.errors}} @property="note" /> --}}
-            <p> Maximum: <b>500</b> characters. You’ve used
-                {{gh-count-down-characters this.feedbackMessage 500}}</p>
-        </GhFormGroup>
+    <div class="modal-body gh-modal-feedback-lexical">
+        {{!-- <p>Have any issues? Feedback? Let us know!</p> --}}
+        <form>
+            <GhFormGroup>
+                <label for="feedback-lexical">Have any issues? Feedback? Let us know below!</label>
+                <GhTextarea 
+                    @id="feedback-lexical"
+                    @name="feedback-lexical" 
+                    @value={{this.feedbackMessage}}
+                />
+                {{!--
+                <GhErrorMessage @errors={{this.member.errors}} @property="note" /> --}}
+                <p> Maximum: <b>500</b> characters. You’ve used
+                    {{gh-count-down-characters this.feedbackMessage 500}}</p>
+            </GhFormGroup>
+        </form>
     </div>
 
     <div class="modal-footer">
-        <GhTaskButton @buttonText="Submit" @task={{this.submitFeedback}} @class="gh-btn gh-btn-icon" />
+        <button class="gh-btn" type="button" {{action "closeModal" }}><span>Cancel</span></button>
+        <GhTaskButton @buttonText="Send feedback" @task={{this.submitFeedback}} @class="gh-btn gh-btn-black gh-btn-icon" />
     </div>
 </div>

--- a/ghost/admin/app/components/modal-feedback-lexical.hbs
+++ b/ghost/admin/app/components/modal-feedback-lexical.hbs
@@ -15,6 +15,7 @@
                     @name="feedback-lexical" 
                     @value={{this.feedbackMessage}}
                     @placeholder="I've noticed that..."
+                    @shouldFocus={{true}}
                 />
                 {{!--
                 <GhErrorMessage @errors={{this.member.errors}} @property="note" /> --}}

--- a/ghost/admin/app/components/modal-feedback-lexical.hbs
+++ b/ghost/admin/app/components/modal-feedback-lexical.hbs
@@ -1,44 +1,18 @@
-{{!-- disable mouseDown so it doesn't trigger focus-out validations --}}
-<a class="close" href role="button" title="Close" {{action "closeModal"}} {{action (optional this.noop) on="mouseDown"}}>
-    {{svg-jar "close"}}<span class="hidden">Close</span>
-</a>
-
-<div class="gh-modal-invite-user">
-    <header class="modal-header" data-test-modal="invite-staff-user">
-        <h1>Editor beta</h1>
-        <p>Have any issues? Feedback? Let us know!</p>
+<div class="modal-content">
+    <header class="modal-header">
+        <h1>Lexical Beta Feedback</h1>
     </header>
+    <a class="close" href="" role="button" title="Close" {{action "closeModal" }}>{{svg-jar "close"}}<span
+            class="hidden">Close</span></a>
 
-    {{!-- <div class="modal-body">
-        <fieldset>
-            <GhFormGroup @errors={{this.errors}} @hasValidated={{this.hasValidated}} @property="email">
-                <label for="new-user-email">Email address</label>
-                <GhTextArea
-                    @class="email"
-                    @id="new-user-email"
-                    @type="email"
-                    @placeholder="youremail@example.com"
-                    @name="email"
-                    @shouldFocus={{true}}
-                    @autocapitalize="off"
-                    @autocorrect="off"
-                    @value={{readonly this.email}}
-                    @input={{action (mut this.email) value="target.value"}}
-                    @keyEvents={{hash
-                        Enter=(action "confirm")
-                    }}
-                />
-                <GhErrorMessage @errors={{this.errors}} @property="email" />
-            </GhFormGroup>
-        </fieldset>
+    <div class="modal-body gh-modal-reset-passwords">
+        <p>Have any issues? Feedback? Let us know!</p>
+        <div class="flex mt2 mb2">
+
+        </div>
     </div>
+
     <div class="modal-footer">
-            <GhTaskButton @buttonText="Send feedback &rarr;"
-                @successText="Sent"
-                @task={{this.sendInvitation}}
-                @class="gh-btn gh-btn-black gh-btn-icon"
-                @disabled={{this.fetchRoles.isRunning}}
-                @disableMouseDown="true"
-                data-test-button="send-user-invite" />
-    </div> --}}
+        <GhTaskButton @buttonText="Submit" @task={{this.submitFeedback}} @class="gh-btn gh-btn-icon" />
+    </div>
 </div>

--- a/ghost/admin/app/components/modal-feedback-lexical.hbs
+++ b/ghost/admin/app/components/modal-feedback-lexical.hbs
@@ -14,11 +14,12 @@
                     @id="feedback-lexical"
                     @name="feedback-lexical" 
                     @value={{this.feedbackMessage}}
+                    @placeholder="I've noticed that..."
                 />
                 {{!--
                 <GhErrorMessage @errors={{this.member.errors}} @property="note" /> --}}
-                <p> Maximum: <b>500</b> characters. You’ve used
-                    {{gh-count-down-characters this.feedbackMessage 2000}}</p>
+                {{!-- <p> Maximum: <b>500</b> characters. You’ve used
+                    {{gh-count-down-characters this.feedbackMessage 500}}</p> --}}
             </GhFormGroup>
         </form>
     </div>

--- a/ghost/admin/app/components/modal-feedback-lexical.hbs
+++ b/ghost/admin/app/components/modal-feedback-lexical.hbs
@@ -7,9 +7,17 @@
 
     <div class="modal-body gh-modal-reset-passwords">
         <p>Have any issues? Feedback? Let us know!</p>
-        <div class="flex mt2 mb2">
-
-        </div>
+        <GhFormGroup>
+            <GhTextarea 
+                @id="feedback-lexical"
+                @name="feedback-lexical" 
+                @value={{this.feedbackMessage}}
+            />
+            {{!--
+            <GhErrorMessage @errors={{this.member.errors}} @property="note" /> --}}
+            <p> Maximum: <b>500</b> characters. You’ve used
+                {{gh-count-down-characters this.feedbackMessage 500}}</p>
+        </GhFormGroup>
     </div>
 
     <div class="modal-footer">

--- a/ghost/admin/app/components/modal-feedback-lexical.js
+++ b/ghost/admin/app/components/modal-feedback-lexical.js
@@ -1,0 +1,8 @@
+import ModalComponent from 'ghost-admin/components/modal-base';
+
+export default ModalComponent.extend({
+    actions: {
+        // noop - we don't want the enter key doing anything
+        confirm() {}
+    }
+});

--- a/ghost/admin/app/components/modal-feedback-lexical.js
+++ b/ghost/admin/app/components/modal-feedback-lexical.js
@@ -1,9 +1,16 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
+import {task} from 'ember-concurrency';
 
 export default class FeedbackLexicalModalComponent extends Component {
     @service modals;
+    @service ajax;
+
+    constructor(...args) {
+        super(...args);
+        this.feedbackMessage = this.args.feedbackMessage;
+    }
 
     // not working?
     @action
@@ -22,5 +29,24 @@ export default class FeedbackLexicalModalComponent extends Component {
     @action
     closeModal() {
         this.args.closeModal();
+    }
+
+    @task({drop: true})
+    *submitFeedback() {
+        let url = `https://submit-form.com/us6uBWv8`;
+
+        let response = yield this.ajax.post(url, {
+            data: {
+                message: this.feedbackMessage
+            }
+        });
+
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error('api failed ' + response.status + ' ' + response.statusText);
+        }
+        
+        // note: do we want to just do this.send('closeModal') here? or do we want to display a thanks message and close after a delay?
+
+        return response;
     }
 }

--- a/ghost/admin/app/components/modal-feedback-lexical.js
+++ b/ghost/admin/app/components/modal-feedback-lexical.js
@@ -49,11 +49,11 @@ export default class FeedbackLexicalModalComponent extends Component {
             ...postData
         };
 
-        // let response = yield this.ajax.post(url, {data});
+        let response = yield this.ajax.post(url, {data});
 
-        // if (response.status < 200 || response.status >= 300) {
-        //     throw new Error('api failed ' + response.status + ' ' + response.statusText);
-        // }
+        if (response.status < 200 || response.status >= 300) {
+            throw new Error('api failed ' + response.status + ' ' + response.statusText);
+        }
 
         this.args.close();
 
@@ -64,7 +64,6 @@ export default class FeedbackLexicalModalComponent extends Component {
             }
         );
 
-        yield data;
-        // return response;
+        return response;
     }
 }

--- a/ghost/admin/app/components/modal-feedback-lexical.js
+++ b/ghost/admin/app/components/modal-feedback-lexical.js
@@ -37,7 +37,7 @@ export default class FeedbackLexicalModalComponent extends Component {
 
         let response = yield this.ajax.post(url, {
             data: {
-                message: this.feedbackMessage
+                Feedback: this.feedbackMessage
             }
         });
 

--- a/ghost/admin/app/components/modal-feedback-lexical.js
+++ b/ghost/admin/app/components/modal-feedback-lexical.js
@@ -5,7 +5,6 @@ import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
 export default class FeedbackLexicalModalComponent extends Component {
-    @service modals;
     @service ajax;
     @service ghostPaths;
     @service session;
@@ -18,23 +17,9 @@ export default class FeedbackLexicalModalComponent extends Component {
         this.feedbackMessage = this.args.feedbackMessage;
     }
 
-    // not working?
-    @action
-    willDestroy() {
-        super.willDestroy(...arguments);
-        window.removeEventListener('keydown', this.handleKeyDown);
-    }
-
-    @action
-    handleKeyDown(event) {
-        if (event.key === 'Escape') {
-            this.args.closeModal();
-        }
-    }
-
     @action
     closeModal() {
-        this.args.closeModal();
+        this.args.close();
     }
 
     @task({drop: true})
@@ -70,12 +55,14 @@ export default class FeedbackLexicalModalComponent extends Component {
             throw new Error('api failed ' + response.status + ' ' + response.statusText);
         }
 
+        this.args.close();
+
         this.notifications.showNotification('Feedback sent',
-                {
-                    icon: 'send-email',
-                    description: 'Thank you!'
-                }
-            );
+            {
+                icon: 'send-email',
+                description: 'Thank you!'
+            }
+        );
 
         return response;
     }

--- a/ghost/admin/app/components/modal-feedback-lexical.js
+++ b/ghost/admin/app/components/modal-feedback-lexical.js
@@ -9,6 +9,7 @@ export default class FeedbackLexicalModalComponent extends Component {
     @service ajax;
     @service ghostPaths;
     @service session;
+    @service notifications;
 
     @inject config;
 
@@ -68,6 +69,13 @@ export default class FeedbackLexicalModalComponent extends Component {
         if (response.status < 200 || response.status >= 300) {
             throw new Error('api failed ' + response.status + ' ' + response.statusText);
         }
+
+        this.notifications.showNotification('Feedback sent',
+                {
+                    icon: 'send-email',
+                    description: 'Thank you!'
+                }
+            );
 
         return response;
     }

--- a/ghost/admin/app/components/modal-feedback-lexical.js
+++ b/ghost/admin/app/components/modal-feedback-lexical.js
@@ -49,11 +49,11 @@ export default class FeedbackLexicalModalComponent extends Component {
             ...postData
         };
 
-        let response = yield this.ajax.post(url, {data});
+        // let response = yield this.ajax.post(url, {data});
 
-        if (response.status < 200 || response.status >= 300) {
-            throw new Error('api failed ' + response.status + ' ' + response.statusText);
-        }
+        // if (response.status < 200 || response.status >= 300) {
+        //     throw new Error('api failed ' + response.status + ' ' + response.statusText);
+        // }
 
         this.args.close();
 
@@ -64,6 +64,7 @@ export default class FeedbackLexicalModalComponent extends Component {
             }
         );
 
-        return response;
+        yield data;
+        // return response;
     }
 }

--- a/ghost/admin/app/components/modal-feedback-lexical.js
+++ b/ghost/admin/app/components/modal-feedback-lexical.js
@@ -1,8 +1,26 @@
-import ModalComponent from 'ghost-admin/components/modal-base';
+import Component from '@glimmer/component';
+import {action} from '@ember/object';
+import {inject as service} from '@ember/service';
 
-export default ModalComponent.extend({
-    actions: {
-        // noop - we don't want the enter key doing anything
-        confirm() {}
+export default class FeedbackLexicalModalComponent extends Component {
+    @service modals;
+
+    // not working?
+    @action
+    willDestroy() {
+        super.willDestroy(...arguments);
+        window.removeEventListener('keydown', this.handleKeyDown);
     }
-});
+
+    @action
+    handleKeyDown(event) {
+        if (event.key === 'Escape') {
+            this.args.closeModal();
+        }
+    }
+
+    @action
+    closeModal() {
+        this.args.closeModal();
+    }
+}

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -2,6 +2,7 @@ import ConfirmEditorLeaveModal from '../components/modals/editor/confirm-leave';
 import Controller, {inject as controller} from '@ember/controller';
 import DeletePostModal from '../components/modals/delete-post';
 import DeleteSnippetModal from '../components/editor/modals/delete-snippet';
+import FeedbackLexicalModal from '../components/modal-feedback-lexical';
 import PostModel from 'ghost-admin/models/post';
 import PublishLimitModal from '../components/modals/limits/publish-limit';
 import ReAuthenticateModal from '../components/editor/modals/re-authenticate';
@@ -412,13 +413,8 @@ export default class LexicalEditorController extends Controller {
     }
 
     @action
-    openFeedbackLexical() {
-        this.showFeedbackLexicalModal = true;
-    }
-
-    @action
-    closeFeedbackLexical() {
-        this.showFeedbackLexicalModal = false;
+    async openFeedbackLexical() {
+        await this.modals.open(FeedbackLexicalModal);
     }
 
     /* Public tasks ----------------------------------------------------------*/

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -23,6 +23,7 @@ import {isArray as isEmberArray} from '@ember/array';
 import {isHostLimitError, isServerUnreachableError, isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {isInvalidError} from 'ember-ajax/errors';
 import {inject as service} from '@ember/service';
+import {tracked} from '@glimmer/tracking';
 
 const DEFAULT_TITLE = '(Untitled)';
 
@@ -112,6 +113,8 @@ export default class LexicalEditorController extends Controller {
     @service ui;
 
     @inject config;
+
+    @tracked showFeedbackLexicalModal = false;
 
     /* public properties -----------------------------------------------------*/
 
@@ -406,6 +409,16 @@ export default class LexicalEditorController extends Controller {
         await this.modals.open(DeleteSnippetModal, {
             snippet
         });
+    }
+
+    @action
+    openFeedbackLexical() {
+        this.showFeedbackLexicalModal = true;
+    }
+
+    @action
+    closeFeedbackLexical() {
+        this.showFeedbackLexicalModal = false;
     }
 
     /* Public tasks ----------------------------------------------------------*/

--- a/ghost/admin/app/controllers/settings/labs.js
+++ b/ghost/admin/app/controllers/settings/labs.js
@@ -4,6 +4,7 @@ import {inject as service} from '@ember/service';
 import Controller from '@ember/controller';
 import DeleteAllModal from '../../components/settings/labs/delete-all-content-modal';
 import ImportContentModal from '../../components/modal-import-content';
+import LexicalFeedbackModal from '../../components/modal-feedback-lexical';
 import RSVP from 'rsvp';
 import config from 'ghost-admin/config/environment';
 import {
@@ -17,6 +18,7 @@ import {isBlank} from '@ember/utils';
 import {isArray as isEmberArray} from '@ember/array';
 import {run} from '@ember/runloop';
 import {task, timeout} from 'ember-concurrency';
+import {tracked} from '@glimmer/tracking';
 
 const {Promise} = RSVP;
 
@@ -50,6 +52,8 @@ export default class LabsController extends Controller {
 
     @inject config;
 
+    @tracked showFeedbackLexicalModal = false;
+
     importErrors = null;
     importSuccessful = false;
     showEarlyAccessModal = false;
@@ -61,7 +65,6 @@ export default class LabsController extends Controller {
     yamlExtension = null;
     yamlMimeType = null;
     yamlAccept = null;
-    showLexicalFeedbackModal = false;
 
     init() {
         super.init(...arguments);
@@ -162,9 +165,25 @@ export default class LabsController extends Controller {
     }
 
     @action
-    toggleLexicalFeedbackModal() {
-        this.showLexicalFeedbackModal = !this.showLexicalFeedbackModal;
+    openFeedbackLexical() {
+        this.showFeedbackLexicalModal = true;
     }
+
+    @action
+    closeFeedbackLexical() {
+        this.showFeedbackLexicalModal = false;
+    }
+
+    // @action
+    // toggleLexicalFeedbackModal(event) {
+    //     event?.preventDefault();
+    //     this.showFeedbackLexicalModal = !this.showFeedbackLexicalModal;
+
+    //     if (this.showFeedbackLexicalModal) {
+    //         this.modals.open(LexicalFeedbackModal);
+    //     }
+    //     console.log(`toggling modal for feedback`,this.showFeedbackLexicalModal);
+    // }
 
     /**
      * Opens a file selection dialog - Triggered by "Upload x" buttons,

--- a/ghost/admin/app/controllers/settings/labs.js
+++ b/ghost/admin/app/controllers/settings/labs.js
@@ -4,7 +4,6 @@ import {inject as service} from '@ember/service';
 import Controller from '@ember/controller';
 import DeleteAllModal from '../../components/settings/labs/delete-all-content-modal';
 import ImportContentModal from '../../components/modal-import-content';
-import LexicalFeedbackModal from '../../components/modal-feedback-lexical';
 import RSVP from 'rsvp';
 import config from 'ghost-admin/config/environment';
 import {
@@ -173,17 +172,6 @@ export default class LabsController extends Controller {
     closeFeedbackLexical() {
         this.showFeedbackLexicalModal = false;
     }
-
-    // @action
-    // toggleLexicalFeedbackModal(event) {
-    //     event?.preventDefault();
-    //     this.showFeedbackLexicalModal = !this.showFeedbackLexicalModal;
-
-    //     if (this.showFeedbackLexicalModal) {
-    //         this.modals.open(LexicalFeedbackModal);
-    //     }
-    //     console.log(`toggling modal for feedback`,this.showFeedbackLexicalModal);
-    // }
 
     /**
      * Opens a file selection dialog - Triggered by "Upload x" buttons,

--- a/ghost/admin/app/controllers/settings/labs.js
+++ b/ghost/admin/app/controllers/settings/labs.js
@@ -61,7 +61,7 @@ export default class LabsController extends Controller {
     yamlExtension = null;
     yamlMimeType = null;
     yamlAccept = null;
-    showInviteUserModal = false;
+    showLexicalFeedbackModal = false;
 
     init() {
         super.init(...arguments);

--- a/ghost/admin/app/controllers/settings/labs.js
+++ b/ghost/admin/app/controllers/settings/labs.js
@@ -3,6 +3,7 @@ import {inject as service} from '@ember/service';
 /* eslint-disable ghost/ember/alias-model-in-controller */
 import Controller from '@ember/controller';
 import DeleteAllModal from '../../components/settings/labs/delete-all-content-modal';
+import FeedbackLexicalModal from '../../components/modal-feedback-lexical';
 import ImportContentModal from '../../components/modal-import-content';
 import RSVP from 'rsvp';
 import config from 'ghost-admin/config/environment';
@@ -164,13 +165,8 @@ export default class LabsController extends Controller {
     }
 
     @action
-    openFeedbackLexical() {
-        this.showFeedbackLexicalModal = true;
-    }
-
-    @action
-    closeFeedbackLexical() {
-        this.showFeedbackLexicalModal = false;
+    async openFeedbackLexical() {
+        await this.modals.open(FeedbackLexicalModal);
     }
 
     /**

--- a/ghost/admin/app/controllers/settings/labs.js
+++ b/ghost/admin/app/controllers/settings/labs.js
@@ -61,6 +61,7 @@ export default class LabsController extends Controller {
     yamlExtension = null;
     yamlMimeType = null;
     yamlAccept = null;
+    showInviteUserModal = false;
 
     init() {
         super.init(...arguments);
@@ -158,6 +159,11 @@ export default class LabsController extends Controller {
     @action
     toggleEarlyAccessModal() {
         this.toggleProperty('showEarlyAccessModal');
+    }
+
+    @action
+    toggleLexicalFeedbackModal() {
+        this.showLexicalFeedbackModal = !this.showLexicalFeedbackModal;
     }
 
     /**

--- a/ghost/admin/app/styles/components/publishmenu.css
+++ b/ghost/admin/app/styles/components/publishmenu.css
@@ -732,6 +732,18 @@
     font-size: 1.6rem;
 }
 
+.gh-publish-confirmation-with-feedback {
+    display: flex;
+    justify-content: space-between;
+}
+
+.gh-publish-confirmation-feedback {
+    color: var(--green);
+    font-size: 1.6rem;
+    font-weight: 400;
+    letter-spacing: .4px;
+}
+
 .gh-revert-to-draft {
     color: var(--green-d1);
     font-weight: 500;

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -387,6 +387,10 @@
     font-weight: 400;
 }
 
+.gh-editor-feedback {
+    color: var(--green);
+}
+
 .gh-editor-status {
     color: var(--midgrey);
     font-size: 1.3rem;

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -99,6 +99,7 @@
                         type="button"
                         class="gh-editor-feedback"
                         {{on "click" this.openFeedbackLexical}}
+                        data-test-button="lexical-editor-feedback"
                     >
                         <span>Feedback?</span>
                     </button>

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -98,7 +98,6 @@
                     <button
                         type="button"
                         class="gh-editor-feedback"
-                        {{on "click" @publishManagement.openUpdateFlow}}
                     >
                         <span>Feedback?</span>
                     </button>

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -98,6 +98,7 @@
                     <button
                         type="button"
                         class="gh-editor-feedback"
+                        {{on "click" @publishManagement.openUpdateFlow}}
                     >
                         <span>Feedback?</span>
                     </button>

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -94,6 +94,14 @@
             />
 
             <div class="gh-editor-wordcount-container">
+                {{#if (feature 'lexicalEditor')}}
+                    <button
+                        type="button"
+                        class="gh-editor-feedback"
+                    >
+                        <span>Feedback?</span>
+                    </button>
+                {{/if}}
                 <div class="gh-editor-wordcount">
                     {{gh-pluralize this.wordCount.wordCount "word"}}
                 </div>

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -98,6 +98,7 @@
                     <button
                         type="button"
                         class="gh-editor-feedback"
+                        {{on "click" this.openFeedbackLexical}}
                     >
                         <span>Feedback?</span>
                     </button>
@@ -144,6 +145,12 @@
                 @close={{this.closePostHistory}}
                 @modifier="total-overlay post-history" />
         {{/if}}
+    {{/if}}
+    {{#if this.showFeedbackLexicalModal}}
+        <GhFullscreenModal
+            @modal="feedback-lexical"
+            @close={{this.closeFeedbackLexical}}
+            @modifier="action wide" />
     {{/if}}
 {{/if}}
 

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -146,12 +146,6 @@
                 @modifier="total-overlay post-history" />
         {{/if}}
     {{/if}}
-    {{#if this.showFeedbackLexicalModal}}
-        <GhFullscreenModal
-            @modal="feedback-lexical"
-            @close={{this.closeFeedbackLexical}}
-            @modifier="action wide" />
-    {{/if}}
 {{/if}}
 
 {{outlet}}

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -207,7 +207,7 @@
                             <h4 class="gh-expandable-title">Lexical editor</h4>
                             <p class="gh-expandable-description">
                                 {{#if (feature 'lexicalEditor')}}
-                                    <span>Makes lexical editor the default when creating new posts/pages. Any issues? Feedback?</span><button class="green ml1" role="button" {{on "click" this.openFeedbackLexical}}>Let us know</button>
+                                    <span>Makes lexical editor the default when creating new posts/pages. Any issues? Feedback?</span><button class="green ml1" role="button" {{on "click" this.openFeedbackLexical}} data-test-button="lexical-feedback">Let us know</button>
                                 {{else}}
                                     <span>Makes lexical editor the default when creating new posts/pages.</span>
                                 {{/if}}

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -207,7 +207,7 @@
                             <h4 class="gh-expandable-title">Lexical editor</h4>
                             <p class="gh-expandable-description">
                                 {{#if (feature 'lexicalEditor')}}
-                                    <span>Makes lexical editor the default when creating new posts/pages. Any issues? Feedback?</span><button class="green ml2" role="button" {{on "click" this.toggleLexicalFeedbackModal}}>Let us know</button>
+                                    <span>Makes lexical editor the default when creating new posts/pages. Any issues? Feedback?</span><button class="green ml2" role="button" {{on "click" this.openFeedbackLexical}}>Let us know</button>
                                 {{else}}
                                     <span>Makes lexical editor the default when creating new posts/pages.</span>
                                 {{/if}}
@@ -369,9 +369,10 @@
         </div>
         {{/if}}
     </section>
-    {{#if this.showLexicalFeedbackModal}}
-        <GhFullscreenModal @modal="feedback-lexical"
-            @close={{this.toggleLexicalFeedbackModal}}
+    {{#if this.showFeedbackLexicalModal}}
+        <GhFullscreenModal
+            @modal="feedback-lexical"
+            @close={{this.closeFeedbackLexical}}
             @modifier="action wide" />
     {{/if}}
 </section>

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -206,7 +206,11 @@
                         <div>
                             <h4 class="gh-expandable-title">Lexical editor</h4>
                             <p class="gh-expandable-description">
-                               Makes lexical editor the default when creating new posts/pages.
+                                {{#if (feature 'lexicalEditor')}}
+                                    <span>Makes lexical editor the default when creating new posts/pages. Any issues? Feedback?</span><button class="green ml2" role="button" {{on "click" this.toggleLexicalFeedbackModal}}>Let us know</button>
+                                {{else}}
+                                    <span>Makes lexical editor the default when creating new posts/pages.</span>
+                                {{/if}}
                             </p>
                         </div>
                         <div class="for-switch">
@@ -365,4 +369,9 @@
         </div>
         {{/if}}
     </section>
+    {{#if this.showLexicalFeedbackModal}}
+        <GhFullscreenModal @modal="feedback-lexical"
+            @close={{this.toggleLexicalFeedbackModal}}
+            @modifier="action wide" />
+    {{/if}}
 </section>

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -369,10 +369,4 @@
         </div>
         {{/if}}
     </section>
-    {{#if this.showFeedbackLexicalModal}}
-        <GhFullscreenModal
-            @modal="feedback-lexical"
-            @close={{this.closeFeedbackLexical}}
-            @modifier="action wide" />
-    {{/if}}
 </section>

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -207,7 +207,7 @@
                             <h4 class="gh-expandable-title">Lexical editor</h4>
                             <p class="gh-expandable-description">
                                 {{#if (feature 'lexicalEditor')}}
-                                    <span>Makes lexical editor the default when creating new posts/pages. Any issues? Feedback?</span><button class="green ml2" role="button" {{on "click" this.openFeedbackLexical}}>Let us know</button>
+                                    <span>Makes lexical editor the default when creating new posts/pages. Any issues? Feedback?</span><button class="green ml1" role="button" {{on "click" this.openFeedbackLexical}}>Let us know</button>
                                 {{else}}
                                     <span>Makes lexical editor the default when creating new posts/pages.</span>
                                 {{/if}}

--- a/ghost/admin/tests/acceptance/editor/lexical-test.js
+++ b/ghost/admin/tests/acceptance/editor/lexical-test.js
@@ -1,7 +1,9 @@
 import loginAsRole from '../../helpers/login-as-role';
 import {BLANK_DOC} from 'koenig-editor/components/koenig-editor';
 import {currentURL} from '@ember/test-helpers';
+import {enableLabsFlag} from '../../helpers/labs-flag';
 import {expect} from 'chai';
+import {find} from '@ember/test-helpers';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
 import {visit} from '../../helpers/visit';
@@ -17,6 +19,8 @@ describe('Acceptance: Lexical editor', function () {
         const config = this.server.schema.configs.find(1);
         config.attrs.editor = {url: 'https://cdn.pkg/editor.js'};
         config.save();
+
+        enableLabsFlag(this.server, 'lexicalEditor');
 
         // stub loaded external module to avoid loading of external dep
         window['@tryghost/koenig-lexical'] = {
@@ -45,6 +49,14 @@ describe('Acceptance: Lexical editor', function () {
         await loginAsRole('Administrator', this.server);
         await visit('/lexical-editor/post/');
         expect(currentURL(), 'currentURL').to.equal('/lexical-editor/post/');
+    });
+
+    it('shows feedback link in lexical editor', async function () {
+        await loginAsRole('Administrator', this.server);
+        await visit('/lexical-editor/post/');
+        expect(currentURL(), 'currentURL').to.equal('/lexical-editor/post/');
+
+        expect(find('.gh-editor-feedback'), 'feedback button').to.exist;
     });
 
     it('redirects mobiledoc editor to lexical editor when post.lexical is present', async function () {


### PR DESCRIPTION
no refs
- add lexical feedback modal in the editor, labs, and publish workflows
- modal is a basic textarea form