### PR TITLE
Added `StripeLiveEnabledEvent` and `StripeLiveDisabledEvent` to Stripe service

### DIFF
--- a/ghost/stripe/lib/StripeLiveDisabledEvent.js
+++ b/ghost/stripe/lib/StripeLiveDisabledEvent.js
@@ -1,0 +1,23 @@
+/**
+ * @typedef {object} StripeLiveDisabledEventData
+ * @prop {string?} message
+ */
+
+module.exports = class StripeLiveDisabledEvent {
+    /**
+     * @param {StripeLiveDisabledEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {StripeLiveDisabledEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new StripeLiveDisabledEvent(data, timestamp || new Date);
+    }
+};

--- a/ghost/stripe/lib/StripeLiveEnabledEvent.js
+++ b/ghost/stripe/lib/StripeLiveEnabledEvent.js
@@ -1,0 +1,23 @@
+/**
+ * @typedef {object} StripeLiveEnabledEventData
+ * @prop {string} message
+ */
+
+module.exports = class StripeLiveEnabledEvent {
+    /**
+     * @param {StripeLiveEnabledEventData} data
+     * @param {Date} timestamp
+     */
+    constructor(data, timestamp) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * @param {StripeLiveEnabledEventData} data
+     * @param {Date} [timestamp]
+     */
+    static create(data, timestamp) {
+        return new StripeLiveEnabledEvent(data, timestamp || new Date);
+    }
+};

--- a/ghost/stripe/lib/StripeService.js
+++ b/ghost/stripe/lib/StripeService.js
@@ -2,6 +2,9 @@ const WebhookManager = require('./WebhookManager');
 const StripeAPI = require('./StripeAPI');
 const StripeMigrations = require('./StripeMigrations');
 const WebhookController = require('./WebhookController');
+const DomainEvents = require('@tryghost/domain-events');
+const StripeLiveEnabledEvent = require('./StripeLiveEnabledEvent');
+const StripeLiveDisabledEvent = require('./StripeLiveDisabledEvent');
 
 module.exports = class StripeService {
     constructor({
@@ -50,6 +53,7 @@ module.exports = class StripeService {
     }
 
     async connect() {
+        DomainEvents.dispatch(StripeLiveEnabledEvent.create({message: 'Stripe Live Mode Enabled'}));
     }
 
     async disconnect() {
@@ -66,6 +70,8 @@ module.exports = class StripeService {
         await this.webhookManager.stop();
 
         this.api.configure(null);
+
+        DomainEvents.dispatch(StripeLiveDisabledEvent.create({message: 'Stripe Live Mode Disabled'}));
     }
 
     async configure(config) {


### PR DESCRIPTION
<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57d8aa1</samp>

This pull request introduces domain events for Stripe live mode changes in the `StripeService` class. It also adds two new classes, `StripeLiveEnabledEvent` and `StripeLiveDisabledEvent`, to represent the event data objects.
