### PR TITLE
Move duplicate post functionality out of labs

### DIFF
--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -48,7 +48,6 @@ const messages = {
 
 export default class PostsContextMenu extends Component {
     @service ajax;
-    @service feature;
     @service ghostPaths;
     @service session;
     @service infinity;
@@ -453,10 +452,6 @@ export default class PostsContextMenu extends Component {
     }
 
     get canCopySelection() {
-        if (this.feature.makingItRain === false) {
-            return false;
-        }
-
         return this.selectionList.availableModels.length === 1;
     }
 }


### PR DESCRIPTION
no issue

Removed the labs check for the duplicate post functionality making it available for everybody