### PR TITLE
Moved migrate app labs flag to Beta features

### DIFF
--- a/ghost/admin/app/routes/migrate.js
+++ b/ghost/admin/app/routes/migrate.js
@@ -8,13 +8,8 @@ export default class MigrateRoute extends AuthenticatedRoute {
     beforeModel() {
         super.beforeModel(...arguments);
 
-        // Redirect to Home is feature not enabled
-        if (!this.feature.migrateApp) {
-            return this.transitionTo('home');
-        }
-
         // Only allow Owner & Administrator to access this route
-        if (!this.session.user.isAdmin || !this.feature.migrateApp) {
+        if (!this.session.user.isAdmin) {
             return this.transitionTo('home');
         }
     }

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -68,7 +68,6 @@ export default class FeatureService extends Service {
     @feature('websockets') websockets;
     @feature('stripeAutomaticTax') stripeAutomaticTax;
     @feature('makingItRain') makingItRain;
-    @feature('migrateApp') migrateApp;
     @feature('i18n') i18n;
     @feature('postHistory') postHistory;
     @feature('postDiffing') postDiffing;

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -31,20 +31,6 @@
                     </div>
                 </div>
 
-                {{#if this.feature.migrateApp}}
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
-                            <h4 class="gh-expandable-title">Migrate content</h4>
-                            <p class="gh-expandable-description">Import your content from Substack</p>
-                        </div>
-                        <LinkTo @route="migrate" class="gh-btn" data-test-link="migrate">
-                            <span>Open</span>
-                        </LinkTo>
-                    </div>
-                </div>
-                {{/if}}
-
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
@@ -70,6 +56,20 @@
         <div class="gh-main-section">
             <h4 class="gh-main-section-header small bn">Beta features</h4>
             <div class="gh-expandable">
+                {{#if this.feature.migrateApp}}
+                <div class="gh-expandable-block">
+                    <div class="gh-expandable-header">
+                        <div>
+                            <h4 class="gh-expandable-title">Substack migrator</h4>
+                            <p class="gh-expandable-description">Import all your content, members and paid subscriptions</p>
+                        </div>
+                        <LinkTo @route="migrate" class="gh-btn" data-test-link="migrate">
+                            <span>Open</span>
+                        </LinkTo>
+                    </div>
+                </div>
+                {{/if}}
+
                 <div class="gh-expandable-block">
                     <GhUploader
                         @extensions={{this.redirectsFileExtensions}}

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -56,7 +56,6 @@
         <div class="gh-main-section">
             <h4 class="gh-main-section-header small bn">Beta features</h4>
             <div class="gh-expandable">
-                {{#if this.feature.migrateApp}}
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
@@ -68,7 +67,6 @@
                         </LinkTo>
                     </div>
                 </div>
-                {{/if}}
 
                 <div class="gh-expandable-block">
                     <GhUploader
@@ -290,19 +288,6 @@
                         </div>
                         <div class="for-switch">
                             <GhFeatureFlag @flag="makingItRain" />
-                        </div>
-                    </div>
-                </div>
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
-                            <h4 class="gh-expandable-title">Migrate content</h4>
-                            <p class="gh-expandable-description">
-                               Import content from other platforms to Ghost
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                            <GhFeatureFlag @flag="migrateApp" />
                         </div>
                     </div>
                 </div>

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -32,7 +32,6 @@ const BETA_FEATURES = [
 
 const ALPHA_FEATURES = [
     'urlCache',
-    'migrateApp',
     'lexicalEditor',
     'lexicalMultiplayer',
     'websockets',


### PR DESCRIPTION

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c173531</samp>

This pull request removes the `migrateApp` feature flag and replaces the migrate content section in the labs settings with a new substack migrator section. This allows users to import their content, members and subscriptions from substack without needing to enable a feature flag. It also simplifies and cleans up the code related to the migrate route and the feature service.
