### PR TITLE
🐛 Handled BOM character for Unicode encoded file uploads

### DIFF
--- a/ghost/members-csv/lib/parse.js
+++ b/ghost/members-csv/lib/parse.js
@@ -18,8 +18,7 @@ module.exports = (path, headerMapping, defaultLabels = []) => {
                 const cleanHeader = _header.replace(papaparse.BYTE_ORDER_MARK, '');
                 if (!headerMapping || !Reflect.has(headerMapping, cleanHeader)) {
                     return undefined;
-                  }
-
+                }
                 return headerMapping[cleanHeader];
             },
             transform(value, header) {

--- a/ghost/members-csv/lib/parse.js
+++ b/ghost/members-csv/lib/parse.js
@@ -15,11 +15,12 @@ module.exports = (path, headerMapping, defaultLabels = []) => {
         const csvParserStream = papaparse.parse(papaparse.NODE_STREAM_INPUT, {
             header: true,
             transformHeader(_header) {
-                if (!headerMapping || !Reflect.has(headerMapping, _header)) {
+                const cleanHeader = _header.replace(papaparse.BYTE_ORDER_MARK, '');
+                if (!headerMapping || !Reflect.has(headerMapping, cleanHeader)) {
                     return undefined;
-                }
+                  }
 
-                return headerMapping[_header];
+                return headerMapping[cleanHeader];
             },
             transform(value, header) {
                 if (header === 'labels') {

--- a/ghost/members-csv/lib/parse.js
+++ b/ghost/members-csv/lib/parse.js
@@ -15,7 +15,7 @@ module.exports = (path, headerMapping, defaultLabels = []) => {
         const csvParserStream = papaparse.parse(papaparse.NODE_STREAM_INPUT, {
             header: true,
             transformHeader(_header) {
-                const cleanHeader = _header.replace(papaparse.BYTE_ORDER_MARK, '');
+                const cleanHeader = _header.replace(papaparse.BYTE_ORDER_MARK, ''); //Removing BOM characters for Unicode-based encodings
                 if (!headerMapping || !Reflect.has(headerMapping, cleanHeader)) {
                     return undefined;
                 }

--- a/ghost/members-csv/test/fixtures/single-column-with-header-bom.csv
+++ b/ghost/members-csv/test/fixtures/single-column-with-header-bom.csv
@@ -1,0 +1,3 @@
+﻿email
+jbloggs@example.com
+test@example.com

--- a/ghost/members-csv/test/parse.test.js
+++ b/ghost/members-csv/test/parse.test.js
@@ -35,6 +35,24 @@ describe('parse', function () {
         assert.equal(result.length, 0);
     });
 
+    it('one column with bom', async function () {
+        const filePath = csvPath + 'single-column-with-header-bom.csv';
+        const result = await parse(filePath, DEFAULT_HEADER_MAPPING);
+
+        assert.ok(result);
+        assert.equal(result.length, 2);
+        assert.equal(result[0].email, 'jbloggs@example.com');
+        assert.equal(result[1].email, 'test@example.com');
+    });
+
+    it('one column with bom and without header mapping returns empty result', async function () {
+        const filePath = csvPath + 'single-column-with-header-bom.csv';
+        const result = await parse(filePath);
+
+        assert.ok(result);
+        assert.equal(result.length, 0);
+    });
+
     it('two columns, 1 filter', async function () {
         const filePath = csvPath + 'two-columns-with-header.csv';
         const result = await parse(filePath, DEFAULT_HEADER_MAPPING);


### PR DESCRIPTION
https://github.com/TryGhost/Ghost/issues/16917

For details of how I debugged this issue, see this comment: https://github.com/TryGhost/Ghost/issues/16917#issuecomment-1602984601

After this PR, I was able to upload the file provided in the issue and I have also tested it by uploading other files of ascii and utf-8 encoding.

<img width="634" alt="image" src="https://github.com/TryGhost/Ghost/assets/17474532/ab9ed0cf-09ab-4491-ba57-755715b78012">
<img width="475" alt="image" src="https://github.com/TryGhost/Ghost/assets/17474532/02ccfda0-3659-4929-8066-748e182bee76">
