### PR TITLE
Added CI step to allow PR automerge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -448,6 +448,17 @@ jobs:
         with:
           flags: unit-tests
 
+  check:
+    name: Allow Pull Request auto-merge
+    if: always() && github.event_name == 'pull_request'
+    needs: [lint, ghost-cli, admin-tests, migrations, unit-tests, database-tests, regression-tests]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
+
   canary:
     needs: [lint, ghost-cli, admin-tests, migrations, unit-tests, database-tests, regression-tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
fixes https://github.com/TryGhost/Toolbox/issues/608

- this step will be waited on in CI config so we can ensure all tests have passed before automerging PRs

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8f8a41</samp>

Add a new `check` job to the `test` workflow that uses `alls-green` action to enable auto-merge of pull requests if all required checks pass. This improves the workflow efficiency and reduces manual intervention.
