### PR TITLE
🎨 Added missing translation strings in portal

### DIFF
--- a/apps/portal/src/components/common/ProductsSection.js
+++ b/apps/portal/src/components/common/ProductsSection.js
@@ -738,8 +738,6 @@ function ProductCardButton({selectedProduct, product, disabled, noOfProducts, tr
                 }}
             />
         );
-        // return ('Start ' + trialDays + '-day free trial');
-        // return t('Start {{amount}}-day free trial', trialDays);
     }
 
     return (noOfProducts > 1 ? t('Choose') : t('Continue'));

--- a/apps/portal/src/components/common/ProductsSection.js
+++ b/apps/portal/src/components/common/ProductsSection.js
@@ -4,6 +4,8 @@ import {ReactComponent as CheckmarkIcon} from '../../images/icons/checkmark.svg'
 import {getCurrencySymbol, getPriceString, getStripeAmount, getMemberActivePrice, getProductFromPrice, getFreeTierTitle, getFreeTierDescription, getFreeProduct, getFreeProductBenefits, formatNumber, isCookiesDisabled, hasOnlyFreeProduct, isMemberActivePrice, hasFreeTrialTier} from '../../utils/helpers';
 import AppContext from '../../AppContext';
 import calculateDiscount from '../../utils/discount';
+import Interpolate from '@doist/react-interpolate';
+import {SYNTAX_I18NEXT} from '@doist/react-interpolate';
 
 export const ProductsSectionStyles = ({site}) => {
     // const products = getSiteProducts({site});
@@ -636,7 +638,7 @@ function ProductCardPrice({product}) {
 }
 
 function FreeProductCard({products, handleChooseSignup, error}) {
-    const {site, action} = useContext(AppContext);
+    const {site, action, t} = useContext(AppContext);
     const {selectedProduct, setSelectedProduct} = useContext(ProductsContext);
 
     let cardClass = selectedProduct === 'free' ? 'gh-portal-product-card free checked' : 'gh-portal-product-card free';
@@ -707,7 +709,7 @@ function FreeProductCard({products, handleChooseSignup, error}) {
                                 onClick={(e) => {
                                     handleChooseSignup(e, 'free');
                                 }}>
-                                {((selectedProduct === 'free' && disabled) ? <LoaderIcon className='gh-portal-loadingicon' /> : 'Choose')}
+                                {((selectedProduct === 'free' && disabled) ? <LoaderIcon className='gh-portal-loadingicon' /> : t('Choose'))}
                             </button>
                             {error && <div className="gh-portal-error-message">{error}</div>}
                         </div>
@@ -719,6 +721,7 @@ function FreeProductCard({products, handleChooseSignup, error}) {
 }
 
 function ProductCardButton({selectedProduct, product, disabled, noOfProducts, trialDays}) {
+    const {t} = useContext(AppContext);
     if (selectedProduct === product.id && disabled) {
         return (
             <LoaderIcon className='gh-portal-loadingicon' />
@@ -726,10 +729,20 @@ function ProductCardButton({selectedProduct, product, disabled, noOfProducts, tr
     }
 
     if (trialDays > 0) {
-        return ('Start ' + trialDays + '-day free trial');
+        return (
+            <Interpolate
+                syntax={SYNTAX_I18NEXT}
+                string={t('Start {{amount}}-day free trial')}
+                mapping={{
+                    amount: trialDays
+                }}
+            />
+        );
+        // return ('Start ' + trialDays + '-day free trial');
+        // return t('Start {{amount}}-day free trial', trialDays);
     }
 
-    return (noOfProducts > 1 ? 'Choose' : 'Continue');
+    return (noOfProducts > 1 ? t('Choose') : t('Continue'));
 }
 
 function ProductCard({product, products, selectedInterval, handleChooseSignup, error}) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3613

- Strings around the buttons was still hardcoded. 
- This replaces them with the `i18n` integration.

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 068d0d6</samp>

Added internationalization support to the `ProductsSection` component using the `t` function and the `Interpolate` component. This enables the component to display product information in different languages and currencies.
