### PR TITLE
Added killswitch for collection sync functionality

### DIFF
--- a/ghost/core/core/server/services/collections/service.js
+++ b/ghost/core/core/server/services/collections/service.js
@@ -31,6 +31,13 @@ class CollectionsServiceWrapper {
     }
 
     async init() {
+        const config = require('../../../shared/config');
+        const labs = require('../../../shared/labs');
+        // host setting OR labs "collections" flag has to be enabled to run collections service
+        if (!config.get('hostSettings:collections:enabled') && !(labs.isSet('collections'))) {
+            return;
+        }
+
         if (inited) {
             return;
         }

--- a/ghost/core/test/e2e-api/admin/posts-bulk.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-bulk.test.js
@@ -8,6 +8,7 @@ describe('Posts Bulk API', function () {
 
     before(async function () {
         mockManager.mockLabsEnabled('collections');
+
         agent = await agentProvider.getAdminAPIAgent();
 
         // Note that we generate lots of fixtures here to test the bulk deletion correctly


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/80
refs https://github.com/TryGhost/Ghost/commit/3960bfac1db578fb0f359e761d3a9ef19d2c1b49

- The killswitch (a setting in host settings) is needed to control the feature on a hosted environment, so we can safely turn it off if it causes any major issues.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd0485f</samp>

This pull request adds feature flag support for the collections feature, which allows grouping posts by custom routes and templates. It also updates the existing tests to use the feature flag and a utility module to modify the config options.
