### PR TITLE
🐛 Fixed custom routing with collections

### DIFF
--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -6,7 +6,6 @@ import UnpublishPostsModal from './modals/unpublish-posts';
 import nql from '@tryghost/nql';
 import {action} from '@ember/object';
 import {capitalizeFirstLetter} from 'ghost-admin/helpers/capitalize-first-letter';
-import {posts as postExpansions} from '@tryghost/nql-filter-expansions';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 
@@ -258,7 +257,29 @@ export default class PostsContextMenu extends Component {
         const updatedModels = this.selectionList.availableModels;
         const filter = this.selectionList.allFilter;
         const filterNql = nql(filter, {
-            expansions: postExpansions
+            expansions: [
+                {
+                    key: 'primary_tag',
+                    replacement: 'tags.slug',
+                    expansion: 'posts_tags.sort_order:0+tags.visibility:public'
+                }, {
+                    key: 'primary_author',
+                    replacement: 'authors.slug',
+                    expansion: 'posts_authors.sort_order:0+authors.visibility:public'
+                }, {
+                    key: 'authors',
+                    replacement: 'authors.slug'
+                }, {
+                    key: 'author',
+                    replacement: 'authors.slug'
+                }, {
+                    key: 'tag',
+                    replacement: 'tags.slug'
+                }, {
+                    key: 'tags',
+                    replacement: 'tags.slug'
+                }
+            ]
         });
 
         const remainingModels = this.selectionList.infinityModel.content.filter((model) => {

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -52,7 +52,6 @@
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/mobiledoc-kit": "0.12.5-ghost.2",
     "@tryghost/nql": "0.11.0",
-    "@tryghost/nql-filter-expansions": "0.0.0",
     "@tryghost/nql-lang": "0.5.0",
     "@tryghost/string": "0.2.4",
     "@tryghost/timezone-data": "0.3.0",

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -7,7 +7,6 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const nql = require('@tryghost/nql');
 const htmlToPlaintext = require('@tryghost/html-to-plaintext');
-const {posts: postExpansions} = require('@tryghost/nql-filter-expansions');
 const ghostBookshelf = require('./base');
 const config = require('../../shared/config');
 const settingsCache = require('../../shared/settings-cache');
@@ -291,6 +290,28 @@ Post = ghostBookshelf.Model.extend({
     filterExpansions: function filterExpansions() {
         const postsMetaKeys = _.without(ghostBookshelf.model('PostsMeta').prototype.orderAttributes(), 'posts_meta.id', 'posts_meta.post_id');
 
+        const expansions = [{
+            key: 'primary_tag',
+            replacement: 'tags.slug',
+            expansion: 'posts_tags.sort_order:0+tags.visibility:public'
+        }, {
+            key: 'primary_author',
+            replacement: 'authors.slug',
+            expansion: 'posts_authors.sort_order:0+authors.visibility:public'
+        }, {
+            key: 'authors',
+            replacement: 'authors.slug'
+        }, {
+            key: 'author',
+            replacement: 'authors.slug'
+        }, {
+            key: 'tag',
+            replacement: 'tags.slug'
+        }, {
+            key: 'tags',
+            replacement: 'tags.slug'
+        }];
+
         const postMetaKeyExpansions = postsMetaKeys.map((pmk) => {
             return {
                 key: pmk.split('.')[1],
@@ -298,7 +319,7 @@ Post = ghostBookshelf.Model.extend({
             };
         });
 
-        return postExpansions.concat(postMetaKeyExpansions);
+        return expansions.concat(postMetaKeyExpansions);
     },
 
     filterRelations: function filterRelations() {

--- a/ghost/core/core/server/services/url/UrlGenerator.js
+++ b/ghost/core/core/server/services/url/UrlGenerator.js
@@ -3,7 +3,26 @@ const nql = require('@tryghost/nql');
 const debug = require('@tryghost/debug')('services:url:generator');
 const localUtils = require('../../../shared/url-utils');
 
-const {posts: postExpansions} = require('@tryghost/nql-filter-expansions');
+// @TODO: merge with filter plugin
+const EXPANSIONS = [{
+    key: 'author',
+    replacement: 'authors.slug'
+}, {
+    key: 'tags',
+    replacement: 'tags.slug'
+}, {
+    key: 'tag',
+    replacement: 'tags.slug'
+}, {
+    key: 'authors',
+    replacement: 'authors.slug'
+}, {
+    key: 'primary_tag',
+    replacement: 'primary_tag.slug'
+}, {
+    key: 'primary_author',
+    replacement: 'primary_author.slug'
+}];
 
 /**
  * The UrlGenerator class is responsible to generate urls based on a router's conditions.
@@ -38,7 +57,7 @@ class UrlGenerator {
         if (filter) {
             this.filter = filter;
             this.nql = nql(this.filter, {
-                expansions: postExpansions,
+                expansions: EXPANSIONS,
                 transformer: nql.utils.mapKeyValues({
                     key: {
                         from: 'page',

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -136,7 +136,6 @@
     "@tryghost/mw-vhost": "0.0.0",
     "@tryghost/nodemailer": "0.3.35",
     "@tryghost/nql": "0.11.0",
-    "@tryghost/nql-filter-expansions": "0.0.0",
     "@tryghost/oembed-service": "0.0.0",
     "@tryghost/package-json": "0.0.0",
     "@tryghost/post-revisions": "0.0.0",


### PR DESCRIPTION
When we updated the way we handled NQL filter expansion, we broke custom routing collections.
This reverts the changes made.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bd227e</samp>

This pull request removes the `@tryghost/nql-filter-expansions` module and replaces it with local arrays of expansions in the admin and core apps. This simplifies the NQL filter logic and ensures consistency across the codebase.
