### PR TITLE
Handled sort_order updates for Collections

### DIFF
--- a/ghost/core/core/server/models/base/bookshelf.js
+++ b/ghost/core/core/server/models/base/bookshelf.js
@@ -80,7 +80,7 @@ ghostBookshelf.plugin('bookshelf-relations', {
                 };
 
                 // CASE: disable after hook for specific relations
-                if (['permissions_roles', 'members_newsletters', 'collections_posts'].indexOf(existing.relatedData.joinTableName) !== -1) {
+                if (['permissions_roles', 'members_newsletters'].indexOf(existing.relatedData.joinTableName) !== -1) {
                     return Promise.resolve();
                 }
 

--- a/ghost/core/core/server/models/collection.js
+++ b/ghost/core/core/server/models/collection.js
@@ -4,6 +4,39 @@ const urlUtils = require('../../shared/url-utils');
 const Collection = ghostBookshelf.Model.extend({
     tableName: 'collections',
 
+    hooks: {
+        belongsToMany: {
+            /**
+             * @this {Collection}
+             * @param {*} existing
+             * @param {*} targets
+             * @param {*} options
+             */
+            after(existing, targets, options) {
+                if (this.get('type') === 'automatic') {
+                    return;
+                }
+
+                const queryOptions = {
+                    query: {
+                        where: {}
+                    }
+                };
+
+                return Promise.all(targets.models.map((target, index) => {
+                    queryOptions.query.where[existing.relatedData.otherKey] = target.id;
+
+                    return existing.updatePivot({
+                        sort_order: index
+                    }, {
+                        ...options,
+                        ...queryOptions
+                    });
+                }));
+            }
+        }
+    },
+
     formatOnWrite(attrs) {
         if (attrs.feature_image) {
             attrs.feature_image = urlUtils.toTransformReady(attrs.feature_image);

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -166,7 +166,7 @@
     "bluebird": "3.7.2",
     "body-parser": "1.20.2",
     "bookshelf": "1.2.0",
-    "bookshelf-relations": "2.5.1",
+    "bookshelf-relations": "2.6.0",
     "brute-knex": "4.0.1",
     "bson-objectid": "2.0.4",
     "chalk": "4.1.2",

--- a/ghost/core/test/regression/models/model_collections.test.js
+++ b/ghost/core/test/regression/models/model_collections.test.js
@@ -13,7 +13,7 @@ describe('Collection Model', function () {
     before(testUtils.setup('users:roles', 'posts'));
 
     describe('add', function () {
-        it('does not update the sort_order of the collections_posts table', async function () {
+        it('does not update the sort_order of the collections_posts table if the type is "automatic"', async function () {
             if (db?.knex?.client?.config?.client !== 'sqlite3') {
                 return this.skip();
             }
@@ -34,7 +34,44 @@ describe('Collection Model', function () {
 
             await models.Collection.add({
                 title: 'Test Collection',
-                slug: 'test-collection',
+                slug: 'test-collection-automatic',
+                description: 'Test description',
+                type: 'automatic',
+                filter: 'featured:true',
+                posts: posts.toJSON().map(post => ({id: post.id})),
+                feature_image: null
+            });
+
+            database.off('query', handler);
+
+            const actual = didUpdateCollectionPosts;
+            const expected = false;
+
+            assert.equal(actual, expected, 'collections_posts should not have been updated');
+        });
+
+        it('does update the sort_order of the collections_posts table if the type is "manual"', async function () {
+            if (db?.knex?.client?.config?.client !== 'sqlite3') {
+                return this.skip();
+            }
+            /** @type {import('sqlite3').Database} */
+            const database = db.knex.client;
+
+            let didUpdateCollectionPosts = false;
+
+            function handler(/** @type {{sql: string}} */ query) {
+                if (query.sql.toLowerCase().includes('update `collections_posts` set `sort_order`')) {
+                    didUpdateCollectionPosts = true;
+                }
+            }
+
+            const posts = await models.Post.findAll();
+
+            database.on('query', handler);
+
+            await models.Collection.add({
+                title: 'Test Collection',
+                slug: 'test-collection-manual',
                 description: 'Test description',
                 type: 'manual',
                 filter: null,
@@ -45,7 +82,7 @@ describe('Collection Model', function () {
             database.off('query', handler);
 
             const actual = didUpdateCollectionPosts;
-            const expected = false;
+            const expected = true;
 
             assert.equal(actual, expected, 'collections_posts should not have been updated');
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10251,10 +10251,10 @@ body@^5.1.0:
     raw-body "~1.1.0"
     safe-json-parse "~1.0.1"
 
-bookshelf-relations@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/bookshelf-relations/-/bookshelf-relations-2.5.1.tgz#7e3ae0dec200170fe7ccc45cfb74e6ed75143c77"
-  integrity sha512-PH4DXw6RboAdPhwr4/Q2q734x7EmgPHeHnwjl+DnefmPJpf96gF05cQ/n9It7CPwlR9QS3ExvOYnr5MGHKcYow==
+bookshelf-relations@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/bookshelf-relations/-/bookshelf-relations-2.6.0.tgz#a67fc95893bc045b59a06f9c694450982d88b7db"
+  integrity sha512-AnMlXAHcnu+JXhiStfJ/IsSW44tK65S63qPIOOCpyyAI9CkXrMr8pMLCVQEVb2tLv5GkJQOiiSE+J7icBmY76w==
   dependencies:
     "@tryghost/debug" "^0.1.13"
     "@tryghost/errors" "^1.2.3"


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/73

With the latest version of bookshelf-relations we're able to define a model specific hook which allows us to ignore sort_order updates on automatic collections, which don't require their order to be persisted.
