### PR TITLE
Added fetchLabels to the Lexical config

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -213,6 +213,16 @@ export default class KoenigLexicalEditor extends Component {
         return this.offers;
     }
 
+    @task({restartable: true})
+    *fetchLabelsTask() {
+        if (this.labels) {
+            return this.labels;
+        }
+
+        this.labels = yield this.store.query('label', {limit: 'all', fields: 'id, name'});
+        return this.labels;
+    }
+
     ReactComponent = (props) => {
         const fetchEmbed = async (url, {type}) => {
             let oembedEndpoint = this.ghostPaths.url.api('oembed');
@@ -239,6 +249,17 @@ export default class KoenigLexicalEditor extends Component {
             return [...defaults, ...offersLinks];
         };
 
+        const fetchLabels = async () => {
+            const labels = await this.fetchLabelsTask.perform();
+
+            return labels.toArray().map((label) => {
+                return {
+                    id: label.id,
+                    name: label.name
+                };
+            });
+        };
+
         const defaultCardConfig = {
             unsplash: {
                 defaultHeaders: {
@@ -252,6 +273,7 @@ export default class KoenigLexicalEditor extends Component {
             tenor: this.config.tenor?.googleApiKey ? this.config.tenor : null,
             fetchEmbed: fetchEmbed,
             fetchAutocompleteLinks,
+            fetchLabels,
             feature: {
                 signupCard: this.feature.get('signupCard')
             }


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3183
- fetches all existing labels
- returns "id" and "name" fields
