### PR TITLE
Fixed analytics exports to fetch on demand in Admin X

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
@@ -27,21 +27,22 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
         handleEditingChange(true);
     };
 
-    const {data: postsData} = usePostsExports({
+    const {refetch: postsData} = usePostsExports({
         searchParams: {
             limit: '1000'
-        }
+        },
+        enabled: false
     });
 
     const exportPosts = async () => {
-        // it should download posts as csv
-        if (postsData) {
-            const blob = new Blob([postsData], {type: 'text/csv'});
+        const {data} = await postsData();
+        if (data) {
+            const blob = new Blob([data], {type: 'text/csv'});
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.setAttribute('hidden', '');
             a.setAttribute('href', url);
-            a.setAttribute('download', 'posts.csv');
+            a.setAttribute('download', `post-analytics.${new Date().toISOString().split('T')[0]}.csv`);
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C0568LN2CGJ/p1692804385770949

- Analytics exports was previously retrieved on on page load instead of on demand.
- This fixes that to ensure it gets fetched when the user hits the download button.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c96e78</samp>

Improved the export posts feature in the membership settings by fetching the data only on demand and adding a date to the file name. Modified the `usePostsExports` hook and the `exportPosts` function in `Analytics.tsx`.
