### PR TITLE
Fixed flaky frontend members test

### DIFF
--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -455,8 +455,7 @@ describe('Front-end members behavior', function () {
                     .expect(200)
                     .expect(assertContentIsPresent);
 
-                // Give a little time for the MemberPageViewEvent to be processed by any subscribers that write to the database
-                await testUtils.sleep(250);
+                await DomainEvents.allSettled();
 
                 assert(spy.calledOnce, 'A page view from a member should generate a MemberPageViewEvent event');
                 member = await models.Member.findOne({email});
@@ -540,8 +539,7 @@ describe('Front-end members behavior', function () {
                     .expect(200)
                     .expect(assertContentIsPresent);
 
-                // Give a little time for the MemberPageViewEvent to be processed by any subscribers that write to the database
-                await testUtils.sleep(250);
+                await DomainEvents.allSettled();
 
                 assert(spy.calledOnce, 'A page view from a member should generate a MemberPageViewEvent event');
                 member = await models.Member.findOne({email});

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -455,6 +455,9 @@ describe('Front-end members behavior', function () {
                     .expect(200)
                     .expect(assertContentIsPresent);
 
+                // Give a little time for the MemberPageViewEvent to be processed by any subscribers that write to the database
+                await testUtils.sleep(250);
+
                 assert(spy.calledOnce, 'A page view from a member should generate a MemberPageViewEvent event');
                 member = await models.Member.findOne({email});
                 assert.notEqual(member.get('last_seen_at'), null, 'The member should have a `last_seen_at` property after having visited a page while logged-in.');
@@ -536,6 +539,9 @@ describe('Front-end members behavior', function () {
                     .get('/free-to-see/')
                     .expect(200)
                     .expect(assertContentIsPresent);
+
+                // Give a little time for the MemberPageViewEvent to be processed by any subscribers that write to the database
+                await testUtils.sleep(250);
 
                 assert(spy.calledOnce, 'A page view from a member should generate a MemberPageViewEvent event');
                 member = await models.Member.findOne({email});

--- a/ghost/core/test/utils/index.js
+++ b/ghost/core/test/utils/index.js
@@ -92,6 +92,12 @@ const createEmailedPost = async function createEmailedPost({postOptions, emailOp
     return {post, email};
 };
 
+const sleep = ms => (
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    })
+);
+
 module.exports = {
     startGhost: e2eUtils.startGhost,
     stopGhost: e2eUtils.stopGhost,
@@ -162,5 +168,6 @@ module.exports = {
             contributor: DataGenerator.Content.roles[4].id
         }
     },
-    cacheRules: cacheRules
+    cacheRules: cacheRules,
+    sleep
 };

--- a/ghost/core/test/utils/index.js
+++ b/ghost/core/test/utils/index.js
@@ -92,12 +92,6 @@ const createEmailedPost = async function createEmailedPost({postOptions, emailOp
     return {post, email};
 };
 
-const sleep = ms => (
-    new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    })
-);
-
 module.exports = {
     startGhost: e2eUtils.startGhost,
     stopGhost: e2eUtils.stopGhost,
@@ -168,6 +162,5 @@ module.exports = {
             contributor: DataGenerator.Content.roles[4].id
         }
     },
-    cacheRules: cacheRules,
-    sleep
+    cacheRules: cacheRules
 };


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3325

Awaited `DomainEvents.allSettled()` to ensure domain event is fully processed before asserting member was successfully updated