### PR TITLE
Added core content API integration fixture

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-03-10-add-ghost-core-content-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-03-10-add-ghost-core-content-integration.js
@@ -1,0 +1,57 @@
+// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
+
+const logging = require('@tryghost/logging');
+const {default: ObjectID} = require('bson-objectid');
+const {createTransactionalMigration, meta} = require('../../utils');
+
+const coreContentIntegration = {
+    slug: 'ghost-core-content',
+    name: 'Ghost Core Content API',
+    description: 'Internal Content API integration for Admin access',
+    type: 'core'
+};
+
+const addIntegration = async (knex, integration) => {
+    const message = `Adding "${integration.name}" integration`;
+
+    const existing = await knex('integrations').select('id').where('slug', integration.slug).first();
+
+    if (existing?.id) {
+        logging.warn(`Skipping ${message} - already exists`);
+        return;
+    }
+
+    logging.info(message);
+
+    const now = knex.raw('CURRENT_TIMESTAMP');
+    integration.id = (new ObjectID()).toHexString();
+    integration.created_at = now;
+    integration.created_by = meta.MIGRATION_USER;
+
+    await knex('integrations').insert(integration);
+};
+
+const removeIntegration = async (knex, integration) => {
+    const message = `Removing ${integration.name} integration`;
+
+    const existing = await knex('integrations').select('id').where('slug', integration.slug).first();
+
+    if (!existing?.id) {
+        logging.warn(`Skipping ${message} - doesn't exist`);
+        return;
+    }
+
+    logging.info(message);
+
+    await knex('api_keys').where('integration_id', existing.id).del();
+    await knex('integrations').where('id', existing.id).del();
+};
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        await addIntegration(knex, coreContentIntegration);
+    },
+    async function down(knex) {
+        await removeIntegration(knex, coreContentIntegration);
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-34-11-add-ghost-core-content-integration-key.js
+++ b/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-34-11-add-ghost-core-content-integration-key.js
@@ -22,7 +22,7 @@ const addIntegrationContentKey = async (knex, integration) => {
 
     if (!existingIntegration) {
         throw new InternalServerError({
-            message: `Count not find "${integration.name}" integration`
+            message: `Could not find "${integration.name}" integration`
         });
     }
 

--- a/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-34-11-add-ghost-core-content-integration-key.js
+++ b/ghost/core/core/server/data/migrations/versions/5.63/2023-09-13-13-34-11-add-ghost-core-content-integration-key.js
@@ -1,0 +1,87 @@
+// For information on writing migrations, see https://www.notion.so/ghost/Database-migrations-eb5b78c435d741d2b34a582d57c24253
+
+const {InternalServerError} = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
+const security = require('@tryghost/security');
+const {default: ObjectID} = require('bson-objectid');
+const {createTransactionalMigration, meta} = require('../../utils');
+
+const coreContentIntegration = {
+    slug: 'ghost-core-content',
+    name: 'Ghost Core Content API',
+    description: 'Internal Content API integration for Admin access',
+    type: 'core'
+};
+
+const addIntegrationContentKey = async (knex, integration) => {
+    const message = `Adding "${integration.name}" integration content key`;
+
+    const existingIntegration = await knex('integrations').select('id').where({
+        slug: integration.slug
+    }).first();
+
+    if (!existingIntegration) {
+        throw new InternalServerError({
+            message: `Count not find "${integration.name}" integration`
+        });
+    }
+
+    const existing = await knex('api_keys').select('id')
+        .where('integration_id', existingIntegration.id)
+        .where('type', 'content')
+        .first();
+
+    if (existing?.id) {
+        logging.warn(`Skipping ${message} - already exists`);
+        return;
+    }
+
+    logging.info(message);
+
+    await knex('api_keys').insert({
+        id: (new ObjectID()).toHexString(),
+        type: 'content',
+        secret: security.secret.create('content'),
+        role_id: null,
+        integration_id: existingIntegration.id,
+        created_at: knex.raw('current_timestamp'),
+        created_by: meta.MIGRATION_USER
+    });
+};
+
+const removeIntegrationContentKey = async (knex, integration) => {
+    const message = `Removing "${integration.name}" integration content key`;
+
+    const existingIntegration = await knex('integrations').select('id').where({
+        slug: integration.slug
+    }).first();
+
+    if (!existingIntegration?.id) {
+        logging.warn(`Skipping ${message} - integration does not exist`);
+        return;
+    }
+
+    const existing = await knex('api_keys').select('id').where({
+        integration_id: existingIntegration.id,
+        type: 'content'
+    }).first();
+
+    if (!existing?.id) {
+        logging.warn(`Skipping ${message} - content key does not exist`);
+        return;
+    }
+
+    logging.info(message);
+
+    await knex('api_keys').where('id', existing.id).del();
+};
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        await addIntegrationContentKey(knex, coreContentIntegration);
+    },
+
+    async function down(knex) {
+        await removeIntegrationContentKey(knex, coreContentIntegration);
+    }
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -807,6 +807,13 @@
                     "description": "Internal frontend integration",
                     "type": "internal",
                     "api_keys": [{"type": "content"}]
+                },
+                {
+                    "slug": "ghost-core-content",
+                    "name": "Ghost Core Content API",
+                    "description": "Internal Content API integration for Admin access",
+                    "type": "core",
+                    "api_keys": [{"type": "content"}]
                 }
             ]
         }

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '38fa7cfe8d74659ec75a5963b13cb4eb';
-    const currentFixturesHash = '31865c37aacfec9b8f16c1354b36a7de';
+    const currentFixturesHash = '6e8d5e89044320656de4900dd0529e68';
     const currentSettingsHash = '3a7ca0aa6a06cba47e3e898aef7029c2';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3874

- the new collections card needs to access the Content API rather than the Admin API in order to show the card as it will appear on the front-end but we don't have a default integration that can be fetched via the Admin API for Admin to use when fetching from the Content API
- adds a new "Ghost Core Content API" integration with the `core` type so that it can be read via the `/admin/integrations/` endpoint and used in Admin to make Content API requests
