### PR TITLE
Fixed "hidden" icon for feature img/title showing on posts

### DIFF
--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -569,3 +569,6 @@ add|ember-template-lint|no-action|34|16|34|16|5b7ad6ecbae8b6379d42a3c7f343485cf7
 add|ember-template-lint|require-valid-alt-text|3|44|3|44|a7f0566c430150bae4153e0dfb489a218bdeb8a4|1688342400000|1698714000000|1703898000000|lib/koenig-editor/addon/components/koenig-card-embed/nft.hbs
 add|ember-template-lint|require-valid-alt-text|8|20|8|20|9d0c591086dc9139ff38a7b385c3367a83438786|1688342400000|1698714000000|1703898000000|lib/koenig-editor/addon/components/koenig-card-embed/nft.hbs
 add|ember-template-lint|require-input-label|10|12|10|12|8c3c0ea315ff4da828363989a45fa11256a78796|1688342400000|1698714000000|1703898000000|lib/koenig-editor/addon/components/koenig-card-image/selector-tenor.hbs
+remove|ember-template-lint|no-invalid-interactive|3|4|3|4|1fcf990141becf2a97482e17ba7205413916e11d|1688342400000|1698714000000|1703898000000|app/components/gh-editor-feature-image.hbs
+remove|ember-template-lint|require-input-label|61|20|61|20|213bf91395d670b2af5fc667fca46d3d20238465|1688342400000|1698714000000|1703898000000|app/components/gh-editor-feature-image.hbs
+remove|ember-template-lint|require-valid-alt-text|47|16|47|16|079fc89fa5c7c47f6b0b219820cdda3819c44e26|1688342400000|1698714000000|1703898000000|app/components/gh-editor-feature-image.hbs

--- a/ghost/admin/app/components/gh-editor-feature-image.hbs
+++ b/ghost/admin/app/components/gh-editor-feature-image.hbs
@@ -1,8 +1,10 @@
+{{!-- template-lint-disable no-invalid-interactive --}}
 <div
     class="gh-editor-feature-image-container"
     {{on "mouseover" (fn (mut this.isHovered) true)}}
     {{on "mouseleave" (fn (mut this.isHovered) false)}}
 >
+{{!-- template-lint-enable no-invalid-interactive --}}
     <GhUploader
         @extensions={{this.imageExtensions}}
         @onComplete={{this.setUploadedImage}}
@@ -34,7 +36,7 @@
             {{/each}}
         {{else if @image}}
             {{!-- image is present --}}
-            {{#if (and (feature 'pageImprovements') (feature 'lexicalEditor'))}}
+            {{#if (and @isPage @isLexical (feature 'pageImprovements'))}}
                 <span class="gh-editor-hidden-indicator" data-tooltip="Feature image and post title are hidden">
                     {{svg-jar "eye-closed"}}
                 </span>
@@ -44,7 +46,7 @@
                 </span>
             {{/if}}
             <div class="gh-editor-feature-image">
-                <img src={{@image}}>
+                <img src={{@image}} alt={{@alt}} role={{if @alt "img" "presentation"}}>
                 <div class="gh-editor-feature-image-overlay"></div>
                 {{#if (feature 'lexicalEditor')}}
                     <KoenigImageEditor
@@ -66,6 +68,7 @@
                         value={{@alt}}
                         {{autofocus}}
                         {{on "input" this.onAltInput}}
+                        aria-label="Alt text for feature image"
                     >
                 {{else}}
                     <KoenigBasicHtmlInput

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -15,10 +15,12 @@
             @caption={{@featureImageCaption}}
             @updateCaption={{@setFeatureImageCaption}}
             @forceButtonDisplay={{or (not @title) (eq @title "(Untitled)") this.titleIsHovered this.titleIsFocused}}
+            @isPage={{@cardOptions.post.isPage}}
+            @isLexical={{true}}
         />
 
         <div class="gh-editor-title-container {{if (feature "pageImprovements") "page-improvements"}}">
-            {{#if (and (feature 'pageImprovements') (feature 'lexicalEditor'))}}
+            {{#if (and @cardOptions.post.isPage (feature 'pageImprovements'))}}
                 <span class="gh-editor-hidden-indicator" data-tooltip="Feature image and post title are hidden">
                     {{svg-jar "eye-closed"}}
                 </span>


### PR DESCRIPTION
no issue

- adjusted conditional to take post type into account
- removed usage of `lexicalEditor` feature flag as the flag only adjusts default editor rather than access to the editor (existing lexical posts/pages will always load lexical editor)
