### PR TITLE
Handled CollectionPost relations manually

### DIFF
--- a/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
+++ b/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
@@ -115,7 +115,7 @@ module.exports = class BookshelfCollectionsRepository {
 
         if (collection.deleted) {
             await this.#relationModel.query().delete().where('collection_id', collection.id).transacting(options.transaction);
-            await this.#model.destroy({id: collection.id, transaction: options.transaction});
+            await this.#model.query().delete().where('id', collection.id).transacting(options.transaction);
             return;
         }
 

--- a/ghost/core/core/server/services/collections/service.js
+++ b/ghost/core/core/server/services/collections/service.js
@@ -12,7 +12,7 @@ class CollectionsServiceWrapper {
         const DomainEvents = require('@tryghost/domain-events');
         const postsRepository = require('./PostsRepository').getInstance();
         const models = require('../../models');
-        const collectionsRepositoryInMemory = new BookshelfCollectionsRepository(models.Collection);
+        const collectionsRepositoryInMemory = new BookshelfCollectionsRepository(models.Collection, models.CollectionPost);
 
         const collectionsService = new CollectionsService({
             collectionsRepository: collectionsRepositoryInMemory,

--- a/ghost/core/test/e2e-api/admin/posts-bulk.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-bulk.test.js
@@ -30,8 +30,8 @@ describe('Posts Bulk API', function () {
 
             assert(amount > 0, 'Expect at least one post to be affected for this test to work');
 
-            let featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['posts']});
-            let featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().posts.length;
+            let featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['collectionPosts']});
+            let featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().collectionPosts.length;
             assert(featuredCollectionPostsAmount > 0, 'Expect to have multiple featured collection posts');
 
             const response = await agent
@@ -52,8 +52,8 @@ describe('Posts Bulk API', function () {
             const posts = await models.Post.findAll({filter, status: 'all'});
             assert.equal(posts.length, amount, `Expect all matching posts (${amount}) to be changed`);
 
-            featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['posts']});
-            featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().posts.length;
+            featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['collectionPosts']});
+            featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().collectionPosts.length;
             assert.equal(featuredCollectionPostsAmount, amount, 'Expect to have same amount featured collection posts as changed');
 
             for (const post of posts) {
@@ -70,8 +70,8 @@ describe('Posts Bulk API', function () {
 
             assert(amount > 0, 'Expect at least one post to be affected for this test to work');
 
-            let featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['posts']});
-            let featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().posts.length;
+            featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['collectionPosts']});
+            featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().collectionPosts.length;
             assert(featuredCollectionPostsAmount > 0, 'Expect to have multiple featured collection posts');
 
             const response = await agent
@@ -92,8 +92,8 @@ describe('Posts Bulk API', function () {
             const posts = await models.Post.findAll({filter, status: 'all'});
             assert.equal(posts.length, amount, `Expect all matching posts (${amount}) to be changed`);
 
-            featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['posts']});
-            featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().posts.length;
+            featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['collectionPosts']});
+            featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().collectionPosts.length;
             assert.equal(featuredCollectionPostsAmount, 0, 'Expect to have no featured collection posts');
 
             for (const post of posts) {
@@ -354,8 +354,8 @@ describe('Posts Bulk API', function () {
             const posts = await models.Post.findPage({filter, status: 'all'});
             assert.equal(posts.meta.pagination.total, 0, `Expect all matching posts (${amount}) to be deleted`);
 
-            let latestCollection = await models.Collection.findPage({filter: 'slug:latest', limit: 1, withRelated: ['posts']});
-            latestCollection = latestCollection.data[0].toJSON().posts.length;
+            let latestCollection = await models.Collection.findPage({filter: 'slug:latest', limit: 1, withRelated: ['collectionPosts']});
+            latestCollection = latestCollection.data[0].toJSON().collectionPosts.length;
             assert.equal(latestCollection, 0, 'Expect to have no collection posts');
         });
     });

--- a/ghost/core/test/e2e-api/admin/posts-bulk.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-bulk.test.js
@@ -70,8 +70,8 @@ describe('Posts Bulk API', function () {
 
             assert(amount > 0, 'Expect at least one post to be affected for this test to work');
 
-            featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['collectionPosts']});
-            featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().collectionPosts.length;
+            let featuredCollection = await models.Collection.findPage({filter: 'slug:featured', limit: 1, withRelated: ['collectionPosts']});
+            let featuredCollectionPostsAmount = featuredCollection.data[0].toJSON().collectionPosts.length;
             assert(featuredCollectionPostsAmount > 0, 'Expect to have multiple featured collection posts');
 
             const response = await agent


### PR DESCRIPTION
bookshelf-relations was generating tonnes of select queries from the posts table in order to update the relations. I spent all of yesterday trying to get it working with a hasMany relationship, but couldn't manage it, so we've instead switched to handling the relations manually. Aside from the naming of temporary variables, I quite like this approach, it isn't overly complex, and it allows for customisations in the future such as an inverted sort_order.

This logic could be pulled out into a util (not bookshelf plugin) where it could be used explicitly, but with the complexity hidden, we'll see ig.


---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 239f2b7</samp>

This pull request refactors the collections service and the collection model to use a separate relation model for collection-post associations. It also updates the tests and the service wrapper to match the new implementation. This is done to improve the performance and reliability of the collections feature.
