### PR TITLE
Fixed collections card display when admin/front-end URLs are different

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/ember';
 import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
+import fetch from 'fetch';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {action} from '@ember/object';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -131,7 +132,6 @@ const WordCountPlugin = (props) => {
 export default class KoenigLexicalEditor extends Component {
     @service ajax;
     @service feature;
-    @service frontend;
     @service ghostPaths;
     @service session;
     @service store;
@@ -250,12 +250,12 @@ export default class KoenigLexicalEditor extends Component {
                 this.contentKey = contentIntegration?.contentKey.secret;
             }
 
-            const postsUrl = new URL(this.frontend.getUrl('/ghost/api/content/posts/'));
+            const postsUrl = new URL(this.ghostPaths.url.admin('/api/content/posts/'), window.location.origin);
             postsUrl.searchParams.append('key', this.contentKey);
             postsUrl.searchParams.append('collection', collectionSlug);
             postsUrl.searchParams.append('limit', 12);
 
-            const response = await this.frontend.fetch(postsUrl.toString());
+            const response = await fetch(postsUrl.toString());
             const {posts} = await response.json();
 
             return posts;


### PR DESCRIPTION
no issue

- the Content API is served from the Admin URL not the Frontend URL but we were fetching from the Frontend URL. That resulted in a 302 response with no CORS headers so the request was blocked by the browser
