### PR TITLE
Enabled `collections` param for Post APIs

### DIFF
--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -43,7 +43,7 @@ class PostsService {
      */
     async browsePosts(options) {
         let posts;
-        if (this.isSet('collections') && options.collection) {
+        if (options.collection) {
             let collection = await this.collectionsService.getById(options.collection);
 
             if (!collection) {


### PR DESCRIPTION
This will allow us to browse posts based on their collection which will be used for rendering the collections card. As with the Collections API we're not opening up the write endpoints yet.


---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c50db0</samp>

Refactor the `PostsService` class to remove redundant condition and simplify the `browsePosts` method. This improves the performance and readability of the posts service.
