### PR TITLE
Fixed `#bulkDestroy` from calling `bulkDestroy`

### DIFF
--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -349,7 +349,7 @@ class PostsService {
     async #bulkDestroy(options) {
         if (!options.transacting) {
             return await this.models.Post.transaction(async (transacting) => {
-                return await this.bulkDestroy({
+                return await this.#bulkDestroy({
                     ...options,
                     transacting
                 });


### PR DESCRIPTION
Rather than calling itself with the newly created transaction, it would call
the "parent" method, which meant that two events were dispatched. TBH I think
we can get rid of the check for a transaction here, and so the parent method
too, but not 100% sure.

