### PR TITLE
🐛 Fixed trailing slash and space in HTML metadata elements

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -208,15 +208,15 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
         if (context) {
             // head is our main array that holds our meta data
             if (meta.metaDescription && meta.metaDescription.length > 0) {
-                head.push('<meta name="description" content="' + escapeExpression(meta.metaDescription) + '" />');
+                head.push('<meta name="description" content="' + escapeExpression(meta.metaDescription) + '">');
             }
 
             // no output in head if a publication icon is not set
             if (settingsCache.get('icon')) {
-                head.push('<link rel="icon" href="' + favicon + '" type="image/' + iconType + '" />');
+                head.push('<link rel="icon" href="' + favicon + '" type="image/' + iconType + '">');
             }
 
-            head.push('<link rel="canonical" href="' + escapeExpression(meta.canonicalUrl) + '" />');
+            head.push('<link rel="canonical" href="' + escapeExpression(meta.canonicalUrl) + '">');
 
             if (_.includes(context, 'preview')) {
                 head.push(writeMetaTag('robots', 'noindex,nofollow', 'name'));
@@ -228,17 +228,17 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
             // show amp link in post when 1. we are not on the amp page and 2. amp is enabled
             if (_.includes(context, 'post') && !_.includes(context, 'amp') && settingsCache.get('amp')) {
                 head.push('<link rel="amphtml" href="' +
-                    escapeExpression(meta.ampUrl) + '" />');
+                    escapeExpression(meta.ampUrl) + '">');
             }
 
             if (meta.previousUrl) {
                 head.push('<link rel="prev" href="' +
-                    escapeExpression(meta.previousUrl) + '" />');
+                    escapeExpression(meta.previousUrl) + '">');
             }
 
             if (meta.nextUrl) {
                 head.push('<link rel="next" href="' +
-                    escapeExpression(meta.nextUrl) + '" />');
+                    escapeExpression(meta.nextUrl) + '">');
             }
 
             if (!_.includes(context, 'paged') && useStructuredData) {
@@ -255,11 +255,11 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
         }
 
         head.push('<meta name="generator" content="Ghost ' +
-            escapeExpression(safeVersion) + '" />');
+            escapeExpression(safeVersion) + '">');
 
         head.push('<link rel="alternate" type="application/rss+xml" title="' +
             escapeExpression(meta.site.title) + '" href="' +
-            escapeExpression(meta.rssUrl) + '" />');
+            escapeExpression(meta.rssUrl) + '">');
 
         // no code injection for amp context!!!
         if (!_.includes(context, 'amp')) {

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -19,7 +19,7 @@ const {get: getMetaData, getAssetUrl} = metaData;
 
 function writeMetaTag(property, content, type) {
     type = type || property.substring(0, 7) === 'twitter' ? 'name' : 'property';
-    return '<meta ' + type + '="' + property + '" content="' + content + '" />';
+    return '<meta ' + type + '="' + property + '" content="' + content + '">';
 }
 
 function finaliseStructuredData(meta) {
@@ -126,7 +126,7 @@ function getWebmentionDiscoveryLink() {
     try {
         const siteUrl = urlUtils.getSiteUrl();
         const webmentionUrl = new URL('webmentions/receive/', siteUrl);
-        return `<link href="${webmentionUrl.href}" rel="webmention" />`;
+        return `<link href="${webmentionUrl.href}" rel="webmention">`;
     } catch (err) {
         logging.warn(err);
         return '';

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`{{ghost_head}} helper accent_color attaches style tag to existing script/style tag 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -65,8 +65,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"false\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
@@ -140,8 +140,8 @@ Object {
 
 exports[`{{ghost_head}} helper accent_color does not include style tag in AMP context 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -202,17 +202,17 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />",
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper accent_color does not include style tag when not set 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -272,8 +272,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -283,8 +283,8 @@ Object {
 
 exports[`{{ghost_head}} helper accent_color includes style tag on templates with no context 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+  "rendered": "<meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
     
@@ -294,10 +294,10 @@ Object {
 
 exports[`{{ghost_head}} helper accent_color includes style tag when set 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -357,8 +357,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
     
@@ -368,8 +368,8 @@ Object {
 
 exports[`{{ghost_head}} helper amp is disabled does not contain amphtml link 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -430,8 +430,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -721,8 +721,8 @@ Object {
 
 exports[`{{ghost_head}} helper attribution scripts is included when tracking setting is enabled 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -760,8 +760,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"false\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
@@ -835,8 +835,8 @@ Object {
 
 exports[`{{ghost_head}} helper attribution scripts is not included when tracking setting is disabled 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -874,8 +874,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"false\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
@@ -948,8 +948,8 @@ Object {
 
 exports[`{{ghost_head}} helper members scripts includes portal when members enabled 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -987,8 +987,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"false\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
@@ -1062,8 +1062,8 @@ Object {
 
 exports[`{{ghost_head}} helper members scripts includes stripe when connected 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1101,8 +1101,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"false\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
@@ -1176,8 +1176,8 @@ Object {
 
 exports[`{{ghost_head}} helper members scripts skips portal and stripe when members are disabled 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1215,8 +1215,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1226,8 +1226,8 @@ Object {
 
 exports[`{{ghost_head}} helper members scripts skips stripe if not set up 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1265,8 +1265,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"false\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
 .gh-post-upgrade-cta {
     display: flex;
@@ -1340,8 +1340,8 @@ Object {
 
 exports[`{{ghost_head}} helper search scripts includes search when labs flag enabled 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1379,8 +1379,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 4.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1390,11 +1390,11 @@ Object {
 
 exports[`{{ghost_head}} helper with /site subdirectory returns correct rss url with subdirectory 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"icon\\" href=\\"/site/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/site/\\" />
+  "rendered": "<link rel=\\"icon\\" href=\\"/site/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/site/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/site/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/site/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1404,11 +1404,11 @@ Object {
 
 exports[`{{ghost_head}} helper with Code Injection handles post codeinjection being empty 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1419,11 +1419,11 @@ Object {
 
 exports[`{{ghost_head}} helper with Code Injection handles post codeinjection being null 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1434,11 +1434,11 @@ Object {
 
 exports[`{{ghost_head}} helper with Code Injection outputs post codeinjection as well 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1450,11 +1450,11 @@ Object {
 
 exports[`{{ghost_head}} helper with Code Injection returns meta tag plus injected code 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1465,9 +1465,9 @@ Object {
 
 exports[`{{ghost_head}} helper with Code Injection returns meta tag without injected code for amp context 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
-    <link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1528,18 +1528,18 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />",
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper with changed origin in config file contains the changed origin 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"icon\\" href=\\"/site/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/site/\\" />
+  "rendered": "<link rel=\\"icon\\" href=\\"/site/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/site/\\">
     <meta name=\\"referrer\\" content=\\"origin\\">
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1549,13 +1549,13 @@ Object {
 
 exports[`{{ghost_head}} helper with useStructuredData is set to false in config file does not return structured data 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\">
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1565,10 +1565,10 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection disallows indexing for preview pages 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"robots\\" content=\\"noindex,nofollow\\">
     <meta name=\\"referrer\\" content=\\"same-origin\\">
-    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"website\\">
@@ -1580,8 +1580,8 @@ Object {
     <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
     <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
     
-    <meta name=\\"generator\\" content=\\"Ghost \\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost \\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1591,8 +1591,8 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection does not inject count script if comments off 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1630,8 +1630,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1641,10 +1641,10 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection does not return structured data on paginated author pages 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/author/authorname1/page/2/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/author/authorname1/page/2/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1654,10 +1654,10 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection does not return structured data on paginated tag pages 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/page/2/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/page/2/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1667,18 +1667,18 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection implicit indexing settings for non-preview pages 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <meta name=\\"generator\\" content=\\"Ghost \\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />",
+    <meta name=\\"generator\\" content=\\"Ghost \\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection injects comment count script if comments all 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1716,8 +1716,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1728,8 +1728,8 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection injects comment count script if comments paid 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1767,8 +1767,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1779,7 +1779,7 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection outputs structured data but not schema for custom collection 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/featured/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/featured/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1790,8 +1790,8 @@ Object {
     <meta name=\\"twitter:title\\" content=\\"Ghost\\">
     <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/featured/\\">
     
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1801,7 +1801,7 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns canonical URL 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/about/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/about/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1855,8 +1855,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1866,8 +1866,8 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns meta structured data on homepage with site metadata defined 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site SEO description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site SEO description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1905,8 +1905,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1916,7 +1916,7 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns meta tag string even if safeVersion is invalid 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -1927,8 +1927,8 @@ Object {
     <meta name=\\"twitter:title\\" content=\\"Ghost\\">
     <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
     
-    <meta name=\\"generator\\" content=\\"Ghost 0.9\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.9\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1938,10 +1938,10 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns meta tag string on paginated index page without structured data and schema 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/page/2/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/page/2/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1951,12 +1951,12 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns next & prev URL correctly for middle page 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/page/3/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/page/3/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"prev\\" href=\\"http://localhost:65530/page/2/\\" />
-    <link rel=\\"next\\" href=\\"http://localhost:65530/page/4/\\" />
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <link rel=\\"prev\\" href=\\"http://localhost:65530/page/2/\\">
+    <link rel=\\"next\\" href=\\"http://localhost:65530/page/4/\\">
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1966,12 +1966,12 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns next & prev URL correctly for second page 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/page/2/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/page/2/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"prev\\" href=\\"http://localhost:65530/\\" />
-    <link rel=\\"next\\" href=\\"http://localhost:65530/page/3/\\" />
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <link rel=\\"prev\\" href=\\"http://localhost:65530/\\">
+    <link rel=\\"next\\" href=\\"http://localhost:65530/page/3/\\">
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -1981,8 +1981,8 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data and schema first tag page with meta description and meta title 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"tag meta description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"tag meta description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -2022,8 +2022,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2033,8 +2033,8 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data and schema on first author page with cover image 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"Author bio\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/author/authorname/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"Author bio\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/author/authorname/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -2072,8 +2072,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2083,10 +2083,10 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data if metaTitle and metaDescription have double quotes 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site &quot;test&quot; description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site &quot;test&quot; description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -2153,8 +2153,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2164,8 +2164,8 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data on AMP post page with author image and post cover image 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -2233,15 +2233,15 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />",
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data on first index page 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -2279,8 +2279,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2290,10 +2290,10 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data on post page with author image and post cover image 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -2360,8 +2360,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2371,10 +2371,10 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data on post page with custom excerpt for description and meta description 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -2441,8 +2441,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2452,9 +2452,9 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data on post page with fall back excerpt if no meta description provided 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -2510,8 +2510,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2521,10 +2521,10 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data on post page with null author image and post cover image 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -2583,8 +2583,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2594,8 +2594,8 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data on static page 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/about/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/about/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -2656,8 +2656,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2667,8 +2667,8 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data on static page with custom post structured data 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/about/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/about/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -2729,8 +2729,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2740,10 +2740,10 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data without tags if there are no tags 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"site description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -2803,8 +2803,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2814,9 +2814,9 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection returns twitter and facebook descriptions even if no meta description available 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
-    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
+    <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
     <meta property=\\"og:type\\" content=\\"article\\">
@@ -2869,8 +2869,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2880,7 +2880,7 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection tag first page without meta and model description returns no description fields 1 1`] = `
 Object {
-  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\" />
+  "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -2917,8 +2917,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
@@ -2928,8 +2928,8 @@ Object {
 
 exports[`{{ghost_head}} helper without Code Injection tag first page without meta data if no meta title and meta description, but model description provided 1 1`] = `
 Object {
-  "rendered": "<meta name=\\"description\\" content=\\"tag description\\" />
-    <link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\" />
+  "rendered": "<meta name=\\"description\\" content=\\"tag description\\">
+    <link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\">
     <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
     <meta property=\\"og:site_name\\" content=\\"Ghost\\">
@@ -2969,8 +2969,8 @@ Object {
 }
     </script>
 
-    <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
-    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost_head.test.js.snap
@@ -4,26 +4,26 @@ exports[`{{ghost_head}} helper accent_color attaches style tag to existing scrip
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\" />
-    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\" />
-    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\">
+    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\">
+    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -133,7 +133,7 @@ Object {
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script><style>:root {--ghost-accent-color: #123456;}</style>",
 }
 `;
@@ -142,25 +142,25 @@ exports[`{{ghost_head}} helper accent_color does not include style tag in AMP co
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\" />
-    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\" />
-    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\">
+    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\">
+    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -211,26 +211,26 @@ exports[`{{ghost_head}} helper accent_color does not include style tag when not 
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\" />
-    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\" />
-    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\">
+    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\">
+    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -277,7 +277,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -288,7 +288,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -296,26 +296,26 @@ exports[`{{ghost_head}} helper accent_color includes style tag when set 1 1`] = 
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://127.0.0.1:2369/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\" />
-    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\" />
-    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\">
+    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\">
+    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -362,7 +362,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script><style>:root {--ghost-accent-color: #123456;}</style>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -370,25 +370,25 @@ exports[`{{ghost_head}} helper amp is disabled does not contain amphtml link 1 1
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\" />
-    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\" />
-    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\">
+    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-og-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\">
+    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -435,7 +435,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -723,19 +723,19 @@ exports[`{{ghost_head}} helper attribution scripts is included when tracking set
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -828,7 +828,7 @@ Object {
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -837,19 +837,19 @@ exports[`{{ghost_head}} helper attribution scripts is not included when tracking
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -942,7 +942,7 @@ Object {
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -950,19 +950,19 @@ exports[`{{ghost_head}} helper members scripts includes portal when members enab
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1055,7 +1055,7 @@ Object {
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -1064,19 +1064,19 @@ exports[`{{ghost_head}} helper members scripts includes stripe when connected 1 
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1169,7 +1169,7 @@ Object {
 }</style><script async src=\\"https://js.stripe.com/v3/\\"></script>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -1178,19 +1178,19 @@ exports[`{{ghost_head}} helper members scripts skips portal and stripe when memb
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1220,7 +1220,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -1228,19 +1228,19 @@ exports[`{{ghost_head}} helper members scripts skips stripe if not set up 1 1`] 
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1333,7 +1333,7 @@ Object {
 }</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/member-attribution.min.js?v=asset-hash\\"></script>",
 }
 `;
@@ -1342,19 +1342,19 @@ exports[`{{ghost_head}} helper search scripts includes search when labs flag ena
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1384,7 +1384,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -1392,13 +1392,13 @@ exports[`{{ghost_head}} helper with /site subdirectory returns correct rss url w
 Object {
   "rendered": "<link rel=\\"icon\\" href=\\"/site/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/site/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/site/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/site/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/site/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -1406,13 +1406,13 @@ exports[`{{ghost_head}} helper with Code Injection handles post codeinjection be
 Object {
   "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
     <style>body {background: red;}</style>",
 }
 `;
@@ -1421,13 +1421,13 @@ exports[`{{ghost_head}} helper with Code Injection handles post codeinjection be
 Object {
   "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
     <style>body {background: red;}</style>",
 }
 `;
@@ -1436,13 +1436,13 @@ exports[`{{ghost_head}} helper with Code Injection outputs post codeinjection as
 Object {
   "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
     <style>body {background: red;}</style>
     post-codeinjection",
 }
@@ -1452,13 +1452,13 @@ exports[`{{ghost_head}} helper with Code Injection returns meta tag plus injecte
 Object {
   "rendered": "<link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
     <style>body {background: red;}</style>",
 }
 `;
@@ -1468,25 +1468,25 @@ Object {
   "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
     <link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\" />
-    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-og-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\" />
-    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\">
+    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-og-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\">
+    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1537,13 +1537,13 @@ exports[`{{ghost_head}} helper with changed origin in config file contains the c
 Object {
   "rendered": "<link rel=\\"icon\\" href=\\"/site/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/site/\\" />
-    <meta name=\\"referrer\\" content=\\"origin\\" />
+    <meta name=\\"referrer\\" content=\\"origin\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/site/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/site/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/site/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -1552,40 +1552,40 @@ Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"icon\\" href=\\"/content/images/size/w256h256/favicon.png\\" type=\\"image/png\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection disallows indexing for preview pages 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"robots\\" content=\\"noindex,nofollow\\" />
-    <meta name=\\"referrer\\" content=\\"same-origin\\" />
+    <meta name=\\"robots\\" content=\\"noindex,nofollow\\">
+    <meta name=\\"referrer\\" content=\\"same-origin\\">
     <link rel=\\"amphtml\\" href=\\"http://localhost:65530/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
     
     <meta name=\\"generator\\" content=\\"Ghost \\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -1593,19 +1593,19 @@ exports[`{{ghost_head}} helper without Code Injection does not inject count scri
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1635,33 +1635,33 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection does not return structured data on paginated author pages 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/author/authorname1/page/2/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection does not return structured data on paginated tag pages 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/page/2/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -1669,7 +1669,7 @@ exports[`{{ghost_head}} helper without Code Injection implicit indexing settings
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost \\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />",
 }
@@ -1679,19 +1679,19 @@ exports[`{{ghost_head}} helper without Code Injection injects comment count scri
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1721,7 +1721,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/comment-counts.min.js?v=asset-hash\\" data-ghost-comments-counts-api=\\"http://localhost:65530/members/api/comments/counts/\\"></script>",
 }
 `;
@@ -1730,19 +1730,19 @@ exports[`{{ghost_head}} helper without Code Injection injects comment count scri
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1772,7 +1772,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">
     <script defer src=\\"/public/comment-counts.min.js?v=asset-hash\\" data-ghost-comments-counts-api=\\"http://localhost:65530/members/api/comments/counts/\\"></script>",
 }
 `;
@@ -1780,51 +1780,51 @@ Object {
 exports[`{{ghost_head}} helper without Code Injection outputs structured data but not schema for custom collection 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/featured/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/featured/\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/featured/\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/featured/\\">
+    <meta name=\\"twitter:card\\" content=\\"summary\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/featured/\\">
     
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection returns canonical URL 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/about/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"This is a short post\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/about/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:tag\\" content=\\"tag1\\" />
-    <meta property=\\"article:tag\\" content=\\"tag2\\" />
-    <meta property=\\"article:tag\\" content=\\"tag3\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\">
+    <meta property=\\"og:description\\" content=\\"This is a short post\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/about/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:tag\\" content=\\"tag1\\">
+    <meta property=\\"article:tag\\" content=\\"tag2\\">
+    <meta property=\\"article:tag\\" content=\\"tag3\\">
     
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"This is a short post\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/about/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\" />
-    <meta name=\\"twitter:label2\\" content=\\"Filed under\\" />
-    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\" />
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"This is a short post\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/about/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:label2\\" content=\\"Filed under\\">
+    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1860,7 +1860,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -1868,19 +1868,19 @@ exports[`{{ghost_head}} helper without Code Injection returns meta structured da
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site SEO description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"facebook site title\\" />
-    <meta property=\\"og:description\\" content=\\"facebook site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/facebook-image.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"twitter site title\\" />
-    <meta name=\\"twitter:description\\" content=\\"twitter site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/twitter-image.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"facebook site title\\">
+    <meta property=\\"og:description\\" content=\\"facebook site description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/facebook-image.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"twitter site title\\">
+    <meta name=\\"twitter:description\\" content=\\"twitter site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/twitter-image.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -1910,49 +1910,49 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection returns meta tag string even if safeVersion is invalid 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\">
+    <meta name=\\"twitter:card\\" content=\\"summary\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
     
     <meta name=\\"generator\\" content=\\"Ghost 0.9\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection returns meta tag string on paginated index page without structured data and schema 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/page/2/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\" />
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection returns next & prev URL correctly for middle page 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/page/3/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"prev\\" href=\\"http://localhost:65530/page/2/\\" />
     <link rel=\\"next\\" href=\\"http://localhost:65530/page/4/\\" />
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
@@ -1960,14 +1960,14 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection returns next & prev URL correctly for second page 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/page/2/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"prev\\" href=\\"http://localhost:65530/\\" />
     <link rel=\\"next\\" href=\\"http://localhost:65530/page/3/\\" />
     <meta name=\\"generator\\" content=\\"Ghost 0.3\\" />
@@ -1975,7 +1975,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -1983,20 +1983,20 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data an
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"tag meta description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"tag meta title\\" />
-    <meta property=\\"og:description\\" content=\\"tag meta description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"tag meta title\\" />
-    <meta name=\\"twitter:description\\" content=\\"tag meta description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"tag meta title\\">
+    <meta property=\\"og:description\\" content=\\"tag meta description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"tag meta title\\">
+    <meta name=\\"twitter:description\\" content=\\"tag meta description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2027,7 +2027,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2035,22 +2035,22 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data an
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"Author bio\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/author/authorname/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"profile\\" />
-    <meta property=\\"og:title\\" content=\\"Author name - Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"Author bio\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/author/authorname/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/author-cover-image.png\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Author name - Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"Author bio\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/author/authorname/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/author-cover-image.png\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"profile\\">
+    <meta property=\\"og:title\\" content=\\"Author name - Ghost\\">
+    <meta property=\\"og:description\\" content=\\"Author bio\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/author/authorname/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/author-cover-image.png\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Author name - Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"Author bio\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/author/authorname/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/author-cover-image.png\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2077,7 +2077,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2085,32 +2085,32 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data if
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site &quot;test&quot; description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Welcome to Ghost &quot;test&quot;\\" />
-    <meta property=\\"og:description\\" content=\\"site &quot;test&quot; description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:tag\\" content=\\"tag1\\" />
-    <meta property=\\"article:tag\\" content=\\"tag2\\" />
-    <meta property=\\"article:tag\\" content=\\"tag3\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Welcome to Ghost &quot;test&quot;\\">
+    <meta property=\\"og:description\\" content=\\"site &quot;test&quot; description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:tag\\" content=\\"tag1\\">
+    <meta property=\\"article:tag\\" content=\\"tag2\\">
+    <meta property=\\"article:tag\\" content=\\"tag3\\">
     
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost &quot;test&quot;\\" />
-    <meta name=\\"twitter:description\\" content=\\"site &quot;test&quot; description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\" />
-    <meta name=\\"twitter:label2\\" content=\\"Filed under\\" />
-    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost &quot;test&quot;\\">
+    <meta name=\\"twitter:description\\" content=\\"site &quot;test&quot; description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:label2\\" content=\\"Filed under\\">
+    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2158,7 +2158,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2166,31 +2166,31 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data on
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-facebook-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:tag\\" content=\\"tag1\\" />
-    <meta property=\\"article:tag\\" content=\\"tag2\\" />
-    <meta property=\\"article:tag\\" content=\\"tag3\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-facebook-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:tag\\" content=\\"tag1\\">
+    <meta property=\\"article:tag\\" content=\\"tag2\\">
+    <meta property=\\"article:tag\\" content=\\"tag3\\">
     
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\" />
-    <meta name=\\"twitter:label2\\" content=\\"Filed under\\" />
-    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:label2\\" content=\\"Filed under\\">
+    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2242,19 +2242,19 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data on
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2284,7 +2284,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2292,32 +2292,32 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data on
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\" />
-    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"2008-05-31T19:18:15.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"2014-10-06T15:23:54.000Z\\" />
-    <meta property=\\"article:tag\\" content=\\"tag1\\" />
-    <meta property=\\"article:tag\\" content=\\"tag2\\" />
-    <meta property=\\"article:tag\\" content=\\"tag3\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\">
+    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"2008-05-31T19:18:15.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"2014-10-06T15:23:54.000Z\\">
+    <meta property=\\"article:tag\\" content=\\"tag1\\">
+    <meta property=\\"article:tag\\" content=\\"tag2\\">
+    <meta property=\\"article:tag\\" content=\\"tag3\\">
     
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\" />
-    <meta name=\\"twitter:label2\\" content=\\"Filed under\\" />
-    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:label2\\" content=\\"Filed under\\">
+    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2365,7 +2365,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2373,32 +2373,32 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data on
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"post custom excerpt\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-facebook-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:tag\\" content=\\"tag1\\" />
-    <meta property=\\"article:tag\\" content=\\"tag2\\" />
-    <meta property=\\"article:tag\\" content=\\"tag3\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\">
+    <meta property=\\"og:description\\" content=\\"post custom excerpt\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-facebook-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:tag\\" content=\\"tag1\\">
+    <meta property=\\"article:tag\\" content=\\"tag2\\">
+    <meta property=\\"article:tag\\" content=\\"tag3\\">
     
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\" />
-    <meta name=\\"twitter:description\\" content=\\"post custom excerpt\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\" />
-    <meta name=\\"twitter:label2\\" content=\\"Filed under\\" />
-    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\">
+    <meta name=\\"twitter:description\\" content=\\"post custom excerpt\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:label2\\" content=\\"Filed under\\">
+    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2446,33 +2446,33 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection returns structured data on post page with fall back excerpt if no meta description provided 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"This is a short post\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"This is a short post\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\">
+    <meta property=\\"og:description\\" content=\\"This is a short post\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"This is a short post\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2515,7 +2515,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2523,32 +2523,32 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data on
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:tag\\" content=\\"tag1\\" />
-    <meta property=\\"article:tag\\" content=\\"tag2\\" />
-    <meta property=\\"article:tag\\" content=\\"tag3\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:tag\\" content=\\"tag1\\">
+    <meta property=\\"article:tag\\" content=\\"tag2\\">
+    <meta property=\\"article:tag\\" content=\\"tag3\\">
     
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\" />
-    <meta name=\\"twitter:label2\\" content=\\"Filed under\\" />
-    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:label2\\" content=\\"Filed under\\">
+    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2588,7 +2588,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2596,25 +2596,25 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data on
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/about/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"About\\" />
-    <meta property=\\"og:description\\" content=\\"all about our site\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/about/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-image-about.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"About\\" />
-    <meta name=\\"twitter:description\\" content=\\"all about our site\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/about/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-image-about.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"About\\">
+    <meta property=\\"og:description\\" content=\\"all about our site\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/about/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-image-about.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"About\\">
+    <meta name=\\"twitter:description\\" content=\\"all about our site\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/about/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-image-about.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2661,7 +2661,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2669,25 +2669,25 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data on
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"all about our site\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/about/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\" />
-    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/about/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-og-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\" />
-    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/about/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"Custom Facebook title\\">
+    <meta property=\\"og:description\\" content=\\"Custom Facebook description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/about/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-og-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Custom Twitter title\\">
+    <meta name=\\"twitter:description\\" content=\\"Custom Twitter description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/about/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-twitter-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2734,7 +2734,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2742,26 +2742,26 @@ exports[`{{ghost_head}} helper without Code Injection returns structured data wi
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"site description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"site description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\" />
-    <meta name=\\"twitter:creator\\" content=\\"@testuser\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\">
+    <meta property=\\"og:description\\" content=\\"site description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"site description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/test-image.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2808,37 +2808,37 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection returns twitter and facebook descriptions even if no meta description available 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     <link rel=\\"amphtml\\" href=\\"http://localhost:65530/post/amp/\\" />
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"article\\" />
-    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"This is a short post\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta property=\\"article:tag\\" content=\\"tag1\\" />
-    <meta property=\\"article:tag\\" content=\\"tag2\\" />
-    <meta property=\\"article:tag\\" content=\\"tag3\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"article\\">
+    <meta property=\\"og:title\\" content=\\"Welcome to Ghost\\">
+    <meta property=\\"og:description\\" content=\\"This is a short post\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:tag\\" content=\\"tag1\\">
+    <meta property=\\"article:tag\\" content=\\"tag2\\">
+    <meta property=\\"article:tag\\" content=\\"tag3\\">
     
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"This is a short post\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\" />
-    <meta name=\\"twitter:label1\\" content=\\"Written by\\" />
-    <meta name=\\"twitter:data1\\" content=\\"Author name\\" />
-    <meta name=\\"twitter:label2\\" content=\\"Filed under\\" />
-    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\" />
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"Welcome to Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"This is a short post\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/post/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/site-cover.png\\">
+    <meta name=\\"twitter:label1\\" content=\\"Written by\\">
+    <meta name=\\"twitter:data1\\" content=\\"Author name\\">
+    <meta name=\\"twitter:label2\\" content=\\"Filed under\\">
+    <meta name=\\"twitter:data2\\" content=\\"tag1, tag2, tag3\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2874,25 +2874,25 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
 exports[`{{ghost_head}} helper without Code Injection tag first page without meta and model description returns no description fields 1 1`] = `
 Object {
   "rendered": "<link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"tagtitle - Ghost\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"tagtitle - Ghost\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"tagtitle - Ghost\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"tagtitle - Ghost\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2922,7 +2922,7 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;
 
@@ -2930,20 +2930,20 @@ exports[`{{ghost_head}} helper without Code Injection tag first page without met
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"tag description\\" />
     <link rel=\\"canonical\\" href=\\"http://localhost:65530/tag/tagtitle/\\" />
-    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\" />
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
     
-    <meta property=\\"og:site_name\\" content=\\"Ghost\\" />
-    <meta property=\\"og:type\\" content=\\"website\\" />
-    <meta property=\\"og:title\\" content=\\"tagtitle - Ghost\\" />
-    <meta property=\\"og:description\\" content=\\"tag description\\" />
-    <meta property=\\"og:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\" />
-    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\" />
-    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\" />
-    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\" />
-    <meta name=\\"twitter:title\\" content=\\"tagtitle - Ghost\\" />
-    <meta name=\\"twitter:description\\" content=\\"tag description\\" />
-    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\" />
-    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\" />
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"tagtitle - Ghost\\">
+    <meta property=\\"og:description\\" content=\\"tag description\\">
+    <meta property=\\"og:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\">
+    <meta property=\\"og:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"tagtitle - Ghost\\">
+    <meta name=\\"twitter:description\\" content=\\"tag description\\">
+    <meta name=\\"twitter:url\\" content=\\"http://localhost:65530/tag/tagtitle/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://localhost:65530/content/images/tag-image.png\\">
     
     <script type=\\"application/ld+json\\">
 {
@@ -2974,6 +2974,6 @@ Object {
     
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:65530/\\" crossorigin=\\"anonymous\\"></script>
     
-    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\" />",
+    <link href=\\"http://localhost:65530/webmentions/receive/\\" rel=\\"webmention\\">",
 }
 `;


### PR DESCRIPTION
no issue
The Nu Html Checker from https://validator.w3.org/nu/ says "Trailing slash on void elements has no effect and interacts badly with unquoted attribute values."

For example: https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.merisia.ca%2F
![image](https://github.com/TryGhost/Ghost/assets/7907713/058e45bf-392c-4be3-8317-453353f726c9)


Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f18867</samp>

Refactor `ghost_head` helper to generate valid HTML5 and enable webmention integration.
