### PR TITLE
Bumbed express-hbs and fixed inline async helpers

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -179,7 +179,7 @@
     "downsize": "0.0.8",
     "express": "4.18.2",
     "express-brute": "1.0.1",
-    "express-hbs": "2.4.0",
+    "express-hbs": "2.4.1",
     "express-jwt": "8.4.1",
     "express-lazy-router": "1.0.5",
     "express-query-boolean": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16308,6 +16308,18 @@ express-hbs@2.4.0:
   optionalDependencies:
     js-beautify "^1.13.11"
 
+express-hbs@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/express-hbs/-/express-hbs-2.4.1.tgz#e9957c9611bc7f6580d8f0f680943eda349ee12b"
+  integrity sha512-a+gcjKVp44wGU+UxWUbVrKB0ZXLIPgo76lz4o/sodTMWuyhNywOOBbjw64xDprNB7NL4WKx8okOWtqKdjyiUUA==
+  dependencies:
+    bluebird "^3.5.3"
+    handlebars "^4.7.7"
+    lodash "^4.17.21"
+    readdirp "^3.6.0"
+  optionalDependencies:
+    js-beautify "^1.13.11"
+
 express-jwt@8.4.1:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/express-jwt/-/express-jwt-8.4.1.tgz#ba817c1ced7c6f1f7017fc2e6deac207011e8acb"


### PR DESCRIPTION
refs https://github.com/TryGhost/express-hbs/commit/ce088f06ff990685ee68a6e6dfb8c5edf02f3fe3

TL;DR This makes {{asyncHelper "foo"}} usage more stable.

See the linked commit for details on the fix.
