### PR TITLE
🐛 Fixed revision save reverting newly published post to draft

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -1059,7 +1059,9 @@ export default class LexicalEditorController extends Controller {
 
         while (config.environment !== 'test' && true) {
             yield timeout(REVISIONSAVE_TIMEOUT);
-            this.autosaveTask.perform({saveRevision: true});
+            this.autosaveTask.perform({
+                saveRevision: this._canAutosave
+            });
         }
     }).drop())
         _revisionSaveTask;


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/17076

When a post is saved `_revisionSaveTask` gets queued to execute 10 minutes from the save. When a post is published via the publish modal `_revisionSaveTask` does not get dequeued. When `_revisionSaveTask` gets executed at the 10 minute mark it is  assumed that it is ok to save a revision, which will cause the post to be reverted back to a draft. This change enforces another check during the task exection to ensure that it is in fact still ok to save a revision (in case anything has changed in the 10 minutes since the task queued, i.e the post being published)
