### PR TITLE
🐛 Fixed post scheduling for sites with transferred ownership

### DIFF
--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -875,7 +875,11 @@ Post = ghostBookshelf.Model.extend({
                     revision_interval_ms: POST_REVISIONS_INTERVAL_MS
                 }
             });
-            const authorId = this.contextUser(options);
+            let authorId = this.contextUser(options);
+            const authorExists = await ghostBookshelf.model('User').findOne({id: authorId}, {transacting: options.transacting});
+            if (!authorExists) {
+                authorId = await ghostBookshelf.model('User').getOwnerUser().get('id');
+            }
             ops.push(async function updateRevisions() {
                 const revisionModels = await ghostBookshelf.model('PostRevision')
                     .findAll(Object.assign({


### PR DESCRIPTION
refs TryGhost/Ghost#3494

- By default, the post scheduler runs as user_id = 1, which is the original owner of the site
- If ownership has been transferred to a different user, it's possible that there is no user with id = 1
- In this case, the scheduler would fail to publish a post, because updating the post using user_id = 1 failed a foreign key constraint in the post_revisions table
- This commit fixes the issue by checking if the contextUser exists, and if not, replacing it with the current owner of the site
