### PR TITLE
Fixed transaction lock from rendering pages with collections when saving

### DIFF
--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -1335,12 +1335,15 @@ Post = ghostBookshelf.Model.extend({
         // pages are rendered after saving so data can be fetched outside of a transaction
         if (model.get('lexical') !== null && model.get('html') === null) {
             const html = await lexicalLib.render(model.get('lexical'));
+            const plaintext = htmlToPlaintext.excerpt(html);
 
+            // set model attributes so they are available immediately in code that uses the returned model
             model.set('html', html);
+            model.set('plaintext', plaintext);
 
             // update database manually using knex to avoid hooks being called multiple times
             await ghostBookshelf.transaction(async (transacting) => {
-                await ghostBookshelf.knex.raw('UPDATE posts SET html = ? WHERE id = ?', [html, model.id]).transacting(transacting);
+                await ghostBookshelf.knex.raw('UPDATE posts SET html = ?, plaintext = ? WHERE id = ?', [html, plaintext, model.id]).transacting(transacting);
             });
         }
 


### PR DESCRIPTION
no issue

- rendering with a collection card means the lexical renderer fetches post data, however when saving a post we're inside of a `FOR UPDATE` transaction meaning the fetches that the renderer attempts stall out due to a transaction lock
- all bookshelf events like `onSaving`, `onSaved` etc end up being wrapped up in a transaction due to the post model's custom `edit` and `add` methods which enforces a transaction around the bookshelf method meaning we can't use the hook methods to handle the render+update
- added a new `rerenderIfNeeded` method that is explicitly called once the add/edit transactions have completed, this checks if we have lexical content that hasn't been rendered then renders outside of a transaction before updating the page's html field directly via knex to avoid triggering extra bookshelf hooks/events
- updated `onSaving` method to set `html` to `null` rather than rendering when we're saving a page so the new `rerenderIfNeeded` methods conditions are met to render after the initial save
