### PR TITLE
Lazyloaded `@extractus/oembed-extractor` dependency

### DIFF
--- a/ghost/core/core/server/services/oembed/TwitterOEmbedProvider.js
+++ b/ghost/core/core/server/services/oembed/TwitterOEmbedProvider.js
@@ -1,4 +1,3 @@
-const {extract} = require('@extractus/oembed-extractor');
 const logging = require('@tryghost/logging');
 
 /**
@@ -38,6 +37,8 @@ class TwitterOEmbedProvider {
         if (!match) {
             return null;
         }
+
+        const {extract} = require('@extractus/oembed-extractor');
 
         /** @type {object} */
         const oembedData = await extract(url.href);

--- a/ghost/oembed-service/lib/OEmbedService.js
+++ b/ghost/oembed-service/lib/OEmbedService.js
@@ -1,7 +1,6 @@
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
-const {extract, hasProvider} = require('@extractus/oembed-extractor');
 const cheerio = require('cheerio');
 const _ = require('lodash');
 const charset = require('charset');
@@ -19,6 +18,8 @@ const messages = {
  * @returns {{url: string, provider: boolean}}
  */
 const findUrlWithProvider = (url) => {
+    const {hasProvider} = require('@extractus/oembed-extractor');
+
     let provider;
 
     // build up a list of URL variations to test against because the oembed
@@ -95,6 +96,8 @@ class OEmbedService {
      * @param {string} url
      */
     async knownProvider(url) {
+        const {extract} = require('@extractus/oembed-extractor');
+
         try {
             return await extract(url);
         } catch (err) {


### PR DESCRIPTION
- this dependency seems a pretty heavy one to require upon boot and given most sites don't need it to function as normal, this saves several MB of RAM per instance

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 138c3c6</samp>

Optimized the oembed extraction process by moving module imports to local scopes. This reduces the loading time and memory usage of the `TwitterOEmbedProvider` and the `OEmbedService` classes.
