### PR TITLE
Fixed caching build assets

### DIFF
--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -1,5 +1,5 @@
-name: "Restore dependency cache"
-description: "Restore the dependency cache."
+name: "Restore dependency & build cache"
+description: "Restore the dependency & build cache."
 
 runs:
   using: "composite"
@@ -11,8 +11,15 @@ runs:
         path: ${{ env.CACHED_DEPENDENCY_PATHS }}
         key: ${{ env.DEPENDENCY_CACHE_KEY }}
 
+    - name: Check build cache
+      uses: actions/cache/restore@v3
+      id: build-cache
+      with:
+        path: ${{ env.CACHED_BUILD_PATHS }}
+        key: ${{ github.sha }}
+
     - name: Check if caches are restored
       uses: actions/github-script@v6
-      if: steps.dep-cache.outputs.cache-hit != 'true'
+      if: steps.dep-cache.outputs.cache-hit != 'true' || steps.build-cache.outputs.cache-hit != 'true'
       with:
-        script: core.setFailed('Dependency cache could not be restored - please re-run ALL jobs.')
+        script: core.setFailed('Dependency or build cache could not be restored - please re-run ALL jobs.')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ env:
     ${{ github.workspace }}/node_modules
     ${{ github.workspace }}/apps/*/node_modules
     ${{ github.workspace }}/ghost/*/node_modules
-    ${{ github.workspace }}/ghost/*/build
     ~/.cache/ms-playwright/
+  CACHED_BUILD_PATHS: |
+    ${{ github.workspace }}/ghost/*/build
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -131,6 +132,13 @@ jobs:
           path: ${{ env.CACHED_DEPENDENCY_PATHS }}
           key: ${{ steps.compute_lockfile_hash.outputs.hash }}
 
+      - name: Check build cache
+        uses: actions/cache@v3
+        id: cache_built_packages
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.HEAD_COMMIT }}
+
       - name: Set up Node
         uses: actions/setup-node@v3
         if: steps.cache_dependencies.outputs.cache-hit != 'true'
@@ -143,6 +151,10 @@ jobs:
       - name: Install dependencies
         if: steps.cache_dependencies.outputs.cache-hit != 'true'
         run: yarn install --prefer-offline --frozen-lockfile
+
+      - name: Build packages
+        if: steps.cache_built_packages.outputs.cache-hit != 'true'
+        run: yarn prepare
     outputs:
       dependency_cache_key: ${{ steps.compute_lockfile_hash.outputs.hash }}
 


### PR DESCRIPTION
- we shouldn't cache the build assets against the yarn.lock hash because the files could change independent of that file
- this bring the build caching more inline with https://github.com/getsentry/sentry-javascript/blob/develop/.github/workflows/build.yml, which is a big inspiration for this file

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fff073</samp>

Improved the CI performance by caching the built packages of Ghost. Updated the `restore-cache` action to handle the build cache as well.
