### PR TITLE
Added lexical config for hiding old cards

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -314,7 +314,12 @@ export default class KoenigLexicalEditor extends Component {
             },
             membersEnabled: this.settings.get('membersSignupAccess') === 'all',
             siteTitle: this.settings.title,
-            siteDescription: this.settings.description
+            siteDescription: this.settings.description,
+
+            // if false, shows header v1 in the menu. We want to set this to true when we release v2
+            depreciated: {
+                headerV1: false
+            }
         };
         const cardConfig = Object.assign({}, defaultCardConfig, props.cardConfig, {pinturaConfig: this.pinturaConfig});
 


### PR DESCRIPTION
no issue

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 609c013</samp>

Added a `depreciated` property to the editor card configuration to control the visibility of the old header version. This is part of a feature to update the site header.
