### PR TITLE
🐛 Fixed bookmark card creation and pasted link unfurls

### DIFF
--- a/ghost/oembed-service/lib/OEmbedService.js
+++ b/ghost/oembed-service/lib/OEmbedService.js
@@ -208,8 +208,8 @@ class OEmbedService {
 
         const pickFn = (sizes, pickDefault) => {
             // Prioritize apple touch icon with sizes > 180
-            const appleTouchIcon = sizes.find(item => item.rel.includes('apple') && item.sizes && item.size.width >= 180);
-            const svgIcon = sizes.find(item => item.href.endsWith('svg'));
+            const appleTouchIcon = sizes.find(item => item.rel?.includes('apple') && item.sizes && item.size.width >= 180);
+            const svgIcon = sizes.find(item => item.href?.endsWith('svg'));
             return appleTouchIcon || svgIcon || pickDefault(sizes);
         };
 


### PR DESCRIPTION
no issue

- recently added code to grab apple touch icons or SVGs before falling back to the default metascraper behaviour wrongly assumed that every size would have a `rel` and `href` attribute which is not the case
