### PR TITLE
Updated `data-members-newsletter` to use the name of the newsletter

### DIFF
--- a/apps/portal/src/data-attributes.js
+++ b/apps/portal/src/data-attributes.js
@@ -25,7 +25,7 @@ export function formSubmitHandler({event, form, errorEl, siteUrl, submitHandler}
 
     let newsletterInputs = event.target.querySelectorAll('input[type=hidden][data-members-newsletter], input[type=checkbox][data-members-newsletter]:checked, input[type=radio][data-members-newsletter]:checked') || [];
     for (let i = 0; i < newsletterInputs.length; ++i) {
-        newsletters.push({id: newsletterInputs[i].value});
+        newsletters.push({name: newsletterInputs[i].value});
     }
 
     if (form.dataset.membersForm) {

--- a/apps/portal/src/tests/data-attributes.test.js
+++ b/apps/portal/src/tests/data-attributes.test.js
@@ -244,7 +244,7 @@ describe('Member Data attributes:', () => {
         test('includes specified newsletters in request', () => {
             const {event, form, errorEl, siteUrl, submitHandler} = getMockData({
                 newsletterQuerySelectorResult: [{
-                    value: 'some_newsletter'
+                    value: 'Some Newsletter'
                 }]
             });
 
@@ -264,7 +264,7 @@ describe('Member Data attributes:', () => {
                     refUrl: 'https://example.com/blog/',
                     time: 1611234567890
                 }],
-                newsletters: [{id: 'some_newsletter'}]
+                newsletters: [{name: 'Some Newsletter'}]
             });
             expect(window.fetch).toHaveBeenCalledWith('https://portal.localhost/members/api/send-magic-link/', {body: expectedBody, headers: {'Content-Type': 'application/json'}, method: 'POST'});
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3860

`data-members-newsletter` implementation was updated to use the `name` of the newsletter instead of it's `id`