### PR TITLE
Enabled errors for our errors in eslint

### DIFF
--- a/ghost/core/.eslintrc.js
+++ b/ghost/core/.eslintrc.js
@@ -13,9 +13,7 @@ module.exports = {
         // @TODO: remove this rule once it's turned into "error" in the base plugin
         'no-shadow': 'error',
         'no-var': 'error',
-        'one-var': ['error', 'never'],
-        'ghost/ghost-custom/ghost-error-usage': [1],
-        'ghost/ghost-custom/no-native-error': [1]
+        'one-var': ['error', 'never']
     },
     overrides: [
         {

--- a/ghost/core/core/server/data/migrations/versions/5.21/2022-10-26-04-50-member-subscription-created-batch-id.js
+++ b/ghost/core/core/server/data/migrations/versions/5.21/2022-10-26-04-50-member-subscription-created-batch-id.js
@@ -3,6 +3,7 @@ const logging = require('@tryghost/logging');
 const ObjectId = require('bson-objectid').default;
 const {createTransactionalMigration} = require('../../utils');
 const DatabaseInfo = require('@tryghost/database-info');
+const GhostError = require('@tryghost/errors').GhostError;
 
 // This migration links together members_created_events and members_subscription_created_events
 
@@ -46,7 +47,9 @@ module.exports = createTransactionalMigration(
 
             if (response1[0] !== 0) {
                 logging.error(`Inserted ${response1[0]} members_created_events, expected 0`);
-                throw new Error('Rolling back');
+                throw new GhostError({
+                    message: 'Rolling back'
+                });
             }
 
             const response2 = await knex('members_subscription_created_events').insert(batch.map((r) => {
@@ -61,7 +64,9 @@ module.exports = createTransactionalMigration(
 
             if (response2[0] !== 0) {
                 logging.error(`Inserted ${response1[0]} members_subscription_created_events, expected 0`);
-                throw new Error('Rolling back');
+                throw new GhostError({
+                    message: 'Rolling back'
+                });
             }
         }
         logging.info(`Linked ${rows.length} members_created_events and members_subscription_created_events`);

--- a/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-26-add-ghost-explore-integration-api-key.js
+++ b/ghost/core/core/server/data/migrations/versions/5.3/2022-07-06-09-26-add-ghost-explore-integration-api-key.js
@@ -14,7 +14,9 @@ module.exports = createTransactionalMigration(
         }).first();
 
         if (!integration) {
-            throw new InternalServerError('Could not find Ghost Explore Integration');
+            throw new InternalServerError({
+                message: 'Could not find Ghost Explore Integration'
+            });
         }
 
         const role = await knex('roles').where({
@@ -22,7 +24,9 @@ module.exports = createTransactionalMigration(
         }).first();
 
         if (!role) {
-            throw new InternalServerError('Could not find Ghost Explore Integration Role');
+            throw new InternalServerError({
+                message: 'Could not find Ghost Explore Integration Role'
+            });
         }
 
         const existingKey = await knex('api_keys').where({

--- a/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-19-02-add-self-serve-integration-api-key.js
+++ b/ghost/core/core/server/data/migrations/versions/5.40/2023-03-21-19-02-add-self-serve-integration-api-key.js
@@ -14,7 +14,9 @@ module.exports = createTransactionalMigration(
         }).first();
 
         if (!integration) {
-            throw new InternalServerError('Could not find "Self-Serve Migration Integration"');
+            throw new InternalServerError({
+                message: 'Could not find "Self-Serve Migration Integration"'
+            });
         }
 
         const role = await knex('roles').where({
@@ -22,7 +24,9 @@ module.exports = createTransactionalMigration(
         }).first();
 
         if (!role) {
-            throw new InternalServerError('Could not find "Self-Serve Migration Integration" Role');
+            throw new InternalServerError({
+                message: 'Could not find "Self-Serve Migration Integration" Role'
+            });
         }
 
         const existingKey = await knex('api_keys').where({

--- a/ghost/core/core/server/data/migrations/versions/5.41/2023-03-27-17-51-fix-self-serve-integration-api-key-type.js
+++ b/ghost/core/core/server/data/migrations/versions/5.41/2023-03-27-17-51-fix-self-serve-integration-api-key-type.js
@@ -12,7 +12,9 @@ module.exports = module.exports = createTransactionalMigration(
         }).first();
 
         if (!integration) {
-            throw new InternalServerError('Could not find "Self-Serve Migration Integration"');
+            throw new InternalServerError({
+                message: 'Could not find "Self-Serve Migration Integration"'
+            });
         }
 
         const existingKey = await knex('api_keys').where({

--- a/ghost/core/core/shared/config/helpers.js
+++ b/ghost/core/core/shared/config/helpers.js
@@ -89,7 +89,7 @@ const getContentPath = function getContentPath(type) {
     default:
         // new Error is allowed here, as we do not want config to depend on @tryghost/error
         // @TODO: revisit this decision when @tryghost/error is no longer dependent on all of ghost-ignition
-        // eslint-disable-next-line no-restricted-syntax
+        // eslint-disable-next-line ghost/ghost-custom/no-native-error
         throw new Error('getContentPath was called with: ' + type);
     }
 };

--- a/ghost/core/core/shared/config/utils.js
+++ b/ghost/core/core/shared/config/utils.js
@@ -28,7 +28,7 @@ const doesContentPathExist = function doesContentPathExist(contentPath) {
     if (!fs.pathExistsSync(contentPath)) {
         // new Error is allowed here, as we do not want config to depend on @tryghost/error
         // @TODO: revisit this decision when @tryghost/error is no longer dependent on all of ghost-ignition
-        // eslint-disable-next-line no-restricted-syntax
+        // eslint-disable-next-line ghost/ghost-custom/no-native-error
         throw new Error('Your content path does not exist! Please double check `paths.contentPath` in your custom config file e.g. config.production.json.');
     }
 };
@@ -40,7 +40,7 @@ const checkUrlProtocol = function checkUrlProtocol(url) {
     if (!url.match(/^https?:\/\//i)) {
         // new Error is allowed here, as we do not want config to depend on @tryghost/error
         // @TODO: revisit this decision when @tryghost/error is no longer dependent on all of ghost-ignition
-        // eslint-disable-next-line no-restricted-syntax
+        // eslint-disable-next-line ghost/ghost-custom/no-native-error
         throw new Error('URL in config must be provided with protocol, eg. "http://my-ghost-blog.com"');
     }
 };

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -105,7 +105,11 @@ module.exports.enabledHelper = function enabledHelper(options, callback) {
     errDetails.help = tpl(options.errorHelp || messages.errorHelp, {url: options.helpUrl});
 
     // eslint-disable-next-line no-restricted-syntax
-    logging.error(new errors.DisabledFeatureError(errDetails));
+    logging.error(new errors.DisabledFeatureError({
+        message: errDetails.message,
+        context: errDetails.context,
+        help: errDetails.help
+    }));
 
     const {SafeString} = require('express-hbs');
     errString = new SafeString(`<script>console.error("${_.values(errDetails).join(' ')}");</script>`);


### PR DESCRIPTION
Yo dawg, I heard you like errors?

This fixes the last issues we had with incorrect error usage and updates eslint to longer allow them through!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e017d2</samp>

This pull request updates several migration files to use the new error handling logic of the `GhostError` and `InternalServerError` classes. It also removes some custom ESLint rules that enforced the use of the `GhostError` class. The goal of these changes is to simplify and improve the error handling code in Ghost.
