### PR TITLE
Added test email rate limiting

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -314,6 +314,7 @@ module.exports = function apiRoutes() {
 
     // ## Email Preview
     router.get('/email_previews/posts/:id', mw.authAdminApi, http(api.email_previews.read));
+    // preview sending have an additional rate limiter to prevent abuse
     router.post('/email_previews/posts/:id', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.email_previews.sendTestEmail));
 
     // ## Emails

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -314,7 +314,7 @@ module.exports = function apiRoutes() {
 
     // ## Email Preview
     router.get('/email_previews/posts/:id', mw.authAdminApi, http(api.email_previews.read));
-    router.post('/email_previews/posts/:id', mw.authAdminApi, http(api.email_previews.sendTestEmail));
+    router.post('/email_previews/posts/:id', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.email_previews.sendTestEmail));
 
     // ## Emails
     router.get('/emails', mw.authAdminApi, http(api.emails.browse));

--- a/ghost/core/core/server/web/shared/middleware/api/spam-prevention.js
+++ b/ghost/core/core/server/web/shared/middleware/api/spam-prevention.js
@@ -22,7 +22,7 @@ const messages = {
     },
     tooManyAttempts: 'Too many attempts.',
     webmentionsBlock: 'Too many mention attempts',
-    emailPreviewBlock: 'Only 10 preview emails can be sent per hour'
+    emailPreviewBlock: 'Only 10 test emails can be sent per hour'
 };
 let spamPrivateBlock = spam.private_block || {};
 let spamGlobalBlock = spam.global_block || {};

--- a/ghost/core/core/server/web/shared/middleware/api/spam-prevention.js
+++ b/ghost/core/core/server/web/shared/middleware/api/spam-prevention.js
@@ -21,7 +21,8 @@ const messages = {
         context: 'Too many login attempts.'
     },
     tooManyAttempts: 'Too many attempts.',
-    webmentionsBlock: 'Too many mention attempts'
+    webmentionsBlock: 'Too many mention attempts',
+    emailPreviewBlock: 'Only 10 preview emails can be sent per hour'
 };
 let spamPrivateBlock = spam.private_block || {};
 let spamGlobalBlock = spam.global_block || {};

--- a/ghost/core/core/server/web/shared/middleware/api/spam-prevention.js
+++ b/ghost/core/core/server/web/shared/middleware/api/spam-prevention.js
@@ -31,6 +31,7 @@ let spamUserLogin = spam.user_login || {};
 let spamMemberLogin = spam.member_login || {};
 let spamContentApiKey = spam.content_api_key || {};
 let spamWebmentionsBlock = spam.webmentions_block || {};
+let spamEmailPreviewBlock = spam.email_preview_block || {};
 
 let store;
 let memoryStore;
@@ -43,6 +44,7 @@ let membersAuthInstance;
 let membersAuthEnumerationInstance;
 let userResetInstance;
 let contentApiKeyInstance;
+let emailPreviewBlockInstance;
 
 const spamConfigKeys = ['freeRetries', 'minWait', 'maxWait', 'lifetime'];
 
@@ -150,6 +152,32 @@ const webmentionsBlock = () => {
     );
 
     return webmentionsBlockInstance;
+};
+
+const emailPreviewBlock = () => {
+    const ExpressBrute = require('express-brute');
+    const BruteKnex = require('brute-knex');
+    const db = require('../../../../data/db');
+
+    store = store || new BruteKnex({
+        tablename: 'brute',
+        createTable: false,
+        knex: db.knex
+    });
+
+    emailPreviewBlockInstance = emailPreviewBlockInstance || new ExpressBrute(store,
+        extend({
+            attachResetToRequest: false,
+            failCallback(req, res, next) {
+                return next(new errors.TooManyRequestsError({
+                    message: messages.emailPreviewBlock
+                }));
+            },
+            handleStoreError: handleStoreError
+        }, pick(spamEmailPreviewBlock, spamConfigKeys))
+    );
+
+    return emailPreviewBlockInstance;
 };
 
 const membersAuth = () => {
@@ -349,6 +377,7 @@ module.exports = {
     privateBlog: privateBlog,
     contentApiKey: contentApiKey,
     webmentionsBlock: webmentionsBlock,
+    emailPreviewBlock: emailPreviewBlock,
     reset: () => {
         store = undefined;
         memoryStore = undefined;

--- a/ghost/core/core/server/web/shared/middleware/brute.js
+++ b/ghost/core/core/server/web/shared/middleware/brute.js
@@ -117,5 +117,18 @@ module.exports = {
                 return _next('webmention_blocked');
             }
         })(req, res, next);
+    },
+
+    /**
+     * Blocks preview email spam
+     */
+
+    previewEmailLimiter(req, res, next) {
+        return spamPrevention.emailPreviewBlock().getMiddleware({
+            ignoreIP: false,
+            key(_req, _res, _next) {
+                return _next('preview_email_blocked');
+            }
+        })(req, res, next);
     }
 };

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -108,6 +108,12 @@
             "maxWait": 100,
             "lifetime": 1000,
             "freeRetries": 100
+        },
+        "email_preview_block": {
+            "minWait": 360000,
+            "maxWait": 360000,
+            "lifetime": 3600,
+            "freeRetries": 10
         }
     },
     "caching": {

--- a/ghost/core/core/shared/config/env/config.testing-browser.json
+++ b/ghost/core/core/shared/config/env/config.testing-browser.json
@@ -49,6 +49,12 @@
             "maxWait": 100000,
             "lifetime": 3600,
             "freeRetries": 3
+        },
+        "email_preview_block": {
+            "minWait": 360000,
+            "maxWait": 360000,
+            "lifetime": 3600,
+            "freeRetries": 10
         }
     },
     "privacy": {

--- a/ghost/core/core/shared/config/env/config.testing-browser.json
+++ b/ghost/core/core/shared/config/env/config.testing-browser.json
@@ -54,7 +54,7 @@
             "minWait": 360000,
             "maxWait": 360000,
             "lifetime": 3600,
-            "freeRetries": 100
+            "freeRetries": 10
         }
     },
     "privacy": {

--- a/ghost/core/core/shared/config/env/config.testing-browser.json
+++ b/ghost/core/core/shared/config/env/config.testing-browser.json
@@ -54,7 +54,7 @@
             "minWait": 360000,
             "maxWait": 360000,
             "lifetime": 3600,
-            "freeRetries": 10
+            "freeRetries": 100
         }
     },
     "privacy": {

--- a/ghost/core/core/shared/config/env/config.testing-mysql.json
+++ b/ghost/core/core/shared/config/env/config.testing-mysql.json
@@ -55,7 +55,7 @@
             "minWait": 360000,
             "maxWait": 360000,
             "lifetime": 3600,
-            "freeRetries": 100
+            "freeRetries": 10
         }
     },
     "privacy": {

--- a/ghost/core/core/shared/config/env/config.testing-mysql.json
+++ b/ghost/core/core/shared/config/env/config.testing-mysql.json
@@ -50,6 +50,12 @@
             "maxWait": 100000,
             "lifetime": 3600,
             "freeRetries": 3
+        },
+        "email_preview_block": {
+            "minWait": 360000,
+            "maxWait": 360000,
+            "lifetime": 3600,
+            "freeRetries": 100
         }
     },
     "privacy": {

--- a/ghost/core/core/shared/config/env/config.testing-mysql.json
+++ b/ghost/core/core/shared/config/env/config.testing-mysql.json
@@ -51,7 +51,6 @@
             "lifetime": 3600,
             "freeRetries": 3
         }
-
     },
     "privacy": {
         "useTinfoil": true,

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -49,6 +49,12 @@
             "maxWait": 100000,
             "lifetime": 3600,
             "freeRetries": 3
+        },
+        "email_preview_block": {
+            "minWait": 360000,
+            "maxWait": 360000,
+            "lifetime": 3600,
+            "freeRetries": 10
         }
     },
     "privacy": {

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -36,7 +36,7 @@
             "minWait": 3600000,
             "maxWait": 3600000,
             "lifetime": 3600,
-            "freeRetries":5
+            "freeRetries":4
         },
         "private_block": {
             "minWait": 3600000,

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -54,7 +54,7 @@
             "minWait": 360000,
             "maxWait": 360000,
             "lifetime": 3600,
-            "freeRetries": 10
+            "freeRetries": 100
         }
     },
     "privacy": {

--- a/ghost/core/core/shared/config/env/config.testing.json
+++ b/ghost/core/core/shared/config/env/config.testing.json
@@ -36,7 +36,7 @@
             "minWait": 3600000,
             "maxWait": 3600000,
             "lifetime": 3600,
-            "freeRetries":4
+            "freeRetries":5
         },
         "private_block": {
             "minWait": 3600000,
@@ -54,7 +54,7 @@
             "minWait": 360000,
             "maxWait": 360000,
             "lifetime": 3600,
-            "freeRetries": 100
+            "freeRetries": 10
         }
     },
     "privacy": {

--- a/ghost/core/test/e2e-api/admin/email-preview-rate-limiter.test.js
+++ b/ghost/core/test/e2e-api/admin/email-preview-rate-limiter.test.js
@@ -1,0 +1,49 @@
+const {agentProvider, fixtureManager, mockManager, configUtils} = require('../../utils/e2e-framework');
+const sinon = require('sinon');
+const DomainEvents = require('@tryghost/domain-events');
+
+async function allSettled() {
+    await DomainEvents.allSettled();
+}
+
+describe('Rate limiter', function () {
+    let agent;
+
+    afterEach(function () {
+        mockManager.restore();
+        sinon.restore();
+    });
+
+    beforeEach(function () {
+        mockManager.mockMailgun();
+    });
+
+    before(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users', 'newsletters', 'posts');
+        await agent.loginAsOwner();
+    });
+    
+    it('is rate limited against spammmer requests', async function () {
+        const testEmailSpamBlock = configUtils.config.get('spam').email_preview_block;
+        const requests = [];
+        for (let i = 0; i < testEmailSpamBlock.freeRetries + 1; i += 1) {
+            const req = await agent
+                .post(`email_previews/posts/${fixtureManager.get('posts', 0).id}/`)
+                .body({
+                    emails: ['test@ghost.org']
+                });
+            requests.push(req);
+        }
+        await Promise.all(requests);
+
+        await agent
+            .post(`email_previews/posts/${fixtureManager.get('posts', 0).id}/`)
+            .body({
+                emails: ['test@ghost.org']
+            })
+            .expectStatus(429);
+
+        await allSettled();
+    });
+});

--- a/ghost/core/test/e2e-api/admin/email-preview-rate-limiter.test.js
+++ b/ghost/core/test/e2e-api/admin/email-preview-rate-limiter.test.js
@@ -1,3 +1,5 @@
+// Decided to have this test separately from the other email preview tests since the rate limiter would interfere with the other tests
+
 const {agentProvider, fixtureManager, mockManager, configUtils} = require('../../utils/e2e-framework');
 const sinon = require('sinon');
 const DomainEvents = require('@tryghost/domain-events');

--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -1,4 +1,4 @@
-const {agentProvider, fixtureManager, matchers, mockManager, configUtils} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers, mockManager} = require('../../utils/e2e-framework');
 const {anyEtag, anyErrorId, anyContentVersion, anyString} = matchers;
 const assert = require('assert/strict');
 const sinon = require('sinon');
@@ -10,11 +10,6 @@ const ObjectId = require('bson-objectid').default;
 const testUtils = require('../../utils');
 const models = require('../../../core/server/models/index');
 const logging = require('@tryghost/logging');
-const DomainEvents = require('@tryghost/domain-events');
-
-async function allSettled() {
-    await DomainEvents.allSettled();
-}
 
 function testCleanedSnapshot(html, cleaned) {
     for (const [key, value] of Object.entries(cleaned)) {
@@ -345,33 +340,6 @@ describe('Email Preview API', function () {
                     }]
                 });
             sinon.assert.calledOnce(loggingStub);
-        });
-    });
-    describe('Rate limiter', function () {
-        before(async function () {
-            await agent.loginAsAdmin();
-        });
-        it('is rate limited against spammmer requests', async function () {
-            const testEmailSpamBlock = configUtils.config.get('spam').email_preview_block;
-            const requests = [];
-            for (let i = 0; i < testEmailSpamBlock.freeRetries + 1; i += 1) {
-                const req = await agent
-                    .post(`email_previews/posts/${fixtureManager.get('posts', 0).id}/`)
-                    .body({
-                        emails: ['test@ghost.org']
-                    });
-                requests.push(req);
-            }
-            await Promise.all(requests);
-
-            await agent
-                .post(`email_previews/posts/${fixtureManager.get('posts', 0).id}/`)
-                .body({
-                    emails: ['test@ghost.org']
-                })
-                .expectStatus(429);
-
-            await allSettled();
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -1,4 +1,4 @@
-const {agentProvider, fixtureManager, matchers, mockManager} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers, mockManager, configUtils} = require('../../utils/e2e-framework');
 const {anyEtag, anyErrorId, anyContentVersion, anyString} = matchers;
 const assert = require('assert/strict');
 const sinon = require('sinon');
@@ -10,6 +10,11 @@ const ObjectId = require('bson-objectid').default;
 const testUtils = require('../../utils');
 const models = require('../../../core/server/models/index');
 const logging = require('@tryghost/logging');
+const DomainEvents = require('@tryghost/domain-events');
+
+async function allSettled() {
+    await DomainEvents.allSettled();
+}
 
 function testCleanedSnapshot(html, cleaned) {
     for (const [key, value] of Object.entries(cleaned)) {
@@ -340,6 +345,33 @@ describe('Email Preview API', function () {
                     }]
                 });
             sinon.assert.calledOnce(loggingStub);
+        });
+    });
+    describe('Rate limiter', function () {
+        before(async function () {
+            await agent.loginAsAdmin();
+        });
+        it('is rate limited against spammmer requests', async function () {
+            const testEmailSpamBlock = configUtils.config.get('spam').email_preview_block;
+            const requests = [];
+            for (let i = 0; i < testEmailSpamBlock.freeRetries + 1; i += 1) {
+                const req = await agent
+                    .post(`email_previews/posts/${fixtureManager.get('posts', 0).id}/`)
+                    .body({
+                        emails: ['test@ghost.org']
+                    });
+                requests.push(req);
+            }
+            await Promise.all(requests);
+
+            await agent
+                .post(`email_previews/posts/${fixtureManager.get('posts', 0).id}/`)
+                .body({
+                    emails: ['test@ghost.org']
+                })
+                .expectStatus(429);
+
+            await allSettled();
         });
     });
 });

--- a/ghost/email-service/lib/EmailController.js
+++ b/ghost/email-service/lib/EmailController.js
@@ -4,7 +4,8 @@ const tpl = require('@tryghost/tpl');
 const messages = {
     postNotFound: 'Post not found.',
     noEmailsProvided: 'No emails provided.',
-    emailNotFound: 'Email not found.'
+    emailNotFound: 'Email not found.',
+    tooManyEmailsProvided: 'Too many emails provided. Maximum of 1 test email can be sent at once.'
 };
 
 class EmailController {
@@ -64,6 +65,13 @@ class EmailController {
         if (emails.length === 0) {
             throw new errors.ValidationError({
                 message: tpl(messages.noEmailsProvided)
+            });
+        }
+
+        // test emails are limited to 1
+        if (emails.length > 1) {
+            throw new errors.ValidationError({
+                message: tpl(messages.tooManyEmailsProvided)
             });
         }
 

--- a/ghost/email-service/test/email-controller.test.js
+++ b/ghost/email-service/test/email-controller.test.js
@@ -230,6 +230,34 @@ describe('Email Controller', function () {
             });
             assert.equal(result, undefined);
         });
+
+        it('throw if more than one email is provided', async function () {
+            const service = {
+                sendTestEmail: () => {
+                    return Promise.resolve({id: 'mail@id'});
+                }
+            };
+
+            const controller = new EmailController(service, {
+                models: {
+                    Post: createModelClass({
+                        findOne: {
+                            title: 'Post title'
+                        }
+                    }),
+                    Newsletter: createModelClass()
+                }
+            });
+
+            await assert.rejects(controller.sendTestEmail({
+                options: {},
+                data: {
+                    id: '123',
+                    newsletter: 'newsletter-slug',
+                    emails: ['example@example.com', 'example2@example.com']
+                }
+            }), /Too many emails provided. Maximum of 1 test email can be sent at once./);
+        });
     });
 
     describe('retryFailedEmail', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3651

- This is a security fix that addresses an issue causing malicious users to abuse the test / preview email API endpoint.
- We have multiple procedures in place now to limit such users.
- First, we now only allow one email address to be passed into the `sendTestEmail` method. This method only have one purpose, which is to compliment the test email functionality within the Editor in Admin and therefore have no reason to send to more than one email address at a time.
- We then add an additional rate limiter to prevent a user from making multiple requests, eg via a script.
- The new imposed limit is 10 test emails per hour.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f4b6db</samp>

No summary available (Limit exceeded: required to process 105780 tokens, but only 50000 are allowed per call)
