### PR TITLE
Fixed hack to kill Ghost after boot in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,10 +128,9 @@ jobs:
       - run: yarn --prefer-offline
 
       - name: Run Ghost and then kill it
-        working-directory: ghost/core
-        run: |
-          node index.js &
-          sleep 20 && { kill $! && wait $!; } 2>/dev/null
+        run: yarn workspace ghost run start
+        env:
+          GHOST_TESTS_KILL_SERVER_AFTER_BOOT: true
 
       - run: sqlite3 ${{ env.database__connection__filename }} "DELETE FROM migrations WHERE version LIKE '5.%';"
         if: matrix.env.DB == 'sqlite3'

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -534,6 +534,14 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
         // Step 7 - Init our background services, we don't wait for this to finish
         initBackgroundServices({config});
 
+        // Step 8 - Kill the process - what??
+        // During the migration tests, we want to boot ghost, run migrations, then shut down
+        // This is the easiest way to get Ghost to boot and then kill itself
+        if (process.env.GHOST_TESTS_KILL_SERVER_AFTER_BOOT === 'true') {
+            debug('Killing Ghost Server after boot');
+            process.exit(0);
+        }
+
         // We return the server purely for testing purposes
         if (server) {
             debug('End Boot: Returning Ghost Server');


### PR DESCRIPTION
- in the migration tests we need to boot Ghost and then kill it afterwards
- because there was no easy way to do this, the workflow waits for 20s and then kills the last process ID
- aside from being a terrible idea, it means we're also just arbitrarily waiting for 20s, which burns time when it takes shorter to boot Ghost
- this commit implements an environment variable that will kill the server once it has run the whole boot process, and then fixes the workflow to use that

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 45026a6</samp>

Simplify test workflow by using `yarn workspace` and `GHOST_TESTS_KILL_SERVER_AFTER_BOOT` environment variable. Add logic to `bootGhost` function to exit Ghost after booting if the variable is set to `true`.
