### PR TITLE
Disabled CI workflows for Renovate branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
       - 'v5.*'
       - 3.x
       - 2.x
-      - 'renovate/*'
 
 env:
   FORCE_COLOR: 1
@@ -30,7 +29,6 @@ jobs:
   job_get_metadata:
     name: Metadata
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     permissions:
       pull-requests: read
     steps:
@@ -732,7 +730,7 @@ jobs:
         job_comments_ui,
         job_signup_form,
       ]
-    if: always() && (github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/')))
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check for failures


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/43

- because we now enforce all commits through a PR, Renovate can no longer automerge commits
- this is actually a huge bonus because it simplifies a lot of the issues we were having with the GHA setup
- this commit removes the triggers and special handling to remove the duplicate executions

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53a755e</samp>

Simplify CI workflow configuration and enable it for any branch. Remove branch filter and conditionals from `.github/workflows/ci.yml`.
