### PR TITLE
Replaced modal feedback on dropdown in editor

### DIFF
--- a/ghost/admin/app/components/modal-feedback-lexical.hbs
+++ b/ghost/admin/app/components/modal-feedback-lexical.hbs
@@ -1,4 +1,4 @@
-<div class="modal-content" data-test-modal="lexical-feedback">
+<div class="modal-content {{@class}}" data-test-modal="lexical-feedback">
     <header class="modal-header">
         <h1>Editor beta feedback</h1>
     </header>
@@ -10,9 +10,9 @@
         <form>
             <GhFormGroup>
                 <label for="feedback-lexical">Have any issues? Feedback? Let us know below!</label>
-                <GhTextarea 
+                <GhTextarea
                     @id="feedback-lexical"
-                    @name="feedback-lexical" 
+                    @name="feedback-lexical"
                     @value={{this.feedbackMessage}}
                     @placeholder="I've noticed that..."
                     @shouldFocus={{true}}
@@ -28,7 +28,7 @@
 
     <div class="modal-footer">
         <button class="gh-btn" type="button" {{on "click" this.closeModal}}><span>Cancel</span></button>
-        <GhTaskButton 
+        <GhTaskButton
             @buttonText="Send feedback"
             @task={{this.submitFeedback}}
             @class="gh-btn gh-btn-black gh-btn-icon"

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -2,7 +2,6 @@ import ConfirmEditorLeaveModal from '../components/modals/editor/confirm-leave';
 import Controller, {inject as controller} from '@ember/controller';
 import DeletePostModal from '../components/modals/delete-post';
 import DeleteSnippetModal from '../components/editor/modals/delete-snippet';
-import FeedbackLexicalModal from '../components/modal-feedback-lexical';
 import PostModel from 'ghost-admin/models/post';
 import PublishLimitModal from '../components/modals/limits/publish-limit';
 import ReAuthenticateModal from '../components/editor/modals/re-authenticate';
@@ -24,7 +23,6 @@ import {isArray as isEmberArray} from '@ember/array';
 import {isHostLimitError, isServerUnreachableError, isVersionMismatchError} from 'ghost-admin/services/ajax';
 import {isInvalidError} from 'ember-ajax/errors';
 import {inject as service} from '@ember/service';
-import {tracked} from '@glimmer/tracking';
 
 const DEFAULT_TITLE = '(Untitled)';
 
@@ -114,8 +112,6 @@ export default class LexicalEditorController extends Controller {
     @service ui;
 
     @inject config;
-
-    @tracked showFeedbackLexicalModal = false;
 
     /* public properties -----------------------------------------------------*/
 
@@ -410,11 +406,6 @@ export default class LexicalEditorController extends Controller {
         await this.modals.open(DeleteSnippetModal, {
             snippet
         });
-    }
-
-    @action
-    async openFeedbackLexical() {
-        await this.modals.open(FeedbackLexicalModal);
     }
 
     /* Public tasks ----------------------------------------------------------*/

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -395,6 +395,16 @@
     align-items: center;
     border-radius: 3px;
     background: #fff;
+    cursor: pointer;
+}
+
+.gh-editor-feedback-dropdown {
+    border-radius: 3px;
+    box-shadow: 0 0 0 1px rgba(0,0,0,.04), 0 8px 20px -3px rgba(0,0,0,.2);
+    padding: 32px;
+    background-color: #fff;
+    background-clip: padding-box;
+    margin-bottom: 20px;
 }
 
 .gh-editor-feedback {

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -94,16 +94,25 @@
             />
 
             {{#if (feature 'lexicalEditor')}}
-            <div class="gh-editor-feedback-container">
-                <button
-                    type="button"
-                    class="gh-editor-feedback"
-                    {{on "click" this.openFeedbackLexical}}
-                    data-test-button="lexical-editor-feedback"
+                <GhBasicDropdown
+                    @verticalPosition="above"
+                    @horizontalPosition="left" as |dd|
                 >
-                    <span>Feedback?</span>
-                </button>
-            </div>
+                    <dd.Trigger
+                        class="gh-editor-feedback-container"
+                        data-test-button="lexical-editor-feedback"
+                    >
+                        <span class="gh-editor-feedback">
+                            Feedback?
+                        </span>
+                    </dd.Trigger>
+
+                    <dd.Content>
+                        <div {{css-transition "anim-fade-in-scale"}}>
+                            <ModalFeedbackLexical @class="gh-editor-feedback-dropdown" @close={{dd.actions.close}} />
+                        </div>
+                    </dd.Content>
+                </GhBasicDropdown>
             {{/if}}
 
             <div class="gh-editor-wordcount-container">


### PR DESCRIPTION
refs TryGhost/Team#3213

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a96438</samp>

This pull request enhances the feedback modal feature in the lexical editor. It improves the layout and appearance of the modal and its trigger button, and uses a dropdown component to show and hide the modal.
