### PR TITLE
Fixed typo in Brazilian Portuguese translations

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.33.5",
+  "version": "2.33.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/ghost/i18n/locales/pt-BR/portal.json
+++ b/ghost/i18n/locales/pt-BR/portal.json
@@ -118,7 +118,7 @@
     "The email address we have for you is {{memberEmail}} — if that's not correct, you can update it in your <button>account settings area</button>.": "O endereço de e-mail que temos para você é {{memberEmail}} — se isso não estiver correto, você pode atualizá-lo na sua <button>área de configurações da conta</button>.",
     "There was a problem submitting your feedback. Please try again a little later.": "Houve um problema ao enviar sua avaliação. Tente novamente mais tarde.",
     "This site is invite-only, contact the owner for access.": "Este site é apenas para convidados. Contate o proprietário para obter acesso.",
-    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Para completar o cadastro, clique no link de confirmação enviado para sua caixa de entrada. Se o link não chegar detro de 3 minutos, confira a pasta de spam!",
+    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Para completar o cadastro, clique no link de confirmação enviado para sua caixa de entrada. Se o link não chegar dentro de 3 minutos, confira a pasta de spam!",
     "Try free for {{amount}} days, then {{originalPrice}}.": "Experimente grátis por {{amount}} dias, depois {{originalPrice}}.",
     "Unlock access to all newsletters by becoming a paid subscriber.": "Desbloqueie o acesso a todas as newsletters se tornando um assinante pago.",
     "Unsubscribe from all emails": "Cancelar inscrição em todos os e-mails",


### PR DESCRIPTION
refs https://secure.helpscout.net/conversation/2299289258/127776?folderId=7510559

- as reported by a customer :)

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d4bfcba</samp>

This pull request fixes a typo in the `portal.json` file for the Portuguese (Brazil) locale. This improves the localization of the portal feature for Portuguese speakers.
