### PR TITLE
Added traditional Chinese translatinos for signup-form

### DIFF
--- a/ghost/i18n/locales/zh-Hant/signup-form.json
+++ b/ghost/i18n/locales/zh-Hant/signup-form.json
@@ -1,7 +1,7 @@
 {
-    "Now check your email!": "",
-    "Please enter a valid email address": "",
-    "Something went wrong, please try again.": "",
-    "Subscribe": "",
-    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": ""
+    "Now check your email!": "請檢查你的 email 收件夾",
+    "Please enter a valid email address": "請輸入正確的 email 地址",
+    "Something went wrong, please try again.": "錯誤發生，請再試一次",
+    "Subscribe": "訂閱",
+    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "請在 email 收件夾中找到註冊確認信件，點擊內文中的連結完成註冊。如果在三分鐘後還沒收到信件，請檢查你的垃圾收件夾!"
 }


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69e05e3</samp>

This change adds a new file `ghost/i18n/locales/zh-Hant/signup-form.json` that contains the Traditional Chinese translation for the signup form messages. This enables the Ghost blog to support the Traditional Chinese language and improve the user experience for the subscribers.
