### PR TITLE
Removed `edit` method from Collection

### DIFF
--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -421,7 +421,26 @@ export class CollectionsService {
             }
 
             const collectionData = this.fromDTO(data);
-            await collection.edit(collectionData, this.uniqueChecker);
+
+            if (collectionData.title) {
+                collection.title = collectionData.title;
+            }
+
+            if (data.slug !== undefined) {
+                await collection.setSlug(data.slug, this.uniqueChecker);
+            }
+
+            if (data.description !== undefined) {
+                collection.description = data.description;
+            }
+
+            if (data.filter !== undefined) {
+                collection.filter = data.filter;
+            }
+
+            if (data.feature_image !== undefined) {
+                collection.featureImage = data.feature_image;
+            }
 
             if (collection.type === 'manual' && data.posts) {
                 for (const post of data.posts) {

--- a/ghost/collections/test/Collection.test.ts
+++ b/ghost/collections/test/Collection.test.ts
@@ -172,59 +172,64 @@ describe('Collection', function () {
         });
     });
 
-    describe('edit', function () {
-        it('Can edit Collection values', async function () {
-            const collection = await Collection.create({
-                slug: 'test-collection',
-                title: 'Testing edits',
-                type: 'automatic',
-                filter: 'featured:true'
-            });
-
-            assert.equal(collection.title, 'Testing edits');
-
-            await collection.edit({
-                title: 'Edited title',
-                slug: 'edited-slug'
-            }, uniqueChecker);
-
-            assert.equal(collection.title, 'Edited title');
-            assert.equal(collection.slug, 'edited-slug');
+    it('Can edit Collection values', async function () {
+        const collection = await Collection.create({
+            slug: 'test-collection',
+            title: 'Testing edits',
+            type: 'automatic',
+            filter: 'featured:true'
         });
 
-        it('Throws when the collection filter is empty', async function () {
-            const collection = await Collection.create({
-                title: 'Testing edits',
-                type: 'automatic',
-                filter: 'featured:true'
-            });
+        assert.equal(collection.title, 'Testing edits');
 
-            assert.rejects(async () => {
-                await collection.edit({
-                    filter: null
-                }, uniqueChecker);
-            }, (err: any) => {
-                assert.equal(err.message, 'Invalid filter provided for automatic Collection', 'Error message should match');
-                assert.equal(err.context, 'Automatic type of collection should always have a filter value', 'Error message should match');
-                return true;
-            });
+        collection.title = 'Edited title';
+        await collection.setSlug('edited-slug', uniqueChecker);
+
+        assert.equal(collection.title, 'Edited title');
+        assert.equal(collection.slug, 'edited-slug');
+    });
+
+    it('Throws when the collection filter is empty', async function () {
+        const collection = await Collection.create({
+            title: 'Testing edits',
+            type: 'automatic',
+            filter: 'featured:true'
         });
 
-        it('Does not throw when collection filter is empty for automatic "latest" collection', async function (){
-            const collection = await Collection.create({
-                title: 'Latest',
-                slug: 'latest',
-                type: 'automatic',
-                filter: ''
-            });
+        assert.throws(() => {
+            collection.filter = null;
+        }, (err: any) => {
+            assert.equal(err.message, 'Invalid filter provided for automatic Collection', 'Error message should match');
+            assert.equal(err.context, 'Automatic type of collection should always have a filter value', 'Error message should match');
+            return true;
+        });
+    });
 
-            const editedCollection = await collection.edit({
-                title: 'Edited latest',
-                filter: ''
-            }, uniqueChecker);
+    it('Does not throw when collection filter is empty for automatic "latest" collection', async function (){
+        const collection = await Collection.create({
+            title: 'Latest',
+            slug: 'latest',
+            type: 'automatic',
+            filter: ''
+        });
 
-            assert.equal(editedCollection.title, 'Edited latest');
-            assert.equal(editedCollection.filter, '');
+        collection.filter = '';
+    });
+
+    it('throws when trying to set filter on a manual collection', async function () {
+        const collection = await Collection.create({
+            title: 'Testing Manual Filter',
+            slug: 'testing-manual-filter',
+            type: 'manual',
+            filter: null
+        });
+
+        assert.throws(() => {
+            collection.filter = 'awesome:true';
+        }, (err: any) => {
+            assert.equal(err.message, 'Invalid filter provided for automatic Collection', 'Error message should match');
+            assert.equal(err.context, 'Automatic type of collection should always have a filter value', 'Error message should match');
+            return true;
         });
     });
 


### PR DESCRIPTION
We want to keep Entities as basic as possible, particularly when setting property, so that each property can handle its own validation.
