### PR TITLE
🐛 Fixed newsletter post duplication

### DIFF
--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -526,7 +526,8 @@ class PostsService {
                 'published_at',
                 'published_by',
                 'canonical_url',
-                'count__clicks'
+                'count__clicks',
+                'newsletter_id'
             ]
         );
 
@@ -544,7 +545,9 @@ class PostsService {
                 existingPostMeta.attributes,
                 [
                     'id',
-                    'post_id'
+                    'post_id',
+                    'email_only',
+                    'email_subject'
                 ]
             );
         }

--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -3,7 +3,7 @@ const {BadRequestError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const ObjectId = require('bson-objectid').default;
-const omit = require('lodash/omit');
+const pick = require('lodash/pick');
 
 const messages = {
     invalidVisibilityFilter: 'Invalid visibility filter.',
@@ -512,22 +512,24 @@ class PostsService {
             status: 'all'
         }, frame.options);
 
-        const newPostData = omit(
+        const newPostData = pick(
             existingPost.attributes,
             [
-                'id',
-                'uuid',
-                'slug',
-                'comment_id',
-                'created_at',
-                'created_by',
-                'updated_at',
-                'updated_by',
-                'published_at',
-                'published_by',
-                'canonical_url',
-                'count__clicks',
-                'newsletter_id'
+                'title',
+                'mobiledoc',
+                'lexical',
+                'html',
+                'plaintext',
+                'feature_image',
+                'featured',
+                'type',
+                'locale',
+                'visibility',
+                'email_recipient_filter',
+                'custom_excerpt',
+                'codeinjection_head',
+                'codeinjection_foot',
+                'custom_template'
             ]
         );
 
@@ -541,13 +543,20 @@ class PostsService {
         const existingPostMeta = existingPost.related('posts_meta');
 
         if (existingPostMeta.isNew() === false) {
-            newPostData.posts_meta = omit(
+            newPostData.posts_meta = pick(
                 existingPostMeta.attributes,
                 [
-                    'id',
-                    'post_id',
-                    'email_only',
-                    'email_subject'
+                    'og_image',
+                    'og_title',
+                    'og_description',
+                    'twitter_image',
+                    'twitter_title',
+                    'twitter_description',
+                    'meta_title',
+                    'meta_description',
+                    'frontmatter',
+                    'feature_image_alt',
+                    'feature_image_caption'
                 ]
             );
         }

--- a/ghost/posts-service/test/PostsService.test.js
+++ b/ghost/posts-service/test/PostsService.test.js
@@ -130,6 +130,22 @@ describe('Posts Service', function () {
             assert.equal(copiedPostData.slug, undefined);
         });
 
+        it('omits unnecessary data from a copied newsletter', async function () {
+            existingPostModel.attributes = {
+                id: POST_ID,
+                title: 'Test Post',
+                slug: 'test-post',
+                status: 'sent',
+                newsletter_id: 'abc123'
+            };
+
+            await makePostService().copyPost(frame);
+
+            const copiedPostData = postModelStub.add.getCall(0).args[0];
+
+            assert.equal(copiedPostData.newsletter_id, undefined);
+        });
+
         it('updates the title of the copied post', async function () {
             await makePostService().copyPost(frame);
 
@@ -217,7 +233,9 @@ describe('Posts Service', function () {
                 attributes: {
                     post_id: POST_ID,
                     meta_title: 'Test Post',
-                    meta_description: 'Test Post Description'
+                    meta_description: 'Test Post Description',
+                    email_only: 1,
+                    email_subject: 'Test Email Subject'
                 },
                 isNew: () => false
             };

--- a/ghost/posts-service/test/PostsService.test.js
+++ b/ghost/posts-service/test/PostsService.test.js
@@ -71,7 +71,8 @@ describe('Posts Service', function () {
                     id: POST_ID,
                     title: 'Test Post',
                     slug: 'test-post',
-                    status: 'published'
+                    status: 'published',
+                    newsletter_id: 'abc123'
                 },
                 related: sinon.stub()
             };
@@ -128,22 +129,6 @@ describe('Posts Service', function () {
 
             assert.equal(copiedPostData.id, undefined);
             assert.equal(copiedPostData.slug, undefined);
-        });
-
-        it('omits unnecessary data from a copied newsletter', async function () {
-            existingPostModel.attributes = {
-                id: POST_ID,
-                title: 'Test Post',
-                slug: 'test-post',
-                status: 'sent',
-                newsletter_id: 'abc123'
-            };
-
-            await makePostService().copyPost(frame);
-
-            const copiedPostData = postModelStub.add.getCall(0).args[0];
-
-            assert.equal(copiedPostData.newsletter_id, undefined);
         });
 
         it('updates the title of the copied post', async function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3521

When duplicating a newsletter (email only post) some of the fields relating to the newsletter (i.e `newsletter_id`) were being erroneously copied over. Upon publishing this made the post appear as if it was an email only post that had been sent to subscribers when it actually had not
