### PR TITLE
Enabled collections rendering

### DIFF
--- a/ghost/core/core/server/lib/lexical.js
+++ b/ghost/core/core/server/lib/lexical.js
@@ -3,6 +3,8 @@ const errors = require('@tryghost/errors');
 const urlUtils = require('../../shared/url-utils');
 const config = require('../../shared/config');
 const storage = require('../adapters/storage');
+const getPostServiceInstance = require('../services/posts/posts-service');
+const postsService = getPostServiceInstance();
 
 let nodes;
 let lexicalHtmlRenderer;
@@ -43,7 +45,8 @@ module.exports = {
             createDocument() {
                 const {JSDOM} = require('jsdom');
                 return (new JSDOM()).window.document;
-            }
+            },
+            postsService
         }, userOptions);
 
         return await this.lexicalHtmlRenderer.render(lexical, options);

--- a/ghost/core/core/server/lib/lexical.js
+++ b/ghost/core/core/server/lib/lexical.js
@@ -30,6 +30,13 @@ module.exports = {
     },
 
     async render(lexical, userOptions = {}) {
+        const getCollectionPosts = async (collectionSlug, postCount) => {
+            const transacting = userOptions.transacting;
+            const {data} = await postsService.browsePosts({collection: collectionSlug, limit: postCount, transacting});
+            let posts = data.map(p => p.toJSON());
+            return posts;
+        };
+
         const options = Object.assign({
             siteUrl: config.get('url'),
             imageOptimization: config.get('imageOptimization'),
@@ -46,7 +53,7 @@ module.exports = {
                 const {JSDOM} = require('jsdom');
                 return (new JSDOM()).window.document;
             },
-            postsService
+            getCollectionPosts
         }, userOptions);
 
         return await this.lexicalHtmlRenderer.render(lexical, options);


### PR DESCRIPTION
refs TryGhost/Product#3883
- passes endpoint through to the lexical renderer for collections rendering
- ghost still needs a `kg-default-nodes` and `kg-lexical-html-renderer` update to support this completely