### PR TITLE
Updated Renovate presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,7 @@
   },
   "renovate": {
     "extends": [
-      "github>tryghost/renovate-config:quiet",
-      "@tryghost:groupTestLint",
-      "@tryghost:groupCSS",
-      "@tryghost:groupBuildTools"
+      "github>tryghost/renovate-config:quiet"
     ],
     "rebaseWhen": "never",
     "ignoreDeps": [
@@ -71,12 +68,6 @@
       "ghost/admin/lib/koenig-editor/package.json"
     ],
     "packageRules": [
-      {
-        "packagePatterns": [
-          "metascraper"
-        ],
-        "groupName": "metascraper"
-      },
       {
         "groupName": "ember-basic-dropdown addons",
         "packagePatterns": [


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/69

- deleted the preset extensions as these are all part of the base preset now

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d675b5f</samp>

Simplify and clean up `package.json` file by removing unnecessary renovate settings. This improves the readability and maintainability of the project's dependencies.
