### PR TITLE
Refactored `truncateAll` util to async-await

### DIFF
--- a/ghost/core/test/utils/db-utils.js
+++ b/ghost/core/test/utils/db-utils.js
@@ -126,64 +126,44 @@ const forceReinit = async () => {
  * Has to run in a transaction for MySQL, otherwise the foreign key check does not work.
  * Sqlite3 has no truncate command.
  */
-const truncateAll = () => {
+const truncateAll = async () => {
     debug('Database teardown');
     urlServiceUtils.reset();
 
     const tables = schemaTables.concat(['migrations']);
 
     if (module.exports.isSQLite()) {
-        return Promise
-            .mapSeries(tables, function createTable(table) {
-                return (async function () {
-                    const [foreignKeysEnabled] = await db.knex.raw('PRAGMA foreign_keys;');
-                    if (foreignKeysEnabled.foreign_keys) {
-                        await db.knex.raw('PRAGMA foreign_keys = OFF;');
-                    }
-                    await db.knex.raw('DELETE FROM ' + table + ';');
-                    if (foreignKeysEnabled.foreign_keys) {
-                        await db.knex.raw('PRAGMA foreign_keys = ON;');
-                    }
-                })();
-            })
-            .catch(function (err) {
-                // CASE: table does not exist
-                if (err.errno === 1) {
-                    return Promise.resolve();
-                }
+        try {
+            const [foreignKeysEnabled] = await db.knex.raw('PRAGMA foreign_keys;');
+            if (foreignKeysEnabled.foreign_keys) {
+                await db.knex.raw('PRAGMA foreign_keys = OFF;');
+            }
 
-                throw err;
-            })
-            .finally(() => {
-                debug('Database teardown end');
-            });
+            await Promise.each(tables, table => db.knex.raw('DELETE FROM ' + table + ';'));
+
+            if (foreignKeysEnabled.foreign_keys) {
+                await db.knex.raw('PRAGMA foreign_keys = ON;');
+            }
+
+            return;
+        } catch (err) {
+            // CASE: table does not exist
+            if (err.errno === 1) {
+                return Promise.resolve();
+            }
+
+            throw err;
+        } finally {
+            debug('Database teardown end');
+        }
     }
 
-    return db.knex.transaction(function (trx) {
-        return db.knex.raw('SET FOREIGN_KEY_CHECKS=0;').transacting(trx)
-            .then(function () {
-                return Promise
-                    .each(tables, function createTable(table) {
-                        return db.knex.raw('TRUNCATE ' + table + ';').transacting(trx);
-                    });
-            })
-            .then(function () {
-                return db.knex.raw('SET FOREIGN_KEY_CHECKS=1;').transacting(trx);
-            })
-            .catch(function (err) {
-                // CASE: table does not exist || DB does not exist
-                // If the table or DB are not present, we can safely ignore
-                if (err.errno === 1146 || err.errno === 1049) {
-                    return Promise.resolve();
-                }
-
-                throw err;
-            })
-            .finally(() => {
-                debug('Database teardown end');
-            });
-    })
-        .catch(function (err) {
+    await db.knex.transaction(async (trx) => {
+        try {
+            await db.knex.raw('SET FOREIGN_KEY_CHECKS=0;').transacting(trx);
+            await Promise.each(tables, table => db.knex.raw('TRUNCATE ' + table + ';').transacting(trx));
+            await db.knex.raw('SET FOREIGN_KEY_CHECKS=1;').transacting(trx);
+        } catch (err) {
             // CASE: table does not exist || DB does not exist
             // If the table or DB are not present, we can safely ignore
             if (err.errno === 1146 || err.errno === 1049) {
@@ -191,7 +171,10 @@ const truncateAll = () => {
             }
 
             throw err;
-        });
+        } finally {
+            debug('Database teardown end');
+        }
+    });
 };
 
 /**


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/592

- async-await makes the code easier to read
- also performs a small optimization to only load the foreign_keys pragma once for SQLite

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97ac9a7</samp>

This pull request enhances the test utility function `truncateAll` in `ghost/core/test/utils/db-utils.js` by using modern syntax, simplifying the code, and improving the logging.
