### PR TITLE
Updated fetching latest base commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
 env:
   FORCE_COLOR: 1
   HEAD_COMMIT: ${{ github.sha }}
-  BASE_COMMIT: ${{ github.event.pull_request.base.sha || github.event.before }}
   GITHUB_CONTEXT: ${{ toJson(github) }}
   CACHED_DEPENDENCY_PATHS: |
     ${{ github.workspace }}/node_modules
@@ -43,10 +42,22 @@ jobs:
       - name: Get metadata
         id: get_metadata
         run: |
-          COMMIT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.event.head_commit.id || env.HEAD_COMMIT }})
-          echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
-          echo "COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s $COMMIT_SHA)" >> $GITHUB_ENV
-          echo "COMMON_COMMIT=$(git merge-base HEAD ${{ env.BASE_COMMIT }})" >> $GITHUB_ENV
+          # get base commit for pushes
+          if [ "${{ github.event_name }}" = "push" ]; then
+            if [ -n "${{ github.event.before }}" ]; then
+              if [ "${{ github.event.forced }}" = 'true' ]; then
+                NUMBER_OF_COMMITS=$(printf "%s\n" < '${{ env.GITHUB_CONTEXT }}' | jq '.event.commits | length')
+                echo "BASE_COMMIT=$(git rev-parse HEAD~$NUMBER_OF_COMMITS)" >> $GITHUB_ENV
+              else
+                # only set the base commit if it wasn't a force push (we can't get the base commit in that case)
+                echo "BASE_COMMIT=${{ github.event.before }}" >> $GITHUB_ENV
+              fi
+            fi
+          else
+            # get base commit for PRs
+            BASE_COMMIT=$(curl --location --request GET 'https://api.github.com/repos/TryGhost/Ghost/pulls/${{ github.event.pull_request.number }}' --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq .base.sha | tr -d '"')
+            echo "BASE_COMMIT=$BASE_COMMIT" >> $GITHUB_ENV
+          fi
 
       - name: Determine changed packages
         uses: AurorNZ/paths-filter@v3.0.1
@@ -94,7 +105,7 @@ jobs:
       changed_signup_form: ${{ steps.changed.outputs.signup-form }}
       changed_sodo_search: ${{ steps.changed.outputs.sodo-search }}
       changed_any_code: ${{ steps.changed.outputs.any-code }}
-      commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
+      base_commit: ${{ env.BASE_COMMIT }}
       is_canary_branch: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/arch') }}
       is_git_sync: ${{ github.head_ref == 'main' || github.ref == 'refs/heads/main' }}
 
@@ -104,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: 'Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})'
+      - name: 'Checkout current commit'
         uses: actions/checkout@v3
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -160,7 +171,7 @@ jobs:
           path: ghost/**/.eslintcache
           key: eslint-cache
 
-      - run: yarn lint --since ${{ env.COMMON_COMMIT }}
+      - run: yarn lint --since ${{ needs.job_get_metadata.outputs.BASE_COMMIT }}
 
       - uses: tryghost/actions/actions/slack-build@main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -233,7 +244,7 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_install_deps.outputs.dependency_cache_key }}
 
-      - run: yarn test:unit --include-dependents --since ${{ env.COMMON_COMMIT }}
+      - run: yarn test:unit --include-dependents --since ${{ needs.job_get_metadata.outputs.BASE_COMMIT }}
 
       - uses: actions/upload-artifact@v3
         if: startsWith(matrix.node, '18')
@@ -703,6 +714,7 @@ jobs:
     name: All required tests passed or skipped
     needs:
       [
+        job_get_metadata,
         job_install_deps,
         job_lint,
         job_ghost-cli,


### PR DESCRIPTION
- unfortunately GitHub makes this incredibly hard and this commit doesn't even provide a full solution, but it should allow us to fetch the latest commit for PRs and pushes to a branch, but not force pushes

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d078c34</samp>

Refactor `BASE_COMMIT` logic and clean up `ci.yml` workflow. This improves the accuracy and efficiency of the linting and testing jobs.
