### PR TITLE
Added typescript declerations to i18n

### DIFF
--- a/ghost/i18n/lib/i18n.js
+++ b/ghost/i18n/lib/i18n.js
@@ -38,7 +38,7 @@ const SUPPORTED_LOCALES = [
 
 /**
  * @param {string} [lng]
- * @param {'ghost'|'portal'|'test'} ns
+ * @param {'ghost'|'portal'|'test'|'signup-form'} ns
  */
 module.exports = (lng = 'en', ns = 'portal') => {
     const i18nextInstance = i18next.createInstance();

--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -28,7 +28,7 @@
     "c8": "7.13.0",
     "i18next-parser": "8.0.0",
     "mocha": "10.2.0",
-    "typescript": "^5.0.4"
+    "typescript": "5.0.4"
   },
   "dependencies": {
     "i18next": "22.5.0"

--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -5,8 +5,10 @@
   "author": "Ghost Foundation",
   "private": true,
   "main": "index.js",
+  "types": "./build/i18n.d.ts",
   "scripts": {
     "dev": "echo \"Implement me!\"",
+    "build": "tsc",
     "test:unit:base": "NODE_ENV=testing c8 --include index.js --include lib --check-coverage --100  --reporter text --reporter cobertura mocha './test/**/*.test.js'",
     "test:unit": "yarn test:unit:base && yarn translate",
     "test": "yarn test:unit",
@@ -25,7 +27,8 @@
   "devDependencies": {
     "c8": "7.13.0",
     "i18next-parser": "8.0.0",
-    "mocha": "10.2.0"
+    "mocha": "10.2.0",
+    "typescript": "^5.0.4"
   },
   "dependencies": {
     "i18next": "22.5.0"

--- a/ghost/i18n/tsconfig.json
+++ b/ghost/i18n/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+      "allowJs": true,
+      "declaration": true,
+      "emitDeclarationOnly": true,
+      "outDir": "./build",
+      "skipLibCheck": true,
+      "esModuleInterop": true
+    },
+    "include": ["lib/**/*.js"],
+    "exclude": ["node_modules", "test"]
+  }

--- a/yarn.lock
+++ b/yarn.lock
@@ -31949,7 +31949,7 @@ typescript-memoize@^1.0.0-alpha.3, typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.1.tgz#02737495d5df6ebf72c07ba0d002e8f4cf5ccfa0"
   integrity sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==
 
-typescript@5.0.4:
+typescript@5.0.4, typescript@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3307

- added typescript declaration generation as we are building the new signup ember form in React + Typescript and we want to add support for i18n from the beginning.
- This adds a declaration to support importing the i18n js module inside typescript.

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd8d195</samp>

Added TypeScript support and a new namespace for the `i18n` module. This enables type checking and localization for the signup form component in the portal frontend.
