### PR TITLE
Fixed AdminX modal routing

### DIFF
--- a/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
@@ -1,11 +1,11 @@
 import AddIntegrationModal from '../settings/advanced/integrations/AddIntegrationModal';
 import AddNewsletterModal from '../settings/email/newsletters/AddNewsletterModal';
 import AddRecommendationModal from '../settings/site/recommendations/AddRecommendationModal';
-import AddRecommendationModalConfirm from '../settings/site/recommendations/AddRecommendationModalConfirm';
 import AmpModal from '../settings/advanced/integrations/AmpModal';
 import ChangeThemeModal from '../settings/site/ThemeModal';
 import CustomIntegrationModal from '../settings/advanced/integrations/CustomIntegrationModal';
 import DesignModal from '../settings/site/DesignModal';
+import EditRecommendationModal from '../settings/site/recommendations/EditRecommendationModal';
 import FirstpromoterModal from '../settings/advanced/integrations/FirstPromoterModal';
 import HistoryModal from '../settings/advanced/HistoryModal';
 import InviteUserModal from '../settings/general/InviteUserModal';
@@ -77,7 +77,9 @@ const modalPaths: {[key: string]: React.FC<NiceModalHocProps & RoutingModalProps
     'integrations/firstpromoter': FirstpromoterModal,
     'integrations/pintura': PinturaModal,
     'integrations/add': AddIntegrationModal,
-    'integrations/show/:id': CustomIntegrationModal
+    'integrations/show/:id': CustomIntegrationModal,
+    'recommendations/add': AddRecommendationModal,
+    'recommendations/:id': EditRecommendationModal
 };
 
 function getHashPath(urlPath: string | undefined) {
@@ -116,44 +118,6 @@ const handleNavigation = (scroll: boolean = true) => {
 
         if (path && modal) {
             NiceModal.show(modal, {params: matchRoute(pathName, path)});
-        }
-
-        if (pathName === 'design/edit/themes') {
-            NiceModal.show(ChangeThemeModal);
-        } else if (pathName === 'design/edit') {
-            NiceModal.show(DesignModal);
-        } else if (pathName === 'navigation/edit') {
-            NiceModal.show(NavigationModal);
-        } else if (pathName === 'users/invite') {
-            NiceModal.show(InviteUserModal);
-        } else if (pathName === 'portal/edit') {
-            NiceModal.show(PortalModal);
-        } else if (pathName === 'tiers/add') {
-            NiceModal.show(TierDetailModal);
-        } else if (pathName === 'stripe-connect') {
-            NiceModal.show(StripeConnectModal);
-        } else if (pathName === 'newsletters/add') {
-            NiceModal.show(AddNewsletterModal);
-        } else if (pathName === 'history/view') {
-            NiceModal.show(HistoryModal);
-        } else if (pathName === 'integrations/zapier') {
-            NiceModal.show(ZapierModal);
-        } else if (pathName === 'integrations/slack') {
-            NiceModal.show(SlackModal);
-        } else if (pathName === 'integrations/amp') {
-            NiceModal.show(AmpModal);
-        } else if (pathName === 'integrations/unsplash') {
-            NiceModal.show(UnsplashModal);
-        } else if (pathName === 'integrations/firstpromoter') {
-            NiceModal.show(FirstpromoterModal);
-        } else if (pathName === 'integrations/pintura') {
-            NiceModal.show(PinturaModal);
-        } else if (pathName === 'integrations/add') {
-            NiceModal.show(AddIntegrationModal);
-        } else if (pathName === 'recommendations/add') {
-            NiceModal.show(AddRecommendationModal);
-        } else if (pathName === 'recommendations/add-confirm') {
-            NiceModal.show(AddRecommendationModalConfirm);
         }
 
         if (scroll) {

--- a/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
@@ -130,9 +130,13 @@ const handleNavigation = (scroll: boolean = true) => {
 };
 
 const matchRoute = (pathname: string, routeDefinition: string) => {
-    const regex = new RegExp(routeDefinition.replace(/:(\w+)/, '(?<$1>[^/]+)'));
+    const regex = new RegExp('^' + routeDefinition.replace(/:(\w+)/, '(?<$1>[^/]+)') + '$');
 
-    return pathname.match(regex)?.groups;
+    const match = pathname.match(regex);
+
+    if (match) {
+        return match.groups || {};
+    }
 };
 
 const callRouteChangeListeners = (newPath: string, listeners: RouteChangeListener[]) => {

--- a/apps/admin-x-settings/src/components/settings/site/recommendations/EditRecommendationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/recommendations/EditRecommendationModal.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import RecommendationReasonForm from './RecommendationReasonForm';
 import useForm from '../../../../hooks/useForm';
 import useRouting from '../../../../hooks/useRouting';
-import {Recommendation, useEditRecommendation} from '../../../../api/recommendations';
+import {Recommendation, useBrowseRecommendations, useEditRecommendation} from '../../../../api/recommendations';
+import {RoutingModalProps} from '../../../providers/RoutingProvider';
 import {showToast} from '../../../../admin-x-ds/global/Toast';
 import {toast} from 'react-hot-toast';
 
@@ -77,4 +78,15 @@ const EditRecommendationModalConfirm: React.FC<AddRecommendationModalProps> = ({
     </Modal>;
 };
 
-export default NiceModal.create(EditRecommendationModalConfirm);
+const EditRecommendationModal: React.FC<RoutingModalProps> = ({params}) => {
+    const {data: {recommendations} = {}} = useBrowseRecommendations();
+    const recommendation = recommendations?.find(({id}) => id === params?.id);
+
+    if (recommendation) {
+        return <EditRecommendationModalConfirm recommendation={recommendation} />;
+    } else {
+        return null;
+    }
+};
+
+export default NiceModal.create(EditRecommendationModal);


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3349

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 612a2a8</samp>

Refactored the routing and modal components for recommendations in the admin-x-settings app. Added a new `EditRecommendationModal` component and a new `useBrowseRecommendations` hook. Removed some unused code and improved the user interface for editing recommendations from the site settings.
