### PR TITLE
Added more debugging to find caused of skipped canary tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -765,10 +765,13 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+      - name: Output needs
+        run: echo "${{ toJson(needs) }}"
+
+      - name: Check if any required jobs failed or been cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
-          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
+          echo "One of the dependent jobs have failed or been cancelled. You may need to re-run it." && exit 1
 
   canary:
     needs: [
@@ -777,7 +780,7 @@ jobs:
     ]
     name: Canary
     runs-on: ubuntu-latest
-    if: always() && needs.job_get_metadata.outputs.is_canary_branch == 'true' && !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped'))
+    if: always() && needs.job_get_metadata.outputs.is_canary_branch == 'true' && !(contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped'))
     steps:
       - name: Set env variables
         run: |


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/57

- adds a step to output the `needs` context
- adds `cancelled` as a "failed" step because it means we haven't run all the tests
- unfortunately there's no way to assert all elements are one type (success), so we have to check for existence of the negative ones

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bbe1a0b</samp>

This pull request enhances the CI workflow by adding a debug step and a skip condition for the `canary` job. This helps to avoid unnecessary or erroneous runs of the `canary` job when the dependencies are not met.
