### PR TITLE
Update portal.json

### DIFF
--- a/ghost/i18n/locales/es/portal.json
+++ b/ghost/i18n/locales/es/portal.json
@@ -17,6 +17,7 @@
     "An unexpected error occured. Please try again or <a>contact support</a> if the error persists.": "Un error inesperado ha ocurrido. Por favor intente de nuevo o <a>contacte soporte técnico</a> si el error persiste.",
     "Back": "Atrás",
     "Back to Log in": "Volver al inicio de sesión",
+    "Become a paid member of {{siteName}} to get access to all subscriber-only content": "Conviértete en un miembro de pago de {{siteName}} para tener acceso a todo el contenido para suscriptores"
     "Billing info": "Informacion de pago",
     "Black Friday": "Viernes negro",
     "Cancel anytime.": "Cancelacion en cualquier momento.",
@@ -107,6 +108,7 @@
     "Starting today": "A partir de hoy",
     "Submit feedback": "Enviar comentarios",
     "Subscribe": "Suscribir",
+    "Subscribe to continue reading": "Suscríbete para continuar leyendo"
     "Subscribed": "Suscrito",
     "Success": "Éxito",
     "Success! Check your email for magic link to sign-in.": "¡Éxito! Revise su correo electrónico para ver el enlace mágico para iniciar sesión.",


### PR DESCRIPTION
those messages appear when a free user receive an e-mail with a sign-up form

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9330a95</samp>

This pull request adds Spanish translations for portal messages in `ghost/i18n/locales/es/portal.json`. This helps Spanish-speaking visitors interact with the membership and subscription features of Ghost sites.
