### PR TITLE
Updated Chinese translations

### DIFF
--- a/ghost/i18n/locales/zh/signup-form.json
+++ b/ghost/i18n/locales/zh/signup-form.json
@@ -1,9 +1,9 @@
 {
-    "Email sent": "",
-    "Now check your email!": "",
-    "Please enter a valid email address": "",
-    "Something went wrong, please try again.": "",
-    "Subscribe": "",
-    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "",
-    "Your email address": ""
+    "Email sent": "邮件已发送",
+    "Now check your email!": "现在请检查您的电子邮箱！",
+    "Please enter a valid email address": "请输入有效的电子邮件地址",
+    "Something went wrong, please try again.": "遇到未知错误，请重试。",
+    "Subscribe": "订阅",
+    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "请点击您收件箱中的确认链接以完成注册。如果3分钟后仍没有收到确认邮件，请检查垃圾邮件！",
+    "Your email address": "您的电子邮件地址"
 }


### PR DESCRIPTION
This pull request will complete the Chinese translations of the signup form.

Related file: `ghost/i18n/locales/zh/signup-form.json`

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3bfeee</samp>

This file adds Chinese translations for the signup form messages in `ghost/i18n/locales/zh/signup-form.json`. It is part of a larger effort to localize Ghost for Chinese users.
