### PR TITLE
Fixed posts Content API test run in isolation

### DIFF
--- a/ghost/core/test/e2e-api/content/posts.test.js
+++ b/ghost/core/test/e2e-api/content/posts.test.js
@@ -26,6 +26,8 @@ describe('Posts Content API', function () {
     let agent;
 
     before(async function () {
+        // NOTE: can be removed after collections -> GA
+        mockManager.mockLabsEnabled('collections');
         agent = await agentProvider.getContentAPIAgent();
         await fixtureManager.init('owner:post', 'users', 'user:inactive', 'posts', 'tags:extra', 'api_keys', 'newsletters', 'members:newsletters');
         await agent.authenticate();


### PR DESCRIPTION
closes https://github.com/TryGhost/Arch/issues/76

- The posts test suite was failing when run in isolation. This was due to "collections" labs flag not being turned on, the events were not going through to collections service correctly

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1152ff2</samp>

This pull request adds tests for the new collections API endpoints, using the collections feature flag to enable them. It also modifies `ghost/core/test/e2e-api/content/posts.test.js` to use the feature flag.
