### PR TITLE
Reset URL service between test boots

### DIFF
--- a/ghost/core/test/e2e-server/services/milestones.test.js
+++ b/ghost/core/test/e2e-server/services/milestones.test.js
@@ -162,9 +162,9 @@ describe('Milestones Service', function () {
         threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
         clock = sinon.useFakeTimers({
             now: threeMonthsAgo.getTime(),
+            shouldAdvanceTime: true,
             toFake: ['setTimeout']
         });
-        sinon.createSandbox();
         configUtils.set('milestones', milestonesConfig);
         mockManager.mockMail();
     });

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -73,6 +73,9 @@ const startGhost = async (options = {}) => {
     // Adapter cache has to be cleared to avoid reusing cached adapter instances between restarts
     adapterManager.clearCache();
 
+    // Reset the URL service so we clear out all the listeners
+    urlServiceUtils.resetGenerators();
+
     const defaults = {
         backend: true,
         frontend: false,


### PR DESCRIPTION
<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a921d90</samp>

Reset URL generators for e2e tests. This ensures that the URLs for the CMS entities are stable and reliable across different test scenarios.
