### PR TITLE
Ignored pull requests from branches starting with `renovate/*`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   pull_request:
+    branches-ignore:
+      - 'renovate/*'
   push:
     branches:
       - main


### PR DESCRIPTION
- these should be handled by the `push` action in order to avoid duplicate executions

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ab168e</samp>

Improve CI workflow efficiency by skipping Renovate branches. This change modifies the `.github/workflows/ci.yml` file to exclude branches that start with `renovate/` from the workflow trigger.
