### PR TITLE
🐛 Fixed visibility of the post history feature

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -150,7 +150,7 @@ export default class GhPostSettingsMenu extends Component {
             && this.post.emailOnly === false;
 
         if (this.post.isPublished === true) {
-            showPostHistory = this.post.hasEmail === false;
+            return showPostHistory && this.post.hasEmail === false;
         }
 
         return showPostHistory;


### PR DESCRIPTION
We had side stepped the existing checks of lexical and the feature flag when checking if a published post was sent as an email. This takes into account the existing checks to make sure the feature isn't leaked without the flag


<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8ed05e</samp>

Fix bug with post history menu item for emailed posts. Hide the menu item in `gh-post-settings-menu.js` if the post has an email.
