### PR TITLE
Added Collections Content API

### DIFF
--- a/ghost/core/core/server/api/endpoints/collections-public.js
+++ b/ghost/core/core/server/api/endpoints/collections-public.js
@@ -1,0 +1,53 @@
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+const collectionsService = require('../../services/collections');
+
+const messages = {
+    collectionNotFound: 'Collection not found.'
+};
+
+module.exports = {
+    docName: 'collections',
+
+    readBySlug: {
+        headers: {
+            cacheInvalidate: false
+        },
+        data: [
+            'slug'
+        ],
+        permissions: true,
+        async query(frame) {
+            const model = await collectionsService.api.getBySlug(frame.data.slug);
+
+            if (!model) {
+                throw new errors.NotFoundError({
+                    message: tpl(messages.collectionNotFound)
+                });
+            }
+
+            return model;
+        }
+    },
+
+    readById: {
+        headers: {
+            cacheInvalidate: false
+        },
+        data: [
+            'id'
+        ],
+        permissions: true,
+        async query(frame) {
+            const model = await collectionsService.api.getById(frame.data.id);
+
+            if (!model) {
+                throw new errors.NotFoundError({
+                    message: tpl(messages.collectionNotFound)
+                });
+            }
+
+            return model;
+        }
+    }
+};

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -217,6 +217,10 @@ module.exports = {
         return apiFramework.pipeline(require('./pages-public'), localUtils, 'content');
     },
 
+    get collectionsPublic() {
+        return apiFramework.pipeline(require('./collections-public'), localUtils);
+    },
+
     get tagsPublic() {
         return apiFramework.pipeline(require('./tags-public'), localUtils, 'content');
     },

--- a/ghost/core/core/server/web/api/endpoints/content/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/content/routes.js
@@ -39,5 +39,8 @@ module.exports = function apiRoutes() {
     router.get('/tiers', mw.authenticatePublic, http(api.tiersPublic.browse));
     router.get('/offers/:id', mw.authenticatePublic, http(api.offersPublic.read));
 
+    router.get('/collections/:id', mw.authenticatePublic, http(api.collectionsPublic.readById));
+    router.get('/collections/slug/:slug', mw.authenticatePublic, http(api.collectionsPublic.readBySlug));
+
     return router;
 };

--- a/ghost/core/test/e2e-api/content/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/content/__snapshots__/collections.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Collections Content API Can request a collection by slug and id 1: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": "Featured posts",
+      "feature_image": null,
+      "filter": "featured:true",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "slug": "featured",
+      "title": "Featured",
+      "type": "automatic",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+}
+`;
+
+exports[`Collections Content API Can request a collection by slug and id 2: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": "Featured posts",
+      "feature_image": null,
+      "filter": "featured:true",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "slug": "featured",
+      "title": "Featured",
+      "type": "automatic",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+}
+`;

--- a/ghost/core/test/e2e-api/content/collections.test.js
+++ b/ghost/core/test/e2e-api/content/collections.test.js
@@ -1,0 +1,34 @@
+const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {anyISODateTime, anyObjectId} = matchers;
+
+const collectionMatcher = {
+    id: anyObjectId,
+    created_at: anyISODateTime,
+    updated_at: anyISODateTime
+};
+
+describe('Collections Content API', function () {
+    let agent;
+
+    before(async function () {
+        agent = await agentProvider.getContentAPIAgent();
+        await fixtureManager.init('users', 'api_keys');
+        await agent.authenticate();
+    });
+
+    it('Can request a collection by slug and id', async function () {
+        const {body: {collections: [collection]}} = await agent
+            .get(`collections/slug/featured`)
+            .expectStatus(200)
+            .matchBodySnapshot({
+                collections: [collectionMatcher]
+            });
+
+        await agent
+            .get(`collections/${collection.id}`)
+            .expectStatus(200)
+            .matchBodySnapshot({
+                collections: [collectionMatcher]
+            });
+    });
+});


### PR DESCRIPTION
The only usecases we need to support at the moment are reading individual
collections by ID and by Slug. We can extend this API as we get more usescases
in future.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ebb235</samp>

This pull request adds a new feature to the content API that allows querying public collections of posts. It implements the API endpoints, the routes, and the tests for the feature. It also updates the index file of the API endpoints to expose the new module.
