### PR TITLE
Added `Access-Control-Allow-Origin: *` to image assets

### DIFF
--- a/ghost/core/core/frontend/web/middleware/serve-public-file.js
+++ b/ghost/core/core/frontend/web/middleware/serve-public-file.js
@@ -46,6 +46,8 @@ function createPublicFileMiddleware(location, file, mime, maxAge) {
 
         // send image files directly and let express handle content-length, etag, etc
         if (mime.match(/^image/)) {
+            // In admin we need to read images and calculate the average color (blocked by CORS otherwise)
+            res.setHeader('Access-Control-Allow-Origin', '*');
             return res.sendFile(filePath, (err) => {
                 if (err && err.status === 404) {
                     // ensure we're triggering basic asset 404 and not a templated 404


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C025584CA/p1687506966658799
refs https://ghost.slack.com/archives/C04TMVA1D7A/p1687426009256949

This change is required because we otherwise hit CORS issues when admin tries to load an image and calculate the average color (to determine the text color).