### PR TITLE
Fixed VSCode launch.json config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "program": "${workspaceFolder}/.github/dev.js",
+            "program": "${workspaceFolder}/.github/scripts/dev.js",
             "args": [
                 "--all"
             ],
@@ -26,7 +26,7 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "program": "${workspaceFolder}/.github/dev.js",
+            "program": "${workspaceFolder}/.github/scripts/dev.js",
             "args": [
                 "--all",
                 "--offline"


### PR DESCRIPTION
The dev script was moved and the launch config was not updated.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ff8c50</samp>

Fixed VS Code debugger by updating launch configurations. The `.vscode/launch.json` file now uses the correct `dev.js` script path for both development and test environments.
