### PR TITLE
Added migrations for donations API

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -3,6 +3,7 @@ const BACKUP_TABLES = [
     'actions',
     'api_keys',
     'brute',
+    'donation_payment_events',
     'emails',
     'integrations',
     'invites',

--- a/ghost/core/core/server/data/migrations/versions/5.57/2023-07-26-12-44-stripe-products-nullable-product.js
+++ b/ghost/core/core/server/data/migrations/versions/5.57/2023-07-26-12-44-stripe-products-nullable-product.js
@@ -1,0 +1,4 @@
+const {createSetNullableMigration} = require('../../utils');
+
+// We need to disable foreign key checks because if MySQL is missing the STRICT_TRANS_TABLES mode, we cannot revert the migration
+module.exports = createSetNullableMigration('stripe_products', 'product_id', {disableForeignKeyChecks: true});

--- a/ghost/core/core/server/data/migrations/versions/5.57/2023-07-27-11-47-49-create-donation-events.js
+++ b/ghost/core/core/server/data/migrations/versions/5.57/2023-07-27-11-47-49-create-donation-events.js
@@ -1,0 +1,19 @@
+// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
+
+const {addTable} = require('../../utils');
+
+module.exports = addTable('donation_payment_events', {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    name: {type: 'string', maxlength: 191, nullable: true},
+    email: {type: 'string', maxlength: 191, nullable: false, unique: false},
+    member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id', setNullDelete: true},
+    amount: {type: 'integer', nullable: false},
+    currency: {type: 'string', maxlength: 50, nullable: false},
+    attribution_id: {type: 'string', maxlength: 24, nullable: true},
+    attribution_type: {type: 'string', maxlength: 50, nullable: true},
+    attribution_url: {type: 'string', maxlength: 2000, nullable: true},
+    referrer_source: {type: 'string', maxlength: 191, nullable: true},
+    referrer_medium: {type: 'string', maxlength: 191, nullable: true},
+    referrer_url: {type: 'string', maxlength: 2000, nullable: true},
+    created_at: {type: 'dateTime', nullable: false}
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -738,9 +738,28 @@ module.exports = {
         },
         newsletter_id: {type: 'string', maxlength: 24, nullable: true, references: 'newsletters.id', cascadeDelete: false}
     },
+    donation_payment_events: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        name: {type: 'string', maxlength: 191, nullable: true},
+        email: {type: 'string', maxlength: 191, nullable: false, unique: false, validations: {isEmail: true}},
+        member_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'members.id', setNullDelete: true},
+        amount: {type: 'integer', nullable: false},
+        currency: {type: 'string', maxlength: 50, nullable: false},
+        attribution_id: {type: 'string', maxlength: 24, nullable: true},
+        attribution_type: {
+            type: 'string', maxlength: 50, nullable: true, validations: {
+                isIn: [['url', 'post', 'page', 'author', 'tag']]
+            }
+        },
+        attribution_url: {type: 'string', maxlength: 2000, nullable: true},
+        referrer_source: {type: 'string', maxlength: 191, nullable: true},
+        referrer_medium: {type: 'string', maxlength: 191, nullable: true},
+        referrer_url: {type: 'string', maxlength: 2000, nullable: true},
+        created_at: {type: 'dateTime', nullable: false}
+    },
     stripe_products: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        product_id: {type: 'string', maxlength: 24, nullable: false, unique: false, references: 'products.id'},
+        product_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'products.id'},
         stripe_product_id: {type: 'string', maxlength: 255, nullable: false, unique: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}
@@ -755,7 +774,7 @@ module.exports = {
         // so we should decide whether we should reduce it down in the future
         currency: {type: 'string', maxlength: 191, nullable: false},
         amount: {type: 'integer', nullable: false},
-        type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'recurring', validations: {isIn: [['recurring', 'one_time']]}},
+        type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'recurring', validations: {isIn: [['recurring', 'one_time', 'donation']]}},
         interval: {type: 'string', maxlength: 50, nullable: true},
         description: {type: 'string', maxlength: 191, nullable: true},
         created_at: {type: 'dateTime', nullable: false},

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -31,6 +31,7 @@ describe('Exporter', function () {
                 'comment_likes',
                 'comment_reports',
                 'custom_theme_settings',
+                'donation_payment_events',
                 'email_batches',
                 'email_recipient_failures',
                 'email_recipients',

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '66b77c27bab9cb43e1076fbb6c6d1233';
+    const currentSchemaHash = '99a8fe2394b685cc1ce4c44d8e87a1ad';
     const currentFixturesHash = 'af43eef1ac4f14fc1bc0ea351300420f';
     const currentSettingsHash = '4f23a583335dcb4cb3fae553122ea200';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/3655

- This adds a new table for storing donation events in the database.
- Makes it possible to store stripe_products without associating it with a tier/Ghost product (required for one time purchases).
- Updates the schema for stripe_prices to allow enum value of `donation`, which is required to query specifically on the prices used for donations (existing one_time is not enough).

Database changes are discussed in the Tech Spec: https://www.notion.so/ghost/Tech-Spec-5cd6929f7960462ebcbf198176e0d899?pvs=4#1f18cc5a38294f61a091e5be63fe1059