### PR TITLE
Improved efficiency of Members request caching for the Posts Content API 

### DIFF
--- a/ghost/api-framework/lib/pipeline.js
+++ b/ghost/api-framework/lib/pipeline.js
@@ -1,5 +1,6 @@
 const debug = require('@tryghost/debug')('pipeline');
 const _ = require('lodash');
+const stringify = require('json-stable-stringify');
 const errors = require('@tryghost/errors');
 const {sequence} = require('@tryghost/promise');
 
@@ -229,7 +230,13 @@ const pipeline = (apiController, apiUtils, apiType) => {
             frame.docName = docName;
             frame.method = method;
 
-            let cacheKey = JSON.stringify(frame.options);
+            let cacheKeyData = frame.options;
+            if (apiImpl.generateCacheKeyData) {
+                cacheKeyData = await apiImpl.generateCacheKeyData(frame);
+            }
+
+            const cacheKey = stringify(cacheKeyData);
+
             if (apiImpl.cache) {
                 const response = await apiImpl.cache.get(cacheKey);
 

--- a/ghost/core/core/server/services/members/content-gating.js
+++ b/ghost/core/core/server/services/members/content-gating.js
@@ -8,18 +8,22 @@ const BLOCK_ACCESS = false;
 
 // TODO: better place to store this?
 const MEMBER_NQL_EXPANSIONS = [{
-    key: 'labels',
-    replacement: 'labels.slug'
-}, {
-    key: 'label',
-    replacement: 'labels.slug'
-}, {
     key: 'products',
     replacement: 'products.slug'
 }, {
     key: 'product',
     replacement: 'products.slug'
 }];
+
+const rejectUnknownKeys = input => nql.utils.mapQuery(input, function (value, key) {
+    if (!['product', 'products', 'status'].includes(key.toLowerCase())) {
+        return;
+    }
+
+    return {
+        [key]: value
+    };
+});
 
 /**
  * @param {object} post - A post object to check access to
@@ -50,7 +54,7 @@ function checkPostAccess(post, member) {
         }).join(',');
     }
 
-    if (visibility && member.status && nql(visibility, {expansions: MEMBER_NQL_EXPANSIONS}).queryJSON(member)) {
+    if (visibility && member.status && nql(visibility, {expansions: MEMBER_NQL_EXPANSIONS, transformer: rejectUnknownKeys}).queryJSON(member)) {
         return PERMIT_ACCESS;
     }
 

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -196,6 +196,7 @@
     "intl-messageformat": "5.4.3",
     "js-yaml": "4.1.0",
     "jsdom": "22.1.0",
+    "json-stable-stringify": "1.0.2",
     "jsonpath": "1.1.1",
     "jsonwebtoken": "8.5.1",
     "juice": "9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21272,6 +21272,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json-stable-stringify@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz#e06f23128e0bbe342dc996ed5a19e28b57b580e0"
+  integrity sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==
+  dependencies:
+    jsonify "^0.0.1"
+
 json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
@@ -21338,7 +21345,7 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonify@~0.0.0:
+jsonify@^0.0.1, jsonify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
   integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==


### PR DESCRIPTION
At the moment we're using the entire `option` object as the cache key for requests to the posts content API. For unauthenticated requests this is fairly okay, but for requests with members authentication we are storing the same content under many keys!

The changes here are to enable custom key data generation at the endpoint layer, as well as implementing custom key data for the posts api.

We strip all options which don't have an effect on the content, e.g. `debug`. And then only include member data that has an effect on the content. This reduces the number of unique keys and so allows us to cache more data.

 