### PR TITLE
Fixed showing name in Portal notification

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.33.4",
+  "version": "2.33.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/portal/src/components/Notification.js
+++ b/apps/portal/src/components/Notification.js
@@ -34,7 +34,7 @@ const NotificationText = ({type, status, context}) => {
         const firstname = context.member.firstname || '';
         return (
             <p>
-                {firstname ? t('Welcome back, {{name}}!', firstname) : t('Welcome back!')}<br />{t('You\'ve successfully signed in.')}
+                {firstname ? t('Welcome back, {{name}}!', {name: firstname}) : t('Welcome back!')}<br />{t('You\'ve successfully signed in.')}
             </p>
         );
     } else if (type === 'signin' && status === 'error') {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/17242

- we weren't passing the correct parameter to the translation function, so the name placeholder wasn't being replaced

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6af4d65</samp>

Fixed a bug in the `t` function call in `Notification.js` to enable proper internationalization of the portal notification message.
