### PR TITLE
Fixed Portal temporary donation link saved in browser history

### DIFF
--- a/apps/portal/src/components/pages/SupportPage.js
+++ b/apps/portal/src/components/pages/SupportPage.js
@@ -19,7 +19,7 @@ const SupportPage = () => {
                 const response = await api.member.checkoutDonation({successUrl, cancelUrl});
 
                 if (response.url) {
-                    window.location.assign(response.url);
+                    window.location.replace(response.url);
                 }
             } catch (err) {
                 const errorMessage = err.message || 'There was an error processing your payment. Please try again.';


### PR DESCRIPTION
no issue

- When clicking back button in the browser when on the checkout page, will not open Stripe again
- Does not open Stripe checkout in peek and pop mode in Arc