### PR TITLE
🐛 Fixed draft pages not saving on forced revisions

### DIFF
--- a/ghost/core/core/server/api/endpoints/pages.js
+++ b/ghost/core/core/server/api/endpoints/pages.js
@@ -140,6 +140,7 @@ module.exports = {
             'formats',
             'source',
             'force_rerender',
+            'save_revision',
             // NOTE: only for internal context
             'forUpdate',
             'transacting'


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/3493

- Fixed pages not saving on force revision. As a side effect, it broke admin navigation as it doesn't manage to create a new revision successfully.
- This was simply caused by a missing option in the API endpoint config.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b646916</samp>

This change enables the `pages` endpoint to handle page revisions by adding the `save_revision` permission. This is part of a pull request that adds page versioning and restoring functionality to Ghost.
