### PR TITLE
Reformatted list of fingerprint-enabled file extensions

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -145,6 +145,8 @@ module.exports = function (defaults) {
                 'map',
                 'svg',
                 'ttf',
+                'woff2',
+                'mp4',
                 'ico'
             ]
         },

--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -135,7 +135,18 @@ module.exports = function (defaults) {
         },
         fingerprint: {
             enabled: isProduction,
-            extensions: ['js', 'css', 'png', 'jpg', 'jpeg', 'gif', 'map', 'svg', 'ttf', 'ico']
+            extensions: [
+                'js',
+                'css',
+                'png',
+                'jpg',
+                'jpeg',
+                'gif',
+                'map',
+                'svg',
+                'ttf',
+                'ico'
+            ]
         },
         minifyJS: {
             options: {


### PR DESCRIPTION
- this makes it easier to read the diff when you're adding extensions

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f83e28c</samp>

This change updates the asset fingerprinting configuration to handle `woff2` and `mp4` files. This is needed for the new feature of uploading and serving mp4 videos in Ghost.
