### PR TITLE
Added update to Explore iframe on nightShift change

### DIFF
--- a/ghost/admin/app/components/gh-explore-iframe.hbs
+++ b/ghost/admin/app/components/gh-explore-iframe.hbs
@@ -1,1 +1,10 @@
-<iframe id="explore-frame" class="explore-frame" frameborder="0" title="Explore" ...attributes {{did-insert this.setup}}></iframe>
+<iframe
+    id="explore-frame"
+    class="explore-frame"
+    frameborder="0"
+    title="Explore"
+    {{did-insert this.setup}}
+    {{did-update this.handleDarkModeChange this.feature.nightShift}}
+    ...attributes
+>
+</iframe>

--- a/ghost/admin/app/components/gh-explore-iframe.js
+++ b/ghost/admin/app/components/gh-explore-iframe.js
@@ -40,6 +40,13 @@ export default class GhExploreIframe extends Component {
         }
     }
 
+    @action
+    async handleDarkModeChange() {
+        if (this.explore.exploreWindowOpen) {
+            this.explore.sendUIUpdate({darkMode: this.feature.nightShift});
+        }
+    }
+
     // The iframe can send route updates to navigate to within Admin, as some routes
     // have to be rendered within the iframe and others require to break out of it.
     _handleRouteUpdate(data) {

--- a/ghost/admin/app/services/explore.js
+++ b/ghost/admin/app/services/explore.js
@@ -79,6 +79,13 @@ export default class ExploreService extends Service {
         }, '*');
     }
 
+    sendUIUpdate(data) {
+        this.getExploreIframe().contentWindow.postMessage({
+            query: 'uiUpdate',
+            response: data
+        }, '*');
+    }
+
     // Controls explore window modal visibility and sync of the URL visible in browser
     // and the URL opened on the iframe. It is responsible to non user triggered iframe opening,
     // for example: by entering "/explore" route in the URL or using history navigation (back and forward)


### PR DESCRIPTION
no issue

- This change listens to updated values of the night shift toggle and sends a message to the Explore iframe - if mounted - to ensure the themes are in sync
- For now, this won't cause any changes in Explore and is in preparation of supporting dark mode