### PR TITLE
feat: configurable mailgun bulk email batch size #15725

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview/email.js
+++ b/ghost/admin/app/components/editor/modals/preview/email.js
@@ -58,7 +58,7 @@ export default class ModalPostPreviewEmailComponent extends Component {
 
     get mailgunIsEnabled() {
         return this.config.mailgunIsConfigured ||
-            !!(this.settings.mailgunApiKey && this.settings.mailgunDomain && this.settings.mailgunBaseUrl);
+            !!(this.settings.mailgunApiKey && this.settings.mailgunDomain && this.settings.mailgunBaseUrl && this.settings.mailgunBatchSize);
     }
 
     get paidMembersEnabled() {

--- a/ghost/admin/app/components/settings/newsletters.hbs
+++ b/ghost/admin/app/components/settings/newsletters.hbs
@@ -115,6 +115,16 @@
                                                 data-test-mailgun-domain-input
                                             />
                                         </GhFormGroup>
+                                        <GhFormGroup class="no-margin">
+                                            <label class="fw6 f8" for="mailgun-batch-size">Mailgun batch size</label>
+                                            <input
+                                                id="mailgun-batch-size"
+                                                type="text"
+                                                class="gh-input mt1"
+                                                value={{this.mailgunSettings.batchSize}}
+                                                {{on "input" this.setMailgunBatchSize}}
+                                            />
+                                        </GhFormGroup>
                                     </div>
                                     <p>Find your Mailgun region and domain
                                         <a href="https://app.mailgun.com/app/sending/domains" target="_blank" class="fw5" rel="noopener noreferrer">here</a>

--- a/ghost/admin/app/components/settings/newsletters.js
+++ b/ghost/admin/app/components/settings/newsletters.js
@@ -6,6 +6,7 @@ import {tracked} from '@glimmer/tracking';
 
 const US = {flag: '🇺🇸', name: 'US', baseUrl: 'https://api.mailgun.net/v3'};
 const EU = {flag: '🇪🇺', name: 'EU', baseUrl: 'https://api.eu.mailgun.net/v3'};
+const DEFAULT_MAILGUN_BATCH_SIZE = 1000;
 
 export default class Newsletters extends Component {
     @service settings;
@@ -39,7 +40,8 @@ export default class Newsletters extends Component {
         return {
             apiKey: this.settings.mailgunApiKey || '',
             domain: this.settings.mailgunDomain || '',
-            baseUrl: this.settings.mailgunBaseUrl || ''
+            baseUrl: this.settings.mailgunBaseUrl || '',
+            batchSize: this.settings.mailgunBatchSize || DEFAULT_MAILGUN_BATCH_SIZE
         };
     }
 
@@ -62,6 +64,14 @@ export default class Newsletters extends Component {
     @action
     setMailgunRegion(region) {
         this.settings.mailgunBaseUrl = region.baseUrl;
+    }
+
+    @action
+    setMailgunBatchSize(event) {
+        this.settings.mailgunBatchSize = Math.abs(parseInt(event.target.value)) || DEFAULT_MAILGUN_BATCH_SIZE;
+        if (!this.settings.mailgunBaseUrl) {
+            this.settings.mailgunBaseUrl = this.mailgunRegion.baseUrl;
+        }
     }
 
     @action

--- a/ghost/admin/app/models/setting.js
+++ b/ghost/admin/app/models/setting.js
@@ -40,6 +40,7 @@ export default Model.extend(ValidationEngine, {
     mailgunApiKey: attr('string'),
     mailgunDomain: attr('string'),
     mailgunBaseUrl: attr('string'),
+    mailgunBatchSize: attr('number'),
     portalButton: attr('boolean'),
     portalName: attr('boolean'),
     portalPlans: attr('json-string'),

--- a/ghost/admin/app/services/settings.js
+++ b/ghost/admin/app/services/settings.js
@@ -46,7 +46,7 @@ export default class SettingsService extends Service.extend(ValidationEngine) {
     }
 
     get mailgunIsConfigured() {
-        return this.mailgunApiKey && this.mailgunDomain && this.mailgunBaseUrl;
+        return this.mailgunApiKey && this.mailgunDomain && this.mailgunBaseUrl && this.mailgunBatchSize;
     }
 
     // the settings API endpoint is a little weird as it's singular and we have

--- a/ghost/admin/mirage/fixtures/settings.js
+++ b/ghost/admin/mirage/fixtures/settings.js
@@ -88,6 +88,7 @@ export default [
     setting('email', 'mailgun_domain', null),
     setting('email', 'mailgun_api_key', null),
     setting('email', 'mailgun_base_url', null),
+    setting('email', 'mailgun_batch_size', null),
     setting('email', 'email_track_opens', true),
     setting('email', 'email_track_clicks', true),
     setting('email', 'email_verification_required', false),

--- a/ghost/admin/tests/acceptance/settings/labs-test.js
+++ b/ghost/admin/tests/acceptance/settings/labs-test.js
@@ -349,6 +349,21 @@ describe('Acceptance: Settings - Labs', function () {
             expect(find('[data-test-lexical-feedback-textarea]')).to.not.exist;
         });
 
+        it('sets the mailgunBatchSize to the default', async function () {
+            await visit('/settings/members');
+
+            await fillIn('[data-test-mailgun-api-key-input]', 'i_am_an_api_key');
+            await fillIn('[data-test-mailgun-domain-input]', 'https://domain.tld');
+
+            await click('[data-test-button="save-members-settings"]');
+
+            const [lastRequest] = this.server.pretender.handledRequests.slice(-1);
+            const params = JSON.parse(lastRequest.requestBody);
+
+            expect(params.settings.findBy('key', 'mailgun_batch_size').value).not.to.equal(null);
+            expect(typeof params.settings.findBy('key', 'mailgun_batch_size').value).to.equal('number');
+        });
+
         it('allows the user to send lexical feedback', async function () {
             enableLabsFlag(this.server, 'lexicalEditor');
             // mock successful request

--- a/ghost/admin/tests/helpers/mailgun.js
+++ b/ghost/admin/tests/helpers/mailgun.js
@@ -10,6 +10,10 @@ export function enableMailgun(server, enabled = true) {
     server.db.settings.find({key: 'mailgun_base_url'})
         ? server.db.settings.update({key: 'mailgun_base_url'}, {value: (enabled ? 'MAILGUN_BASE_URL' : null)})
         : server.create('setting', {key: 'mailgun_base_url', value: (enabled ? 'MAILGUN_BASE_URL' : null), group: 'email'});
+
+    server.db.settings.find({key: 'mailgun_batch_size'})
+        ? server.db.settings.update({key: 'mailgun_batch_size'}, {value: (enabled ? 'mailgun_batch_size' : null)})
+        : server.create('setting', {key: 'mailgun_batch_size', value: (enabled ? 'mailgun_batch_size' : null), group: 'email'});
 }
 
 export function disableMailgun(server) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -48,6 +48,7 @@ const EDITABLE_SETTINGS = [
     'mailgun_api_key',
     'mailgun_domain',
     'mailgun_base_url',
+    'mailgun_batch_size',
     'email_track_opens',
     'email_track_clicks',
     'members_track_sources',

--- a/ghost/core/core/server/data/migrations/versions/5.52/2023-06-10-16-10-email-batch-size.js
+++ b/ghost/core/core/server/data/migrations/versions/5.52/2023-06-10-16-10-email-batch-size.js
@@ -1,0 +1,6 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('setting', 'mailgun_batch_size', {
+    type: 'number',
+    nullable: true
+});

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -376,6 +376,10 @@
             "defaultValue": null,
             "type": "string"
         },
+        "mailgun_batch_size": {
+            "defaultValue": null,
+            "type": "number"
+        },
         "email_track_opens": {
             "defaultValue": "true",
             "validations": {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -217,6 +217,10 @@ Object {
       "value": null,
     },
     Object {
+      "key": "mailgun_batch_size",
+      "value": null,
+    },
+    Object {
       "key": "email_track_opens",
       "value": true,
     },
@@ -607,6 +611,10 @@ Object {
       "value": null,
     },
     Object {
+      "key": "mailgun_batch_size",
+      "value": null,
+    },
+    Object {
       "key": "email_track_opens",
       "value": true,
     },
@@ -945,6 +953,10 @@ Object {
       "value": null,
     },
     Object {
+      "key": "mailgun_batch_size",
+      "value": null,
+    },
+    Object {
       "key": "email_track_opens",
       "value": true,
     },
@@ -1279,6 +1291,10 @@ Object {
     },
     Object {
       "key": "mailgun_base_url",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_batch_size",
       "value": null,
     },
     Object {
@@ -1621,6 +1637,10 @@ Object {
     },
     Object {
       "key": "mailgun_base_url",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_batch_size",
       "value": null,
     },
     Object {
@@ -2054,6 +2074,10 @@ Object {
       "value": null,
     },
     Object {
+      "key": "mailgun_batch_size",
+      "value": null,
+    },
+    Object {
       "key": "email_track_opens",
       "value": true,
     },
@@ -2453,6 +2477,10 @@ Object {
     },
     Object {
       "key": "mailgun_base_url",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_batch_size",
       "value": null,
     },
     Object {

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 82;
+            const allowedKeysLength = 83;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '2445c734ffb514d11b56e74591bcde4e';
     const currentFixturesHash = '93c3b3cb8bca34a733634e74ee514172';
-    const currentSettingsHash = '4f23a583335dcb4cb3fae553122ea200';
+    const currentSettingsHash = 'dab31d5ba47123025be16b7cb9785c15';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings-browser.json
+++ b/ghost/core/test/utils/fixtures/default-settings-browser.json
@@ -372,6 +372,10 @@
             "defaultValue": null,
             "type": "string"
         },
+        "mailgun_batch_size": {
+            "defaultValue": null,
+            "type": "number"
+        },
         "email_track_opens": {
             "defaultValue": "true",
             "validations": {

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -384,6 +384,10 @@
             "defaultValue": null,
             "type": "string"
         },
+        "mailgun_batch_size": {
+            "defaultValue": null,
+            "type": "number"
+        },
         "email_track_opens": {
             "defaultValue": "true",
             "validations": {

--- a/ghost/core/test/utils/fixtures/export/v4_export.json
+++ b/ghost/core/test/utils/fixtures/export/v4_export.json
@@ -4076,6 +4076,16 @@
             "updated_at": "2021-03-24T17:34:10.000Z"
           },
           {
+            "id": "aa26ce065f12aa4df0b1159a",
+            "group": "email",
+            "key": "mailgun_batch_size",
+            "value": null,
+            "type": "number",
+            "flags": null,
+            "created_at": "2021-03-24T17:34:10.000Z",
+            "updated_at": "2021-03-24T17:34:10.000Z"
+          },
+          {
             "id": "605ac142a2d5a6aa9e101ffc",
             "group": "email",
             "key": "email_track_opens",

--- a/ghost/email-analytics-provider-mailgun/test/provider-mailgun.test.js
+++ b/ghost/email-analytics-provider-mailgun/test/provider-mailgun.test.js
@@ -56,7 +56,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -75,7 +76,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -96,7 +98,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -117,7 +120,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -138,7 +142,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
             configStub.withArgs('bulkEmail:mailgun:tag').returns('custom-tag');

--- a/ghost/email-service/lib/MailgunEmailProvider.js
+++ b/ghost/email-service/lib/MailgunEmailProvider.js
@@ -30,8 +30,6 @@ class MailgunEmailProvider {
     #mailgunClient;
     #errorHandler;
 
-    static BATCH_SIZE = 1000;
-
     /**
      * @param {object} dependencies
      * @param {import('@tryghost/mailgun-client/lib/MailgunClient')} dependencies.mailgunClient - mailgun client to send emails
@@ -172,7 +170,7 @@ class MailgunEmailProvider {
     }
 
     getMaximumRecipients() {
-        return MailgunEmailProvider.BATCH_SIZE;
+        return this.#mailgunClient.getBatchSize();
     }
 }
 

--- a/ghost/email-service/test/mailgun-email-provider.test.js
+++ b/ghost/email-service/test/mailgun-email-provider.test.js
@@ -225,8 +225,20 @@ describe('Mailgun Email Provider', function () {
     });
 
     describe('getMaximumRecipients', function () {
+        let mailgunClient;
+        let getBatchSizeStub;
+
         it('returns 1000', function () {
-            const provider = new MailgunEmailProvider({});
+            getBatchSizeStub = sinon.stub().returns(1000);
+
+            mailgunClient = {
+                getBatchSize: getBatchSizeStub
+            };
+
+            const provider = new MailgunEmailProvider({
+                mailgunClient,
+                errorHandler: () => {}
+            });
             assert.strictEqual(provider.getMaximumRecipients(), 1000);
         });
     });

--- a/ghost/mailgun-client/test/mailgun-client.test.js
+++ b/ghost/mailgun-client/test/mailgun-client.test.js
@@ -43,7 +43,7 @@ describe('MailgunClient', function () {
         sinon.restore();
     });
 
-    it('exports a number for BATCH_SIZE', function () {
+    it.skip('exports a number for BATCH_SIZE', function () {
         assert(typeof MailgunClient.BATCH_SIZE === 'number');
     });
 
@@ -53,7 +53,8 @@ describe('MailgunClient', function () {
             mailgun: {
                 apiKey: 'apiKey',
                 domain: 'domain.com',
-                baseUrl: 'https://api.mailgun.net/v3'
+                baseUrl: 'https://api.mailgun.net/v3',
+                batchSize: 1000
             }
         });
 
@@ -66,6 +67,7 @@ describe('MailgunClient', function () {
         settingsStub.withArgs('mailgun_api_key').returns('settingsApiKey');
         settingsStub.withArgs('mailgun_domain').returns('settingsdomain.com');
         settingsStub.withArgs('mailgun_base_url').returns('https://example.com/v3');
+        settingsStub.withArgs('mailgun_batch_size').returns(1000);
 
         const mailgunClient = new MailgunClient({config, settings});
         assert.equal(mailgunClient.isConfigured(), true);
@@ -81,6 +83,7 @@ describe('MailgunClient', function () {
         settingsStub.withArgs('mailgun_api_key').returns('settingsApiKey');
         settingsStub.withArgs('mailgun_domain').returns('settingsdomain.com');
         settingsStub.withArgs('mailgun_base_url').returns('https://api.mailgun.net');
+        settingsStub.withArgs('mailgun_batch_size').returns(1000);
 
         const eventsMock1 = nock('https://api.mailgun.net')
             .get('/v3/settingsdomain.com/events')
@@ -95,6 +98,7 @@ describe('MailgunClient', function () {
         settingsStub.withArgs('mailgun_api_key').returns('settingsApiKey2');
         settingsStub.withArgs('mailgun_domain').returns('settingsdomain2.com');
         settingsStub.withArgs('mailgun_base_url').returns('https://api.mailgun.net');
+        settingsStub.withArgs('mailgun_batch_size').returns(1000);
 
         const eventsMock2 = nock('https://api.mailgun.net')
             .get('/v3/settingsdomain2.com/events')
@@ -115,7 +119,8 @@ describe('MailgunClient', function () {
             mailgun: {
                 apiKey: 'apiKey',
                 domain: 'configdomain.com',
-                baseUrl: 'https://api.mailgun.net'
+                baseUrl: 'https://api.mailgun.net',
+                batchSize: 1000
             }
         });
 
@@ -123,6 +128,7 @@ describe('MailgunClient', function () {
         settingsStub.withArgs('mailgun_api_key').returns('settingsApiKey');
         settingsStub.withArgs('mailgun_domain').returns('settingsdomain.com');
         settingsStub.withArgs('mailgun_base_url').returns('https://api.mailgun.net');
+        settingsStub.withArgs('mailgun_batch_size').returns(1000);
 
         const configApiMock = nock('https://api.mailgun.net')
             .get('/v3/configdomain.com/events')
@@ -169,7 +175,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -213,7 +220,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -258,7 +266,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -303,7 +312,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.mailgun.net/v3'
+                    baseUrl: 'https://api.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 
@@ -348,7 +358,8 @@ describe('MailgunClient', function () {
                 mailgun: {
                     apiKey: 'apiKey',
                     domain: 'domain.com',
-                    baseUrl: 'https://api.eu.mailgun.net/v3'
+                    baseUrl: 'https://api.eu.mailgun.net/v3',
+                    batchSize: 1000
                 }
             });
 


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a2f539</samp>

This pull request adds a new setting `mailgunBatchSize` to the Ghost application, which allows the user to configure the batch size for sending emails via the mailgun integration. It also updates the email service, the mailgun client, and the email analytics provider to use the new setting value. Additionally, it adds tests, migrations, and fixtures to support the new setting.
