### PR TITLE
Wired up Amp integration to AdminX

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/AmpModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/AmpModal.tsx
@@ -59,7 +59,7 @@ const AmpModal = NiceModal.create(() => {
                     <Toggle
                         checked={enabled}
                         direction='rtl'
-                        hint={<>Enable Google Accelerated Mobile Pages <strong className='text-red'>[&larr; link to be set]</strong> for your posts</>}
+                        hint={<>Enable <a className='text-green' href="https://amp.dev" rel="noopener noreferrer" target='_blank'>Google Accelerated Mobile Pages</a> for your posts</>}
                         label='Enable AMP'
                         onChange={(e) => {
                             setEnabled(e.target.checked);

--- a/apps/admin-x-settings/test/e2e/advanced/integrations/amp.test.ts
+++ b/apps/admin-x-settings/test/e2e/advanced/integrations/amp.test.ts
@@ -1,0 +1,35 @@
+import {expect, test} from '@playwright/test';
+import {globalDataRequests, mockApi, updatedSettingsResponse} from '../../../utils/e2e';
+
+test.describe('AMP integration', async () => {
+    test('Supports toggling and filling in AMP integration', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'amp', value: true},
+                {key: 'amp_gtag_id', value: 'UA-1234567-1'}
+            ])}
+        }});
+
+        await page.goto('/');
+        const section = page.getByTestId('integrations');
+        const ampElement = section.getByText('AMP').last();
+        await ampElement.hover();
+        await page.getByRole('button', {name: 'Configure'}).click();
+        const ampModal = page.getByTestId('amp-modal');
+        
+        const ampToggle = ampModal.getByRole('switch');
+        await ampToggle.click();
+        const input = ampModal.getByRole('textbox');
+        await input.fill('UA-1234567-1');
+
+        await ampModal.getByRole('button', {name: 'Save'}).click();
+
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [
+                {key: 'amp', value: true},
+                {key: 'amp_gtag_id', value: 'UA-1234567-1'}
+            ]
+        });
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3729

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 930d3b2</samp>

This file adds a modal component to the advanced settings page that allows users to toggle and customize AMP integration for their site. It uses the `settings` API and React hooks to handle the modal logic and state.
