### PR TITLE
Fixed Koenig action bar icon color in dark mode

### DIFF
--- a/ghost/admin/app/styles/components/koenig-dark.css
+++ b/ghost/admin/app/styles/components/koenig-dark.css
@@ -27,12 +27,17 @@
 }
 
 .kg-action-bar-divider {
-    background: var(--lightgrey);
+    background: color-mod(var(--lightgrey) l(+5%));;
 }
 
 .kg-action-bar .fill-white g,
 .kg-action-bar .fill-white path {
     fill: var(--darkgrey);
+}
+
+.kg-action-bar .fill-white-no-conflict g,
+.kg-action-bar .fill-white-no-conflict path {
+    fill: #fff;
 }
 
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/3846

- when the lexical editor is turned off, some action bar icons appear as black in dark mode
- this fixes the icon and divider color for the mobiledoc editor
