### PR TITLE
Extracted domain event interceptor to separate init

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -326,6 +326,7 @@ async function initServices({config}) {
     const slackNotifications = require('./server/services/slack-notifications');
     const mediaInliner = require('./server/services/media-inliner');
     const collections = require('./server/services/collections');
+    const modelToDomainEventInterceptor = require('./server/services/model-to-domain-event-interceptor');
     const mailEvents = require('./server/services/mail-events');
     const donationService = require('./server/services/donations');
 
@@ -365,6 +366,7 @@ async function initServices({config}) {
         emailSuppressionList.init(),
         slackNotifications.init(),
         collections.init(),
+        modelToDomainEventInterceptor.init(),
         mediaInliner.init(),
         mailEvents.init(),
         donationService.init()

--- a/ghost/core/core/server/services/collections/service.js
+++ b/ghost/core/core/server/services/collections/service.js
@@ -36,7 +36,6 @@ class CollectionsServiceWrapper {
         }
         inited = true;
         this.api.subscribeToEvents();
-        require('./intercept-events')();
     }
 }
 

--- a/ghost/core/core/server/services/model-to-domain-event-interceptor/index.js
+++ b/ghost/core/core/server/services/model-to-domain-event-interceptor/index.js
@@ -1,4 +1,11 @@
-module.exports = () => {
+let inited = false;
+
+module.exports.init = async () => {
+    if (inited) {
+        return;
+    }
+    inited = true;
+
     const DomainEvents = require('@tryghost/domain-events/lib/DomainEvents');
     const {ModelToDomainEventInterceptor} = require('@tryghost/model-to-domain-event-interceptor');
     const events = require('../../lib/common/events');
@@ -6,5 +13,6 @@ module.exports = () => {
         ModelEvents: events,
         DomainEvents: DomainEvents
     });
+
     eventInterceptor.init();
 };


### PR DESCRIPTION
closes https://github.com/TryGhost/Arch/issues/13

- Model to Domain event interceptor is a class that does not strictly belong to Collections. It's supposed to be used in any new code that depends on legacy bookshelf model events. Extracted it's initialization to it's own service for clarity and visibility.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3dac038</samp>

This pull request introduces a new `modelToDomainEventInterceptor` service that transforms model events into domain events for the domain-driven design of Ghost. It also updates the `boot.js` and `service.js` files to use the new service and removes the obsolete `intercept-events` module.
