### PR TITLE
Onboarding events

### DIFF
--- a/ghost/core/core/server/services/segment/DomainEventsAnalytics.js
+++ b/ghost/core/core/server/services/segment/DomainEventsAnalytics.js
@@ -9,7 +9,8 @@ const {MilestoneCreatedEvent} = require('@tryghost/milestones');
  */
 
 /**
- * @typedef {import('../../../shared/sentry')} sentry
+ * @typedef {object} IExceptionHandler
+ * @prop {(err: Error) => void} captureException
  */
 
 /**
@@ -22,7 +23,7 @@ const {MilestoneCreatedEvent} = require('@tryghost/milestones');
  * @param {logging} logging
  * @param {object} trackDefaults
  * @param {string} prefix
- * @param {sentry} sentry
+ * @param {IExceptionHandler} exceptionHandler
  * @param {DomainEvents} DomainEvents
  * @prop {} subscribeToEvents
  */
@@ -34,8 +35,8 @@ module.exports = class DomainEventsAnalytics {
     #trackDefaults;
     /** @type {string} */
     #prefix;
-    /** @type {sentry} */
-    #sentry;
+    /** @type {IExceptionHandler} */
+    #exceptionHandler;
     /** @type {logging} */
     #logging;
     /** @type {DomainEvents} */
@@ -45,7 +46,7 @@ module.exports = class DomainEventsAnalytics {
         this.#analytics = deps.analytics;
         this.#trackDefaults = deps.trackDefaults;
         this.#prefix = deps.prefix;
-        this.#sentry = deps.sentry;
+        this.#exceptionHandler = deps.exceptionHandler;
         this.#logging = deps.logging;
         this.#DomainEvents = deps.DomainEvents;
     }
@@ -63,13 +64,13 @@ module.exports = class DomainEventsAnalytics {
         if (event.data.milestone
             && event.data.milestone.value === 100
         ) {
-            const eventName = event.data.milestone.type === 'arr' ? '$100 MRR reached' : '100 members reached';
+            const eventName = event.data.milestone.type === 'arr' ? '$100 MRR reached' : '100 Members reached';
 
             try {
                 this.#analytics.track(Object.assign(this.#trackDefaults, {}, {event: this.#prefix + eventName}));
             } catch (err) {
                 this.#logging.error(err);
-                this.#sentry.captureException(err);
+                this.#exceptionHandler.captureException(err);
             }
         }
     }

--- a/ghost/core/core/server/services/segment/DomainEventsAnalytics.js
+++ b/ghost/core/core/server/services/segment/DomainEventsAnalytics.js
@@ -1,0 +1,40 @@
+const _ = require('lodash');
+const logging = require('@tryghost/logging');
+const DomainEvents = require('@tryghost/domain-events');
+const {MilestoneCreatedEvent} = require('@tryghost/milestones');
+
+module.exports = class DomainEventsAnalytics {
+    #analytics;
+    #trackDefaults;
+    #prefix;
+    #sentry;
+
+    constructor(deps) {
+        this.#analytics = deps.analytics;
+        this.#trackDefaults = deps.trackDefaults;
+        this.#prefix = deps.prefix;
+        this.#sentry = deps.sentry;
+    }
+
+    async #handleMilestoneCreatedEvent(type, event) {
+        if (type === MilestoneCreatedEvent
+            && event.data.milestone
+            && event.data.milestone.value === 100
+        ) {
+            const eventName = event.data.milestone.type === 'arr' ? '$100 MRR reached' : '100 members reached';
+
+            try {
+                this.#analytics.track(_.extend(this.#trackDefaults, {}, {event: this.#prefix + eventName}));
+            } catch (err) {
+                logging.error(err);
+                this.#sentry.captureException(err);
+            }
+        }
+    }
+
+    subscribeToDomainEvents() {
+        DomainEvents.subscribe(MilestoneCreatedEvent, async (event) => {
+            await this.#handleMilestoneCreatedEvent(MilestoneCreatedEvent, event);
+        });
+    }
+};

--- a/ghost/core/core/server/services/segment/DomainEventsAnalytics.js
+++ b/ghost/core/core/server/services/segment/DomainEventsAnalytics.js
@@ -1,40 +1,82 @@
-const _ = require('lodash');
-const logging = require('@tryghost/logging');
-const DomainEvents = require('@tryghost/domain-events');
 const {MilestoneCreatedEvent} = require('@tryghost/milestones');
 
+/**
+ * @typedef {import('@tryghost/logging')} logging
+ */
+
+/**
+ * @typedef {import('analytics-node')} analytics
+ */
+
+/**
+ * @typedef {import('../../../shared/sentry')} sentry
+ */
+
+/**
+ * @typedef {import('@tryghost/domain-events')} DomainEvents
+ */
+
+/**
+ * @typedef {object} IDomainEventsAnalytics
+ * @param {analytics} analytics
+ * @param {logging} logging
+ * @param {object} trackDefaults
+ * @param {string} prefix
+ * @param {sentry} sentry
+ * @param {DomainEvents} DomainEvents
+ * @prop {} subscribeToEvents
+ */
+
 module.exports = class DomainEventsAnalytics {
+    /** @type {analytics} */
     #analytics;
+    /** @type {object} */
     #trackDefaults;
+    /** @type {string} */
     #prefix;
+    /** @type {sentry} */
     #sentry;
+    /** @type {logging} */
+    #logging;
+    /** @type {DomainEvents} */
+    #DomainEvents;
 
     constructor(deps) {
         this.#analytics = deps.analytics;
         this.#trackDefaults = deps.trackDefaults;
         this.#prefix = deps.prefix;
         this.#sentry = deps.sentry;
+        this.#logging = deps.logging;
+        this.#DomainEvents = deps.DomainEvents;
     }
 
-    async #handleMilestoneCreatedEvent(type, event) {
-        if (type === MilestoneCreatedEvent
-            && event.data.milestone
+    /**
+     *
+     * @param {object} event
+     * @param {object} event.data
+     * @param {object} event.data.milestone
+     * @param {number} event.data.milestone.value
+     * @param {string} event.data.milestone.type
+     * @returns {Promise<void>}
+     */
+    async #handleMilestoneCreatedEvent(event) {
+        if (event.data.milestone
             && event.data.milestone.value === 100
         ) {
             const eventName = event.data.milestone.type === 'arr' ? '$100 MRR reached' : '100 members reached';
 
             try {
-                this.#analytics.track(_.extend(this.#trackDefaults, {}, {event: this.#prefix + eventName}));
+                this.#analytics.track(Object.assign(this.#trackDefaults, {}, {event: this.#prefix + eventName}));
             } catch (err) {
-                logging.error(err);
+                this.#logging.error(err);
                 this.#sentry.captureException(err);
             }
         }
     }
 
-    subscribeToDomainEvents() {
-        DomainEvents.subscribe(MilestoneCreatedEvent, async (event) => {
-            await this.#handleMilestoneCreatedEvent(MilestoneCreatedEvent, event);
+    subscribeToEvents() {
+        this.#DomainEvents.subscribe(MilestoneCreatedEvent, async (event) => {
+            await this.#handleMilestoneCreatedEvent(event);
         });
     }
 };

--- a/ghost/core/core/server/services/segment/ModelEventsAnalytics.js
+++ b/ghost/core/core/server/services/segment/ModelEventsAnalytics.js
@@ -9,7 +9,8 @@ const _ = require('lodash');
  */
 
 /**
- * @typedef {import('../../../shared/sentry')} sentry
+ * @typedef {object} IExceptionHandler
+ * @prop {(err: Error) => void} captureException
  */
 
 /**
@@ -22,7 +23,7 @@ const _ = require('lodash');
  * @param {logging} logging
  * @param {object} trackDefaults
  * @param {string} prefix
- * @param {sentry} sentry
+ * @param {IExceptionHandler} exceptionHandler
  * @param {events} events
  * @prop {} subscribeToEvents
  */
@@ -38,8 +39,8 @@ module.exports = class ModelEventsAnalytics {
     #trackDefaults;
     /** @type {string} */
     #prefix;
-    /** @type {sentry} */
-    #sentry;
+    /** @type {IExceptionHandler} */
+    #exceptionHandler;
     /** @type {events} */
     #events;
     /** @type {logging} */
@@ -74,7 +75,7 @@ module.exports = class ModelEventsAnalytics {
         this.#analytics = deps.analytics;
         this.#trackDefaults = deps.trackDefaults;
         this.#prefix = deps.prefix;
-        this.#sentry = deps.sentry;
+        this.#exceptionHandler = deps.exceptionHandler;
         this.#events = deps.events;
         this.#logging = deps.logging;
     }
@@ -84,7 +85,7 @@ module.exports = class ModelEventsAnalytics {
             this.#analytics.track(event);
         } catch (err) {
             this.#logging.error(err);
-            this.#sentry.captureException(err);
+            this.#exceptionHandler.captureException(err);
         }
     }
 

--- a/ghost/core/core/server/services/segment/ModelEventsAnalytics.js
+++ b/ghost/core/core/server/services/segment/ModelEventsAnalytics.js
@@ -1,0 +1,63 @@
+const _ = require('lodash');
+const logging = require('@tryghost/logging');
+// Listens to model events to layer on analytics - also uses the "fake" theme.uploaded event from the theme API
+const events = require('../../lib/common/events');
+
+const TO_TRACK = [
+    {
+        event: 'post.published',
+        name: 'Post Published'
+    },
+    {
+        event: 'page.published',
+        name: 'Page Published'
+    },
+    {
+        event: 'theme.uploaded',
+        name: 'Theme Uploaded',
+        // {keyOnSuppliedEventData: keyOnTrackedEventData}
+        // - used to extract specific properties from event data and give them meaningful names
+        data: {name: 'name'}
+    },
+    {
+        event: 'integration.added',
+        name: 'Custom Integration Added'
+    },
+    {
+        event: 'settings.edited',
+        name: 'Stripe enabled',
+        data: {key: 'key', value: 'value'}
+    }
+];
+
+module.exports = class ModelEventsAnalytics {
+    #analytics;
+    #trackDefaults;
+    #prefix;
+    #sentry;
+    #toTrack;
+
+    constructor(deps) {
+        this.#analytics = deps.analytics;
+        this.#trackDefaults = deps.trackDefaults;
+        this.#prefix = deps.prefix;
+        this.#sentry = deps.sentry;
+        this.#toTrack = TO_TRACK;
+    }
+
+    subscribeToModelEvents() {
+        this.#toTrack.forEach(({event, name, data = {}}) => {
+            events.on(event, function (eventData = {}) {
+                // extract desired properties from eventData and rename keys if necessary
+                const mappedData = _.mapValues(data || {}, v => eventData[v]);
+
+                try {
+                    this.#analytics.track(_.extend(this.#trackDefaults, mappedData, {event: this.#prefix + name}));
+                } catch (err) {
+                    logging.error(err);
+                    this.#sentry.captureException(err);
+                }
+            });
+        });
+    }
+};

--- a/ghost/core/core/server/services/segment/index.js
+++ b/ghost/core/core/server/services/segment/index.js
@@ -17,7 +17,7 @@ module.exports.init = function () {
         analytics,
         trackDefaults,
         prefix,
-        sentry,
+        exceptionHandler: sentry,
         DomainEvents,
         logging
     });
@@ -26,14 +26,14 @@ module.exports.init = function () {
         analytics,
         trackDefaults,
         prefix,
-        sentry,
+        exceptionHandler: sentry,
         events,
         logging
     });
 
     // Listen to model events
-    modelEventsAnalytics.subscribeToModelEvents();
+    modelEventsAnalytics.subscribeToEvents();
 
     // Listen to domain events
-    subscribeToDomainEvents.subscribeToDomainEvents();
+    subscribeToDomainEvents.subscribeToEvents();
 };

--- a/ghost/core/core/server/services/segment/index.js
+++ b/ghost/core/core/server/services/segment/index.js
@@ -1,51 +1,32 @@
-const _ = require('lodash');
 const Analytics = require('analytics-node');
-const logging = require('@tryghost/logging');
-
 const config = require('../../../shared/config');
 const sentry = require('../../../shared/sentry');
 
-// Listens to model events to layer on analytics - also uses the "fake" theme.uploaded event from the theme API
-const events = require('../../lib/common/events');
+const ModelEventsAnalytics = require('./ModelEventsAnalytics');
+const DomainEventsAnalytics = require('./DomainEventsAnalytics');
 
 module.exports.init = function () {
     const analytics = new Analytics(config.get('segment:key'));
     const trackDefaults = config.get('segment:trackDefaults') || {};
     const prefix = config.get('segment:prefix') || '';
 
-    const toTrack = [
-        {
-            event: 'post.published',
-            name: 'Post Published'
-        },
-        {
-            event: 'page.published',
-            name: 'Page Published'
-        },
-        {
-            event: 'theme.uploaded',
-            name: 'Theme Uploaded',
-            // {keyOnSuppliedEventData: keyOnTrackedEventData}
-            // - used to extract specific properties from event data and give them meaningful names
-            data: {name: 'name'}
-        },
-        {
-            event: 'integration.added',
-            name: 'Custom Integration Added'
-        }
-    ];
-
-    _.each(toTrack, function (track) {
-        events.on(track.event, function (eventData = {}) {
-            // extract desired properties from eventData and rename keys if necessary
-            const data = _.mapValues(track.data || {}, v => eventData[v]);
-
-            try {
-                analytics.track(_.extend(trackDefaults, data, {event: prefix + track.name}));
-            } catch (err) {
-                logging.error(err);
-                sentry.captureException(err);
-            }
-        });
+    const subscribeToDomainEvents = new DomainEventsAnalytics({
+        analytics,
+        trackDefaults,
+        prefix,
+        sentry
     });
+
+    const modelEventsAnalytics = new ModelEventsAnalytics({
+        analytics,
+        trackDefaults,
+        prefix,
+        sentry
+    });
+
+    // Listen to model events
+    modelEventsAnalytics.subscribeToModelEvents();
+
+    // Listen to domain events
+    subscribeToDomainEvents.subscribeToDomainEvents();
 };

--- a/ghost/core/core/server/services/segment/index.js
+++ b/ghost/core/core/server/services/segment/index.js
@@ -1,6 +1,9 @@
 const Analytics = require('analytics-node');
 const config = require('../../../shared/config');
 const sentry = require('../../../shared/sentry');
+const logging = require('@tryghost/logging');
+const DomainEvents = require('@tryghost/domain-events');
+const events = require('../../lib/common/events');
 
 const ModelEventsAnalytics = require('./ModelEventsAnalytics');
 const DomainEventsAnalytics = require('./DomainEventsAnalytics');
@@ -14,14 +17,18 @@ module.exports.init = function () {
         analytics,
         trackDefaults,
         prefix,
-        sentry
+        sentry,
+        DomainEvents,
+        logging
     });
 
     const modelEventsAnalytics = new ModelEventsAnalytics({
         analytics,
         trackDefaults,
         prefix,
-        sentry
+        sentry,
+        events,
+        logging
     });
 
     // Listen to model events

--- a/ghost/core/test/unit/server/services/segment/DomainEventsAnalytics.test.js
+++ b/ghost/core/test/unit/server/services/segment/DomainEventsAnalytics.test.js
@@ -19,13 +19,13 @@ describe('DomainEventsAnalytics', function () {
     describe('Domain events analytics service', function () {
         let domainEventsAnalytics;
         let analyticsStub;
-        let sentryStub;
+        let exceptionHandlerStub;
         let loggingStub;
         let domainEventsStub;
 
         beforeEach(function () {
             analyticsStub = sinon.stub();
-            sentryStub = sinon.stub();
+            exceptionHandlerStub = sinon.stub();
             loggingStub = sinon.stub();
             domainEventsStub = sinon.stub();
         });
@@ -42,8 +42,8 @@ describe('DomainEventsAnalytics', function () {
                     properties: {email: 'john@test.com'}
                 },
                 prefix: 'Pro: ',
-                sentry: {
-                    captureException: sentryStub
+                exceptionHandler: {
+                    captureException: exceptionHandlerStub
                 },
                 DomainEvents: {
                     subscribe: domainEventsStub
@@ -68,8 +68,8 @@ describe('DomainEventsAnalytics', function () {
                     properties: {email: 'john@test.com'}
                 },
                 prefix: 'Pro: ',
-                sentry: {
-                    captureException: sentryStub
+                exceptionHandler: {
+                    captureException: exceptionHandlerStub
                 },
                 DomainEvents,
                 logging: {
@@ -95,7 +95,7 @@ describe('DomainEventsAnalytics', function () {
             assert(analyticsStub.calledWith({
                 userId: '1234',
                 properties: {email: 'john@test.com'},
-                event: 'Pro: 100 members reached'
+                event: 'Pro: 100 Members reached'
             }));
 
             DomainEvents.dispatch(MilestoneCreatedEvent.create({
@@ -124,8 +124,8 @@ describe('DomainEventsAnalytics', function () {
                     properties: {email: 'john+arr@test.com'}
                 },
                 prefix: 'Pro: ',
-                sentry: {
-                    captureException: sentryStub
+                exceptionHandler: {
+                    captureException: exceptionHandlerStub
                 },
                 DomainEvents,
                 logging: {
@@ -181,8 +181,8 @@ describe('DomainEventsAnalytics', function () {
                 },
                 trackDefaults: {},
                 prefix: '',
-                sentry: {
-                    captureException: sentryStub
+                exceptionHandler: {
+                    captureException: exceptionHandlerStub
                 },
                 DomainEvents,
                 logging: {
@@ -207,8 +207,8 @@ describe('DomainEventsAnalytics', function () {
                 await DomainEvents.allSettled();
             } catch (err) {
                 assert(analyticsStub.callCount === 1);
-                assert(sentryStub.callCount === 1);
-                assert(sentryStub.calledWith(error));
+                assert(exceptionHandlerStub.callCount === 1);
+                assert(exceptionHandlerStub.calledWith(error));
                 assert(loggingStub.callCount === 1);
             }
         });

--- a/ghost/core/test/unit/server/services/segment/DomainEventsAnalytics.test.js
+++ b/ghost/core/test/unit/server/services/segment/DomainEventsAnalytics.test.js
@@ -1,0 +1,199 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const ObjectId = require('bson-objectid').default;
+
+// To test
+const DomainEventsAnalytics = require('../../../../../core/server/services/segment/DomainEventsAnalytics');
+
+// Stubbed dependencies
+const DomainEvents = require('@tryghost/domain-events');
+const {MilestoneCreatedEvent} = require('@tryghost/milestones');
+const logging = require('@tryghost/logging');
+
+describe('DomainEventsAnalytics', function () {
+    describe('Constructor', function () {
+        it('doesn\'t throw', function () {
+            new DomainEventsAnalytics({});
+        });
+    });
+
+    describe('Domain events analytics service', function () {
+        let domainAnalytics;
+        let analyticsStub;
+        let sentryStub;
+        let loggingStub;
+
+        beforeEach(function () {
+            analyticsStub = sinon.stub();
+            sentryStub = sinon.stub();
+            loggingStub = sinon.stub(logging, 'error');
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('subscribes to events', async function () {
+            const domainEventsStub = sinon.stub(DomainEvents, 'subscribe').resolves();
+
+            domainAnalytics = new DomainEventsAnalytics({
+                analytics: analyticsStub,
+                trackDefaults: {
+                    userId: '1234',
+                    properties: {email: 'john@test.com'}
+                },
+                prefix: 'Pro: ',
+                sentry: {
+                    captureException: sentryStub
+                }
+            });
+
+            domainAnalytics.subscribeToDomainEvents();
+            assert(domainEventsStub.callCount === 1);
+            assert(loggingStub.callCount === 0);
+        });
+
+        it('handles milestone created event for 100 members', async function () {
+            domainAnalytics = new DomainEventsAnalytics({
+                analytics: {
+                    track: analyticsStub
+                },
+                trackDefaults: {
+                    userId: '1234',
+                    properties: {email: 'john@test.com'}
+                },
+                prefix: 'Pro: ',
+                sentry: {
+                    captureException: sentryStub
+                }
+            });
+
+            domainAnalytics.subscribeToDomainEvents();
+
+            DomainEvents.dispatch(MilestoneCreatedEvent.create({
+                milestone: {
+                    id: new ObjectId().toHexString(),
+                    type: 'members',
+                    value: 100,
+                    createdAt: new Date(),
+                    emailSentAt: new Date()
+                }
+            }));
+
+            await DomainEvents.allSettled();
+
+            assert(analyticsStub.callCount === 1);
+            assert(analyticsStub.calledWith({
+                userId: '1234',
+                properties: {email: 'john@test.com'},
+                event: 'Pro: 100 members reached'
+            }));
+
+            DomainEvents.dispatch(MilestoneCreatedEvent.create({
+                milestone: {
+                    id: new ObjectId().toHexString(),
+                    type: 'members',
+                    value: 1000,
+                    createdAt: new Date(),
+                    emailSentAt: new Date()
+                }
+            }));
+
+            await DomainEvents.allSettled();
+            // Analytics should not be called again
+            assert(analyticsStub.callCount === 1);
+            assert(loggingStub.callCount === 0);
+        });
+
+        it('handles milestone created event for $100 ARR', async function () {
+            domainAnalytics = new DomainEventsAnalytics({
+                analytics: {
+                    track: analyticsStub
+                },
+                trackDefaults: {
+                    userId: '9876',
+                    properties: {email: 'john+arr@test.com'}
+                },
+                prefix: 'Pro: ',
+                sentry: {
+                    captureException: sentryStub
+                }
+            });
+
+            domainAnalytics.subscribeToDomainEvents();
+
+            DomainEvents.dispatch(MilestoneCreatedEvent.create({
+                milestone: {
+                    id: new ObjectId().toHexString(),
+                    type: 'arr',
+                    currency: 'usd',
+                    value: 100,
+                    createdAt: new Date(),
+                    emailSentAt: new Date()
+                }
+            }));
+
+            await DomainEvents.allSettled();
+
+            assert(analyticsStub.callCount === 1);
+            assert(analyticsStub.calledWith({
+                userId: '9876',
+                properties: {email: 'john+arr@test.com'},
+                event: 'Pro: $100 MRR reached'
+            }));
+            assert(loggingStub.callCount === 0);
+
+            DomainEvents.dispatch(MilestoneCreatedEvent.create({
+                milestone: {
+                    id: new ObjectId().toHexString(),
+                    type: 'arr',
+                    currency: 'usd',
+                    value: 1000,
+                    createdAt: new Date(),
+                    emailSentAt: new Date()
+                }
+            }));
+
+            await DomainEvents.allSettled();
+            // Analytics should not be called again
+            assert(analyticsStub.callCount === 1);
+            assert(loggingStub.callCount === 0);
+        });
+
+        it('can handle tracking errors', async function () {
+            let error = new Error('Test error');
+            domainAnalytics = new DomainEventsAnalytics({
+                analytics: {
+                    track: analyticsStub.throws(error)
+                },
+                trackDefaults: {},
+                prefix: '',
+                sentry: {
+                    captureException: sentryStub
+                }
+            });
+
+            domainAnalytics.subscribeToDomainEvents();
+
+            try {
+                DomainEvents.dispatch(MilestoneCreatedEvent.create({
+                    milestone: {
+                        id: new ObjectId().toHexString(),
+                        type: 'arr',
+                        currency: 'usd',
+                        value: 100,
+                        createdAt: new Date(),
+                        emailSentAt: new Date()
+                    }
+                }));
+
+                await DomainEvents.allSettled();
+            } catch (err) {
+                assert(analyticsStub.callCount === 1);
+                assert(sentryStub.callCount === 1);
+                assert(sentryStub.calledWith(error));
+                assert(loggingStub.callCount === 1);
+            }
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/segment/ModelEventsAnalytics.test.js
+++ b/ghost/core/test/unit/server/services/segment/ModelEventsAnalytics.test.js
@@ -17,13 +17,13 @@ describe('ModelEventsAnalytics', function () {
     describe('Model events analytics service', function () {
         let modelEventsAnalytics;
         let analyticsStub;
-        let sentryStub;
+        let exceptionHandlerStub;
         let loggingStub;
         let eventStub;
 
         beforeEach(function () {
             analyticsStub = sinon.stub();
-            sentryStub = sinon.stub();
+            exceptionHandlerStub = sinon.stub();
             loggingStub = sinon.stub();
             eventStub = sinon.stub();
         });
@@ -40,8 +40,8 @@ describe('ModelEventsAnalytics', function () {
                     properties: {email: 'john@test.com'}
                 },
                 prefix: 'Pro: ',
-                sentry: {
-                    captureException: sentryStub
+                exceptionHandler: {
+                    captureException: exceptionHandlerStub
                 },
                 events: {
                     on: eventStub
@@ -67,8 +67,8 @@ describe('ModelEventsAnalytics', function () {
                     properties: {email: 'john@test.com'}
                 },
                 prefix: 'Pro: ',
-                sentry: {
-                    captureException: sentryStub
+                exceptionHandler: {
+                    captureException: exceptionHandlerStub
                 },
                 events,
                 logging: {
@@ -124,8 +124,8 @@ describe('ModelEventsAnalytics', function () {
                 },
                 trackDefaults: {},
                 prefix: '',
-                sentry: {
-                    captureException: sentryStub
+                exceptionHandler: {
+                    captureException: exceptionHandlerStub
                 },
                 events,
                 logging: {
@@ -139,8 +139,8 @@ describe('ModelEventsAnalytics', function () {
                 events.emit('post.published');
             } catch (err) {
                 assert(analyticsStub.callCount === 1);
-                assert(sentryStub.callCount === 1);
-                assert(sentryStub.calledWith(error));
+                assert(exceptionHandlerStub.callCount === 1);
+                assert(exceptionHandlerStub.calledWith(error));
                 assert(loggingStub.callCount === 1);
             }
         });

--- a/ghost/core/test/unit/server/services/segment/ModelEventsAnalytics.test.js
+++ b/ghost/core/test/unit/server/services/segment/ModelEventsAnalytics.test.js
@@ -1,0 +1,108 @@
+const assert = require('assert');
+const sinon = require('sinon');
+
+// To test
+const ModelEventsAnalytics = require('../../../../../core/server/services/segment/ModelEventsAnalytics');
+
+// Stubbed dependencies
+const logging = require('@tryghost/logging');
+
+describe('ModelEventsAnalytics', function () {
+    describe('Constructor', function () {
+        it('doesn\'t throw', function () {
+            new ModelEventsAnalytics({});
+        });
+    });
+
+    describe('Model events analytics service', function () {
+        let modelEventsAnalytics;
+        let analyticsStub;
+        let sentryStub;
+        let loggingStub;
+
+        beforeEach(function () {
+            analyticsStub = sinon.stub();
+            sentryStub = sinon.stub();
+            loggingStub = sinon.stub(logging, 'error');
+        });
+
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('subscribes to events', async function () {
+            modelEventsAnalytics = new ModelEventsAnalytics({
+                analytics: analyticsStub,
+                trackDefaults: {
+                    userId: '1234',
+                    properties: {email: 'john@test.com'}
+                },
+                prefix: 'Pro: ',
+                sentry: {
+                    captureException: sentryStub
+                }
+            });
+
+            modelEventsAnalytics.subscribeToModelEvents();
+            assert(loggingStub.callCount === 0);
+        });
+
+        it('handles milestone created event for 100 members', async function () {
+            modelEventsAnalytics = new ModelEventsAnalytics({
+                analytics: {
+                    track: analyticsStub
+                },
+                trackDefaults: {
+                    userId: '1234',
+                    properties: {email: 'john@test.com'}
+                },
+                prefix: 'Pro: ',
+                sentry: {
+                    captureException: sentryStub
+                }
+            });
+
+            modelEventsAnalytics.subscribeToModelEvents();
+
+            assert(analyticsStub.callCount === 1);
+            assert(analyticsStub.calledWith({
+                userId: '1234',
+                properties: {email: 'john@test.com'},
+                event: 'Pro: 100 members reached'
+            }));
+        });
+
+        it('handles milestone created event for $100 ARR', async function () {
+            modelEventsAnalytics = new ModelEventsAnalytics({
+                analytics: {
+                    track: analyticsStub
+                },
+                trackDefaults: {
+                    userId: '9876',
+                    properties: {email: 'john+arr@test.com'}
+                },
+                prefix: 'Pro: ',
+                sentry: {
+                    captureException: sentryStub
+                }
+            });
+
+            modelEventsAnalytics.subscribeToModelEvents();
+        });
+
+        it('can handle tracking errors', async function () {
+            let error = new Error('Test error');
+            modelEventsAnalytics = new ModelEventsAnalytics({
+                analytics: {
+                    track: analyticsStub.throws(error)
+                },
+                trackDefaults: {},
+                prefix: '',
+                sentry: {
+                    captureException: sentryStub
+                }
+            });
+
+            modelEventsAnalytics.subscribeToModelEvents();
+    });
+});

--- a/ghost/core/test/unit/server/services/segment/index.test.js
+++ b/ghost/core/test/unit/server/services/segment/index.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+
+describe('Segment Analytics Service', function () {
+    let segmentService;
+
+    it('Provides expected public API', async function () {
+        segmentService = require('../../../../../core/server/services/segment');
+
+        assert.ok(segmentService.initAndRun);
+    });
+});

--- a/ghost/core/test/unit/server/services/segment/index.test.js
+++ b/ghost/core/test/unit/server/services/segment/index.test.js
@@ -6,6 +6,6 @@ describe('Segment Analytics Service', function () {
     it('Provides expected public API', async function () {
         segmentService = require('../../../../../core/server/services/segment');
 
-        assert.ok(segmentService.initAndRun);
+        assert.ok(segmentService.init);
     });
 });


### PR DESCRIPTION
<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 757ad8c</samp>

This pull request introduces a major refactoring of the segment service, which tracks analytics events for Ghost. It splits the service into two classes, `DomainEventsAnalytics` and `ModelEventsAnalytics`, that handle different types of events. It also adds unit tests for these classes and the service itself.
