### PR TITLE
Removed flatUrls labs flag

### DIFF
--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -73,7 +73,6 @@ export default class FeatureService extends Service {
     @feature('signupForm') signupForm;
     @feature('collections') collections;
     @feature('adminXSettings') adminXSettings;
-    @feature('flatUrls') flatUrls;
     @feature('mailEvents') mailEvents;
     @feature('collectionsCard') collectionsCard;
     @feature('headerUpgrade') headerUpgrade;

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -314,20 +314,6 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
-                            <h4 class="gh-expandable-title">Flat URLs</h4>
-                            <p class="gh-expandable-description">
-                                Enables generating flat Post and Page URLs in `{slug}-{id}` format
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                            <GhFeatureFlag @flag="flatUrls" />
-                        </div>
-                    </div>
-                </div>
-
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
                             <h4 class="gh-expandable-title">Mail Events</h4>
                             <p class="gh-expandable-description">
                                 Enables processing of mail events

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -38,7 +38,6 @@ const ALPHA_FEATURES = [
     'emailCustomization',
     'collections',
     'adminXSettings',
-    'flatUrls',
     'mailEvents',
     'collectionsCard',
     'headerUpgrade',


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/4372a7e1a8b19b48dd5b4fc7ef1d1fc3e059b80d

- We ended up developing a proper customizable routing on the `arch` branch. This flag is obsolete.

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22299a3</samp>

Removed the `flatUrls` feature flag from the admin, core, and template files. This feature flag was no longer needed as the flat URLs feature was deprecated and unsupported.
