### PR TITLE
Added relative URLs for Portal links in Button, Header, Email CTA url…

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -256,15 +256,8 @@ export default class KoenigLexicalEditor extends Component {
 
             const defaults = [
                 {label: 'Homepage', value: window.location.origin + '/'},
-                {label: 'Free signup', value: window.location.origin + '/#/portal/signup/free'}
+                {label: 'Free signup', value: '#/portal/signup/free'}
             ];
-
-            const offersLinks = offers.toArray().map((offer) => {
-                return {
-                    label: `Offer - ${offer.name}`,
-                    value: this.config.getSiteUrl(offer.code)
-                };
-            });
 
             const memberLinks = () => {
                 let links = [];
@@ -272,11 +265,11 @@ export default class KoenigLexicalEditor extends Component {
                     links = [
                         {
                             label: 'Paid signup',
-                            value: this.config.getSiteUrl('/#/portal/signup')
+                            value: '#/portal/signup'
                         },
                         {
                             label: 'Upgrade or change plan',
-                            value: this.config.getSiteUrl('/#/portal/account/plans')
+                            value: '#/portal/account/plans'
                         }];
                 }
 
@@ -289,7 +282,7 @@ export default class KoenigLexicalEditor extends Component {
                     if (this.settings.donationsEnabled) {
                         return [{
                             label: 'Tip or donation',
-                            value: this.config.getSiteUrl('/#/portal/support')
+                            value: '#/portal/support'
                         }];
                     }
                 }
@@ -297,7 +290,14 @@ export default class KoenigLexicalEditor extends Component {
                 return [];
             };
 
-            return [...defaults, ...offersLinks, ...memberLinks(), ...donationLink()];
+            const offersLinks = offers.toArray().map((offer) => {
+                return {
+                    label: `Offer - ${offer.name}`,
+                    value: `${offer.code}`
+                };
+            });
+
+            return [...defaults, ...memberLinks(), ...donationLink(), ...offersLinks];
         };
 
         const fetchLabels = async () => {

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-button.js
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-button.js
@@ -60,26 +60,17 @@ export default class KoenigCardButtonComponent extends Component {
             url: this.config.getSiteUrl('/')
         }, {
             name: 'Free signup',
-            url: this.config.getSiteUrl('/#/portal/signup/free')
+            url: '#/portal/signup/free'
         }]);
 
         if (this.membersUtils.paidMembersEnabled) {
             urls.push(...[{
                 name: 'Paid signup',
-                url: this.config.getSiteUrl('/#/portal/signup')
+                url: '#/portal/signup'
             }, {
                 name: 'Upgrade or change plan',
-                url: this.config.getSiteUrl('/#/portal/account/plans')
+                url: '#/portal/account/plans'
             }]);
-        }
-
-        if (this.offers) {
-            this.offers.forEach((offer) => {
-                urls.push(...[{
-                    name: `Offer - ${offer.name}`,
-                    url: this.config.getSiteUrl(offer.code)
-                }]);
-            });
         }
 
         // TODO: remove feature condition once Tips & Donations have been released
@@ -87,9 +78,18 @@ export default class KoenigCardButtonComponent extends Component {
             if (this.settings.donationsEnabled) {
                 urls.push({
                     name: 'Tip or donation',
-                    url: this.config.getSiteUrl('/#/portal/support')
+                    url: '#/portal/support'
                 });
             }
+        }
+
+        if (this.offers) {
+            this.offers.forEach((offer) => {
+                urls.push(...[{
+                    name: `Offer - ${offer.name}`,
+                    url: `${offer.code}`
+                }]);
+            });
         }
 
         return urls;

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-email-cta.js
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-email-cta.js
@@ -84,26 +84,17 @@ export default class KoenigCardEmailCtaComponent extends Component {
             url: this.config.getSiteUrl('/')
         }, {
             name: 'Free signup',
-            url: this.config.getSiteUrl('/#/portal/signup/free')
+            url: '#/portal/signup/free'
         }]);
 
         if (this.membersUtils.paidMembersEnabled) {
             urls.push(...[{
                 name: 'Paid signup',
-                url: this.config.getSiteUrl('/#/portal/signup')
+                url: '#/portal/signup'
             }, {
                 name: 'Upgrade or change plan',
-                url: this.config.getSiteUrl('/#/portal/account/plans')
+                url: '#/portal/account/plans'
             }]);
-        }
-
-        if (this.offers) {
-            this.offers.forEach((offer) => {
-                urls.push(...[{
-                    name: `Offer - ${offer.name}`,
-                    url: this.config.getSiteUrl(offer.code)
-                }]);
-            });
         }
 
         // TODO: remove feature condition once Tips & Donations have been released
@@ -111,9 +102,18 @@ export default class KoenigCardEmailCtaComponent extends Component {
             if (this.settings.donationsEnabled) {
                 urls.push({
                     name: 'Tip or donation',
-                    url: this.config.getSiteUrl('/#/portal/support')
+                    url: '#/portal/support'
                 });
             }
+        }
+
+        if (this.offers) {
+            this.offers.forEach((offer) => {
+                urls.push(...[{
+                    name: `Offer - ${offer.name}`,
+                    url: `${offer.code}`
+                }]);
+            });
         }
 
         return urls;

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-header.js
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-header.js
@@ -73,26 +73,17 @@ export default class KoenigCardHeaderComponent extends Component {
             url: this.config.getSiteUrl('/')
         }, {
             name: 'Free signup',
-            url: this.config.getSiteUrl('/#/portal/signup/free')
+            url: '#/portal/signup/free'
         }]);
 
         if (this.membersUtils.paidMembersEnabled) {
             urls.push(...[{
                 name: 'Paid signup',
-                url: this.config.getSiteUrl('/#/portal/signup')
+                url: '#/portal/signup'
             }, {
                 name: 'Upgrade or change plan',
-                url: this.config.getSiteUrl('/#/portal/account/plans')
+                url: '#/portal/account/plans'
             }]);
-        }
-
-        if (this.offers) {
-            this.offers.forEach((offer) => {
-                urls.push(...[{
-                    name: `Offer - ${offer.name}`,
-                    url: this.config.getSiteUrl(offer.code)
-                }]);
-            });
         }
 
         // TODO: remove feature condition once Tips & Donations have been released
@@ -100,9 +91,18 @@ export default class KoenigCardHeaderComponent extends Component {
             if (this.settings.donationsEnabled) {
                 urls.push({
                     name: 'Tip or donation',
-                    url: this.config.getSiteUrl('/#/portal/support')
+                    url: '#/portal/support'
                 });
             }
+        }
+
+        if (this.offers) {
+            this.offers.forEach((offer) => {
+                urls.push(...[{
+                    name: `Offer - ${offer.name}`,
+                    url: `${offer.code}`
+                }]);
+            });
         }
 
         return urls;


### PR DESCRIPTION
… suggestions

refs https://github.com/TryGhost/Product/issues/3687

- Today, in Button, Header, Email CTA cards, Portal links are used as absolute URLs to the root, e.g. https://mysite.com/#/portal/signin. When clicking on a Portal link, the reader is redirect to the homepage first, loosing context of the post.
- With this change, the UX becomes smoother: clicking on a Portal link keeps the reader in context, and open the Portal link on the same post e.g., https://mysite.com/POST_URL/#/portal/signin
- Technically, this works by using relative URLs for Portal links. Relative URLs work out of the box for web, but required changes on the email side, cf. https://github.com/TryGhost/Ghost/pull/17630
