### PR TITLE
Fixed error about long filename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get metadata (push)
         if: github.event_name == 'push'
         run: |
-          NUMBER_OF_COMMITS=$(jq '.event.commits | length' < '${{ env.GITHUB_CONTEXT }}')
+          NUMBER_OF_COMMITS=$(echo '${{ env.GITHUB_CONTEXT }}' | jq '.event.commits | length')
           echo "There are $NUMBER_OF_COMMITS commits in this push."
           echo "BASE_COMMIT=$(git rev-parse HEAD~$NUMBER_OF_COMMITS)" >> $GITHUB_ENV
 


### PR DESCRIPTION
- echoing the data should avoid issues with piping in data through a file redirection

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 317b131</samp>

Fix bug in CI workflow that prevented counting commits. Use correct syntax for reading `GITHUB_CONTEXT` file in `.github/workflows/ci.yml`.
