### PR TITLE
Disabled `autoRefresh` when inserting fixtures

### DIFF
--- a/ghost/core/core/server/data/schema/fixtures/FixtureManager.js
+++ b/ghost/core/core/server/data/schema/fixtures/FixtureManager.js
@@ -69,6 +69,7 @@ class FixtureManager {
      */
     async addAllFixtures(options) {
         const localOptions = _.merge({
+            autoRefresh: false,
             context: {internal: true},
             migrating: true
         }, options);


### PR DESCRIPTION
- we don't need to receive the refreshed model back afterwards so we can save an SQL select per insert by disabling auto-refresh

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5026061</samp>

Refactor fixture loading to allow optional auto-refresh on migrations. Add `autoRefresh` property to `FixtureManager` class and update its usage in `ghost/core/core/server/data/schema/fixtures/index.js`.
