### PR TITLE
Fixed flaky announcement test for Admin X

### DIFF
--- a/apps/admin-x-settings/test/e2e/site/announcementbar.test.ts
+++ b/apps/admin-x-settings/test/e2e/site/announcementbar.test.ts
@@ -17,15 +17,15 @@ test.describe('Announcement Bar', async () => {
             url: responseFixtures.latestPost.posts[0].url,
             response: '<html><head><style></style></head><body><div>post preview</div></body></html>'
         });
-    
+
         await page.goto('/');
-    
+
         const section = page.getByTestId('announcement-bar');
-    
+
         await section.getByRole('button', {name: 'Customize'}).click();
-    
+
         await page.waitForSelector('[data-testid="announcement-bar-preview-iframe"]');
-    
+
         const checkTextInIframes = async (iframesHandles, textToSearch) => {
             let textExists = false;
             for (const iframeHandle of iframesHandles) {
@@ -40,16 +40,16 @@ test.describe('Announcement Bar', async () => {
             }
             return textExists;
         };
-    
+
         const iframesHandleHome = await page.$$('[data-testid="announcement-bar-preview-iframe"] > iframe');
         const textExistsInHomeIframes = await checkTextInIframes(iframesHandleHome, 'homepage preview');
         expect(textExistsInHomeIframes).toBeTruthy();
-    
+
         const modal = page.getByTestId('announcement-bar-modal');
         await modal.getByTestId('design-toolbar').getByRole('tab', {name: 'Post'}).click();
-    
+
         await page.waitForSelector('[data-testid="announcement-bar-preview-iframe"]');
-        
+
         const iframesHandlePost = await page.$$('[data-testid="announcement-bar-preview-iframe"] > iframe');
         const textExistsInPostIframes = await checkTextInIframes(iframesHandlePost, 'post preview');
         expect(textExistsInPostIframes).toBeTruthy();

--- a/apps/admin-x-settings/test/e2e/site/announcementbar.test.ts
+++ b/apps/admin-x-settings/test/e2e/site/announcementbar.test.ts
@@ -17,48 +17,42 @@ test.describe('Announcement Bar', async () => {
             url: responseFixtures.latestPost.posts[0].url,
             response: '<html><head><style></style></head><body><div>post preview</div></body></html>'
         });
-
+    
         await page.goto('/');
-
+    
         const section = page.getByTestId('announcement-bar');
-
+    
         await section.getByRole('button', {name: 'Customize'}).click();
-
-        // // Homepage and post preview
+    
         await page.waitForSelector('[data-testid="announcement-bar-preview-iframe"]');
-        const iframeCount = await page.$$eval('[data-testid="announcement-bar-preview-iframe"] > iframe', frames => frames.length);
-
-        expect(iframeCount).toEqual(2);
-
-        const modal = page.getByTestId('announcement-bar-modal');
-
-        await page.waitForSelector('[data-testid="announcement-bar-preview-iframe"]');
-
-        // Get the iframes inside the modal
+    
+        const checkTextInIframes = async (iframesHandles, textToSearch) => {
+            let textExists = false;
+            for (const iframeHandle of iframesHandles) {
+                const frame = await iframeHandle.contentFrame();
+                const textFound = await frame?.$eval('body', (body, text) => {
+                    return body.innerText.includes(text);
+                }, textToSearch);
+                if (textFound) {
+                    textExists = true;
+                    break;
+                }
+            }
+            return textExists;
+        };
+    
         const iframesHandleHome = await page.$$('[data-testid="announcement-bar-preview-iframe"] > iframe');
-
-        const homeiframeHandler = iframesHandleHome[1]; // index 1 since that's the visible iframe
-        const frameHome = await homeiframeHandler.contentFrame();
-        const textExistsInFirstIframe = await frameHome?.$eval('body', (body, textToSearch) => {
-            return body.innerText.includes(textToSearch);
-        }, 'homepage preview');
-
-        expect(textExistsInFirstIframe).toBeTruthy();
-
+        const textExistsInHomeIframes = await checkTextInIframes(iframesHandleHome, 'homepage preview');
+        expect(textExistsInHomeIframes).toBeTruthy();
+    
+        const modal = page.getByTestId('announcement-bar-modal');
         await modal.getByTestId('design-toolbar').getByRole('tab', {name: 'Post'}).click();
-
+    
         await page.waitForSelector('[data-testid="announcement-bar-preview-iframe"]');
-
+        
         const iframesHandlePost = await page.$$('[data-testid="announcement-bar-preview-iframe"] > iframe');
-
-        const postiframeHandler = iframesHandlePost[0]; // index 0 since that's the visible iframe
-        const framePost = await postiframeHandler.contentFrame();
-
-        const textExistsInSecondIframe = await framePost?.$eval('body', (body, textToSearch) => {
-            return body.innerText.includes(textToSearch);
-        }, 'post preview');
-
-        expect(textExistsInSecondIframe).toBeTruthy();
+        const textExistsInPostIframes = await checkTextInIframes(iframesHandlePost, 'post preview');
+        expect(textExistsInPostIframes).toBeTruthy();
     });
 
     // TODO - lexical isn't loading in the preview


### PR DESCRIPTION
no issue

- Attempts to resolve a flaky test.
---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a7d420</samp>

Refactor announcement bar preview test to use a helper function for checking text in iframes. This improves code quality and readability.
