### PR TITLE
Added a timeout when adding a recommendation

### DIFF
--- a/apps/admin-x-settings/src/api/external-ghost-site.ts
+++ b/apps/admin-x-settings/src/api/external-ghost-site.ts
@@ -30,7 +30,8 @@ export const useExternalGhostSite = () => {
             try {
                 const result = await fetchApi(url, {
                     method: 'GET',
-                    credentials: 'omit' // Allow CORS wildcard
+                    credentials: 'omit', // Allow CORS wildcard,
+                    timeout: 5000
                 });
 
                 // We need to validate all data types here for extra safety

--- a/apps/admin-x-settings/src/api/oembed.ts
+++ b/apps/admin-x-settings/src/api/oembed.ts
@@ -25,7 +25,8 @@ export const useGetOembed = () => {
             const url = apiUrl(path, searchParams);
             try {
                 const result = await fetchApi(url, {
-                    method: 'GET'
+                    method: 'GET',
+                    timeout: 5000
                 });
                 return result as OembedResponse;
             } catch (e) {


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3896

- added a timeout option to the useFetchApi() helper, to abort a fetch request after x seconds
- when adding a recommendation, we make two network calls: 1) check whether it's a Ghost site or not, 2) if not, fetch site metadata via embed. Now both of these calls have a timeout of 5 sec, which means a total waiting time of 5 seconds max. for a Ghost site, 10 seconds max. for a non-Ghost site
