### PR TITLE
Allows unknown local cache when testing with Nx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ env:
     nx-Linux-${{ github.ref }}-${{ github.sha }}
     nx-Linux-${{ github.ref }}
     nx-Linux
+  NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
refs: https://github.com/TryGhost/DevOps/issues/55

The documentation for this feature is here: https://nx.dev/recipes/troubleshooting/unknown-local-cache

Ideally, we'd use a remote cache, but we can just share to local cache since it's being shared by identical machines.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22ce864</samp>

Update Nx and other dependencies in Ghost. Allow CI to use local cache with different Nx versions by setting `NX_REJECT_UNKNOWN_LOCAL_CACHE` to 0 in `.github/workflows/ci.yml`.
