### PR TITLE
Allowed disabling collections w/ just labs flag

### DIFF
--- a/ghost/core/core/server/services/collections/service.js
+++ b/ghost/core/core/server/services/collections/service.js
@@ -3,6 +3,14 @@ const {
 } = require('@tryghost/collections');
 const BookshelfCollectionsRepository = require('./BookshelfCollectionsRepository');
 
+function getEnabled(config, labs) {
+    if (config.get('hostSettings:collections:enabled') === false) {
+        return false;
+    }
+
+    return labs.isSet('collections');
+}
+
 let inited = false;
 class CollectionsServiceWrapper {
     /** @type {CollectionsService} */
@@ -33,8 +41,10 @@ class CollectionsServiceWrapper {
     async init() {
         const config = require('../../../shared/config');
         const labs = require('../../../shared/labs');
-        // host setting OR labs "collections" flag has to be enabled to run collections service
-        if (!config.get('hostSettings:collections:enabled') && !(labs.isSet('collections'))) {
+
+        const enabled = getEnabled(config, labs);
+        // If labs isn't set then we don't run collections
+        if (!enabled) {
             return;
         }
 


### PR DESCRIPTION
The previous conditional meant that if the "host settings" collections enabled flag was set, we couldn't disable collections. This makes it so that host settings is used as a killswitch, so it can disable collections if it is explicitly set to false, otherwise we fall back to labs

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa0c3c8</samp>

Added a new function to check collections feature flag and used it in the service wrapper. This makes the code more readable and maintainable.
