### PR TITLE
✨ Added beta of the new Signup Card

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -277,7 +277,7 @@ export default class KoenigLexicalEditor extends Component {
             fetchAutocompleteLinks,
             fetchLabels,
             feature: {
-                signupCard: this.feature.get('signupCard')
+                signupCard: true
             },
             membersEnabled: this.settings.get('membersSignupAccess') === 'all',
             siteTitle: this.settings.title,

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -61,20 +61,6 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
-                            <h4 class="gh-expandable-title">Signup Card</h4>
-                            <p class="gh-expandable-description">
-                                Enables the signup card in the Lexical editor
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                            <GhFeatureFlag @flag="signupCard" />
-                        </div>
-                    </div>
-                </div>
-
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
                             <h4 class="gh-expandable-title">Substack migrator</h4>
                             <p class="gh-expandable-description">A <a href="https://ghost.org/help/importing-from-substack/" target="_blank" rel="noopener noreferrer">step-by-step tool</a> to easily import all your content, members and paid subscriptions</p>
                         </div>

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -61,6 +61,20 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
+                            <h4 class="gh-expandable-title">Signup Card</h4>
+                            <p class="gh-expandable-description">
+                                Enables the signup card in the Lexical editor
+                            </p>
+                        </div>
+                        <div class="for-switch">
+                            <GhFeatureFlag @flag="signupCard" />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="gh-expandable-block">
+                    <div class="gh-expandable-header">
+                        <div>
                             <h4 class="gh-expandable-title">Substack migrator</h4>
                             <p class="gh-expandable-description">A <a href="https://ghost.org/help/importing-from-substack/" target="_blank" rel="noopener noreferrer">step-by-step tool</a> to easily import all your content, members and paid subscriptions</p>
                         </div>
@@ -265,20 +279,6 @@
                         </div>
                         <div class="for-switch">
                             <GhFeatureFlag @flag="emailCustomization" />
-                        </div>
-                    </div>
-                </div>
-
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
-                            <h4 class="gh-expandable-title">Signup Card</h4>
-                            <p class="gh-expandable-description">
-                                Enables the signup card in the Lexical editor
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                            <GhFeatureFlag @flag="signupCard" />
                         </div>
                     </div>
                 </div>

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -37,7 +37,6 @@ const ALPHA_FEATURES = [
     'websockets',
     'stripeAutomaticTax',
     'emailCustomization',
-    'signupCard',
     'collections',
     'adminXSettings',
     'mailEvents'


### PR DESCRIPTION
no issue

Keep an eye on Ghost's changelog (https://ghost.org/changelog/) for the full feature announcement.


<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee03e4d</samp>

This pull request removes the `signupCard` feature flag and enables the signup card for all users in the Lexical editor. This is part of the Lexical editor beta release, which is a new editor for Ghost that provides a better writing experience and more features for content creators.
