### PR TITLE
Removed Bluebird from tests

### DIFF
--- a/ghost/core/test/e2e-api/admin/actions.test.js
+++ b/ghost/core/test/e2e-api/admin/actions.test.js
@@ -1,5 +1,4 @@
 const should = require('should');
-const Promise = require('bluebird');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
 const localUtils = require('./utils');
@@ -54,7 +53,9 @@ describe('Actions API', function () {
         res2.body.actions[0].actor.name.should.eql(testUtils.DataGenerator.Content.users[0].name);
         res2.body.actions[0].actor.slug.should.eql(testUtils.DataGenerator.Content.users[0].slug);
 
-        await Promise.delay(1000);
+        await new Promise((resolve) => {
+            setTimeout(resolve, 1000);
+        });
 
         const res3 = await request
             .put(localUtils.API.getApiQuery(`posts/${postId}/`))
@@ -92,7 +93,9 @@ describe('Actions API', function () {
         res4.body.actions[0].actor.name.should.eql(testUtils.DataGenerator.Content.users[0].name);
         res4.body.actions[0].actor.slug.should.eql(testUtils.DataGenerator.Content.users[0].slug);
 
-        await Promise.delay(1000);
+        await new Promise((resolve) => {
+            setTimeout(resolve, 1000);
+        });
 
         const integrationRequest = supertest.agent(config.get('url'));
         await integrationRequest

--- a/ghost/core/test/e2e-api/admin/users.test.js
+++ b/ghost/core/test/e2e-api/admin/users.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const supertest = require('supertest');
-const Promise = require('bluebird');
 const testUtils = require('../../utils');
 const config = require('../../../core/shared/config');
 const db = require('../../../core/server/data/db');

--- a/ghost/core/test/integration/importer/v2.test.js
+++ b/ghost/core/test/integration/importer/v2.test.js
@@ -1,7 +1,6 @@
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
-const Promise = require('bluebird');
 const moment = require('moment-timezone');
 const ObjectId = require('bson-objectid').default;
 const assert = require('assert/strict');

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -2,7 +2,6 @@ const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
 const _ = require('lodash');
-const Promise = require('bluebird');
 const Models = require('../../../core/server/models');
 
 describe('Database Migration (special functions)', function () {
@@ -193,59 +192,57 @@ describe('Database Migration (special functions)', function () {
         describe('Populate', function () {
             beforeEach(testUtils.setup('default'));
 
-            it('should populate all fixtures correctly', function () {
-                const props = {
-                    posts: Models.Post.findAll({withRelated: ['tags']}),
-                    tags: Models.Tag.findAll(),
-                    users: Models.User.findAll({
+            it('should populate all fixtures correctly', async function () {
+                const [posts, tags, users, roles, permissions] = await Promise.all([
+                    Models.Post.findAll({withRelated: ['tags']}),
+                    Models.Tag.findAll(),
+                    Models.User.findAll({
                         filter: 'status:inactive',
                         context: {internal: true},
                         withRelated: ['roles']
                     }),
-                    roles: Models.Role.findAll(),
-                    permissions: Models.Permission.findAll({withRelated: ['roles']})
-                };
-                return Promise.props(props).then(function (result) {
-                    // Post
-                    should.exist(result.posts);
-                    result.posts.length.should.eql(7);
-                    result.posts.at(0).get('title').should.eql('Start here for a quick overview of everything you need to know');
-                    result.posts.at(6).get('title').should.eql('Setting up apps and custom integrations');
+                    Models.Role.findAll(),
+                    Models.Permission.findAll({withRelated: ['roles']})
+                ]);
+                // Post
+                should.exist(posts);
+                posts.length.should.eql(7);
+                posts.at(0).get('title').should.eql('Start here for a quick overview of everything you need to know');
+                posts.at(6).get('title').should.eql('Setting up apps and custom integrations');
 
-                    // Tag
-                    should.exist(result.tags);
-                    result.tags.length.should.eql(1);
-                    result.tags.at(0).get('name').should.eql('Getting Started');
+                // Tag
+                should.exist(tags);
+                tags.length.should.eql(1);
+                tags.at(0).get('name').should.eql('Getting Started');
 
-                    // Post Tag relation
-                    result.posts.at(0).related('tags').length.should.eql(1);
-                    result.posts.at(0).related('tags').at(0).get('name').should.eql('Getting Started');
+                // Post Tag relation
+                posts.at(0).related('tags').length.should.eql(1);
+                posts.at(0).related('tags').at(0).get('name').should.eql('Getting Started');
 
-                    // User (Owner)
-                    should.exist(result.users);
-                    result.users.length.should.eql(1);
-                    result.users.at(0).get('name').should.eql('Ghost');
-                    result.users.at(0).get('status').should.eql('inactive');
-                    result.users.at(0).related('roles').length.should.eql(1);
-                    result.users.at(0).related('roles').at(0).get('name').should.eql('Owner');
+                // User (Owner)
+                should.exist(users);
+                users.length.should.eql(1);
+                users.at(0).get('name').should.eql('Ghost');
+                users.at(0).get('status').should.eql('inactive');
+                users.at(0).related('roles').length.should.eql(1);
+                users.at(0).related('roles').at(0).get('name').should.eql('Owner');
 
-                    // Roles
-                    should.exist(result.roles);
-                    result.roles.length.should.eql(10);
-                    result.roles.at(0).get('name').should.eql('Administrator');
-                    result.roles.at(1).get('name').should.eql('Editor');
-                    result.roles.at(2).get('name').should.eql('Author');
-                    result.roles.at(3).get('name').should.eql('Contributor');
-                    result.roles.at(4).get('name').should.eql('Owner');
-                    result.roles.at(5).get('name').should.eql('Admin Integration');
-                    result.roles.at(6).get('name').should.eql('Ghost Explore Integration');
-                    result.roles.at(7).get('name').should.eql('Self-Serve Migration Integration');
-                    result.roles.at(8).get('name').should.eql('DB Backup Integration');
-                    result.roles.at(9).get('name').should.eql('Scheduler Integration');
+                // Roles
+                should.exist(roles);
+                roles.length.should.eql(10);
+                roles.at(0).get('name').should.eql('Administrator');
+                roles.at(1).get('name').should.eql('Editor');
+                roles.at(2).get('name').should.eql('Author');
+                roles.at(3).get('name').should.eql('Contributor');
+                roles.at(4).get('name').should.eql('Owner');
+                roles.at(5).get('name').should.eql('Admin Integration');
+                roles.at(6).get('name').should.eql('Ghost Explore Integration');
+                roles.at(7).get('name').should.eql('Self-Serve Migration Integration');
+                roles.at(8).get('name').should.eql('DB Backup Integration');
+                roles.at(9).get('name').should.eql('Scheduler Integration');
 
-                    // Permissions
-                    result.permissions.toJSON().should.be.CompletePermissions();
-                });
+                // Permissions
+                permissions.toJSON().should.be.CompletePermissions();
             });
         });
     });

--- a/ghost/core/test/regression/models/base/listeners.test.js
+++ b/ghost/core/test/regression/models/base/listeners.test.js
@@ -1,6 +1,5 @@
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const moment = require('moment-timezone');
 const rewire = require('rewire');
 const _ = require('lodash');

--- a/ghost/core/test/regression/models/model_posts.test.js
+++ b/ghost/core/test/regression/models/model_posts.test.js
@@ -4,7 +4,6 @@ const sinon = require('sinon');
 const testUtils = require('../../utils');
 const moment = require('moment');
 const _ = require('lodash');
-const Promise = require('bluebird');
 const {sequence} = require('@tryghost/promise');
 const urlService = require('../../../core/server/services/url');
 const ghostBookshelf = require('../../../core/server/models/base');
@@ -475,7 +474,9 @@ describe('Post Model', function () {
                     should.exist(eventsTriggered['post.rescheduled']);
                     eventsTriggered = {};
 
-                    return Promise.delay(1000 * 3);
+                    return new Promise((resolve) => {
+                        setTimeout(resolve, 3000);
+                    });
                 }).then(function () {
                     return models.Post.edit({
                         status: 'scheduled'
@@ -1732,7 +1733,7 @@ describe('Post Model', function () {
                 });
         });
 
-        beforeEach(function () {
+        beforeEach(async function () {
             tagJSON = [];
 
             const post = _.cloneDeep(testUtils.DataGenerator.forModel.posts[0]);
@@ -1752,21 +1753,21 @@ describe('Post Model', function () {
             post.tags = postTags;
             post.status = 'published';
 
-            return Promise.props({
-                post: models.Post.add(post, _.extend({}, context, {withRelated: ['tags']})),
-                tag1: models.Tag.add(extraTags[0], context),
-                tag2: models.Tag.add(extraTags[1], context),
-                tag3: models.Tag.add(extraTags[2], context)
-            }).then(function (result) {
-                postJSON = result.post.toJSON({withRelated: ['tags']});
-                tagJSON.push(result.tag1.toJSON());
-                tagJSON.push(result.tag2.toJSON());
-                tagJSON.push(result.tag3.toJSON());
-                editOptions = _.extend({}, context, {id: postJSON.id, withRelated: ['tags']});
+            const [newPost, tag1, tag2, tag3] = await Promise.all([
+                models.Post.add(post, _.extend({}, context, {withRelated: ['tags']})),
+                models.Tag.add(extraTags[0], context),
+                models.Tag.add(extraTags[1], context),
+                models.Tag.add(extraTags[2], context)
+            ]);
 
-                // reset the eventSpy here
-                sinon.restore();
-            });
+            postJSON = newPost.toJSON({withRelated: ['tags']});
+            tagJSON.push(tag1.toJSON());
+            tagJSON.push(tag2.toJSON());
+            tagJSON.push(tag3.toJSON());
+            editOptions = _.extend({}, context, {id: postJSON.id, withRelated: ['tags']});
+
+            // reset the eventSpy here
+            sinon.restore();
         });
 
         it('should create the test data correctly', function (done) {
@@ -1823,7 +1824,9 @@ describe('Post Model', function () {
             delete newJSON.tags[0].parent;
 
             // Edit the post
-            return Promise.delay(1000)
+            return new Promise((resolve) => {
+                setTimeout(resolve, 1000);
+            })
                 .then(function () {
                     return models.Post.edit(newJSON, editOptions);
                 })

--- a/ghost/core/test/regression/models/model_users.test.js
+++ b/ghost/core/test/regression/models/model_users.test.js
@@ -2,7 +2,6 @@ const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
 const testUtils = require('../../utils');
-const Promise = require('bluebird');
 const _ = require('lodash');
 
 // Stuff we are testing
@@ -213,7 +212,7 @@ describe('User Model', function run() {
         it('can findOne by role name', function () {
             return testUtils.fixtures.createExtraUsers().then(function () {
                 return Promise.all([
-                    UserModel.findOne({role: 'Owner'}), 
+                    UserModel.findOne({role: 'Owner'}),
                     UserModel.findOne({role: 'Editor'})
                 ]);
             }).then(function (results) {

--- a/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
+++ b/ghost/core/test/unit/server/adapters/scheduling/post-scheduling/post-scheduler.test.js
@@ -1,7 +1,6 @@
 const errors = require('@tryghost/errors');
 const should = require('should');
 const sinon = require('sinon');
-const Promise = require('bluebird');
 const moment = require('moment');
 const testUtils = require('../../../../../utils');
 const models = require('../../../../../../core/server/models');
@@ -70,7 +69,9 @@ describe('Scheduling: Post Scheduler', function () {
                 events.emit('post.scheduled', post);
 
                 // let the events bubble up
-                await new Promise(resolve => setTimeout(resolve, 100));
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 100);
+                });
 
                 adapter.schedule.called.should.eql(true);
 

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -1,6 +1,5 @@
 // Utility Packages
 const debug = require('@tryghost/debug')('test');
-const Promise = require('bluebird');
 const _ = require('lodash');
 const fs = require('fs-extra');
 const path = require('path');


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/14882

- we're moving away from using Bluebird in favor of native Promises, so this commit removes nearly all instances from tests

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a5f5b6f</samp>

The pull request removes the `Promise` module dependency from various test files and replaces it with native `Promise` features. This simplifies and standardizes the code for testing different aspects of the Ghost platform. The pull request also adds a `sequence` function to handle promise chains in one test file.
