### PR TITLE
Fixed Segment event named wrong

### DIFF
--- a/ghost/core/core/server/services/segment/DomainEventsAnalytics.js
+++ b/ghost/core/core/server/services/segment/DomainEventsAnalytics.js
@@ -65,7 +65,7 @@ module.exports = class DomainEventsAnalytics {
         if (event.data.milestone
             && event.data.milestone.value === 100
         ) {
-            const eventName = event.data.milestone.type === 'arr' ? '$100 MRR reached' : '100 Members reached';
+            const eventName = event.data.milestone.type === 'arr' ? '$100 ARR reached' : '100 Members reached';
 
             try {
                 this.#analytics.track(Object.assign(this.#trackDefaults, {}, {event: this.#prefix + eventName}));

--- a/ghost/core/test/unit/server/services/segment/DomainEventsAnalytics.test.js
+++ b/ghost/core/test/unit/server/services/segment/DomainEventsAnalytics.test.js
@@ -153,7 +153,7 @@ describe('DomainEventsAnalytics', function () {
             assert(analyticsStub.calledWith({
                 userId: '9876',
                 properties: {email: 'john+arr@test.com'},
-                event: 'Pro: $100 MRR reached'
+                event: 'Pro: $100 ARR reached'
             }));
             assert(loggingStub.callCount === 0);
 


### PR DESCRIPTION
<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c9977d</samp>

This pull request fixes a typo in the segment tracking of the `$100_ARR_MILESTONE` event, which was incorrectly named as `$100_MRR_MILESTONE`. It also updates the unit test file `DomainEventsAnalytics.test.js` to reflect the correct event name.
