### PR TITLE
Fixed new package detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           filters: |
             new-package:
-              - added: 'ghost/*'
+              - added: 'ghost/**/package.json'
 
       - name: Determine changed packages
         uses: AurorNZ/paths-filter@v3.0.1


### PR DESCRIPTION
- turns out new packages folders aren't generating an `A` status in `git diff`, so this line never worked
- if we create a `package.json` file, we can reasonably assume we're creating a new package, so this should fix the issues we were seeing with caching + new packages

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6bf2570</samp>

Improved the filter for new packages in the `ci.yml` workflow. This avoids unnecessary npm publishing for non-package files under `ghost`.
