### PR TITLE
Optimized PostEditedEvent processing in collections

### DIFF
--- a/ghost/collections/package.json
+++ b/ghost/collections/package.json
@@ -34,7 +34,8 @@
         "@tryghost/nql-filter-expansions": "0.0.0",
         "@tryghost/post-events": "0.0.0",
         "@tryghost/tpl": "0.1.25",
-        "bson-objectid": "2.0.4"
+        "bson-objectid": "2.0.4",
+        "lodash": "4.17.21"
     },
     "c8": {
         "exclude": [


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/86

- When PostEditedEvent data contains no visible changes we can skip the matching collections update process altogether. Each call to `updatePostInMatchingCollections` creates a transaction in addition to fetching all collections. There's no need to process anything when there are no relevant changes in the post edit!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f113a92</samp>

Optimized collections service and added test for post edit events. Used `lodash` library for data comparison and added it as a dependency in `package.json`.
