### PR TITLE
🏗️ Added constraint to collections_posts table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.63/2023-09-14-09-03-32-add-unique-collection-post-constraint.js
+++ b/ghost/core/core/server/data/migrations/versions/5.63/2023-09-14-09-03-32-add-unique-collection-post-constraint.js
@@ -1,0 +1,14 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+const {addUnique} = require('../../../schema/commands');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Adding unique constraints to collections_posts table for collection_id and post_id');
+
+        await addUnique('collections_posts', ['collection_id', 'post_id'], knex);
+    },
+    async function down() {
+        // no-op because we'd need to drop FK in MySQL to drop the unique key constraint
+    }
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1066,7 +1066,10 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         collection_id: {type: 'string', maxlength: 24, nullable: false, references: 'collections.id', cascadeDelete: true},
         post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', cascadeDelete: true},
-        sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
+        sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
+        '@@UNIQUE_CONSTRAINTS@@': [
+            ['collection_id', 'post_id']
+        ]
     },
     recommendations: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '38fa7cfe8d74659ec75a5963b13cb4eb';
+    const currentSchemaHash = 'd3041630c4384ddfda0ba61b36091500';
     const currentFixturesHash = '6e8d5e89044320656de4900dd0529e68';
     const currentSettingsHash = '3a7ca0aa6a06cba47e3e898aef7029c2';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/86

- This constraint will make sure each collection contains only one entry of the post
- This came out as a part of deeper investigation into OOM Ghost instance crashes

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f477a0</samp>

This pull request adds a unique constraint on the `collections_posts` table to ensure that each post can only belong to one collection. It includes a new migration file, an updated schema definition, and a revised integrity test.
