### PR TITLE
🐛 Fixed member activity event filter

### DIFF
--- a/ghost/admin/app/components/members-activity/event-type-filter.js
+++ b/ghost/admin/app/components/members-activity/event-type-filter.js
@@ -18,8 +18,8 @@ export default class MembersActivityEventTypeFilter extends Component {
     @service settings;
     @service feature;
 
-    get availableEventTypes() {
-        const extended = ALL_EVENT_TYPES;
+    getAvailableEventTypes() {
+        const extended = [...ALL_EVENT_TYPES];
 
         if (this.settings.commentsEnabled !== 'off') {
             extended.push({event: 'comment_event', icon: 'filter-dropdown-comments', name: 'Comments', group: 'others'});
@@ -40,12 +40,13 @@ export default class MembersActivityEventTypeFilter extends Component {
 
     get eventTypes() {
         const excludedEvents = (this.args.excludedEvents || '').split(',');
+        const availableEventTypes = this.getAvailableEventTypes();
 
-        return this.availableEventTypes.map((type, i) => ({
+        return availableEventTypes.map((type, i) => ({
             event: type.event,
             icon: type.icon,
             name: type.name,
-            divider: this.needDivider(type, this.availableEventTypes[i - 1]),
+            divider: this.needDivider(type, availableEventTypes[i - 1]),
             isSelected: !excludedEvents.includes(type.event)
         }));
     }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/16817

The member activity event filter was broken due to a recursion issue. This commit changes the usage of a getter fn to a normal class method to make the logic more performant and remove the recursion issue
