### PR TITLE
🎨 Improved copy on page & post revisions

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -152,7 +152,7 @@
                         {{#if this.canViewPostHistory}}
                             <li class="nav-list-item">
                                 <button type="button" {{on "click" this.openPostHistory}} data-test-toggle="post-history">
-                                    <span>{{svg-jar "history" class="history"}} Post history</span>
+                                    <span>{{svg-jar "history" class="history"}} {{capitalize this.post.displayName}} history</span>
                                 </button>
                                 {{svg-jar "arrow-right" class="arrow-right"}}
                             </li>

--- a/ghost/admin/app/components/modal-post-history.hbs
+++ b/ghost/admin/app/components/modal-post-history.hbs
@@ -34,7 +34,7 @@
                     {{svg-jar "arrow-left"}}
                     <span class="hidden">Back</span>
                 </button>
-                <h4>Post history</h4>
+                <h4>{{capitalize this.post.displayName}} history</h4>
             </div>
             <div class="settings-menu-content">
                 <ul class="nav-list">

--- a/ghost/admin/app/components/modals/restore-revision.js
+++ b/ghost/admin/app/components/modals/restore-revision.js
@@ -6,19 +6,23 @@ import {task} from 'ember-concurrency';
 export default class RestoreRevisionModal extends Component {
     @service notifications;
 
+    get pageType() {
+        return this.args.data.post.isPost ? 'post' : 'page';
+    }
+
     get title() {
         return this.args.data.post.isPublished === true
-            ? 'Restore version for published post?'
-            : 'Restore this version?';
+            ? `Restore version for published ${this.pageType}?`
+            : `Restore this version?`;
     }
 
     get body() {
         return this.args.data.post.isPublished === true
             ? htmlSafe(`
-                Heads up! This post has already been <strong>published</strong>, restoring a previous
-                version will automatically update the post on your site.
+                Heads up! This ${this.pageType} has already been <strong>published</strong>, restoring a previous
+                version will automatically update the ${this.pageType} on your site.
             `)
-            : 'Replace your existing draft with this version of the post.';
+            : `Replace your existing draft with this version of the ${this.pageType}.`;
     }
 
     @task

--- a/ghost/admin/app/components/modals/restore-revision.js
+++ b/ghost/admin/app/components/modals/restore-revision.js
@@ -6,23 +6,19 @@ import {task} from 'ember-concurrency';
 export default class RestoreRevisionModal extends Component {
     @service notifications;
 
-    get pageType() {
-        return this.args.data.post.isPost ? 'post' : 'page';
-    }
-
     get title() {
         return this.args.data.post.isPublished === true
-            ? `Restore version for published ${this.pageType}?`
+            ? `Restore version for published ${this.args.data.post.displayName}?`
             : `Restore this version?`;
     }
 
     get body() {
         return this.args.data.post.isPublished === true
             ? htmlSafe(`
-                Heads up! This ${this.pageType} has already been <strong>published</strong>, restoring a previous
-                version will automatically update the ${this.pageType} on your site.
+                Heads up! This ${this.args.data.post.displayName} has already been <strong>published</strong>, restoring a previous
+                version will automatically update the ${this.args.data.post.displayName} on your site.
             `)
-            : `Replace your existing draft with this version of the ${this.pageType}.`;
+            : `Replace your existing draft with this version of the ${this.args.data.post.displayName}.`;
     }
 
     @task


### PR DESCRIPTION
no issue

Updates the labels of the post history components to reflect the type of content (post or page). 
It modifies the `restore-revision`, `gh-post-settings-menu`, and `modal-post-history` components.
