### PR TITLE
Expanded has helper to allow multiple slug checks

### DIFF
--- a/ghost/core/core/frontend/helpers/has.js
+++ b/ghost/core/core/frontend/helpers/has.js
@@ -108,7 +108,7 @@ function evaluateSlugList(expr, slug) {
 }
 
 function handleSlug(data, attrs) {
-    if (!attrs.slug) {
+    if (!attrs.slug || !data.slug) {
       return false;
     }
     

--- a/ghost/core/core/frontend/helpers/has.js
+++ b/ghost/core/core/frontend/helpers/has.js
@@ -99,6 +99,22 @@ function evaluateStringMatch(expr, str, ci) {
     return expr === str;
 }
 
+function evaluateSlugList(expr, slug) {
+    const slugList = expr.split(',').map(v => v.trim().toLocaleLowerCase());
+  
+    return slugList.reduce((p, c) => {
+      return p || slug.toLocaleLowerCase() === c; 
+    }, false);
+}
+
+function handleSlug(data, attrs) {
+    if (!attrs.slug) {
+      return false;
+    }
+    
+    return evaluateSlugList(attrs.slug, data.slug) || false;
+}
+
 /**
  *
  * @param {String} type - either some or every - the lodash function to use
@@ -144,7 +160,7 @@ module.exports = function has(options) {
             return attrs.visibility && evaluateStringMatch(attrs.visibility, self.visibility, true) || false;
         },
         slug: function () {
-            return attrs.slug && evaluateStringMatch(attrs.slug, self.slug, true) || false;
+            return handleSlug(self, attrs);
         },
         id: function () {
             return attrs.id && evaluateStringMatch(attrs.id, self.id, true) || false;


### PR DESCRIPTION
This PR adds the ability to check against multiple slug values in the has helper by allowing a comma-separated list (equivalent of an OR query). 

For example, to check if the slug matches either 'smartphones' or 'tablets':

```
{{#has slug="smartphones,tablets"}}
  ...
{{/has}}
```

This provides more flexibility for theme developers to easily check for multiple slug values without having to specify multiple has helper calls (as in the example below).

**Current condition**:

```
{{#has slug="smartphones"}}
...
{{else has slug="tablets"}}
...
{{/has}}
```
or

```
{{#has slug="smartphones"}}
...
{{/has}}

{{#has slug="tablets"}}
...
{{/has}}

```

**Why can't we just do something like this instead if we want to output the same element for multiple slugs?:**
```
{{#has slug="smartphones,tablets"}}
...
{{/has}}
```



This code can be improved, thank you.