### PR TITLE
Bumped Portal version

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.33.6",
+  "version": "2.33.7",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
no issue

- bumped portal to a new minor after publishing.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e70d04</samp>

Updated the portal package to version 2.33.7 with some bug fixes and improvements. The `apps/portal/package.json` file reflects the new version number.
