### PR TITLE
🐛 Fixed link to translation information in general settings

### DIFF
--- a/ghost/admin/app/templates/settings/general.hbs
+++ b/ghost/admin/app/templates/settings/general.hbs
@@ -96,7 +96,7 @@
                                     data-test-input="locale"
                                 />
                                 <GhErrorMessage @errors={{this.settings.errors}} @property="locale" />
-                                <p>Default: English (<strong>en</strong>); find out more about <a href="https://ghost.org/docs/i18n/" target="_blank" rel="noopener noreferrer">using Ghost in other languages</a></p>
+                                <p>Default: English (<strong>en</strong>); find out more about <a href="https://ghost.org/docs/faq/translation/" target="_blank" rel="noopener noreferrer">using Ghost in other languages</a></p>
                             </GhFormGroup>
                         </div>
                         {{/liquid-if}}


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3212

The link in the description for the publication language setting in general settings was pointing to an outdated page (https://ghost.org/docs/i18n/). This fix updates the link to point at https://ghost.org/docs/faq/translation/