### PR TITLE
🐛 Fixed page revision returning empty array on update and restore

### DIFF
--- a/ghost/admin/app/adapters/page.js
+++ b/ghost/admin/app/adapters/page.js
@@ -12,7 +12,6 @@ export default class Page extends ApplicationAdapter {
         }
 
         return parsedUrl.toString();
-        // return this.buildURL(modelName, id, snapshot, requestType, query);
     }
 
     buildURL() {

--- a/ghost/admin/app/adapters/page.js
+++ b/ghost/admin/app/adapters/page.js
@@ -3,7 +3,16 @@ import ApplicationAdapter from 'ghost-admin/adapters/application';
 export default class Page extends ApplicationAdapter {
     // posts and pages now include everything by default
     buildIncludeURL(store, modelName, id, snapshot, requestType, query) {
-        return this.buildURL(modelName, id, snapshot, requestType, query);
+        const url = this.buildURL(modelName, id, snapshot, requestType, query);
+        const parsedUrl = new URL(url);
+
+        if (snapshot?.adapterOptions?.saveRevision) {
+            const saveRevision = snapshot.adapterOptions.saveRevision;
+            parsedUrl.searchParams.append('save_revision', saveRevision);
+        }
+
+        return parsedUrl.toString();
+        // return this.buildURL(modelName, id, snapshot, requestType, query);
     }
 
     buildURL() {

--- a/ghost/admin/app/models/post-revision.js
+++ b/ghost/admin/app/models/post-revision.js
@@ -1,7 +1,6 @@
 import Model, {attr, belongsTo} from '@ember-data/model';
 
 export default class PostRevisionModel extends Model {
-  @belongsTo('post') post;
   @attr('string') lexical;
   @attr('string') title;
   @attr('string') featureImage;


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3491

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ff4186</samp>

This pull request adds a feature to save revisions without creating new versions of posts or pages, and refactors the revision handling to simplify the logic and avoid unnecessary data loading. It modifies the `buildIncludeURL` method in the `page` and `post` adapters, and removes the `post` relationship from the `post-revision` model.
