### PR TITLE
Revert "Fixed post editor items getting cut off on iOS"

### DIFF
--- a/ghost/admin/app/components/gh-koenig-editor.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor.hbs
@@ -1,4 +1,4 @@
-<div class="gh-koenig-editor relative w-100 overflow-x-hidden z-0" {{did-insert this.registerElement}} ...attributes>
+<div class="gh-koenig-editor relative w-100 vh-100 overflow-x-hidden overflow-y-auto z-0" {{did-insert this.registerElement}} ...attributes>
     {{!-- full height content pane --}}
     {{!-- template-lint-disable no-invalid-interactive no-passed-in-event-handlers --}}
     <div

--- a/ghost/admin/app/styles/components/settings-menu.css
+++ b/ghost/admin/app/styles/components/settings-menu.css
@@ -5,7 +5,7 @@
 /* ---------------------------------------------------------- */
 
 .settings-menu-toggle {
-    position: fixed;
+    position: absolute;
     top: 30px;
     right: 24px;
     z-index: 9999;
@@ -76,13 +76,6 @@
     }
 }
 
-@media (max-width: 500px) {
-    .settings-menu-container {
-        width: 100vw;
-        min-width: 100vw;
-    }
-}
-
 .settings-menu-container .settings-menu-pane {
     position: absolute;
     top: 0;
@@ -107,13 +100,6 @@
     right: auto;
     bottom: auto;
     height: 100vh;
-}
-
-@media (max-width: 500px) {
-    .settings-menu-container .settings-menu-pane {
-        width: 100vw;
-        min-width: 100vw;
-    }
 }
 
 /* Header

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -305,7 +305,7 @@
 }
 
 .gh-editor-header {
-    position: fixed;
+    position: absolute;
     top: 0;
     right: 0;
     left: 0;
@@ -361,7 +361,7 @@
 }
 
 .gh-editor-wordcount-container {
-    position: fixed;
+    position: absolute;
     right: 30px;
     bottom: 30px;
     display: flex;


### PR DESCRIPTION
Reverts TryGhost/Ghost#16765

This commit broke the browser tests because the save button is hidden underneath the settings menu:

![image](https://github.com/TryGhost/Ghost/assets/5277847/ec384fbb-6a39-4799-965d-768f66df3ad5)
