### PR TITLE
Add line-height for descenders getting cut off in Post settings Tag names

### DIFF
--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -239,7 +239,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    line-height: 1em;
+    line-height: 1.2em;
 }
 
 .ember-power-select-multiple-remove-btn {


### PR DESCRIPTION
If one looks at the listing of Tags under Post settings one can see that letters that have descenders get cut off. In this case, see the lower-case `p` and the lower-case `g`.

![Xnapper-2023-08-28-11 40 02](https://github.com/TryGhost/Ghost/assets/27488257/84ef5ba7-0b81-4fb4-bdab-a31fcb99dcd9)

By changing the line-height to 1.2em the descenders appear properly.

![Xnapper-2023-08-28-11 41 00](https://github.com/TryGhost/Ghost/assets/27488257/5d18a4ad-46de-44ab-9c7f-fce4d3ccfc85)