### PR TITLE
🐛 Fixed snippet insertion in the new editor

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -392,7 +392,7 @@ export default class LexicalEditorController extends Controller {
         const existingSnippet = this.snippets.find(snippet => snippet.name.toLowerCase() === snippetNameLC);
 
         if (existingSnippet) {
-            await this.confirmUpdateSnippet(existingSnippet, {lexical: data.value});
+            await this.confirmUpdateSnippet(existingSnippet, {lexical: JSON.parse(data.value)});
         } else {
             await this.saveNewSnippet(data);
         }


### PR DESCRIPTION
refs TryGhost/Team#3445
- The snippet model always expects an object as it gets serialized when saving - if we give it a string, it gets doubly serialized. It breaks snippet replacement and insertion in the new editor.

