### PR TITLE
✨ Added new enhanced Header Card

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -325,7 +325,10 @@ export default class KoenigLexicalEditor extends Component {
                 signupCard: true,
                 collectionsCard: this.feature.get('collectionsCard'),
                 collections: this.feature.get('collections'),
-                headerV2: this.feature.get('headerUpgrade')
+                headerV2: true
+            },
+            depreciated: {
+                headerV1: true // if false, shows header v1 in the menu
             },
             membersEnabled: this.settings.get('membersSignupAccess') === 'all',
             siteTitle: this.settings.title,

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -324,8 +324,7 @@ export default class KoenigLexicalEditor extends Component {
             feature: {
                 signupCard: true,
                 collectionsCard: this.feature.get('collectionsCard'),
-                collections: this.feature.get('collections'),
-                headerV2: true
+                collections: this.feature.get('collections')
             },
             depreciated: {
                 headerV1: true // if false, shows header v1 in the menu

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -75,7 +75,6 @@ export default class FeatureService extends Service {
     @feature('adminXSettings') adminXSettings;
     @feature('mailEvents') mailEvents;
     @feature('collectionsCard') collectionsCard;
-    @feature('headerUpgrade') headerUpgrade;
     @feature('importMemberTier') importMemberTier;
     @feature('tipsAndDonations') tipsAndDonations;
     @feature('convertToLexical') convertToLexical;

--- a/ghost/admin/app/templates/settings/labs.hbs
+++ b/ghost/admin/app/templates/settings/labs.hbs
@@ -328,20 +328,6 @@
                 <div class="gh-expandable-block">
                     <div class="gh-expandable-header">
                         <div>
-                            <h4 class="gh-expandable-title">Header Card v2</h4>
-                            <p class="gh-expandable-description">
-                                A new enhanced version of the header card
-                            </p>
-                        </div>
-                        <div class="for-switch">
-                            <GhFeatureFlag @flag="headerUpgrade" />
-                        </div>
-                    </div>
-                </div>
-
-                <div class="gh-expandable-block">
-                    <div class="gh-expandable-header">
-                        <div>
                             <h4 class="gh-expandable-title">Convert to Lexical</h4>
                             <p class="gh-expandable-description">
                                 Convert mobiledoc posts to lexical upon opening in the editor.

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -200,7 +200,7 @@
     },
     "editor": {
         "url": "https://cdn.jsdelivr.net/ghost/koenig-lexical@~{version}/dist/koenig-lexical.umd.js",
-        "version": "0.3"
+        "version": "0.4"
     },
     "adminX": {
         "url": "https://cdn.jsdelivr.net/ghost/admin-x-settings@~{version}/dist/admin-x-settings.umd.js",

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -40,7 +40,6 @@ const ALPHA_FEATURES = [
     'adminXSettings',
     'mailEvents',
     'collectionsCard',
-    'headerUpgrade',
     'tipsAndDonations',
     'importMemberTier',
     'convertToLexical'


### PR DESCRIPTION
no issue

- Keep an eye on Ghost's changelog (https://ghost.org/changelog/) for the full feature announcement. 🎉

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8367091</samp>

This pull request removes the `headerUpgrade` feature flag and enables the new header card by default in the editor. It also hides the old header card from the editor menu unless the `labs.headerV1` setting is enabled.
