### PR TITLE
Added option to share redis connections across caches

### DIFF
--- a/ghost/adapter-cache-redis/lib/redis-store-factory.js
+++ b/ghost/adapter-cache-redis/lib/redis-store-factory.js
@@ -1,0 +1,22 @@
+const defaultCacheManager = require('cache-manager-ioredis');
+let redisStoreSingletonInstance;
+
+/**
+ *
+ * @param {object} [storeOptions] options to pass to the Redis store instance
+ * @param {boolean} [reuseConnection] specifies if the Redis store/connection should be reused within the process
+* @param {object} [CacheManager] CacheManager constructor to instantiate, defaults to cache-manager-ioredis
+ */
+const getRedisStore = (storeOptions, reuseConnection = true, CacheManager = defaultCacheManager) => {
+    if (storeOptions && reuseConnection) {
+        if (!redisStoreSingletonInstance) {
+            redisStoreSingletonInstance = CacheManager.create(storeOptions);
+        }
+
+        return redisStoreSingletonInstance;
+    } else {
+        return CacheManager;
+    }
+};
+
+module.exports.getRedisStore = getRedisStore;

--- a/ghost/adapter-cache-redis/package.json
+++ b/ghost/adapter-cache-redis/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing c8 --all --lines 75  --reporter text --reporter cobertura mocha './test/**/*.test.js'",
+    "test:unit": "NODE_ENV=testing c8 --all --check-coverage --lines 71  --reporter text --reporter cobertura mocha './test/**/*.test.js'",
     "test": "yarn test:unit",
     "lint:code": "eslint *.js lib/ --ext .js --cache",
     "lint": "yarn lint:code && yarn lint:test",

--- a/ghost/adapter-cache-redis/test/redis-store-factory.test.js
+++ b/ghost/adapter-cache-redis/test/redis-store-factory.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert/strict');
+const redisStoreFactory = require('../lib/redis-store-factory');
+
+class CacheManagerMock {
+    static create() {
+        return 'StoreInstance' + new Date().getTime();
+    }
+}
+
+describe('Redis Store Factory', function () {
+    it('returns a cache manager constructor when no extra parameters are provided', function () {
+        const store = redisStoreFactory.getRedisStore();
+
+        assert.ok(store);
+        assert.ok(store.create);
+    });
+
+    it('reuses redis store instance', function () {
+        const store = redisStoreFactory.getRedisStore({}, true, CacheManagerMock);
+        const storeReused = redisStoreFactory.getRedisStore({}, true, CacheManagerMock);
+
+        assert.equal(store.create, undefined);
+
+        assert.equal(store.startsWith('StoreInstance'), true, 'Should be a value of the create method without a random postfix');
+        assert.equal(store, storeReused, 'Should be the same store instance');
+
+        const uniqueStore = redisStoreFactory.getRedisStore({}, false, CacheManagerMock);
+        assert.notEqual(uniqueStore, store, 'Should be a different store instances');
+    });
+});


### PR DESCRIPTION
closes https://github.com/TryGhost/Arch/issues/85

- Added a cache configuration option to signal "reuse of redis connection" for Redis cache adapter. The connection reuse it turned on by default to be shared between caches. They rely on unique "keyPrefix" structure, so there is no collision side-effects when reusing same Redis Store.
- The Redis connection options like "ttl" are shared with the first connection that's crated. So if there's a need to have unique configuration, a separate connection has to be created by passing `"reuseConnection": false` parameter

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d393254</samp>

The pull request adds a feature to `ghost/adapter-cache-redis` to enable reusing the same redis connection for multiple cache instances. It introduces a new module `./redis-store-factory` that handles the logic of creating or returning the redis store based on the `reuseConnection` flag.
