### PR TITLE
Added support to run Admin-X development over HTTPS in Safari

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -63,7 +63,18 @@ if (DASH_DASH_ARGS.includes('admin-x') || DASH_DASH_ARGS.includes('adminx') || D
         prefixColor: '#C35831',
         env: {}
     });
-    COMMAND_GHOST.env['adminX__url'] = 'http://localhost:4174/admin-x-settings.umd.js';
+
+    if (DASH_DASH_ARGS.includes('https')) {
+        // Safari needs HTTPS for it to work
+        // To make this work, you'll need a CADDY server running in front
+        // Note the port is different because of this extra layer. Use the following Caddyfile:
+        //    https://localhost:41740 {
+        //        reverse_proxy http://localhost:4174
+        //    }
+        COMMAND_GHOST.env['adminX__url'] = 'https://localhost:41740/admin-x-settings.umd.js';
+    } else {
+        COMMAND_GHOST.env['adminX__url'] = 'http://localhost:4174/admin-x-settings.umd.js';
+    }
 }
 
 if (DASH_DASH_ARGS.includes('portal') || DASH_DASH_ARGS.includes('all')) {


### PR DESCRIPTION
no issue

Safari requires HTTPs for admin X to work in development mode.

Use `yarn dev --https` in combination with a caddy server to make it work.

```
https://localhost:41740 {
	reverse_proxy http://localhost:4174
}
```