### PR TITLE
Mapped tag.deleted event to TagDeletedEvent

### DIFF
--- a/ghost/collections/src/events/TagDeletedEvent.ts
+++ b/ghost/collections/src/events/TagDeletedEvent.ts
@@ -1,0 +1,15 @@
+export class TagDeletedEvent {
+    id: string;
+    data: {slug: string, id: string};
+    timestamp: Date;
+
+    constructor(data: {slug: string, id: string}, timestamp: Date) {
+        this.id = data.id;
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    static create(data: any, timestamp = new Date()) {
+        return new TagDeletedEvent(data, timestamp);
+    }
+}

--- a/ghost/collections/src/index.ts
+++ b/ghost/collections/src/index.ts
@@ -4,3 +4,4 @@ export * from './Collection';
 export * from './events/PostDeletedEvent';
 export * from './events/PostAddedEvent';
 export * from './events/PostEditedEvent';
+export * from './events/TagDeletedEvent';

--- a/ghost/collections/test/TagDeletedEvent.test.ts
+++ b/ghost/collections/test/TagDeletedEvent.test.ts
@@ -1,0 +1,13 @@
+import assert from 'assert/strict';
+import {TagDeletedEvent} from '../src';
+
+describe('TagDeletedEvent', function () {
+    it('should create a TagDeletedEvent', function () {
+        const event = TagDeletedEvent.create({id: '1', slug: 'tag-1'});
+
+        const actual = event instanceof TagDeletedEvent;
+        const expected = true;
+
+        assert.equal(actual, expected, 'TagDeletedEvent.create() did not return an instance of TagDeletedEvent');
+    });
+});

--- a/ghost/model-to-domain-event-interceptor/src/ModelToDomainEventInterceptor.ts
+++ b/ghost/model-to-domain-event-interceptor/src/ModelToDomainEventInterceptor.ts
@@ -1,4 +1,4 @@
-import { PostDeletedEvent, PostAddedEvent, PostEditedEvent } from '@tryghost/collections';
+import { PostDeletedEvent, PostAddedEvent, PostEditedEvent, TagDeletedEvent } from '@tryghost/collections';
 
 type ModelToDomainEventInterceptorDeps = {
     ModelEvents: {
@@ -25,7 +25,8 @@ export class ModelToDomainEventInterceptor {
             'post.deleted',
             'post.edited',
             // NOTE: currently unmapped and unused event
-            'tag.added'
+            'tag.added',
+            'tag.deleted'
         ];
 
         for (const modelEventName of ghostModelUpdateEvents) {
@@ -82,6 +83,9 @@ export class ModelToDomainEventInterceptor {
                     }))
                 }
             });
+            break;
+        case 'tag.deleted':
+            event = TagDeletedEvent.create({id: data.id, slug: data.attributes.slug});
             break;
         default:
         }

--- a/ghost/model-to-domain-event-interceptor/test/model-to-domain-event-interceptor.test.ts
+++ b/ghost/model-to-domain-event-interceptor/test/model-to-domain-event-interceptor.test.ts
@@ -5,7 +5,8 @@ import DomainEvents from '@tryghost/domain-events';
 import {
     PostDeletedEvent,
     PostEditedEvent,
-    PostAddedEvent
+    PostAddedEvent,
+    TagDeletedEvent
 } from '@tryghost/collections';
 
 import {ModelToDomainEventInterceptor} from '../src';
@@ -142,6 +143,34 @@ describe('ModelToDomainEventInterceptor', function () {
 
         eventRegistry.emit('post.deleted', {
             id: '1234-deleted'
+        });
+
+        await DomainEvents.allSettled();
+
+        assert.ok(interceptedEvent);
+    });
+
+    it('Intercepts tag.deleted Model event and dispatches TagDeletedEvent Domain event', async function () {
+        let eventRegistry = new EventRegistry();
+        const modelToDomainEventInterceptor = new ModelToDomainEventInterceptor({
+            ModelEvents: eventRegistry,
+            DomainEvents: DomainEvents
+        });
+
+        modelToDomainEventInterceptor.init();
+
+        let interceptedEvent;
+        DomainEvents.subscribe(TagDeletedEvent, (event: TagDeletedEvent) => {
+            assert.equal(event.id, '1234-deleted');
+            assert.equal(event.data.slug, 'tag-slug');
+            interceptedEvent = event;
+        });
+
+        eventRegistry.emit('tag.deleted', {
+            id: '1234-deleted',
+            attributes: {
+                slug: 'tag-slug'
+            }
         });
 
         await DomainEvents.allSettled();

--- a/ghost/model-to-domain-event-interceptor/test/model-to-domain-event-interceptor.test.ts
+++ b/ghost/model-to-domain-event-interceptor/test/model-to-domain-event-interceptor.test.ts
@@ -2,11 +2,11 @@ import assert from 'assert/strict';
 import events from 'events';
 import sinon from 'sinon';
 import DomainEvents from '@tryghost/domain-events';
-const {
+import {
     PostDeletedEvent,
     PostEditedEvent,
     PostAddedEvent
-} = require('@tryghost/collections');
+} from '@tryghost/collections';
 
 import {ModelToDomainEventInterceptor} from '../src';
 


### PR DESCRIPTION
Because the tags system is still written in the old way, the tag.deleted
bookshelf event needs to be mapped to the DomainEvents to bridge the gap with
the collections package.

---

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0f9bed</samp>

This pull request adds a new domain event `TagDeletedEvent` to the `@tryghost/collections` package and integrates it with the `ModelToDomainEventInterceptor` class. The purpose is to enable other parts of the system to listen and react to tag deletion events in a consistent and decoupled way. The pull request also includes unit tests for the new functionality.
