### PR TITLE
Enabled Collection background syncing

### DIFF
--- a/ghost/core/core/server/services/collections/service.js
+++ b/ghost/core/core/server/services/collections/service.js
@@ -2,7 +2,6 @@ const {
     CollectionsService
 } = require('@tryghost/collections');
 const BookshelfCollectionsRepository = require('./BookshelfCollectionsRepository');
-const labs = require('../../../shared/labs');
 
 let inited = false;
 class CollectionsServiceWrapper {
@@ -32,9 +31,6 @@ class CollectionsServiceWrapper {
     }
 
     async init() {
-        if (!labs.isSet('collections')) {
-            return;
-        }
         if (inited) {
             return;
         }


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/73

Since we've fixed the issues which were executing performance affecting DB queries, we can enable the background syncing of collections again. This couple with a new migration to populate the default collections will allow us to start work on the collections card and will make rolling that card out to GA smoother and easier as all the required data will be in place.
