### PR TITLE
Configured New Relic to load earlier in the process

### DIFF
--- a/ghost/api-framework/lib/http.js
+++ b/ghost/api-framework/lib/http.js
@@ -14,7 +14,7 @@ const headers = require('./headers');
  * @return {Function}
  */
 const http = (apiImpl) => {
-    return async (req, res, next) => {
+    return async function Http(req, res, next) {
         debug(`External API request to ${req.url}`);
         let apiKey = null;
         let integration = null;

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -477,13 +477,6 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
     try {
         // Step 1 - require more fundamental components
 
-        // Load New Relic
-        debug('Begin: Load New Relic');
-        if (config.get('newRelic:enabled')) {
-            require('newrelic');
-        }
-        debug('End: Load New Relic');
-
         // Sentry must be initialized early, but requires config
         debug('Begin: Load sentry');
         require('./shared/sentry');

--- a/ghost/core/core/frontend/web/middleware/cors.js
+++ b/ghost/core/core/frontend/web/middleware/cors.js
@@ -60,7 +60,7 @@ function corsOptionsDelegate(req, callback) {
  * @param {Express.Response} res
  * @param {Function} next
  */
-const handleCaching = (req, res, next) => {
+const handleCaching = function handleCachingCors(req, res, next) {
     const method = req.method && req.method.toUpperCase && req.method.toUpperCase();
     if (method === 'OPTIONS') {
         // @NOTE: try to add native support for dynamic 'vary' header value in 'cors' module

--- a/ghost/core/core/frontend/web/middleware/handle-image-sizes.js
+++ b/ghost/core/core/frontend/web/middleware/handle-image-sizes.js
@@ -12,7 +12,7 @@ const FORMAT_PATH_REGEX = /^\/format\/([^./]+)\//;
 
 const TRAILING_SLASH_REGEX = /\/+$/;
 
-module.exports = function (req, res, next) {
+module.exports = function handleImageSizes(req, res, next) {
     // In admin we need to read images and calculate the average color (blocked by CORS otherwise)
     res.setHeader('Access-Control-Allow-Origin', '*');
 

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -129,7 +129,7 @@ module.exports = function setupSiteApp(routerConfig) {
     siteApp.use(shared.middleware.prettyUrls);
 
     // ### Caching
-    siteApp.use(function (req, res, next) {
+    siteApp.use(function frontendCaching(req, res, next) {
         // Site frontend is cacheable UNLESS request made by a member or site is in private mode
         if (req.member || res.isPrivateBlog) {
             return shared.middleware.cacheControl('private')(req, res, next);
@@ -138,7 +138,7 @@ module.exports = function setupSiteApp(routerConfig) {
         }
     });
 
-    siteApp.use(function (req, res, next) {
+    siteApp.use(function memberPageViewMiddleware(req, res, next) {
         if (req.member) {
             // This event needs memberLastSeenAt to avoid doing un-necessary database queries when updating `last_seen_at`
             DomainEvents.dispatch(MemberPageViewEvent.create({url: req.url, memberId: req.member.id, memberLastSeenAt: req.member.last_seen_at}, new Date()));

--- a/ghost/core/core/server/services/api-version-compatibility/index.js
+++ b/ghost/core/core/server/services/api-version-compatibility/index.js
@@ -25,7 +25,7 @@ const init = () => {
     });
 };
 
-module.exports.errorHandler = (err, req, res, next) => {
+module.exports.errorHandler = function apiVersionCompatibilityErrorHandler(err, req, res, next) {
     return versionMismatchHandler(serviceInstance)(err, req, res, next);
 };
 
@@ -38,7 +38,7 @@ module.exports.errorHandler = (err, req, res, next) => {
  * @param {import('express').Response} res
  * @param {import('express').NextFunction} next
  */
-module.exports.contentVersion = (req, res, next) => {
+module.exports.contentVersion = function apiVersionCompatibilityContentVersion(req, res, next) {
     res.header('Content-Version', `v${ghostVersion.safe}`);
     res.vary('Accept-Version');
 

--- a/ghost/core/core/server/services/api-version-compatibility/mw-version-rewrites.js
+++ b/ghost/core/core/server/services/api-version-compatibility/mw-version-rewrites.js
@@ -8,7 +8,7 @@ const urlUtils = require('../../../shared/url-utils');
  * @param {import('express').Response} res
  * @param {import('express').NextFunction} next
  */
-module.exports = (req, res, next) => {
+module.exports = function mwVersionRewrites(req, res, next) {
     let {version} = legacyApiPathMatch(req.url);
 
     // If we don't match a valid version, carry on

--- a/ghost/core/core/server/services/auth/api-key/admin.js
+++ b/ghost/core/core/server/services/auth/api-key/admin.js
@@ -44,7 +44,7 @@ const _extractTokenFromUrl = function extractTokenFromUrl(reqUrl) {
     return query.token;
 };
 
-const authenticate = (req, res, next) => {
+const authenticate = function apiKeyAdminAuth(req, res, next) {
     // CASE: we don't have an Authorization header so allow fallthrough to other
     // auth middleware or final "ensure authenticated" check
     if (!req.headers || !req.headers.authorization) {
@@ -63,7 +63,7 @@ const authenticate = (req, res, next) => {
     return authenticateWithToken(req, res, next, {token, JWT_OPTIONS: JWT_OPTIONS_DEFAULTS});
 };
 
-const authenticateWithUrl = (req, res, next) => {
+const authenticateWithUrl = function apiKeyAuthenticateWithUrl(req, res, next) {
     const token = _extractTokenFromUrl(req.originalUrl);
     if (!token) {
         return next(new errors.UnauthorizedError({
@@ -89,7 +89,7 @@ const authenticateWithUrl = (req, res, next) => {
  * - the "Audience" claim should match the requested API path
  *   https://tools.ietf.org/html/rfc7519#section-4.1.3
  */
-const authenticateWithToken = async (req, res, next, {token, JWT_OPTIONS}) => {
+const authenticateWithToken = async function apiKeyAuthenticateWithToken(req, res, next, {token, JWT_OPTIONS}) {
     const decoded = jwt.decode(token, {complete: true});
 
     if (!decoded || !decoded.header) {

--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -16,7 +16,7 @@ const messages = {
 
 // @TODO: This piece of middleware actually belongs to the frontend, not to the member app
 // Need to figure a way to separate these things (e.g. frontend actually talks to members API)
-const loadMemberSession = async function (req, res, next) {
+const loadMemberSession = async function loadMemberSession(req, res, next) {
     try {
         const member = await membersService.ssr.getMemberDataFromSession(req, res);
         Object.assign(req, {member});
@@ -32,7 +32,7 @@ const loadMemberSession = async function (req, res, next) {
  * Require member authentication, and make it possible to authenticate via uuid.
  * You can chain this after loadMemberSession to make it possible to authenticate via both the uuid and the session.
  */
-const authMemberByUuid = async function (req, res, next) {
+const authMemberByUuid = async function authMemberByUuid(req, res, next) {
     try {
         const uuid = req.query.uuid;
         if (!uuid) {
@@ -60,7 +60,7 @@ const authMemberByUuid = async function (req, res, next) {
     }
 };
 
-const getIdentityToken = async function (req, res) {
+const getIdentityToken = async function getIdentityToken(req, res) {
     try {
         const token = await membersService.ssr.getIdentityTokenForMemberFromSession(req, res);
         res.writeHead(200);
@@ -71,7 +71,7 @@ const getIdentityToken = async function (req, res) {
     }
 };
 
-const deleteSession = async function (req, res) {
+const deleteSession = async function deleteSession(req, res) {
     try {
         await membersService.ssr.deleteSession(req, res);
         res.writeHead(204);
@@ -87,7 +87,7 @@ const deleteSession = async function (req, res) {
     }
 };
 
-const getMemberData = async function (req, res) {
+const getMemberData = async function getMemberData(req, res) {
     try {
         const member = await membersService.ssr.getMemberDataFromSession(req, res);
         if (member) {
@@ -101,7 +101,7 @@ const getMemberData = async function (req, res) {
     }
 };
 
-const deleteSuppression = async function (req, res) {
+const deleteSuppression = async function deleteSuppression(req, res) {
     try {
         const member = await membersService.ssr.getMemberDataFromSession(req, res);
         const options = {
@@ -123,7 +123,7 @@ const deleteSuppression = async function (req, res) {
     }
 };
 
-const getMemberNewsletters = async function (req, res) {
+const getMemberNewsletters = async function getMemberNewsletters(req, res) {
     try {
         const memberUuid = req.query.uuid;
 
@@ -151,7 +151,7 @@ const getMemberNewsletters = async function (req, res) {
     }
 };
 
-const updateMemberNewsletters = async function (req, res) {
+const updateMemberNewsletters = async function updateMemberNewsletters(req, res) {
     try {
         const memberUuid = req.query.uuid;
         if (!memberUuid) {
@@ -182,7 +182,7 @@ const updateMemberNewsletters = async function (req, res) {
     }
 };
 
-const updateMemberData = async function (req, res) {
+const updateMemberData = async function updateMemberData(req, res) {
     try {
         const data = _.pick(req.body, 'name', 'expertise', 'subscribed', 'newsletters', 'enable_comment_notifications');
         const member = await membersService.ssr.getMemberDataFromSession(req, res);
@@ -209,7 +209,7 @@ const updateMemberData = async function (req, res) {
     }
 };
 
-const createSessionFromMagicLink = async function (req, res, next) {
+const createSessionFromMagicLink = async function createSessionFromMagicLink(req, res, next) {
     if (!req.url.includes('token=')) {
         return next();
     }

--- a/ghost/core/core/server/web/admin/app.js
+++ b/ghost/core/core/server/web/admin/app.js
@@ -25,7 +25,7 @@ module.exports = function setupAdminApp() {
     adminApp.use('/assets', serveStatic(
         path.join(config.get('paths').adminAssets, 'assets'), {
             maxAge: (configMaxAge || configMaxAge === 0) ? configMaxAge : constants.ONE_YEAR_MS,
-            immutable: true, 
+            immutable: true,
             fallthrough: false
         }
     ));
@@ -59,7 +59,7 @@ module.exports = function setupAdminApp() {
     // Finally, routing
     adminApp.get('*', require('./controller'));
 
-    adminApp.use((err, req, res, next) => {
+    adminApp.use(function fourOhFourMw(err, req, res, next) {
         if (err.statusCode && err.statusCode === 404) {
             // Remove 404 errors for next middleware to inject
             next();

--- a/ghost/core/core/server/web/api/endpoints/admin/middleware.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/middleware.js
@@ -8,7 +8,7 @@ const messages = {
     notImplemented: 'The server does not support the functionality required to fulfill the request.'
 };
 
-const notImplemented = function (req, res, next) {
+const notImplemented = function notImplemented(req, res, next) {
     // CASE: user is logged in, allow
     if (!req.api_key) {
         return next();

--- a/ghost/core/core/server/web/api/middleware/cors.js
+++ b/ghost/core/core/server/web/api/middleware/cors.js
@@ -87,7 +87,7 @@ function corsOptionsDelegate(req, cb) {
  * @param {Express.Response} res
  * @param {Function} next
  */
-const handleCaching = (req, res, next) => {
+const handleCaching = function handleCaching(req, res, next) {
     const method = req.method && req.method.toUpperCase && req.method.toUpperCase();
     if (method === 'OPTIONS') {
         // @NOTE: try to add native support for dynamic 'vary' header value in 'cors' module

--- a/ghost/core/core/server/web/api/middleware/upload.js
+++ b/ghost/core/core/server/web/api/middleware/upload.js
@@ -47,7 +47,7 @@ const upload = multer({dest: os.tmpdir()});
 
 const deleteSingleFile = file => fs.unlink(file.path).catch(err => logging.error(err));
 
-const single = name => (req, res, next) => {
+const single = name => function singleUploadFunction(req, res, next) {
     const singleUpload = upload.single(name);
 
     singleUpload(req, res, (err) => {
@@ -77,7 +77,7 @@ const single = name => (req, res, next) => {
     });
 };
 
-const media = (fileName, thumbName) => (req, res, next) => {
+const media = (fileName, thumbName) => function mediaUploadFunction(req, res, next) {
     const mediaUpload = upload.fields([{
         name: fileName,
         maxCount: 1

--- a/ghost/core/core/server/web/parent/middleware/request-id.js
+++ b/ghost/core/core/server/web/parent/middleware/request-id.js
@@ -3,7 +3,7 @@ const uuid = require('uuid');
 /**
  * @TODO: move this middleware to Framework monorepo?
  */
-module.exports = (req, res, next) => {
+module.exports = function requestIdMw(req, res, next) {
     const requestId = req.get('X-Request-ID') || uuid.v4();
 
     // Set a value for internal use

--- a/ghost/core/core/server/web/shared/middleware/uncapitalise.js
+++ b/ghost/core/core/server/web/shared/middleware/uncapitalise.js
@@ -21,7 +21,7 @@ const messages = {
     pageNotFound: 'Page not found"'
 };
 
-const uncapitalise = (req, res, next) => {
+const uncapitalise = function uncapitalise(req, res, next) {
     let pathToTest = (req.baseUrl ? req.baseUrl : '') + req.path;
     let redirectPath;
     let decodedURI;

--- a/ghost/core/core/server/web/shared/middleware/url-redirects.js
+++ b/ghost/core/core/server/web/shared/middleware/url-redirects.js
@@ -87,7 +87,7 @@ _private.getFrontendRedirectUrl = ({requestedHost, requestedUrl, queryParameters
     }
 };
 
-_private.redirect = (req, res, next, redirectFn) => {
+_private.redirect = function urlRedirectsRedirect(req, res, next, redirectFn) {
     const redirectUrl = redirectFn({
         requestedHost: req.vhost ? req.vhost.host : req.get('host'),
         requestedUrl: url.parse(req.originalUrl || req.url).pathname,
@@ -104,11 +104,11 @@ _private.redirect = (req, res, next, redirectFn) => {
     next();
 };
 
-const frontendRedirect = (req, res, next) => {
+const frontendRedirect = function frontendRedirect(req, res, next) {
     _private.redirect(req, res, next, _private.getFrontendRedirectUrl);
 };
 
-const adminRedirect = (req, res, next) => {
+const adminRedirect = function adminRedirect(req, res, next) {
     _private.redirect(req, res, next, _private.getAdminRedirectUrl);
 };
 

--- a/ghost/core/core/server/web/well-known.js
+++ b/ghost/core/core/server/web/well-known.js
@@ -18,7 +18,7 @@ module.exports = function setupWellKnownApp() {
 
     const cache = cacheControl('public', {maxAge: config.get('caching:wellKnown:maxAge')});
 
-    wellKnownApp.get('/jwks.json', cache, async (req, res) => {
+    wellKnownApp.get('/jwks.json', cache, async function jwksMiddleware(req, res) {
         const jwks = await getSafePublicJWKS();
 
         // there's only one key in the store atm

--- a/ghost/core/index.js
+++ b/ghost/core/index.js
@@ -1,1 +1,6 @@
+// Load New Relic
+if (process.env.PRO_ENV) {
+    require('newrelic');
+}
+
 require('./ghost');


### PR DESCRIPTION
refs TryGhost/DevOps#68

- we want New Relic to be one of the first modules to load so it can
  instrument the rest of our code
- previously this would not have been the case, and it would have missed
  out on instrumenting the config and logging code
- this moves the require to be the first step in the process if the
  PRO_ENV env var is set

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
copilot:summary
