### PR TITLE
Removed duplicate build step during tarballing

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -52,7 +52,7 @@
     "lint:test": "eslint -c test/.eslintrc.js --ignore-path test/.eslintignore 'test/**/*.js' --cache",
     "lint:code": "yarn lint:server && yarn lint:shared && yarn lint:frontend",
     "lint": "yarn lint:server && yarn lint:shared && yarn lint:frontend && yarn lint:test",
-    "prepack": "nx run-many -t build --projects='ghost/*' && monobundle"
+    "prepack": "monobundle"
   },
   "engines": {
     "node": "^16.14.0 || ^18.12.1",
@@ -265,7 +265,13 @@
     "targets": {
       "archive": {
         "dependsOn": [
-          "^build:ts"
+          "^build:ts",
+          {
+            "projects": [
+              "ghost-admin"
+            ],
+            "target": "build"
+          }
         ]
       },
       "dev": {


### PR DESCRIPTION
- we don't need this bit because Nx will run the build steps for us

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a0ea9c</samp>

Simplified the `prepack` script in `ghost/core/package.json` to only run `monobundle`. This improved the packaging speed and avoided redundant builds of the `ghost/*` projects.
