### PR TITLE
🐛 Fixed tiers not appearing on custom signup pages

### DIFF
--- a/ghost/core/core/server/services/tiers/TierRepository.js
+++ b/ghost/core/core/server/services/tiers/TierRepository.js
@@ -49,7 +49,7 @@ module.exports = class TierRepository {
      */
     toPrimitive(tier) {
         return {
-            ...tier,
+            ...tier.toJSON(),
             active: (tier.status === 'active'),
             type: tier.type,
             id: tier.id.toHexString()


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3248

- API queries for tiers are now using the TiersRepository with internal caching
- the repository had a bug with it's `toPrimitive()` method which meant the cached tier objects had very few properties
  - the Tier object has all properties as private getters except for standard `events` property which meant the spread operator didn't have anything to spread into the object resulting in all tiers having a shape like `{events: [], active: true, type: 'paid', id: 'abcd'}`
- the `getAll()` method uses nql to match against the cached tier objects but with them not being fully populated it wasn't able to match and so returned an empty array

---

- changing the spread to use `tier.toJSON()` means we're populating all of the tier data properly allowing filter matches to work
