### PR TITLE
Configured auto-imported assets to load from supplied URL

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -105,6 +105,16 @@ if (process.env.CI) {
     denylist.push('ember-cli-eslint');
 }
 
+let publicAssetURL;
+
+if (isTesting) {
+    publicAssetURL = undefined;
+} else if (process.env.GHOST_CDN_URL) {
+    publicAssetURL = process.env.GHOST_CDN_URL + 'assets/';
+} else {
+    publicAssetURL = 'assets/';
+}
+
 module.exports = function (defaults) {
     let app = new EmberApp(defaults, {
         addons: {denylist},
@@ -233,7 +243,7 @@ module.exports = function (defaults) {
             }
         },
         autoImport: {
-            publicAssetURL: isTesting ? undefined : 'assets/',
+            publicAssetURL,
             webpack: {
                 resolve: {
                     fallback: {


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/47

- this allows us to optionally configure a URL to set as the CDN URL in Admin

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7980db3</samp>

This pull request enables customizing the CDN URL for public assets in different environments and testing modes. It introduces a new variable `publicAssetURL` in `ember-cli-build.js` and passes it to the `autoImport` option.
