### PR TITLE
Tested filtering visibility in Tiers Content API

### DIFF
--- a/ghost/core/test/e2e-api/content/__snapshots__/tiers.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/tiers.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tiers Content API Can request only active tiers 1: [body] 1`] = `
+exports[`Tiers Content API Can filter on visibility 1: [body] 1`] = `
 Object {
   "meta": Object {
     "pagination": Object {
@@ -48,11 +48,89 @@ Object {
 }
 `;
 
-exports[`Tiers Content API Can request only active tiers 2: [headers] 1`] = `
+exports[`Tiers Content API Can filter on visibility 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "public, max-age=0",
   "content-length": "727",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Tiers Content API Can request only active tiers 1: [body] 1`] = `
+Object {
+  "meta": Object {
+    "pagination": Object {
+      "limit": 3,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 3,
+    },
+  },
+  "tiers": Array [
+    Object {
+      "active": true,
+      "benefits": Array [],
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "description": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "name": "Free",
+      "slug": "free",
+      "trial_days": 0,
+      "type": "free",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "visibility": "public",
+      "welcome_page_url": "/welcome-free",
+    },
+    Object {
+      "active": true,
+      "benefits": Array [],
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "currency": "USD",
+      "description": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "monthly_price": 500,
+      "name": "Default Product",
+      "slug": "default-product",
+      "trial_days": 0,
+      "type": "paid",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "visibility": "public",
+      "welcome_page_url": "/welcome-paid",
+      "yearly_price": 5000,
+    },
+    Object {
+      "active": true,
+      "benefits": Array [],
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "currency": "USD",
+      "description": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "monthly_price": 500,
+      "name": "product",
+      "slug": "gold-2",
+      "trial_days": 0,
+      "type": "paid",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}/,
+      "visibility": "none",
+      "welcome_page_url": null,
+      "yearly_price": 5000,
+    },
+  ],
+}
+`;
+
+exports[`Tiers Content API Can request only active tiers 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "public, max-age=0",
+  "content-length": "1051",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/content/tiers.test.js
+++ b/ghost/core/test/e2e-api/content/tiers.test.js
@@ -5,12 +5,28 @@ describe('Tiers Content API', function () {
 
     before(async function () {
         agent = await agentProvider.getContentAPIAgent();
-        await fixtureManager.init('members', 'api_keys', 'tiers:archived');
+        await fixtureManager.init('members', 'api_keys', 'tiers:archived', 'tiers:hidden');
         await agent.authenticate();
     });
 
     it('Can request only active tiers', async function () {
         await agent.get('/tiers/?include=monthly_price')
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': matchers.anyContentVersion,
+                etag: matchers.anyEtag
+            })
+            .matchBodySnapshot({
+                tiers: Array(3).fill({
+                    id: matchers.anyObjectId,
+                    created_at: matchers.anyISODate,
+                    updated_at: matchers.anyISODate
+                })
+            });
+    });
+
+    it('Can filter on visibility', async function () {
+        await agent.get('/tiers/?filter=visibility:public')
             .expectStatus(200)
             .matchHeaderSnapshot({
                 'content-version': matchers.anyContentVersion,

--- a/ghost/core/test/utils/fixture-utils.js
+++ b/ghost/core/test/utils/fixture-utils.js
@@ -479,6 +479,14 @@ const fixtures = {
         return models.Product.add(archivedProduct, context.internal);
     },
 
+    insertHiddenTiers: function insertArchivedTiers() {
+        let hiddenTier = DataGenerator.forKnex.createProduct({
+            visibility: 'none'
+        });
+
+        return models.Product.add(hiddenTier, context.internal);
+    },
+
     insertProducts: async function insertProducts() {
         let coreProductFixtures = fixtureManager.findModelFixtures('Product').entries;
         await Promise.all(coreProductFixtures.map(async (product) => {
@@ -816,6 +824,9 @@ const toDoList = {
     },
     'tiers:archived': function insertArchivedTiers() {
         return fixtures.insertArchivedTiers();
+    },
+    'tiers:hidden': function insertHiddenTiers() {
+        return fixtures.insertHiddenTiers();
     },
     comments: function insertComments() {
         return fixtures.insertComments();


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3248

The current test fixtures didn't include any hidden Tiers, so I've added a new fixture to test the filtering of hidden Tiers. It's not enabled by default to avoid breaking the existing tests.

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 618f36c</samp>

Added tests and fixtures for the content API tiers endpoint and the hidden product feature. The tests check the filter and visibility logic for products with different tiers.
