### PR TITLE
Added CollectionPost model & relation to Collection

### DIFF
--- a/ghost/core/core/server/models/collection-post.js
+++ b/ghost/core/core/server/models/collection-post.js
@@ -1,0 +1,9 @@
+const ghostBookshelf = require('./base');
+
+const CollectionPost = ghostBookshelf.Model.extend({
+    tableName: 'collections_posts'
+});
+
+module.exports = {
+    CollectionPost: ghostBookshelf.model('CollectionPost', CollectionPost)
+};

--- a/ghost/core/core/server/models/collection.js
+++ b/ghost/core/core/server/models/collection.js
@@ -70,6 +70,12 @@ const Collection = ghostBookshelf.Model.extend({
             'id',
             'id'
         );
+    },
+
+    collectionPosts() {
+        return this.hasMany(
+            'CollectionPost'
+        );
     }
 });
 

--- a/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
+++ b/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
@@ -23,7 +23,7 @@ module.exports = class BookshelfCollectionsRepository {
     async getById(id, options = {}) {
         const model = await this.#model.findOne({id}, {
             require: false,
-            withRelated: ['posts'],
+            withRelated: ['collectionPosts'],
             transacting: options.transaction
         });
         if (!model) {
@@ -39,7 +39,7 @@ module.exports = class BookshelfCollectionsRepository {
     async getBySlug(slug, options = {}) {
         const model = await this.#model.findOne({slug}, {
             require: false,
-            withRelated: ['posts'],
+            withRelated: ['collectionPosts'],
             transacting: options.transaction
         });
         if (!model) {
@@ -58,7 +58,7 @@ module.exports = class BookshelfCollectionsRepository {
         const models = await this.#model.findAll({
             ...options,
             transacting: options.transaction,
-            withRelated: ['posts']
+            withRelated: ['collectionPosts']
         });
 
         return await Promise.all(models.map(model => this.#modelToCollection(model)));
@@ -75,7 +75,7 @@ module.exports = class BookshelfCollectionsRepository {
             filter: json.filter,
             type: json.type,
             featureImage: json.feature_image,
-            posts: json.posts.map(post => post.id),
+            posts: json.collectionPosts.map(collectionPost => collectionPost.post_id),
             createdAt: json.created_at,
             updatedAt: json.updated_at
         });


### PR DESCRIPTION
By using the `collections_posts` table as a pivot table, I couldn't see a way to get bookshelf to *not* load the Post models for the relation. We don't actually need those Post models for our usescases, the the queries were causing issues with our database servers! Here we've added a new CollectionPost model which allows us to treat the collections_posts table as a resource ratherthan pivot, and means we can use the hasMany relation rather than belongsToMany relation. This removes all queries to the posts table when fetching collections with relations