### PR TITLE
Added the ability to provide a separate URL for lazy-loaded assets

### DIFF
--- a/ghost/admin/app/components/gh-cm-editor.js
+++ b/ghost/admin/app/components/gh-cm-editor.js
@@ -74,7 +74,7 @@ class CmEditorComponent extends Component {
 
     @task(function* () {
         let loader = this.lazyLoader;
-        yield loader.loadScript('codemirror', 'assets/codemirror/codemirror.js');
+        yield loader.loadScript('codemirror', 'codemirror/codemirror.js');
 
         scheduleOnce('afterRender', this, this._initCodeMirror);
     })

--- a/ghost/admin/app/components/gh-simplemde.js
+++ b/ghost/admin/app/components/gh-simplemde.js
@@ -80,7 +80,7 @@ export default class GhSimplemde extends TextArea {
     }
 
     @task(function* () {
-        yield this.lazyLoader.loadScript('simplemde', 'assets/simplemde/simplemde.js');
+        yield this.lazyLoader.loadScript('simplemde', 'simplemde/simplemde.js');
 
         let editorOptions = assign(
             {element: document.getElementById(this.elementId)},

--- a/ghost/admin/app/index.html
+++ b/ghost/admin/app/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <!--[if (IE 8)&!(IEMobile)]><html class="no-js lt-ie9" lang="en"><![endif]-->
 <!--[if (gte IE 9)| IEMobile |!(IE)]><!--><html class="no-js" lang="en"><!--<![endif]-->
-<head>
+<head data-ghost-cdn-url="">
     <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -154,7 +154,7 @@ export default class FeatureService extends Service {
             nightShift = enabled || this.nightShift;
         }
 
-        return this.lazyLoader.loadStyle('dark', 'assets/ghost-dark.css', true).then(() => {
+        return this.lazyLoader.loadStyle('dark', 'ghost-dark.css', true).then(() => {
             $('link[title=dark]').prop('disabled', !nightShift);
         }).catch(() => {
             //TODO: Also disable toggle from settings and Labs hover

--- a/ghost/admin/app/services/lazy-loader.js
+++ b/ghost/admin/app/services/lazy-loader.js
@@ -32,12 +32,10 @@ export default class LazyLoaderService extends Service {
         }
 
         let scriptPromise = new RSVP.Promise((resolve, reject) => {
-            let {adminRoot} = this.ghostPaths;
-
             let script = document.createElement('script');
             script.type = 'text/javascript';
             script.async = true;
-            script.src = `${adminRoot}${url}`;
+            script.src = `${this.ghostPaths.assetRoot}${url}`;
 
             let el = document.getElementsByTagName('script')[0];
             el.parentNode.insertBefore(script, el);
@@ -65,7 +63,7 @@ export default class LazyLoaderService extends Service {
             let link = document.createElement('link');
             link.id = `${key}-styles`;
             link.rel = alternate ? 'alternate stylesheet' : 'stylesheet';
-            link.href = `${this.ghostPaths.adminRoot}${url}`;
+            link.href = `${this.ghostPaths.assetRoot}${url}`;
             link.onload = () => {
                 link.onload = null;
                 if (alternate) {

--- a/ghost/admin/app/utils/ghost-paths.js
+++ b/ghost/admin/app/utils/ghost-paths.js
@@ -17,7 +17,7 @@ export default function () {
     let path = window.location.pathname;
     let subdir = path.substr(0, path.search('/ghost/'));
     let adminRoot = `${subdir}/ghost/`;
-    let assetRoot = `${subdir}/ghost/assets/`;
+    let assetRoot = document.head.dataset.ghostCdnUrl || `${subdir}/ghost/assets/`;
     let apiRoot = `${subdir}/ghost/api/admin`;
 
     function assetUrl(src) {


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/47

- this allows us to configure a different URL to load assets from by overwriting the data attribute in HTML

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6bff550</samp>

This pull request migrates the admin app to a new asset delivery system that allows loading scripts and styles from a CDN or the default local path. It updates the `ghostPaths` service and the sources of various assets to use the `assetRoot` property, which can be set by a `data-ghost-cdn-url` attribute in the `index.html` file.
