### PR TITLE
Configured Admin to use CDN URLs for lazy-loaded assets

### DIFF
--- a/ghost/admin/app/services/lazy-loader.js
+++ b/ghost/admin/app/services/lazy-loader.js
@@ -32,12 +32,10 @@ export default class LazyLoaderService extends Service {
         }
 
         let scriptPromise = new RSVP.Promise((resolve, reject) => {
-            let {adminRoot} = this.ghostPaths;
-
             let script = document.createElement('script');
             script.type = 'text/javascript';
             script.async = true;
-            script.src = `${adminRoot}${url}`;
+            script.src = `${config.cdnUrl || this.ghostPaths.adminRoot}${url}`;
 
             let el = document.getElementsByTagName('script')[0];
             el.parentNode.insertBefore(script, el);
@@ -65,7 +63,7 @@ export default class LazyLoaderService extends Service {
             let link = document.createElement('link');
             link.id = `${key}-styles`;
             link.rel = alternate ? 'alternate stylesheet' : 'stylesheet';
-            link.href = `${this.ghostPaths.adminRoot}${url}`;
+            link.href = `${config.cdnUrl || this.ghostPaths.adminRoot}${url}`;
             link.onload = () => {
                 link.onload = null;
                 if (alternate) {

--- a/ghost/admin/config/environment.js
+++ b/ghost/admin/config/environment.js
@@ -5,6 +5,7 @@ module.exports = function (environment) {
     let ENV = {
         modulePrefix: 'ghost-admin',
         environment,
+        cdnUrl: process.env.GHOST_CDN_URL || '',
         rootURL: '',
         locationType: 'trailing-hash',
         EmberENV: {
@@ -33,7 +34,7 @@ module.exports = function (environment) {
 
         'ember-simple-auth': { },
 
-        'ember-websockets': { 
+        'ember-websockets': {
             socketIO: true
         },
 


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/47

- this allows Ghost to use a different URL for lazy-loaded assets, so it can be loaded from a CDN

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da429bf</samp>

This pull request adds a `cdnUrl` option to the Ghost admin configuration, allowing users to load scripts and stylesheets from a CDN instead of the local server. This enhances the performance and efficiency of the Ghost admin interface.
