### PR TITLE
🐛 Fixed escaping search terms that contain special characters

### DIFF
--- a/apps/sodo-search/src/components/PopupModal.js
+++ b/apps/sodo-search/src/components/PopupModal.js
@@ -248,10 +248,12 @@ function PostListItem({post, selectedResult, setSelectedResult}) {
 function getMatchIndexes({text, highlight}) {
     let highlightRegexText = '';
     highlight?.split(' ').forEach((d, idx) => {
+        // escape regex syntax in search queries
+        const e = String(d).replace(/\W/g, '\\&');
         if (idx > 0) {
-            highlightRegexText += `|^` + d + `|\\s` + d;
+            highlightRegexText += `|^` + e + `|\\s` + e;
         } else {
-            highlightRegexText = `^` + d + `|\\s` + d;
+            highlightRegexText = `^` + e + `|\\s` + e;
         }
     });
     const matchRegex = new RegExp(`${highlightRegexText}`, 'ig');


### PR DESCRIPTION
- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

Before, Sodo Search was not escaping search input before using the search terms in a regular expression, so using special characters could result in an invalid regular expression which would crash JavaScript.

As regular expressions date back to Perl, so does a standard solution for this, which called `quotemeta` in Perl. It doesn't exist 1:1 in JavaScript, but StackOverflow had the answer:

https://stackoverflow.com/questions/6318710/javascript-equivalent-of-perls-q-e-or-quotemeta

... where it appears I answered this question in 2014. Ha.

So a line of code is added to escape the special characters in the regex for passing them through. This is the same code that the `quotemeta` module on NPM would use.

Fixes: #18133

## QA Log

Unfortunately, my local Ghost development environment is not set up perfectly to test this. I tried using `ghost dev --search` and that did link a local blog to a local version of Sodo search, but a new JavaScript error appears which I think is unrelated:

```
search-index.js:12 Uncaught TypeError: b.Document is not a constructor
    at new cm (search-index.js:12:27)
```

So I'd love if someone with a working dev environment could quickly repro the issue with a "+C" and then apply my match and test again.

Thanks!



