### PR TITLE
Fixed bug when running `yarn dev` on Windows 11

### DIFF
--- a/ghost/core/core/frontend/services/admin-auth-assets/AdminAuthAssetsService.js
+++ b/ghost/core/core/frontend/services/admin-auth-assets/AdminAuthAssetsService.js
@@ -62,7 +62,11 @@ class AdminAuthAssetsService {
      */
     async copyStatic() {
         try {
-            await fs.copyFile(path.join(this.src, 'index.html'), path.join(this.dest, 'index.html'));
+            const FileOrigin = path.join(this.src, 'index.html');
+            const FileDestination = path.join(this.dest, 'index.html');
+
+            await fs.mkdir(path.dirname(FileDestination), {recursive: true});
+            await fs.copyFile(FileOrigin, FileDestination);
         } catch (error) {
             if (error.code === 'EACCES') {
                 logging.error('Ghost was not able to write admin-auth asset files due to permissions.');


### PR DESCRIPTION
This fixes `ERROR Unable to activate the theme "casper".` and `Unable to activate the theme "casper".` when running `yarn dev` on Windows 11 mentioned on this issue: https://github.com/TryGhost/Ghost/issues/17704

This commit doesn't fix the entire issue, but it fixes the first part of the issue. It's also only tested on my Windows 11 system. Someone just needs to test it on MacOS and make sure it's working there too, but I'm 99% sure it won't cause any issues on MacOS and will just work as always.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 47a7921</samp>

Fix admin panel loading bug by ensuring destination directory for `index.html` exists. Refactor `AdminAuthAssetsService.js` to use variables for paths.
