### PR TITLE
Updated i18n translations

### DIFF
--- a/ghost/i18n/locales/af/portal.json
+++ b/ghost/i18n/locales/af/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Deur van eposse af te skakel, sal nie u betaalde subskripsie van {{title}} kanselleer nie",
     "Update": "Opdateer",
     "Update your preferences": "Opdateer u voorkeure",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Bevestig dat u e-posadres korrek is",
     "View plans": "Kyk na planne",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Ons kon u nie afskakel nie, omdat die e-pos adres nie gevind is nie. Kontak asseblief die webwerf eienaar.",

--- a/ghost/i18n/locales/bg/portal.json
+++ b/ghost/i18n/locales/bg/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Спирането на изпращането на писма, няма да ти прекрати абонамента и регистрацията в {{title}}",
     "Update": "Обнови",
     "Update your preferences": "Обнови твоите предпочитания/настройки",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Проверете дали имейл адресът ви е верен",
     "View plans": "Вижте плановете",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Този пощенски адрес който опитвате да разабонирате, изглежда невалиден. Моля, свържете се със собственика на сайта.",

--- a/ghost/i18n/locales/ca/portal.json
+++ b/ghost/i18n/locales/ca/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Cancel·lar la subscripció al teu correu electrònic no cancel·larà la teva subscripció de pagament a {{title}}",
     "Update": "Actualitza",
     "Update your preferences": "Actualitza les preferències",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Verifica que la teva adreça de correu electrònic és correcta",
     "View plans": "Mostrar plans",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "No hem pogut cancel·lar la teva subscripció ja que no s'ha trobar la direcció de correu electrònic. Si us plau, contacta amb el propietari del lloc web.",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -202,6 +202,7 @@
     "Update": "A button to update the billing information",
     "Update your preferences": "A button for updating member preferences in their account area",
     "Upgrade now": "Button text in the comments section, when you need to be a paid member in order to post a comment",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "A section title in the email receiving FAQ",
     "View plans": "A button to view available plans",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "An error message when an unsubscribe link is clicked, but we don't have any record of the address being unsubscribed. Probably because the email address on the account has been changed.",

--- a/ghost/i18n/locales/cs/portal.json
+++ b/ghost/i18n/locales/cs/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Odhlášení ze newsletterů nezruší váš placený odběr {{title}}",
     "Update": "",
     "Update your preferences": "Aktualizovat předvolby",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Nemohli jsme vás odhlásit, protože e-mailová adresa nebyla nalezena. Kontaktujte prosím provozovatele webu.",

--- a/ghost/i18n/locales/da/portal.json
+++ b/ghost/i18n/locales/da/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Du annullerer ikke dit abonnement på {{title}} ved at afmelde dig fra alle e-mails",
     "Update": "Opdater",
     "Update your preferences": "Opdater dine præferencer",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Tjek om din e-mailadresse er korrekt",
     "View plans": "Se abonnementer",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Vi kunne ikke afmelde dig, da e-mailen ikke blev fundet. Kontakt venligst ejeren af siden.",

--- a/ghost/i18n/locales/de/portal.json
+++ b/ghost/i18n/locales/de/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Wenn du dich von diesen E-Mails abmeldest, wird dein bezahltes Abonnement bei {{title}} nicht automatisch gekündigt",
     "Update": "Aktualisieren",
     "Update your preferences": "Aktualisiere deine Einstellungen",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Überprüfe, ob deine E-Mail-Adresse stimmt",
     "View plans": "Tarife ansehen",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Wir konnten dich nicht abmelden, da die E-Mail-Adresse nicht gefunden wurde. Bitte kontaktiere den Seitenbetreiber.",

--- a/ghost/i18n/locales/en/portal.json
+++ b/ghost/i18n/locales/en/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "",
     "Update": "",
     "Update your preferences": "",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "",

--- a/ghost/i18n/locales/eo/portal.json
+++ b/ghost/i18n/locales/eo/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Malabonigi de retpoŝtoj ne nuligos vian pagitan abonon al {{title}}",
     "Update": "",
     "Update your preferences": "Ĝisdatigu viajn agordojn",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Ni ne povis malaboni vin ĉar la retadreso ne estis trovita. Bonvolu kontakti la proprietulo de la retejo",

--- a/ghost/i18n/locales/es/portal.json
+++ b/ghost/i18n/locales/es/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Cancelar la suscripción a los correos electrónicos no cancelará tu suscripción de pago a {{title}}",
     "Update": "Actualizar",
     "Update your preferences": "Actualiza tus preferencias",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Verifique que su dirección de correo electrónico sea correcta",
     "View plans": "Ver planes",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "No pudimos cancelar tu suscripción ya que no se encontró la dirección de correo electrónico. Por favor, contacta al propietario del sitio.",

--- a/ghost/i18n/locales/fi/portal.json
+++ b/ghost/i18n/locales/fi/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Sähköpostien peruuttaminen ei peruuta maksullista tilaustasi {{title}}",
     "Update": "Päivitä",
     "Update your preferences": "Päivitä asetuksesi",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Vahvista sähköpostiosoitteesi oikeellisuus",
     "View plans": "Katso tilausvaihtoehtoja",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Emme voineet peruuttaa tilaustasi, koska sähköpostiosoitetta ei löytynyt. Ota yhteyttä sivuston omistajaan.",

--- a/ghost/i18n/locales/fr/portal.json
+++ b/ghost/i18n/locales/fr/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "La désinscription des e-mails n’annulera pas votre abonnement payant à {{title}}",
     "Update": "Mise à jour",
     "Update your preferences": "Mettez à jour vos préférences",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Vérifiez que votre adresse e-mail est correcte",
     "View plans": "Voir les abonnements",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "La désinscription n’a pas fonctionné car votre adresse e-mail n’a pas été trouvée. Veuillez contacter le propriétaire du site.",

--- a/ghost/i18n/locales/hr/portal.json
+++ b/ghost/i18n/locales/hr/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Odjavljivanjem sa email-ova nećete prekinuti Vašu pretplatu na {{title}}",
     "Update": "",
     "Update your preferences": "Izmijenite Vaše postavke",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Nismo uspjeli odjaviti email. Molimo Vas kontaktirajte vlasnika sajta.",

--- a/ghost/i18n/locales/hu/portal.json
+++ b/ghost/i18n/locales/hu/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Az email-ről történő leiratkozás nem szűnteti meg a fiókját",
     "Update": "",
     "Update your preferences": "Beállítások mentése",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Ehhez az email-hez nem tartozik fiók. Kérjük lépjen kapcsolatba az oldal tulajdonosával.",

--- a/ghost/i18n/locales/id/portal.json
+++ b/ghost/i18n/locales/id/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Berhenti berlangganan dari email tidak akan membatalkan langganan berbayar Anda ke {{title}}",
     "Update": "Perbarui",
     "Update your preferences": "Perbarui preferensi Anda",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Verifikasi bahwa alamat email Anda benar",
     "View plans": "Lihat paket",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Kami tidak dapat menghentikan langganan Anda karena alamat email tidak ditemukan. Harap hubungi pemilik situs.",

--- a/ghost/i18n/locales/is/portal.json
+++ b/ghost/i18n/locales/is/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Uppsögn tölvupósta felur ekki í sér uppsögn áskriftar að {{title}}",
     "Update": "Uppfæra",
     "Update your preferences": "Breyta vali",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Gakktu úr skugga um að netfangið sé rétt",
     "View plans": "Skoða áskriftarleiðir",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Uppsögn mistókst vegna þess að netfangið fannst ekki. Hafðu samband við eiganda síðunnar.",

--- a/ghost/i18n/locales/it/portal.json
+++ b/ghost/i18n/locales/it/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "La disiscrizione dalle email non annullerà l'abbonamento a {{title}}",
     "Update": "Aggiorna",
     "Update your preferences": "Aggiorna le tue preferenze",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Controlla che il tuo indirizzo email sia corretto",
     "View plans": "Vedi piani",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Non è stato possibile disiscriverti poiché l'indirizzo email non è stato trovato. Si prega di contattare il proprietario del sito.",

--- a/ghost/i18n/locales/ja/portal.json
+++ b/ghost/i18n/locales/ja/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "メールの購読を解除しても、{{title}}への有料購読はキャンセルされません",
     "Update": "更新",
     "Update your preferences": "設定を更新する",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "メールアドレスが正しいかどうか確認してください",
     "View plans": "プランを表示",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "メールアドレスが見つからなかったため、購読解除できませんでした。サイトのオーナーに連絡してください。",

--- a/ghost/i18n/locales/ko/portal.json
+++ b/ghost/i18n/locales/ko/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "이메일 구독 취소는 {{title}}에 대한 유료 구독을 취소하지 않습니다",
     "Update": "업데이트",
     "Update your preferences": "설정 업데이트",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "이메일 주소가 올바른지 확인하세요",
     "View plans": "플랜 보기",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "이메일 주소를 찾을 수 없어 구독을 취소할 수 없습니다. 사이트 관리자에게 문의하세요.",

--- a/ghost/i18n/locales/mn/portal.json
+++ b/ghost/i18n/locales/mn/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Имэйлийг зогсоосон ч таны {{title}} төлбөртэй захиалга цуцлагдахгүй",
     "Update": "",
     "Update your preferences": "Тохиргоогоо шинэчлэх",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Энэхүү имэйл хаяг олдоогүй учир захиалгыг цуцлах боломжгүй. Та сайтын админд хандана уу.",

--- a/ghost/i18n/locales/ms/portal.json
+++ b/ghost/i18n/locales/ms/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Memberhentikan langganan dari e-mel tidak akan membatalkan langganan berbayar anda ke {{title}}",
     "Update": "Kemas kini",
     "Update your preferences": "Kemas kini keutamaan anda",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Sahkan jika alamat e-mel anda betul",
     "View plans": "Lihat pelan",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Kami tidak dapat membatalkan langganan anda kerana alamat e-mel tidak ditemui. Sila hubungi pemilik laman web.",

--- a/ghost/i18n/locales/nl/portal.json
+++ b/ghost/i18n/locales/nl/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Je betaalde abonnement voor {{title}} wordt niet geannuleerd als je je uitschrijft voor e-mails",
     "Update": "",
     "Update your preferences": "Voorkeuren aanpassen",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Het is niet gelukt om je uit te schrijven, omdat je e-mailadres niet is gevonden. Neem contact met ons op.",

--- a/ghost/i18n/locales/nn/portal.json
+++ b/ghost/i18n/locales/nn/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Å avslutta e-postabonnementa vil ikkje kansellera det betalta abonnementet ditt til {{title}}",
     "Update": "Oppdater",
     "Update your preferences": "Oppdater preferansane dine",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Bekreft at e-posten din er riktig",
     "View plans": "Sjå abonnementa",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Me kunne ikkje avslutta abonnementet ditt då me ikkje fann e-postadressa di. Vennligst ta kontakt med eigaren av sida.",

--- a/ghost/i18n/locales/no/portal.json
+++ b/ghost/i18n/locales/no/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Å melde seg av e-poster vil ikke avbryte abonnementet ditt på {{title}}",
     "Update": "",
     "Update your preferences": "Oppdater dine valg",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Vi kunne ikke melde deg av siden e-postadressen ikke ble funnet. Vennligst kontakt nettstedseieren.",

--- a/ghost/i18n/locales/pl/portal.json
+++ b/ghost/i18n/locales/pl/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Wypisanie się z otrzymywania emaili nie powoduje anulowania płatnej subskrypcji {{title}}",
     "Update": "Zaktualizuj",
     "Update your preferences": "Zaktualizuj preferencje",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Sprawdź, czy Twój email jest poprawny",
     "View plans": "Zobacz plany",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Nie udało się wypisać, bo nie znaleziono adresu email. Skontaktuj się w właścicielem strony.",

--- a/ghost/i18n/locales/pt-BR/portal.json
+++ b/ghost/i18n/locales/pt-BR/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Cancelar a inscrição nos e-mails não cancelará sua assinatura paga em {{title}}",
     "Update": "atualizar",
     "Update your preferences": "Atualizar preferências",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Verifique se o endereço de e-mail está correto",
     "View plans": "Ver planos",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Não conseguimos cancelar sua inscrição já que o e-mail não foi encontrado. Por favor, entre em contato com o proprietário do site.",

--- a/ghost/i18n/locales/pt/portal.json
+++ b/ghost/i18n/locales/pt/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Cancelar a subscrição dos emails não cancelará sua assinatura paga em {{title}}",
     "Update": "Atualizar",
     "Update your preferences": "Atualizar as tuas preferências",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Verifique se o endereço de email está correto",
     "View plans": "Ver planos",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Não conseguimos cancelar sua inscrição já que o email não foi encontrado. Por favor, entre em contato com o proprietário do site.",

--- a/ghost/i18n/locales/ro/portal.json
+++ b/ghost/i18n/locales/ro/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Dezabonarea de la emailuri nu va anula abonamentul plătit la {{title}}",
     "Update": "",
     "Update your preferences": "Actualizează-ți preferințele",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Nu am putut să te dezabonăm deoarece adresa de email nu a fost găsită. Te rugăm să contactezi proprietarul site-ului.",

--- a/ghost/i18n/locales/ru/portal.json
+++ b/ghost/i18n/locales/ru/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Отключение рассылки не отменит вашу платную подписку на {{title}}",
     "Update": "",
     "Update your preferences": "Обновить настройки",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Мы не смогли отменить вашу подписку, так как адрес электронной почты не найден. Пожалуйста, свяжитесь с владельцем сайта.",

--- a/ghost/i18n/locales/si/portal.json
+++ b/ghost/i18n/locales/si/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Email වලින් unsubscribe වීමෙන්, {{title}} සඳහා වන ඔබගේ paid subscription එක අවලංගු නොවනු ඇත",
     "Update": "Update කරන්න",
     "Update your preferences": "ඔබගේ  preferences update කරන්න",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "ඔබගේ email ලිපිනය නිවැරදි බව තහවුරු කරන්න",
     "View plans": "Plans පෙන්වන්න",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "ඔබගේ email ලිපිනය හමු නොවීම නිසාවෙන් ඔබව unsubscribe කරවීමට නොහැකි විය. කරුණාකර වෙබ් අඩවියෙහි හිමිකරු සම්බන්ධ කරගන්න.",

--- a/ghost/i18n/locales/sl/portal.json
+++ b/ghost/i18n/locales/sl/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Odjava od e-poštnih sporočil ne bo preklicala vaše plačane naročnine na {{title}}",
     "Update": "",
     "Update your preferences": "Posodobite svoje nastavitve",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Nismo vas mogli odjaviti, ker e-poštnega naslova nismo našli. Prosimo, da se obrnete na lastnika spletnega mesta.",

--- a/ghost/i18n/locales/sq/portal.json
+++ b/ghost/i18n/locales/sq/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Çregjistrimi nga emailet nuk do ta anulojë abonimin tuaj me pagesë në {{title}}",
     "Update": "Rifresko",
     "Update your preferences": "Përditësoni preferencat tuaja",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Verifikoni që adresa juaj e emailit është e saktë",
     "View plans": "Shiko planet",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "",

--- a/ghost/i18n/locales/sr/portal.json
+++ b/ghost/i18n/locales/sr/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Odjavljivanjem sa email-ova nećete prekinuti Vašu pretplatu na {{title}}",
     "Update": "",
     "Update your preferences": "Izmenite Vaša podešavanja",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Nismo uspeli da odjavimo email. Molimo Vas kontaktirajte vlasnika sajta.",

--- a/ghost/i18n/locales/sv/portal.json
+++ b/ghost/i18n/locales/sv/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Avregistrering från e-postmeddelanden kommer inte att avbryta din betalda prenumeration på {{title}}",
     "Update": "Uppdatera",
     "Update your preferences": "Uppdatera dina inställningar",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Kontrollera att e-postadressen är korrekt",
     "View plans": "Visa prenumerationsalternativ",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Vi kunde inte avsluta kontot eftersom e-postadressen inte hittades. Vänligen kontakta webbplatsens ägare.",

--- a/ghost/i18n/locales/tr/portal.json
+++ b/ghost/i18n/locales/tr/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "E-postaların aboneliğinden çıkmak, {{title}} sitesine olan ücretli aboneliğini iptal etmeyecek",
     "Update": "Güncelle",
     "Update your preferences": "Tercihlerini güncelle",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "E-posta adresinizin doğru olduğunu doğrulayın",
     "View plans": "Planları göster",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "E-posta adresi bulunamadığı için seni abonelikten çıkaramıyoruz. Lütfen site sahibiyle iletişime geç.",

--- a/ghost/i18n/locales/uk/portal.json
+++ b/ghost/i18n/locales/uk/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Відписка від листів не скасує твою платну підписку на {{title}}",
     "Update": "",
     "Update your preferences": "Онови свої налаштування",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Ми не можемо відписати тебе, оскільки адреса електронної пошти не знайдена. Будь ласка, зв'яжись з власником сайту.",

--- a/ghost/i18n/locales/uz/portal.json
+++ b/ghost/i18n/locales/uz/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Elektron pochtalarga obunani bekor qilish {{title}}ga pulli obunanu bekor qilmaydi",
     "Update": "",
     "Update your preferences": "Sozlamalarni yangilash",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "",
     "View plans": "",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Email manzili topilmagani uchun obunangizni bekor qila olmadik. Iltimos, sayt egasi bilan bog'laning.",

--- a/ghost/i18n/locales/vi/portal.json
+++ b/ghost/i18n/locales/vi/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "Việc hủy theo dõi qua email sẽ không hủy gói đăng ký trả phí của bạn đối với {{title}}",
     "Update": "Cập nhật",
     "Update your preferences": "Cập nhật thiết lập",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "Xác minh địa chỉ mail của bạn là đúng",
     "View plans": "Xem các gói",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "Chúng tôi không thể hủy theo dõi vì không tìm thấy địa chỉ email. Vui lòng liên hệ với chủ sở hữu trang web.",

--- a/ghost/i18n/locales/zh-Hant/portal.json
+++ b/ghost/i18n/locales/zh-Hant/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "取消接收電子報不會取消您對 {{title}} 的付費訂閱。",
     "Update": "更新",
     "Update your preferences": "更新您的偏好設定",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "確認你的 email 地址無誤",
     "View plans": "查詢訂閱方案",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "我們無法取消您的訂閱，因為找不到該 email 地址。請聯繫網站擁有者。",

--- a/ghost/i18n/locales/zh/portal.json
+++ b/ghost/i18n/locales/zh/portal.json
@@ -132,6 +132,7 @@
     "Unsubscribing from emails will not cancel your paid subscription to {{title}}": "取消邮件订阅不会取消您对 {{title}} 的付费订阅。",
     "Update": "更新",
     "Update your preferences": "更新您的偏好设置",
+    "Verification link sent, check your inbox": "",
     "Verify your email address is correct": "确认您的电子邮件地址是正确的",
     "View plans": "查阅订阅计划",
     "We couldn't unsubscribe you as the email address was not found. Please contact the site owner.": "我们无法取消您的订阅，因为找不到该电子邮件地址。请联系网站所有者。",


### PR DESCRIPTION
- updated with changes made since

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a2aa7d</samp>

This pull request adds a new key-value pair to the translation files for the portal feature of Ghost. The key is `Verification link sent, check your inbox` and the value is either the same as the key for English or an empty string for other languages. This is to support a new feature that sends a verification link to the user's email when they sign up or log in.
