### PR TITLE
Reverted Offer links to absolute URLs

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -293,7 +293,7 @@ export default class KoenigLexicalEditor extends Component {
             const offersLinks = offers.toArray().map((offer) => {
                 return {
                     label: `Offer - ${offer.name}`,
-                    value: `${offer.code}`
+                    value: this.config.getSiteUrl(offer.code)
                 };
             });
 

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-button.js
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-button.js
@@ -87,7 +87,7 @@ export default class KoenigCardButtonComponent extends Component {
             this.offers.forEach((offer) => {
                 urls.push(...[{
                     name: `Offer - ${offer.name}`,
-                    url: `${offer.code}`
+                    url: this.config.getSiteUrl(offer.code)
                 }]);
             });
         }

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-email-cta.js
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-email-cta.js
@@ -111,7 +111,7 @@ export default class KoenigCardEmailCtaComponent extends Component {
             this.offers.forEach((offer) => {
                 urls.push(...[{
                     name: `Offer - ${offer.name}`,
-                    url: `${offer.code}`
+                    url: this.config.getSiteUrl(offer.code)
                 }]);
             });
         }

--- a/ghost/admin/lib/koenig-editor/addon/components/koenig-card-header.js
+++ b/ghost/admin/lib/koenig-editor/addon/components/koenig-card-header.js
@@ -100,7 +100,7 @@ export default class KoenigCardHeaderComponent extends Component {
             this.offers.forEach((offer) => {
                 urls.push(...[{
                     name: `Offer - ${offer.name}`,
-                    url: `${offer.code}`
+                    url: this.config.getSiteUrl(offer.code)
                 }]);
             });
         }


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3687

- We're not sure that relative URLs for Offers will work in production, even though they seem to work locally. Reverting for now.

