### PR TITLE
Added drop of intermediate post saves between current running and latest triggered

### DIFF
--- a/ghost/admin/app/controllers/editor.js
+++ b/ghost/admin/app/controllers/editor.js
@@ -149,7 +149,7 @@ export default class EditorController extends Controller {
     // cursor is in the slug field - that would previously trigger a simultaneous
     // slug update and save resulting in ember data errors and inconsistent save
     // results
-    @(taskGroup().enqueue())
+    @(taskGroup().keepLatest())
         saveTasks;
 
     @mapBy('post.tags', 'name')

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -153,7 +153,7 @@ export default class LexicalEditorController extends Controller {
     // cursor is in the slug field - that would previously trigger a simultaneous
     // slug update and save resulting in ember data errors and inconsistent save
     // results
-    @(taskGroup().enqueue())
+    @(taskGroup().keepLatest())
         saveTasks;
 
     @mapBy('post.tags', 'name')


### PR DESCRIPTION
no issue

- every triggered save was being added to a queue resulting in an unnecessary number of requests in some circumstances because it means every triggered save would be run sequentially even though the intermediate saves could be safely thrown away if we're still waiting on a response to a previous one
- switched from a standard queue to ember-concurrency's `keepLatest` behaviour
  - drops intermediate saves if multiple saves are triggered whilst still waiting on a previous save
  - http://ember-concurrency.com/docs/task-concurrency#keepLatest
