### PR TITLE
Added index on posts table for published_at column

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.59/2023-08-07-11-17-05-add-posts-published-at-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.59/2023-08-07-11-17-05-add-posts-published-at-index.js
@@ -1,4 +1,5 @@
 const logging = require('@tryghost/logging');
+const DatabaseInfo = require('@tryghost/database-info');
 const {createNonTransactionalMigration} = require('../../utils');
 
 const INDEX_NAME = 'posts_published_at_index';
@@ -7,7 +8,7 @@ module.exports = createNonTransactionalMigration(
     async function up(knex) {
         let hasIndex = false;
 
-        if (knex.client.config.client === 'sqlite3') {
+        if (DatabaseInfo.isSQLite(knex)) {
             const result = await knex.raw(`select * from sqlite_master where type = 'index' and tbl_name = 'posts' and name = '${INDEX_NAME}'`);
             hasIndex = (result.length !== 0);
         } else {
@@ -29,7 +30,7 @@ module.exports = createNonTransactionalMigration(
     async function down(knex) {
         let missingIndex = false;
 
-        if (knex.client.config.client === 'sqlite3') {
+        if (DatabaseInfo.isSQLite(knex)) {
             const result = await knex.raw(`select * from sqlite_master where type = 'index' and tbl_name = 'posts' and name = '${INDEX_NAME}'`);
             missingIndex = (result.length === 0);
         } else {

--- a/ghost/core/core/server/data/migrations/versions/5.59/2023-08-07-11-17-05-add-posts-published-at-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.59/2023-08-07-11-17-05-add-posts-published-at-index.js
@@ -1,0 +1,50 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+const INDEX_NAME = 'posts_published_at_index';
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        let hasIndex = false;
+
+        if (knex.client.config.client === 'sqlite3') {
+            const result = await knex.raw(`select * from sqlite_master where type = 'index' and tbl_name = 'posts' and name = '${INDEX_NAME}'`);
+            hasIndex = (result.length !== 0);
+        } else {
+            const result = await knex.raw(`show index from posts where Key_name = '${INDEX_NAME}'`);
+            hasIndex = (result[0].length !== 0);
+        }
+
+        if (hasIndex) {
+            logging.info(`Skipping creation of index ${INDEX_NAME} on posts for published_at - already exists`);
+            return;
+        }
+
+        logging.info(`Creating index ${INDEX_NAME} on posts for published_at`);
+        await knex.schema.table('posts', (table) => {
+            table.index(['published_at']);
+        });
+    },
+
+    async function down(knex) {
+        let missingIndex = false;
+
+        if (knex.client.config.client === 'sqlite3') {
+            const result = await knex.raw(`select * from sqlite_master where type = 'index' and tbl_name = 'posts' and name = '${INDEX_NAME}'`);
+            missingIndex = (result.length === 0);
+        } else {
+            const result = await knex.raw(`show index from posts where Key_name = '${INDEX_NAME}'`);
+            missingIndex = (result[0].length === 0);
+        }
+
+        if (missingIndex) {
+            logging.info(`Skipping drop of index ${INDEX_NAME} on posts for published_at - does not exist`);
+            return;
+        }
+
+        logging.info(`Dropping index ${INDEX_NAME} on posts for published_at`);
+        await knex.schema.table('posts', (table) => {
+            table.dropIndex(['published_at']);
+        });
+    }
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -83,7 +83,7 @@ module.exports = {
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true},
-        published_at: {type: 'dateTime', nullable: true},
+        published_at: {type: 'dateTime', nullable: true, index: true},
         published_by: {type: 'string', maxlength: 24, nullable: true},
         custom_excerpt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
         codeinjection_head: {type: 'text', maxlength: 65535, nullable: true},

--- a/ghost/core/test/regression/api/content/posts.test.js
+++ b/ghost/core/test/regression/api/content/posts.test.js
@@ -302,24 +302,28 @@ describe('api/endpoints/content/posts', function () {
         before (function () {
             publicPost = testUtils.DataGenerator.forKnex.createPost({
                 slug: 'free-to-see',
-                visibility: 'public'
+                visibility: 'public',
+                published_at: new Date('2023-07-15T04:20:30.000+00:00')
             });
 
             membersPost = testUtils.DataGenerator.forKnex.createPost({
                 slug: 'thou-shalt-not-be-seen',
-                visibility: 'members'
+                visibility: 'members',
+                published_at: new Date('2023-07-20T04:20:30.000+00:00')
             });
 
             paidPost = testUtils.DataGenerator.forKnex.createPost({
                 slug: 'thou-shalt-be-paid-for',
-                visibility: 'paid'
+                visibility: 'paid',
+                published_at: new Date('2023-07-25T04:20:30.000+00:00')
             });
 
             membersPostWithPaywallCard = testUtils.DataGenerator.forKnex.createPost({
                 slug: 'thou-shalt-have-a-taste',
                 visibility: 'members',
                 mobiledoc: '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["paywall",{}]],"sections":[[1,"p",[[0,[],0,"Free content"]]],[10,0],[1,"p",[[0,[],0,"Members content"]]]]}',
-                html: '<p>Free content</p><!--members-only--><p>Members content</p>'
+                html: '<p>Free content</p><!--members-only--><p>Members content</p>',
+                published_at: new Date('2023-07-30T04:20:30.000+00:00')
             });
 
             return testUtils.fixtures.insertPosts([

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '1c8f47d8f6c93e80a08185f8d36da158';
+    const currentSchemaHash = 'ad44bf95fee71a878704bff2a313a583';
     const currentFixturesHash = '1803057343a6afa7b50f1dabbc21424d';
     const currentSettingsHash = 'dd0e318627ded65e41f188fb5bdf5b74';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes https://github.com/TryGhost/Arch/issues/18

- The prev/next helpers are slow and are causing major performance issues. The helpers are using `posts.published_at` for comparisons extensively, which causes a full table scan - bad for query performance.
- We use published_at in other queries too (like default order for queries fetching all posts), so there  might be a slight performance boost across the system with this new index.


<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71414cb</samp>

This pull request adds an index on the `published_at` column of the `posts` table to improve query performance. It also updates the schema definition, the migration file, and the integrity test file accordingly.
