### PR TITLE
Added `clsx` Tailwind autocomplete support to VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,8 @@
     "**/ghost.map": true,
     "**/node_modules": true,
     "ghost/core/core/built/**": true
-  }
+  },
+  "tailwindCSS.experimental.classRegex": [
+    ["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+  ]
 }


### PR DESCRIPTION
refs https://github.com/lukeed/clsx#tailwind-support

- this should enable Tailwind autocomplete in `clsx` for those who use the Tailwind Intellisense plugin

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69d8ea0</samp>

Add VS Code setting for Tailwind CSS extension. This improves the developer experience when working with `clsx` and Tailwind classes in Ghost.
