### PR TITLE
Allowed optionally enabling collections through a flag

### DIFF
--- a/ghost/core/core/server/services/collections/service.js
+++ b/ghost/core/core/server/services/collections/service.js
@@ -33,16 +33,16 @@ class CollectionsServiceWrapper {
     async init() {
         const config = require('../../../shared/config');
         const labs = require('../../../shared/labs');
-        // host setting OR labs "collections" flag has to be enabled to run collections service
-        if (!config.get('hostSettings:collections:enabled') && !(labs.isSet('collections'))) {
-            return;
-        }
 
-        if (inited) {
-            return;
+        // host setting OR labs "collections" flag has to be enabled to run collections service
+        if (config.get('hostSettings:collections:enabled') || labs.isSet('collections')) {
+            if (inited) {
+                return;
+            }
+
+            inited = true;
+            this.api.subscribeToEvents();
         }
-        inited = true;
-        this.api.subscribeToEvents();
     }
 }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/18028

- The previous conditional meant that if the "host settings" collections enabled flag was set, we couldn't disable collections. The referenced pull request would also disable the collections across all of the hosted environment instances. The updated logic optionally takes into account the "labs" flag, as it should have from the very beginning.

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21a8228</samp>

Refactor the collections service initialization logic in `service.js` to use a positive if condition instead of an early return. This improves readability and aligns with other services.
