### PR TITLE
Fixed leaking pivot fields

### DIFF
--- a/ghost/core/core/server/models/base/plugins/overrides.js
+++ b/ghost/core/core/server/models/base/plugins/overrides.js
@@ -88,7 +88,10 @@ module.exports = function (Bookshelf) {
             // CASE: get JSON of previous attrs
             if (options.previous) {
                 const clonedModel = _.cloneDeep(this);
-                clonedModel.attributes = this._previousAttributes;
+                clonedModel.attributes = _.omitBy(
+                    this._previousAttributes,
+                    (value, key) => key.startsWith('_pivot_')
+                );
 
                 if (this.relationships) {
                     this.relationships.forEach((relation) => {

--- a/ghost/core/core/server/models/base/plugins/overrides.js
+++ b/ghost/core/core/server/models/base/plugins/overrides.js
@@ -1,3 +1,4 @@
+const {PIVOT_PREFIX} = require('bookshelf/lib/constants');
 const _ = require('lodash');
 
 /**
@@ -88,9 +89,11 @@ module.exports = function (Bookshelf) {
             // CASE: get JSON of previous attrs
             if (options.previous) {
                 const clonedModel = _.cloneDeep(this);
+                // Manually remove pivot fields from cloned model as they are not
+                // removed from _previousAttributes via `omitPivot` option
                 clonedModel.attributes = _.omitBy(
                     this._previousAttributes,
-                    (value, key) => key.startsWith('_pivot_')
+                    (value, key) => key.startsWith(PIVOT_PREFIX)
                 );
 
                 if (this.relationships) {

--- a/ghost/core/test/e2e-webhooks/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/members.test.js.snap
@@ -100,8 +100,6 @@ Object {
       "name": "Test Member2",
       "newsletters": Array [
         Object {
-          "_pivot_member_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-          "_pivot_newsletter_id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
           "background_color": "light",
           "body_font_category": "sans_serif",
           "border_color": null,

--- a/ghost/core/test/e2e-webhooks/members.test.js
+++ b/ghost/core/test/e2e-webhooks/members.test.js
@@ -1,7 +1,7 @@
 const {agentProvider, mockManager, fixtureManager, matchers} = require('../utils/e2e-framework');
 const {anyGhostAgent, anyObjectId, anyISODateTime, anyUuid, anyContentVersion, anyNumber} = matchers;
 
-const buildNewsletterSnapshot = (deleteMember = false) => {
+const buildNewsletterSnapshot = () => {
     const newsLetterSnapshot = {
         id: anyObjectId,
         uuid: anyUuid,
@@ -9,21 +9,16 @@ const buildNewsletterSnapshot = (deleteMember = false) => {
         updated_at: anyISODateTime
     };
 
-    if (deleteMember) {
-        newsLetterSnapshot._pivot_member_id = anyObjectId;
-        newsLetterSnapshot._pivot_newsletter_id = anyObjectId;
-    }
-
     return newsLetterSnapshot;
 };
 
-const buildMemberSnapshot = (deleteMember = false) => {
+const buildMemberSnapshot = () => {
     const memberSnapshot = {
         id: anyObjectId,
         uuid: anyUuid,
         created_at: anyISODateTime,
         updated_at: anyISODateTime,
-        newsletters: new Array(1).fill(buildNewsletterSnapshot(deleteMember))
+        newsletters: new Array(1).fill(buildNewsletterSnapshot())
     };
 
     return memberSnapshot;
@@ -99,7 +94,7 @@ describe('member.* events', function () {
                 }]
             })
             .expectStatus(201);
-        
+
         const id = res.body.members[0].id;
 
         await adminAPIAgent
@@ -117,7 +112,7 @@ describe('member.* events', function () {
             .matchBodySnapshot({
                 member: {
                     current: {},
-                    previous: buildMemberSnapshot(true)
+                    previous: buildMemberSnapshot()
                 }
             });
     });
@@ -140,7 +135,7 @@ describe('member.* events', function () {
                 }]
             })
             .expectStatus(201);
-        
+
         const id = res.body.members[0].id;
 
         await adminAPIAgent


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/2657

The `omitPivot` option does not have an affect on a models `_previousAttributes`. When we serialise a model and want to retrieve the previous attributes we need to ensure we manually remove the pivot fields

See https://github.com/bookshelf/bookshelf/blob/7704fbc5e83a35357d89458d9269a7e739964296/lib/base/model.js#L512