### PR TITLE
Enabled Collections Admin API for all sites

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -20,9 +20,9 @@ module.exports = function apiRoutes() {
     router.post('/mail_events', mw.publicAdminApi, http(api.mailEvents.add));
 
     // ## Collections
-    router.get('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.browse));
-    router.get('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.read));
-    router.get('/collections/slug/:slug', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.read));
+    router.get('/collections', mw.authAdminApi, http(api.collections.browse));
+    router.get('/collections/:id', mw.authAdminApi, http(api.collections.read));
+    router.get('/collections/slug/:slug', mw.authAdminApi, http(api.collections.read));
     router.post('/collections', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.add));
     router.put('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.edit));
     router.del('/collections/:id', mw.authAdminApi, labs.enabledMiddleware('collections'), http(api.collections.destroy));


### PR DESCRIPTION


<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f394e75</samp>

Removed `labs.enabledMiddleware('collections')` from collections routes in `routes.js`. This makes the code cleaner and reflects the stability of the collections feature.
