### PR TITLE
Removed canary workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,8 +1,0 @@
-name: Canary Build
-on: workflow_dispatch
-env:
-  FORCE_COLOR: 1
-jobs:
-  canary:
-    uses: tryghost/actions/.github/workflows/canary.yml@main
-    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,14 +749,3 @@ jobs:
         if: contains(needs.*.result, 'failure')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
-
-  canary:
-    needs:
-      [
-        job_get_metadata,
-        job_required_tests
-      ]
-    if: needs.job_get_metadata.outputs.is_canary_branch == 'true'
-    name: Canary
-    secrets: inherit
-    uses: tryghost/actions/.github/workflows/canary.yml@main


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/47

- we need to start building from git refs so this workflow which builds a tarball is no longer needed and just adds to the execution time

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01a1b24</samp>

This pull request removes the `canary.yml` workflow and the `canary` job from the `ci.yml` workflow. This simplifies the CI process and avoids redundant tests on the canary branch.
