### PR TITLE
Fixed duplicate workflow executions on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
   job_get_metadata:
     name: Metadata
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     permissions:
       pull-requests: read
     steps:
@@ -99,6 +100,7 @@ jobs:
   job_install_deps:
     name: Install Dependencies
     needs: job_get_metadata
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -770,7 +772,7 @@ jobs:
         job_comments_ui,
         job_signup_form,
       ]
-    if: always() 
+    if: always() && (github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/')))
     runs-on: ubuntu-latest
     steps:
       - name: Check for failures


### PR DESCRIPTION
- if we push to a branch, and open a PR, we'll get duplicate executions
- this fixes that by adding the same check we have elsewhere in the workflow

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f5b038</samp>

Skip CI workflows for renovate branches. This pull request modifies the `.github/workflows/ci.yml` file to save resources and time for dependency updates.
