### PR TITLE
Reverted `flexsearch` to v0.7.21

### DIFF
--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@tryghost/content-api": "1.11.7",
-    "flexsearch": "0.7.31",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@tryghost/content-api": "1.11.7",
-    "flexsearch": "0.7.31",
+    "flexsearch": "0.7.21",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18018,10 +18018,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flexsearch@0.7.31:
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/flexsearch/-/flexsearch-0.7.31.tgz#065d4110b95083110b9b6c762a71a77cc52e4702"
-  integrity sha512-XGozTsMPYkm+6b5QL3Z9wQcJjNYxp0CYn3U1gO7dwD6PAqU1SVWZxI9CCg3z+ml3YfqdPnrBehaBrnH2AGKbNA==
+flexsearch@0.7.21:
+  version "0.7.21"
+  resolved "https://registry.yarnpkg.com/flexsearch/-/flexsearch-0.7.21.tgz#0f5ede3f2aae67ddc351efbe3b24b69d29e9d48b"
+  integrity sha512-W7cHV7Hrwjid6lWmy0IhsWDFQboWSng25U3VVywpHOTJnnAZNPScog67G+cVpeX9f7yDD21ih0WDrMMT+JoaYg==
 
 flow-parser@0.*:
   version "0.205.1"


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/18151
refs https://github.com/TryGhost/Ghost/commit/1cbbe91a630232e1dd8d76f9378124b2a7e60f48

- something has broken within 0.7.31 and it's causing an error on the frontend
- this commit reverts the dependency back to the previous version
- also cleans up the dependency from announcement-bar, where it is not used

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f7315e</samp>

This pull request removes an unnecessary dependency and updates a shared dependency for two Ghost apps. It removes `flexsearch` from `apps/announcement-bar/package.json` and updates it to version `0.7.21` in `apps/sodo-search/package.json` to ensure consistent and reliable search functionality.
