### PR TITLE
Fixed memberlinks returning undefined in autocomplete.

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -264,8 +264,9 @@ export default class KoenigLexicalEditor extends Component {
             });
 
             const memberLinks = () => {
+                let links = [];
                 if (this.membersUtils.paidMembersEnabled) {
-                    return [
+                    links = [
                         {
                             label: 'Paid signup',
                             value: this.config.getSiteUrl('/#/portal/signup')
@@ -275,6 +276,8 @@ export default class KoenigLexicalEditor extends Component {
                             value: this.config.getSiteUrl('/#/portal/account/plans')
                         }];
                 }
+
+                return links;
             };
             return [...defaults, ...offersLinks, ...memberLinks()];
         };


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/17327

- Added an additional condition to avoid the new memberLinks function from returning undefined, which may lead to nothing being returned at all in the autocomplete.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59d45a1</samp>

Improved `memberLinks` function in `koenig-lexical-editor.js` to support optional links and fix a bug.
