### PR TITLE
🐛 Fixed Post History for posts sent as an email

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -145,14 +145,22 @@ export default class GhPostSettingsMenu extends Component {
     }
 
     get canViewPostHistory() {
-        let showPostHistory = this.post.lexical !== null
-            && this.post.emailOnly === false;
-
-        if (this.post.isPublished === true) {
-            return showPostHistory && this.post.hasEmail === false;
+        // Can only view history for lexical posts
+        if (this.post.lexical === null) {
+            return false;
         }
 
-        return showPostHistory;
+        // Can view history for all unpublished posts
+        if (!this.post.isPublished) {
+            return true;
+        }
+
+        // Cannot view history for published posts if there isn't a web version
+        if (this.post.emailOnly) {
+            return false;
+        }
+
+        return true;
     }
 
     willDestroyElement() {

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -150,8 +150,8 @@ export default class GhPostSettingsMenu extends Component {
             return false;
         }
 
-        // Can view history for all unpublished posts
-        if (!this.post.isPublished) {
+        // Can view history for all unpublished/unsent posts
+        if (!this.post.isPublished && !this.post.isSent) {
             return true;
         }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3458

This fixes the logic for when post history is enabled. From the discussion in slack, for all published posts:
  Published only --> view history & restore
  Published & sent --> view history & restore
  Email only --> history hidden
And for all unpublished posts:
  All states --> view history & restore.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42e52c8</samp>

Refactored `canViewPostHistory` getter in `gh-post-settings-menu.js` to improve readability and fix a bug. The change enables a new feature for viewing the history of changes to a post.
