### PR TITLE
Wired Pintura Editor to Admin X

### DIFF
--- a/apps/admin-x-settings/src/admin-x-ds/global/form/ImageUpload.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/form/ImageUpload.tsx
@@ -27,6 +27,14 @@ interface ImageUploadProps {
     onUpload: (file: File) => void;
     onDelete: () => void;
     onImageClick?: MouseEventHandler<HTMLImageElement>;
+
+    /**
+     * Pintura config
+     */
+    pintura?: {
+        isEnabled: boolean;
+        openEditor: () => void;
+    }
 }
 
 const ImageUpload: React.FC<ImageUploadProps> = ({
@@ -46,7 +54,8 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
     unstyled = false,
     onUpload,
     onDelete,
-    onImageClick
+    onImageClick,
+    pintura
 }) => {
     if (!unstyled) {
         imageContainerClassName = clsx(
@@ -89,6 +98,12 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
                     width: (unstyled ? '' : width || '100%'),
                     height: (unstyled ? '' : height || 'auto')
                 }} onClick={onImageClick} />
+                {
+                    pintura?.isEnabled && pintura?.openEditor &&
+                    <button className='absolute bottom-4 right-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded bg-[rgba(0,0,0,0.75)] text-white hover:bg-black' type='button' onClick={pintura.openEditor}>
+                        <Icon colorClass='text-white' name='pencil' size='sm' />
+                    </button>
+                }
                 <button className={deleteButtonClassName} type='button' onClick={onDelete}>
                     {deleteButtonContent}
                 </button>

--- a/apps/admin-x-settings/src/admin-x-ds/global/form/ImageUpload.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/form/ImageUpload.tsx
@@ -19,6 +19,9 @@ interface ImageUploadProps {
     deleteButtonClassName?: string;
     deleteButtonContent?: React.ReactNode;
     deleteButtonUnstyled?: boolean;
+    editButtonClassName?: string;
+    editButtonContent?: React.ReactNode;
+    editButtonUnstyled?: boolean;
 
     /**
      * Removes all the classnames from all elements so you can set a completely custom styling
@@ -55,7 +58,10 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
     onUpload,
     onDelete,
     onImageClick,
-    pintura
+    pintura,
+    editButtonClassName,
+    editButtonContent,
+    editButtonUnstyled = false
 }) => {
     if (!unstyled) {
         imageContainerClassName = clsx(
@@ -84,9 +90,17 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
                 deleteButtonClassName
             );
         }
+
+        if (!editButtonUnstyled) {
+            editButtonClassName = clsx(
+                'absolute right-16 top-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded bg-[rgba(0,0,0,0.75)] text-white hover:bg-black group-hover:!visible md:invisible',
+                editButtonClassName
+            );
+        }
     }
 
     deleteButtonContent = deleteButtonContent || <Icon colorClass='text-white' name='trash' size='sm' />;
+    editButtonContent = editButtonContent || <Icon colorClass='text-white' name='pen' size='sm' />;
 
     if (imageURL) {
         let image = (
@@ -100,8 +114,8 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
                 }} onClick={onImageClick} />
                 {
                     pintura?.isEnabled && pintura?.openEditor &&
-                    <button className='absolute bottom-4 right-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded bg-[rgba(0,0,0,0.75)] text-white hover:bg-black' type='button' onClick={pintura.openEditor}>
-                        <Icon colorClass='text-white' name='pencil' size='sm' />
+                    <button className={editButtonClassName} type='button' onClick={pintura.openEditor}>
+                        {editButtonContent}
                     </button>
                 }
                 <button className={deleteButtonClassName} type='button' onClick={onDelete}>

--- a/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
@@ -656,6 +656,10 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
 
     const fileUploadButtonClasses = 'absolute left-12 md:left-auto md:right-[104px] bottom-12 bg-[rgba(0,0,0,0.75)] rounded text-sm text-white flex items-center justify-center px-3 h-8 opacity-80 hover:opacity-100 transition cursor-pointer font-medium z-10';
 
+    const deleteButtonClasses = 'absolute left-12 md:left-auto md:right-[152px] bottom-12 bg-[rgba(0,0,0,0.75)] rounded text-sm text-white flex items-center justify-center px-3 h-8 opacity-80 hover:opacity-100 transition cursor-pointer font-medium z-10';
+
+    const editButtonClasses = 'absolute left-12 md:left-auto md:right-[102px] bottom-12 bg-[rgba(0,0,0,0.75)] rounded text-sm text-white flex items-center justify-center px-3 h-8 opacity-80 hover:opacity-100 transition cursor-pointer font-medium z-10';
+
     const suspendedText = userData.status === 'inactive' ? ' (Suspended)' : '';
 
     const validators = {
@@ -714,14 +718,27 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             <div>
                 <div className={`relative -mx-12 -mt-12 rounded-t bg-gradient-to-tr from-grey-900 to-black`}>
                     <ImageUpload
-                        deleteButtonClassName={fileUploadButtonClasses}
+                        deleteButtonClassName={deleteButtonClasses}
                         deleteButtonContent='Delete cover image'
+                        editButtonClassName={editButtonClasses}
                         fileUploadClassName={fileUploadButtonClasses}
                         height={userData.cover_image ? '100%' : '32px'}
                         id='cover-image'
                         imageClassName='w-full h-full object-cover'
                         imageContainerClassName='absolute inset-0 bg-cover group bg-center rounded-t overflow-hidden'
                         imageURL={userData.cover_image || ''}
+                        pintura={
+                            {
+                                isEnabled: pintura || false,
+                                openEditor: async () => editor.openEditor({
+                                    image: userData.cover_image || '',
+                                    // handleSave: async (file:File) => {
+                                    handleSave: async () => {
+                                        // updateSetting('cover_image', getImageUrl(await uploadImage({file})));
+                                    }
+                                })
+                            }
+                        }
                         unstyled={true}
                         onDelete={() => {
                             handleImageDelete('cover_image');

--- a/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
@@ -468,13 +468,14 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
     const [pintura] = getSettingValues<boolean>(settings, ['pintura']);
     const [pinturaJsUrl] = getSettingValues<string>(settings, ['pintura_js_url']);
     const [pinturaCssUrl] = getSettingValues<string>(settings, ['pintura_css_url']);
+    const pinturaEnabled = Boolean(pintura) && Boolean(pinturaJsUrl) && Boolean(pinturaCssUrl);
 
     const editor = usePinturaEditor(
         {config: {
             jsUrl: pinturaJsUrl || '',
             cssUrl: pinturaCssUrl || ''
         },
-        disabled: !pintura}
+        disabled: !pinturaEnabled}
     );
 
     useEffect(() => {
@@ -729,12 +730,11 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                         imageURL={userData.cover_image || ''}
                         pintura={
                             {
-                                isEnabled: pintura || false,
+                                isEnabled: pinturaEnabled,
                                 openEditor: async () => editor.openEditor({
                                     image: userData.cover_image || '',
-                                    // handleSave: async (file:File) => {
-                                    handleSave: async () => {
-                                        // updateSetting('cover_image', getImageUrl(await uploadImage({file})));
+                                    handleSave: async (file:File) => {
+                                        handleImageUpload('cover_image', file);
                                     }
                                 })
                             }
@@ -762,12 +762,11 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                             imageURL={userData.profile_image}
                             pintura={
                                 {
-                                    isEnabled: pintura || false,
+                                    isEnabled: pinturaEnabled,
                                     openEditor: async () => editor.openEditor({
                                         image: userData.profile_image || '',
-                                        // handleSave: async (file:File) => {
-                                        handleSave: async () => {
-                                            // updateSetting('cover_image', getImageUrl(await uploadImage({file})));
+                                        handleSave: async (file:File) => {
+                                            handleImageUpload('profile_image', file);
                                         }
                                     })
                                 }

--- a/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
@@ -35,13 +35,17 @@ const BrandSettings: React.FC<{ values: BrandSettingValues, updateSetting: (key:
     );
     const updateSettingDebounced = debounce(updateSetting, 500);
 
+    const pinturaEnabled = Boolean(pintura) && Boolean(pinturaJsUrl) && Boolean(pinturaCssUrl);
+
     const editor = usePinturaEditor(
         {config: {
             jsUrl: pinturaJsUrl || '',
             cssUrl: pinturaCssUrl || ''
         },
-        disabled: !pintura}
+        disabled: !pinturaEnabled}
     );
+
+    // check if pintura !false and pintura_js_url and pintura_css_url are not '' or null or undefined
 
     return (
         <div className='mt-7'>
@@ -116,7 +120,7 @@ const BrandSettings: React.FC<{ values: BrandSettingValues, updateSetting: (key:
                         imageURL={values.coverImage || ''}
                         pintura={
                             {
-                                isEnabled: pintura || false,
+                                isEnabled: pinturaEnabled,
                                 openEditor: async () => editor.openEditor({
                                     image: values.coverImage || '',
                                     handleSave: async (file:File) => {

--- a/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
@@ -110,6 +110,7 @@ const BrandSettings: React.FC<{ values: BrandSettingValues, updateSetting: (key:
                     <Heading className='mb-2' grey={(values.coverImage ? true : false)} level={6}>Publication cover</Heading>
                     <ImageUpload
                         deleteButtonClassName='!top-1 !right-1'
+                        editButtonClassName='!top-1 !right-10'
                         height='180px'
                         id='cover'
                         imageURL={values.coverImage || ''}

--- a/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
@@ -74,6 +74,7 @@ const BrandSettings: React.FC<{ values: BrandSettingValues, updateSetting: (key:
                     <div className='flex gap-3'>
                         <ImageUpload
                             deleteButtonClassName='!top-1 !right-1'
+                            editButtonClassName='!top-1 !right-1'
                             height={values.icon ? '66px' : '36px'}
                             id='logo'
                             imageBWCheckedBg={true}


### PR DESCRIPTION
no issue

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a11562</samp>

This pull request adds the Pintura image editor as an optional feature for the logo and cover image settings in the admin-x-settings app. It introduces a new `usePinturaEditor` hook that handles the loading and management of the Pintura editor instance, and a custom edit button for the `ImageUpload` component that can open the editor. It also modifies the `BrandSettings` component to use the hook and the button.
