### PR TITLE
Removed synthetic timestamp-based cache resets

### DIFF
--- a/ghost/event-aware-cache-wrapper/lib/EventAwareCacheWrapper.js
+++ b/ghost/event-aware-cache-wrapper/lib/EventAwareCacheWrapper.js
@@ -1,18 +1,13 @@
 class EventAwareCacheWrapper {
     #cache;
-
-    #lastReset;
-
     /**
      * @param {Object} deps
      * @param {Object} deps.cache - cache instance extending adapter-base-cache
      * @param {Object} [deps.eventRegistry] - event registry instance
-     * @param {Number} [deps.lastReset] - timestamp of last reset
      * @param {String[]} [deps.resetEvents] - event to listen to triggering reset
      */
     constructor(deps) {
         this.#cache = deps.cache;
-        this.#lastReset = deps.lastReset || Date.now();
 
         if (deps.resetEvents && deps.eventRegistry) {
             this.#initListeners(deps.eventRegistry, deps.resetEvents);
@@ -27,25 +22,16 @@ class EventAwareCacheWrapper {
         });
     }
 
-    #buildResetAwareKey(key) {
-        return `${this.#lastReset}:${key}`;
-    }
-
     async get(key) {
-        return this.#cache.get(this.#buildResetAwareKey(key));
+        return this.#cache.get(key);
     }
 
     async set(key, value) {
-        return this.#cache.set(this.#buildResetAwareKey(key), value);
+        return this.#cache.set(key, value);
     }
 
-    /**
-     * Reset the cache without removing of flushing the keys
-     * The mechanism is based on adding a timestamp to the key
-     * This way the cache is invalidated but the keys are still there
-     */
     reset() {
-        this.#lastReset = Date.now();
+        return this.#cache.reset();
     }
 }
 

--- a/ghost/event-aware-cache-wrapper/test/EventAwareCacheWrapper.test.js
+++ b/ghost/event-aware-cache-wrapper/test/EventAwareCacheWrapper.test.js
@@ -4,12 +4,6 @@ const InMemoryCache = require('@tryghost/adapter-cache-memory-ttl');
 const EventAwareCacheWrapper = require('../index');
 const {EventEmitter} = require('stream');
 
-const sleep = ms => (
-    new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    })
-);
-
 describe('EventAwareCacheWrapper', function () {
     it('Can initialize', function () {
         const cache = new InMemoryCache();
@@ -22,35 +16,29 @@ describe('EventAwareCacheWrapper', function () {
     describe('get', function () {
         it('calls a wrapped cache with extra key', async function () {
             const cache = new InMemoryCache();
-            const lastReset = Date.now();
             const wrapper = new EventAwareCacheWrapper({
-                cache: cache,
-                lastReset: lastReset
+                cache: cache
             });
 
             await wrapper.set('a', 'b');
             assert.equal(await wrapper.get('a'), 'b');
-            assert.equal(await cache.get(`${lastReset}:a`), 'b');
+            assert.equal(await cache.get('a'), 'b');
         });
     });
 
     describe('listens to reset events', function () {
         it('resets the cache when reset event is triggered', async function () {
             const cache = new InMemoryCache();
-            const lastReset = Date.now();
+
             const eventRegistry = new EventEmitter();
             const wrapper = new EventAwareCacheWrapper({
                 cache: cache,
-                lastReset: lastReset,
                 resetEvents: ['site.changed'],
                 eventRegistry: eventRegistry
             });
 
             await wrapper.set('a', 'b');
             assert.equal(await wrapper.get('a'), 'b');
-
-            // let the time tick to get new lastReset
-            await sleep(100);
 
             eventRegistry.emit('site.changed');
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/5
refs https://github.com/TryGhost/Ghost/pull/16398

- Current event-aware cache wrapper has been using a timestamp as a way to create keys in Redis cache and reset them all at once. We are now moving on to the updated Redis adapter that supports "reset()" natively, so there's no need for synthetic resets.
