### PR TITLE
Fixed enormous site icon issue in Outlook

### DIFF
--- a/ghost/email-service/lib/email-templates/template-old.hbs
+++ b/ghost/email-service/lib/email-templates/template-old.hbs
@@ -47,7 +47,7 @@
                                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                                         {{#if (and showHeaderIcon site.iconUrl) }}
                                                             <tr>
-                                                                <td class="site-icon"><a href="{{site.url}}"><img src="{{site.iconUrl}}" alt="{{site.title}}" border="0"></a></td>
+                                                                <td class="site-icon"><a href="{{site.url}}"><img src="{{site.iconUrl}}" alt="{{site.title}}" border="0" width="48" height="48"></a></td>
                                                             </tr>
                                                         {{/if}}
                                                         {{#if showHeaderTitle }}


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3704

- the site icon has sizes defined in CSS and it works great for most browsers
- but it becomes very large in Outlook and it requires explicit sizes in the image markup for some reason
