### PR TITLE
Added dirty state to user detail modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
@@ -424,13 +424,18 @@ const UserMenuTrigger = () => (
 const UserDetailModal:React.FC<UserDetailModalProps> = ({user}) => {
     const {updateRoute} = useRouting();
     const {ownerUser} = useStaffUsers();
-    const [userData, setUserData] = useState(user);
-    const [saveState, setSaveState] = useState('');
+    const [userData, _setUserData] = useState(user);
+    const [saveState, setSaveState] = useState<'' | 'unsaved' | 'saving' | 'saved'>('');
     const [errors, setErrors] = useState<{
         name?: string;
         email?: string;
         url?: string;
     }>({});
+
+    const setUserData = (newUserData: User | ((current: User) => User)) => {
+        _setUserData(newUserData);
+        setSaveState('unsaved');
+    };
 
     const mainModal = useModal();
     const {mutateAsync: uploadImage} = useUploadImage();
@@ -645,6 +650,7 @@ const UserDetailModal:React.FC<UserDetailModalProps> = ({user}) => {
     return (
         <Modal
             afterClose={() => updateRoute('users')}
+            dirty={saveState === 'unsaved'}
             okLabel={okLabel}
             size='lg'
             stickyFooter={true}


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3349

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e03308</samp>

Improved user experience for editing user details in the admin settings. Added `dirty` state to track and handle unsaved changes in the `UserDetailModal` and `ModalFooter` components.
