### PR TITLE
Added migration and schema change for `posts_meta.hide_title_and_feature_image`

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/pages.js
@@ -8,5 +8,8 @@ module.exports = async (model, frame, options) => {
     delete jsonModel.email_only;
     delete jsonModel.newsletter_id;
 
+    // TODO: remove this once full API support is in place
+    delete jsonModel.hide_title_and_feature_image;
+
     return jsonModel;
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/clean.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/clean.js
@@ -126,6 +126,10 @@ const post = (attrs, frame) => {
         delete attrs.primary_author;
     }
 
+    if (attrs.type !== 'page') {
+        delete attrs.hide_title_and_feature_image;
+    }
+
     delete attrs.locale;
     delete attrs.author;
     delete attrs.type;

--- a/ghost/core/core/server/data/migrations/versions/5.54/2023-07-03-15-22-add-hide-title-and-feature-image-column-to-posts-meta.js
+++ b/ghost/core/core/server/data/migrations/versions/5.54/2023-07-03-15-22-add-hide-title-and-feature-image-column-to-posts-meta.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('posts_meta', 'hide_title_and_feature_image', {
+    type: 'boolean',
+    nullable: false,
+    defaultTo: false
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -110,7 +110,8 @@ module.exports = {
         frontmatter: {type: 'text', maxlength: 65535, nullable: true},
         feature_image_alt: {type: 'string', maxlength: 191, nullable: true, validations: {isLength: {max: 125}}},
         feature_image_caption: {type: 'text', maxlength: 65535, nullable: true},
-        email_only: {type: 'boolean', nullable: false, defaultTo: false}
+        email_only: {type: 'boolean', nullable: false, defaultTo: false},
+        hide_title_and_feature_image: {type: 'boolean', nullable: false, defaultTo: false}
     },
     // NOTE: this is the staff table
     users: {

--- a/ghost/core/core/server/models/posts-meta.js
+++ b/ghost/core/core/server/models/posts-meta.js
@@ -6,7 +6,8 @@ const PostsMeta = ghostBookshelf.Model.extend({
 
     defaults: function defaults() {
         return {
-            email_only: false
+            email_only: false,
+            hide_title_and_feature_image: false
         };
     },
 

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '66549146e850f0e86ca052a4f53fa811';
+    const currentSchemaHash = 'ffd6d6cc850ffa0f69c6a08014e51bf9';
     const currentFixturesHash = '93c3b3cb8bca34a733634e74ee514172';
     const currentSettingsHash = '4f23a583335dcb4cb3fae553122ea200';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes https://github.com/TryGhost/Team/issues/3550

We want to allow an option to hide the title and feature image on a per-page basis, to do that we need somewhere to store the setting value. The existing `posts_meta` table is the simplest candidate, especially as this is a single setting and we don't have a desire to introduce many such settings.

- added migration that adds the `hide_title_and_feature_image` column to the `posts_meta` table with a `boolean` data type and a default value of `false` (matches behaviour of all existing pages)
- updated schema file for initial database creation
- removed property from API output via serializers to keep migration PR minimal
