### PR TITLE
Added truncation to custom theme setting description

### DIFF
--- a/ghost/admin/app/components/custom-theme-settings/boolean.hbs
+++ b/ghost/admin/app/components/custom-theme-settings/boolean.hbs
@@ -12,7 +12,7 @@
             </div>
         </div>
         {{#if @setting.description}}
-            <div class="gh-setting-desc" style="margin-top: 1px">{{@setting.description}}</div>
+            <div class="gh-setting-desc" style="margin-top: 1px">{{truncate @setting.description 100}}</div>
         {{/if}}
     </div>
 </div>

--- a/ghost/admin/app/components/custom-theme-settings/color.hbs
+++ b/ghost/admin/app/components/custom-theme-settings/color.hbs
@@ -4,7 +4,7 @@
             {{humanize-setting-key @setting.key}}
         </label>
         {{#if @setting.description}}
-            <div class="gh-setting-desc">{{@setting.description}}</div>
+            <div class="gh-setting-desc">{{truncate @setting.description 100}}</div>
         {{/if}}
         {{#if this.isInvalid}}
             <div class="gh-setting-error {{if (is-empty @setting.description) "mt3"}}">Enter a color in hex format</div>

--- a/ghost/admin/app/components/custom-theme-settings/image.hbs
+++ b/ghost/admin/app/components/custom-theme-settings/image.hbs
@@ -11,7 +11,7 @@
                     <div class="gh-setting-error" data-test-error="icon">{{or error.context error.message}}</div>
                 {{/each}}
                 {{#if @setting.description}}
-                    <div class="gh-setting-desc" style="margin-top: 8px">{{@setting.description}}</div>
+                    <div class="gh-setting-desc" style="margin-top: 8px">{{truncate @setting.description 100}}</div>
                 {{/if}}
             </div>
             <div class="gh-setting-action gh-uploadbutton-container flex flex-column items-stretch">

--- a/ghost/admin/app/components/custom-theme-settings/select.hbs
+++ b/ghost/admin/app/components/custom-theme-settings/select.hbs
@@ -15,7 +15,7 @@
             {{svg-jar "arrow-down-small"}}
         </span>
         {{#if @setting.description}}
-            <div class="gh-setting-desc">{{@setting.description}}</div>
+            <div class="gh-setting-desc">{{truncate @setting.description 100}}</div>
         {{/if}}
     </div>
 </div>

--- a/ghost/admin/app/components/custom-theme-settings/text.hbs
+++ b/ghost/admin/app/components/custom-theme-settings/text.hbs
@@ -13,7 +13,7 @@
             {{on "blur" this.triggerOnChange}}
         />
         {{#if @setting.description}}
-            <div class="gh-setting-desc">{{@setting.description}}</div>
+            <div class="gh-setting-desc">{{truncate @setting.description 100}}</div>
         {{/if}}
     </div>
 </div>


### PR DESCRIPTION
no issue

Added truncation to custom theme setting description to prevent overly long custom setting descriptions from diminishing the settings UX