### PR TITLE
Fixed console error when leaving new post screen with beta editor

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -954,7 +954,7 @@ export default class LexicalEditorController extends Controller {
         // Check if anything has changed since the last revision
         let postRevisions = post.get('postRevisions').toArray();
         let latestRevision = postRevisions[postRevisions.length - 1];
-        let hasChangedSinceLastRevision = post.get('lexical') !== latestRevision.get('lexical');
+        let hasChangedSinceLastRevision = !post.isNew && post.lexical !== latestRevision.lexical;
 
         let fromNewToEdit = this.router.currentRouteName === 'lexical-editor.new'
             && transition.targetName === 'lexical-editor.edit'


### PR DESCRIPTION
no issue

- when a post is new it has no revisions but in the `willTransition` hook we were using `lastRevision.get` even though `lastRevision` was null
- adjusted the `hasChangedSinceLastRevision` conditional to always be `false` for new posts
