### PR TITLE
Added collections CRUD permissions

### DIFF
--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -19,8 +19,7 @@ module.exports = {
             'page',
             'filter'
         ],
-        // @NOTE: should have permissions when moving out of Alpha
-        permissions: false,
+        permissions: true,
         query(frame) {
             return collectionsService.api.getAll(frame.options);
         }
@@ -33,8 +32,7 @@ module.exports = {
         data: [
             'id'
         ],
-        // @NOTE: should have permissions when moving out of Alpha
-        permissions: false,
+        permissions: true,
         async query(frame) {
             const model = await collectionsService.api.getById(frame.data.id);
 
@@ -53,8 +51,7 @@ module.exports = {
         headers: {
             cacheInvalidate: true
         },
-        // @NOTE: should have permissions when moving out of Alpha
-        permissions: false,
+        permissions: true,
         async query(frame) {
             return await collectionsService.api.createCollection(frame.data.collections[0]);
         }
@@ -74,8 +71,7 @@ module.exports = {
                 }
             }
         },
-        // @NOTE: should have permissions when moving out of Alpha
-        permissions: false,
+        permissions: true,
         async query(frame) {
             const model = await collectionsService.api.edit(Object.assign(frame.data.collections[0], {
                 id: frame.options.id
@@ -101,7 +97,6 @@ module.exports = {
     },
 
     addPost: {
-        docName: 'collection_posts',
         statusCode: 200,
         headers: {
             cacheInvalidate: false
@@ -124,8 +119,9 @@ module.exports = {
                 }
             }
         },
-        // @NOTE: should have permissions when moving out of Alpha
-        permissions: false,
+        permissions: {
+            method: 'edit'
+        },
         async query(frame) {
             const collectionPost = await collectionsService.api.addPostToCollection(frame.options.id, {
                 id: frame.data.posts[0].id
@@ -156,15 +152,13 @@ module.exports = {
                 }
             }
         },
-        // @NOTE: should have permissions when moving out of Alpha
-        permissions: false,
+        permissions: true,
         async query(frame) {
             return await collectionsService.api.destroy(frame.options.id);
         }
     },
 
     destroyPost: {
-        docName: 'collection_posts',
         statusCode: 200,
         headers: {
             cacheInvalidate: true
@@ -183,8 +177,9 @@ module.exports = {
                 }
             }
         },
-        // @NOTE: should have permissions when moving out of Alpha
-        permissions: false,
+        permissions: {
+            method: 'edit'
+        },
         async query(frame) {
             const collection = await collectionsService.api.removePostFromCollection(frame.options.id, frame.options.post_id);
 

--- a/ghost/core/core/server/data/migrations/versions/5.51/2023-06-07-10-17-add-collections-crud-persmissions.js
+++ b/ghost/core/core/server/data/migrations/versions/5.51/2023-06-07-10-17-add-collections-crud-persmissions.js
@@ -1,0 +1,54 @@
+const {combineTransactionalMigrations, addPermissionWithRoles} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addPermissionWithRoles({
+        name: 'Browse collections',
+        action: 'browse',
+        object: 'collection'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor',
+        'Author',
+        'Contributor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Read collections',
+        action: 'read',
+        object: 'collection'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor',
+        'Author',
+        'Contributor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Edit collections',
+        action: 'edit',
+        object: 'collection'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor'
+    ]),
+    addPermissionWithRoles({
+        name: 'Add collections',
+        action: 'add',
+        object: 'collection'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor',
+        'Author'
+    ]),
+    addPermissionWithRoles({
+        name: 'Delete collections',
+        action: 'destroy',
+        object: 'collection'
+    }, [
+        'Administrator',
+        'Admin Integration',
+        'Editor'
+    ])
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -642,6 +642,31 @@
                     "name": "Browse mentions",
                     "action_type": "browse",
                     "object_type": "mention"
+                },
+                {
+                    "name": "Browse collections",
+                    "action_type": "browse",
+                    "object_type": "collection"
+                },
+                {
+                    "name": "Read collections",
+                    "action_type": "read",
+                    "object_type": "collection"
+                },
+                {
+                    "name": "Edit collections",
+                    "action_type": "edit",
+                    "object_type": "collection"
+                },
+                {
+                    "name": "Add collections",
+                    "action_type": "add",
+                    "object_type": "collection"
+                },
+                {
+                    "name": "Delete collections",
+                    "action_type": "destroy",
+                    "object_type": "collection"
                 }
             ]
         },
@@ -785,7 +810,8 @@
                     "explore": "read",
                     "comment": "all",
                     "link": "all",
-                    "mention": "browse"
+                    "mention": "browse",
+                    "collection": "all"
                 },
                 "DB Backup Integration": {
                     "db": "all"
@@ -826,7 +852,8 @@
                     "explore": "read",
                     "comment": "all",
                     "link": "all",
-                    "mention": "browse"
+                    "mention": "browse",
+                    "collection": "all"
                 },
                 "Editor": {
                     "notification": "all",
@@ -843,7 +870,8 @@
                     "snippet": "all",
                     "label": ["browse", "read"],
                     "product": ["browse", "read"],
-                    "newsletter": ["browse", "read"]
+                    "newsletter": ["browse", "read"],
+                    "collection": "all"
                 },
                 "Author": {
                     "post": ["browse", "read", "add"],
@@ -858,7 +886,8 @@
                     "snippet": ["browse", "read"],
                     "label": ["browse", "read"],
                     "product": ["browse", "read"],
-                    "newsletter": ["browse", "read"]
+                    "newsletter": ["browse", "read"],
+                    "collection": ["browse", "read", "add"]
                 },
                 "Contributor": {
                     "post": ["browse", "read", "add"],
@@ -870,7 +899,8 @@
                     "theme": ["browse"],
                     "email_preview": "read",
                     "email": "read",
-                    "snippet": ["browse", "read"]
+                    "snippet": ["browse", "read"],
+                    "collection": ["browse", "read"]
                 }
             }
         },

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -45,7 +45,7 @@ describe('Database Migration (special functions)', function () {
             const permissions = this.obj;
 
             // If you have to change this number, please add the relevant `havePermission` checks below
-            permissions.length.should.eql(110);
+            permissions.length.should.eql(115);
 
             permissions.should.havePermission('Export database', ['Administrator', 'DB Backup Integration']);
             permissions.should.havePermission('Import database', ['Administrator', 'Self-Serve Migration Integration', 'DB Backup Integration']);
@@ -182,6 +182,12 @@ describe('Database Migration (special functions)', function () {
             permissions.should.havePermission('Report comments', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Browse links', ['Administrator', 'Admin Integration']);
             permissions.should.havePermission('Browse mentions', ['Administrator', 'Admin Integration']);
+
+            permissions.should.havePermission('Browse collections', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Read collections', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration']);
+            permissions.should.havePermission('Edit collections', ['Administrator', 'Editor', 'Admin Integration']);
+            permissions.should.havePermission('Add collections', ['Administrator', 'Editor', 'Author', 'Admin Integration']);
+            permissions.should.havePermission('Delete collections', ['Administrator', 'Editor', 'Admin Integration']);
         });
 
         describe('Populate', function () {

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -191,7 +191,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             fixtureManager.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
-                const FIXTURE_COUNT = 101;
+                const FIXTURE_COUNT = 106;
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '2445c734ffb514d11b56e74591bcde4e';
-    const currentFixturesHash = '869ceb3302303494c645f4201540ead3';
+    const currentFixturesHash = '93c3b3cb8bca34a733634e74ee514172';
     const currentSettingsHash = '4f23a583335dcb4cb3fae553122ea200';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -642,6 +642,31 @@
                     "name": "Browse mentions",
                     "action_type": "browse",
                     "object_type": "mention"
+                },
+                {
+                    "name": "Browse collections",
+                    "action_type": "browse",
+                    "object_type": "collection"
+                },
+                {
+                    "name": "Read collections",
+                    "action_type": "read",
+                    "object_type": "collection"
+                },
+                {
+                    "name": "Edit collections",
+                    "action_type": "edit",
+                    "object_type": "collection"
+                },
+                {
+                    "name": "Add collections",
+                    "action_type": "add",
+                    "object_type": "collection"
+                },
+                {
+                    "name": "Delete collections",
+                    "action_type": "destroy",
+                    "object_type": "collection"
                 }
             ]
         },
@@ -965,7 +990,8 @@
                     "explore": "read",
                     "comment": "all",
                     "link": "all",
-                    "mention": "browse"
+                    "mention": "browse",
+                    "collection": "all"
                 },
                 "DB Backup Integration": {
                     "db": "all"
@@ -1006,7 +1032,8 @@
                     "explore": "read",
                     "comment": "all",
                     "link": "all",
-                    "mention": "browse"
+                    "mention": "browse",
+                    "collection": "all"
                 },
                 "Editor": {
                     "notification": "all",
@@ -1023,7 +1050,8 @@
                     "snippet": "all",
                     "label": ["browse", "read"],
                     "product": ["browse", "read"],
-                    "newsletter": ["browse", "read"]
+                    "newsletter": ["browse", "read"],
+                    "collection": "all"
                 },
                 "Author": {
                     "post": ["browse", "read", "add"],
@@ -1038,7 +1066,8 @@
                     "snippet": ["browse", "read"],
                     "label": ["browse", "read"],
                     "product": ["browse", "read"],
-                    "newsletter": ["browse", "read"]
+                    "newsletter": ["browse", "read"],
+                    "collection": ["browse", "read", "add"]
                 },
                 "Contributor": {
                     "post": ["browse", "read", "add"],
@@ -1050,7 +1079,8 @@
                     "theme": ["browse"],
                     "email_preview": "read",
                     "email": "read",
-                    "snippet": ["browse", "read"]
+                    "snippet": ["browse", "read"],
+                    "collection": ["browse", "read"]
                 }
             }
         },


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3220

- Added permissions for collection resources

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2d51619</samp>

This pull request adds new permissions for collections, a feature that allows users to group posts by custom criteria. It modifies the `fixtures.json` files in the `data/schema` and `test/utils` folders, and creates a new migration file in the `data/migrations` folder. It also updates the relevant tests in the `test` folder to match the new permissions.
