### PR TITLE
Added Japanese to list of supported languages

### DIFF
--- a/ghost/i18n/lib/i18n.js
+++ b/ghost/i18n/lib/i18n.js
@@ -17,6 +17,7 @@ const SUPPORTED_LOCALES = [
     'id', // Indonesian
     'it', // Italian
     'ko', // Korean
+    'ja', // Japanese
     'mn', // Mongolian
     'ms', // Malay
     'nl', // Dutch

--- a/ghost/i18n/locales/ja/ghost.json
+++ b/ghost/i18n/locales/ja/ghost.json
@@ -17,7 +17,7 @@
     "See you soon!": "引き続きよろしくお願いします。",
     "Sent to {{email}}": "{{email}}に送信",
     "Sign in": "ログイン",
-    "Sign in to {{siteTitle}}": "{{siteTitle}にログイン}",
+    "Sign in to {{siteTitle}}": "{{siteTitle}にログイン",
     "Tap the link below to complete the signup process for {{siteTitle}}, and be automatically signed in:": "下のリンクを選択すると新規登録が完了し、自動でログインします。",
     "Thank you for signing up to {{siteTitle}}!": "{{siteTitle}}の新規登録ありがとうございます！",
     "Thank you for subscribing to {{siteTitle}}!": "{{siteTitle}}の購読ありがとうございます！",

--- a/ghost/i18n/locales/ja/ghost.json
+++ b/ghost/i18n/locales/ja/ghost.json
@@ -17,7 +17,7 @@
     "See you soon!": "引き続きよろしくお願いします。",
     "Sent to {{email}}": "{{email}}に送信",
     "Sign in": "ログイン",
-    "Sign in to {{siteTitle}}": "{{siteTitle}にログイン",
+    "Sign in to {{siteTitle}}": "{{siteTitle}}にログイン",
     "Tap the link below to complete the signup process for {{siteTitle}}, and be automatically signed in:": "下のリンクを選択すると新規登録が完了し、自動でログインします。",
     "Thank you for signing up to {{siteTitle}}!": "{{siteTitle}}の新規登録ありがとうございます！",
     "Thank you for subscribing to {{siteTitle}}!": "{{siteTitle}}の購読ありがとうございます！",

--- a/ghost/i18n/locales/ja/ghost.json
+++ b/ghost/i18n/locales/ja/ghost.json
@@ -13,7 +13,7 @@
     "If you did not make this request, you can safely ignore this email.": "このリクエストを行っていない場合は、このメールを無視してください。",
     "If you did not make this request, you can simply delete this message.": "このリクエストを行っていない場合は、このメールを削除してください。",
     "Please confirm your email address with this link:": "このリンクを使用してメールアドレスを確認してください：",
-    "Secuore sign in link for {{siteTitle}}": "{{siteTitle}}への安全なログイン先リンク",
+    "Secure sign in link for {{siteTitle}}": "{{siteTitle}}への安全なログイン先リンク",
     "See you soon!": "引き続きよろしくお願いします。",
     "Sent to {{email}}": "{{email}}に送信",
     "Sign in": "ログイン",

--- a/ghost/i18n/locales/ja/portal.json
+++ b/ghost/i18n/locales/ja/portal.json
@@ -1,7 +1,7 @@
 {
     "{{amount}} days free": "{{amount}}日間無料",
     "{{amount}} off": "{{amount}}オフ",
-    "{{amount}} off for first {{number}} months.": "最初の{{number}}ヶ月間{{amount}オフ}",
+    "{{amount}} off for first {{number}} months.": "最初の{{number}}ヶ月間{{amount}}オフ",
     "{{amount}} off for first {{period}}.": "最初の{{period}}{{amount}}オフ",
     "{{amount}} off forever.": "永久に{{amount}}オフ",
     "{{discount}}% discount": "{{discount}}% 割引",


### PR DESCRIPTION
Japanese was missing in the `i18n.js` file. I added it to the file and it fixes this issue: https://github.com/TryGhost/Ghost/issues/17715

There was also a couple of bracket mismatches with the translations that I've fixed as well.

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)


---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 94bb2d4</samp>

Added Japanese locale support for Ghost admin and themes. Updated `i18n.js` to include `ja` in the list of locales.
