### PR TITLE
Refactored Collection and extracted Entity

### DIFF
--- a/ghost/collections/src/Collection.ts
+++ b/ghost/collections/src/Collection.ts
@@ -1,9 +1,10 @@
 import {UniqueChecker} from './UniqueChecker';
-import {ValidationError} from '@tryghost/errors';
+import {ValidationError, MethodNotAllowedError} from '@tryghost/errors';
 import tpl from '@tryghost/tpl';
 import nql from '@tryghost/nql';
 import {posts as postExpansions} from '@tryghost/nql-filter-expansions';
 import {CollectionPost} from './CollectionPost';
+import {Entity} from './Entity';
 
 import ObjectID from 'bson-objectid';
 
@@ -15,8 +16,198 @@ const messages = {
         context: 'Automatic type of collection should always have a filter value'
     },
     noTitleProvided: 'Title must be provided',
-    slugMustBeUnique: 'Slug must be unique'
+    slugMustBeUnique: 'Slug must be unique',
+    cannotDeleteBuiltInCollectionError: {
+        message: 'Cannot delete builtin collection',
+        context: 'The collection {id} is a builtin collection and cannot be deleted'
+    }
 };
+
+/**
+ * This defines how the Entity can be interacted with
+ */
+type CollectionData = {
+    readonly id: string;
+    readonly slug: string;
+    readonly type: 'manual' | 'automatic';
+    readonly posts: string[];
+    title: string;
+    description: string | null;
+    filter: string | null;
+    featureImage: string | null;
+    readonly createdAt: Date;
+    readonly updatedAt: Date | null;
+}
+
+export class Collection extends Entity<CollectionData> {
+    // Optional, but handles delete logic - obviously
+    delete() {
+        if (this.slug !== 'latest' && this.slug !== 'featured') {
+            this.setDeleted();
+        } else {
+            throw new MethodNotAllowedError({
+                message: tpl(messages.cannotDeleteBuiltInCollectionError.message),
+                context: tpl(messages.cannotDeleteBuiltInCollectionError.context, {
+                    id: this.id
+                })
+            });
+        }
+    }
+
+    // Optional, but handle validation - obviously
+    protected validations: Partial<{[T in keyof CollectionData]: (entity: Collection, value: unknown) => void}>  = {
+        id(collection, id) {
+            // We have to cast to string;
+            if (!ObjectID.isValid(id + '')) {
+                throw new ValidationError({
+                    message: tpl(messages.invalidIDProvided)
+                });
+            }
+        },
+        type(collection, type) {
+            if (type !== 'automatic' && type !== 'manual') {
+                throw new ValidationError({
+                    message: 'Invalid type ' + type
+                });
+            }
+        },
+        description(collection, value) {
+            if (typeof value === 'string' && value.length > 2000) {
+                throw new ValidationError({
+                    message: 'Invalid description'
+                });
+            }
+        },
+        filter(collection, filter) {
+            validateFilter(filter as string | null, collection.type, collection.slug === 'latest');
+        },
+        createdAt(collection, date) {
+            validateDateField(date, 'created_at');
+        },
+        updatedAt(collection, date) {
+            validateDateField(date, 'updated_at');
+        }
+    };
+
+    // Custom setter
+    set filter(value: string | null) {
+        if (this.slug === 'latest' || this.slug === 'featured') {
+            return;
+        }
+        this.validate('filter', value)
+        this.attr.filter = value;
+    }
+
+    /**
+     * Functionality
+     */
+
+    async setSlug(slug: string, uniqueChecker: UniqueChecker) {
+        if (slug === this.slug) {
+            return;
+        }
+        if (await uniqueChecker.isUniqueSlug(slug)) {
+            this.attr.slug = slug;
+        } else {
+            throw new ValidationError({
+                message: tpl(messages.slugMustBeUnique)
+            });
+        }
+    }
+
+    postMatchesFilter(post: CollectionPost): boolean {
+        const filterNql = nql(this.filter, {
+            expansions: postExpansions
+        });
+        return filterNql.queryJSON(post);
+    }
+
+    /**
+     * @param post - The post to add to the collection
+     * @param index - The index to insert the post at, use negative numbers to count from the end.
+     */
+    addPost(post: CollectionPost, index: number = -0) {
+        if (this.type === 'automatic') {
+            const matchesFilter = this.postMatchesFilter(post);
+
+            if (!matchesFilter) {
+                return false;
+            }
+        }
+
+        if (this.posts.includes(post.id)) {
+            this.attr.posts = this.posts.filter(id => id !== post.id);
+        }
+
+        if (index < 0 || Object.is(index, -0)) {
+            index = this.posts.length + index;
+        }
+
+        this.posts.splice(index, 0, post.id);
+        return true;
+    }
+
+    removePost(id: string) {
+        if (this.posts.includes(id)) {
+            this.attr.posts = this.posts.filter(postId => postId !== id);
+        }
+    }
+
+    removeAllPosts() {
+        this.attr.posts = [];
+    }
+
+    /**
+     * Boilerplate
+     */
+
+    // Some boilerplate - used to setup getters and setters;
+    protected fields: (keyof CollectionData)[] = ['id', 'title', 'slug', 'description', 'type', 'filter', 'featureImage', 'posts', 'createdAt', 'updatedAt'];
+    protected writeableFields: (keyof CollectionData)[] = ['filter', 'title', 'description', 'featureImage'];
+
+
+
+    /**
+     * The create method is the factory for creating instances of the Entity
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    static async create(data: any): Promise<Collection> {
+        // Here we can handle any "global defaults" - these are things that we want to always enforce.
+        const type = data.type ? data.type : 'manual';
+        const filter = typeof data.filter === 'string' ? data.filter : null;
+
+        let id = data.id;
+        if (!id) {
+            id = (new ObjectID()).toHexString();
+        }
+
+        // Global defaults are done, we pass all the values into the Collection now.
+        const collection = new Collection({
+            id: id,
+            title: data.title,
+            slug: data.slug,
+            description: data.description || null,
+            type: type,
+            filter: filter,
+            featureImage: data.feature_image || null,
+            createdAt: data.created_at || new Date(),
+            updatedAt: data.updated_at || new Date(),
+            posts: data.posts || []
+        });
+
+        // This is boilerplate, it sets up all the getters and setters
+        collection.initialise();
+
+        // This will throw if any of the passed values are invalid
+        collection.validate();
+
+        return collection;
+    }
+}
+
+/**
+ * Validations, could eventually be pulled into ValueObjects, validation utility files etc..
+ */
 
 function validateFilter(filter: string | null, type: 'manual' | 'automatic', isAllowedEmpty = false) {
     const allowedProperties = ['featured', 'published_at', 'tag', 'tags']
@@ -63,191 +254,13 @@ function validateFilter(filter: string | null, type: 'manual' | 'automatic', isA
     }
 }
 
-export class Collection {
-    id: string;
-    title: string;
-    private _slug: string;
-    get slug() {
-        return this._slug;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function validateDateField(date: unknown, fieldName: string): Date {
+    if (date instanceof Date) {
+        return date;
     }
 
-    async setSlug(slug: string, uniqueChecker: UniqueChecker) {
-        if (slug === this.slug) {
-            return;
-        }
-        if (await uniqueChecker.isUniqueSlug(slug)) {
-            this._slug = slug;
-        } else {
-            throw new ValidationError({
-                message: tpl(messages.slugMustBeUnique)
-            });
-        }
-    }
-    description: string;
-    type: 'manual' | 'automatic';
-    _filter: string | null;
-    get filter() {
-        return this._filter;
-    }
-    set filter(value) {
-        if (this.slug === 'latest' || this.slug === 'featured') {
-            return;
-        }
-        validateFilter(value, this.type);
-        this._filter = value;
-    }
-    featureImage: string | null;
-    createdAt: Date;
-    updatedAt: Date;
-    get deletable() {
-        return this.slug !== 'latest' && this.slug !== 'featured';
-    }
-    private _deleted: boolean = false;
-
-    private _posts: string[];
-    get posts() {
-        return this._posts;
-    }
-
-    public get deleted() {
-        return this._deleted;
-    }
-
-    public set deleted(value: boolean) {
-        if (this.deletable) {
-            this._deleted = value;
-        }
-    }
-
-    postMatchesFilter(post: CollectionPost) {
-        const filterNql = nql(this.filter, {
-            expansions: postExpansions
-        });
-        return filterNql.queryJSON(post);
-    }
-
-    /**
-     * @param post {{id: string}} - The post to add to the collection
-     * @param index {number} - The index to insert the post at, use negative numbers to count from the end.
-     */
-    addPost(post: CollectionPost, index: number = -0) {
-        if (this.type === 'automatic') {
-            const matchesFilter = this.postMatchesFilter(post);
-
-            if (!matchesFilter) {
-                return false;
-            }
-        }
-
-        if (this.posts.includes(post.id)) {
-            this._posts = this.posts.filter(id => id !== post.id);
-        }
-
-        if (index < 0 || Object.is(index, -0)) {
-            index = this.posts.length + index;
-        }
-
-        this.posts.splice(index, 0, post.id);
-        return true;
-    }
-
-    removePost(id: string) {
-        if (this.posts.includes(id)) {
-            this._posts = this.posts.filter(postId => postId !== id);
-        }
-    }
-
-    includesPost(id: string) {
-        return this.posts.includes(id);
-    }
-
-    removeAllPosts() {
-        this._posts = [];
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private constructor(data: any) {
-        this.id = data.id;
-        this.title = data.title;
-        this._slug = data.slug;
-        this.description = data.description;
-        this.type = data.type;
-        this._filter = data.filter;
-        this.featureImage = data.featureImage;
-        this.createdAt = data.createdAt;
-        this.updatedAt = data.updatedAt;
-        this.deleted = data.deleted;
-        this._posts = data.posts;
-    }
-
-    toJSON() {
-        return {
-            id: this.id,
-            title: this.title,
-            slug: this.slug,
-            description: this.description,
-            type: this.type,
-            filter: this.filter,
-            featureImage: this.featureImage,
-            createdAt: this.createdAt,
-            updatedAt: this.updatedAt,
-            posts: this.posts
-        };
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    static validateDateField(date: any, fieldName: string): Date {
-        if (!date) {
-            return new Date();
-        }
-
-        if (date instanceof Date) {
-            return date;
-        }
-
-        throw new ValidationError({
-            message: tpl(messages.invalidDateProvided, {fieldName})
-        });
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    static async create(data: any): Promise<Collection> {
-        let id;
-
-        if (!data.id) {
-            id = new ObjectID();
-        } else if (typeof data.id === 'string') {
-            id = ObjectID.createFromHexString(data.id);
-        } else if (data.id instanceof ObjectID) {
-            id = data.id;
-        } else {
-            throw new ValidationError({
-                message: tpl(messages.invalidIDProvided)
-            });
-        }
-
-        const type = data.type === 'automatic' ? 'automatic' : 'manual';
-        const filter = typeof data.filter === 'string' ? data.filter : null;
-        validateFilter(filter, type, data.slug === 'latest');
-
-        if (!data.title) {
-            throw new ValidationError({
-                message: tpl(messages.noTitleProvided)
-            });
-        }
-
-        return new Collection({
-            id: id.toHexString(),
-            title: data.title,
-            slug: data.slug,
-            description: data.description || null,
-            type: type,
-            filter: filter,
-            featureImage: data.feature_image || null,
-            createdAt: Collection.validateDateField(data.created_at, 'created_at'),
-            updatedAt: Collection.validateDateField(data.updated_at, 'updated_at'),
-            deleted: data.deleted || false,
-            posts: data.posts || []
-        });
-    }
+    throw new ValidationError({
+        message: tpl(messages.invalidDateProvided, {fieldName})
+    });
 }

--- a/ghost/collections/src/Entity.ts
+++ b/ghost/collections/src/Entity.ts
@@ -1,0 +1,104 @@
+
+type Writeable<T> = {
+    -readonly [K in keyof T]: T[K]
+};
+class EntityImpl<Data> {
+    private _attr: Writeable<Data>
+    protected attr: Writeable<Data>
+    protected fields!: (keyof Data)[]
+    protected writeableFields!: (keyof Data)[]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    protected validations!: any;
+
+    constructor(data: Data) {
+        this._attr = data;
+        this.attr = new Proxy(this._attr, {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            set(target: any, key: any, value: unknown) {
+                if (target[key] !== value) {
+                    if (Reflect.has(target, 'updatedAt')) {
+                        target.updatedAt = new Date();
+                    }
+                }
+                target[key] = value;
+                return true;
+            }
+        });
+    }
+
+    protected initialise() {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const entity = this;
+        for (const field of entity.fields) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const definition = Object.getOwnPropertyDescriptor((entity as any).constructor.prototype, field)
+            let setter = definition?.set;
+
+            if (!setter && entity.writeableFields.includes(field)) {
+                setter = function setter(value: unknown) {
+                    const validator = entity.validations && Reflect.get(entity.validations, field);
+                    if (validator !== undefined) {
+                        validator((entity as unknown as Entity<Data>), value);
+                    }
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    entity.attr[field] = value as any;
+                }
+            }
+            Object.defineProperty(entity, field, {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                get(): any {
+                    return entity.attr[field];
+                },
+                set: setter
+            });
+        }
+    }
+
+    protected validate(field?: keyof Data, value?: Data[keyof Data]) {
+        if (field && arguments.length === 2) {
+            const validator = Reflect.get(this.validations, field);
+            if (validator !== undefined) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (validator as any)(this, value);
+            }
+        } else {
+            for (const field of this.fields) {
+                const validator = Reflect.get(this.validations, field);
+                if (validator !== undefined) {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    (validator as any)(this, (this as unknown as Data)[field]);
+                }
+            }
+        }
+    }
+
+    toJSON(): Data {
+        const json = {} as Data;
+        for (const field of this.fields) {
+            json[field] = (this as unknown as Data)[field];
+        }
+        return json;
+    }
+
+    private _deleted = false;
+    get deleted() {
+        return this._deleted;
+    }
+    protected setDeleted() {
+        this._deleted = true;
+    }
+}
+
+// Copy is required so that we can add a getter in the derived class
+type Copy<T> = {
+    [K in keyof T]: T[K]
+}
+type Entity<T> = EntityImpl<T> & Copy<T>;
+
+// export const Entity: new <T>(data: T) => WriteableEntity<T> & Copy<T> = WriteableEntity as any;
+
+// This indirection gives better type feedback
+// instead of above
+type EntityBase<T> = Entity<T>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const Entity: new <T>(data: T) => EntityBase<T> = EntityImpl as any;

--- a/ghost/collections/test/Collection.test.ts
+++ b/ghost/collections/test/Collection.test.ts
@@ -20,7 +20,7 @@ describe('Collection', function () {
 
         assert.equal(collection.title, 'Test Collection');
         assert.ok(collection.createdAt instanceof Date);
-        assert.equal(collection.updatedAt, null);
+        assert.ok(collection.updatedAt instanceof Date);
         assert.ok((collection.deleted === false), 'deleted should be false');
     });
 

--- a/ghost/collections/test/Collection.test.ts
+++ b/ghost/collections/test/Collection.test.ts
@@ -20,13 +20,41 @@ describe('Collection', function () {
 
         assert.equal(collection.title, 'Test Collection');
         assert.ok(collection.createdAt instanceof Date);
-        assert.ok(collection.updatedAt instanceof Date);
+        assert.equal(collection.updatedAt, null);
         assert.ok((collection.deleted === false), 'deleted should be false');
     });
 
     it('Cannot create a collection without a title', async function () {
         assert.rejects(async () => {
             await Collection.create({});
+        });
+    });
+
+    it('Cannot create a collection with an invalid type', async function () {
+        assert.rejects(async () => {
+            await Collection.create({
+                title: 'Broken',
+                type: 'what??'
+            });
+        });
+    });
+
+    it('Cannot create a collection with an invalid filter', async function () {
+        assert.rejects(async () => {
+            await Collection.create({
+                title: 'Broken',
+                type: 'automatic',
+                filter: 'what-the-fuck'
+            });
+        });
+    });
+
+    it('Cannot create a collection with an invalid description', async function () {
+        assert.rejects(async () => {
+            await Collection.create({
+                title: 'Broken',
+                description: ('Description').repeat(2000)
+            });
         });
     });
 
@@ -45,10 +73,8 @@ describe('Collection', function () {
         assert.ok(json);
         assert.equal(json.id, collection.id);
         assert.equal(json.title, 'Serialize me');
-        assert.ok(collection.createdAt instanceof Date);
-        assert.ok(collection.updatedAt instanceof Date);
         assert.equal(Object.keys(json).length, 10, 'should only have 9 keys + 1 posts relation');
-        assert.deepEqual(Object.keys(json), [
+        assert.deepEqual(Object.keys(json).sort(), [
             'id',
             'title',
             'slug',
@@ -59,7 +85,7 @@ describe('Collection', function () {
             'createdAt',
             'updatedAt',
             'posts'
-        ]);
+        ].sort());
 
         assert.equal(json.posts.length, 2, 'should have 2 posts');
         const serializedPost = json.posts[0];
@@ -399,7 +425,9 @@ describe('Collection', function () {
 
         assert.equal(collection.deleted, false);
 
-        collection.deleted = true;
+        assert.throws(() => {
+            collection.delete();
+        });
 
         assert.equal(collection.deleted, false);
     });
@@ -412,7 +440,9 @@ describe('Collection', function () {
 
         assert.equal(collection.deleted, false);
 
-        collection.deleted = true;
+        assert.throws(() => {
+            collection.delete();
+        });
 
         assert.equal(collection.deleted, false);
     });
@@ -425,7 +455,7 @@ describe('Collection', function () {
 
         assert.equal(collection.deleted, false);
 
-        collection.deleted = true;
+        collection.delete();
 
         assert.equal(collection.deleted, true);
     });


### PR DESCRIPTION
This is a small spike into making it easier to work with entities, attemping to remove the boiler plate required for getters and setters of properties, whilst retaining type information.

It also supports validation of properties, both in the default setters, and on instantiation (but that requires boilerplate in the create factory)

Custom setters will need to call `validate` manually.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3fd22c4</samp>

This pull request refactors the `Collection` and `CollectionsService` classes to use a new abstract `Entity` class, which provides common functionality and validations for entities. It also adds a custom error for deleting built-in collections, and updates the test cases accordingly. The changes improve the code quality, consistency, and user experience of the collections feature.
