### PR TITLE
🐛 Fixed comments admin menu not visible when not logged in as member

### DIFF
--- a/apps/comments-ui/src/App.test.jsx
+++ b/apps/comments-ui/src/App.test.jsx
@@ -101,50 +101,6 @@ afterEach(() => {
     vi.restoreAllMocks();
 });
 
-describe('Auth frame', () => {
-    it('renders the auth frame', () => {
-        const {container} = renderApp();
-        const iframeElement = container.querySelector('iframe[data-frame="admin-auth"]');
-        expect(iframeElement).toBeInTheDocument();
-    });
-});
-
-describe('Dark mode', () => {
-    it('uses dark mode when container has a light text color', async () => {
-        const {iframeDocument} = renderApp({documentStyles: {
-            color: '#FFFFFF'
-        }});
-        const darkModeContentBox = await within(iframeDocument).findByTestId('content-box');
-        expect([...darkModeContentBox.classList]).toContain('dark');
-    });
-    it('uses dark mode when container has a dark text color', async () => {
-        const {iframeDocument} = renderApp({documentStyles: {
-            color: '#000000'
-        }});
-        const darkModeContentBox = await within(iframeDocument).findByTestId('content-box');
-        expect([...darkModeContentBox.classList]).not.toContain('dark');
-    });
-    it('uses dark mode when custom mode has been passed as a property', async () => {
-        const {iframeDocument} = renderApp({
-            props: {
-                colorScheme: 'dark'
-            }
-        });
-        const darkModeContentBox = await within(iframeDocument).findByTestId('content-box');
-        expect([...darkModeContentBox.classList]).toContain('dark');
-    });
-    it('uses light mode when custom mode has been passed as a property', async () => {
-        const {iframeDocument} = renderApp({
-            props: {
-                colorScheme: 'light'
-            },
-            color: '#FFFFFF'
-        });
-        const darkModeContentBox = await within(iframeDocument).findByTestId('content-box');
-        expect([...darkModeContentBox.classList]).not.toContain('dark');
-    });
-});
-
 describe('Comments', () => {
     it('renders comments', async () => {
         const {api, iframeDocument} = renderApp();

--- a/apps/comments-ui/src/components/content/buttons/MoreButton.tsx
+++ b/apps/comments-ui/src/components/content/buttons/MoreButton.tsx
@@ -11,6 +11,7 @@ type Props = {
 const MoreButton: React.FC<Props> = ({comment, toggleEdit}) => {
     const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
     const {member, admin} = useAppContext();
+    const isAdmin = !!admin;
 
     const toggleContextMenu = () => {
         setIsContextMenuOpen(current => !current);
@@ -24,15 +25,15 @@ const MoreButton: React.FC<Props> = ({comment, toggleEdit}) => {
      * Whether we have at least one action inside the context menu
      * (to hide the 'more' icon if we don't have any actions)
     */
-    const show = (!!member && comment.status === 'published') || !!admin;
+    const show = (!!member && comment.status === 'published') || isAdmin;
 
-    if (!member) {
+    if (!show) {
         return null;
     }
 
     return (
         <div className="relative" data-testid="more-button">
-            {show ? <button className="outline-0" type="button" onClick={toggleContextMenu}><MoreIcon className='duration-50 gh-comments-icon gh-comments-icon-more fill-[rgba(0,0,0,0.5)] outline-0 transition ease-linear hover:fill-[rgba(0,0,0,0.75)] dark:fill-[rgba(255,255,255,0.5)] dark:hover:fill-[rgba(255,255,255,0.25)]' /></button> : null}
+            <button className="outline-0" type="button" onClick={toggleContextMenu}><MoreIcon className='duration-50 gh-comments-icon gh-comments-icon-more fill-[rgba(0,0,0,0.5)] outline-0 transition ease-linear hover:fill-[rgba(0,0,0,0.75)] dark:fill-[rgba(255,255,255,0.5)] dark:hover:fill-[rgba(255,255,255,0.25)]' /></button>
             {isContextMenuOpen ? <CommentContextMenu close={closeContextMenu} comment={comment} toggleEdit={toggleEdit} /> : null}
         </div>
     );

--- a/apps/comments-ui/test/e2e/auth-frame.test.ts
+++ b/apps/comments-ui/test/e2e/auth-frame.test.ts
@@ -1,0 +1,167 @@
+import {MOCKED_SITE_URL, MockedApi, initialize, mockAdminAuthFrame} from '../utils/e2e';
+import {expect, test} from '@playwright/test';
+
+const admin = MOCKED_SITE_URL + '/ghost/';
+
+test.describe('Auth Frame', async () => {
+    test('renders the auth frame', async ({page}) => {
+        const mockedApi = new MockedApi({});
+        await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly',
+            admin
+        });
+
+        const iframeElement = await page.locator('iframe[data-frame="admin-auth"]');
+        await expect(iframeElement).toHaveCount(1);
+    });
+
+    test('has no admin options', async ({page}) => {
+        const mockedApi = new MockedApi({});
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 2</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 3</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 4</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 5</p>'
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly',
+            admin
+        });
+
+        const iframeElement = await page.locator('iframe[data-frame="admin-auth"]');
+        await expect(iframeElement).toHaveCount(1);
+
+        const comments =  await frame.getByTestId('comment-component');
+        await expect(comments).toHaveCount(5);
+
+        const moreButtons = await frame.getByTestId('more-button');
+        await expect(moreButtons).toHaveCount(0);
+    });
+
+    test('has admin options when signed in to Ghost admin', async ({page}) => {
+        const mockedApi = new MockedApi({});
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 2</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 3</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 4</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 5</p>'
+        });
+
+        await mockAdminAuthFrame({
+            admin,
+            page
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly',
+            admin
+        });
+
+        const iframeElement = await page.locator('iframe[data-frame="admin-auth"]');
+        await expect(iframeElement).toHaveCount(1);
+
+        // Check if more actions button is visible on each comment
+        const comments =  await frame.getByTestId('comment-component');
+        await expect(comments).toHaveCount(5);
+
+        const moreButtons = await frame.getByTestId('more-button');
+        await expect(moreButtons).toHaveCount(5);
+
+        // Click the 2nd button
+        await moreButtons.nth(1).click();
+        await moreButtons.nth(1).getByText('Hide comment').click();
+
+        // Check comment2 is replaced with a hidden message
+        const secondComment = comments.nth(1);
+        await expect(secondComment).toHaveText('This comment has been hidden.');
+        await expect(secondComment).not.toContainText('This is comment 4');
+
+        // Check can show it again
+        await moreButtons.nth(1).click();
+        await moreButtons.nth(1).getByText('Show comment').click();
+        await expect(secondComment).toContainText('This is comment 4');
+    });
+
+    test('has admin options when signed in to Ghost admin and as a member', async ({page}) => {
+        const mockedApi = new MockedApi({});
+        mockedApi.setMember({});
+
+        mockedApi.addComment({
+            html: '<p>This is comment 1</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 2</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 3</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 4</p>'
+        });
+        mockedApi.addComment({
+            html: '<p>This is comment 5</p>'
+        });
+
+        await mockAdminAuthFrame({
+            admin,
+            page
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly',
+            admin
+        });
+
+        const iframeElement = await page.locator('iframe[data-frame="admin-auth"]');
+        await expect(iframeElement).toHaveCount(1);
+
+        // Check if more actions button is visible on each comment
+        const comments =  await frame.getByTestId('comment-component');
+        await expect(comments).toHaveCount(5);
+
+        const moreButtons = await frame.getByTestId('more-button');
+        await expect(moreButtons).toHaveCount(5);
+
+        // Click the 2nd button
+        await moreButtons.nth(1).click();
+        await moreButtons.nth(1).getByText('Hide comment').click();
+
+        // Check comment2 is replaced with a hidden message
+        const secondComment = comments.nth(1);
+        await expect(secondComment).toHaveText('This comment has been hidden.');
+        await expect(secondComment).not.toContainText('This is comment 4');
+
+        // Check can show it again
+        await moreButtons.nth(1).click();
+        await moreButtons.nth(1).getByText('Show comment').click();
+        await expect(secondComment).toContainText('This is comment 4');
+    });
+});
+

--- a/apps/comments-ui/test/e2e/options.test.ts
+++ b/apps/comments-ui/test/e2e/options.test.ts
@@ -297,25 +297,6 @@ test.describe('Options', async () => {
             expect(titleColor).toBe('rgba(255, 255, 255, 0.85)');
         });
 
-        test('Uses dark text in light mode', async ({page}) => {
-            const mockedApi = new MockedApi({});
-            mockedApi.addComment();
-
-            const {frame} = await initialize({
-                mockedApi,
-                page,
-                publication: 'Publisher Weekly',
-                colorScheme: 'light'
-            });
-
-            const title = await frame.locator('[data-testid="cta-box"] h1');
-            const titleColor = await title.evaluate((node) => {
-                const style = window.getComputedStyle(node);
-                return style.getPropertyValue('color');
-            });
-            expect(titleColor).toBe('rgb(0, 0, 0)');
-        });
-
         test('Uses light mode by default', async ({page}) => {
             const mockedApi = new MockedApi({});
             mockedApi.addComment();
@@ -354,6 +335,27 @@ test.describe('Options', async () => {
             });
             expect(titleColor).toBe('rgba(255, 255, 255, 0.85)');
         });
+
+        test('Uses dark text in light mode', async ({page}) => {
+            const mockedApi = new MockedApi({});
+            mockedApi.addComment();
+
+            const {frame} = await initialize({
+                mockedApi,
+                page,
+                publication: 'Publisher Weekly',
+                colorScheme: 'light',
+                bodyStyle: 'color: #fff;'
+            });
+
+            const title = await frame.locator('[data-testid="cta-box"] h1');
+            const titleColor = await title.evaluate((node) => {
+                const style = window.getComputedStyle(node);
+                return style.getPropertyValue('color');
+            });
+            expect(titleColor).toBe('rgb(0, 0, 0)');
+        });
+
     });
 });
 

--- a/apps/comments-ui/test/utils/MockedApi.ts
+++ b/apps/comments-ui/test/utils/MockedApi.ts
@@ -202,6 +202,21 @@ export class MockedApi {
             });
         });
 
+        // GET a single comment
+        await page.route(`${path}/members/api/comments/*/`, async (route) => {
+            const url = new URL(route.request().url());
+            const commentId = url.pathname.split('/').reverse()[1];
+
+            await route.fulfill({
+                status: 200,
+                body: JSON.stringify(this.browseComments({
+                    limit: 1,
+                    filter: `id:'${commentId}'`,
+                    page: 1
+                }))
+            });
+        });
+
         await page.route(`${path}/members/api/comments/*/replies/*`, async (route) => {
             const url = new URL(route.request().url());
 

--- a/apps/comments-ui/test/utils/e2e.ts
+++ b/apps/comments-ui/test/utils/e2e.ts
@@ -14,6 +14,61 @@ function escapeHtml(unsafe: string) {
         .replace(/>/g, '&gt;');
 }
 
+function authFrameMain() {
+    window.addEventListener('message', function (event) {
+        let d = null;
+        try {
+            d = JSON.parse(event.data);
+        } catch (err) {
+            console.error(err);
+        }
+
+        if (!d) {
+            return
+        }
+        const data: {uid: string, action: string} = d;
+
+        function respond(error, result) {
+            event.source!.postMessage(JSON.stringify({
+                uid: data.uid,
+                error: error,
+                result: result
+            }));
+        }
+
+        if (data.action === 'getUser') {
+            try {
+                respond(null, {
+                    users: [
+                        {
+                            id: 'someone'
+                        }
+                    ]
+                });
+            } catch (err) {
+                respond(err, null);
+            }
+            return;
+        }
+
+        // Other actions: return empty object
+        try {
+            respond(null, {});
+        } catch (err) {
+            respond(err, null);
+        }
+    });
+}
+
+export async function mockAdminAuthFrame({admin, page}) {
+    await page.route(admin + 'auth-frame/', async (route) => {
+        await route.fulfill({
+            status: 200,
+            body: `<html><head><meta charset="UTF-8" /></head><body><script>${authFrameMain.toString()}; authFrameMain();</script></body></html>`
+        });
+    });
+}
+
 export async function initialize({mockedApi, page, bodyStyle, ...options}: {
     mockedApi: MockedApi,
     page: Page,
@@ -67,7 +122,7 @@ export async function initialize({mockedApi, page, bodyStyle, ...options}: {
     await page.waitForSelector('iframe');
 
     return {
-        frame: page.frameLocator('iframe')
+        frame: page.frameLocator('iframe[title="comments-frame"]')
     };
 }
 
@@ -112,7 +167,7 @@ export async function setClipboard(page, text) {
 
 export function getModifierKey() {
     const os = require('os');
-    let platform = os.platform();
+    const platform = os.platform();
     if (platform === 'darwin') {
         return 'Meta';
     } else {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3504

- When you are logged in as an admin, but not as a member, no buttons showed (discovered in new e2e tests)
- Added E2E tests for admin actions