### PR TITLE
Fixed transaction errors using PostsService inside of Post model's `onSaving` hook

### DIFF
--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -559,12 +559,12 @@ export class CollectionsService {
         });
     }
 
-    async getById(id: string): Promise<Collection | null> {
-        return await this.collectionsRepository.getById(id);
+    async getById(id: string, options?: {transaction: Knex.Transaction}): Promise<Collection | null> {
+        return await this.collectionsRepository.getById(id, options);
     }
 
-    async getBySlug(slug: string): Promise<Collection | null> {
-        return await this.collectionsRepository.getBySlug(slug);
+    async getBySlug(slug: string, options?: {transaction: Knex.Transaction}): Promise<Collection | null> {
+        return await this.collectionsRepository.getBySlug(slug, options);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -700,7 +700,7 @@ Post = ghostBookshelf.Model.extend({
             )
         ) {
             try {
-                this.set('html', await lexicalLib.render(this.get('lexical')));
+                this.set('html', await lexicalLib.render(this.get('lexical'), {transacting: options.transacting}));
             } catch (err) {
                 throw new errors.ValidationError({
                     message: tpl(messages.invalidLexicalStructure),

--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -44,10 +44,10 @@ class PostsService {
     async browsePosts(options) {
         let posts;
         if (options.collection) {
-            let collection = await this.collectionsService.getById(options.collection);
+            let collection = await this.collectionsService.getById(options.collection, {transaction: options.transacting});
 
             if (!collection) {
-                collection = await this.collectionsService.getBySlug(options.collection);
+                collection = await this.collectionsService.getBySlug(options.collection, {transaction: options.transacting});
             }
 
             if (!collection) {


### PR DESCRIPTION
no issue

`PostsService` and `CollectionsService` were missing some passthroughs and had differing naming for a transaction instance on the `options` object which meant SQLite would hang if the Lexical renderer called out to `PostsService.browsePosts`

- added passthrough of `transacting` to the Lexical renderer ready for implementation of the collection-fetching function
- added rename of `options.transacting` to `options.transaction` and passthrough from `PostsService` to `CollectionsService` (passthrough from collections repository to bookshelf and required `transaction->transacting` was already in place)
