### PR TITLE
Removed `jest` from tsconfig types array

### DIFF
--- a/ghost/tsconfig.json
+++ b/ghost/tsconfig.json
@@ -36,7 +36,6 @@
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     "types": [
-      "jest",
       "mocha",
       "node",
     ],                                      /* Specify type package names to be included without being referenced in a source file. */


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/45

- this was a mistake resulting from a copy+paste, we don't even use Jest :P

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c25d47a</samp>

Removed `jest` option from `tsconfig.json` to avoid conflicts with Mocha. Part of TypeScript refactor.
