### PR TITLE
Enabled sourcemaps in tsconfig

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,18 @@
         {
             "type": "node",
             "request": "launch",
+            "name": "Ghost core + Admin",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/.github/scripts/dev.js",
+            "autoAttachChildProcesses": true,
+            "outputCapture": "std",
+            "console": "integratedTerminal",
+        },
+        {
+            "type": "node",
+            "request": "launch",
             "name": "Full Dev",
             "skipFiles": [
                 "<node_internals>/**"

--- a/ghost/tsconfig.json
+++ b/ghost/tsconfig.json
@@ -55,7 +55,7 @@
     "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "build",                                   /* Specify an output folder for all emitted files. */

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "archive": "nx run ghost:archive",
     "build": "nx run-many -t build",
+    "build:clean": "nx reset && rimraf -g 'ghost/*/build'",
     "dev:debug": "DEBUG_COLORS=true DEBUG=@tryghost*,ghost:* yarn dev",
     "dev:admin": "node .github/scripts/dev.js --admin",
     "dev:ghost": "node .github/scripts/dev.js --ghost",
@@ -129,6 +130,7 @@
     "husky": "8.0.3",
     "lint-staged": "13.2.3",
     "nx": "16.5.2",
+    "rimraf": "5.0.1",
     "ts-node": "10.9.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18029,7 +18029,7 @@ glob@8.1.0, glob@^8.0.3, glob@^8.1.0:
     minimatch "^5.0.1"
     once "^1.3.0"
 
-glob@^10.0.0:
+glob@^10.0.0, glob@^10.2.5:
   version "10.3.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.3.tgz#8360a4ffdd6ed90df84aa8d52f21f452e86a123b"
   integrity sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==
@@ -27948,6 +27948,13 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha512-zgn5OjNQXLUTdq8m17KdaicF6w89TZs8ZU8y0AYENIU6wG8GG6LLm0yLSiPY8DmaYmHdgRW8rnApjoT0fQRfMg==
+
+rimraf@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.1.tgz#0881323ab94ad45fec7c0221f27ea1a142f3f0d0"
+  integrity sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==
+  dependencies:
+    glob "^10.2.5"
 
 rimraf@^2.2.8, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C05DUT549JR/p1689604345421799

- this enables sourcemap creation in our tsconfig setup so breakpoints work correctly in a debugger
- this should eventually be switched out for a CLI flag as we don't want to produce sourcemaps all the time (for example during release)

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d708d28</samp>

Enabled `sourceMap` option for TypeScript compiler to generate source maps for JavaScript files. This improves debugging and tracing capabilities for the Ghost project.
