### PR TITLE
Fixed resetting database in migrations tests

### DIFF
--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -31,6 +31,7 @@ describe('Migrations', function () {
 
     describe('Database initialization + rollback', function () {
         beforeEach(async function () {
+            await knexMigrator.reset({force: true});
             await knexMigrator.init();
         });
     


### PR DESCRIPTION
- due to schema changes between versions, we need to completely nuke the DB between these tests
- this is definitely not the best way to do it but I'll fix properly next week

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41d7554</samp>

Reset database before each migration test using `knexMigrator`. This improves test reliability and speed.
