### PR TITLE
Added margin override to the signup card input

### DIFF
--- a/ghost/core/core/frontend/src/cards/css/signup.css
+++ b/ghost/core/core/frontend/src/cards/css/signup.css
@@ -207,7 +207,7 @@
 .kg-signup-card-input {
     width: 100%;
     height: 4.6rem;
-    margin-right: 3px;
+    margin: 0 3px 0 0;
     padding: 12px 16px;
     border: none;
     background: #FFFFFF;


### PR DESCRIPTION
no issues

- some themes have global styles applied to inputs and it breaks the card input layout because of the style conflict
- this adds some default margin values to fix the issue
