### PR TITLE
Fixed disabling search via config

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -76,6 +76,11 @@ function getMembersHelper(data, frontendKey) {
 function getSearchHelper(frontendKey) {
     const adminUrl = urlUtils.getAdminUrl() || urlUtils.getSiteUrl();
     const {scriptUrl, stylesUrl} = getFrontendAppConfig('sodoSearch');
+
+    if (!scriptUrl) {
+        return '';
+    }
+
     const attrs = {
         key: frontendKey,
         styles: stylesUrl,

--- a/ghost/core/core/frontend/utils/frontend-apps.js
+++ b/ghost/core/core/frontend/utils/frontend-apps.js
@@ -4,10 +4,10 @@ function getFrontendAppConfig(app) {
     const appVersion = config.get(`${app}:version`);
     let scriptUrl = config.get(`${app}:url`);
     let stylesUrl = config.get(`${app}:styles`);
-    if (scriptUrl.includes('{version}')) {
+    if (typeof scriptUrl === 'string' && scriptUrl.includes('{version}')) {
         scriptUrl = scriptUrl.replace('{version}', appVersion);
     }
-    if (stylesUrl?.includes('{version}')) {
+    if (typeof stylesUrl === 'string' && stylesUrl?.includes('{version}')) {
         stylesUrl = stylesUrl.replace('{version}', appVersion);
     }
     return {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/16120

- if you set `sodoSearch.url` to `false` in config, it'll currently crash because we're not correctly handling the types correctly
- the first part of the fix is ensuring the value is a string so we can call `.includes` on it
- second, the `false` value is passed into the output as a string, so we should detect if we passed a false value and early return with an empty string if so

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9e15fa</samp>

Refactor the `getFrontendAppConfig` function and add error handling for the `scriptUrl` and `stylesUrl` variables. This improves the robustness of the frontend app config logic and prevents potential errors in the `ghost_head` helper.
