### PR TITLE
Fixed update check due to tiers service changes

### DIFF
--- a/ghost/core/core/server/run-update-check.js
+++ b/ghost/core/core/server/run-update-check.js
@@ -40,6 +40,9 @@ if (parentPort) {
 
     const settings = require('./services/settings/settings-service');
     await settings.init();
+
+    const tiers = require('./services/tiers');
+    await tiers.init();
     // Finished INIT
 
     await updateCheck({


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3234

The update check was failing to run due to recent changes in the tiers service. This service now needs initialising before the update check can be run.