### PR TITLE
Updated path to label-actions package

### DIFF
--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -18,4 +18,4 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'TryGhost'
     steps:
-      - uses: tryghost/label-actions@main
+      - uses: tryghost/actions/actions/label-actions@main


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/67

- this now lives in the Actions repo to cut down on maintenance cost

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d80f8f1</samp>

This pull request fixes a bug in the `label-actions` workflow that runs on GitHub Actions. It corrects the path to the `label-actions` action from the `tryghost/actions` repository.
