### PR TITLE
deps: remove bluebird override because bluebird has been removed from Ghost software

### DIFF
--- a/ghost/core/core/server/overrides.js
+++ b/ghost/core/core/server/overrides.js
@@ -1,10 +1,3 @@
-/**
- * If we enable bluebird debug logs we see a huge memory usage.
- * You can reproduce by removing this line and import a big database export into Ghost.
- * `NODE_ENV=development node index.js`
- */
-process.env.BLUEBIRD_DEBUG = 0;
-
 const luxon = require('luxon');
 const moment = require('moment-timezone');
 


### PR DESCRIPTION
Work on #14882 has removed Bluebird as a dependency for Ghost components.

As a result, this toggle is not needed anymore
