### PR TITLE
🐛 Fixed empty icon crashing signup embed preview

### DIFF
--- a/ghost/admin/app/components/modals/settings/signup-form-embed.js
+++ b/ghost/admin/app/components/modals/settings/signup-form-embed.js
@@ -101,7 +101,9 @@ export default class SignupFormEmbedModal extends Component {
         if (this.style === 'all-in-one') {
             // We serve twice the size of the icon to support high resolution screens
             // (note that you'll need to change the resolution in the backend config as well, as not all resolutions are supported)
-            options.icon = this.settings.icon.replace(/\/content\/images\//, '/content/images/size/w192h192/');
+            if (this.settings.icon || !this.settings.icon === '') {
+                options.icon = this.settings.icon.replace(/\/content\/images\//, '/content/images/size/w192h192/');
+            }
             options.title = this.settings.title;
             options.description = this.settings.description;
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3471

- after adding and removing an icon, icon settings passed an undefined icon to the signup form's all-in-one style. The AIO conditions didn't take that into account and caused the entire component to crash.
- We also take an empty string into account now.

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e1aea3</samp>

Fix signup form embed code generation when icon is not set. Add a check for `this.settings.icon` in `signup-form-embed.js` before replacing image path.
