### PR TITLE
Configured storing Nx cache in GHA to speed up builds

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -25,7 +25,7 @@ let commands = [];
 const COMMAND_GHOST = {
     name: 'ghost',
     // Note: if this isn't working for you, please use Node 18 and above
-    command: 'node --watch index.js',
+    command: 'nx run ghost:dev',
     cwd: path.resolve(__dirname, '../../ghost/core'),
     prefixColor: 'blue',
     env: {}

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -52,9 +52,13 @@ jobs:
     - name: Install dependencies
       run: yarn
 
+    - name: Build packages
+      run: yarn nx run-many -t build:ts
+
     - name: Run migrations
       working-directory: ghost/core
       run: yarn knex-migrator init
+
     - name: Get Playwright version
       id: playwright-version
       run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ env:
     ~/.cache/ms-playwright/
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/ghost/*/build
+  NX_CACHE_RESTORE_KEYS: |
+    nx-Linux-${{ github.ref }}-${{ github.sha }}
+    nx-Linux-${{ github.ref }}
+    nx-Linux
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -100,7 +104,7 @@ jobs:
       changed_any_code: ${{ steps.changed.outputs.any-code }}
       base_commit: ${{ env.BASE_COMMIT }}
       is_canary_branch: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/arch') }}
-      is_git_sync: ${{ github.head_ref == 'main' || github.ref == 'refs/heads/main' }}
+      is_main: ${{ github.ref == 'refs/heads/main' }}
 
   job_install_deps:
     name: Install Dependencies
@@ -116,6 +120,14 @@ jobs:
       - name: Compute dependency cache key
         id: compute_lockfile_hash
         run: echo "hash=${{ hashFiles('yarn.lock') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Nx cache
+        uses: actions/cache@v3
+        id: cache_nx
+        with:
+          path: .nxcache
+          key: nx-Linux-${{ github.ref }}-${{ env.HEAD_COMMIT }}
+          restore-keys: ${{needs.job_get_metadata.outputs.is_main == 'false' && env.NX_CACHE_RESTORE_KEYS || 'nx-never-restore'}}
 
       - name: Check dependency cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Build packages
         if: steps.cache_built_packages.outputs.cache-hit != 'true'
-        run: yarn prepare
+        run: yarn nx run-many -t build:ts
     outputs:
       dependency_cache_key: ${{ steps.compute_lockfile_hash.outputs.hash }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ typings/
 # Optional npm cache directory
 .npm
 
+# Nx cache
+.nxcache
+
 # Optional eslint cache
 .eslintcache
 

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "scripts": {
     "archive": "npm pack",
-    "start": "node index",
+    "dev": "node --watch index.js",
     "build": "postcss core/frontend/public/ghost.css --no-map --use cssnano -o core/frontend/public/ghost.min.css",
     "test": "yarn test:unit",
     "test:base": "mocha --require=./test/utils/overrides.js --exit --trace-warnings --recursive --extension=test.js",
@@ -260,5 +260,19 @@
     "@tryghost/logging": "2.4.4",
     "moment": "2.24.0",
     "moment-timezone": "0.5.23"
+  },
+  "nx": {
+    "targets": {
+      "archive": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      },
+      "dev": {
+        "dependsOn": [
+          "^build:ts"
+        ]
+      }
+    }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -8,7 +8,8 @@
                     "lint",
                     "test",
                     "test:unit"
-                ]
+                ],
+                "cacheDirectory": ".nxcache"
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "**/node_modules/**"
   ],
   "scripts": {
-    "archive": "yarn workspace ghost run archive",
+    "archive": "nx run ghost:archive",
     "build": "nx run-many -t build",
     "dev:debug": "DEBUG_COLORS=true DEBUG=@tryghost*,ghost:* yarn dev",
     "dev:admin": "node .github/scripts/dev.js --admin",
@@ -35,7 +35,7 @@
     "main": "yarn main:monorepo && yarn main:submodules",
     "main:monorepo": "git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn",
     "main:submodules": "git submodule sync && git submodule update && git submodule foreach \"git checkout main && git pull ${GHOST_UPSTREAM:-origin} main && yarn\"",
-    "prepare": "husky install .github/hooks && nx run-many -t build:ts"
+    "prepare": "husky install .github/hooks"
   },
   "resolutions": {
     "@elastic/elasticsearch": "8.5.0",


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/47

- this allows us to store and restore the cache for TS builds, which should speed up the whole process

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c72023</samp>

This pull request enhances the CI workflow by using `Nx cache` to speed up builds and tests. It also updates the `nx.json` and `.github/workflows/ci.yml` files to configure the cache location and keys.
