### PR TITLE
🐛 Fixed signup card in post plaintext and email preheader

### DIFF
--- a/ghost/core/test/integration/services/email-service/cards.test.js
+++ b/ghost/core/test/integration/services/email-service/cards.test.js
@@ -5,10 +5,17 @@ const configUtils = require('../../../utils/configUtils');
 const {sendEmail} = require('./utils');
 const cheerio = require('cheerio');
 
+/**
+ * Remove the preheader span from the email html and put it in a separate field called preheader
+ * @template {{html: string}} T
+ * @param {T} data
+ * @returns {asserts data is T & {preheader: string}}
+ */
 function splitPreheader(data) {
     // Remove the preheader span from the email using cheerio
     const $ = cheerio.load(data.html);
     const preheader = $('.preheader');
+    // @ts-ignore
     data.preheader = preheader.html();
     preheader.remove();
     data.html = $.html();
@@ -120,10 +127,8 @@ describe('Can send cards via email', function () {
 
         // Check the plaintext does contain the paragraph, but doesn't contain the signup card
         assert.ok(!data.html.includes('Sign up for Koenig Lexical'));
-
-        // This is a bug! The plaintext and preheader should not contain the signup card
-        //assert.ok(!data.plaintext.includes('Sign up for Koenig Lexical'));
-        //assert.ok(!data.preheader.includes('Sign up for Koenig Lexical'));
+        assert.ok(!data.plaintext.includes('Sign up for Koenig Lexical'));
+        assert.ok(!data.preheader.includes('Sign up for Koenig Lexical'));
 
         assert.ok(data.html.includes('This is a paragraph'));
         assert.ok(data.plaintext.includes('This is a paragraph'));

--- a/ghost/core/test/integration/services/email-service/utils.js
+++ b/ghost/core/test/integration/services/email-service/utils.js
@@ -58,6 +58,10 @@ async function createPublishedPostEmail(agent, settings = {}, email_recipient_fi
 }
 let lastEmailModel;
 
+/**
+ *
+ * @returns {Promise<{html: string, plaintext: string, emailModel: any, recipientData: any}>}
+ */
 async function sendEmail(agent, settings, email_recipient_filter) {
     // Prepare a post and email model
     const completedPromise = jobManager.awaitCompletion('batch-sending-service-job');

--- a/ghost/html-to-plaintext/lib/html-to-plaintext.js
+++ b/ghost/html-to-plaintext/lib/html-to-plaintext.js
@@ -53,7 +53,9 @@ const loadConverters = () => {
             // Don't output hrs
             {selector: 'hr', format: 'skip'},
             // Don't output > in blockquotes
-            {selector: 'blockquote', format: 'block'}
+            {selector: 'blockquote', format: 'block'},
+            // Don't include signup cards in excerpts
+            {selector: '.kg-signup-card', format: 'skip'}
         ]
     });
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Team/issues/3542

The signup card text was included in the post plaintext/excerpt and email preheader