### PR TITLE
Revert "Added drop of intermediate post saves between current running and latest triggered"

### DIFF
--- a/ghost/admin/app/controllers/editor.js
+++ b/ghost/admin/app/controllers/editor.js
@@ -149,7 +149,7 @@ export default class EditorController extends Controller {
     // cursor is in the slug field - that would previously trigger a simultaneous
     // slug update and save resulting in ember data errors and inconsistent save
     // results
-    @(taskGroup().keepLatest())
+    @(taskGroup().enqueue())
         saveTasks;
 
     @mapBy('post.tags', 'name')

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -153,7 +153,7 @@ export default class LexicalEditorController extends Controller {
     // cursor is in the slug field - that would previously trigger a simultaneous
     // slug update and save resulting in ember data errors and inconsistent save
     // results
-    @(taskGroup().keepLatest())
+    @(taskGroup().enqueue())
         saveTasks;
 
     @mapBy('post.tags', 'name')


### PR DESCRIPTION
Reverts TryGhost/Ghost#17912

- unfortunately dropping save tasks when one is already running has side-effects for code that is initiating the save tasks
- e.g. the slug or title update actions call `saveTask.perform()` and if that related save request fails they expect to get a standard request error so they can show a message and perform a model rollback. However with `keepLatest` the save task can be dropped and "fail" immediately with a `TaskCancelation` error which has unintended side-effects:
  1. error handling is no longer tied to the specific request meaning we could have slug-related failures being handled by non-slug-save code which is unexpected
  2. the internal `TaskCancelation` error is handled as if it was general error and we end up showing a useless error in the red error bar that makes it look like something failed when it didn't
  3. we initiate a model rollback when we do not have a failure situation that requires it meaning we can lose changes