### PR TITLE
Prevented git tags from being created for apps

### DIFF
--- a/apps/admin-x-settings/.yarnrc
+++ b/apps/admin-x-settings/.yarnrc
@@ -1,2 +1,3 @@
 version-tag-prefix "@tryghost/admin-x-settings@"
 version-git-message "Released Admin-x-settings v%s"
+version-git-tag false

--- a/apps/announcement-bar/.yarnrc
+++ b/apps/announcement-bar/.yarnrc
@@ -1,2 +1,3 @@
 version-tag-prefix "@tryghost/announcement-bar@"
 version-git-message "Released Announcement-Bar v%s"
+version-git-tag false

--- a/apps/comments-ui/.yarnrc
+++ b/apps/comments-ui/.yarnrc
@@ -1,2 +1,3 @@
 version-tag-prefix "@tryghost/comments-ui@"
 version-git-message "Released comments-ui v%s"
+version-git-tag false

--- a/apps/portal/.yarnrc
+++ b/apps/portal/.yarnrc
@@ -1,2 +1,3 @@
 version-tag-prefix "@tryghost/portal@"
 version-git-message "Released Portal v%s"
+version-git-tag false

--- a/apps/signup-form/.yarnrc
+++ b/apps/signup-form/.yarnrc
@@ -1,2 +1,3 @@
 version-tag-prefix "@tryghost/signup-form@"
 version-git-message "Released Signup Form v%s"
+version-git-tag false

--- a/apps/sodo-search/.yarnrc
+++ b/apps/sodo-search/.yarnrc
@@ -1,2 +1,3 @@
 version-tag-prefix "@tryghost/sodo-search@"
 version-git-message "Released Sodo-Search v%s"
+version-git-tag false


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1688983916615989?thread_ts=1687341349.559679&cid=C02G9E68C

- these cause issues with our PR workflow because we can't push tags in a PR and the commit is rebased onto `main` so the hash changes
- this disables tags for now