### PR TITLE
Hardcoded success criteria for running canary job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,7 +780,7 @@ jobs:
     ]
     name: Canary
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.job_get_metadata.outputs.is_canary_branch == 'true' && !(contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped')) }}
+    if: always() && needs.job_get_metadata.outputs.is_canary_branch == 'true' && needs.job_required_tests.result == 'success' && needs.job_get_metadata.result == 'success'
     steps:
       - name: Output needs (for debugging)
         run: echo "${{ toJson(needs) }}"


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/57

- I'm not sure why but I think the `contains` are doing funky things and not allowing the build to run when we expect it to
- switching to a slightly different if-statement should help with that

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b72aaf7</samp>

Simplify and debug the Canary job condition in `.github/workflows/ci.yml` to fix skipping issues.
