### PR TITLE
Bumped CI to use Node 18 for majority of tests

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -38,7 +38,7 @@ jobs:
         submodules: true
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '18.x'
         cache: yarn
 
     - name: Install Stripe-CLI

--- a/.github/workflows/signup-form-tests.yml
+++ b/.github/workflows/signup-form-tests.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: "16.13.0"
+          node-version: "18.12.1"
           cache: yarn
 
       - run: yarn --prefer-offline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           cache: yarn
 
       - uses: actions/cache@v3
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.13.0"
+          node-version: "18.12.1"
 
       - run: yarn --prefer-offline
       - run: yarn workspace ghost-admin run test
@@ -98,7 +98,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '16.13.0'
+          node-version: '18.12.1'
           cache: yarn
 
       - name: Shutdown MySQL
@@ -160,7 +160,7 @@ jobs:
       - run: yarn test:unit
 
       - uses: actions/upload-artifact@v3
-        if: startsWith(matrix.node, '16')
+        if: startsWith(matrix.node, '18')
         with:
           name: unit-coverage
           path: ghost/*/coverage/cobertura-coverage.xml
@@ -182,7 +182,7 @@ jobs:
           - DB: mysql8
             NODE_ENV: testing-mysql
         include:
-          - node: 16.13.0
+          - node: 18.12.1
             env:
               DB: sqlite3
               NODE_ENV: testing
@@ -245,7 +245,7 @@ jobs:
           echo "test_time=$(($endTime-$startTime))" >> $GITHUB_ENV
 
       - uses: actions/upload-artifact@v3
-        if: startsWith(matrix.node, '16') && contains(matrix.env.DB, 'mysql')
+        if: startsWith(matrix.node, '18') && contains(matrix.env.DB, 'mysql')
         with:
           name: e2e-coverage
           path: |


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/7

- we're moving towards making Node 18 our recommended version, so that involves ensuring all of CI is running Node 18
- we still have some Node 16 matrix runs to ensure compatibility

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b5cfce</samp>

Updated the node version for all GitHub workflows to `18.12.1`. This ensures compatibility and consistency with the latest LTS release and improves the reliability of the test suite.
