### PR TITLE
Removed postHistory flag and updated post history logic

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -446,18 +446,16 @@
         </div>
         {{/if}}
 
-        {{#if (feature 'postHistory')}}
-            {{#if this.showPostHistory}}
-                <GhFullscreenModal
-                    @modal="post-history"
-                    @model={{hash
-                        post=this.post
-                        editorAPI=this.editorAPI
-                        toggleSettingsMenu=this.toggleSettingsMenu
-                    }}
-                    @close={{this.closePostHistory}}
-                    @modifier="total-overlay post-history" />
-            {{/if}}
+        {{#if this.showPostHistory}}
+            <GhFullscreenModal
+                @modal="post-history"
+                @model={{hash
+                    post=this.post
+                    editorAPI=this.editorAPI
+                    toggleSettingsMenu=this.toggleSettingsMenu
+                }}
+                @close={{this.closePostHistory}}
+                @modifier="total-overlay post-history" />
         {{/if}}
     </div>
 </div>

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -145,8 +145,7 @@ export default class GhPostSettingsMenu extends Component {
     }
 
     get canViewPostHistory() {
-        let showPostHistory = this.feature.postHistory === true
-            && this.post.lexical !== null
+        let showPostHistory = this.post.lexical !== null
             && this.post.emailOnly === false;
 
         if (this.post.isPublished === true) {

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -69,7 +69,6 @@ export default class FeatureService extends Service {
     @feature('stripeAutomaticTax') stripeAutomaticTax;
     @feature('makingItRain') makingItRain;
     @feature('i18n') i18n;
-    @feature('postHistory') postHistory;
     @feature('postDiffing') postDiffing;
     @feature('announcementBar') announcementBar;
     @feature('imageEditor') imageEditor;

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -132,14 +132,12 @@
             @close={{this.toggleReAuthenticateModal}}
             @modifier="action wide" />
     {{/if}}
-    {{#if (feature 'postHistory')}}
-        {{#if this.showPostHistory}}
-            <GhFullscreenModal
-                @modal="post-history"
-                @model={{this.post}}
-                @close={{this.closePostHistory}}
-                @modifier="total-overlay post-history" />
-        {{/if}}
+    {{#if this.showPostHistory}}
+        <GhFullscreenModal
+            @modal="post-history"
+            @model={{this.post}}
+            @close={{this.closePostHistory}}
+            @modifier="total-overlay post-history" />
     {{/if}}
 {{/if}}
 

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -280,19 +280,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
-                            <h4 class="gh-expandable-title">Post history</h4>
-                            <p class="gh-expandable-description">
-                                Enables post history revision within the editor
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                            <GhFeatureFlag @flag="postHistory" />
-                        </div>
-                    </div>
-                </div>
 
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -20,7 +20,6 @@ const {Tag} = require('./tag');
 const {Newsletter} = require('./newsletter');
 const {BadRequestError} = require('@tryghost/errors');
 const {PostRevisions} = require('@tryghost/post-revisions');
-const labs = require('../../shared/labs');
 
 const messages = {
     isAlreadyPublished: 'Your post is already published, please reload your page.',
@@ -869,80 +868,45 @@ Post = ghostBookshelf.Model.extend({
                     });
             });
         }
+        if (!model.get('mobiledoc') && !options.importing && !options.migrating) {
+            const postRevisions = new PostRevisions({
+                config: {
+                    max_revisions: POST_REVISIONS_COUNT,
+                    revision_interval_ms: POST_REVISIONS_INTERVAL_MS
+                }
+            });
+            const authorId = this.contextUser(options);
+            ops.push(async function updateRevisions() {
+                const revisionModels = await ghostBookshelf.model('PostRevision')
+                    .findAll(Object.assign({
+                        filter: `post_id:${model.id}`,
+                        columns: ['id', 'lexical', 'created_at', 'author_id', 'title', 'reason', 'post_status', 'created_at_ts', 'feature_image']
+                    }, _.pick(options, 'transacting')));
 
-        if (!labs.isSet('postHistory')) {
-            if (model.hasChanged('lexical') && !model.get('mobiledoc') && !options.importing && !options.migrating) {
-                ops.push(function updateRevisions() {
-                    return ghostBookshelf.model('PostRevision')
-                        .findAll(Object.assign({
-                            filter: `post_id:${model.id}`,
-                            columns: ['id']
-                        }, _.pick(options, 'transacting')))
-                        .then((revisions) => {
-                            // Store previous + latest lexical content
-                            if (!revisions.length && options.method !== 'insert') {
-                                model.set('post_revisions', [{
-                                    post_id: model.id,
-                                    lexical: model.previous('lexical'),
-                                    created_at_ts: Date.now() - 1
-                                }, {
-                                    post_id: model.id,
-                                    lexical: model.get('lexical'),
-                                    created_at_ts: Date.now()
-                                }]);
-                            } else {
-                                const revisionsJSON = revisions.toJSON().slice(0, POST_REVISIONS_COUNT - 1);
+                const revisions = revisionModels.toJSON();
 
-                                model.set('post_revisions', revisionsJSON.concat([{
-                                    post_id: model.id,
-                                    lexical: model.get('lexical'),
-                                    created_at_ts: Date.now()
-                                }]));
-                            }
-                        });
-                });
-            }
-        } else {
-            if (!model.get('mobiledoc') && !options.importing && !options.migrating) {
-                const postRevisions = new PostRevisions({
-                    config: {
-                        max_revisions: POST_REVISIONS_COUNT,
-                        revision_interval_ms: POST_REVISIONS_INTERVAL_MS
-                    }
-                });
-                const authorId = this.contextUser(options);
-                ops.push(async function updateRevisions() {
-                    const revisionModels = await ghostBookshelf.model('PostRevision')
-                        .findAll(Object.assign({
-                            filter: `post_id:${model.id}`,
-                            columns: ['id', 'lexical', 'created_at', 'author_id', 'title', 'reason', 'post_status', 'created_at_ts', 'feature_image']
-                        }, _.pick(options, 'transacting')));
+                const current = {
+                    id: model.id,
+                    lexical: model.get('lexical'),
+                    html: model.get('html'),
+                    author_id: authorId,
+                    feature_image: model.get('feature_image'),
+                    feature_image_alt: model.get('posts_meta')?.feature_image_alt,
+                    feature_image_caption: model.get('posts_meta')?.feature_image_caption,
+                    title: model.get('title'),
+                    post_status: model.get('status')
+                };
 
-                    const revisions = revisionModels.toJSON();
-
-                    const current = {
-                        id: model.id,
-                        lexical: model.get('lexical'),
-                        html: model.get('html'),
-                        author_id: authorId,
-                        feature_image: model.get('feature_image'),
-                        feature_image_alt: model.get('posts_meta')?.feature_image_alt,
-                        feature_image_caption: model.get('posts_meta')?.feature_image_caption,
-                        title: model.get('title'),
-                        post_status: model.get('status')
-                    };
-
-                    // This can be refactored once we have the status stored in each revision
-                    const revisionOptions = {
-                        forceRevision: options.save_revision,
-                        isPublished: newStatus === 'published',
-                        newStatus,
-                        olderStatus
-                    };
-                    const newRevisions = await postRevisions.getRevisions(current, revisions, revisionOptions);
-                    model.set('post_revisions', newRevisions);
-                });
-            }
+                // This can be refactored once we have the status stored in each revision
+                const revisionOptions = {
+                    forceRevision: options.save_revision,
+                    isPublished: newStatus === 'published',
+                    newStatus,
+                    olderStatus
+                };
+                const newRevisions = await postRevisions.getRevisions(current, revisions, revisionOptions);
+                model.set('post_revisions', newRevisions);
+            });
         }
 
         if (this.get('tiers')) {

--- a/ghost/core/core/server/services/Users.js
+++ b/ghost/core/core/server/services/Users.js
@@ -5,7 +5,6 @@ const path = require('path');
  * @TODO: pass these in as dependencies
  */
 const {PostRevisions} = require('@tryghost/post-revisions');
-const labs = require('../../shared/labs');
 
 /**
  * @typedef {Object} IdbBackup
@@ -156,15 +155,13 @@ class Users {
         return this.models.Base.transaction(async (t) => {
             frameOptions.transacting = t;
 
-            if (labs.isSet('postHistory')) {
-                const postRevisions = new PostRevisions({
-                    model: this.models.PostRevision
-                });
+            const postRevisions = new PostRevisions({
+                model: this.models.PostRevision
+            });
 
-                await postRevisions.removeAuthorFromRevisions(frameOptions.id, {
-                    transacting: frameOptions.transacting
-                });
-            }
+            await postRevisions.removeAuthorFromRevisions(frameOptions.id, {
+                transacting: frameOptions.transacting
+            });
 
             await this.assignTagToUserPosts({
                 id: frameOptions.id,

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -37,7 +37,6 @@ const ALPHA_FEATURES = [
     'websockets',
     'stripeAutomaticTax',
     'makingItRain',
-    'postHistory',
     'postDiffing',
     'imageEditor',
     'signupCard',


### PR DESCRIPTION
no issue

- Removed the postHistory flag from labs
- Post History will be saved and displayed for all lexical posts, regardless of whether the lexicalEditor flag is currently set
- Post History will still not be displayed for any mobiledoc posts
- With this change, the logic is simplified as we don't have to worry about flags, but only the content in the given post (mobiledoc vs lexical)
- If someone toggles the lexicalEditor flag on, creates a new post, then toggles the lexicalEditor off, we still want Post History to work for the existing lexical post
