### PR TITLE
Added Portal development --https option support for Safari

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -112,7 +112,7 @@ if (DASH_DASH_ARGS.includes('portal') || DASH_DASH_ARGS.includes('all')) {
         // To make this work, you'll need a CADDY server running in front
         // Note the port is different because of this extra layer. Use the following Caddyfile:
         //    https://localhost:4176 {
-        //        reverse_proxy http://127.0.0.1:4175
+        //        reverse_proxy http://localhost:4175
         //    }
 
         COMMAND_GHOST.env['portal__url'] = 'https://localhost:4176/portal.min.js';

--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -106,7 +106,19 @@ if (DASH_DASH_ARGS.includes('portal') || DASH_DASH_ARGS.includes('all')) {
         prefixColor: 'magenta',
         env: {}
     });
-    COMMAND_GHOST.env['portal__url'] = 'http://localhost:4175/portal.min.js';
+
+    if (DASH_DASH_ARGS.includes('https')) {
+        // Safari needs HTTPS for it to work
+        // To make this work, you'll need a CADDY server running in front
+        // Note the port is different because of this extra layer. Use the following Caddyfile:
+        //    https://localhost:4176 {
+        //        reverse_proxy http://127.0.0.1:4175
+        //    }
+
+        COMMAND_GHOST.env['portal__url'] = 'https://localhost:4176/portal.min.js';
+    } else {
+        COMMAND_GHOST.env['portal__url'] = 'http://localhost:4175/portal.min.js';
+    }
 }
 
 if (DASH_DASH_ARGS.includes('signup') || DASH_DASH_ARGS.includes('all')) {


### PR DESCRIPTION
no issue

This --https option allows to test Portal in Safari when the site is hosted on https.