### PR TITLE
Updated workflow for code coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,16 +5,16 @@ coverage:
     patch: false
     project:
       default: false
+      admin-tests:
+        flags:
+        - admin-tests
+        threshold: 0.2%
       e2e-tests:
         flags:
         - e2e-tests
         threshold: 0.2%
-      unit-tests:
-        flags:
-        - unit-tests
-        threshold: 0.2%
 flags:
-  e2e-tests:
+  admin-tests:
     carryforward: true
-  unit-tests:
+  e2e-tests:
     carryforward: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,8 @@ jobs:
           BROWSER: Chrome
 
       # Merge coverage reports and upload
-      - run: yarn ember coverage-merge
+      - name: Merge Admin test coverage
+        run: yarn ember coverage-merge
         working-directory: ghost/admin
       - uses: actions/upload-artifact@v3
         with:
@@ -660,35 +661,39 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Restore Admin coverage
+        if: contains(needs.job_admin-tests.result, 'success')
         uses: actions/download-artifact@v3
         with:
           name: admin-coverage
+
+      - name: Move coverage
+        if: contains(needs.job_admin-tests.result, 'success')
+        run: |
+          rsync -av --remove-source-files admin/* ghost/admin
+
+      - name: Upload Admin test coverage
+        uses: codecov/codecov-action@v3
+        with:
+          flags: admin-tests
+          move_coverage_to_trash: true
+
       - name: Restore E2E coverage
+        if: contains(needs.job_database-tests.result, 'success')
         uses: actions/download-artifact@v3
         with:
           name: e2e-coverage
 
       - name: Move coverage
+        if: contains(needs.job_database-tests.result, 'success')
         run: |
-          rsync -av --remove-source-files admin/* ghost/admin
           rsync -av --remove-source-files core/* ghost/core
 
       - name: Upload E2E test coverage
+        if: contains(needs.job_database-tests.result, 'success')
         uses: codecov/codecov-action@v3
         with:
           flags: e2e-tests
           move_coverage_to_trash: true
-
-      - name: Restore Unit test coverage
-        uses: actions/download-artifact@v3
-        with:
-          name: unit-coverage
-          path: coverage
-      - run: rsync -av --remove-source-files coverage/* ghost/
-      - name: Upload unit test coverage
-        uses: codecov/codecov-action@v3
-        with:
-          flags: unit-tests
 
   job_required_tests:
     name: All required tests passed or skipped

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - arch
       - 'v5.*'
       - 3.x
       - 2.x
@@ -91,6 +92,7 @@ jobs:
       changed_sodo_search: ${{ steps.changed.outputs.sodo-search }}
       changed_any_code: ${{ steps.changed.outputs.any-code }}
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
+      is_canary_branch: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/arch') }}
       is_git_sync: ${{ github.head_ref == 'main' || github.ref == 'refs/heads/main' }}
 
   job_install_deps:
@@ -721,6 +723,7 @@ jobs:
   canary:
     needs: 
       [
+        job_get_metadata,
         job_lint,
         job_ghost-cli,
         job_admin-tests,
@@ -728,7 +731,7 @@ jobs:
         job_database-tests,
         job_regression-tests
       ]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: needs.job_get_metadata.outputs.is_canary_branch == 'true'
     name: Canary
     secrets: inherit
     uses: tryghost/actions/.github/workflows/canary.yml@main


### PR DESCRIPTION
- added separate Admin codecov step
- removed unit test until we figure out handling for partial runs

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 531788c</samp>

This pull request enhances the continuous integration and testing process for Ghost by adding support for multiple architectures, splitting the test coverage for different parts of the application, and deploying canary versions to a staging environment. It also updates the `codecov.yml` file to reflect the new test coverage flag for the admin panel.
