### PR TITLE
Allowed for index collection to have empty filter

### DIFF
--- a/ghost/collections/src/Collection.ts
+++ b/ghost/collections/src/Collection.ts
@@ -69,7 +69,7 @@ export class Collection {
     }
 
     public async edit(data: Partial<Collection>, uniqueChecker: UniqueChecker) {
-        if (this.type === 'automatic' && (data.filter === null || data.filter === '')) {
+        if (this.type === 'automatic' && this.slug !== 'index' && (data.filter === null || data.filter === '')) {
             throw new ValidationError({
                 message: tpl(messages.invalidFilterProvided.message),
                 context: tpl(messages.invalidFilterProvided.context)
@@ -201,7 +201,7 @@ export class Collection {
             });
         }
 
-        if (data.type === 'automatic' && !data.filter) {
+        if (data.type === 'automatic' && (data.slug !== 'index') && !data.filter) {
             // @NOTE: add filter validation here
             throw new ValidationError({
                 message: tpl(messages.invalidFilterProvided.message),

--- a/ghost/collections/test/Collection.test.ts
+++ b/ghost/collections/test/Collection.test.ts
@@ -209,6 +209,23 @@ describe('Collection', function () {
                 return true;
             });
         });
+
+        it('Does not throw when collection filter is empty for automatic "index" collection', async function (){
+            const collection = await Collection.create({
+                title: 'Index',
+                slug: 'index',
+                type: 'automatic',
+                filter: ''
+            });
+
+            const editedCollection = await collection.edit({
+                title: 'Edited index',
+                filter: ''
+            }, uniqueChecker);
+
+            assert.equal(editedCollection.title, 'Edited index');
+            assert.equal(editedCollection.filter, '');
+        });
     });
 
     it('Can add posts to different positions', async function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/25

- The built in index (soon -> "latest") collection does not require any filtering so that it could contain an index of all posts in the system. All other automatic collections should have a filter defined.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ac93e4c</samp>

This pull request fixes a validation bug for the 'index' collection, which is a special type of automatic collection that can have an empty filter. It updates the `Collection` class and adds a test case to verify the fix.
