### PR TITLE
Fixed logic for checking theme compatibility with @page properties

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.js
+++ b/ghost/admin/app/components/gh-post-settings-menu.js
@@ -165,7 +165,7 @@ export default class GhPostSettingsMenu extends Component {
     }
 
     get themeMissingShowTitleAndFeatureImage() {
-        return this.themeManagement.activeTheme.hasPageBuilderFeature('show_title_and_feature_image');
+        return !this.themeManagement.activeTheme.hasPageBuilderFeature('show_title_and_feature_image');
     }
 
     willDestroyElement() {

--- a/ghost/admin/app/models/theme.js
+++ b/ghost/admin/app/models/theme.js
@@ -40,10 +40,10 @@ export default Model.extend({
         return codedWarnings;
     }),
 
-    codedErrors: computed('errors.[]', function () {
+    codedErrors: computed('gscanErrors.[]', function () {
         const codedErrors = {};
 
-        this.errors.forEach((error) => {
+        this.gscanErrors.forEach((error) => {
             if (!codedErrors[error.code]) {
                 codedErrors[error.code] = [];
             }
@@ -82,7 +82,7 @@ export default Model.extend({
         }
 
         return !failures['GS110-NO-MISSING-PAGE-BUILDER-USAGE'].some((failure) => {
-            return !failure.failures.some(({ref}) => ref === `@page.${feature}`);
+            return failure.failures.some(({ref}) => ref === `@page.${feature}`);
         });
     },
 


### PR DESCRIPTION
no issue

- logic was incorrect in two places that meant we were showing the incompatibility warning for compatible themes
- `codedErrors` was looking at the Ember Data `errors` object instead of the renamed `gscanErrors` object
