### PR TITLE
Fixed "new post" button showing 500 error when editor beta is enabled

### DIFF
--- a/ghost/admin/app/routes/editor.js
+++ b/ghost/admin/app/routes/editor.js
@@ -13,8 +13,14 @@ export default AuthenticatedRoute.extend({
     beforeModel(transition) {
         // redirect to the beta editor so the post gets auto-migrated
         if (this.feature.lexicalEditor) {
+            const {name} = transition.to;
             const {type, post_id: id} = transition.to.params;
-            return this.router.transitionTo('lexical-editor.edit', type, id);
+
+            if (name === 'editor.new') {
+                return this.router.transitionTo('lexical-editor.new', type);
+            } else if (name === 'editor.edit') {
+                return this.router.transitionTo('lexical-editor.edit', type, id);
+            }
         }
     },
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/17876

- the redirect added for the beta editor was always redirecting to `lexical-editor.edit` even when accessing `editor.new` which resulted in an incorrect route params error and a 500 screen
- switched to redirecting to the correct new/edit route based on the route we're trying to access
