### PR TITLE
🐛 Fixed newsletter image rendering in Outlook

### DIFF
--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -343,7 +343,7 @@ class EmailRenderer {
 
         // Juice HTML (inline CSS)
         const juice = require('juice');
-        html = juice(html, {inlinePseudoElements: true, removeStyleTags: true});
+        html = juice(html, {inlinePseudoElements: true, removeStyleTags: true, applyWidthAttributes: false, applyHeightAttributes: false});
 
         // happens after inlining of CSS so we can change element types without worrying about styling
         $ = cheerio.load(html);


### PR DESCRIPTION
refs TryGhost/Product#3647

- In our email renderer, we use a package called 'juice' to inline the css into the HTML
- In this commit (https://github.com/TryGhost/Ghost/commit/1b336344955ca526ff40fed043bb928fdb0af53a) we updated juice to the latest version, which introduced a breaking change to our email rendering
- The latest version of juice added support for overwriting height/width attributes with whatever values are in the CSS, so it was overwriting our image dimensions
- Luckily this feature juice added is optional, so we can disable it and get back to the old behaviour without reverting the version bump