### PR TITLE
🐛 Fixed member signup from offer when terms are not specified

### DIFF
--- a/apps/portal/src/components/pages/OfferPage.js
+++ b/apps/portal/src/components/pages/OfferPage.js
@@ -160,7 +160,7 @@ export default class OfferPage extends React.Component {
     }
 
     getFormErrors(state) {
-        const checkboxRequired = this.context.site.portal_signup_checkbox_required;
+        const checkboxRequired = this.context.site.portal_signup_checkbox_required && this.context.site.portal_signup_terms_html;
         const checkboxError = checkboxRequired && !state.termsCheckboxChecked;
 
         return {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/3753

The validation for the terms checkbox was being executed when the terms checkbox was not being rendered. The validation checks needed to be updated to account for if the checkbox was rendered or not. Basically the same as this: https://github.com/TryGhost/Ghost/commit/45a70a3f4cf0dd7cccbb63d0a7d8444fb04af732
