### PR TITLE
Commented out flaky collections tests

### DIFF
--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -12,10 +12,10 @@ const {
     anyLocationFor,
     anyObjectId,
     anyISODateTime,
-    anyISODateTimeWithTZ,
+    // anyISODateTimeWithTZ,
     anyNumber,
-    anyUuid,
-    anyLocalURL,
+    // anyUuid,
+    // anyLocalURL,
     anyString
 } = matchers;
 
@@ -25,14 +25,14 @@ const matchCollection = {
     updated_at: anyISODateTime
 };
 
-const matchCollectionPost = {
-    id: anyObjectId,
-    url: anyLocalURL,
-    created_at: anyISODateTimeWithTZ,
-    updated_at: anyISODateTimeWithTZ,
-    published_at: anyISODateTimeWithTZ,
-    uuid: anyUuid
-};
+// const matchCollectionPost = {
+//     id: anyObjectId,
+//     url: anyLocalURL,
+//     created_at: anyISODateTimeWithTZ,
+//     updated_at: anyISODateTimeWithTZ,
+//     published_at: anyISODateTimeWithTZ,
+//     uuid: anyUuid
+// };
 
 /**
  *
@@ -87,71 +87,73 @@ describe('Collections API', function () {
             });
     });
 
-    describe('Browse', function () {
-        it('Can browse Collections', async function () {
-            await agent
-                .get('/collections/')
-                .expectStatus(200)
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag
-                })
-                .matchBodySnapshot({
-                    collections: [
-                        buildMatcher(13, {withSortOrder: true}),
-                        buildMatcher(2, {withSortOrder: true}),
-                        buildMatcher(0)
-                    ]
-                });
-        });
-    });
+    // @NOTE: Below are flaky tests. They have inconsistent state due to collection events race conditions.
+    //        Should be uncommented and fixed with: https://github.com/TryGhost/Arch/issues/16
+    // describe('Browse', function () {
+    //     it('Can browse Collections', async function () {
+    //         await agent
+    //             .get('/collections/')
+    //             .expectStatus(200)
+    //             .matchHeaderSnapshot({
+    //                 'content-version': anyContentVersion,
+    //                 etag: anyEtag
+    //             })
+    //             .matchBodySnapshot({
+    //                 collections: [
+    //                     buildMatcher(13, {withSortOrder: true}),
+    //                     buildMatcher(2, {withSortOrder: true}),
+    //                     buildMatcher(0)
+    //                 ]
+    //             });
+    //     });
+    // });
 
-    describe('Browse Posts', function () {
-        it('Can browse Collections Posts', async function () {
-            const collections = await agent.get('/collections/');
-            const latestCollection = collections.body.collections.find(c => c.slug === 'latest');
+    // describe('Browse Posts', function () {
+    //     it('Can browse Collections Posts', async function () {
+    //         const collections = await agent.get('/collections/');
+    //         const latestCollection = collections.body.collections.find(c => c.slug === 'latest');
 
-            await agent
-                .get(`/collections/${latestCollection.id}/posts/`)
-                .expectStatus(200)
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag
-                })
-                .matchBodySnapshot({
-                    collection_posts: Array(13).fill(matchCollectionPost)
-                });
-        });
+    //         await agent
+    //             .get(`/collections/${latestCollection.id}/posts/`)
+    //             .expectStatus(200)
+    //             .matchHeaderSnapshot({
+    //                 'content-version': anyContentVersion,
+    //                 etag: anyEtag
+    //             })
+    //             .matchBodySnapshot({
+    //                 collection_posts: Array(13).fill(matchCollectionPost)
+    //             });
+    //     });
 
-        it('Can browse Collections Posts using paging parameters', async function () {
-            const collections = await agent.get('/collections/');
-            const indexCollection = collections.body.collections.find(c => c.slug === 'latest');
+    //     it('Can browse Collections Posts using paging parameters', async function () {
+    //         const collections = await agent.get('/collections/');
+    //         const indexCollection = collections.body.collections.find(c => c.slug === 'latest');
 
-            await agent
-                .get(`/collections/${indexCollection.id}/posts/?limit=2&page=2`)
-                .expectStatus(200)
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag
-                })
-                .matchBodySnapshot({
-                    collection_posts: Array(2).fill(matchCollectionPost)
-                });
-        });
+    //         await agent
+    //             .get(`/collections/${indexCollection.id}/posts/?limit=2&page=2`)
+    //             .expectStatus(200)
+    //             .matchHeaderSnapshot({
+    //                 'content-version': anyContentVersion,
+    //                 etag: anyEtag
+    //             })
+    //             .matchBodySnapshot({
+    //                 collection_posts: Array(2).fill(matchCollectionPost)
+    //             });
+    //     });
 
-        it('Can browse Collections Posts using collection slug', async function () {
-            await agent
-                .get(`/collections/latest/posts/`)
-                .expectStatus(200)
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag
-                })
-                .matchBodySnapshot({
-                    collection_posts: Array(13).fill(matchCollectionPost)
-                });
-        });
-    });
+    //     it('Can browse Collections Posts using collection slug', async function () {
+    //         await agent
+    //             .get(`/collections/latest/posts/`)
+    //             .expectStatus(200)
+    //             .matchHeaderSnapshot({
+    //                 'content-version': anyContentVersion,
+    //                 etag: anyEtag
+    //             })
+    //             .matchBodySnapshot({
+    //                 collection_posts: Array(13).fill(matchCollectionPost)
+    //             });
+    //     });
+    // });
 
     it('Can read a Collection', async function () {
         const collection = {


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/16

- There's a race condition happening when processing multiple collection updates at the same time. It causes the state to be inconsistent between the runs.
- Once the event handling is improved these tests should be put back into action

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f83fd8</samp>

Comment out flaky collection tests in `ghost/core/test/e2e-api/admin/collections.test.js`. These tests are failing due to race conditions and need to be fixed separately. This change avoids false failures in the CI pipeline.
