### PR TITLE
Fixed issue with list borders

### DIFF
--- a/ghost/admin/app/styles/components/lists.css
+++ b/ghost/admin/app/styles/components/lists.css
@@ -48,7 +48,6 @@ ul.nostyle li {
 .gh-list-header {
     display: table-cell;
     vertical-align: middle;
-    border-bottom: var(--main-color-area-divider) 1px solid;
     font-size: 1.1rem;
     font-weight: 500;
     letter-spacing: 0.03em;
@@ -89,10 +88,6 @@ ul.nostyle li {
 
 .gh-list.small .gh-list-data {
     padding: 8px 20px;
-}
-
-.gh-list-row:nth-of-type(2) .gh-list-data {
-    border-top: none;
 }
 
 .gh-list-row .gh-list-data:first-child {


### PR DESCRIPTION
no refs

- Removed unnecessary `border-bottom` on list header and `border-top: none` that was added to avoid double borders
