### PR TITLE
Set trailingSlash: true for @site.url

### DIFF
--- a/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
+++ b/ghost/core/core/frontend/services/theme-engine/middleware/update-local-template-options.js
@@ -9,7 +9,7 @@ function updateLocalTemplateOptions(req, res, next) {
 
     // adjust @site.url for http/https based on the incoming request
     const siteData = {
-        url: urlUtils.urlFor('home', {trailingSlash: false}, true)
+        url: urlUtils.urlFor('home', {trailingSlash: true}, true)
     };
 
     // @TODO: it would be nicer if this was proper middleware somehow...


### PR DESCRIPTION
[Ghost policy](https://github.com/TryGhost/Ghost/issues/9189#issuecomment-340292525) is to add a trailing slash to all URLs generated. However, it was not doing that for `@site.url`. That created a problem for Ghost installations at subdirectories, because requests to the generated URL like `example.com/blog` would be redirected by Ghost to the trailing-slash version like `example.com/blog/`. That redirect harmed SEO.

This replaces `trailingSlash: false` with `trailingSlash: true` in the `@site.url` generation. Now Ghost complies with its trailing slash policy and avoids creating an unnecessary, SEO-harming redirect. This helps Ghost installations at subdirectories, and does not affect Ghost installations at domains.

Resolves #16712