### PR TITLE
🐛 Fixed email only to post rescheduling.

### DIFF
--- a/ghost/admin/app/utils/publish-options.js
+++ b/ghost/admin/app/utils/publish-options.js
@@ -340,6 +340,7 @@ export default class PublishOptions {
             }
 
             this.post.status = 'draft';
+            this.post.emailOnly = false;
 
             return yield this.post.save();
         } catch (e) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3657

- When reverting a post to a draft, the meta, `email_only` remained true.
- This fix switches `email_only` back to false when the `revertToDraftTask` is executed.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 78c8263</samp>

Add `emailOnly` property to `post` object and set it to `false` by default. This enables users to choose whether to send posts only to email subscribers or also publish them on the site. The change affects the `publishOptions` utility function in `ghost/admin/app/utils/publish-options.js`.
