### PR TITLE
🐛 Fixed broken "< Posts" and "Back to editor" links in beta editor (infinite save loop)

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -969,7 +969,7 @@ export default class LexicalEditorController extends Controller {
         // Check if anything has changed since the last revision
         let postRevisions = post.get('postRevisions').toArray();
         let latestRevision = postRevisions[postRevisions.length - 1];
-        let hasChangedSinceLastRevision = !post.isNew && post.lexical !== latestRevision.lexical;
+        let hasChangedSinceLastRevision = !post.isNew && post.lexical.replaceAll(this.config.blogUrl, '') !== latestRevision.lexical.replaceAll(this.config.blogUrl, '');
 
         let fromNewToEdit = this.router.currentRouteName === 'lexical-editor.new'
             && transition.targetName === 'lexical-editor.edit'


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3843

If you used relative URLs in the beta editor, when it came to leaving the editor you would get stuck due to an infinite save loop occurring in the background requiring a refresh to get back to a working state.

- when saving relative URLs the server will convert them to absolute for consistency and to ensure URLs work in other situations such as emails, RSS, 3rd party editors, etc
- although we get different data back from the server we don't overwrite the content in the editor with it as that would cause loss of changes since the save as well as loss of the cursor position
- when leaving the editor we compare content from the last save revision with the current editor content to see if we need to save a new revision but if the server data has been modified with relative->absolute URLs then we'd enter an infinite loop because the content would never match
- relative->absolute URLs should be the only thing to ever be modified in the underlying data when saving so we can work around the issue by replacing each instance of the site's URL before comparing revision data to current data
