### PR TITLE
Added Header Card V2 feature flags

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -277,7 +277,8 @@ export default class KoenigLexicalEditor extends Component {
             fetchAutocompleteLinks,
             fetchLabels,
             feature: {
-                signupCard: true
+                signupCard: true,
+                headerV2: this.feature.get('headerUpgrade')
             },
             membersEnabled: this.settings.get('membersSignupAccess') === 'all',
             siteTitle: this.settings.title,

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -76,6 +76,7 @@ export default class FeatureService extends Service {
     @feature('pageImprovements') pageImprovements;
     @feature('flatUrls') flatUrls;
     @feature('mailEvents') mailEvents;
+    @feature('headerUpgrade') headerUpgrade;
 
     _user = null;
 

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -338,6 +338,20 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="gh-expandable-block">
+                    <div class="gh-expandable-header">
+                        <div>
+                            <h4 class="gh-expandable-title">Header Card v2</h4>
+                            <p class="gh-expandable-description">
+                                A new enhanced version of the header card
+                            </p>
+                        </div>
+                        <div class="for-switch">
+                            <GhFeatureFlag @flag="headerUpgrade" />
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
         {{/if}}

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -41,7 +41,8 @@ const ALPHA_FEATURES = [
     'adminXSettings',
     'pageImprovements',
     'flatUrls',
-    'mailEvents'
+    'mailEvents',
+    'headerUpgrade'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3508

- added a feature flag for Header Cards that's being upgraded.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10ac1e4</samp>

This pull request adds a new feature flag `headerUpgrade` to the server and the admin settings, which allows the user to opt-in to a new header design. The feature flag is only available if the labs toggle is enabled.
