### PR TITLE
Fixed mismatched bracket count in translations

### DIFF
--- a/ghost/i18n/locales/nn/portal.json
+++ b/ghost/i18n/locales/nn/portal.json
@@ -119,7 +119,7 @@
     "There was a problem submitting your feedback. Please try again a little later.": "Det var eit problem med å senda tilbakemeldinga di. Vennligst prøv igjen litt seinare.",
     "This site is invite-only, contact the owner for access.": "Denne sida er kun for inviterte, ta kontakt med eigaren for tilgang.",
     "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Klikk på bekreftelseslenka i innboksen din for å fullføra registreringa. Sjekk spam-mappa di om lenka ikkje har kome innan 3 minutt.",
-    "Try free for {{amount}} days, then {{originalPrice}}.": "Prøv gratis i {{amount} dagar, deretter {{originalPrice}}.",
+    "Try free for {{amount}} days, then {{originalPrice}}.": "Prøv gratis i {{amount}} dagar, deretter {{originalPrice}}.",
     "Unlock access to all newsletters by becoming a paid subscriber.": "Få tilgang til alle nyheitsbreva med å bli ein betalande abonnent.",
     "Unsubscribe from all emails": "Slutt å motta e-postar",
     "Unsubscribed": "Abonnement avslutta",

--- a/ghost/i18n/locales/si/ghost.json
+++ b/ghost/i18n/locales/si/ghost.json
@@ -1,5 +1,5 @@
 {
-    "All the best!": "සියලු දේ සාර්ථකත්වයට පත් වේවායි ප්‍රාර්ථනා කරන්නෙමු!",
+    "All the best!": "සියලු දේ සාර්ථකත්වයට පත් වේවායි ප්\u200dරාර්ථනා කරන්නෙමු!",
     "Complete signup for {{siteTitle}}!": "{{siteTitle}} වෙත signup වීම සම්පූර්ණ කරන්න",
     "Complete your sign up to {{siteTitle}}!": "{{siteTitle}} වෙත ඔබගේ signup වීම සම්පූර්ණ කරන්න!",
     "Confirm email address": "Email ලිපිනය තහවුරු කරන්න",


### PR DESCRIPTION
- fixes a typo that would have lead to the raw placeholder being output

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06b0378</samp>

This pull request updates some translation files for the portal feature. However, it contains a no-op change to `ghost/i18n/locales/nn/portal.json` and a copy-paste error in `ghost/i18n/locales/si/ghost.json` that should be fixed before merging.
