### PR TITLE
Collections Admin API

### DIFF
--- a/ghost/collections/package.json
+++ b/ghost/collections/package.json
@@ -28,6 +28,9 @@
         "typescript": "5.0.4"
     },
     "dependencies": {
-        "@tryghost/in-memory-repository": "0.0.0"
+        "@tryghost/errors": "^1.2.25",
+        "@tryghost/in-memory-repository": "0.0.0",
+        "@tryghost/tpl": "^0.1.25",
+        "bson-objectid": "^2.0.4"
     }
 }

--- a/ghost/collections/src/CollectionsRepositoryInMemory.ts
+++ b/ghost/collections/src/CollectionsRepositoryInMemory.ts
@@ -1,9 +1,44 @@
+// have to use requires until there are type definitions for these modules
+const {ValidationError} = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+
+import ObjectID from 'bson-objectid';
 import {InMemoryRepository} from '@tryghost/in-memory-repository';
 import {Collection} from './Collection';
+
+const messages = {
+    invalidIDProvided: 'Invalid ID provided for Collection'
+};
 
 export class CollectionsRepositoryInMemory extends InMemoryRepository<string, Collection> {
     constructor() {
         super();
+    }
+
+    async create(data: any): Promise<Collection> {
+        let id;
+
+        if (!data.id) {
+            id = new ObjectID();
+        } else if (typeof data.id === 'string') {
+            id = ObjectID.createFromHexString(data.id);
+        } else if (data.id instanceof ObjectID) {
+            id = data.id;
+        } else {
+            throw new ValidationError({
+                message: tpl(messages.invalidIDProvided)
+            });
+        }
+
+        return {
+            id: id.toHexString(),
+            title: data.title,
+            description: data.description,
+            type: data.type,
+            filter: data.filter,
+            feature_image: data.feature_image,
+            deleted: data.deleted || false
+        };
     }
 
     protected toPrimitive(entity: Collection): object {

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -21,8 +21,22 @@ export class CollectionsService {
         return await this.repository.getById(id);
     }
 
-    async getAll(): Promise<Collection[]> {
-        return await this.repository.getAll();
+    async getAll(options?: any): Promise<{data: Collection[], meta: any}> {
+        const collections = await this.repository.getAll(options);
+
+        return {
+            data: collections,
+            meta: {
+                pagination: {
+                    page: 1,
+                    pages: 1,
+                    limit: collections.length,
+                    total: collections.length,
+                    prev: null,
+                    next: null
+                }
+            }
+        };
     }
 
     async destroy(id: string): Promise<void> {

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -17,6 +17,19 @@ export class CollectionsService {
         return collection;
     }
 
+    async edit(data: any): Promise<Collection | null> {
+        const collection = await this.repository.getById(data.id);
+
+        if (!collection) {
+            return null;
+        }
+
+        Object.assign(collection, data);
+        await this.repository.save(collection);
+
+        return collection;
+    }
+
     async getById(id: string): Promise<Collection | null> {
         return await this.repository.getById(id);
     }

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -11,8 +11,10 @@ export class CollectionsService {
         this.repository = deps.repository;
     }
 
-    async save(collection: Collection): Promise<Collection> {
-        return await this.repository.save(collection);
+    async save(data: any): Promise<Collection> {
+        const collection = await this.repository.create(data);
+        await this.repository.save(collection);
+        return collection;
     }
 
     async getById(id: string): Promise<Collection | null> {

--- a/ghost/collections/src/index.ts
+++ b/ghost/collections/src/index.ts
@@ -1,1 +1,2 @@
 export * from './CollectionsService';
+export * from './CollectionsRepositoryInMemory';

--- a/ghost/collections/test/collections.test.ts
+++ b/ghost/collections/test/collections.test.ts
@@ -4,16 +4,18 @@ import {CollectionsService} from '../src/index';
 import {CollectionsRepositoryInMemory} from '../src/CollectionsRepositoryInMemory';
 
 describe('collections', function () {
-    it('Instantiates a CollectionsService', function () {
+    let collectionsService: CollectionsService;
+
+    beforeEach(function () {
         const repository = new CollectionsRepositoryInMemory();
-        const collectionsService = new CollectionsService({repository});
+        collectionsService = new CollectionsService({repository});
+    });
+
+    it('Instantiates a CollectionsService', function () {
         assert.ok(collectionsService, 'CollectionsService should initialize');
     });
 
     it('Can do CRUD operations on a collection', async function () {
-        const repository = new CollectionsRepositoryInMemory();
-        const collectionsService = new CollectionsService({repository});
-
         const savedCollection = await collectionsService.save({
             title: 'testing collections',
             description: 'testing collections description',
@@ -39,9 +41,6 @@ describe('collections', function () {
     });
 
     it('Can create a collection with predefined ID', async function () {
-        const repository = new CollectionsRepositoryInMemory();
-        const collectionsService = new CollectionsService({repository});
-
         const id = new ObjectID();
         const savedCollection = await collectionsService.save({
             id: id.toHexString()
@@ -51,9 +50,6 @@ describe('collections', function () {
     });
 
     it('Can create a collection with predefined ObjectID instance', async function () {
-        const repository = new CollectionsRepositoryInMemory();
-        const collectionsService = new CollectionsService({repository});
-
         const id = new ObjectID();
         const savedCollection = await collectionsService.save({
             id: id
@@ -63,9 +59,6 @@ describe('collections', function () {
     });
 
     it('Throws an error when trying to save a collection with an invalid ID', async function () {
-        const repository = new CollectionsRepositoryInMemory();
-        const collectionsService = new CollectionsService({repository});
-
         try {
             await collectionsService.save({
                 id: 12345

--- a/ghost/collections/test/collections.test.ts
+++ b/ghost/collections/test/collections.test.ts
@@ -30,7 +30,7 @@ describe('collections', function () {
         assert.equal(createdCollection.title, 'testing collections', 'Collection title should match');
 
         const allCollections = await collectionsService.getAll();
-        assert.equal(allCollections.length, 1, 'There should be one collection');
+        assert.equal(allCollections.data.length, 1, 'There should be one collection');
 
         await collectionsService.destroy(savedCollection.id);
         const deletedCollection = await collectionsService.getById(savedCollection.id);

--- a/ghost/collections/test/collections.test.ts
+++ b/ghost/collections/test/collections.test.ts
@@ -67,4 +67,30 @@ describe('collections', function () {
             assert.equal(error.message, 'Invalid ID provided for Collection', 'Error message should match');
         }
     });
+
+    describe('edit', function () {
+        it('Can edit existing collection', async function () {
+            const savedCollection = await collectionsService.save({
+                title: 'testing collections',
+                description: 'testing collections description',
+                type: 'manual',
+                deleted: false
+            });
+
+            const editedCollection = await collectionsService.edit({
+                id: savedCollection.id,
+                description: 'Edited description'
+            });
+
+            assert.equal(editedCollection?.description, 'Edited description', 'Collection description should be edited');
+        });
+
+        it('Resolves to null when editing unexistend collection', async function () {
+            const editedCollection = await collectionsService.edit({
+                id: '12345'
+            });
+
+            assert.equal(editedCollection, null, 'Collection should be null');
+        });
+    });
 });

--- a/ghost/collections/test/collections.test.ts
+++ b/ghost/collections/test/collections.test.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import ObjectID from 'bson-objectid';
 import {CollectionsService} from '../src/index';
 import {CollectionsRepositoryInMemory} from '../src/CollectionsRepositoryInMemory';
 
@@ -13,8 +14,7 @@ describe('collections', function () {
         const repository = new CollectionsRepositoryInMemory();
         const collectionsService = new CollectionsService({repository});
 
-        await collectionsService.save({
-            id: 'test_id_1',
+        const savedCollection = await collectionsService.save({
             title: 'testing collections',
             description: 'testing collections description',
             type: 'manual',
@@ -23,17 +23,55 @@ describe('collections', function () {
             deleted: false
         });
 
-        const createdCollection = await collectionsService.getById('test_id_1');
+        const createdCollection = await collectionsService.getById(savedCollection.id);
 
         assert.ok(createdCollection, 'Collection should be saved');
+        assert.ok(savedCollection.id, 'Collection should have an id');
         assert.equal(createdCollection.title, 'testing collections', 'Collection title should match');
 
         const allCollections = await collectionsService.getAll();
         assert.equal(allCollections.length, 1, 'There should be one collection');
 
-        await collectionsService.destroy('test_id_1');
-        const deletedCollection = await collectionsService.getById('test_id_1');
+        await collectionsService.destroy(savedCollection.id);
+        const deletedCollection = await collectionsService.getById(savedCollection.id);
 
         assert.equal(deletedCollection, null, 'Collection should be deleted');
+    });
+
+    it('Can create a collection with predefined ID', async function () {
+        const repository = new CollectionsRepositoryInMemory();
+        const collectionsService = new CollectionsService({repository});
+
+        const id = new ObjectID();
+        const savedCollection = await collectionsService.save({
+            id: id.toHexString()
+        });
+
+        assert.equal(savedCollection.id, id.toHexString(), 'Collection should have same id');
+    });
+
+    it('Can create a collection with predefined ObjectID instance', async function () {
+        const repository = new CollectionsRepositoryInMemory();
+        const collectionsService = new CollectionsService({repository});
+
+        const id = new ObjectID();
+        const savedCollection = await collectionsService.save({
+            id: id
+        });
+
+        assert.equal(savedCollection.id, id.toHexString(), 'Collection should have same id');
+    });
+
+    it('Throws an error when trying to save a collection with an invalid ID', async function () {
+        const repository = new CollectionsRepositoryInMemory();
+        const collectionsService = new CollectionsService({repository});
+
+        try {
+            await collectionsService.save({
+                id: 12345
+            });
+        } catch (error: any) {
+            assert.equal(error.message, 'Invalid ID provided for Collection', 'Error message should match');
+        }
     });
 });

--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -49,12 +49,14 @@ module.exports = {
         // @NOTE: should have permissions when moving out of Alpha
         permissions: false,
         async query(frame) {
-            const model = await collectionsService.api.edit(frame.data.collections[0], frame.options);
+            const model = await collectionsService.api.edit(Object.assign(frame.data.collections[0], {
+                id: frame.options.id
+            }), frame.options);
 
             if (!model) {
-                return Promise.reject(new errors.NotFoundError({
-                    message: tpl(messages.tagNotFound)
-                }));
+                throw new errors.NotFoundError({
+                    message: tpl(messages.collectionNotFound)
+                });
             }
 
             // @NOTE: cache invalidation has to be done manually for now

--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -22,6 +22,25 @@ module.exports = {
         }
     },
 
+    read: {
+        data: [
+            'id'
+        ],
+        // @NOTE: should have permissions when moving out of Alpha
+        permissions: false,
+        async query(frame) {
+            const model = await collectionsService.api.read(frame.data.id, frame.options);
+
+            if (!model) {
+                throw new errors.NotFoundError({
+                    message: tpl(messages.collectionNotFound)
+                });
+            }
+
+            return model;
+        }
+    },
+
     add: {
         statusCode: 201,
         headers: {

--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -1,4 +1,10 @@
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
 const collectionsService = require('../../services/collections');
+
+const messages = {
+    collectionNotFound: 'Collection not found.'
+};
 
 module.exports = {
     docName: 'collections',
@@ -25,6 +31,42 @@ module.exports = {
         permissions: false,
         async query(frame) {
             return await collectionsService.api.add(frame.data.collections[0], frame.options);
+        }
+    },
+
+    edit: {
+        headers: {},
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        // @NOTE: should have permissions when moving out of Alpha
+        permissions: false,
+        async query(frame) {
+            const model = await collectionsService.api.edit(frame.data.collections[0], frame.options);
+
+            if (!model) {
+                return Promise.reject(new errors.NotFoundError({
+                    message: tpl(messages.tagNotFound)
+                }));
+            }
+
+            // @NOTE: cache invalidation has to be done manually for now
+            //        because the model's wasChanged is not returned from
+            //        the service using in-memory repository layer
+            // if (model.wasChanged()) {
+            this.headers.cacheInvalidate = true;
+            // } else {
+            //     this.headers.cacheInvalidate = false;
+            // }
+
+            return model;
         }
     }
 };

--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -1,0 +1,18 @@
+const collectionsService = require('../../services/collections');
+
+module.exports = {
+    docName: 'collections',
+
+    browse: {
+        options: [
+            'limit',
+            'order',
+            'page'
+        ],
+        // @NOTE: should have permissions when moving out of Alpha
+        permissions: false,
+        query(frame) {
+            return collectionsService.api.browse(frame.options);
+        }
+    }
+};

--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -89,5 +89,27 @@ module.exports = {
 
             return model;
         }
+    },
+
+    destroy: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: true
+        },
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        // @NOTE: should have permissions when moving out of Alpha
+        permissions: false,
+        async query(frame) {
+            return await collectionsService.api.destroy(frame.options.id);
+        }
     }
 };

--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -14,5 +14,17 @@ module.exports = {
         query(frame) {
             return collectionsService.api.browse(frame.options);
         }
+    },
+
+    add: {
+        statusCode: 201,
+        headers: {
+            cacheInvalidate: true
+        },
+        // @NOTE: should have permissions when moving out of Alpha
+        permissions: false,
+        async query(frame) {
+            return await collectionsService.api.add(frame.data.collections[0], frame.options);
+        }
     }
 };

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -12,6 +12,10 @@ module.exports = {
         return apiFramework.pipeline(require('./authentication'), localUtils);
     },
 
+    get collections() {
+        return apiFramework.pipeline(require('./collections'), localUtils);
+    },
+
     get db() {
         return apiFramework.pipeline(require('./db'), localUtils);
     },

--- a/ghost/core/core/server/services/collections/index.js
+++ b/ghost/core/core/server/services/collections/index.js
@@ -11,7 +11,8 @@ class CollectionsServiceWrapper {
 
         this.api = {
             browse: collectionsService.getAll.bind(collectionsService),
-            add: collectionsService.save.bind(collectionsService)
+            add: collectionsService.save.bind(collectionsService),
+            edit: collectionsService.save.bind(collectionsService)
         };
     }
 }

--- a/ghost/core/core/server/services/collections/index.js
+++ b/ghost/core/core/server/services/collections/index.js
@@ -1,0 +1,18 @@
+const {CollectionsService, CollectionsRepositoryInMemory} = require('@tryghost/collections');
+
+class CollectionsServiceWrapper {
+    api;
+
+    constructor() {
+        const inMemoryCollectionsRepository = new CollectionsRepositoryInMemory();
+        const collectionsService = new CollectionsService({
+            repository: inMemoryCollectionsRepository
+        });
+
+        this.api = {
+            browse: collectionsService.getAll.bind(collectionsService)
+        };
+    }
+}
+
+module.exports = new CollectionsServiceWrapper();

--- a/ghost/core/core/server/services/collections/index.js
+++ b/ghost/core/core/server/services/collections/index.js
@@ -12,7 +12,7 @@ class CollectionsServiceWrapper {
         this.api = {
             browse: collectionsService.getAll.bind(collectionsService),
             add: collectionsService.save.bind(collectionsService),
-            edit: collectionsService.save.bind(collectionsService)
+            edit: collectionsService.edit.bind(collectionsService)
         };
     }
 }

--- a/ghost/core/core/server/services/collections/index.js
+++ b/ghost/core/core/server/services/collections/index.js
@@ -13,7 +13,8 @@ class CollectionsServiceWrapper {
             browse: collectionsService.getAll.bind(collectionsService),
             read: collectionsService.getById.bind(collectionsService),
             add: collectionsService.save.bind(collectionsService),
-            edit: collectionsService.edit.bind(collectionsService)
+            edit: collectionsService.edit.bind(collectionsService),
+            destroy: collectionsService.destroy.bind(collectionsService)
         };
     }
 }

--- a/ghost/core/core/server/services/collections/index.js
+++ b/ghost/core/core/server/services/collections/index.js
@@ -11,6 +11,7 @@ class CollectionsServiceWrapper {
 
         this.api = {
             browse: collectionsService.getAll.bind(collectionsService),
+            read: collectionsService.getById.bind(collectionsService),
             add: collectionsService.save.bind(collectionsService),
             edit: collectionsService.edit.bind(collectionsService)
         };

--- a/ghost/core/core/server/services/collections/index.js
+++ b/ghost/core/core/server/services/collections/index.js
@@ -10,7 +10,8 @@ class CollectionsServiceWrapper {
         });
 
         this.api = {
-            browse: collectionsService.getAll.bind(collectionsService)
+            browse: collectionsService.getAll.bind(collectionsService),
+            add: collectionsService.save.bind(collectionsService)
         };
     }
 }

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -23,6 +23,7 @@ module.exports = function apiRoutes() {
     router.get('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.read));
     router.post('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.add));
     router.put('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.edit));
+    router.del('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.destroy));
 
     // ## Configuration
     router.get('/config', mw.authAdminApi, http(api.config.read));

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -20,6 +20,7 @@ module.exports = function apiRoutes() {
 
     // ## Collections
     router.get('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.browse));
+    router.post('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.add));
 
     // ## Configuration
     router.get('/config', mw.authAdminApi, http(api.config.read));

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -18,6 +18,9 @@ module.exports = function apiRoutes() {
     // ## Public
     router.get('/site', mw.publicAdminApi, http(api.site.read));
 
+    // ## Collections
+    router.get('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.browse));
+
     // ## Configuration
     router.get('/config', mw.authAdminApi, http(api.config.read));
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -21,6 +21,7 @@ module.exports = function apiRoutes() {
     // ## Collections
     router.get('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.browse));
     router.post('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.add));
+    router.put('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.edit));
 
     // ## Configuration
     router.get('/config', mw.authAdminApi, http(api.config.read));

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -20,6 +20,7 @@ module.exports = function apiRoutes() {
 
     // ## Collections
     router.get('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.browse));
+    router.get('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.read));
     router.post('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.add));
     router.put('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.edit));
 

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -70,6 +70,7 @@
     "@tryghost/audience-feedback": "0.0.0",
     "@tryghost/bookshelf-plugins": "0.6.7",
     "@tryghost/bootstrap-socket": "0.0.0",
+    "@tryghost/collections": "0.0.0",
     "@tryghost/color-utils": "0.1.24",
     "@tryghost/config-url-helpers": "1.0.6",
     "@tryghost/constants": "0.0.0",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -63,3 +63,56 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Collections API Can edit a Collection 1: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "deleted": false,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "title": "Test Collection to Edit",
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can edit a Collection 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "101",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/collections\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Collections API Can edit a Collection 3: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "deleted": false,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "title": "Test Collection Edited",
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can edit a Collection 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "100",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Collections API Can browse Collections 1: [body] 1`] = `
+Object {
+  "collections": Array [
+    Array [],
+  ],
+}
+`;
+
+exports[`Collections API Can browse Collections 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "20",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": "v5.47",
+  "etag": "W/\\"14-8OY9ZEqoQYKIwHgKOLz+0dUdl7A\\"",
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -1,10 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Collections API Can add a Collection 1: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "deleted": false,
+      "description": "Test Collection Description",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "title": "Test Collection",
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can add a Collection 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "137",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/collections\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Collections API Can browse Collections 1: [body] 1`] = `
 Object {
   "collections": Array [
-    Array [],
+    Object {
+      "deleted": false,
+      "description": "Test Collection Description",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "title": "Test Collection",
+    },
   ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 1,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 1,
+    },
+  },
 }
 `;
 
@@ -12,10 +55,10 @@ exports[`Collections API Can browse Collections 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "20",
+  "content-length": "224",
   "content-type": "application/json; charset=utf-8",
-  "content-version": "v5.47",
-  "etag": "W/\\"14-8OY9ZEqoQYKIwHgKOLz+0dUdl7A\\"",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-powered-by": "Express",
 }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -117,6 +117,58 @@ Object {
 }
 `;
 
+exports[`Collections API Can read a Collection 1: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "deleted": false,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "title": "Test Collection to Read",
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can read a Collection 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "101",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/collections\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Collections API Can read a Collection 3: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "deleted": false,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "title": "Test Collection to Read",
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can read a Collection 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "101",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Collections API Fails to edit unexistent Collection 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -64,6 +64,78 @@ Object {
 }
 `;
 
+exports[`Collections API Can delete a Collection 1: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "deleted": false,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "title": "Test Collection to Delete",
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can delete a Collection 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "103",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/collections\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Collections API Can delete a Collection 3: [body] 1`] = `Object {}`;
+
+exports[`Collections API Can delete a Collection 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Collections API Can delete a Collection 5: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Collection not found.",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Resource not found error, cannot read collection.",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can delete a Collection 6: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "254",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Collections API Can edit a Collection 1: [body] 1`] = `
 Object {
   "collections": Array [

--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -116,3 +116,34 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Collections API Fails to edit unexistent Collection 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Collection not found.",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Resource not found error, cannot edit collection.",
+      "property": null,
+      "type": "NotFoundError",
+    },
+  ],
+}
+`;
+
+exports[`Collections API Fails to edit unexistent Collection 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "254",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -1,3 +1,4 @@
+const assert = require('assert');
 const {
     agentProvider,
     fixtureManager,
@@ -61,5 +62,46 @@ describe('Collections API', function () {
             .matchBodySnapshot({
                 collections: [matchCollection]
             });
+    });
+
+    it('Can edit a Collection', async function () {
+        const collection = {
+            title: 'Test Collection to Edit'
+        };
+
+        const addResponse = await agent
+            .post('/collections/')
+            .body({
+                collections: [collection]
+            })
+            .expectStatus(201)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('collections')
+            })
+            .matchBodySnapshot({
+                collections: [matchCollection]
+            });
+
+        const collectionId = addResponse.body.collections[0].id;
+
+        const editResponse = await agent
+            .put(`/collections/${collectionId}/`)
+            .body({
+                collections: [{
+                    title: 'Test Collection Edited'
+                }]
+            })
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                collections: [matchCollection]
+            });
+
+        assert.equal(editResponse.body.collections[0].title, 'Test Collection Edited');
     });
 });

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -1,10 +1,21 @@
 const {
     agentProvider,
     fixtureManager,
-    mockManager
+    mockManager,
+    matchers
 } = require('../../utils/e2e-framework');
+const {
+    anyContentVersion,
+    anyEtag,
+    anyLocationFor,
+    anyObjectId
+} = matchers;
 
-describe.only('Collections API', function () {
+const matchCollection = {
+    id: anyObjectId
+};
+
+describe('Collections API', function () {
     let agent;
 
     before(async function () {
@@ -17,11 +28,38 @@ describe.only('Collections API', function () {
         mockManager.restore();
     });
 
+    it('Can add a Collection', async function () {
+        const collection = {
+            title: 'Test Collection',
+            description: 'Test Collection Description'
+        };
+
+        await agent
+            .post('/collections/')
+            .body({
+                collections: [collection]
+            })
+            .expectStatus(201)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('collections')
+            })
+            .matchBodySnapshot({
+                collections: [matchCollection]
+            });
+    });
+
     it('Can browse Collections', async function () {
         await agent
             .get('/collections/')
             .expectStatus(200)
-            .matchHeaderSnapshot()
-            .matchBodySnapshot();
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                collections: [matchCollection]
+            });
     });
 });

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -1,0 +1,27 @@
+const {
+    agentProvider,
+    fixtureManager,
+    mockManager
+} = require('../../utils/e2e-framework');
+
+describe.only('Collections API', function () {
+    let agent;
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+        await agent.loginAsOwner();
+    });
+
+    afterEach(function () {
+        mockManager.restore();
+    });
+
+    it('Can browse Collections', async function () {
+        await agent
+            .get('/collections/')
+            .expectStatus(200)
+            .matchHeaderSnapshot()
+            .matchBodySnapshot();
+    });
+});

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -65,6 +65,42 @@ describe('Collections API', function () {
             });
     });
 
+    it('Can read a Collection', async function () {
+        const collection = {
+            title: 'Test Collection to Read'
+        };
+
+        const addResponse = await agent
+            .post('/collections/')
+            .body({
+                collections: [collection]
+            })
+            .expectStatus(201)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('collections')
+            })
+            .matchBodySnapshot({
+                collections: [matchCollection]
+            });
+
+        const collectionId = addResponse.body.collections[0].id;
+
+        const readResponse = await agent
+            .get(`/collections/${collectionId}/`)
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                collections: [matchCollection]
+            });
+
+        assert.equal(readResponse.body.collections[0].title, 'Test Collection to Read');
+    });
+
     it('Can edit a Collection', async function () {
         const collection = {
             title: 'Test Collection to Edit'

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -163,4 +163,49 @@ describe('Collections API', function () {
                 etag: anyEtag
             });
     });
+
+    it('Can delete a Collection', async function () {
+        const collection = {
+            title: 'Test Collection to Delete'
+        };
+
+        const addResponse = await agent
+            .post('/collections/')
+            .body({
+                collections: [collection]
+            })
+            .expectStatus(201)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('collections')
+            })
+            .matchBodySnapshot({
+                collections: [matchCollection]
+            });
+
+        const collectionId = addResponse.body.collections[0].id;
+
+        await agent
+            .delete(`/collections/${collectionId}/`)
+            .expectStatus(204)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot();
+
+        await agent
+            .get(`/collections/${collectionId}/`)
+            .expectStatus(404)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
+            });
+    });
 });

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -8,6 +8,7 @@ const {
 const {
     anyContentVersion,
     anyEtag,
+    anyErrorId,
     anyLocationFor,
     anyObjectId
 } = matchers;
@@ -103,5 +104,27 @@ describe('Collections API', function () {
             });
 
         assert.equal(editResponse.body.collections[0].title, 'Test Collection Edited');
+    });
+
+    it('Fails to edit unexistent Collection', async function () {
+        const unexistentID = '5951f5fca366002ebd5dbef7';
+        await agent
+            .put(`/collections/${unexistentID}/`)
+            .body({
+                collections: [{
+                    id: unexistentID,
+                    title: 'Editing unexistent Collection'
+                }]
+            })
+            .expectStatus(404)
+            .matchBodySnapshot({
+                errors: [{
+                    id: anyErrorId
+                }]
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            });
     });
 });


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3167

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e895646</samp>

This pull request introduces a new feature for managing collections of posts in Ghost, using a new module called `@tryghost/collections`. It adds a service and a repository layer for creating and fetching collections, and exposes them through the admin API endpoints. It also adds some unit tests and end-to-end tests for the collections feature, and updates the package dependencies accordingly.
