### PR TITLE
Added migrations for Tips & Donations' settings

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.58/2023-08-02-09-42-add-donation-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/5.58/2023-08-02-09-42-add-donation-settings.js
@@ -1,0 +1,23 @@
+const {combineTransactionalMigrations, addSetting} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    addSetting({
+        key: 'donations_enabled',
+        value: false,
+        type: 'boolean',
+        group: 'donations',
+        flags: 'PUBLIC'
+    }),
+    addSetting({
+        key: 'donations_currency',
+        value: 'USD',
+        type: 'string',
+        group: 'donations'
+    }),
+    addSetting({
+        key: 'donations_suggested_amount',
+        value: 0,
+        type: 'number',
+        group: 'donations'
+    })
+);

--- a/ghost/core/core/server/data/migrations/versions/5.58/2023-08-02-09-42-add-donation-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/5.58/2023-08-02-09-42-add-donation-settings.js
@@ -2,13 +2,6 @@ const {combineTransactionalMigrations, addSetting} = require('../../utils');
 
 module.exports = combineTransactionalMigrations(
     addSetting({
-        key: 'donations_enabled',
-        value: false,
-        type: 'boolean',
-        group: 'donations',
-        flags: 'PUBLIC'
-    }),
-    addSetting({
         key: 'donations_currency',
         value: 'USD',
         type: 'string',

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -551,20 +551,6 @@
         }
     },
     "donations": {
-        "donations_enabled": {
-            "defaultValue": "false",
-            "validations": {
-                "isEmpty": false,
-                "isIn": [
-                    [
-                        "true",
-                        "false"
-                    ]
-                ]
-            },
-            "type": "boolean",
-            "flags": "PUBLIC"
-        },
         "donations_currency": {
             "defaultValue": "USD",
             "validations": {

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -549,5 +549,35 @@
             "defaultValue": null,
             "type": "string"
         }
+    },
+    "donations": {
+        "donations_enabled": {
+            "defaultValue": "false",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [
+                    [
+                        "true",
+                        "false"
+                    ]
+                ]
+            },
+            "type": "boolean",
+            "flags": "PUBLIC"
+        },
+        "donations_currency": {
+            "defaultValue": "USD",
+            "validations": {
+                "isEmpty": false
+            },
+            "type": "string"
+        },
+        "donations_suggested_amount": {
+            "defaultValue": 0,
+            "validations": {
+                "isEmpty": false
+            },
+            "type": "number"
+        }
     }
 }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -305,10 +305,6 @@ Object {
       "value": null,
     },
     Object {
-      "key": "donations_enabled",
-      "value": false,
-    },
-    Object {
       "key": "donations_currency",
       "value": "USD",
     },
@@ -707,10 +703,6 @@ Object {
       "value": null,
     },
     Object {
-      "key": "donations_enabled",
-      "value": false,
-    },
-    Object {
       "key": "donations_currency",
       "value": "USD",
     },
@@ -742,7 +734,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4146",
+  "content-length": "4104",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1055,10 +1047,6 @@ Object {
     Object {
       "key": "pintura_css_url",
       "value": null,
-    },
-    Object {
-      "key": "donations_enabled",
-      "value": false,
     },
     Object {
       "key": "donations_currency",
@@ -1404,10 +1392,6 @@ Object {
     Object {
       "key": "pintura_css_url",
       "value": null,
-    },
-    Object {
-      "key": "donations_enabled",
-      "value": false,
     },
     Object {
       "key": "donations_currency",
@@ -1758,10 +1742,6 @@ Object {
     Object {
       "key": "pintura_css_url",
       "value": null,
-    },
-    Object {
-      "key": "donations_enabled",
-      "value": false,
     },
     Object {
       "key": "donations_currency",
@@ -2202,10 +2182,6 @@ Object {
       "value": null,
     },
     Object {
-      "key": "donations_enabled",
-      "value": false,
-    },
-    Object {
       "key": "donations_currency",
       "value": "USD",
     },
@@ -2614,10 +2590,6 @@ Object {
     Object {
       "key": "pintura_css_url",
       "value": null,
-    },
-    Object {
-      "key": "donations_enabled",
-      "value": false,
     },
     Object {
       "key": "donations_currency",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -305,6 +305,18 @@ Object {
       "value": null,
     },
     Object {
+      "key": "donations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "0",
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -695,6 +707,18 @@ Object {
       "value": null,
     },
     Object {
+      "key": "donations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "0",
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -718,7 +742,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4012",
+  "content-length": "4146",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1031,6 +1055,18 @@ Object {
     Object {
       "key": "pintura_css_url",
       "value": null,
+    },
+    Object {
+      "key": "donations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "0",
     },
     Object {
       "key": "members_enabled",
@@ -1368,6 +1404,18 @@ Object {
     Object {
       "key": "pintura_css_url",
       "value": null,
+    },
+    Object {
+      "key": "donations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "0",
     },
     Object {
       "key": "members_enabled",
@@ -1710,6 +1758,18 @@ Object {
     Object {
       "key": "pintura_css_url",
       "value": null,
+    },
+    Object {
+      "key": "donations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "0",
     },
     Object {
       "key": "members_enabled",
@@ -2142,6 +2202,18 @@ Object {
       "value": null,
     },
     Object {
+      "key": "donations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "0",
+    },
+    Object {
       "key": "members_enabled",
       "value": true,
     },
@@ -2542,6 +2614,18 @@ Object {
     Object {
       "key": "pintura_css_url",
       "value": null,
+    },
+    Object {
+      "key": "donations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "0",
     },
     Object {
       "key": "members_enabled",

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -8,7 +8,7 @@ const {stringMatching, anyEtag, anyUuid, anyContentLength, anyContentVersion} = 
 const models = require('../../../core/server/models');
 const {anyErrorId} = matchers;
 
-const CURRENT_SETTINGS_COUNT = 79;
+const CURRENT_SETTINGS_COUNT = 82;
 
 const settingsMatcher = {};
 

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -8,7 +8,7 @@ const {stringMatching, anyEtag, anyUuid, anyContentLength, anyContentVersion} = 
 const models = require('../../../core/server/models');
 const {anyErrorId} = matchers;
 
-const CURRENT_SETTINGS_COUNT = 82;
+const CURRENT_SETTINGS_COUNT = 81;
 
 const settingsMatcher = {};
 

--- a/ghost/core/test/regression/models/model_settings.test.js
+++ b/ghost/core/test/regression/models/model_settings.test.js
@@ -5,7 +5,7 @@ const db = require('../../../core/server/data/db');
 // Stuff we are testing
 const models = require('../../../core/server/models');
 
-const SETTINGS_LENGTH = 90;
+const SETTINGS_LENGTH = 93;
 
 describe('Settings Model', function () {
     before(models.init);

--- a/ghost/core/test/regression/models/model_settings.test.js
+++ b/ghost/core/test/regression/models/model_settings.test.js
@@ -5,7 +5,7 @@ const db = require('../../../core/server/data/db');
 // Stuff we are testing
 const models = require('../../../core/server/models');
 
-const SETTINGS_LENGTH = 93;
+const SETTINGS_LENGTH = 92;
 
 describe('Settings Model', function () {
     before(models.init);

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 82;
+            const allowedKeysLength = 85;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -236,7 +236,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 85;
+            const allowedKeysLength = 84;
             totalKeysLength.should.eql(SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '99a8fe2394b685cc1ce4c44d8e87a1ad';
     const currentFixturesHash = 'af43eef1ac4f14fc1bc0ea351300420f';
-    const currentSettingsHash = '4f23a583335dcb4cb3fae553122ea200';
+    const currentSettingsHash = 'e1204cc1579a7089ff0edda6733bc9a7';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '99a8fe2394b685cc1ce4c44d8e87a1ad';
     const currentFixturesHash = 'af43eef1ac4f14fc1bc0ea351300420f';
-    const currentSettingsHash = 'e1204cc1579a7089ff0edda6733bc9a7';
+    const currentSettingsHash = 'dd0e318627ded65e41f188fb5bdf5b74';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -557,5 +557,35 @@
             "defaultValue": null,
             "type": "string"
         }
+    },
+    "donations": {
+        "donations_enabled": {
+            "defaultValue": "false",
+            "validations": {
+                "isEmpty": false,
+                "isIn": [
+                    [
+                        "true",
+                        "false"
+                    ]
+                ]
+            },
+            "type": "boolean",
+            "flags": "PUBLIC"
+        },
+        "donations_currency": {
+            "defaultValue": "USD",
+            "validations": {
+                "isEmpty": false
+            },
+            "type": "string"
+        },
+        "donations_suggested_amount": {
+            "defaultValue": 0,
+            "validations": {
+                "isEmpty": false
+            },
+            "type": "number"
+        }
     }
 }

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -559,20 +559,6 @@
         }
     },
     "donations": {
-        "donations_enabled": {
-            "defaultValue": "false",
-            "validations": {
-                "isEmpty": false,
-                "isIn": [
-                    [
-                        "true",
-                        "false"
-                    ]
-                ]
-            },
-            "type": "boolean",
-            "flags": "PUBLIC"
-        },
         "donations_currency": {
             "defaultValue": "USD",
             "validations": {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3668

- `Tips and Donations` feature offers two settings: `donations_currency`, and `donations_suggested_amount`
   - `donation_currency`: the currency to be used for the donation. Defaults to `USD`, not nullable.
   - `donation_suggested_amount`: an anchor price for the donation. Defaults to `0`, not nullable.
- Both settings belong to a new group `donations`

cf. [Tech Spec](https://www.notion.so/ghost/Tech-Spec-5cd6929f7960462ebcbf198176e0d899?pvs=4#6e8b34c45f0c4c78b48c9e7725a307c8)
