### PR TITLE
Added support for prepending CDN URLs to Admin assets

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -135,6 +135,7 @@ module.exports = function (defaults) {
         },
         fingerprint: {
             enabled: isProduction,
+            prepend: process.env.GHOST_CDN_URL || '',
             extensions: [
                 'js',
                 'css',


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/47

- this allows us to produce builds that use URLs from a CDN if the env var is provided

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7393614</samp>

This pull request enables serving the admin panel from a CDN by prepending a configurable URL to the assets. It modifies the `ember-cli-build.js` file to accept a new option `assetURL`.
