### PR TITLE
Removed leftover signup flag in Koenig config

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -322,7 +322,6 @@ export default class KoenigLexicalEditor extends Component {
             fetchAutocompleteLinks,
             fetchLabels,
             feature: {
-                signupCard: true,
                 collectionsCard: this.feature.get('collectionsCard'),
                 collections: this.feature.get('collections'),
                 headerV2: this.feature.get('headerUpgrade')


### PR DESCRIPTION
no issue

- Removed a leftover signup property in the Koenig lexical config.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e10cc3</samp>

Removed `signupCard` property from `koenig-lexical-editor` component. This property was used for a feature that was moved to a new component.
