### PR TITLE
Fixed uploading single code coverage to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         working-directory: ghost/admin
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage
+          name: admin-coverage
           path: ghost/*/coverage/cobertura-coverage.xml
 
       - uses: tryghost/actions/actions/slack-build@main
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: startsWith(matrix.node, '16')
         with:
-          name: coverage
+          name: unit-coverage
           path: ghost/*/coverage/cobertura-coverage.xml
 
       - uses: tryghost/actions/actions/slack-build@main
@@ -233,10 +233,11 @@ jobs:
           endTime="$(date +%s)"
           echo "test_time=$(($endTime-$startTime))" >> $GITHUB_ENV
 
-      - uses: codecov/codecov-action@v3
+      - uses: actions/upload-artifact@v3
         if: startsWith(matrix.node, '16') && contains(matrix.env.DB, 'mysql')
         with:
-          flags: e2e-tests
+          name: e2e-coverage
+          path: ghost/*/coverage-e2e/cobertura-coverage.xml
 
       # Continue on error if TailScale service is down
       - name: Tailscale Action
@@ -340,15 +341,43 @@ jobs:
 
   coverage:
     name: Coverage
-    needs: [unit-tests, admin-tests]
+    needs: [unit-tests, admin-tests, database-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Restore coverage
+
+      - name: Restore Admin coverage
         uses: actions/download-artifact@v3
         with:
-          path: ghost
-      - run: rsync -av --remove-source-files ghost/coverage/* ghost/
+          name: admin-coverage
+      - name: Restore E2E coverage
+        uses: actions/download-artifact@v3
+        with:
+          name: e2e-coverage
+
+      - name: Move coverage
+        run: |
+          rsync -av --remove-source-files admin/* ghost/admin
+          rsync -av --remove-source-files core/* ghost/core
+
+      - uses: codecov/codecov-action@v3
+        with:
+          flags: e2e-tests
+          move_coverage_to_trash: true
+
+      - name: Restore Unit test coverage
+        uses: actions/download-artifact@v3
+        with:
+          name: unit-coverage
+          path: coverage
+
+      - run: |
+          ls
+          echo ---
+          ls coverage
+          echo ---
+          ls ghost
+      - run: rsync -av --remove-source-files coverage/* ghost/
       - uses: codecov/codecov-action@v3
         with:
           flags: unit-tests


### PR DESCRIPTION
fixes https://github.com/TryGhost/Toolbox/issues/583

- we currently upload the codecov for unit tests and e2e/admin tests separately
- unfortunately this means that when one submits before the other, the codecov % will be incorrect
- this leaves a big red cross on the commit until the other coverage is uploaded
- this should fix that by upload the coverage in one step once CI is happy

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19ee95f</samp>

Enhanced the test workflow to produce more reliable and unified coverage reports. Used artifacts and a dedicated job to merge the reports from `.github/workflows/test.yml` before uploading to codecov.
