### PR TITLE
Fixed loading CDN assets via lazy loading

### DIFF
--- a/ghost/admin/app/services/lazy-loader.js
+++ b/ghost/admin/app/services/lazy-loader.js
@@ -35,7 +35,7 @@ export default class LazyLoaderService extends Service {
             let script = document.createElement('script');
             script.type = 'text/javascript';
             script.async = true;
-            script.src = `${config.cdnUrl || this.ghostPaths.adminRoot}${url}`;
+            script.src = `${config.cdnUrl ? '' : this.ghostPaths.adminRoot}${url}`;
 
             let el = document.getElementsByTagName('script')[0];
             el.parentNode.insertBefore(script, el);
@@ -63,7 +63,7 @@ export default class LazyLoaderService extends Service {
             let link = document.createElement('link');
             link.id = `${key}-styles`;
             link.rel = alternate ? 'alternate stylesheet' : 'stylesheet';
-            link.href = `${config.cdnUrl || this.ghostPaths.adminRoot}${url}`;
+            link.href = `${config.cdnUrl ? '' : this.ghostPaths.adminRoot}${url}`;
             link.onload = () => {
                 link.onload = null;
                 if (alternate) {


### PR DESCRIPTION
- in the event we supply a CDN URL, don't prefix the URL with anything as this will get auto-prefixed
- if not, add the Ghost Admin root because the assets sit under there

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8589354</samp>

This pull request fixes a bug in the `lazy-loader` service that prevented loading external resources from a CDN. It avoids duplicating the CDN URL in the `src` or `href` attributes of the `script` and `link` elements.
