### PR TITLE
Wired up toggle for hiding page title and feature image

### DIFF
--- a/ghost/admin/app/components/gh-editor-feature-image.hbs
+++ b/ghost/admin/app/components/gh-editor-feature-image.hbs
@@ -36,7 +36,7 @@
             {{/each}}
         {{else if @image}}
             {{!-- image is present --}}
-            {{#if (and @isPage @isLexical (feature 'pageImprovements'))}}
+            {{#if @isHidden}}
                 <span class="gh-editor-hidden-indicator" data-tooltip="Feature image and post title are hidden">
                     {{svg-jar "eye-closed"}}
                 </span>

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.hbs
@@ -15,12 +15,11 @@
             @caption={{@featureImageCaption}}
             @updateCaption={{@setFeatureImageCaption}}
             @forceButtonDisplay={{or (not @title) (eq @title "(Untitled)") this.titleIsHovered this.titleIsFocused}}
-            @isPage={{@cardOptions.post.isPage}}
-            @isLexical={{true}}
+            @isHidden={{and (feature 'pageImprovements') @cardOptions.post.hideTitleAndFeatureImage}}
         />
 
         <div class="gh-editor-title-container {{if (feature "pageImprovements") "page-improvements"}}">
-            {{#if (and @cardOptions.post.isPage (feature 'pageImprovements'))}}
+            {{#if (and @cardOptions.post.hideTitleAndFeatureImage (feature 'pageImprovements'))}}
                 <span class="gh-editor-hidden-indicator" data-tooltip="Feature image and post title are hidden">
                     {{svg-jar "eye-closed"}}
                 </span>

--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -149,6 +149,28 @@
                                 </div>
                             </li>
                         {{/unless}}
+                        {{#if (and this.post.isPage this.post.lexical (feature 'pageImprovements'))}}
+                            <li class="nav-list-item">
+                                <div class="for-switch x-small">
+                                    <label class="switch">
+                                        <span>
+                                            {{svg-jar "eye-closed" class="feature"}}
+                                            Hide title and feature image
+                                        </span>
+                                        <div class="gh-toggle-featured">
+                                            <input
+                                                type="checkbox"
+                                                checked={{this.post.hideTitleAndFeatureImage}}
+                                                class="gh-input post-settings-featured"
+                                                {{on "change" this.toggleHideTitleAndFeatureImage}}
+                                                data-test-checkbox="hide-title-and-feature-image"
+                                            >
+                                            <span class="input-toggle-component"></span>
+                                        </div>
+                                    </label>
+                                </div>
+                            </li>
+                        {{/if}}
                         {{#if this.canViewPostHistory}}
                             <li class="nav-list-item">
                                 <button type="button" {{on "click" this.openPostHistory}} data-test-toggle="post-history">

--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -197,11 +197,27 @@ export default class GhPostSettingsMenu extends Component {
 
     @action
     toggleFeatured() {
-        this.toggleProperty('post.featured');
+        this.post.featured = !this.post.featured;
 
         // If this is a new post.  Don't save the post.  Defer the save
         // to the user pressing the save button
-        if (this.get('post.isNew')) {
+        if (this.post.isNew) {
+            return;
+        }
+
+        this.savePostTask.perform().catch((error) => {
+            this.showError(error);
+            this.post.rollbackAttributes();
+        });
+    }
+
+    @action
+    toggleHideTitleAndFeatureImage(event) {
+        this.post.hideTitleAndFeatureImage = event.target.checked;
+
+        // If this is a new post.  Don't save the post.  Defer the save
+        // to the user pressing the save button
+        if (this.post.isNew) {
             return;
         }
 

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -131,6 +131,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     featureImage: attr('string'),
     featureImageAlt: attr('string'),
     featureImageCaption: attr('string'),
+    hideTitleAndFeatureImage: attr('boolean', {defaultValue: false}),
 
     authors: hasMany('user', {embedded: 'always', async: false}),
     createdBy: belongsTo('user', {async: true}),

--- a/ghost/admin/app/serializers/post.js
+++ b/ghost/admin/app/serializers/post.js
@@ -15,7 +15,7 @@ export default class PostSerializer extends ApplicationSerializer.extend(Embedde
         postRevisions: {embedded: 'always'}
     };
 
-    serialize(/*snapshot, options*/) {
+    serialize(snapshot/*, options*/) {
         let json = super.serialize(...arguments);
 
         // Inserted locally as a convenience.
@@ -29,6 +29,10 @@ export default class PostSerializer extends ApplicationSerializer.extend(Embedde
         delete json.newsletter;
         // Deprecated property (replaced with data.authors)
         delete json.author;
+        // Page-only properties
+        if (snapshot.modelName !== 'page') {
+            delete json.hide_title_and_feature_image;
+        }
 
         if (json.visibility === null) {
             delete json.visibility;


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3558
closes https://github.com/TryGhost/Product/issues/3559

- added property to post model
- updated post serializer to not send property when saving a post rather than a page
- added property toggle to post settings menu
- updated indicators next to title and feature image to show real property state
