### PR TITLE
Enabled Sentry Replay within Admin

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -1,9 +1,9 @@
+import * as Sentry from '@sentry/ember';
 import AuthConfiguration from 'ember-simple-auth/configuration';
 import Route from '@ember/routing/route';
 import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import windowProxy from 'ghost-admin/utils/window-proxy';
-import {InitSentryForEmber} from '@sentry/ember';
 import {inject} from 'ghost-admin/decorators/inject';
 import {
     isAjaxError,
@@ -161,7 +161,7 @@ export default Route.extend(ShortcutsRoute, {
         // init Sentry here rather than app.js so that we can use API-supplied
         // sentry_dsn and sentry_env rather than building it into release assets
         if (this.config.sentry_dsn) {
-            InitSentryForEmber({
+            Sentry.init({
                 dsn: this.config.sentry_dsn,
                 environment: this.config.sentry_env,
                 release: `ghost@${this.config.version}`,
@@ -171,6 +171,18 @@ export default Route.extend(ShortcutsRoute, {
                     event.tags.grammarly = !!document.querySelector('[data-gr-ext-installed]');
                     return event;
                 },
+
+                // Enable collecting Replay events
+                integrations: [
+                    new Sentry.Replay()
+                ],
+
+                // Don't collect any Replays for general users
+                replaysSessionSampleRate: 0,
+
+                // Collect all Replays coming from errors
+                replaysOnErrorSampleRate: 1.0,
+
                 // TransitionAborted errors surface from normal application behaviour
                 // - https://github.com/emberjs/ember.js/issues/12505
                 ignoreErrors: [/^TransitionAborted$/]


### PR DESCRIPTION
fixes https://github.com/TryGhost/DevOps/issues/44

- this enables Sentry Replay within Admin, so we're able to debug errors and bugs easier

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c07c5d</samp>

This change updates the error monitoring and debugging tool for the admin app by switching to the new `@sentry/ember` package and enabling user interaction recordings for error resolution.
