### PR TITLE
Updated French translations for signup-form

### DIFF
--- a/ghost/i18n/locales/fr/signup-form.json
+++ b/ghost/i18n/locales/fr/signup-form.json
@@ -1,7 +1,7 @@
 {
-    "Now check your email!": "",
-    "Please enter a valid email address": "",
-    "Something went wrong, please try again.": "",
-    "Subscribe": "",
-    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": ""
+    "Now check your email!": "Maintenant, vérifiez votre e-mail!",
+    "Please enter a valid email address": "S'il vous plaît, mettez une adresse e-mail valide",
+    "Something went wrong, please try again.": "Un problème est survenu, veuillez réessayer.",
+    "Subscribe": "S'abonner",
+    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Pour terminer l'inscription, cliquez sur le lien de confirmation dans votre boîte de réception. S'il n'arrive pas dans les 3 minutes, vérifiez votre dossier des spams !"
 }

--- a/ghost/i18n/locales/fr/signup-form.json
+++ b/ghost/i18n/locales/fr/signup-form.json
@@ -3,5 +3,5 @@
     "Please enter a valid email address": "S'il vous plaît, mettez une adresse e-mail valide",
     "Something went wrong, please try again.": "Un problème est survenu, veuillez réessayer.",
     "Subscribe": "S'abonner",
-    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Pour terminer l'inscription, cliquez sur le lien de confirmation dans votre boîte de réception. S'il n'arrive pas dans les 3 minutes, vérifiez votre dossier des spams !"
+    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Pour terminer l'inscription, cliquez sur le lien de confirmation dans votre boîte de réception. S'il n'arrive pas dans les 3 minutes, vérifiez votre dossier de spam !"
 }


### PR DESCRIPTION
All is in the title ^^.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 164a0ec</samp>

This change adds French translations for the signup form messages in `ghost/i18n/locales/fr/signup-form.json`. This improves the user experience for French-speaking visitors who want to sign up for a Ghost blog.
