### PR TITLE
Updated comment

### DIFF
--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -238,9 +238,9 @@ export default class MembersController extends Controller {
     getApiQueryObject({params, extraFilters = []} = {}) {
         let {label, paidParam, searchParam, filterParam} = params ? params : this;
 
-        // NOTE: this is a temporary fix to help where the API isn't handling the parentheses correctly
+        // NOTE: this is a temporary fix to help where the API/NQL isn't handling the parentheses correctly
         // It's potentially a deeper issue with NQL. This should be removed once the API is fixed.
-        // refs https://ghost.slack.com/archives/C05EQPTMEP7/p1692025845788769
+        // This could be related https://github.com/TryGhost/NQL/issues/16
         if (filterParam) {
             filterParam = this.refineFilterParam(filterParam);
         }


### PR DESCRIPTION
no issue

- added some more info to the comment
- found the actual issue that needed the admin p0 fix last night. Updated the comment info block with a link to that issue.


<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcec294</samp>

Updated a comment in `members.js` to link to a possible NQL issue. This helps explain the temporary fix for filtering members by labels with parentheses.
