### PR TITLE
Updated minimum price validation in Tiers, to support more currencies

### DIFF
--- a/ghost/admin/app/components/modal-tier.js
+++ b/ghost/admin/app/components/modal-tier.js
@@ -2,7 +2,7 @@ import ModalBase from 'ghost-admin/components/modal-base';
 import TierBenefitItem from '../models/tier-benefit-item';
 import classic from 'ember-classic-decorator';
 import {action} from '@ember/object';
-import {currencies, getCurrencyOptions, getSymbol} from 'ghost-admin/utils/currency';
+import {currencies, getCurrencyOptions, getSymbol, minimumAmountForCurrency} from 'ghost-admin/utils/currency';
 import {A as emberA} from '@ember/array';
 import {htmlSafe} from '@ember/template';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -214,12 +214,14 @@ export default class ModalTierPrice extends ModalBase {
             const yearlyAmount = this.stripeYearlyAmount;
             const monthlyAmount = this.stripeMonthlyAmount;
             const symbol = getSymbol(this.currency);
-            if (!yearlyAmount || yearlyAmount < 1 || !monthlyAmount || monthlyAmount < 1) {
-                throw new TypeError(`Subscription amount must be at least ${symbol}1.00`);
+            const minimumAmount = minimumAmountForCurrency(this.currency) / 100;
+
+            if (!yearlyAmount || (yearlyAmount < minimumAmount) || !monthlyAmount || (monthlyAmount < minimumAmount)) {
+                throw new TypeError(`Subscription amount cannot be less than ${symbol}${minimumAmount}`);
             }
 
             if (yearlyAmount > MAX_AMOUNT || monthlyAmount > MAX_AMOUNT) {
-                throw new TypeError(`Subscription amount cannot be higher than ${symbol}${MAX_AMOUNT}`);
+                throw new TypeError(`Subscription amount cannot be more than ${symbol}${MAX_AMOUNT}`);
             }
         } catch (err) {
             this.stripePlanError = err.message;

--- a/ghost/admin/app/utils/currency.js
+++ b/ghost/admin/app/utils/currency.js
@@ -171,7 +171,9 @@ export function getCurrencyOptions() {
 * @retuns {Number} — Minimum amount in cents (e.g. 100 for $1.00)
 */
 export function minimumAmountForCurrency(currency) {
-    switch (currency) {
+    const isoCurrency = currency?.toUpperCase();
+
+    switch (isoCurrency) {
     case 'AED':
         return 400;
     case 'BGN':


### PR DESCRIPTION
no issue

- Stripe imposes different minimum charges based on the currency used, see https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
- Our validation uses double that limit, to take into account conversions to the main currency in use in the Stripe account
