### PR TITLE
Cleanup unused property in attribution builder

### DIFF
--- a/ghost/member-attribution/lib/AttributionBuilder.js
+++ b/ghost/member-attribution/lib/AttributionBuilder.js
@@ -94,7 +94,7 @@ class Attribution {
         }
 
         // Fetch model
-        const model = await this.#urlTranslator.getResourceById(this.id, this.type, {absolute: true});
+        const model = await this.#urlTranslator.getResourceById(this.id, this.type);
         return this.getResource(model);
     }
 }


### PR DESCRIPTION
no issue

- just a little cleanup with a property passed to a function that doesn't make use of that prop at all.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa92599</samp>

Fixed a bug in member attribution that caused wrong URLs for some resources. Removed the `absolute` option from `getResourceById` in `AttributionBuilder.js`.
