### PR TITLE
Fixed edit recommendation & URL uniqueness validation

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/recommendations/AddRecommendationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/recommendations/AddRecommendationModal.tsx
@@ -23,7 +23,7 @@ const AddRecommendationModal: React.FC<AddRecommendationModalProps> = ({recommen
     const {updateRoute} = useRouting();
     const {query: queryOembed} = useGetOembed();
     const {query: queryExternalGhostSite} = useExternalGhostSite();
-    const {data: {recommendations} = {}} = useBrowseRecommendations();
+    const {data: {recommendations} = {}} = useBrowseRecommendations({searchParams: {limit: 'all'}});
 
     const {formState, updateForm, handleSave, errors, validate, saveState, clearError} = useForm({
         initialState: recommendation ?? {

--- a/apps/admin-x-settings/src/components/settings/site/recommendations/EditRecommendationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/recommendations/EditRecommendationModal.tsx
@@ -115,7 +115,7 @@ const EditRecommendationModalConfirm: React.FC<AddRecommendationModalProps> = ({
 };
 
 const EditRecommendationModal: React.FC<RoutingModalProps> = ({params}) => {
-    const {data: {recommendations} = {}} = useBrowseRecommendations();
+    const {data: {recommendations} = {}} = useBrowseRecommendations({searchParams: {limit: 'all'}});
     const recommendation = recommendations?.find(({id}) => id === params?.id);
 
     if (recommendation) {

--- a/ghost/recommendations/src/RecommendationController.ts
+++ b/ghost/recommendations/src/RecommendationController.ts
@@ -69,7 +69,8 @@ export class RecommendationController {
         const options = new UnsafeData(frame.options);
 
         const page = options.optionalKey('page')?.integer ?? 1;
-        const limit = options.optionalKey('limit')?.integer ?? 5;
+        const all = options.optionalKey('limit')?.string === 'all';
+        const limit = all ? 'all' : options.optionalKey('limit')?.integer ?? 5;
         const include = options.optionalKey('withRelated')?.array.map(item => item.enum<RecommendationIncludeFields>(['count.clicks', 'count.subscribers'])) ?? [];
 
         const order = [
@@ -186,7 +187,7 @@ export class RecommendationController {
         };
     }
 
-    #serializePagination({page, limit, count}: {page: number, limit: number, count: number}) {
+    #serializePagination({page, limit, count}: {page: number, limit: number | 'all', count: number}) {
         const pages = Math.ceil(count / limit);
 
         return {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3903 refs https://github.com/TryGhost/Product/issues/3818

- by default, the browse endpoint of the recommendations api returns 5 elements
- the URL uniqueness check was happening only against these 5 elements of the first page, instead of all existing recommendations
- editing a recommendation from page 2 or more would not work, as the object would not exist in the returned response from the browse endpoint

