### PR TITLE
Added Casper-2023 under the placeholder name 'masthead'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = ghost/core/content/themes/casper
 	url = ../../TryGhost/Casper.git
 	ignore = all
+[submodule "ghost/core/content/themes/casper_6-0"]
+	path = ghost/core/content/themes/casper_6-0
+	url = ../../TryGhost/Casper-2023.git

--- a/ghost/core/.npmignore
+++ b/ghost/core/.npmignore
@@ -31,6 +31,7 @@ content/settings/**
 !content/settings/README.md
 content/themes/**
 !content/themes/casper/**
+!content/themes/casper_[0-9]-[0-9]/**
 content/themes/casper/yarn.lock
 node_modules/**
 core/server/lib/members/static/auth/node_modules/**


### PR DESCRIPTION
refs TryGhost/Product#3510

- Added Casper-2023 as a git submodule with the placeholder name 'masthead'
- Updated hard coded references and protections to `casper` to include `masthead`
