### PR TITLE
Extracted regression tests to a separate workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,10 +229,6 @@ jobs:
         working-directory: ghost/core
         run: yarn test:ci:e2e
 
-      - name: Regression tests
-        working-directory: ghost/core
-        run: yarn test:ci:regression
-
       - name: Integration tests
         working-directory: ghost/core
         run: yarn test:ci:integration
@@ -287,6 +283,67 @@ jobs:
                 "password": "${{ secrets.ELASTICSEARCH_PASSWORD }}"
               }
             }
+
+      - uses: tryghost/actions/actions/slack-build@main
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  regression-tests:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+    strategy:
+      matrix:
+        include:
+          - node: 18.12.1
+            env:
+              DB: mysql8
+              NODE_ENV: testing-mysql
+          - node: 18.12.1
+            env:
+              DB: sqlite3
+              NODE_ENV: testing
+    env:
+      DB: ${{ matrix.env.DB }}
+      NODE_ENV: ${{ matrix.env.NODE_ENV }}
+    name: Regression Tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: yarn
+
+      - name: Shutdown MySQL
+        run: sudo service mysql stop
+        if: matrix.env.DB == 'mysql8'
+
+      - uses: daniellockyer/mysql-action@main
+        if: matrix.env.DB == 'mysql8'
+        with:
+          authentication plugin: 'caching_sha2_password'
+          mysql version: '8.0'
+          mysql database: 'ghost_testing'
+          mysql root password: 'root'
+
+      - name: Install dependencies
+        run: yarn --prefer-offline
+
+      - name: Set env vars (SQLite)
+        if: contains(matrix.env.DB, 'sqlite')
+        run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
+
+      - name: Set env vars (MySQL)
+        if: contains(matrix.env.DB, 'mysql')
+        run: echo "database__connection__password=root" >> $GITHUB_ENV
+
+      - name: Regression tests
+        working-directory: ghost/core
+        run: yarn test:ci:regression
 
       - uses: tryghost/actions/actions/slack-build@main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -393,7 +450,7 @@ jobs:
           flags: unit-tests
 
   canary:
-    needs: [lint, ghost-cli, admin-tests, migrations, unit-tests, database-tests]
+    needs: [lint, ghost-cli, admin-tests, migrations, unit-tests, database-tests, regression-tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: Canary
     secrets: inherit

--- a/ghost/core/test/regression/mock-express-style/parent-app-vhosts.test.js
+++ b/ghost/core/test/regression/mock-express-style/parent-app-vhosts.test.js
@@ -1,5 +1,7 @@
 const should = require('should');
 const sinon = require('sinon');
+const path = require('path');
+
 const testUtils = require('../../utils');
 const localUtils = require('./utils');
 const configUtils = require('../../utils/configUtils');
@@ -26,13 +28,10 @@ describe('Integration - Web - vhosts', function () {
 
             configUtils.set('url', 'http://example.com');
             configUtils.set('admin:url', null);
+            configUtils.set('paths:adminAssets', path.resolve('test/utils/fixtures/admin-build'));
 
             app = await localUtils.initGhost({backend: true});
-        });
 
-        before(function () {
-            configUtils.set('url', 'http://example.com');
-            configUtils.set('admin:url', null);
             urlUtils.stubUrlUtilsFromConfig();
         });
 
@@ -134,13 +133,12 @@ describe('Integration - Web - vhosts', function () {
 
             configUtils.set('url', 'http://example.com');
             configUtils.set('admin:url', 'https://admin.example.com');
+            configUtils.set('paths:adminAssets', path.resolve('test/utils/fixtures/admin-build'));
 
             app = await localUtils.initGhost({backend: true});
 
             sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(2);
-        });
 
-        before(function () {
             urlUtils.stubUrlUtilsFromConfig();
         });
 
@@ -287,13 +285,12 @@ describe('Integration - Web - vhosts', function () {
             configUtils.set('url', 'http://example.com');
             configUtils.set('admin:url', 'https://admin.example.com');
             configUtils.set('admin:redirects', false);
+            configUtils.set('paths:adminAssets', path.resolve('test/utils/fixtures/admin-build'));
 
             sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
             app = await localUtils.initGhost({backend: true});
-        });
 
-        before(function () {
             urlUtils.stubUrlUtilsFromConfig();
         });
 
@@ -326,13 +323,12 @@ describe('Integration - Web - vhosts', function () {
 
             configUtils.set('url', 'http://example.com');
             configUtils.set('admin:url', 'https://example.com');
+            configUtils.set('paths:adminAssets', path.resolve('test/utils/fixtures/admin-build'));
 
             sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
             app = await localUtils.initGhost({backend: true});
-        });
 
-        before(function () {
             urlUtils.stubUrlUtilsFromConfig();
         });
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/592

- this commit extracts the regression tests into a separate workflow
- this means they run in parallel and reduce the time we have to wait for DB tests in general

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8ed777</samp>

Refactor CI pipeline to run regression tests in parallel with different node and database versions. This speeds up the tests and makes them more robust. Add `test.yml` as a dependency for `canary.yml`.
