### PR TITLE
🐛 Fixed issue where single letter product slugs cause 500 error

### DIFF
--- a/ghost/core/core/server/services/members/content-gating.js
+++ b/ghost/core/core/server/services/members/content-gating.js
@@ -46,7 +46,7 @@ function checkPostAccess(post, member) {
             return BLOCK_ACCESS;
         }
         visibility = post.tiers.map((product) => {
-            return `product:${product.slug}`;
+            return `product:'${product.slug}'`;
         }).join(',');
     }
 

--- a/ghost/core/test/unit/server/services/members/content-gating.test.js
+++ b/ghost/core/test/unit/server/services/members/content-gating.test.js
@@ -44,6 +44,15 @@ describe('Members Service - Content gating', function () {
             should(access).be.true();
         });
 
+        it('should not error out if the slug associated with a tier is only 1 character in length', async function () {
+            post = {visibility: 'tiers', tiers: [{slug: 'x'}]};
+            member = {id: 'test', status: 'paid', products: [{
+                slug: 'x'
+            }]};
+
+            (() => checkPostAccess(post, member)).should.not.throw();
+        });
+
         it('should block access to members only post without member', async function () {
             post = {visibility: 'members'};
             member = null;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3224

When a product has a slug that is a single letter, checking if a user had access to view a post associated with that product would cause a 500 error. The underlying cause of this issue is https://github.com/TryGhost/NQL/issues/20 This fix circumvents this issue by providing a value that the nql lexer will not error out on