### PR TITLE
Improved DX when working with collections

### DIFF
--- a/.github/dev.js
+++ b/.github/dev.js
@@ -67,6 +67,16 @@ if (DASH_DASH_ARGS.includes('in-memory-repository') || DASH_DASH_ARGS.includes('
     });
 }
 
+if (DASH_DASH_ARGS.includes('collections') || DASH_DASH_ARGS.includes('all')) {
+    commands.push({
+        name: 'collections',
+        command: 'yarn dev',
+        cwd: path.resolve(__dirname, '../ghost/collections'),
+        prefixColor: 'pink',
+        env: {}
+    });
+}
+
 if (DASH_DASH_ARGS.includes('admin-x') || DASH_DASH_ARGS.includes('adminx') || DASH_DASH_ARGS.includes('adminX') || DASH_DASH_ARGS.includes('all')) {
     commands.push({
         name: 'adminX',


### PR DESCRIPTION
This was missing from the initial package creation, adding the command here means that `yarn dev` in the top level will watch and build collections
