### PR TITLE
Fixed migrator initialization error

### DIFF
--- a/ghost/core/core/server/lib/lexical.js
+++ b/ghost/core/core/server/lib/lexical.js
@@ -3,8 +3,6 @@ const errors = require('@tryghost/errors');
 const urlUtils = require('../../shared/url-utils');
 const config = require('../../shared/config');
 const storage = require('../adapters/storage');
-const getPostServiceInstance = require('../services/posts/posts-service');
-const postsService = getPostServiceInstance();
 
 let nodes;
 let lexicalHtmlRenderer;
@@ -30,6 +28,9 @@ module.exports = {
     },
 
     async render(lexical, userOptions = {}) {
+        const getPostServiceInstance = require('../services/posts/posts-service');
+        const postsService = getPostServiceInstance();
+
         const getCollectionPosts = async (collectionSlug, postCount) => {
             const transacting = userOptions.transacting;
             const {data} = await postsService.browsePosts({collection: collectionSlug, limit: postCount, transacting});


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/488af56ef94c42ddb2dc1608ab6f7fb99ccb1e74

- The referenced commit introduced a postsService initializaiton at the top level of the module - causing cascading failure all the way down in the URL service, whe the ENV variables are not set.
- This fix is just a quick fix to unblock the main branch. A proper initialization of the service should be done ensuring we don't have to re-create a posts-service instance on each render method call.