### PR TITLE
Enabled `no-explicit-any` for majority of packages

### DIFF
--- a/apps/signup-form/.eslintrc.cjs
+++ b/apps/signup-form/.eslintrc.cjs
@@ -9,14 +9,16 @@ module.exports = {
         'ghost',
         'tailwindcss'
     ],
+    settings: {
+        react: {
+            version: 'detect'
+        }
+    },
     rules: {
         // sort multiple import lines into alphabetical groups
         'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
             memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
         }],
-
-        // TODO: fix + remove this
-        '@typescript-eslint/no-explicit-any': 'warn',
 
         // suppress errors for missing 'import React' in JSX files, as we don't need it
         'react/react-in-jsx-scope': 'off',

--- a/apps/signup-form/src/App.tsx
+++ b/apps/signup-form/src/App.tsx
@@ -41,6 +41,7 @@ const App: React.FC<AppProps> = ({scriptTag}) => {
     };
 
     const PageComponent = pages[page.name];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data = page.data as any; // issue with TypeScript understanding the type here when passing it to the component
     return (
         <>

--- a/apps/signup-form/src/AppContext.ts
+++ b/apps/signup-form/src/AppContext.ts
@@ -21,10 +21,12 @@ export type AppContextType = {
     setPage: <T extends PageName>(name: T, data: ComponentProps<typeof pages[T]>) => void,
     options: SignupFormOptions,
     api: GhostApi,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     t: any,
     scriptTag: HTMLElement
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const AppContext = React.createContext<AppContextType>({} as any);
 
 export const AppContextProvider = AppContext.Provider;

--- a/apps/signup-form/src/Preview.stories.tsx
+++ b/apps/signup-form/src/Preview.stories.tsx
@@ -16,6 +16,7 @@ const Preview: React.FC<SignupFormOptions & {
         data: {}
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const _setPage = (name: PageName, data: any) => {
         setPage(() => ({
             name,
@@ -24,6 +25,7 @@ const Preview: React.FC<SignupFormOptions & {
     };
 
     const PageComponent = pages[page.name];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data = page.data as any;
 
     const i18n = i18nLib(options.locale || 'en', 'signup-form');

--- a/apps/signup-form/src/components/IFrame.tsx
+++ b/apps/signup-form/src/components/IFrame.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {Component} from 'react';
 import {createPortal} from 'react-dom';
 

--- a/apps/signup-form/test/e2e/attribution.test.ts
+++ b/apps/signup-form/test/e2e/attribution.test.ts
@@ -2,6 +2,7 @@ import {expect} from '@playwright/test';
 import {initialize} from '../utils/e2e';
 import {test} from '@playwright/test';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function testHistory({page, embeddedOnUrl, path, urlHistory, localStorageHistory}: {page: any, embeddedOnUrl?: string, path: string, urlHistory: any[], localStorageHistory?: any[]}) {
     const {frame, lastApiRequest} = await initialize({page, title: 'Sign up', embeddedOnUrl, path});
 

--- a/apps/signup-form/test/utils/e2e.ts
+++ b/apps/signup-form/test/utils/e2e.ts
@@ -4,6 +4,7 @@ import {Page} from '@playwright/test';
 const MOCKED_SITE_URL = 'https://localhost:1234';
 
 type LastApiRequest = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     body: null | any
 };
 
@@ -44,6 +45,7 @@ export async function initialize({page, path, apiStatus, embeddedOnUrl, ...optio
     };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function mockApi({page, status = 200}: {page: any, status?: number}) {
     const lastApiRequest: LastApiRequest = {
         body: null

--- a/ghost/collections/.eslintrc.js
+++ b/ghost/collections/.eslintrc.js
@@ -2,9 +2,5 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/ts'
-    ],
-    rules: {
-        // TODO: fix + remove this
-        '@typescript-eslint/no-explicit-any': 'warn',
-    }
+    ]
 };

--- a/ghost/collections/src/Collection.ts
+++ b/ghost/collections/src/Collection.ts
@@ -141,6 +141,7 @@ export class Collection {
         this._posts = [];
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private constructor(data: any) {
         this.id = data.id;
         this.title = data.title;
@@ -170,6 +171,7 @@ export class Collection {
         };
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     static validateDateField(date: any, fieldName: string): Date {
         if (!date) {
             return new Date();
@@ -184,6 +186,7 @@ export class Collection {
         });
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     static async create(data: any): Promise<Collection> {
         let id;
 

--- a/ghost/collections/src/CollectionRepository.ts
+++ b/ghost/collections/src/CollectionRepository.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {Collection} from './Collection';
 
 export interface CollectionRepository {

--- a/ghost/collections/src/CollectionsRepositoryInMemory.ts
+++ b/ghost/collections/src/CollectionsRepositoryInMemory.ts
@@ -6,6 +6,7 @@ export class CollectionsRepositoryInMemory extends InMemoryRepository<string, Co
         return entity.toJSON();
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     createTransaction(cb: (transaction: any) => Promise<any>): Promise<any> {
         return cb(null);
     }

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -22,6 +22,7 @@ const messages = {
 };
 
 interface SlugService {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     generate(desired: string, options: {transaction: any}): Promise<string>;
 }
 
@@ -30,6 +31,7 @@ type CollectionsServiceDeps = {
     postsRepository: PostsRepository;
     slugService: SlugService;
     DomainEvents: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         subscribe: (event: any, handler: (e: any) => void) => void;
     };
 };
@@ -92,6 +94,7 @@ type QueryOptions = {
     include?: string;
     page?: number;
     limit?: number;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     transaction?: any;
 }
 
@@ -103,6 +106,7 @@ export class CollectionsService {
     private collectionsRepository: CollectionRepository;
     private postsRepository: PostsRepository;
     private DomainEvents: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         subscribe: (event: any, handler: (e: any) => void) => void;
     };
     private uniqueChecker: RepositoryUniqueChecker;
@@ -134,7 +138,9 @@ export class CollectionsService {
         };
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private fromDTO(data: any): any {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const mappedDTO: {[index: string]:any} = {
             title: data.title,
             slug: data.slug,
@@ -308,6 +314,7 @@ export class CollectionsService {
         });
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async edit(data: any): Promise<CollectionDTO | null> {
         return await this.collectionsRepository.createTransaction(async (transaction) => {
             const collection = await this.collectionsRepository.getById(data.id, {transaction});
@@ -352,6 +359,7 @@ export class CollectionsService {
         return await this.collectionsRepository.getBySlug(slug);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async getAll(options?: QueryOptions): Promise<{data: CollectionDTO[], meta: any}> {
         const collections = await this.collectionsRepository.getAll(options);
 

--- a/ghost/collections/src/events/PostAddedEvent.ts
+++ b/ghost/collections/src/events/PostAddedEvent.ts
@@ -16,6 +16,7 @@ export class PostAddedEvent {
         this.timestamp = timestamp;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     static create(data: any, timestamp = new Date()) {
         return new PostAddedEvent(data, timestamp);
     }

--- a/ghost/collections/src/events/PostDeletedEvent.ts
+++ b/ghost/collections/src/events/PostDeletedEvent.ts
@@ -1,5 +1,6 @@
 export class PostDeletedEvent {
     id: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data: any;
     timestamp: Date;
 
@@ -9,6 +10,7 @@ export class PostDeletedEvent {
         this.timestamp = timestamp;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     static create(data: any, timestamp = new Date()) {
         return new PostDeletedEvent(data, timestamp);
     }

--- a/ghost/collections/src/events/PostEditedEvent.ts
+++ b/ghost/collections/src/events/PostEditedEvent.ts
@@ -23,12 +23,14 @@ export class PostEditedEvent {
     data: PostEditData;
     timestamp: Date;
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(data: any, timestamp: Date) {
         this.id = data.id;
         this.data = data;
         this.timestamp = timestamp;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     static create(data: any, timestamp = new Date()) {
         return new PostEditedEvent(data, timestamp);
     }

--- a/ghost/collections/src/events/TagDeletedEvent.ts
+++ b/ghost/collections/src/events/TagDeletedEvent.ts
@@ -9,6 +9,7 @@ export class TagDeletedEvent {
         this.timestamp = timestamp;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     static create(data: any, timestamp = new Date()) {
         return new TagDeletedEvent(data, timestamp);
     }

--- a/ghost/in-memory-repository/.eslintrc.js
+++ b/ghost/in-memory-repository/.eslintrc.js
@@ -2,9 +2,5 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/ts'
-    ],
-    rules: {
-        // TODO: fix + remove this
-        '@typescript-eslint/no-explicit-any': 'warn',
-    }
+    ]
 };

--- a/ghost/in-memory-repository/src/InMemoryRepository.ts
+++ b/ghost/in-memory-repository/src/InMemoryRepository.ts
@@ -10,6 +10,7 @@ type Order<T> = {
     direction: 'asc' | 'desc';
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type OrderOption<T extends Entity<any>> = Order<T>[];
 
 export abstract class InMemoryRepository<IDType, T extends Entity<IDType>> {
@@ -51,6 +52,7 @@ export abstract class InMemoryRepository<IDType, T extends Entity<IDType>> {
             for (const order of options.order) {
                 results.sort((a, b) => {
                     if (order.direction === 'asc') {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         return a[order.field] as any > (b[order.field] as any) ? 1 : -1;
                     } else {
                         return a[order.field] < b[order.field] ? 1 : -1;

--- a/ghost/mail-events/.eslintrc.js
+++ b/ghost/mail-events/.eslintrc.js
@@ -2,9 +2,5 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/ts'
-    ],
-    rules: {
-        // TODO: fix + remove this
-        '@typescript-eslint/no-explicit-any': 'warn',
-    }
+    ]
 };

--- a/ghost/mail-events/src/MailEventService.ts
+++ b/ghost/mail-events/src/MailEventService.ts
@@ -39,6 +39,7 @@ interface Labs {
 }
 
 interface Config {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     get(key: string): any;
 }
 

--- a/ghost/model-to-domain-event-interceptor/.eslintrc.js
+++ b/ghost/model-to-domain-event-interceptor/.eslintrc.js
@@ -2,9 +2,5 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/ts'
-    ],
-    rules: {
-        // TODO: fix + remove this
-        '@typescript-eslint/no-explicit-any': 'warn',
-    }
+    ]
 };

--- a/ghost/model-to-domain-event-interceptor/src/ModelToDomainEventInterceptor.ts
+++ b/ghost/model-to-domain-event-interceptor/src/ModelToDomainEventInterceptor.ts
@@ -2,10 +2,13 @@ import { PostDeletedEvent, PostAddedEvent, PostEditedEvent, TagDeletedEvent } fr
 
 type ModelToDomainEventInterceptorDeps = {
     ModelEvents: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         hasRegisteredListener: (event: any, listenerName: string) => boolean;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         on: (eventName: string, callback: (data: any) => void) => void;
     },
     DomainEvents: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         dispatch: (event: any) => void;
     }
 }
@@ -32,6 +35,7 @@ export class ModelToDomainEventInterceptor {
         for (const modelEventName of ghostModelUpdateEvents) {
             if (!this.ModelEvents.hasRegisteredListener(modelEventName, 'collectionListener')) {
                 const dispatcher = this.domainEventDispatcher.bind(this);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const listener = function (data: any) {
                     dispatcher(modelEventName, data);
                 };
@@ -42,6 +46,7 @@ export class ModelToDomainEventInterceptor {
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     domainEventDispatcher(modelEventName: string, data: any) {
         let event;
 
@@ -66,6 +71,7 @@ export class ModelToDomainEventInterceptor {
                     status: data.attributes.status,
                     featured: data.attributes.featured,
                     published_at: data.attributes.published_at,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     tags: data.relations?.tags?.models.map((tag: any) => ({
                         slug: tag.get('slug')
                     }))
@@ -78,6 +84,7 @@ export class ModelToDomainEventInterceptor {
                     status: data._previousAttributes?.status,
                     featured: data._previousAttributes?.featured,
                     published_at: data._previousAttributes?.published_at,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     tags: data._previousRelations?.tags?.models.map((tag: any) => ({
                         slug: tag.get('slug')
                     }))

--- a/ghost/post-revisions/.eslintrc.js
+++ b/ghost/post-revisions/.eslintrc.js
@@ -2,8 +2,5 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/ts'
-    ],
-    rules: {
-        '@typescript-eslint/no-explicit-any': 'warn',
-    }
+    ]
 };

--- a/ghost/post-revisions/src/PostRevisions.ts
+++ b/ghost/post-revisions/src/PostRevisions.ts
@@ -29,6 +29,7 @@ type PostRevisionsDeps = {
         max_revisions: number;
         revision_interval_ms: number;
     },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     model: any
 }
 
@@ -41,6 +42,7 @@ type RevisionResult = {
 
 export class PostRevisions {
     config: PostRevisionsDeps['config'];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     model: any;
 
     constructor(deps: PostRevisionsDeps) {
@@ -122,6 +124,7 @@ export class PostRevisions {
         };
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async removeAuthorFromRevisions(authorId: string, options: any): Promise<void> {
         const revisions = await this.model.findAll({
             filter: `author_id:${authorId}`,


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/50

- we should default to keeping the rule on and so I've excluded lines that currently use `any` to avoid the need to go and fix them all up

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10582ea</samp>

This pull request disables the TypeScript linting rule that warns about the use of `any` type in several files and packages. The author adds inline comments to explain why `any` is used and where possible, updates the ESLint configuration files to reflect this change. The purpose of this pull request is to avoid linting errors and to allow the use of `any` type for generic or untyped objects. The files and packages affected by this pull request are `apps/signup-form`, `ghost/collections`, `ghost/in-memory-repository`, and `ghost/mail-events`.
