### PR TITLE
🐛 Fixed member signup source attributed to Stripe

### DIFF
--- a/ghost/member-attribution/lib/ReferrerTranslator.js
+++ b/ghost/member-attribution/lib/ReferrerTranslator.js
@@ -39,6 +39,12 @@ class ReferrerTranslator {
 
         for (const item of history) {
             const referrerUrl = this.getUrlFromStr(item.referrerUrl);
+
+            if (referrerUrl?.hostname === 'checkout.stripe.com') {
+                // Ignore stripe, because second try payments should not be attributed to Stripe
+                continue;
+            }
+
             const referrerSource = item.referrerSource;
             const referrerMedium = item.referrerMedium;
 


### PR DESCRIPTION
no issue

When a user fails to pay the first time, and returns to the site, the next payment will be attributed to Stripe instead of the original referrer. This change always ignores the Stripe checkout as referrer in the URL history.