### PR TITLE
Switched to fully resetting the URL service in tests

### DIFF
--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -247,7 +247,7 @@ const stopGhost = async () => {
         // NOTE: similarly to urlService.reset() there doesn't seem to be a need for this call
         //       probable best location for this type of cleanup if it's needed is registering
         //       a hood during the "server cleanup" phase of the server stop
-        urlService.resetGenerators();
+        urlService.reset();
     }
 };
 

--- a/ghost/core/test/utils/url-service-utils.js
+++ b/ghost/core/test/utils/url-service-utils.js
@@ -22,7 +22,7 @@ module.exports.init = ({urlCache} = {}) => {
 };
 
 module.exports.reset = () => {
-    urlService.softReset();
+    urlService.reset();
 },
 
 module.exports.resetGenerators = () => {


### PR DESCRIPTION
<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa4376f</samp>

Fixed a bug in the test utils module that caused the urlService to cache stale data. Changed the `reset` function to use `urlService.reset` instead of `urlService.softReset` in `ghost/core/test/utils/url-service-utils.js`.
