### PR TITLE
🐛 Fixed newsletter filters not working in bulk operations

### DIFF
--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -216,8 +216,20 @@ export default class MembersController extends Controller {
         });
     }
 
+    refineFilterParam(filterParam) {
+        const regex = new RegExp(`\\(([^)]*[,+\\-]?email_disabled[^)]*)\\)(?![+\\-]|:\\'[^']*\\'|:\\"[^"]*\\")`, 'g');
+        return filterParam.replace(regex, '$1');
+    }
+
     getApiQueryObject({params, extraFilters = []} = {}) {
         let {label, paidParam, searchParam, filterParam} = params ? params : this;
+
+        // NOTE: this is a temporary fix to help where the API isn't handling the parentheses correctly
+        // It's potentially a deeper issue with NQL. This should be removed once the API is fixed.
+        // refs https://ghost.slack.com/archives/C05EQPTMEP7/p1692025845788769
+        if (filterParam) {
+            filterParam = this.refineFilterParam(filterParam);
+        }
 
         let filters = [];
 

--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -217,6 +217,20 @@ export default class MembersController extends Controller {
     }
 
     refineFilterParam(filterParam) {
+        // We have some crazy regex below, here's a breakdown of what it does:
+        // \\(             - Matches an opening parenthesis "("
+        // [^)]*          - Matches zero or more characters that are NOT a closing parenthesis ")"
+        // [,+\\-]?       - Matches an optional comma, plus, or minus sign
+        // email_disabled - Matches the exact string "email_disabled"
+        // [^)]*          - Matches zero or more characters that are NOT a closing parenthesis ")"
+        // \\)             - Matches a closing parenthesis ")"
+        // (?!
+        //  [+\\-]        - Negative lookahead: Asserts what directly follows is neither a plus "+" nor a minus "-"
+        //  |             - OR
+        //  :\\'[^']*\\'  - Negative lookahead: Asserts what follows is not a colon ":" followed by a string in single quotes
+        //  |             - OR
+        //  :\\"[^"]*\\"  - Negative lookahead: Asserts what follows is not a colon ":" followed by a string in double quotes
+        // )
         const regex = new RegExp(`\\(([^)]*[,+\\-]?email_disabled[^)]*)\\)(?![+\\-]|:\\'[^']*\\'|:\\"[^"]*\\")`, 'g');
         return filterParam.replace(regex, '$1');
     }


### PR DESCRIPTION
refs https://ghost.slack.com/archives/CTH5NDJMS/p1692021848890629

- Addresses an NQL / API edge case where standalone filters with parentheses doesn't get handled correctly within bulk operations such as member labelling, member unsubscribe and member deletion.
- This is currently only affected by newsletter related filters.
- This adds a regex functions that checks when those filters are used and removes the parentheses when required.
- Ideally we fix the NQL / API issue in the near future and remove this regex hack altogether, but taking all things into consideration, this should mitigate the risk of potential data-loss for Ghost users.

