### PR TITLE
Updated @tryghost/errors 1.2.21 to 1.2.24

### DIFF
--- a/apps/comments-ui/playwright.config.ts
+++ b/apps/comments-ui/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     workers: process.env.CI ? '100%' : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: 'html',
-    timeout: process.env.PLAYWRIGHT_SLOWMO ? 100000 : 10000,
+    timeout: process.env.PLAYWRIGHT_SLOWMO ? 100000 : 20000,
     expect: {
         timeout: process.env.PLAYWRIGHT_SLOWMO ? 100000 : 5000
     },

--- a/ghost/adapter-manager/package.json
+++ b/ghost/adapter-manager/package.json
@@ -24,6 +24,6 @@
     "sinon": "15.2.0"
   },
   "dependencies": {
-    "@tryghost/errors": "1.2.21"
+    "@tryghost/errors": "1.2.24"
   }
 }

--- a/ghost/session-service/package.json
+++ b/ghost/session-service/package.json
@@ -25,6 +25,6 @@
     "sinon": "15.2.0"
   },
   "dependencies": {
-    "@tryghost/errors": "1.2.21"
+    "@tryghost/errors": "1.2.24"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7730,7 +7730,7 @@
     focus-trap "^6.7.2"
     postcss-preset-env "^7.3.1"
 
-"@tryghost/errors@1.2.21", "@tryghost/errors@1.2.24", "@tryghost/errors@1.2.25", "@tryghost/errors@^1.0.0", "@tryghost/errors@^1.2.1", "@tryghost/errors@^1.2.24", "@tryghost/errors@^1.2.26", "@tryghost/errors@^1.2.3":
+"@tryghost/errors@1.2.24", "@tryghost/errors@1.2.25", "@tryghost/errors@^1.0.0", "@tryghost/errors@^1.2.1", "@tryghost/errors@^1.2.24", "@tryghost/errors@^1.2.26", "@tryghost/errors@^1.2.3":
   version "1.2.24"
   resolved "https://registry.yarnpkg.com/@tryghost/errors/-/errors-1.2.24.tgz#5daceff6cdee9421297849474fd885857c4bfe3f"
   integrity sha512-5iRF8dl2wirb/1gQA2dv8MtxK204vnjbWvmb3fULNZoVlmuHY1ZUgwRJRquClfUEFyl2qGmNDuoxGoTvur8JKA==


### PR DESCRIPTION
- we have this set as a higher resolution anyway, but I think having
  some hardcoded lower versions causes some weird yarn issues
- at the very least, this removes any mention of 1.2.21 from our
  yarn.lock
---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f748c0</samp>

This pull request increases the timeout for the playwright tests in `apps/comments-ui` and updates the `@tryghost/errors` dependency in `ghost/adapter-manager` and `ghost/session-service` packages. These changes aim to improve the reliability and consistency of the tests and the error handling.
