### PR TITLE
Added feature flag for flatUrls

### DIFF
--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -74,6 +74,7 @@ export default class FeatureService extends Service {
     @feature('collections') collections;
     @feature('adminXSettings') adminXSettings;
     @feature('pageImprovements') pageImprovements;
+    @feature('flatUrls') flatUrls;
     @feature('mailEvents') mailEvents;
 
     _user = null;

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -314,6 +314,20 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
+                            <h4 class="gh-expandable-title">Flat URLs</h4>
+                            <p class="gh-expandable-description">
+                                Enables generating flat Post and Page URLs in `{slug}-{id}` format
+                            </p>
+                        </div>
+                        <div class="for-switch">
+                            <GhFeatureFlag @flag="flatUrls" />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="gh-expandable-block">
+                    <div class="gh-expandable-header">
+                        <div>
                             <h4 class="gh-expandable-title">Mail Events</h4>
                             <p class="gh-expandable-description">
                                 Enables processing of mail events

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -40,6 +40,7 @@ const ALPHA_FEATURES = [
     'collections',
     'adminXSettings',
     'pageImprovements',
+    'flatUrls',
     'mailEvents'
 ];
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/24

- Enables generating Post and Page URLs in a flat `{slug}-{id}` format

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3dce0c2</samp>

This pull request introduces the Flat URLs feature, which is an alpha feature that allows users to generate post and page URLs with a flat structure. It adds a new section in the `settings/labs.hbs` template and a new feature flag in the `labs.js` file.
