### PR TITLE
🐛 Fixed outbound link tagger tagging non http urls

### DIFF
--- a/ghost/member-attribution/lib/OutboundLinkTagger.js
+++ b/ghost/member-attribution/lib/OutboundLinkTagger.js
@@ -55,6 +55,11 @@ class OutboundLinkTagger {
             return url;
         }
 
+        // Check protocol
+        if (!url.protocol.startsWith('http')) {
+            return url;
+        }
+
         // Check blocked domains
         const referrerDomain = url.hostname;
         if (blockedReferrerDomains.includes(referrerDomain)) {

--- a/ghost/member-attribution/test/outbound-link-tagger.test.js
+++ b/ghost/member-attribution/test/outbound-link-tagger.test.js
@@ -118,6 +118,17 @@ describe('OutboundLinkTagger', function () {
             const updatedUrl = await service.addToUrl(url);
             should(updatedUrl.toString()).equal('https://example.com/?source=hello');
         });
+
+        it('does not add ref if the protocol is not http(s)', async function () {
+            const service = new OutboundLinkTagger({
+                getSiteUrl: () => 'https://blog.com',
+                isEnabled: () => true
+            });
+            const urlStr = 'javascript:alert("Hello, World!")';
+            const url = new URL(urlStr);
+            const updatedUrl = await service.addToUrl(url);
+            should(updatedUrl.toString()).equal(urlStr);
+        });
     });
 
     describe('addToHtml', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3172

The outbound link tagger was tagging non http urls (i.e `javascript:`, `mailto:`) which would prevent these urls from working as expected. This change only allows urls to be tagged if they use the `http(s)` protocol.