### PR TITLE
🐛 Fixed portal free trial message incorrectly showing

### DIFF
--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -606,8 +606,8 @@ class SignupPage extends React.Component {
     }
 
     renderFreeTrialMessage() {
-        const {site, t} = this.context;
-        if (hasFreeTrialTier({site}) && !isInviteOnlySite({site})) {
+        const {site, t, pageQuery} = this.context;
+        if (hasFreeTrialTier({site, pageQuery}) && !isInviteOnlySite({site})) {
             return (
                 <p className='gh-portal-free-trial-notification' data-testid="free-trial-notification-text">
                     {t('After a free trial ends, you will be charged the regular price for the tier you\'ve chosen. You can always cancel before then.')}

--- a/apps/portal/src/components/pages/SignupPage.test.js
+++ b/apps/portal/src/components/pages/SignupPage.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import SignupPage from './SignupPage';
+import {getFreeProduct, getProductData, getSiteData} from '../../utils/fixtures-generator';
 import {render, fireEvent} from '../../utils/test-utils';
 
 const setup = (overrides) => {
@@ -7,7 +8,8 @@ const setup = (overrides) => {
         <SignupPage />,
         {
             overrideContext: {
-                member: null
+                member: null,
+                ...overrides
             }
         }
     );
@@ -16,12 +18,14 @@ const setup = (overrides) => {
     const submitButton = utils.queryByRole('button', {name: 'Continue'});
     const chooseButton = utils.queryAllByRole('button', {name: 'Choose'});
     const signinButton = utils.queryByRole('button', {name: 'Sign in'});
+    const freeTrialMessage = utils.queryByText(/After a free trial ends/i);
     return {
         nameInput,
         emailInput,
         submitButton,
         chooseButton,
         signinButton,
+        freeTrialMessage,
         mockOnActionFn,
         ...utils
     };
@@ -58,5 +62,32 @@ describe('SignupPage', () => {
 
         fireEvent.click(signinButton);
         expect(mockOnActionFn).toHaveBeenCalledWith('switchPage', {page: 'signin'});
+    });
+
+    test('renders free trial message', () => {
+        const {freeTrialMessage} = setup({
+            site: getSiteData({
+                products: [
+                    getProductData({trialDays: 7}),
+                    getFreeProduct({})
+                ]
+            })
+        });
+
+        expect(freeTrialMessage).toBeInTheDocument();
+    });
+
+    test('does not render free trial message on free signup', () => {
+        const {freeTrialMessage} = setup({
+            site: getSiteData({
+                products: [
+                    getProductData({trialDays: 7}),
+                    getFreeProduct({})
+                ]
+            }),
+            pageQuery: 'free'
+        });
+
+        expect(freeTrialMessage).not.toBeInTheDocument();
     });
 });

--- a/apps/portal/src/utils/fixtures-generator.js
+++ b/apps/portal/src/utils/fixtures-generator.js
@@ -189,7 +189,8 @@ export function getProductData({
     id = `product_${objectId()}`,
     monthlyPrice = getPriceData(),
     yearlyPrice = getPriceData({interval: 'year'}),
-    numOfBenefits = 2
+    numOfBenefits = 2,
+    trialDays = null
 }) {
     return {
         id: id,
@@ -198,7 +199,8 @@ export function getProductData({
         monthlyPrice: type === 'free' ? null : monthlyPrice,
         yearlyPrice: type === 'free' ? null : yearlyPrice,
         type: type,
-        benefits: getBenefits({numOfBenefits})
+        benefits: getBenefits({numOfBenefits}),
+        trial_days: trialDays
     };
 }
 

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -410,8 +410,8 @@ export function getSiteProducts({site, pageQuery}) {
     return products;
 }
 
-export function hasFreeTrialTier({site}) {
-    const tiers = getSiteProducts({site});
+export function hasFreeTrialTier({site, pageQuery}) {
+    const tiers = getSiteProducts({site, pageQuery});
     return tiers.some((tier) => {
         return !!tier?.trial_days;
     });


### PR DESCRIPTION
no issue

Fixed portal free trial message incorrectly showing when signing up for free. Message was showing due to `pageQuery` erroneously  not being passed down the call stack to `getSiteProducts`
