### PR TITLE
Configured new Renovate presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   },
   "renovate": {
     "extends": [
-      "@tryghost:quietJS",
-      "@tryghost:disableTryGhostAutomerge",
+      "github>tryghost/renovate-config:quiet",
       "@tryghost:groupTestLint",
       "@tryghost:groupCSS",
       "@tryghost:groupBuildTools"
@@ -72,12 +71,6 @@
       "ghost/admin/lib/koenig-editor/package.json"
     ],
     "packageRules": [
-      {
-        "packagePatterns": [
-          "@tryghost"
-        ],
-        "groupName": "@tryghost"
-      },
       {
         "packagePatterns": [
           "metascraper"


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/69

- we're doing some work to update our Renovate rules
- part of that is the fact that they're deprecating package-based presets, so I've moved the rules into a repo
- this commit switches the Ghost repo over to that

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c05d754</samp>

Simplified renovate configuration in `package.json` to improve dependency management. Used a new preset to group and schedule updates more efficiently.
