### PR TITLE
Supported `?include=count.posts` for Collections API

### DIFF
--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -17,8 +17,16 @@ module.exports = {
             'limit',
             'order',
             'page',
-            'filter'
+            'filter',
+            'include'
         ],
+        validation: {
+            options: {
+                include: {
+                    values: ['count.posts']
+                }
+            }
+        },
         permissions: true,
         query(frame) {
             return collectionsService.api.getAll(frame.options);
@@ -29,10 +37,20 @@ module.exports = {
         headers: {
             cacheInvalidate: false
         },
+        options: [
+            'include'
+        ],
         data: [
             'id',
             'slug'
         ],
+        validation: {
+            options: {
+                include: {
+                    values: ['count.posts']
+                }
+            }
+        },
         permissions: true,
         async query(frame) {
             let model;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/collections.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/collections.js
@@ -4,7 +4,7 @@
  *
  * @returns {SerializedCollection}
  */
-const mapper = (collection) => {
+const mapper = (collection, frame) => {
     let json;
     if (collection.toJSON) {
         json = collection.toJSON();
@@ -23,6 +23,12 @@ const mapper = (collection) => {
         created_at: (json.created_at || json.createdAt).toISOString().replace(/\d{3}Z$/, '000Z'),
         updated_at: (json.updated_at || json.updatedAt).toISOString().replace(/\d{3}Z$/, '000Z')
     };
+
+    if (frame?.options?.withRelated?.includes('count.posts')) {
+        serialized.count = {
+            posts: json.posts.length
+        };
+    }
 
     return serialized;
 };

--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -1145,26 +1145,15 @@ Object {
       "type": "automatic",
       "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
     },
-    Object {
-      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-      "description": "Test Collection Description",
-      "feature_image": null,
-      "filter": null,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "slug": "test-collection",
-      "title": "Test Collection",
-      "type": "manual",
-      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
-    },
   ],
   "meta": Object {
     "pagination": Object {
-      "limit": 3,
+      "limit": 2,
       "next": null,
       "page": 1,
       "pages": 1,
       "prev": null,
-      "total": 3,
+      "total": 2,
     },
   },
 }
@@ -1174,7 +1163,7 @@ exports[`Collections API Browse Can browse Collections 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "838",
+  "content-length": "578",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -1172,6 +1172,64 @@ Object {
 }
 `;
 
+exports[`Collections API Browse Can browse Collections and include the posts count 1: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "count": Object {
+        "posts": 13,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": "All posts",
+      "feature_image": null,
+      "filter": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "slug": "latest",
+      "title": "Latest",
+      "type": "automatic",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+    Object {
+      "count": Object {
+        "posts": 2,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": "Featured posts",
+      "feature_image": null,
+      "filter": "featured:true",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "slug": "featured",
+      "title": "Featured",
+      "type": "automatic",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+  "meta": Object {
+    "pagination": Object {
+      "limit": 2,
+      "next": null,
+      "page": 1,
+      "pages": 1,
+      "prev": null,
+      "total": 2,
+    },
+  },
+}
+`;
+
+exports[`Collections API Browse Can browse Collections and include the posts count 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "619",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Collections API Can add a Collection 1: [body] 1`] = `
 Object {
   "collections": Array [
@@ -1370,6 +1428,74 @@ Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "268",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Collections API Can read a Collection by id and slug and include the post counts 1: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "count": Object {
+        "posts": 2,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": "Featured posts",
+      "feature_image": null,
+      "filter": "featured:true",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "slug": "featured",
+      "title": "Featured",
+      "type": "automatic",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can read a Collection by id and slug and include the post counts 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "284",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Collections API Can read a Collection by id and slug and include the post counts 3: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "count": Object {
+        "posts": 2,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": "Featured posts",
+      "feature_image": null,
+      "filter": "featured:true",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "slug": "featured",
+      "title": "Featured",
+      "type": "automatic",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+}
+`;
+
+exports[`Collections API Can read a Collection by id and slug and include the post counts 4: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "284",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -102,6 +102,22 @@ describe('Collections API', function () {
                     ]
                 });
         });
+
+        it('Can browse Collections and include the posts count', async function () {
+            await agent
+                .get('/collections/?include=count.posts')
+                .expectStatus(200)
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                })
+                .matchBodySnapshot({
+                    collections: [
+                        {...matchCollection, count: {posts: 13}},
+                        {...matchCollection, count: {posts: 2}}
+                    ]
+                });
+        });
     });
 
     it('Can read a Collection by id and slug', async function () {
@@ -156,6 +172,38 @@ describe('Collections API', function () {
         await agent
             .delete(`/collections/${collectionId}/`)
             .expectStatus(204);
+    });
+
+    it('Can read a Collection by id and slug and include the post counts', async function () {
+        const {body: {collections: [collection]}} = await agent.get(`/collections/slug/featured/?include=count.posts`)
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                collections: [{
+                    ...matchCollection,
+                    count: {
+                        posts: 2
+                    }
+                }]
+            });
+
+        await agent.get(`/collections/${collection.id}/?include=count.posts`)
+            .expectStatus(200)
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag
+            })
+            .matchBodySnapshot({
+                collections: [{
+                    ...matchCollection,
+                    count: {
+                        posts: 2
+                    }
+                }]
+            });
     });
 
     describe('Edit', function () {

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -66,7 +66,7 @@ describe('Collections API', function () {
             description: 'Test Collection Description'
         };
 
-        await agent
+        const {body: {collections: [{id: collectionId}]}} = await agent
             .post('/collections/')
             .body({
                 collections: [collection]
@@ -80,6 +80,10 @@ describe('Collections API', function () {
             .matchBodySnapshot({
                 collections: [matchCollection]
             });
+
+        await agent
+            .delete(`/collections/${collectionId}/`)
+            .expectStatus(204);
     });
 
     describe('Browse', function () {
@@ -93,7 +97,6 @@ describe('Collections API', function () {
                 })
                 .matchBodySnapshot({
                     collections: [
-                        matchCollection,
                         matchCollection,
                         matchCollection
                     ]


### PR DESCRIPTION
Unfortuantely our framework is bookshelf centric so we have to refer to the
`withRelated` property rather than a more generic `include` property.

--- 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebfb923</samp>

This pull request adds the ability to fetch the number of posts in each collection via the `browse` endpoint for collections. It updates the `mapper` function for collections, the `collections.js` endpoint file, and the `collections.test.js` file to support the new `include` option with `count.posts`.
