### PR TITLE
Added build:dev action as local dependency for build:dev

### DIFF
--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -201,8 +201,8 @@ export const importSettings = async () => {
         return window['@tryghost/admin-x-settings'];
     }
 
-    const baseUrl = (config.cdnUrl || ghostPaths().assetRootWithHost);
-    const url = new URL(`${baseUrl}libs/admin-x-settings/admin-x-settings.js`);
+    const baseUrl = (config.cdnUrl ? `${config.cdnUrl}assets/` : ghostPaths().assetRootWithHost);
+    const url = new URL(`${baseUrl}admin-x-settings/admin-x-settings.js`);
 
     if (url.protocol === 'http:') {
         window['@tryghost/admin-x-settings'] = await import(`http://${url.host}${url.pathname}`);

--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -46,7 +46,7 @@ module.exports = {
 
         // copy the @tryghost/admin-x-settings assets
         const adminXSettingsPath = '../../apps/admin-x-settings/dist';
-        const assetsAdminXPath = `${assetsOut}/assets/libs/admin-x-settings`;
+        const assetsAdminXPath = `${assetsOut}/assets/admin-x-settings`;
 
         if (fs.existsSync(adminXSettingsPath)) {
             if (this.env === 'production') {

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -186,6 +186,7 @@
     "targets": {
       "build:dev": {
         "dependsOn": [
+          "build:dev",
           {
             "projects": [
               "@tryghost/admin-x-settings"


### PR DESCRIPTION
refs TryGhost/DevOps#80

- this is needed so we run the local `build:dev` and not just the one
  for Admin-X-Settings

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56ce1e9</samp>

This pull request fixes the asset delivery for the admin-x-settings app, which is a dependency for the admin app. It corrects the URL and path for loading and copying the admin-x-settings script and adds a `build:dev` script to the `package.json` file.
