### PR TITLE
Fixed importer breaking any posts written in the new editor

### DIFF
--- a/ghost/core/core/server/data/importer/importers/data/PostsImporter.js
+++ b/ghost/core/core/server/data/importer/importers/data/PostsImporter.js
@@ -237,7 +237,7 @@ class PostsImporter extends BaseImporter {
             // CASE 1: you are importing old editor posts
             // CASE 2: you are importing Koenig Beta posts
             // CASE 3: you are importing Koenig 2.0 posts
-            if (model.mobiledoc) {
+            if (model.mobiledoc && !model.lexical) {
                 let mobiledoc;
 
                 try {
@@ -272,7 +272,7 @@ class PostsImporter extends BaseImporter {
 
                 model.mobiledoc = JSON.stringify(mobiledoc);
                 model.html = mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(model.mobiledoc));
-            } else if (model.html) {
+            } else if (model.html && !model.lexical) {
                 model.mobiledoc = JSON.stringify(mobiledocLib.htmlToMobiledocConverter(model.html));
                 model.html = mobiledocLib.mobiledocHtmlRenderer.render(JSON.parse(model.mobiledoc));
             }

--- a/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
+++ b/ghost/core/test/unit/server/data/importer/importers/data/posts.test.js
@@ -120,5 +120,21 @@ describe('PostsImporter', function () {
             // @TODO: need to check this mapping
             //post.newsletter_id.should.eql();
         });
+
+        it('Doesn\'t populate the mobiledoc column if it is a lexical post', function () {
+            const fakePosts = [{
+                slug: 'post-with-newsletter',
+                lexical: '{"root":{"children":[{"children":[{"detail":0,"format":0,"mode":"normal","style":"","text":"Bananas!","type":"text","version":1}],"direction":"ltr","format":"","indent":0,"type":"paragraph","version":1}],"direction":"ltr","format":"","indent":0,"type":"root","version":1}}',
+                html: '<p>Bananas!</p>'
+            }];
+
+            const importer = new PostsImporter({posts: fakePosts});
+
+            importer.beforeImport();
+
+            const post = find(importer.dataToImport, {slug: 'post-with-newsletter'});
+            should.exist(post);
+            should.equal(post.mobiledoc, null);
+        });
     });
 });


### PR DESCRIPTION
refs @TryGhost/Product#3551

- PostsImporter would convert the HTML from the import file into Mobiledoc, even if the post was written in Lexical
- As a result, the imported posts would have both mobiledoc & lexical fields populated, which prevents the post from being updated in the Lexical editor
- Added a check to see if the post was written in Lexical, and if so, skip the HTML > Mobiledoc conversion
