### PR TITLE
Reverted "Enabled Sentry Replay within Admin"

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -1,9 +1,9 @@
-import * as Sentry from '@sentry/ember';
 import AuthConfiguration from 'ember-simple-auth/configuration';
 import Route from '@ember/routing/route';
 import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import windowProxy from 'ghost-admin/utils/window-proxy';
+import {InitSentryForEmber} from '@sentry/ember';
 import {inject} from 'ghost-admin/decorators/inject';
 import {
     isAjaxError,
@@ -161,7 +161,7 @@ export default Route.extend(ShortcutsRoute, {
         // init Sentry here rather than app.js so that we can use API-supplied
         // sentry_dsn and sentry_env rather than building it into release assets
         if (this.config.sentry_dsn) {
-            Sentry.init({
+            InitSentryForEmber({
                 dsn: this.config.sentry_dsn,
                 environment: this.config.sentry_env,
                 release: `ghost@${this.config.version}`,
@@ -171,18 +171,6 @@ export default Route.extend(ShortcutsRoute, {
                     event.tags.grammarly = !!document.querySelector('[data-gr-ext-installed]');
                     return event;
                 },
-
-                // Enable collecting Replay events
-                integrations: [
-                    new Sentry.Replay()
-                ],
-
-                // Don't collect any Replays for general users
-                replaysSessionSampleRate: 0,
-
-                // Collect all Replays coming from errors
-                replaysOnErrorSampleRate: 1.0,
-
                 // TransitionAborted errors surface from normal application behaviour
                 // - https://github.com/emberjs/ember.js/issues/12505
                 ignoreErrors: [/^TransitionAborted$/]


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1689599266267649

- this reverts commit bb6deda10edfe4ae85c989d6d2110b906b7edb3e
- we're seeing some weird errors when Admin boots otherwise

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afdcbb0</samp>

Improved error reporting by migrating to `@sentry/ember` package and simplifying Sentry configuration in `application.js` route.
