### PR TITLE
🐛 Updated content importer background in dark theme

### DIFF
--- a/ghost/admin/app/styles/app-dark.css
+++ b/ghost/admin/app/styles/app-dark.css
@@ -1545,3 +1545,8 @@ kbd {
     background: var(--dark-main-bg-color);
     box-shadow: 0 0 1px rgba(0,0,0,.65), 0 8px 28px rgba(0,0,0,.72);
 }
+
+/* Labs Content Importer */
+.gh-import-content-spinner .gh-loading-content {
+    background: color-mod(var(--white) l(+2%));
+}


### PR DESCRIPTION
fixes #17287

- Added content importer background for dark theme

## Screengrab
https://github.com/TryGhost/Ghost/assets/34619861/fc46eeee-a3f2-4e4b-9a31-6f93d590f8cf

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39b0ef7</samp>

This change improves the appearance of the Labs Content Importer spinner in the dark mode theme. It adds a CSS rule for the spinner in `ghost/admin/app/styles/app-dark.css` that adjusts its background color.
