### PR TITLE
Removed required webmentions flag for mentions admin endpoint

### DIFF
--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -46,7 +46,7 @@ module.exports = function apiRoutes() {
     router.del('/posts/:id', mw.authAdminApi, http(api.posts.destroy));
     router.post('/posts/:id/copy', mw.authAdminApi, http(api.posts.copy));
 
-    router.get('/mentions', labs.enabledMiddleware('webmentions'), mw.authAdminApi, http(api.mentions.browse));
+    router.get('/mentions', mw.authAdminApi, http(api.mentions.browse));
 
     router.put('/comments/:id', mw.authAdminApi, http(api.comments.edit));
 

--- a/ghost/core/test/e2e-api/admin/mentions.test.js
+++ b/ghost/core/test/e2e-api/admin/mentions.test.js
@@ -14,7 +14,6 @@ describe('Mentions API', function () {
 
     before(async function () {
         agent = await agentProvider.getAdminAPIAgent();
-        mockManager.mockLabsEnabled('webmentions');
         // TODO: test various users' access
         await fixtureManager.init('users','mentions');
         await agent.loginAsOwner();
@@ -30,11 +29,5 @@ describe('Mentions API', function () {
             .matchBodySnapshot({
                 mentions: new Array(2).fill(matchMentionShallowIncludes)
             });
-    });
-
-    it('Cannot browse when lab disabled', async function () {
-        mockManager.mockLabsDisabled('webmentions');
-        await agent.get('mentions/')
-            .expectStatus(404);
     });
 });


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/3830

This endpoint is required for recommendations to work: admin-x loads the incoming recommendations by querying the mentions endpoint. If the mentions flag was not enabled, this endpoint wasn't available.