### PR TITLE
Implemented post slug update on duplicated post title update (mobiledoc)

### DIFF
--- a/ghost/admin/app/controllers/editor.js
+++ b/ghost/admin/app/controllers/editor.js
@@ -25,7 +25,8 @@ import {isInvalidError} from 'ember-ajax/errors';
 import {inject as service} from '@ember/service';
 
 const DEFAULT_TITLE = '(Untitled)';
-
+// suffix that is applied to the title of a post when it has been duplicated
+const DUPLICATED_POST_TITLE_SUFFIX = '(Copy)';
 // time in ms to save after last content edit
 const AUTOSAVE_TIMEOUT = 3000;
 // time in ms to force a save if the user is continuously typing
@@ -685,9 +686,15 @@ export default class EditorController extends Controller {
         // this is necessary to force a save when the title is blank
         this.set('hasDirtyAttributes', true);
 
-        // generate a slug if a post is new and doesn't have a title yet or
-        // if the title is still '(Untitled)'
-        if ((post.get('isNew') && !currentTitle) || currentTitle === DEFAULT_TITLE) {
+        // generate slug if post
+        //  - is new and doesn't have a title yet
+        //  - still has the default title
+        //  - previously had a title that ended with the duplicated post title suffix
+        if (
+            (post.get('isNew') && !currentTitle) ||
+            (currentTitle === DEFAULT_TITLE) ||
+            currentTitle?.endsWith(DUPLICATED_POST_TITLE_SUFFIX)
+        ) {
             yield this.generateSlugTask.perform();
         }
 

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -734,7 +734,7 @@ export default class LexicalEditorController extends Controller {
         if (
             (post.get('isNew') && !currentTitle) ||
             (currentTitle === DEFAULT_TITLE) ||
-            currentTitle.endsWith(DUPLICATED_POST_TITLE_SUFFIX)
+            currentTitle?.endsWith(DUPLICATED_POST_TITLE_SUFFIX)
         ) {
             yield this.generateSlugTask.perform();
         }

--- a/ghost/admin/tests/unit/controllers/editor-test.js
+++ b/ghost/admin/tests/unit/controllers/editor-test.js
@@ -97,6 +97,27 @@ describe('Unit: Controller: editor', function () {
             expect(controller.get('post.slug')).to.equal('test-slug');
         });
 
+        it('should invoke generateSlug if the post is a duplicated post', async function () {
+            let {controller} = this;
+
+            controller.set('target', {send() {}});
+            defineProperty(controller, 'generateSlugTask', task(function * () {
+                this.set('post.slug', 'test-slug');
+                yield RSVP.resolve();
+            }));
+            controller.set('post', EmberObject.create({isNew: false, title: 'Some Title (Copy)'}));
+
+            expect(controller.get('post.isNew')).to.be.false;
+            expect(controller.get('post.titleScratch')).to.not.be.ok;
+
+            controller.set('post.titleScratch', 'Some Title');
+
+            await controller.saveTitleTask.perform();
+
+            expect(controller.get('post.titleScratch')).to.equal('Some Title');
+            expect(controller.get('post.slug')).to.equal('test-slug');
+        });
+
         it('should not invoke generateSlug if the post is new but has a title', async function () {
             let {controller} = this;
 


### PR DESCRIPTION
no issue

Updated the slug generation logic so that when a mobiledoc post is duplicated and the title is edited, the slug gets updated to reflect the new title of the post. See lexical implementation here: https://github.com/TryGhost/Ghost/pull/16802
