### PR TITLE
Fixed pages API test snapshot having a flaky cache string

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
@@ -404,7 +404,7 @@ Object {
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
   "vary": "Accept-Version, Origin, Accept-Encoding",
-  "x-cache-invalidate": "/p/6b776308-98f3-44eb-931c-0e235024d7f2/",
+  "x-cache-invalidate": Any<String>,
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-api/admin/pages.test.js
+++ b/ghost/core/test/e2e-api/admin/pages.test.js
@@ -73,7 +73,8 @@ describe('Pages API', function () {
                 })
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
-                    etag: anyEtag
+                    etag: anyEtag,
+                    'x-cache-invalidate': anyString
                 });
         });
     });


### PR DESCRIPTION
no issue

- `x-cache-invalidate` will vary across different runs as the post's preview uuid will be different each time the post is created
