### PR TITLE
Prevent prepack errors when cache restored in CI

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -243,7 +243,7 @@
     "mocha": "10.2.0",
     "mocha-slow-test-reporter": "0.1.2",
     "mock-knex": "TryGhost/mock-knex#d8b93b1c20d4820323477f2c60db016ab3e73192",
-    "monobundle": "TryGhost/monobundle#2aca618f8880250fb99ad48d61f0ca7251f1e648",
+    "monobundle": "TryGhost/monobundle#44fdf2c8e304e797a04858bfd7339b2a1fa47441",
     "nock": "13.3.1",
     "papaparse": "5.3.2",
     "postcss": "8.4.27",


### PR DESCRIPTION
refs: https://github.com/TryGhost/DevOps/issues/56

The new monobundle package now ignores any package directory if it doesn't contain a package.json. These non-packages are occasionally restored from cache when pulling dependencies.
