### PR TITLE
Removed more Bluebird usages

### DIFF
--- a/ghost/core/core/frontend/services/apps/loader.js
+++ b/ghost/core/core/frontend/services/apps/loader.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const _ = require('lodash');
-const Promise = require('bluebird');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const config = require('../../../shared/config');
@@ -35,7 +34,7 @@ function getAppByName(name) {
 
 module.exports = {
     // Activate a app and return it
-    activateAppByName: function (name) {
+    activateAppByName: async function (name) {
         const {app, proxy} = getAppByName(name);
 
         // Check for an activate() method on the app.
@@ -45,8 +44,9 @@ module.exports = {
             }));
         }
 
-        // Wrapping the activate() with a when because it's possible
+        // Wrapping the activate() with a Promise because it's possible
         // to not return a promise from it.
-        return Promise.resolve(app.activate(proxy)).return(app);
+        await Promise.resolve(app.activate(proxy));
+        return app;
     }
 };

--- a/ghost/core/core/frontend/services/data/entry-lookup.js
+++ b/ghost/core/core/frontend/services/data/entry-lookup.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const Promise = require('bluebird');
 const url = require('url');
 const debug = require('@tryghost/debug')('services:data:entry-lookup');
 const routeMatch = require('path-match')();

--- a/ghost/core/core/frontend/services/rss/generate-feed.js
+++ b/ghost/core/core/frontend/services/rss/generate-feed.js
@@ -1,5 +1,4 @@
 const downsize = require('downsize');
-const Promise = require('bluebird');
 const RSS = require('rss');
 const urlUtils = require('../../../shared/url-utils');
 const {routerManager} = require('../routing');

--- a/ghost/core/core/server/adapters/storage/LocalStorageBase.js
+++ b/ghost/core/core/server/adapters/storage/LocalStorageBase.js
@@ -4,7 +4,6 @@ const serveStatic = require('../../../shared/express').static;
 
 const fs = require('fs-extra');
 const path = require('path');
-const Promise = require('bluebird');
 const moment = require('moment');
 const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/roles.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/roles.js
@@ -14,10 +14,14 @@ module.exports = {
         } else {
             return Promise.all(
                 roles.map(async (role) => {
-                    const permissionResult = await canThis(frame.options.context).assign.role(role)
-                        .return(role)
-                        .catch(() => {});
-                    return permissionResult && (permissionResult.name !== 'Owner');   
+                    let permissionResult;
+                    try {
+                        await canThis(frame.options.context).assign.role(role);
+                        permissionResult = role;
+                    } catch (err) {
+                        permissionResult = {};
+                    }
+                    return permissionResult && permissionResult.name && (permissionResult.name !== 'Owner');   
                 }))
                 .then(results => roles.filter((_v, index) => results[index]))   
                 .then((filteredRoles) => {

--- a/ghost/core/core/server/data/migrations/hooks/init/before.js
+++ b/ghost/core/core/server/data/migrations/hooks/init/before.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const models = require('../../../../models');
 
 module.exports = function before() {

--- a/ghost/core/core/server/data/migrations/hooks/migrate/afterEach.js
+++ b/ghost/core/core/server/data/migrations/hooks/migrate/afterEach.js
@@ -1,5 +1,4 @@
 /* eslint-disable ghost/filenames/match-regex */
-const Promise = require('bluebird');
 
 module.exports = function afterEach() {
     return Promise.resolve();

--- a/ghost/core/core/server/data/migrations/hooks/migrate/beforeEach.js
+++ b/ghost/core/core/server/data/migrations/hooks/migrate/beforeEach.js
@@ -1,5 +1,4 @@
 /* eslint-disable ghost/filenames/match-regex */
-const Promise = require('bluebird');
 
 module.exports = function beforeEach() {
     return Promise.resolve();

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const Promise = require('bluebird');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');

--- a/ghost/core/core/server/data/schema/validator.js
+++ b/ghost/core/core/server/data/schema/validator.js
@@ -1,6 +1,4 @@
 const _ = require('lodash');
-const Promise = require('bluebird');
-
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const validator = require('@tryghost/validator');

--- a/ghost/core/core/server/lib/image/BlogIcon.js
+++ b/ghost/core/core/server/lib/image/BlogIcon.js
@@ -1,5 +1,4 @@
 const sizeOf = require('image-size');
-const Promise = require('bluebird');
 const _ = require('lodash');
 const path = require('path');
 const errors = require('@tryghost/errors');
@@ -40,12 +39,12 @@ class BlogIcon {
                     }).height;
                 }
 
-                return resolve({
+                resolve({
                     width: dimensions.width,
                     height: dimensions.height
                 });
             } catch (err) {
-                return reject(new errors.ValidationError({
+                reject(new errors.ValidationError({
                     message: tpl(messages.error, {
                         file: storagePath,
                         error: err.message

--- a/ghost/core/core/server/lib/image/Gravatar.js
+++ b/ghost/core/core/server/lib/image/Gravatar.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const crypto = require('crypto');
 const tpl = require('@tryghost/tpl');
 

--- a/ghost/core/core/server/lib/image/ImageSize.js
+++ b/ghost/core/core/server/lib/image/ImageSize.js
@@ -3,7 +3,6 @@ const sizeOf = require('image-size');
 const probeSizeOf = require('probe-image-size');
 const url = require('url');
 const path = require('path');
-const Promise = require('bluebird');
 const _ = require('lodash');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
@@ -59,9 +58,9 @@ class ImageSize {
                     dimensions.height = _.maxBy(dimensions.images, img => img.height).height;
                 }
 
-                return resolve(dimensions);
+                resolve(dimensions);
             } catch (err) {
-                return reject(err);
+                reject(err);
             }
         });
     }
@@ -113,9 +112,9 @@ class ImageSize {
             const extension = (extensionMatch[1] || '').toLowerCase();
 
             if (FETCH_ONLY_FORMATS.includes(extension)) {
-                return resolve(this._fetchImageSizeFromUrl(imageUrl));
+                resolve(this._fetchImageSizeFromUrl(imageUrl));
             } else {
-                return resolve(this._probeImageSizeFromUrl(imageUrl));
+                resolve(this._probeImageSizeFromUrl(imageUrl));
             }
         });
     }
@@ -344,12 +343,12 @@ class ImageSize {
                     }).height;
                 }
 
-                return resolve({
+                resolve({
                     width: dimensions.width,
                     height: dimensions.height
                 });
             } catch (err) {
-                return reject(new errors.ValidationError({
+                reject(new errors.ValidationError({
                     message: tpl(messages.invalidDimensions, {
                         file: imagePath,
                         error: err.message

--- a/ghost/core/core/server/models/base/listeners.js
+++ b/ghost/core/core/server/models/base/listeners.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const models = require('../../models');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
-const Promise = require('bluebird');
+const {sequence} = require('@tryghost/promise');
 
 // Listen to settings.timezone.edited and settings.notifications.edited to bind extra logic to settings, similar to the bridge and member service
 const events = require('../../lib/common/events');
@@ -46,7 +46,7 @@ events.on('settings.timezone.edited', function (settingModel, options) {
                 return;
             }
 
-            await Promise.mapSeries(results, async (post) => {
+            await sequence(results.map(post => async () => {
                 const newPublishedAtMoment = moment(post.get('published_at')).add(timezoneOffsetDiff, 'minutes');
 
                 /**
@@ -73,7 +73,7 @@ events.on('settings.timezone.edited', function (settingModel, options) {
                         err
                     }));
                 }
-            });
+            }));
         } catch (err) {
             logging.error(new errors.InternalServerError({
                 err: err,

--- a/ghost/core/core/server/models/base/utils.js
+++ b/ghost/core/core/server/models/base/utils.js
@@ -4,7 +4,6 @@
  */
 const _ = require('lodash');
 
-const Promise = require('bluebird');
 const ObjectId = require('bson-objectid').default;
 const errors = require('@tryghost/errors');
 

--- a/ghost/core/core/server/models/invite.js
+++ b/ghost/core/core/server/models/invite.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const _ = require('lodash');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -2,7 +2,6 @@
 const _ = require('lodash');
 const uuid = require('uuid');
 const moment = require('moment');
-const Promise = require('bluebird');
 const {sequence} = require('@tryghost/promise');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');

--- a/ghost/core/core/server/models/role.js
+++ b/ghost/core/core/server/models/role.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const ghostBookshelf = require('./base');
-const Promise = require('bluebird');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 

--- a/ghost/core/core/server/models/webhook.js
+++ b/ghost/core/core/server/models/webhook.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const ghostBookshelf = require('./base');
 const ghostVersion = require('@tryghost/version');
 let Webhook;

--- a/ghost/core/core/server/services/notifications/Notifications.js
+++ b/ghost/core/core/server/services/notifications/Notifications.js
@@ -1,6 +1,5 @@
 const moment = require('moment-timezone');
 const semver = require('semver');
-const Promise = require('bluebird');
 const _ = require('lodash');
 const errors = require('@tryghost/errors');
 const ghostVersion = require('@tryghost/version');

--- a/ghost/core/core/server/services/permissions/can-this.js
+++ b/ghost/core/core/server/services/permissions/can-this.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const Promise = require('bluebird');
 const models = require('../../models');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');

--- a/ghost/core/core/server/services/permissions/providers.js
+++ b/ghost/core/core/server/services/permissions/providers.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const Promise = require('bluebird');
 const models = require('../../models');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');

--- a/ghost/core/core/server/services/route-settings/DefaultSettingsManager.js
+++ b/ghost/core/core/server/services/route-settings/DefaultSettingsManager.js
@@ -1,5 +1,4 @@
 const fs = require('fs-extra');
-const Promise = require('bluebird');
 const path = require('path');
 const debug = require('@tryghost/debug')('frontend:services:settings:ensure-settings');
 const tpl = require('@tryghost/tpl');

--- a/ghost/core/core/server/services/route-settings/RouteSettings.js
+++ b/ghost/core/core/server/services/route-settings/RouteSettings.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const fs = require('fs-extra');
 const crypto = require('crypto');
 const urlService = require('../url');
@@ -120,7 +119,9 @@ class RouteSettings {
 
         function isBlogRunning() {
             debug('waiting for blog running');
-            return Promise.delay(1000)
+            return new Promise((resolve) => {
+                setTimeout(resolve, 1000);
+            })
                 .then(() => {
                     debug('waited for blog running');
                     if (!urlService.hasFinished()) {

--- a/ghost/core/core/server/services/webhooks/payload.js
+++ b/ghost/core/core/server/services/webhooks/payload.js
@@ -1,5 +1,4 @@
 const serialize = require('./serialize');
-const Promise = require('bluebird');
 
 module.exports = (event, model) => {
     const payload = {};

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const Promise = require('bluebird');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/14882

- we're nuking our use of Bluebird in favor of native Promises

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at acfda37</samp>

Removed the `Promise` module from various files in the Ghost codebase. This module was unnecessary because the native `Promise` object is supported in Node.js. This change simplifies the code and reduces dependencies.
