### PR TITLE
🏗️ Repopulated collections_posts  built-in collections data

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.64/2023-09-19-04-25-40-truncate-stale-built-in-collections-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.64/2023-09-19-04-25-40-truncate-stale-built-in-collections-posts.js
@@ -1,0 +1,12 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info('Clearing collections_posts table');
+        await knex('collections_posts').truncate();
+    },
+    async function down() {
+        logging.info('Not doing anything - collections_posts table has been truncated');
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/5.64/2023-09-19-04-34-10-repopulate-built-in-collection-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.64/2023-09-19-04-34-10-repopulate-built-in-collection-posts.js
@@ -1,0 +1,69 @@
+const logging = require('@tryghost/logging');
+const {default: ObjectID} = require('bson-objectid');
+const {createTransactionalMigration} = require('../../utils');
+
+const insertPostCollections = async (knex, collectionId, postIds) => {
+    logging.warn(`Batch inserting ${postIds.length} collection posts for collection ${collectionId}`);
+
+    const collectionPosts = postIds.map((postId) => {
+        return {
+            id: (new ObjectID()).toHexString(),
+            collection_id: collectionId,
+            post_id: postId,
+            sort_order: 0
+        };
+    });
+
+    await knex.batchInsert('collections_posts', collectionPosts, 1000);
+};
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Populating built-in collections');
+
+        const existingLatestCollection = await knex('collections')
+            .where({
+                slug: 'latest'
+            })
+            .first();
+
+        if (!existingLatestCollection) {
+            logging.warn('Latest collection does not exists, skipping');
+        } else {
+            const latestPostsRows = await knex('posts')
+                .select('id')
+                .where({
+                    type: 'post'
+                });
+
+            const latestPostsIds = latestPostsRows.map(row => row.id);
+
+            await insertPostCollections(knex, existingLatestCollection.id, latestPostsIds);
+        }
+
+        const existingFeaturedCollection = await knex('collections')
+            .where({
+                slug: 'featured'
+            })
+            .first();
+
+        if (!existingFeaturedCollection) {
+            logging.warn('Featured collection does not exist, skipping');
+        } else {
+            const featuredPostsRows = await knex('posts')
+                .select('id')
+                .where({
+                    featured: true,
+                    type: 'post'
+                });
+
+            const featuredPostsIds = featuredPostsRows.map(row => row.id);
+
+            await insertPostCollections(knex, existingFeaturedCollection.id, featuredPostsIds);
+        }
+    },
+    async function down(knex) {
+        logging.info('Clearing collections_posts table');
+        await knex('collections_posts').truncate();
+    }
+);


### PR DESCRIPTION
✅  unblocked by https://github.com/TryGhost/Arch/issues/73

closes https://github.com/TryGhost/Arch/issues/74
refs https://github.com/TryGhost/Ghost/commit/b5d1245be1bfbbcb8bde9d16eedb039b511fc892

- We have turned off the collections feature flag after a unsuccessful attempt to make collections GA. With the flag turned off, collections_posts data has gone stale and needs repopulation to function properly again.
- This migration is meant to clear the data on collections_posts table and repopulated it again the same way initial migration did in 5.5/2023-07-10-05-16-55-add-built-in-collection-posts.js script.

This is the same migration like the one in [5.55](https://github.com/TryGhost/Ghost/commit/b5d1245be1bfbbcb8bde9d16eedb039b511fc892), with an exception that we truncate `collections_posts` table both ways up/down to make sure the data is clean.