### PR TITLE
Added test coverage for collection update on tag removal

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/collections.test.js.snap
@@ -1365,7 +1365,7 @@ Object {
 }
 `;
 
-exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk 1: [body] 1`] = `
+exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed 1: [body] 1`] = `
 Object {
   "collections": Array [
     Object {
@@ -1383,7 +1383,7 @@ Object {
 }
 `;
 
-exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk 2: [headers] 1`] = `
+exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -1398,7 +1398,7 @@ Object {
 }
 `;
 
-exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk 3: [body] 1`] = `
+exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed 3: [body] 1`] = `
 Object {
   "collections": Array [
     Object {
@@ -1419,7 +1419,7 @@ Object {
 }
 `;
 
-exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk 4: [headers] 1`] = `
+exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
@@ -1432,7 +1432,7 @@ Object {
 }
 `;
 
-exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk 5: [body] 1`] = `
+exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed 5: [body] 1`] = `
 Object {
   "bulk": Object {
     "meta": Object {
@@ -1445,7 +1445,7 @@ Object {
 }
 `;
 
-exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk 6: [body] 1`] = `
+exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed 6: [body] 1`] = `
 Object {
   "collections": Array [
     Object {
@@ -1466,11 +1466,45 @@ Object {
 }
 `;
 
-exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk 7: [headers] 1`] = `
+exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed 7: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
   "content-length": "287",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed 8: [body] 1`] = `
+Object {
+  "collections": Array [
+    Object {
+      "count": Object {
+        "posts": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "description": null,
+      "feature_image": null,
+      "filter": "tags:['papaya']",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "slug": "papaya-madness",
+      "title": "Papaya madness",
+      "type": "automatic",
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+    },
+  ],
+}
+`;
+
+exports[`Collections API Collection Posts updates automatically Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed 9: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "286",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -584,7 +584,7 @@ describe('Collections API', function () {
                 });
         });
 
-        it('Updates a collection with tag filter when tag is added to posts in bulk', async function (){
+        it('Updates a collection with tag filter when tag is added to posts in bulk and when tag is removed', async function (){
             const collection = {
                 title: 'Papaya madness',
                 type: 'automatic',
@@ -655,7 +655,7 @@ describe('Collections API', function () {
 
             await DomainEvents.allSettled();
 
-            // should contain published posts with papaya tags
+            // should contain posts with papaya tags
             await agent
                 .get(`/collections/${collectionId}/?include=count.posts`)
                 .expectStatus(200)
@@ -668,6 +668,29 @@ describe('Collections API', function () {
                         ...matchCollection,
                         count: {
                             posts: 11
+                        }
+                    }]
+                });
+
+            await agent
+                .delete(`/tags/${tagId}/`)
+                .expectStatus(204);
+
+            await DomainEvents.allSettled();
+
+            // should contain ZERO posts with papaya tags
+            await agent
+                .get(`/collections/${collectionId}/?include=count.posts`)
+                .expectStatus(200)
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                })
+                .matchBodySnapshot({
+                    collections: [{
+                        ...matchCollection,
+                        count: {
+                            posts: 0
                         }
                     }]
                 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/77

- We were missing e2e test coverage for when the tag used in collection filters was removed. This changeset improves the situation.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da9763f</samp>

Improve and fix collection API tests. Add more cases for `collections.test.js` to check how the collection responds to tag changes.
