### PR TITLE
Fixed product card image overflow in Gmail

### DIFF
--- a/ghost/email-service/lib/email-templates/partials/styles-old.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles-old.hbs
@@ -1012,6 +1012,9 @@ a[data-flickr-embed] img {
     border-radius: 3px;
     border: 1px solid #e5eff5;
 }
+.kg-product-card-image {
+    width: 100%;
+}
 .kg-product-rating img {
     width: 96px;
     border: none;


### PR DESCRIPTION
no issues

- product card images have explicit width/height attributes, and when the width value is large (e.g. 2560), it causes an overflow on Gmail on Android
- the reason why there's no issue on other email clients is that Gmail on Android has autofit feature which makes the email width fit inside the screen automatically, and it made the email width very narrow when the product card image width isn't responsive
- this fix makes the product card image width responsive by explicitly setting it 100%

