### PR TITLE
Optimized collection repository queries

### DIFF
--- a/ghost/core/core/server/api/endpoints/collections.js
+++ b/ghost/core/core/server/api/endpoints/collections.js
@@ -29,7 +29,11 @@ module.exports = {
         },
         permissions: true,
         query(frame) {
-            return collectionsService.api.getAll(frame.options);
+            return collectionsService.api.getAll({
+                filter: frame.options.filter,
+                limit: frame.options.limit,
+                page: frame.options.page
+            });
         }
     },
 

--- a/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
+++ b/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
@@ -66,6 +66,15 @@ module.exports = class BookshelfCollectionsRepository {
      * @returns {Promise<Array<{post_id: string}>>}
      */
     async #fetchCollectionPostIds(collectionId, options = {}) {
+        if (!options.transaction) {
+            return this.createTransaction((transaction) => {
+                return this.#fetchCollectionPostIds(collectionId, {
+                    ...options,
+                    transaction
+                });
+            });
+        }
+
         return await this.#relationModel
             .query()
             .select('post_id')

--- a/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
+++ b/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
@@ -86,11 +86,20 @@ module.exports = class BookshelfCollectionsRepository {
      * @param {object} [options]
      * @param {string} [options.filter]
      * @param {string} [options.order]
+     * @param {string[]} [options.withRelated]
      * @param {import('knex').Transaction} [options.transaction]
      */
     async getAll(options = {}) {
+        const filteredOptions = Object.assign({}, options);
+        // NOTE: There is no need to do count queries as these are done on serializer level with available Entity data
+        //       We also don't allow for nay other relations to be fetched with collections, so the count.posts would
+        //       be the only one to filter out.
+        if (filteredOptions?.withRelated?.includes('count.posts')) {
+            filteredOptions.withRelated = filteredOptions.withRelated.filter(item => item !== 'count.posts');
+        }
+
         const models = await this.#model.findAll({
-            ...options,
+            ...filteredOptions,
             transacting: options.transaction
         });
 

--- a/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
+++ b/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
@@ -71,15 +71,6 @@ module.exports = class BookshelfCollectionsRepository {
      * @returns {Promise<Array<{post_id: string}>>}
      */
     async #fetchCollectionPostIds(collectionId, options = {}) {
-        if (!options.transaction) {
-            return this.createTransaction((transaction) => {
-                return this.#fetchCollectionPostIds(collectionId, {
-                    ...options,
-                    transaction
-                });
-            });
-        }
-
         const toSelect = options.columns || ['post_id'];
 
         return await this.#relationModel

--- a/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
+++ b/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
@@ -73,11 +73,14 @@ module.exports = class BookshelfCollectionsRepository {
     async #fetchCollectionPostIds(collectionId, options = {}) {
         const toSelect = options.columns || ['post_id'];
 
-        return await this.#relationModel
-            .query()
+        const query = this.#relationModel.query();
+        if (options.transaction) {
+            query.transacting(options.transaction);
+        }
+
+        return await query
             .select(toSelect)
-            .where('collection_id', collectionId)
-            .transacting(options.transaction);
+            .where('collection_id', collectionId);
     }
 
     /**

--- a/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
+++ b/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
@@ -90,22 +90,6 @@ module.exports = class BookshelfCollectionsRepository {
     }
 
     /**
-     * @param {object} options
-     * @param {string[]} [options.withRelated]
-     */
-    #filterOptions(options) {
-        const filteredOptions = Object.assign({}, options);
-        // NOTE: There is no need to do count queries as these are done on serializer level with available Entity data
-        //       We also don't allow for nay other relations to be fetched with collections, so the count.posts would
-        //       be the only one to filter out.
-        if (filteredOptions?.withRelated?.includes('count.posts')) {
-            filteredOptions.withRelated = filteredOptions.withRelated.filter(item => item !== 'count.posts');
-        }
-
-        return filteredOptions;
-    }
-
-    /**
      * @param {object} [options]
      * @param {string} [options.filter]
      * @param {string} [options.order]
@@ -114,7 +98,7 @@ module.exports = class BookshelfCollectionsRepository {
      */
     async getAll(options = {}) {
         const models = await this.#model.findAll({
-            ...this.#filterOptions(options),
+            ...options,
             transacting: options.transaction
         });
 

--- a/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
+++ b/ghost/core/core/server/services/collections/BookshelfCollectionsRepository.js
@@ -83,13 +83,10 @@ module.exports = class BookshelfCollectionsRepository {
     }
 
     /**
-     * @param {object} [options]
-     * @param {string} [options.filter]
-     * @param {string} [options.order]
+     * @param {object} options
      * @param {string[]} [options.withRelated]
-     * @param {import('knex').Transaction} [options.transaction]
      */
-    async getAll(options = {}) {
+    #filterOptions(options) {
         const filteredOptions = Object.assign({}, options);
         // NOTE: There is no need to do count queries as these are done on serializer level with available Entity data
         //       We also don't allow for nay other relations to be fetched with collections, so the count.posts would
@@ -98,8 +95,19 @@ module.exports = class BookshelfCollectionsRepository {
             filteredOptions.withRelated = filteredOptions.withRelated.filter(item => item !== 'count.posts');
         }
 
+        return filteredOptions;
+    }
+
+    /**
+     * @param {object} [options]
+     * @param {string} [options.filter]
+     * @param {string} [options.order]
+     * @param {string[]} [options.withRelated]
+     * @param {import('knex').Transaction} [options.transaction]
+     */
+    async getAll(options = {}) {
         const models = await this.#model.findAll({
-            ...filteredOptions,
+            ...this.#filterOptions(options),
             transacting: options.transaction
         });
 

--- a/ghost/core/test/e2e-api/admin/collections.test.js
+++ b/ghost/core/test/e2e-api/admin/collections.test.js
@@ -117,7 +117,7 @@ describe('Collections API', function () {
                     });
             }, this.skip.bind(this));
             const collectionRelatedQueries = queries.filter(query => query.sql.includes('collection'));
-            assert(collectionRelatedQueries.length === 2);
+            assert(collectionRelatedQueries.length === 3);
         });
 
         it('Can browse Collections and include the posts count', async function () {
@@ -572,7 +572,7 @@ describe('Collections API', function () {
                 }, this.skip.bind(this));
 
                 const collectionRelatedQueries = queries.filter(query => query.sql.includes('collection'));
-                assert.equal(collectionRelatedQueries.length, 8);
+                assert.equal(collectionRelatedQueries.length, 13);
             }
 
             await agent
@@ -604,7 +604,7 @@ describe('Collections API', function () {
                 }, this.skip.bind(this));
 
                 const collectionRelatedQueries = queries.filter(query => query.sql.includes('collection'));
-                assert.equal(collectionRelatedQueries.length, 14);
+                assert.equal(collectionRelatedQueries.length, 18);
             }
 
             await agent


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/86

- Creating bookshelf models for each collection_post relation created a massive overhead. On a dataset with 500k collections_posts records the timing was roughly 7s comparing to 810ms after the optimization.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66d4782</samp>

Optimize memory and performance of collections fetching by querying post ids only. Refactor `BookshelfCollectionsRepository` to use a new private method and modify existing methods.
