### PR TITLE
Wired up Slack integration in AdminX

### DIFF
--- a/apps/admin-x-settings/src/api/slack.ts
+++ b/apps/admin-x-settings/src/api/slack.ts
@@ -1,0 +1,6 @@
+import {createMutation} from '../utils/apiRequests';
+
+export const useTestSlack = createMutation<unknown, null>({
+    method: 'POST',
+    path: () => '/slack/test/'
+});

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/SlackModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/SlackModal.tsx
@@ -4,8 +4,10 @@ import IntegrationHeader from './IntegrationHeader';
 import Modal from '../../../../admin-x-ds/global/modal/Modal';
 import NiceModal from '@ebay/nice-modal-react';
 import TextField from '../../../../admin-x-ds/global/form/TextField';
+import toast from 'react-hot-toast';
 import useRouting from '../../../../hooks/useRouting';
 import useSettingGroup from '../../../../hooks/useSettingGroup';
+import validator from 'validator';
 import {ReactComponent as Icon} from '../../../../assets/icons/slack.svg';
 import {getSettingValues} from '../../../../api/settings';
 import {showToast} from '../../../../admin-x-ds/global/Toast';
@@ -15,18 +17,35 @@ const SlackModal = NiceModal.create(() => {
     const {updateRoute} = useRouting();
     const modal = NiceModal.useModal();
 
-    const {localSettings, updateSetting, handleSave} = useSettingGroup();
+    const {localSettings, updateSetting, handleSave, validate, errors, clearError} = useSettingGroup({
+        onValidate: () => {
+            const newErrors: Record<string, string> = {};
+
+            if (slackUrl && !validator.isURL(slackUrl, {require_protocol: true})) {
+                newErrors.slackUrl = 'The URL must be in a format like https://hooks.slack.com/services/<your personal key>';
+            }
+
+            return newErrors;
+        }
+    });
     const [slackUrl, slackUsername] = getSettingValues<string>(localSettings, ['slack_url', 'slack_username']);
 
     const {mutateAsync: testSlack} = useTestSlack();
 
     const handleTestClick = async () => {
-        await handleSave();
-        await testSlack(null);
-        showToast({
-            message: 'Check your Slack channel for the test message',
-            type: 'neutral'
-        });
+        toast.remove();
+        if (await handleSave()) {
+            await testSlack(null);
+            showToast({
+                message: 'Check your Slack channel for the test message',
+                type: 'neutral'
+            });
+        } else {
+            showToast({
+                type: 'pageError',
+                message: 'Can\'t save Slack settings! One or more fields have errors, please doublecheck you filled all mandatory fields'
+            });
+        }
     };
 
     return (
@@ -37,11 +56,19 @@ const SlackModal = NiceModal.create(() => {
             dirty={localSettings.some(setting => setting.dirty)}
             okColor='black'
             okLabel='Save & close'
+            testId='slack-modal'
             title=''
             onOk={async () => {
-                await handleSave();
-                modal.remove();
-                updateRoute('integrations');
+                toast.remove();
+                if (await handleSave()) {
+                    modal.remove();
+                    updateRoute('integrations');
+                } else {
+                    showToast({
+                        type: 'pageError',
+                        message: 'Can\'t save Slack settings! One or more fields have errors, please doublecheck you filled all mandatory fields'
+                    });
+                }
             }}
         >
             <IntegrationHeader
@@ -52,13 +79,16 @@ const SlackModal = NiceModal.create(() => {
             <div className='mt-7'>
                 <Form marginBottom={false} title='Slack configuration' grouped>
                     <TextField
-                        hint={<>
+                        error={Boolean(errors.slackUrl)}
+                        hint={errors.slackUrl || <>
                             Automatically send newly published posts to a channel in Slack or any Slack-compatible service like Discord or Mattermost. Set up a new incoming webhook <a href='https://my.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks'>here</a>, and grab the URL.
                         </>}
                         placeholder='https://hooks.slack.com/services/...'
                         title='Webhook URL'
                         value={slackUrl}
+                        onBlur={validate}
                         onChange={e => updateSetting('slack_url', e.target.value)}
+                        onKeyDown={() => clearError('slackUrl')}
                     />
                     <div className='flex w-full items-center gap-2'>
                         <TextField

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/SlackModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/SlackModal.tsx
@@ -5,22 +5,43 @@ import Modal from '../../../../admin-x-ds/global/modal/Modal';
 import NiceModal from '@ebay/nice-modal-react';
 import TextField from '../../../../admin-x-ds/global/form/TextField';
 import useRouting from '../../../../hooks/useRouting';
+import useSettingGroup from '../../../../hooks/useSettingGroup';
 import {ReactComponent as Icon} from '../../../../assets/icons/slack.svg';
+import {getSettingValues} from '../../../../api/settings';
+import {showToast} from '../../../../admin-x-ds/global/Toast';
+import {useTestSlack} from '../../../../api/slack';
 
 const SlackModal = NiceModal.create(() => {
     const {updateRoute} = useRouting();
     const modal = NiceModal.useModal();
+
+    const {localSettings, updateSetting, handleSave} = useSettingGroup();
+    const [slackUrl, slackUsername] = getSettingValues<string>(localSettings, ['slack_url', 'slack_username']);
+
+    const {mutateAsync: testSlack} = useTestSlack();
+
+    const handleTestClick = async () => {
+        await handleSave();
+        await testSlack(null);
+        showToast({
+            message: 'Check your Slack channel for the test message',
+            type: 'neutral'
+        });
+    };
 
     return (
         <Modal
             afterClose={() => {
                 updateRoute('integrations');
             }}
+            dirty={localSettings.some(setting => setting.dirty)}
             okColor='black'
             okLabel='Save & close'
             title=''
-            onOk={() => {
+            onOk={async () => {
+                await handleSave();
                 modal.remove();
+                updateRoute('integrations');
             }}
         >
             <IntegrationHeader
@@ -32,18 +53,22 @@ const SlackModal = NiceModal.create(() => {
                 <Form marginBottom={false} title='Slack configuration' grouped>
                     <TextField
                         hint={<>
-                            Automatically send newly published posts to a channel in Slack or any Slack-compatible service like Discord or Mattermost. Set up a new incoming webhook here <strong className='text-red'>[&larr; link to be set]</strong>, and grab the URL.
+                            Automatically send newly published posts to a channel in Slack or any Slack-compatible service like Discord or Mattermost. Set up a new incoming webhook <a href='https://my.slack.com/apps/new/A0F7XDUAZ-incoming-webhooks'>here</a>, and grab the URL.
                         </>}
                         placeholder='https://hooks.slack.com/services/...'
                         title='Webhook URL'
+                        value={slackUrl}
+                        onChange={e => updateSetting('slack_url', e.target.value)}
                     />
                     <div className='flex w-full items-center gap-2'>
                         <TextField
                             containerClassName='flex-grow'
                             hint='The username to display messages from'
                             title='Username'
+                            value={slackUsername}
+                            onChange={e => updateSetting('slack_username', e.target.value)}
                         />
-                        <Button color='outline' label='Send test notification' />
+                        <Button color='outline' label='Send test notification' onClick={handleTestClick} />
                     </div>
                 </Form>
             </div>

--- a/apps/admin-x-settings/src/hooks/useSettingGroup.tsx
+++ b/apps/admin-x-settings/src/hooks/useSettingGroup.tsx
@@ -19,9 +19,12 @@ export interface SettingGroupHook {
     handleCancel: () => void;
     updateSetting: (key: string, value: SettingValue) => void;
     handleEditingChange: (newState: boolean) => void;
+    validate: () => boolean;
+    errors: Record<string, string>;
+    clearError: (key: string) => void;
 }
 
-const useSettingGroup = (): SettingGroupHook => {
+const useSettingGroup = ({onValidate}: {onValidate?: () => Record<string, string>} = {}): SettingGroupHook => {
     // create a ref to focus the input field
     const focusRef = useRef<HTMLInputElement>(null);
 
@@ -30,11 +33,12 @@ const useSettingGroup = (): SettingGroupHook => {
 
     const [isEditing, setEditing] = useState(false);
 
-    const {formState: localSettings, saveState, handleSave, updateForm, reset} = useForm<LocalSetting[]>({
+    const {formState: localSettings, saveState, handleSave, updateForm, reset, validate, errors, clearError} = useForm<LocalSetting[]>({
         initialState: settings || [],
         onSave: async () => {
             await editSettings?.(changedSettings());
-        }
+        },
+        onValidate
     });
 
     const {setGlobalDirtyState} = useGlobalDirtyState();
@@ -98,7 +102,10 @@ const useSettingGroup = (): SettingGroupHook => {
         },
         handleCancel,
         updateSetting,
-        handleEditingChange
+        handleEditingChange,
+        validate,
+        errors,
+        clearError
     };
 };
 

--- a/apps/admin-x-settings/test/e2e/advanced/integrations/slack.test.ts
+++ b/apps/admin-x-settings/test/e2e/advanced/integrations/slack.test.ts
@@ -1,0 +1,68 @@
+import {expect, test} from '@playwright/test';
+import {globalDataRequests, mockApi, updatedSettingsResponse} from '../../../utils/e2e';
+
+test.describe('Slack integration', async () => {
+    test('Supports updating Slack settings', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'slack_url', value: 'https://hooks.slack.com/services/123456789/123456789/123456789'},
+                {key: 'slack_username', value: 'My site'}
+            ])}
+        }});
+
+        await page.goto('/');
+        const section = page.getByTestId('integrations');
+        const slackElement = section.getByText('Slack').last();
+        await slackElement.hover();
+        await section.getByRole('button', {name: 'Configure'}).click();
+
+        const slackModal = page.getByTestId('slack-modal');
+
+        await slackModal.getByLabel('Webhook URL').fill('https://hooks.slack.com/services/123456789/123456789/123456789');
+        await slackModal.getByLabel('Username').fill('My site');
+        await slackModal.getByRole('button', {name: 'Save & close'}).click();
+
+        await expect(slackModal).toHaveCount(0);
+
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [
+                {key: 'slack_url', value: 'https://hooks.slack.com/services/123456789/123456789/123456789'},
+                {key: 'slack_username', value: 'My site'}
+            ]
+        });
+    });
+
+    test('Supports testing Slack messages', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
+                {key: 'slack_url', value: 'https://hooks.slack.com/services/123456789/123456789/123456789'},
+                {key: 'slack_username', value: 'My site'}
+            ])},
+            testSlack: {method: 'POST', path: '/slack/test/', responseStatus: 204, response: ''}
+        }});
+
+        await page.goto('/');
+        const section = page.getByTestId('integrations');
+        const slackElement = section.getByText('Slack').last();
+        await slackElement.hover();
+        await section.getByRole('button', {name: 'Configure'}).click();
+
+        const slackModal = page.getByTestId('slack-modal');
+
+        await slackModal.getByLabel('Webhook URL').fill('https://hooks.slack.com/services/123456789/123456789/123456789');
+        await slackModal.getByLabel('Username').fill('My site');
+        await slackModal.getByRole('button', {name: 'Send test notification'}).click();
+
+        await expect(page.getByTestId('toast')).toHaveText(/Check your Slack channel for the test message/);
+
+        expect(lastApiRequests.editSettings?.body).toEqual({
+            settings: [
+                {key: 'slack_url', value: 'https://hooks.slack.com/services/123456789/123456789/123456789'},
+                {key: 'slack_username', value: 'My site'}
+            ]
+        });
+        expect(lastApiRequests.testSlack).toBeTruthy();
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3729

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b273635</samp>

This pull request improves the Slack integration settings by allowing users to test the webhook URL and save the settings from a modal. It also refactors the `SlackModal` component and adds a new API function `useTestSlack` to handle the test message.
