### PR TITLE
WIP: evaluate whether recommendations_enabled can be a calculated set…

### DIFF
--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -85,11 +85,13 @@ module.exports = {
     getCalculatedFields() {
         const fields = [];
 
-        fields.push(new CalculatedField({key: 'members_enabled', type: 'boolean', group: 'members', fn: settingsHelpers.isMembersEnabled.bind(settingsHelpers), dependents: ['members_signup_access']}));
-        fields.push(new CalculatedField({key: 'members_invite_only', type: 'boolean', group: 'members', fn: settingsHelpers.isMembersInviteOnly.bind(settingsHelpers), dependents: ['members_signup_access']}));
-        fields.push(new CalculatedField({key: 'paid_members_enabled', type: 'boolean', group: 'members', fn: settingsHelpers.arePaidMembersEnabled.bind(settingsHelpers), dependents: ['members_signup_access', 'stripe_secret_key', 'stripe_publishable_key', 'stripe_connect_secret_key', 'stripe_connect_publishable_key']}));
-        fields.push(new CalculatedField({key: 'firstpromoter_account', type: 'string', group: 'firstpromoter', fn: settingsHelpers.getFirstpromoterId.bind(settingsHelpers), dependents: ['firstpromoter', 'firstpromoter_id']}));
-        fields.push(new CalculatedField({key: 'donations_enabled', type: 'boolean', group: 'donations', fn: settingsHelpers.areDonationsEnabled.bind(settingsHelpers), dependents: ['stripe_secret_key', 'stripe_publishable_key', 'stripe_connect_secret_key', 'stripe_connect_publishable_key']}));
+        fields.push(new CalculatedField({key: 'members_enabled', type: 'boolean', group: 'members', fn: settingsHelpers.isMembersEnabled.bind(settingsHelpers), dependents: ['settings.members_signup_access.edited']}));
+        fields.push(new CalculatedField({key: 'members_invite_only', type: 'boolean', group: 'members', fn: settingsHelpers.isMembersInviteOnly.bind(settingsHelpers), dependents: ['settings.members_signup_access.edited']}));
+        fields.push(new CalculatedField({key: 'paid_members_enabled', type: 'boolean', group: 'members', fn: settingsHelpers.arePaidMembersEnabled.bind(settingsHelpers), dependents: ['settings.members_signup_access.edited', 'settings.stripe_secret_key.edited', 'settings.stripe_publishable_key.edited', 'settings.stripe_connect_secret_key.edited', 'settings.stripe_connect_publishable_key.edited']}));
+        fields.push(new CalculatedField({key: 'firstpromoter_account', type: 'string', group: 'firstpromoter', fn: settingsHelpers.getFirstpromoterId.bind(settingsHelpers), dependents: ['settings.firstpromoter.edited', 'settings.firstpromoter_id.edited']}));
+        fields.push(new CalculatedField({key: 'donations_enabled', type: 'boolean', group: 'donations', fn: settingsHelpers.areDonationsEnabled.bind(settingsHelpers), dependents: ['settings.stripe_secret_key.edited', 'settings.stripe_publishable_key.edited', 'settings.stripe_connect_secret_key.edited', 'settings.stripe_connect_publishable_key.edited']}));
+
+        fields.push(new CalculatedField({key: 'recommendations_enabled', type: 'boolean', group: 'recommendations', fn: settingsHelpers.areRecommendationsEnabled.bind(settingsHelpers), dependents: ['recommendations.added', 'recommendations.deleted']}));
 
         return fields;
     },

--- a/ghost/core/core/shared/settings-cache/CacheManager.js
+++ b/ghost/core/core/shared/settings-cache/CacheManager.js
@@ -181,7 +181,7 @@ class CacheManager {
         this.calculatedFields.forEach((field) => {
             this._updateCalculatedField(field)();
             field.dependents.forEach((dependent) => {
-                events.on(`settings.${dependent}.edited`, this._updateCalculatedField(field));
+                events.on(`${dependent}`, this._updateCalculatedField(field));
             });
         });
 


### PR DESCRIPTION
…ting

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3a1a4d</samp>

This pull request refactors the settings service and the settings cache to use a new event naming convention and to add a new calculated field for `recommendations_enabled`. This field determines whether the recommendations feature, which shows related posts, is enabled or not.
