### PR TITLE
🐛 Fixed portal showing incorrect expiry date for comped subscription

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-edit-subscriptions.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-edit-subscriptions.test.js.snap
@@ -283,7 +283,7 @@ exports[`Members API: edit subscriptions Can cancel a subscription for a member 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3657",
+  "content-length": "3635",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -330,7 +330,7 @@ exports[`Members API: edit subscriptions Can cancel a subscription for a member 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2757",
+  "content-length": "2735",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members-newsletters.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members-newsletters.test.js.snap
@@ -71,7 +71,7 @@ exports[`Members API - With Newsletters - compat mode Can fetch members who are 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2251",
+  "content-length": "2229",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -331,7 +331,7 @@ exports[`Members API - With Newsletters Can fetch members who are NOT subscribed
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2251",
+  "content-length": "2229",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -2242,7 +2242,7 @@ exports[`Members API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "10122",
+  "content-length": "10100",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2614,7 +2614,7 @@ exports[`Members API Can create a new member with a product (complimentary) 2: [
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2218",
+  "content-length": "2196",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3104,7 +3104,7 @@ exports[`Members API Can filter by paid status 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8088",
+  "content-length": "8066",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3442,7 +3442,7 @@ exports[`Members API Can filter by tier id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "7454",
+  "content-length": "7432",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -4033,7 +4033,7 @@ exports[`Members API Can filter on tier slug 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "17782",
+  "content-length": "17716",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -4270,7 +4270,7 @@ exports[`Members API Can ignore any unknown includes 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8088",
+  "content-length": "8066",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/members-api/lib/services/MemberBREADService.js
+++ b/ghost/members-api/lib/services/MemberBREADService.js
@@ -99,7 +99,7 @@ module.exports = class MemberBREADService {
                     default_payment_card_last4: '****',
                     cancel_at_period_end: false,
                     cancellation_reason: null,
-                    current_period_end: moment(startDate).add(1, 'year'),
+                    current_period_end: moment(product.expiry_at),
                     price: {
                         id: '',
                         price_id: '',

--- a/ghost/members-api/test/unit/lib/services/member-bread.test.js
+++ b/ghost/members-api/test/unit/lib/services/member-bread.test.js
@@ -1,0 +1,287 @@
+const assert = require('assert/strict');
+const sinon = require('sinon');
+const MemberBreadService = require('../../../../lib/services/MemberBREADService');
+const moment = require('moment');
+
+describe('MemberBreadService', function () {
+    describe('read', function () {
+        const MEMBER_ID = 123;
+        const DEFAULT_RELATIONS = [
+            'labels',
+            'stripeSubscriptions',
+            'stripeSubscriptions.customer',
+            'stripeSubscriptions.stripePrice',
+            'stripeSubscriptions.stripePrice.stripeProduct',
+            'stripeSubscriptions.stripePrice.stripeProduct.product',
+            'products',
+            'newsletters',
+            'productEvents'
+        ];
+
+        let memberModelStub,
+            memberModelJSON,
+            memberRepositoryStub,
+            memberAttributionServiceStub,
+            emailSuppressionListStub;
+
+        const getService = () => {
+            return new MemberBreadService({
+                memberRepository: memberRepositoryStub,
+                memberAttributionService: memberAttributionServiceStub,
+                emailSuppressionList: emailSuppressionListStub
+            });
+        };
+
+        beforeEach(function () {
+            memberModelJSON = {
+                id: MEMBER_ID,
+                name: 'foo bar',
+                email: 'foo@bar.baz',
+                subscriptions: []
+            };
+            memberModelStub = {
+                id: MEMBER_ID,
+                related: sinon.stub().returns([]),
+                toJSON: sinon.stub().returns({...memberModelJSON})
+            };
+            memberRepositoryStub = {
+                get: sinon.stub().resolves(null),
+                related: sinon.stub().returns([])
+            };
+            memberAttributionServiceStub = {
+                getMemberCreatedAttribution: sinon.stub().resolves(null)
+            };
+            emailSuppressionListStub = {
+                getSuppressionData: sinon.stub().resolves({})
+            };
+
+            memberRepositoryStub.get
+                .withArgs(
+                    {id: MEMBER_ID},
+                    {withRelated: DEFAULT_RELATIONS}
+                )
+                .resolves(memberModelStub);
+        });
+
+        it('returns a member', async function () {
+            const memberBreadService = getService();
+            const member = await memberBreadService.read({id: MEMBER_ID});
+
+            assert.equal(member.id, memberModelJSON.id);
+            assert.equal(member.email, memberModelJSON.email);
+        });
+
+        it('returns a member with subscriptions', async function () {
+            const subscriptionsJSON = [
+                {
+                    subscription_id: 'sub_123',
+                    price: {}
+                }
+            ];
+            const subscriptionModels = [
+                {
+                    get: sinon.stub()
+                }
+            ];
+
+            subscriptionModels[0].get
+                .withArgs('subscription_id')
+                .returns(subscriptionsJSON[0].subscription_id);
+
+            memberModelStub.related
+                .withArgs('stripeSubscriptions')
+                .returns(subscriptionModels);
+
+            memberModelStub.toJSON.returns({
+                ...memberModelJSON,
+                subscriptions: subscriptionsJSON
+            });
+
+            const memberBreadService = getService();
+            const member = await memberBreadService.read({id: MEMBER_ID});
+
+            assert.deepEqual(member.subscriptions, subscriptionsJSON);
+        });
+
+        it('returns a member with subscriptions that only have a price', async function () {
+            const subscriptionsJSON = [
+                {
+                    subscription_id: 'sub_123',
+                    price: {}
+                },
+                {
+                    subscription_id: 'sub_456'
+                }
+            ];
+            const subscriptionModels = subscriptionsJSON.map((subscription) => {
+                const model = {
+                    get: sinon.stub()
+                };
+
+                model.get.withArgs('subscription_id').returns(subscription.subscription_id);
+                model.get.withArgs('offer_id').returns(undefined);
+
+                return model;
+            });
+
+            memberModelStub.related
+                .withArgs('stripeSubscriptions')
+                .returns(subscriptionModels);
+
+            memberModelStub.toJSON.returns({
+                ...memberModelJSON,
+                subscriptions: subscriptionsJSON
+            });
+
+            const memberBreadService = getService();
+            const member = await memberBreadService.read({id: MEMBER_ID});
+
+            assert.deepEqual(member.subscriptions, [
+                subscriptionsJSON[0]
+            ]);
+        });
+
+        it('returns a member with a comped subscription', async function () {
+            const productsJSON = [
+                {
+                    id: 'prod_123',
+                    expiry_at: new Date('2023-10-13T15:15:00')
+                },
+                {
+                    id: 'prod_456',
+                    expiry_at: new Date('2023-10-13T15:15:00')
+                }
+            ];
+            const productEventsJSON = [
+                {
+                    product_id: productsJSON[0].id,
+                    created_at: new Date('2023-09-13T15:15:00'),
+                    action: 'added'
+                },
+                {
+                    product_id: productsJSON[1].id,
+                    created_at: new Date('2023-09-13T15:20:00'),
+                    action: 'added'
+                }
+            ];
+            const subscriptionsJSON = [
+                {
+                    subscription_id: 'sub_123',
+                    price: {
+                        product: {
+                            product_id: productsJSON[0].id
+                        }
+                    },
+                    status: 'cancelled',
+                    product_id: productsJSON[0].id
+                },
+                // Comped subscription - Has no price
+                {
+                    subscription_id: 'sub_456',
+                    status: 'active',
+                    product_id: productsJSON[1].id
+                }
+            ];
+            const subscriptionModels = subscriptionsJSON.map((subscription) => {
+                const model = {
+                    get: sinon.stub()
+                };
+
+                model.get.withArgs('subscription_id').returns(subscription.subscription_id);
+                model.get.withArgs('offer_id').returns(undefined);
+
+                return model;
+            });
+
+            memberModelStub.related
+                .withArgs('stripeSubscriptions')
+                .returns(subscriptionModels);
+
+            memberModelStub.toJSON.returns({
+                ...memberModelJSON,
+                subscriptions: subscriptionsJSON,
+                products: productsJSON,
+                productEvents: productEventsJSON
+            });
+
+            memberRepositoryStub.isActiveSubscriptionStatus = sinon.stub().returns(true);
+
+            const memberBreadService = getService();
+            const member = await memberBreadService.read({id: MEMBER_ID});
+
+            // Ensure only 2 subscriptions are returned
+            assert.equal(member.subscriptions.length, 2);
+
+            const compedSubscription = member.subscriptions[1];
+
+            // Ensure the 2nd subscription is the comped one
+            sinon.assert.match(compedSubscription, {
+                id: '',
+                tier: productsJSON[1],
+                customer: {
+                    id: '',
+                    name: memberModelJSON.name,
+                    email: memberModelJSON.email
+                },
+                plan: {
+                    id: '',
+                    nickname: 'Complimentary',
+                    interval: 'year',
+                    currency: 'USD',
+                    amount: 0
+                },
+                status: 'active',
+                start_date: moment(productEventsJSON[1].created_at),
+                default_payment_card_last4: '****',
+                cancel_at_period_end: false,
+                cancellation_reason: null,
+                current_period_end: moment(productsJSON[1].expiry_at),
+                price: {
+                    id: '',
+                    price_id: '',
+                    nickname: 'Complimentary',
+                    amount: 0,
+                    interval: 'year',
+                    type: 'recurring',
+                    currency: 'USD',
+                    product: {
+                        id: '',
+                        product_id: productsJSON[1].id
+                    }
+                }
+            });
+        });
+
+        it('returns a member with attribution data', async function () {
+            const attributionData = {
+                url: 'https://example.com'
+            };
+
+            memberAttributionServiceStub.getMemberCreatedAttribution
+                .withArgs(MEMBER_ID)
+                .resolves(attributionData);
+
+            const memberBreadService = getService();
+            const member = await memberBreadService.read({id: MEMBER_ID});
+
+            assert.deepEqual(member.attribution, attributionData);
+        });
+
+        it('returns a member with suppression data', async function () {
+            emailSuppressionListStub.getSuppressionData
+                .withArgs(memberModelJSON.email)
+                .resolves({
+                    suppressed: true,
+                    info: 'bounce'
+                });
+
+            const memberBreadService = getService();
+            const member = await memberBreadService.read({id: MEMBER_ID});
+
+            assert.deepEqual(member.email_suppression, {
+                suppressed: true,
+                info: 'bounce'
+            });
+        });
+    });
+});


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3875

When a member had a comped subscription, the portal was showing an incorrect expiry date. This was because the `expiry_date` was being set to the `created_at` date of the subscription, rather than the `expiry_date` of the comped subscription