### PR TITLE
Fixed Admin-X path variable

### DIFF
--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -48,7 +48,7 @@ module.exports = {
         const adminXSettingsPath = '../../apps/admin-x-settings/dist';
         const assetsAdminXPath = `${assetsOut}/assets/libs/admin-x-settings`;
 
-        if (fs.existsSync(assetsAdminXPath)) {
+        if (fs.existsSync(adminXSettingsPath)) {
             if (this.env === 'production') {
                 fs.copySync(adminXSettingsPath, assetsAdminXPath, {overwrite: true, dereference: true});
             } else {


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/80

- I'd previously used the wrong one

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad21940</samp>

Fixed a bug with asset delivery for Ghost themes by checking the existence of the `admin-x-settings` file before copying it. Updated the condition in `ghost/admin/lib/asset-delivery/index.js`.
