### PR TITLE
Added Staff Token copy and generation to Admin X

### DIFF
--- a/apps/admin-x-settings/src/api/staffToken.ts
+++ b/apps/admin-x-settings/src/api/staffToken.ts
@@ -1,0 +1,31 @@
+import {Meta, createMutation, createPaginatedQuery} from '../utils/apiRequests';
+
+export type staffToken = {
+    id: string;
+    created_at: string;
+    integration_id: string | null;
+    last_seen_at: string | null;
+    last_seen_version: string | null;
+    role_id: string;
+    secret: string;
+    type: string;
+    updated_at: string;
+    user_id: string;
+};
+
+export interface StaffTokenResponseType {
+    meta?: Meta
+    apiKey: staffToken
+}
+
+const dataType = 'StaffTokenResponseType';
+
+export const getStaffToken = createPaginatedQuery<StaffTokenResponseType>({
+    dataType,
+    path: '/users/me/token'
+});
+
+export const genStaffToken = createMutation<StaffTokenResponseType, []>({
+    path: () => '/users/me/token',
+    method: 'PUT'
+});


### PR DESCRIPTION
refs https://www.notion.so/ghost/Staff-access-token-is-missing-from-user-detail-screen-0336ea3e586c4b88ad7dae266a95429c?pvs=4

- Added API routes to retrieve and regenrate Staff Token keys.
- Wired up UI

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ae12a5</samp>

This pull request introduces a new feature for staff access tokens, which enable users to access the Ghost Admin API securely and conveniently. It adds a new `staffToken.ts` module for the API logic and a new `StaffToken` component for the UI. It also integrates the feature into the user profile and settings in the `general` page.
