### PR TITLE
Added /collections/slug/:slug Admin API endpoint

### DIFF
--- a/ghost/admin/app/adapters/collection.js
+++ b/ghost/admin/app/adapters/collection.js
@@ -1,0 +1,10 @@
+import ApplicationAdapter from 'ghost-admin/adapters/application';
+import SlugUrl from 'ghost-admin/utils/slug-url';
+
+export default class Tag extends ApplicationAdapter {
+    buildURL(_modelName, _id, _snapshot, _requestType, query) {
+        let url = super.buildURL(...arguments);
+
+        return SlugUrl(url, query);
+    }
+}

--- a/ghost/admin/app/router.js
+++ b/ghost/admin/app/router.js
@@ -53,6 +53,7 @@ Router.map(function () {
     this.route('collections');
     this.route('collection.new', {path: '/collections/new'});
     this.route('collection', {path: '/collections/:collection_slug'});
+
     this.route('settings-x', function () {
         this.route('settings-x', {path: '/*sub'});
     });

--- a/ghost/admin/app/routes/collection.js
+++ b/ghost/admin/app/routes/collection.js
@@ -8,6 +8,10 @@ export default class CollectionRoute extends AuthenticatedRoute {
     @service router;
     @service session;
 
+    // ensures if a tag model is passed in directly we show it immediately
+    // and refresh in the background
+    _requiresBackgroundRefresh = true;
+
     beforeModel() {
         super.beforeModel(...arguments);
 
@@ -28,6 +32,21 @@ export default class CollectionRoute extends AuthenticatedRoute {
 
     serialize(collection) {
         return {collection_slug: collection.get('slug')};
+    }
+
+    setupController(controller, tag) {
+        super.setupController(...arguments);
+
+        if (this._requiresBackgroundRefresh) {
+            tag.reload();
+        }
+    }
+
+    deactivate() {
+        this._requiresBackgroundRefresh = true;
+
+        this.confirmModal = null;
+        this.hasConfirmed = false;
     }
 
     @action

--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -30,11 +30,17 @@ module.exports = {
             cacheInvalidate: false
         },
         data: [
-            'id'
+            'id',
+            'slug'
         ],
         permissions: true,
         async query(frame) {
-            const model = await collectionsService.api.getById(frame.data.id);
+            let model;
+            if (frame.data.id) {
+                model = await collectionsService.api.getById(frame.data.id);
+            } else {
+                model = await collectionsService.api.getBySlug(frame.data.slug);
+            }
 
             if (!model) {
                 throw new errors.NotFoundError({

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -22,6 +22,7 @@ module.exports = function apiRoutes() {
     // ## Collections
     router.get('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.browse));
     router.get('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.read));
+    router.get('/collections/slug/:slug', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.read));
     router.post('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.add));
     router.put('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.edit));
     router.del('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.destroy));

--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -604,7 +604,7 @@ Object {
 }
 `;
 
-exports[`Collections API Can read a Collection 1: [body] 1`] = `
+exports[`Collections API Can read a Collection by id and slug 1: [body] 1`] = `
 Object {
   "collections": Array [
     Object {
@@ -623,7 +623,7 @@ Object {
 }
 `;
 
-exports[`Collections API Can read a Collection 2: [headers] 1`] = `
+exports[`Collections API Can read a Collection by id and slug 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -638,7 +638,7 @@ Object {
 }
 `;
 
-exports[`Collections API Can read a Collection 3: [body] 1`] = `
+exports[`Collections API Can read a Collection by id and slug 3: [body] 1`] = `
 Object {
   "collections": Array [
     Object {
@@ -657,7 +657,39 @@ Object {
 }
 `;
 
-exports[`Collections API Can read a Collection 4: [headers] 1`] = `
+exports[`Collections API Can read a Collection by id and slug 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "279",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Collections API Can read a Collection by id and slug 5: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": null,
+      "feature_image": null,
+      "filter": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "posts": Array [],
+      "slug": "test-collection-to-read",
+      "title": "Test Collection to Read",
+      "type": "manual",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can read a Collection by id and slug 6: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -119,7 +119,7 @@ describe('Collections API', function () {
         });
     });
 
-    it('Can read a Collection', async function () {
+    it('Can read a Collection by id and slug', async function () {
         const collection = {
             title: 'Test Collection to Read'
         };
@@ -153,6 +153,20 @@ describe('Collections API', function () {
             });
 
         assert.equal(readResponse.body.collections[0].title, 'Test Collection to Read');
+
+        const collectionSlug = addResponse.body.collections[0].slug;
+        const readBySlugResponse = await agent
+            .get(`/collections/slug/${collectionSlug}/`)
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                collections: [matchCollection]
+            });
+
+        assert.equal(readBySlugResponse.body.collections[0].title, 'Test Collection to Read');
 
         await agent
             .delete(`/collections/${collectionId}/`)


### PR DESCRIPTION
closes https://github.com/TryGhost/Arch/issues/45

- This endpoint is here to keep the convention of being able to fetch the resource by it's slug through a `GET /{resource_name}/slug/:slug`. It has identical output as the `GET /collections/:id` endpoint
- The alternative would be having an alias and try fetching by :id and then by slug if the result for id was null, but that would be a completely new pattern we have not used anywhere else yet.


<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2dfd898</samp>

This pull request adds the ability to fetch collections by slug in the admin API and UI. It introduces a new `slug` attribute and a new `/collections/slug/:slug` route to the collection model and API. It also updates the collection route, adapter, and tests to support the new feature.
