### PR TITLE
Updated Norwegian Nynorsk translation

### DIFF
--- a/ghost/i18n/locales/no/ghost.json
+++ b/ghost/i18n/locales/no/ghost.json
@@ -8,7 +8,7 @@
     "Confirm your email update for {{siteTitle}}!": "Bekreft e-postoppdateringen din for {{siteTitle}}!",
     "Confirm your subscription to {{siteTitle}}": "Bekreft abonnementet ditt på {{siteTitle}}",
     "For your security, the link will expire in 24 hours time.": "For din sikkerhet så vil denne linken utløpe om 24 timer",
-    "Hey there,": "Halloen.",
+    "Hey there,": "Hei,",
     "Hey there!": "",
     "If you did not make this request, you can safely ignore this email.": "Hvis du ikke har bedt om dette, kan du trygt ignorere denne e-posten.",
     "If you did not make this request, you can simply delete this message.": "Hvis du ikke har bedt om dette, kan du enkelt slette denne meldingen.",


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---
The email a user is sent to log in to a Ghost-site starts with "Hey there," in bold. The Norwegian translation for this is "Halloen." This is a regional-specific slang for "hello" and the word "Halloen" does not exist in the official dictionary for Norwegian: https://ordbokene.no/bm/search?q=halloen&scope=ei

This PR changes this to "Hei," which is common Norwegian. 

To sum it up: Starting an email with "Halloen" is unprofessional and not what any business would do. 

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dc28b2f</samp>

Updated the Norwegian translation of the email greeting in `ghost.json` to be more formal and consistent.
