### PR TITLE
Cleaned up `clearData` and `initData` utils

### DIFF
--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -342,8 +342,7 @@ describe('Default Frontend routing', function () {
 
     describe('Site Map', function () {
         before(async function () {
-            await testUtils.clearData();
-            await testUtils.initData();
+            await testUtils.resetDb();
             await testUtils.initFixtures('posts');
         });
 

--- a/ghost/core/test/e2e-frontend/preview_routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview_routes.test.js
@@ -20,8 +20,7 @@ function assertCorrectFrontendHeaders(res) {
 
 describe('Frontend Routing: Preview Routes', function () {
     async function addPosts() {
-        await testUtils.clearData();
-        await testUtils.initData();
+        await testUtils.resetDb();
         await testUtils.fixtures.insertPostsAndTags();
     }
 

--- a/ghost/core/test/regression/site/dynamic_routing.test.js
+++ b/ghost/core/test/regression/site/dynamic_routing.test.js
@@ -83,7 +83,7 @@ describe('Dynamic Routing', function () {
 
     describe('Collection Entry', function () {
         before(function () {
-            return testUtils.initData().then(function () {
+            return testUtils.resetDb().then(function () {
                 return testUtils.fixtures.overrideOwnerUser();
             }).then(function () {
                 return testUtils.fixtures.insertPostsAndTags();
@@ -111,10 +111,7 @@ describe('Dynamic Routing', function () {
 
     describe('Tag', function () {
         before(function (done) {
-            testUtils.clearData().then(function () {
-                // we initialise data, but not a user. No user should be required for navigating the frontend
-                return testUtils.initData();
-            }).then(function () {
+            testUtils.resetDb().then(function () {
                 return testUtils.fixtures.overrideOwnerUser('ghost-owner');
             }).then(function () {
                 done();
@@ -272,10 +269,7 @@ describe('Dynamic Routing', function () {
         const ownerSlug = 'ghost-owner';
 
         before(function (done) {
-            testUtils.clearData().then(function () {
-                // we initialise data, but not a user. No user should be required for navigating the frontend
-                return testUtils.initData();
-            }).then(function () {
+            testUtils.resetDb().then(function () {
                 return testUtils.fixtures.overrideOwnerUser(ownerSlug);
             }).then(function (insertedUser) {
                 return testUtils.fixtures.insertPosts([
@@ -456,10 +450,7 @@ describe('Dynamic Routing', function () {
         describe('Paged', function () {
             // Add enough posts to trigger pages
             before(function (done) {
-                testUtils.clearData().then(function () {
-                    // we initialize data, but not a user. No user should be required for navigating the frontend
-                    return testUtils.initData();
-                }).then(function () {
+                testUtils.resetDb().then(function () {
                     return testUtils.fixtures.insertPostsAndTags();
                 }).then(function () {
                     return testUtils.fixtures.insertExtraPosts(9);

--- a/ghost/core/test/regression/site/frontend.test.js
+++ b/ghost/core/test/regression/site/frontend.test.js
@@ -37,9 +37,7 @@ describe('Frontend Routing', function () {
     }
 
     function addPosts(done) {
-        testUtils.clearData().then(function () {
-            return testUtils.initData();
-        }).then(function () {
+        testUtils.resetDb().then(function () {
             return testUtils.fixtures.insertPostsAndTags();
         }).then(function () {
             done();

--- a/ghost/core/test/utils/db-utils.js
+++ b/ghost/core/test/utils/db-utils.js
@@ -177,25 +177,4 @@ const truncateAll = async () => {
     });
 };
 
-/**
- * @deprecated Use teardown or reset instead
- * Old method for clearing data from the database that also mixes in url service behavior
- */
-module.exports.clearData = async () => {
-    debug('Database reset');
-    await knexMigrator.reset({force: true});
-    urlServiceUtils.reset();
-};
-
-/**
- * @deprecated Use reset instead
- * Old method for clearing data from the database that also mixes in url service behavior
- */
-module.exports.initData = async () => {
-    await knexMigrator.init();
-    await urlServiceUtils.reset();
-    await urlServiceUtils.init();
-    await urlServiceUtils.isFinished();
-};
-
 module.exports.knex = db.knex;

--- a/ghost/core/test/utils/index.js
+++ b/ghost/core/test/utils/index.js
@@ -97,6 +97,7 @@ module.exports = {
     stopGhost: e2eUtils.stopGhost,
     getExistingData: e2eUtils.getExistingData,
 
+    resetDb: dbUtils.reset,
     teardownDb: dbUtils.teardown,
     truncate: dbUtils.truncate,
     knex: dbUtils.knex,
@@ -134,8 +135,6 @@ module.exports = {
     },
 
     initFixtures: initFixtures,
-    initData: dbUtils.initData,
-    clearData: dbUtils.clearData,
     setupRedirectsFile: redirects.setupFile,
 
     fixtures: fixtureUtils.fixtures,


### PR DESCRIPTION
- these are deprecated and only used in a handful of places
- they're also not efficient, whereas we do have some utils that optimize the reset process
- this cleans up the utils and alters the tests to use the preferred utils

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fbb099b</samp>

This pull request refactors several test suites to use a new `testUtils.resetDb` method for resetting the database before each test, and removes the old and deprecated `testUtils.clearData` and `testUtils.initData` methods. This simplifies the test setup and ensures a consistent database state across different tests. The affected files are `dynamic_routing.test.js`, `default_routes.test.js`, `preview_routes.test.js`, `frontend.test.js`, `index.js`, and `db-utils.js`.
