### PR TITLE
Released Portal 2.34.3

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.34.2",
+  "version": "2.34.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
no issue

- this version allows use of the /signup/free link even if the free plan is hidden from portal