### PR TITLE
Fixed the ability to return to the main post page after scheduling a post in lexical

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -937,7 +937,7 @@ export default class LexicalEditorController extends Controller {
                 this.cancelAutosave();
                 this.autosaveTask.cancelAll();
             }
-            await this.autosaveTask.perform({leavingEditor: true});
+            await this.autosaveTask.perform({leavingEditor: true, backgroundSave: false});
             return transition.retry();
         }
 


### PR DESCRIPTION
refs TryGhost/Team#3405
- BackgroundSave option sets post status as Draft. Don't need such behaviour as a post already can have a different status when a user leaves the page.

