### PR TITLE
Add ability to specify newsletter in a custom sign-up form

### DIFF
--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -38,12 +38,14 @@ export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}
         email: email,
         emailType: emailType,
         labels: labels,
-        newsletters: newsletters,
         name: name,
         autoRedirect: (autoRedirect === 'true')
     };
     if (urlHistory) {
         reqBody.urlHistory = urlHistory;
+    }
+    if (newsletterInputs.length > 0) {
+        reqBody.newsletters = newsletters;
     }
 
     fetch(`${siteUrl}/members/api/send-magic-link/`, {

--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -16,10 +16,16 @@ export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}
     let name = (nameInput && nameInput.value) || undefined;
     let emailType = undefined;
     let labels = [];
+    let newsletters = [];
 
     let labelInputs = event.target.querySelectorAll('input[data-members-label]') || [];
     for (let i = 0; i < labelInputs.length; ++i) {
         labels.push(labelInputs[i].value);
+    }
+
+    let newsletterInputs = event.target.querySelectorAll('input[data-members-newsletter]') || [];
+    for (let i = 0; i < newsletterInputs.length; ++i) {
+        newsletters.push({id: newsletterInputs[i].value});
     }
 
     if (form.dataset.membersForm) {
@@ -32,6 +38,7 @@ export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}
         email: email,
         emailType: emailType,
         labels: labels,
+        newsletters: newsletters,
         name: name,
         autoRedirect: (autoRedirect === 'true')
     };

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -63,6 +63,11 @@ function getMockData() {
                         value: 'Gold'
                     }];
                 }
+                if (elem === 'input[data-members-newsletter]') {
+                    return [{
+                        value: 'some_newsletter'
+                    }];
+                }
             }
         }
     };
@@ -146,6 +151,7 @@ describe('Member Data attributes:', () => {
                 email: 'jamie@example.com',
                 emailType: 'signup',
                 labels: ['Gold'],
+                newsletters: [{id: 'some_newsletter'}],
                 name: 'Jamie Larsen',
                 autoRedirect: true,
                 urlHistory: [{


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3809

When an input is added to a custom sign-up form with the attribute `data-members-newsletter`, the value of the input will be used as the newsletter to subscribe the member to.