### PR TITLE
Updated AdminX settings to link from the usual footer button

### DIFF
--- a/apps/admin-x-settings/src/components/Settings.tsx
+++ b/apps/admin-x-settings/src/components/Settings.tsx
@@ -12,6 +12,9 @@ const Settings: React.FC = () => {
             <SiteSettings />
             <MembershipSettings />
             <EmailSettings />
+            <div className='mt-40 text-sm'>
+                <a className='text-green' href="/ghost/#/settings">Click here</a> to open the original Admin settings.
+            </div>
         </>
     );
 };

--- a/ghost/admin/app/components/gh-nav-menu/footer.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/footer.hbs
@@ -100,7 +100,11 @@
         </div>
         <div class="flex items-center pe-all">
             {{#if (gh-user-can-admin this.session.user)}}
-                <LinkTo class="gh-nav-bottom-tabicon" @route="settings" @current-when={{this.isSettingsRoute}} data-test-nav="settings">{{svg-jar "settings"}}</LinkTo>
+                {{#if (feature "adminXSettings")}}
+                    <LinkTo class="gh-nav-bottom-tabicon" @route="settings-x" @current-when={{this.isSettingsRoute}} data-test-nav="settings">{{svg-jar "settings"}}</LinkTo>
+                {{else}}
+                    <LinkTo class="gh-nav-bottom-tabicon" @route="settings" @current-when={{this.isSettingsRoute}} data-test-nav="settings">{{svg-jar "settings"}}</LinkTo>
+                {{/if}}
             {{/if}}
             {{#if this.session.user.isEditor}}
                 <LinkTo class="gh-nav-bottom-tabicon" @route="settings.staff" @current-when={{this.isSettingsRoute}} data-test-nav="settings">{{svg-jar "settings"}}</LinkTo>

--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -120,11 +120,6 @@
                             </li>
                         {{/if}}
                     {{/if}}
-                    {{#if (and (gh-user-can-admin this.session.user) (feature "adminXSettings"))}}
-                            <li>
-                                <LinkTo @route="settings-x" @current-when={{this.isSettingsRoute}} data-test-nav="settings">{{svg-jar "settings"}} AdminX Settings</LinkTo>
-                            </li>
-                    {{/if}}
                 </ul>
 
                 {{#if this.session.user.isOwnerOnly}}


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3349

Now that we're a bit further, we can open AdminX settings from the usual gearwheel button when the Labs flag is enabled instead of having a separate navigation item