### PR TITLE
Removed `imageEditor` flag

### DIFF
--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -587,3 +587,5 @@ add|ember-template-lint|no-invalid-interactive|3|4|3|4|1e038cea298e74d9c774ed441
 remove|ember-template-lint|no-invalid-interactive|3|4|3|4|8e05ced79d8f5f5e13cd43033670b3b1e14db3ab|1681776000000|1692144000000|1697328000000|app/components/gh-editor-feature-image.hbs
 remove|ember-template-lint|no-action|21|127|21|127|7233183d00299a45a813392b99c8442210cdaeb3|1681862400000|1692230400000|1697414400000|app/components/modal-post-history.hbs
 remove|ember-template-lint|require-valid-alt-text|13|20|13|20|41dff435a7aba8088be689c6d9b1e76bef081d17|1682035200000|1692403200000|1697587200000|app/components/modal-post-history.hbs
+remove|ember-template-lint|no-invalid-interactive|3|4|3|4|1e038cea298e74d9c774ed441ca6daf50060a8ec|1685318400000|1695686400000|1700874000000|app/components/gh-editor-feature-image.hbs
+add|ember-template-lint|no-invalid-interactive|3|4|3|4|6f7786d5ed3e8c09f39e3595839ee291749aeb01|1685664000000|1696032000000|1701219600000|app/components/gh-editor-feature-image.hbs

--- a/ghost/admin/app/components/gh-editor-feature-image.hbs
+++ b/ghost/admin/app/components/gh-editor-feature-image.hbs
@@ -40,7 +40,7 @@
             <div class="gh-editor-feature-image">
                 <img src={{@image}}>
                 <div class="gh-editor-feature-image-overlay"></div>
-                {{#if (feature 'imageEditor')}}
+                {{#if (feature 'lexicalEditor')}}
                     <KoenigImageEditor
                         @imageSrc={{@image}}
                         @saveImage={{fn this.saveImage uploader.setFiles}}

--- a/ghost/admin/app/components/gh-image-uploader-with-preview.hbs
+++ b/ghost/admin/app/components/gh-image-uploader-with-preview.hbs
@@ -1,7 +1,7 @@
 {{#if @image}}
     <div class="gh-image-uploader -with-image">
         <div><img src={{@image}}></div>
-        {{#if (feature 'imageEditor')}}
+        {{#if (feature 'lexicalEditor')}}
             <KoenigImageEditor
                 @imageSrc={{@image}}
                 @saveUrl={{@update}}

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -151,7 +151,7 @@ export default class KoenigLexicalEditor extends Component {
     get pinturaConfig() {
         const jsUrl = this.getImageEditorJSUrl();
         const cssUrl = this.getImageEditorCSSUrl();
-        if (!this.feature.imageEditor || !jsUrl || !cssUrl) {
+        if (!this.feature.lexicalEditor || !jsUrl || !cssUrl) {
             return null;
         }
         return {

--- a/ghost/admin/app/components/settings/form-fields/publication-cover.hbs
+++ b/ghost/admin/app/components/settings/form-fields/publication-cover.hbs
@@ -24,7 +24,7 @@
                         {{on "click" uploader.triggerFileDialog}}
                         data-test-cover-img
                     >
-                    {{#if (feature 'imageEditor')}}
+                    {{#if (feature 'lexicalEditor')}}
                     <KoenigImageEditor
                         @className="gh-setting-action-largeimg-delete gh-setting-action-largeimg-edit"
                         @imageSrc={{this.settings.coverImage}}

--- a/ghost/admin/app/components/settings/form-fields/publication-logo.hbs
+++ b/ghost/admin/app/components/settings/form-fields/publication-logo.hbs
@@ -24,7 +24,7 @@
                             {{on "click" uploader.triggerFileDialog}}
                             data-test-logo-img
                         >
-                        {{#if (feature 'imageEditor')}}
+                        {{#if (feature 'lexicalEditor')}}
                         <KoenigImageEditor
                             @className="gh-setting-action-smallimg-delete gh-setting-action-smallimg-edit"
                             @imageSrc={{this.settings.logo}}

--- a/ghost/admin/app/components/settings/staff/modals/upload-image.hbs
+++ b/ghost/admin/app/components/settings/staff/modals/upload-image.hbs
@@ -3,7 +3,7 @@
         {{#if this.url}}
             <div class="gh-image-uploader -with-image">
                 <div><img src={{this.url}} alt="" role="presentation"></div>
-                {{#if (feature 'imageEditor')}}
+                {{#if (feature 'lexicalEditor')}}
                     <KoenigImageEditor
                         @imageSrc={{this.url}}
                         @saveUrl={{this.fileUploaded}}

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -69,7 +69,6 @@ export default class FeatureService extends Service {
     @feature('emailCustomization') emailCustomization;
     @feature('i18n') i18n;
     @feature('announcementBar') announcementBar;
-    @feature('imageEditor') imageEditor;
     @feature('signupCard') signupCard;
     @feature('signupForm') signupForm;
     @feature('collections') collections;

--- a/ghost/admin/app/templates/settings/integrations.hbs
+++ b/ghost/admin/app/templates/settings/integrations.hbs
@@ -204,7 +204,7 @@
                 </article>
                 </LinkTo>
             </div>
-            {{#if (feature 'imageEditor')}}
+            {{#if (feature 'lexicalEditor')}}
             <div class="apps-grid-cell" data-test-app="pintura">
                 <LinkTo @route="settings.integrations.pintura" data-test-link="pintura">
                 <article class="apps-card-app">

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -271,20 +271,6 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
-                            <h4 class="gh-expandable-title">Image Editor</h4>
-                            <p class="gh-expandable-description">
-                                Allows publishers to edit images in the lexical editor
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                            <GhFeatureFlag @flag="imageEditor" />
-                        </div>
-                    </div>
-                </div>
-
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
                             <h4 class="gh-expandable-title">Signup Card</h4>
                             <p class="gh-expandable-description">
                                 Enables the signup card in the Lexical editor

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -36,7 +36,6 @@ const ALPHA_FEATURES = [
     'websockets',
     'stripeAutomaticTax',
     'emailCustomization',
-    'imageEditor',
     'signupCard',
     'collections',
     'adminXSettings',


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3337

Removed `imageEditor` flag and moved gated logic to be behind the `lexicalEditor` flag as part of the labs clean up