### PR TITLE
ℹ️ Bumped minimum Node 16 version to 16.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
     if: needs.job_get_metadata.outputs.changed_any_code == 'true'
     strategy:
       matrix:
-        node: [ '16.13.0', '18.12.1' ]
+        node: [ '16.14.0', '18.12.1' ]
     name: Unit tests (Node ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v3
@@ -271,7 +271,7 @@ jobs:
     if: needs.job_get_metadata.outputs.changed_core == 'true'
     strategy:
       matrix:
-        node: [ '16.13.0', '18.12.1' ]
+        node: [ '16.14.0', '18.12.1' ]
         env:
           - DB: mysql8
             NODE_ENV: testing-mysql
@@ -622,7 +622,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: '16.13.0'
+          node-version: '16.14.0'
 
       - name: Install Ghost-CLI
         run: npm install -g ghost-cli@latest

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -26,7 +26,7 @@
     "lint": "yarn lint:js && yarn lint:hbs"
   },
   "engines": {
-    "node": "^16.13.0 || ^18.12.1"
+    "node": "^16.14.0 || ^18.12.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.22.5",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -57,7 +57,7 @@
     "prepack": "lerna run build && monobundle"
   },
   "engines": {
-    "node": "^16.13.0 || ^18.12.1",
+    "node": "^16.14.0 || ^18.12.1",
     "cli": "^1.17.0"
   },
   "dependencies": {


### PR DESCRIPTION
fixes https://github.com/TryGhost/DevOps/issues/42

- several of our dependencies require this so making the minor bump to increase the version helps keep them updated

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14c0d65</samp>

This pull request updates the node version to `16.14.0` in various files and workflows to ensure consistency and compatibility across the Ghost project.
