### PR TITLE
Collection refresh on bulk updates

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -41,7 +41,7 @@ const COMMAND_ADMIN = {
 
 const COMMAND_TYPESCRIPT = {
     name: 'ts',
-    command: 'nx watch --projects=ghost/collections,ghost/in-memory-repository,ghost/mail-events,ghost/model-to-domain-event-interceptor,ghost/post-revisions,ghost/nql-filter-expansions,ghost/donations -- nx run \\$NX_PROJECT_NAME:build:ts',
+    command: 'nx watch --projects=ghost/collections,ghost/in-memory-repository,ghost/mail-events,ghost/model-to-domain-event-interceptor,ghost/post-revisions,ghost/nql-filter-expansions,ghost/post-events,ghost/donations -- nx run \\$NX_PROJECT_NAME:build:ts',
     cwd: path.resolve(__dirname, '../../'),
     prefixColor: 'cyan',
     env: {}

--- a/ghost/collections/package.json
+++ b/ghost/collections/package.json
@@ -31,6 +31,7 @@
         "@tryghost/logging": "2.4.5",
         "@tryghost/nql": "0.11.0",
         "@tryghost/nql-filter-expansions": "0.0.0",
+        "@tryghost/post-events": "0.0.0",
         "@tryghost/tpl": "0.1.25",
         "bson-objectid": "2.0.4"
     },

--- a/ghost/collections/src/CollectionRepository.ts
+++ b/ghost/collections/src/CollectionRepository.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {Collection} from './Collection';
+import {Knex} from "knex";
 
 export interface CollectionRepository {
-    createTransaction(fn: (transaction: any) => Promise<any>): Promise<any>
-    save(collection: Collection, options?: {transaction: any}): Promise<void>
-    getById(id: string, options?: {transaction: any}): Promise<Collection | null>
-    getBySlug(slug: string, options?: {transaction: any}): Promise<Collection | null>
+    createTransaction(fn: (transaction: Knex.Transaction) => Promise<any>): Promise<any>
+    save(collection: Collection, options?: {transaction: Knex.Transaction}): Promise<void>
+    getById(id: string, options?: {transaction: Knex.Transaction}): Promise<Collection | null>
+    getBySlug(slug: string, options?: {transaction: Knex.Transaction}): Promise<Collection | null>
     getAll(options?: any): Promise<Collection[]>
 }

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -105,7 +105,6 @@ type QueryOptions = {
 
 interface PostsRepository {
     getAll(options: QueryOptions): Promise<CollectionPost[]>;
-    getBulk(ids: string[], transaction?: Knex.Transaction): Promise<CollectionPost[]>;
 }
 
 export class CollectionsService {
@@ -392,8 +391,10 @@ export class CollectionsService {
     }
 
     async updatePostsInCollections(postIds: string[], collections: Collection[], transaction: Knex.Transaction) {
-        const posts = await this.postsRepository.getBulk(postIds, transaction);
-
+        const posts = await this.postsRepository.getAll({
+            filter: `id:[${postIds.join(',')}]`,
+            transaction: transaction
+        });
 
         for (const collection of collections) {
             for (const post of posts) {

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -23,8 +23,7 @@ const messages = {
 };
 
 interface SlugService {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    generate(desired: string, options: {transaction: any}): Promise<string>;
+    generate(desired: string, options: {transaction: Knex.Transaction}): Promise<string>;
 }
 
 type CollectionsServiceDeps = {
@@ -95,12 +94,12 @@ type QueryOptions = {
     include?: string;
     page?: number;
     limit?: number;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    transaction?: any;
+    transaction?: Knex.Transaction;
 }
 
 interface PostsRepository {
     getAll(options: QueryOptions): Promise<CollectionPost[]>;
+    getBulk(ids: string[], transaction?: Knex.Transaction): Promise<CollectionPost[]>;
 }
 
 export class CollectionsService {

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -368,7 +368,7 @@ export class CollectionsService {
                 return;
             }
 
-            this.updatePostsInCollections(postIds, collections, transaction);
+            await this.updatePostsInCollections(postIds, collections, transaction);
         });
     }
 
@@ -386,7 +386,7 @@ export class CollectionsService {
                 return;
             }
 
-            this.updatePostsInCollections(postIds, collections, transaction);
+            await this.updatePostsInCollections(postIds, collections, transaction);
         });
     }
 

--- a/ghost/collections/test/fixtures/PostsRepositoryInMemory.ts
+++ b/ghost/collections/test/fixtures/PostsRepositoryInMemory.ts
@@ -10,10 +10,4 @@ export class PostsRepositoryInMemory extends InMemoryRepository<string, Collecti
             tags: entity.tags.map(tag => tag.slug)
         };
     }
-
-    async getBulk(ids: string[]) {
-        return this.getAll({
-            filter: `id:[${ids.join(',')}]`
-        });
-    }
 }

--- a/ghost/collections/test/fixtures/PostsRepositoryInMemory.ts
+++ b/ghost/collections/test/fixtures/PostsRepositoryInMemory.ts
@@ -10,4 +10,10 @@ export class PostsRepositoryInMemory extends InMemoryRepository<string, Collecti
             tags: entity.tags.map(tag => tag.slug)
         };
     }
+
+    async getBulk(ids: string[]) {
+        return this.getAll({
+            filter: `id:[${ids.join(',')}]`
+        });
+    }
 }

--- a/ghost/core/test/e2e-api/admin/posts-bulk.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-bulk.test.js
@@ -6,6 +6,7 @@ describe('Posts Bulk API', function () {
     let agent;
 
     before(async function () {
+        mockManager.mockLabsEnabled('collections');
         agent = await agentProvider.getAdminAPIAgent();
 
         // Note that we generate lots of fixtures here to test the bulk deletion correctly

--- a/ghost/in-memory-repository/test/InMemoryRepository.test.ts
+++ b/ghost/in-memory-repository/test/InMemoryRepository.test.ts
@@ -6,6 +6,7 @@ type SimpleEntity = {
     deleted: boolean;
     name: string;
     age: number;
+    birthday: string;
 }
 
 class SimpleInMemoryRepository extends InMemoryRepository<string, SimpleEntity> {
@@ -15,7 +16,8 @@ class SimpleInMemoryRepository extends InMemoryRepository<string, SimpleEntity> 
     protected toPrimitive(entity: SimpleEntity): object {
         return {
             name: entity.name,
-            age: entity.age
+            age: entity.age,
+            birthday: entity.birthday
         };
     }
 }
@@ -29,7 +31,8 @@ describe('InMemoryRepository', function () {
                 id: '1',
                 deleted: false,
                 name: 'John',
-                age: 30
+                age: 30,
+                birthday: new Date('2000-01-01').toISOString()
             };
 
             await repository.save(entity);
@@ -48,7 +51,8 @@ describe('InMemoryRepository', function () {
                 id: '2',
                 deleted: false,
                 name: 'John',
-                age: 24
+                age: 24,
+                birthday: new Date('2000-01-01').toISOString()
             };
 
             await repository.save(entity);
@@ -72,7 +76,8 @@ describe('InMemoryRepository', function () {
                 id: '3',
                 deleted: false,
                 name: 'Egg',
-                age: 180
+                age: 180,
+                birthday: new Date('2010-01-01').toISOString()
             };
 
             await repository.save(entity);
@@ -95,17 +100,20 @@ describe('InMemoryRepository', function () {
             id: '1',
             deleted: false,
             name: 'Kym',
-            age: 24
+            age: 24,
+            birthday: new Date('2000-01-01').toISOString()
         }, {
             id: '2',
             deleted: false,
             name: 'John',
-            age: 30
+            age: 30,
+            birthday: new Date('2000-01-01').toISOString()
         }, {
             id: '3',
             deleted: false,
             name: 'Kevin',
-            age: 5
+            age: 5,
+            birthday: new Date('2000-01-01').toISOString()
         }];
 
         for (const entity of entities) {
@@ -126,29 +134,34 @@ describe('InMemoryRepository', function () {
         assert(result[2].age === 5);
     });
 
-    it('Can save and retrieve a page of entities', async function () {
+    it('Can save and retrieve a filtered page of entities', async function () {
         const repository = new SimpleInMemoryRepository();
-        const entities = [{
-            id: '1',
-            deleted: false,
-            name: 'John',
-            age: 30
-        }, {
-            id: '2',
-            deleted: false,
-            name: 'Kym',
-            age: 24
-        }, {
-            id: '3',
-            deleted: false,
-            name: 'Egg',
-            age: 180
-        }, {
-            id: '4',
-            deleted: false,
-            name: 'Kevin',
-            age: 36
-        }];
+        const entities = [
+            {
+                id: '3',
+                deleted: false,
+                name: 'Egg',
+                age: 180,
+                birthday: new Date('2010-01-01').toISOString()
+            }, {
+                id: '1',
+                deleted: false,
+                name: 'John',
+                age: 30,
+                birthday: new Date('2000-01-01').toISOString()
+            }, {
+                id: '2',
+                deleted: false,
+                name: 'Kym',
+                age: 24,
+                birthday: new Date('2000-01-01').toISOString()
+            }, {
+                id: '4',
+                deleted: false,
+                name: 'Kevin',
+                age: 36,
+                birthday: new Date('2010-01-01').toISOString()
+            }];
 
         for (const entity of entities) {
             await repository.save(entity);
@@ -171,5 +184,20 @@ describe('InMemoryRepository', function () {
         assert(result);
         assert(result.length === 3);
         assert(count === 1);
+
+        const resultBirthdayFilter = await repository.getPage({
+            filter: 'birthday:>2005-01-01T00:00:00.000Z',
+            page: 1,
+            limit: 3,
+            order: [{
+                field: 'age',
+                direction: 'asc'
+            }]
+        });
+
+        assert(resultBirthdayFilter);
+        assert.equal(resultBirthdayFilter.length, 2);
+        assert.equal(resultBirthdayFilter[0].name, 'Kevin');
+        assert.equal(resultBirthdayFilter[1].name, 'Egg');
     });
 });

--- a/ghost/post-events/.eslintrc.js
+++ b/ghost/post-events/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node'
+    ]
+};

--- a/ghost/post-events/README.md
+++ b/ghost/post-events/README.md
@@ -1,0 +1,23 @@
+# Post Events
+
+Post Entity Domain events
+
+
+## Usage
+
+
+## Develop
+
+This is a monorepo package.
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests
+

--- a/ghost/post-events/package.json
+++ b/ghost/post-events/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
     "build": "tsc",
-    "prepare": "tsc",
+    "build:ts": "yarn build",
     "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura mocha -r ts-node/register './test/**/*.test.ts'",
     "test": "yarn test:types && yarn test:unit",
     "test:types": "tsc --noEmit",

--- a/ghost/post-events/package.json
+++ b/ghost/post-events/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@tryghost/post-events",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/post-events",
+  "author": "Ghost Foundation",
+  "private": true,
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "dev": "tsc --watch --preserveWatchOutput --sourceMap",
+    "build": "tsc",
+    "prepare": "tsc",
+    "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --100 --reporter text --reporter cobertura mocha -r ts-node/register './test/**/*.test.ts'",
+    "test": "yarn test:types && yarn test:unit",
+    "test:types": "tsc --noEmit",
+    "lint:code": "eslint src/ --ext .ts --cache",
+    "lint": "yarn lint:code && yarn lint:test",
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .ts --cache"
+  },
+  "files": [
+    "build"
+  ],
+  "devDependencies": {
+    "c8": "8.0.0",
+    "mocha": "10.2.0",
+    "sinon": "15.2.0",
+    "ts-node": "10.9.1",
+    "typescript": "5.1.6"
+  },
+  "dependencies": {}
+}

--- a/ghost/post-events/src/PostsBulkDestroyedEvent.ts
+++ b/ghost/post-events/src/PostsBulkDestroyedEvent.ts
@@ -1,0 +1,13 @@
+export class PostsBulkDestroyedEvent {
+    data: string[];
+    timestamp: Date;
+
+    constructor(data: string[], timestamp: Date) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    static create(data: string[], timestamp = new Date()) {
+        return new PostsBulkDestroyedEvent(data, timestamp);
+    }
+}

--- a/ghost/post-events/src/PostsBulkFeaturedEvent.ts
+++ b/ghost/post-events/src/PostsBulkFeaturedEvent.ts
@@ -1,0 +1,13 @@
+export class PostsBulkFeaturedEvent {
+    data: string[];
+    timestamp: Date;
+
+    constructor(data: string[], timestamp: Date) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    static create(data: string[], timestamp = new Date()) {
+        return new PostsBulkFeaturedEvent(data, timestamp);
+    }
+}

--- a/ghost/post-events/src/PostsBulkUnfeaturedEvent.ts
+++ b/ghost/post-events/src/PostsBulkUnfeaturedEvent.ts
@@ -1,0 +1,13 @@
+export class PostsBulkUnfeaturedEvent {
+    data: string[];
+    timestamp: Date;
+
+    constructor(data: string[], timestamp: Date) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    static create(data: string[], timestamp = new Date()) {
+        return new PostsBulkUnfeaturedEvent(data, timestamp);
+    }
+}

--- a/ghost/post-events/src/PostsBulkUnpublishedEvent.ts
+++ b/ghost/post-events/src/PostsBulkUnpublishedEvent.ts
@@ -1,0 +1,13 @@
+export class PostsBulkUnpublishedEvent {
+    data: string[];
+    timestamp: Date;
+
+    constructor(data: string[], timestamp: Date) {
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    static create(data: string[], timestamp = new Date()) {
+        return new PostsBulkUnpublishedEvent(data, timestamp);
+    }
+}

--- a/ghost/post-events/src/index.ts
+++ b/ghost/post-events/src/index.ts
@@ -1,0 +1,1 @@
+export * from './PostsBulkDestroyedEvent';

--- a/ghost/post-events/src/index.ts
+++ b/ghost/post-events/src/index.ts
@@ -1,1 +1,4 @@
 export * from './PostsBulkDestroyedEvent';
+export * from './PostsBulkUnpublishedEvent';
+export * from './PostsBulkFeaturedEvent';
+export * from './PostsBulkUnfeaturedEvent';

--- a/ghost/post-events/test/.eslintrc.js
+++ b/ghost/post-events/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/ghost/post-events/test/post-events.test.ts
+++ b/ghost/post-events/test/post-events.test.ts
@@ -1,9 +1,32 @@
 import assert from 'assert/strict';
-import {PostsBulkDestroyedEvent} from '../src/index';
+import {
+    PostsBulkDestroyedEvent,
+    PostsBulkUnpublishedEvent,
+    PostsBulkFeaturedEvent,
+    PostsBulkUnfeaturedEvent
+} from '../src/index';
 
 describe('Post Events', function () {
     it('Can instantiate BulkDestroyEvent', function () {
         const event = PostsBulkDestroyedEvent.create(['1', '2', '3']);
+        assert.ok(event);
+        assert.equal(event.data.length, 3);
+    });
+
+    it('Can instantiate PostsBulkUnpublishedEvent', function () {
+        const event = PostsBulkUnpublishedEvent.create(['1', '2', '3']);
+        assert.ok(event);
+        assert.equal(event.data.length, 3);
+    });
+
+    it('Can instantiate PostsBulkFeaturedEvent', function () {
+        const event = PostsBulkFeaturedEvent.create(['1', '2', '3']);
+        assert.ok(event);
+        assert.equal(event.data.length, 3);
+    });
+
+    it('Can instantiate PostsBulkUnfeaturedEvent', function () {
+        const event = PostsBulkUnfeaturedEvent.create(['1', '2', '3']);
         assert.ok(event);
         assert.equal(event.data.length, 3);
     });

--- a/ghost/post-events/test/post-events.test.ts
+++ b/ghost/post-events/test/post-events.test.ts
@@ -1,0 +1,10 @@
+import assert from 'assert/strict';
+import {PostsBulkDestroyedEvent} from '../src/index';
+
+describe('Post Events', function () {
+    it('Can instantiate BulkDestroyEvent', function () {
+        const event = PostsBulkDestroyedEvent.create(['1', '2', '3']);
+        assert.ok(event);
+        assert.equal(event.data.length, 3);
+    });
+});

--- a/ghost/post-events/tsconfig.json
+++ b/ghost/post-events/tsconfig.json
@@ -1,0 +1,110 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": ["es2019"],                                      /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "rootDir": "src",                                    /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    "resolveJsonModule": true,                           /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "build",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    "noImplicitAny": true,                               /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  "include": ["src/**/*"]
+}

--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -4,6 +4,8 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const ObjectId = require('bson-objectid').default;
 const pick = require('lodash/pick');
+const DomainEvents = require('@tryghost/domain-events/lib/DomainEvents');
+const {PostsBulkDestroyedEvent} = require('@tryghost/post-events');
 
 const messages = {
     invalidVisibilityFilter: 'Invalid visibility filter.',
@@ -385,7 +387,12 @@ class PostsService {
 
         // Posts and emails
         await this.models.Post.bulkDestroy(deleteEmailIds, 'emails', {transacting: options.transacting, throwErrors: true});
-        return await this.models.Post.bulkDestroy(deleteIds, 'posts', {...options, throwErrors: true});
+        const result = await this.models.Post.bulkDestroy(deleteIds, 'posts', {...options, throwErrors: true});
+
+        const event = PostsBulkDestroyedEvent.create(deleteIds);
+        DomainEvents.dispatch(event);
+
+        return result;
     }
 
     async export(frame) {

--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -5,7 +5,12 @@ const errors = require('@tryghost/errors');
 const ObjectId = require('bson-objectid').default;
 const pick = require('lodash/pick');
 const DomainEvents = require('@tryghost/domain-events/lib/DomainEvents');
-const {PostsBulkDestroyedEvent} = require('@tryghost/post-events');
+const {
+    PostsBulkDestroyedEvent,
+    PostsBulkUnpublishedEvent,
+    PostsBulkFeaturedEvent,
+    PostsBulkUnfeaturedEvent
+} = require('@tryghost/post-events');
 
 const messages = {
     invalidVisibilityFilter: 'Invalid visibility filter.',
@@ -456,6 +461,23 @@ class PostsService {
                 transacting: options.transacting,
                 throwErrors: true
             });
+        }
+
+        if (options.actionName) {
+            let bulkActionEvent;
+            switch (options.actionName) {
+            case 'unpublished':
+                bulkActionEvent = PostsBulkUnpublishedEvent.create(editIds);
+                break;
+            case 'featured':
+                bulkActionEvent = PostsBulkFeaturedEvent.create(editIds);
+                break;
+            case 'unfeatured':
+                bulkActionEvent = PostsBulkUnfeaturedEvent.create(editIds);
+                break;
+            }
+
+            DomainEvents.dispatch(bulkActionEvent);
         }
 
         return result;

--- a/ghost/posts-service/package.json
+++ b/ghost/posts-service/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@tryghost/errors": "1.2.24",
     "@tryghost/nql": "0.11.0",
+    "@tryghost/post-events": "0.0.0",
     "@tryghost/tpl": "0.1.24",
     "bson-objectid": "2.0.4"
   }


### PR DESCRIPTION
closes https://github.com/TryGhost/Arch/issues/16

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca51677</samp>

This pull request introduces a new package `@tryghost/post-events` that contains the post entity domain events, such as `PostsBulkDestroyedEvent`. It also adds a feature that updates the collections when posts are deleted in bulk, using the `PostsBulkDestroyedEvent` to trigger the `CollectionsService`. It also adds unit tests and linting configurations for the new package and the feature.
