### PR TITLE
Fixed the `{{#collection}}` helper

### DIFF
--- a/ghost/core/core/frontend/helpers/collection.js
+++ b/ghost/core/core/frontend/helpers/collection.js
@@ -113,6 +113,7 @@ module.exports = async function collection(slug, options) {
     // Parse the options we're going to pass to the API
     apiOptions = parseOptions(apiOptions);
     apiOptions.context = {member: data.member};
+    apiOptions.collection = slug;
 
     try {
         const response = await makeAPICall(resource, controllerName, action, apiOptions);

--- a/ghost/core/core/server/api/endpoints/posts-public.js
+++ b/ghost/core/core/server/api/endpoints/posts-public.js
@@ -40,7 +40,8 @@ module.exports = {
             'order',
             'page',
             'debug',
-            'absolute_urls'
+            'absolute_urls',
+            'collection'
         ],
         validation: {
             options: {


### PR DESCRIPTION
We were not passing the `slug` to the `apiOptions` so the posts were not correctly filtered, and on top of that the `collection` option had not been added to the allow list of the Posts Content API. With these two fixes the collection helper works as expected.
