### PR TITLE
Ensure hidden settings return falsy when used with the `@custom` helper

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/design.js
+++ b/ghost/admin/app/components/gh-nav-menu/design.js
@@ -72,7 +72,7 @@ export default class DesignMenuComponent extends Component {
 
     @action
     handleThemeSettingChange() {
-        this.customThemeSettings.rebuildSettings();
+        this.customThemeSettings.updateSettingsVisibility();
         this.themeManagement.updatePreviewHtmlTask.perform();
     }
 

--- a/ghost/admin/app/components/gh-nav-menu/design.js
+++ b/ghost/admin/app/components/gh-nav-menu/design.js
@@ -72,7 +72,7 @@ export default class DesignMenuComponent extends Component {
 
     @action
     handleThemeSettingChange() {
-        this.customThemeSettings.rebuildSettingGroups();
+        this.customThemeSettings.rebuildSettings();
         this.themeManagement.updatePreviewHtmlTask.perform();
     }
 

--- a/ghost/admin/app/components/settings/design/theme-settings-form.hbs
+++ b/ghost/admin/app/components/settings/design/theme-settings-form.hbs
@@ -1,20 +1,22 @@
 <div class="gh-stack">
     <form>
         {{#each @themeSettings as |setting index|}}
-            {{#if (eq setting.type "select")}}
-                <CustomThemeSettings::Select @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
-            {{/if}}
-            {{#if (eq setting.type "boolean")}}
-                <CustomThemeSettings::Boolean @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
-            {{/if}}
-            {{#if (eq setting.type "color")}}
-                <CustomThemeSettings::Color @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
-            {{/if}}
-            {{#if (eq setting.type "text")}}
-                <CustomThemeSettings::Text @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
-            {{/if}}
-            {{#if (eq setting.type "image")}}
-                <CustomThemeSettings::Image @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
+            {{#if setting.visible}}
+                {{#if (eq setting.type "select")}}
+                    <CustomThemeSettings::Select @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
+                {{/if}}
+                {{#if (eq setting.type "boolean")}}
+                    <CustomThemeSettings::Boolean @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
+                {{/if}}
+                {{#if (eq setting.type "color")}}
+                    <CustomThemeSettings::Color @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
+                {{/if}}
+                {{#if (eq setting.type "text")}}
+                    <CustomThemeSettings::Text @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
+                {{/if}}
+                {{#if (eq setting.type "image")}}
+                    <CustomThemeSettings::Image @setting={{setting}} @index={{index}} @onChange={{@onChange}} />
+                {{/if}}
             {{/if}}
         {{/each}}
     </form>

--- a/ghost/admin/app/models/custom-theme-setting.js
+++ b/ghost/admin/app/models/custom-theme-setting.js
@@ -8,5 +8,6 @@ export default Model.extend({
     default: attr('string'),
     value: attr(),
     group: attr('string'),
-    visibility: attr('string')
+    visibility: attr('string'),
+    visible: attr('boolean', {defaultValue: true})
 });

--- a/ghost/admin/app/services/custom-theme-settings.js
+++ b/ghost/admin/app/services/custom-theme-settings.js
@@ -36,7 +36,7 @@ export default class CustomThemeSettingsServices extends Service {
         const keyValue = {};
 
         this.settings.forEach((setting) => {
-            keyValue[setting.key] = setting.value;
+            keyValue[setting.key] = this._isSettingVisible(setting) ? setting.value : HIDDEN_SETTING_VALUE;
         });
 
         return keyValue;
@@ -148,6 +148,12 @@ export default class CustomThemeSettingsServices extends Service {
             return true;
         }
 
-        return nql(setting.visibility).queryJSON(this.keyValueObject);
+        const settingsMap = this.settings.reduce((map, {key, value}) => {
+            map[key] = value;
+
+            return map;
+        }, {});
+
+        return nql(setting.visibility).queryJSON(settingsMap);
     }
 }

--- a/ghost/custom-theme-settings-service/lib/CustomThemeSettingsService.js
+++ b/ghost/custom-theme-settings-service/lib/CustomThemeSettingsService.js
@@ -10,6 +10,8 @@ const messages = {
     invalidValueForSetting: 'Invalid value for \'{key}\'. The value must follow this format: {format}.'
 };
 
+const HIDDEN_SETTING_VALUE = null;
+
 module.exports = class CustomThemeSettingsService {
     /**
      * @param {Object} options
@@ -106,6 +108,12 @@ module.exports = class CustomThemeSettingsService {
 
         settings.forEach((setting) => {
             const definition = this._activeThemeSettings[setting.key];
+
+            // skip validation for hidden settings
+            if (definition.visibility && setting.value === HIDDEN_SETTING_VALUE) {
+                return;
+            }
+
             switch (definition.type) {
             case 'select':
                 if (!definition.options.includes(setting.value)) {

--- a/ghost/custom-theme-settings-service/package.json
+++ b/ghost/custom-theme-settings-service/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@tryghost/debug": "0.1.24",
     "@tryghost/errors": "1.2.24",
+    "@tryghost/nql": "0.11.0",
     "@tryghost/tpl": "0.1.24",
     "lodash": "4.17.21"
   }

--- a/ghost/custom-theme-settings-service/test/service.test.js
+++ b/ghost/custom-theme-settings-service/test/service.test.js
@@ -876,7 +876,7 @@ describe('Service', function () {
             ).should.be.resolved();
         });
 
-        it('does not validate hidden settings', async function () {
+        it('does not expose hidden settings in the public cache', async function () {
             const HIDDEN_SETTING_VALUE = null;
 
             const settingName = 'foo';
@@ -896,12 +896,15 @@ describe('Service', function () {
 
             await service.updateSettings(
                 [{
-                    id: 1,
                     key: settingName,
-                    value: HIDDEN_SETTING_VALUE,
+                    value: 'Foo',
                     ...settingDefinition
                 }]
-            ).should.be.resolved();
+            );
+
+            cache.getAll().should.deepEqual({
+                [settingName]: HIDDEN_SETTING_VALUE
+            });
         });
     });
 });

--- a/ghost/custom-theme-settings-service/test/service.test.js
+++ b/ghost/custom-theme-settings-service/test/service.test.js
@@ -875,5 +875,33 @@ describe('Service', function () {
                 }]
             ).should.be.resolved();
         });
+
+        it('does not validate hidden settings', async function () {
+            const HIDDEN_SETTING_VALUE = null;
+
+            const settingName = 'foo';
+            const settingDefinition = {
+                type: 'select',
+                options: ['Foo', 'Bar', 'Baz'],
+                default: 'Foo',
+                visibility: 'some_other_setting:bar'
+            };
+
+            await service.activateTheme('test', {
+                name: 'test',
+                customSettings: {
+                    [settingName]: settingDefinition
+                }
+            });
+
+            await service.updateSettings(
+                [{
+                    id: 1,
+                    key: settingName,
+                    value: HIDDEN_SETTING_VALUE,
+                    ...settingDefinition
+                }]
+            ).should.be.resolved();
+        });
     });
 });


### PR DESCRIPTION
no refs

When a theme setting is hidden, it should return a falsy value when used