### PR TITLE
Added logging to collections event handlers

### DIFF
--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -177,7 +177,7 @@ export class CollectionsService {
             try {
                 await this.removePostFromAllCollections(event.id);
             } catch (err) {
-                logging.error({err});
+                logging.error({err, message: 'Error handling PostDeletedEvent'});
             }
         });
 
@@ -186,7 +186,7 @@ export class CollectionsService {
             try {
                 await this.addPostToMatchingCollections(event.data);
             } catch (err) {
-                logging.error({err});
+                logging.error({err, message: 'Error handling PostAddedEvent'});
             }
         });
 
@@ -195,7 +195,7 @@ export class CollectionsService {
             try {
                 await this.updatePostInMatchingCollections(event.data);
             } catch (err) {
-                logging.error({err});
+                logging.error({err, message: 'Error handling PostEditedEvent'});
             }
         });
 
@@ -204,7 +204,7 @@ export class CollectionsService {
             try {
                 await this.removePostsFromAllCollections(event.data);
             } catch (err) {
-                logging.error({err});
+                logging.error({err, message: 'Error handling PostsBulkDestroyedEvent'});
             }
         });
 
@@ -213,7 +213,7 @@ export class CollectionsService {
             try {
                 await this.updateUnpublishedPosts(event.data);
             } catch (err) {
-                logging.error({err});
+                logging.error({err, message: 'Error handling PostsBulkUnpublishedEvent'});
             }
         });
 
@@ -222,7 +222,7 @@ export class CollectionsService {
             try {
                 await this.updateFeaturedPosts(event.data);
             } catch (err) {
-                logging.error({err});
+                logging.error({err, message: 'Error handling PostsBulkFeaturedEvent'});
             }
         });
 
@@ -231,7 +231,7 @@ export class CollectionsService {
             try {
                 await this.updateFeaturedPosts(event.data);
             } catch (err) {
-                logging.error({err});
+                logging.error({err, message: 'Error handling PostsBulkUnfeaturedEvent'});
             }
         });
 
@@ -240,7 +240,7 @@ export class CollectionsService {
             try {
                 await this.updateAllAutomaticCollections();
             } catch (err) {
-                logging.error({err});
+                logging.error({err, message: 'Error handling TagDeletedEvent'});
             }
         });
 
@@ -249,7 +249,7 @@ export class CollectionsService {
             try {
                 await this.updateAllAutomaticCollections();
             } catch (err) {
-                logging.error({err});
+                logging.error({err, message: 'Error handling PostsBulkAddTagsEvent'});
             }
         });
     }

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -174,47 +174,83 @@ export class CollectionsService {
     subscribeToEvents() {
         this.DomainEvents.subscribe(PostDeletedEvent, async (event: PostDeletedEvent) => {
             logging.info(`PostDeletedEvent received, removing post ${event.id} from all collections`);
-            await this.removePostFromAllCollections(event.id);
+            try {
+                await this.removePostFromAllCollections(event.id);
+            } catch (err) {
+                logging.error({err});
+            }
         });
 
         this.DomainEvents.subscribe(PostAddedEvent, async (event: PostAddedEvent) => {
             logging.info(`PostAddedEvent received, adding post ${event.data.id} to matching collections`);
-            await this.addPostToMatchingCollections(event.data);
+            try {
+                await this.addPostToMatchingCollections(event.data);
+            } catch (err) {
+                logging.error({err});
+            }
         });
 
         this.DomainEvents.subscribe(PostEditedEvent, async (event: PostEditedEvent) => {
             logging.info(`PostEditedEvent received, updating post ${event.data.id} in matching collections`);
-            await this.updatePostInMatchingCollections(event.data);
+            try {
+                await this.updatePostInMatchingCollections(event.data);
+            } catch (err) {
+                logging.error({err});
+            }
         });
 
         this.DomainEvents.subscribe(PostsBulkDestroyedEvent, async (event: PostsBulkDestroyedEvent) => {
             logging.info(`BulkDestroyEvent received, removing posts ${event.data} from all collections`);
-            await this.removePostsFromAllCollections(event.data);
+            try {
+                await this.removePostsFromAllCollections(event.data);
+            } catch (err) {
+                logging.error({err});
+            }
         });
 
         this.DomainEvents.subscribe(PostsBulkUnpublishedEvent, async (event: PostsBulkUnpublishedEvent) => {
             logging.info(`PostsBulkUnpublishedEvent received, updating collection posts ${event.data}`);
-            await this.updateUnpublishedPosts(event.data);
+            try {
+                await this.updateUnpublishedPosts(event.data);
+            } catch (err) {
+                logging.error({err});
+            }
         });
 
         this.DomainEvents.subscribe(PostsBulkFeaturedEvent, async (event: PostsBulkFeaturedEvent) => {
             logging.info(`PostsBulkFeaturedEvent received, updating collection posts ${event.data}`);
-            await this.updateFeaturedPosts(event.data);
+            try {
+                await this.updateFeaturedPosts(event.data);
+            } catch (err) {
+                logging.error({err});
+            }
         });
 
         this.DomainEvents.subscribe(PostsBulkUnfeaturedEvent, async (event: PostsBulkUnfeaturedEvent) => {
             logging.info(`PostsBulkUnfeaturedEvent received, updating collection posts ${event.data}`);
-            await this.updateFeaturedPosts(event.data);
+            try {
+                await this.updateFeaturedPosts(event.data);
+            } catch (err) {
+                logging.error({err});
+            }
         });
 
         this.DomainEvents.subscribe(TagDeletedEvent, async (event: TagDeletedEvent) => {
             logging.info(`TagDeletedEvent received for ${event.data.id}, updating all collections`);
-            await this.updateAllAutomaticCollections();
+            try {
+                await this.updateAllAutomaticCollections();
+            } catch (err) {
+                logging.error({err});
+            }
         });
 
         this.DomainEvents.subscribe(PostsBulkAddTagsEvent, async (event: PostsBulkAddTagsEvent) => {
             logging.info(`PostsBulkAddTagsEvent received for ${event.data}, updating all collections`);
-            await this.updateAllAutomaticCollections();
+            try {
+                await this.updateAllAutomaticCollections();
+            } catch (err) {
+                logging.error({err});
+            }
         });
     }
 

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -176,6 +176,7 @@ export class CollectionsService {
             logging.info(`PostDeletedEvent received, removing post ${event.id} from all collections`);
             try {
                 await this.removePostFromAllCollections(event.id);
+                /* c8 ignore next 3 */
             } catch (err) {
                 logging.error({err, message: 'Error handling PostDeletedEvent'});
             }
@@ -185,6 +186,7 @@ export class CollectionsService {
             logging.info(`PostAddedEvent received, adding post ${event.data.id} to matching collections`);
             try {
                 await this.addPostToMatchingCollections(event.data);
+                /* c8 ignore next 3 */
             } catch (err) {
                 logging.error({err, message: 'Error handling PostAddedEvent'});
             }
@@ -194,6 +196,7 @@ export class CollectionsService {
             logging.info(`PostEditedEvent received, updating post ${event.data.id} in matching collections`);
             try {
                 await this.updatePostInMatchingCollections(event.data);
+                /* c8 ignore next 3 */
             } catch (err) {
                 logging.error({err, message: 'Error handling PostEditedEvent'});
             }
@@ -203,6 +206,7 @@ export class CollectionsService {
             logging.info(`BulkDestroyEvent received, removing posts ${event.data} from all collections`);
             try {
                 await this.removePostsFromAllCollections(event.data);
+                /* c8 ignore next 3 */
             } catch (err) {
                 logging.error({err, message: 'Error handling PostsBulkDestroyedEvent'});
             }
@@ -212,6 +216,7 @@ export class CollectionsService {
             logging.info(`PostsBulkUnpublishedEvent received, updating collection posts ${event.data}`);
             try {
                 await this.updateUnpublishedPosts(event.data);
+                /* c8 ignore next 3 */
             } catch (err) {
                 logging.error({err, message: 'Error handling PostsBulkUnpublishedEvent'});
             }
@@ -221,6 +226,7 @@ export class CollectionsService {
             logging.info(`PostsBulkFeaturedEvent received, updating collection posts ${event.data}`);
             try {
                 await this.updateFeaturedPosts(event.data);
+                /* c8 ignore next 3 */
             } catch (err) {
                 logging.error({err, message: 'Error handling PostsBulkFeaturedEvent'});
             }
@@ -230,6 +236,7 @@ export class CollectionsService {
             logging.info(`PostsBulkUnfeaturedEvent received, updating collection posts ${event.data}`);
             try {
                 await this.updateFeaturedPosts(event.data);
+                /* c8 ignore next 3 */
             } catch (err) {
                 logging.error({err, message: 'Error handling PostsBulkUnfeaturedEvent'});
             }
@@ -239,6 +246,7 @@ export class CollectionsService {
             logging.info(`TagDeletedEvent received for ${event.data.id}, updating all collections`);
             try {
                 await this.updateAllAutomaticCollections();
+                /* c8 ignore next 3 */
             } catch (err) {
                 logging.error({err, message: 'Error handling TagDeletedEvent'});
             }
@@ -248,6 +256,7 @@ export class CollectionsService {
             logging.info(`PostsBulkAddTagsEvent received for ${event.data}, updating all collections`);
             try {
                 await this.updateAllAutomaticCollections();
+                /* c8 ignore next 3 */
             } catch (err) {
                 logging.error({err, message: 'Error handling PostsBulkAddTagsEvent'});
             }


### PR DESCRIPTION
This will help us with debugging issues we're seeing with large sites

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fbd7308</samp>

This change adds error handling to the `CollectionsService` class, which manages the collections of posts in Ghost. It prevents unhandled promise rejections and logs the errors when domain events affect the collections. It is part of a pull request that fixes several collections-related issues.
