### PR TITLE
Fixed missing command in browser tests

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Run migrations
       working-directory: ghost/core
-      run: yarn setup && yarn knex-migrator init
+      run: yarn knex-migrator init
     - name: Get Playwright version
       id: playwright-version
       run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- `setup` no longer exists after the monorepo changes and this test should reflect that

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9673c1</samp>

Removed `yarn setup` from browser tests workflow to fix database initialization errors. This change resolves issue #13076.
