### PR TITLE
Migrated to Actions trigger-metric workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,7 @@ jobs:
       # Report time taken to metrics service
       # Continue on error if previous TailScale step fails
       - name: Store test duration
-        uses: tryghost/action-trigger-metric@main
+        uses: tryghost/actions/actions/trigger-metric@main
         timeout-minutes: 1
         continue-on-error: true
         if: (github.event_name == 'push' && github.repository_owner == 'TryGhost') || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'TryGhost/'))


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/70

- I've moved the code and history into the Actions repo to keep these things more maintainable
- this commit updates the reference to the action

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d055d8</samp>

Fix a typo in the `ci.yml` workflow that prevented storing test duration metrics. Use the correct path to the `trigger-metric` action from the `tryghost/actions` repository.
