### PR TITLE
🐛 Fixed member links not added to autocomplete

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -135,6 +135,7 @@ export default class KoenigLexicalEditor extends Component {
     @service session;
     @service store;
     @service settings;
+    @service membersUtils;
 
     @inject config;
     offers = null;
@@ -261,7 +262,21 @@ export default class KoenigLexicalEditor extends Component {
                     value: this.config.getSiteUrl(offer.code)
                 };
             });
-            return [...defaults, ...offersLinks];
+
+            const memberLinks = () => {
+                if (this.membersUtils.paidMembersEnabled) {
+                    return [
+                        {
+                            label: 'Paid signup',
+                            value: this.config.getSiteUrl('/#/portal/signup')
+                        },
+                        {
+                            label: 'Upgrade or change plan',
+                            value: this.config.getSiteUrl('/#/portal/account/plans')
+                        }];
+                }
+            };
+            return [...defaults, ...offersLinks, ...memberLinks()];
         };
 
         const fetchLabels = async () => {


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C056H5Z4HEK/p1689168376165479

- Added missing paid member links to the autocomplete function within the Koenig-Lexical editor.
- This bring it in line with the mobiledoc editor.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f49f6a5</samp>

This change adds a new feature to the editor component that allows users to insert links related to members and subscriptions. It depends on the `membersUtils` service and the `koenig-lexical-editor` component.
