### PR TITLE
🐛 Fixed validation error when creating 0% offer

### DIFF
--- a/ghost/admin/app/validators/offer.js
+++ b/ghost/admin/app/validators/offer.js
@@ -16,12 +16,8 @@ export default BaseValidator.create({
     },
 
     amount(model) {
-        if (!model.amount) {
-            if (model.type === 'trial') {
-                model.errors.add('amount', 'Free trial must be at least 1 day.');
-            } else {
-                model.errors.add('amount', 'Please enter the amount.');
-            }
+        if (model.amount === '' || model.amount === undefined) {
+            model.errors.add('amount', 'Please enter the amount.');
 
             return this.invalidate();
         }


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3073

Fixed validation error when creating 0% offer. Issue was occurring due to a falsy check on the offer value. Have resolved by having a more strict check on the offer value based on the possible empty value it can be - If creating a new offer without providing an offer value, the value will be `undefined`. If supplying an offer value, then removing the offer value, the value will be an empty string. This check prevents `0` being classed as an invalid value.