### PR TITLE
Added a validation for a minimum suggested amount for Tips & Donations

### DIFF
--- a/ghost/admin/app/components/settings/tips-and-donations.hbs
+++ b/ghost/admin/app/components/settings/tips-and-donations.hbs
@@ -73,7 +73,11 @@
                                 @class="gh-btn gh-btn-black gh-btn-icon" />
                         </div>
                     </GhFormGroup>
+
                 </div>
+                {{#if this.tipsAndDonationsError}}
+                    <p class="gh-setting-error"><span class="red">{{this.tipsAndDonationsError}}</span></p>
+                {{/if}}
             </GhFormGroup>
         </div>
         {{/liquid-if}}

--- a/ghost/admin/app/components/settings/tips-and-donations.js
+++ b/ghost/admin/app/components/settings/tips-and-donations.js
@@ -65,7 +65,7 @@ export default class TipsAndDonations extends Component {
         const minimumAmount = minimumAmountForCurrency(currency);
 
         if (amountInCents !== 0 && amountInCents < minimumAmount) {
-            this.tipsAndDonationsError = `The suggested amount should be at least of ${symbol}${minimumAmount / 100}.`;
+            this.tipsAndDonationsError = `The suggested amount cannot be less than ${symbol}${minimumAmount / 100}.`;
             return;
         }
 

--- a/ghost/admin/app/utils/currency.js
+++ b/ghost/admin/app/utils/currency.js
@@ -162,3 +162,45 @@ export function getCurrencyOptions() {
         }
     ];
 }
+
+/*
+* Returns the minimum charge amount for a given currency,
+* based on Stripe's requirements. Values here are double the Stripe limits, to take conversions to the settlement currency into account.
+* @see https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
+* @param {String} currency — Currency in the 3-letter ISO format (e.g. "USD", "EUR")
+* @retuns {Number} — Minimum amount in cents (e.g. 100 for $1.00)
+*/
+export function minimumAmountForCurrency(currency) {
+    switch (currency) {
+    case 'AED':
+        return 400;
+    case 'BGN':
+        return 200;
+    case 'CZK':
+        return 3000;
+    case 'DKK':
+        return 500;
+    case 'HKD':
+        return 800;
+    case 'HUF':
+        return 25000;
+    case 'JPY':
+        return 10000;
+    case 'MXN':
+        return 2000;
+    case 'MYR':
+        return 400;
+    case 'NOK':
+        return 600;
+    case 'PLN':
+        return 400;
+    case 'RON':
+        return 400;
+    case 'SEK':
+        return 600;
+    case 'THB':
+        return 2000;
+    default:
+        return 100;
+    }
+}


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3695

- Stripe has minimum charge amounts per currency, see https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
- We double these limits in our validation, to take into account currency conversions to the main currency used on the Stripe account. If the publishers enters a suggested amount below the limit, they will see an error in Admin
- 0 is permitted as default value and corresponds to "no suggested amount"