### PR TITLE
🐛 Fixed Unsplash integration toggle in Koenig editor

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -306,16 +306,18 @@ export default class KoenigLexicalEditor extends Component {
             return labels.map(label => label.name);
         };
 
+        const unsplashConfig = {
+            defaultHeaders: {
+                Authorization: `Client-ID 8672af113b0a8573edae3aa3713886265d9bb741d707f6c01a486cde8c278980`,
+                'Accept-Version': 'v1',
+                'Content-Type': 'application/json',
+                'App-Pragma': 'no-cache',
+                'X-Unsplash-Cache': true
+            }
+        };
+
         const defaultCardConfig = {
-            unsplash: {
-                defaultHeaders: {
-                    Authorization: `Client-ID 8672af113b0a8573edae3aa3713886265d9bb741d707f6c01a486cde8c278980`,
-                    'Accept-Version': 'v1',
-                    'Content-Type': 'application/json',
-                    'App-Pragma': 'no-cache',
-                    'X-Unsplash-Cache': true
-                }
-            },
+            unsplash: this.settings.unsplash ? unsplashConfig : null,
             tenor: this.config.tenor?.googleApiKey ? this.config.tenor : null,
             fetchEmbed,
             fetchCollectionPosts,


### PR DESCRIPTION
no issue

- since Unsplash can be toggled on / off in integrations, we need to pass that to the Koenig-Lexical editor as well.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e4caf3</samp>

This change makes the unsplash integration in the `koenig-lexical-editor` component optional and configurable based on the `settings.unsplash` property. This is part of a feature that adds a new editor settings screen.
