### PR TITLE
Add schema as a post setting

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -93,6 +93,10 @@
                             {{/if}}
                         {{/if}}
 
+                        <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="schema">
+                            <label for="schema-input">{{capitalize @post.displayName}} schema</label>
+                            <GhPsmSchemaInput @post={{this.post}} @triggerId="schema-input" />
+                        </GhFormGroup>
 
                         <GhFormGroup @errors={{this.post.errors}} @hasValidated={{this.post.hasValidated}} @property="customExcerpt">
                             <label for="custom-excerpt">Excerpt</label>

--- a/ghost/admin/app/components/gh-psm-schema-input.hbs
+++ b/ghost/admin/app/components/gh-psm-schema-input.hbs
@@ -1,0 +1,11 @@
+<span class="gh-select">
+    <OneWaySelect @value={{this.selectedSchema}}
+        @options={{this.availableSchemas}}
+        @optionValuePath="name"
+        @optionLabelPath="label"
+        @optionTargetPath="name"
+        @update={{action "updateSchema"}}
+        @data-test-select="post-schema"
+    />
+    {{svg-jar "arrow-down-small"}}
+</span>

--- a/ghost/admin/app/components/gh-psm-schema-input.js
+++ b/ghost/admin/app/components/gh-psm-schema-input.js
@@ -1,0 +1,32 @@
+import Component from '@ember/component';
+import classic from 'ember-classic-decorator';
+import {action, computed} from '@ember/object';
+import {inject as service} from '@ember/service';
+
+const SCHEMAS = [
+    {label: 'Article', name: 'article'},
+    {label: 'News Article', name: 'newsArticle'}
+];
+
+@classic
+export default class GhPsmSchemaInput extends Component {
+    @service settings;
+
+    // public attrs
+    post = null;
+
+    @computed('post.schema')
+    get selectedSchema() {
+        return this.get('post.schema') || 'article';
+    }
+
+    init() {
+        super.init(...arguments);
+        this.availableSchemas = [...SCHEMAS];
+    }
+
+    @action
+    updateSchema(newSchema) {
+        this.post.set('schema', newSchema);
+    }
+}

--- a/ghost/admin/app/controllers/posts-loading.js
+++ b/ghost/admin/app/controllers/posts-loading.js
@@ -26,6 +26,14 @@ export default class PostsLoadingController extends Controller {
         return this.postsController.availableVisibilities;
     }
 
+    get selectedSchema() {
+        return this.postsController.selectedSchema;
+    }
+
+    get availableSchemas() {
+        return this.postsController.availableSchemas;
+    }
+
     get availableTags() {
         return this.postsController.availableTags;
     }

--- a/ghost/admin/app/models/post.js
+++ b/ghost/admin/app/models/post.js
@@ -99,6 +99,7 @@ export default Model.extend(Comparable, ValidationEngine, {
     emailSubject: attr('string'),
     html: attr('string'),
     visibility: attr('string'),
+    schema: attr('string'),
     metaDescription: attr('string'),
     metaTitle: attr('string'),
     mobiledoc: attr('json-string', {defaultValue: (modelInstance) => {

--- a/ghost/admin/app/validators/post.js
+++ b/ghost/admin/app/validators/post.js
@@ -8,6 +8,7 @@ export default BaseValidator.create({
         'title',
         'authors',
         'customExcerpt',
+        'schema',
         'canonicalUrl',
         'codeinjectionHead',
         'codeinjectionFoot',
@@ -70,6 +71,13 @@ export default BaseValidator.create({
     visibility(model) {
         if (isBlank(model.visibility) && !model.isNew) {
             model.errors.add('visibility', 'Please select at least one tier');
+            this.invalidate();
+        }
+    },
+
+    schema(model) {
+        if (isBlank(model.schema) && !model.isNew) {
+            model.errors.add('schema', 'Please select at least one schema');
             this.invalidate();
         }
     },

--- a/ghost/admin/mirage/factories/post.js
+++ b/ghost/admin/mirage/factories/post.js
@@ -13,6 +13,7 @@ export default Factory.extend({
     featureImage(i) { return `/content/images/2015/10/post-${i}.jpg`; },
     html(i) { return `<p>HTML for post ${i}.</p>`; },
     visibility: 'public',
+    schema: 'article',
     metaDescription(i) { return `Meta description for post ${i}.`; },
     metaTitle(i) { return `Meta Title for post ${i}`; },
     ogDescription: null,

--- a/ghost/admin/mirage/factories/tag.js
+++ b/ghost/admin/mirage/factories/tag.js
@@ -5,6 +5,7 @@ export default Factory.extend({
     createdBy: 1,
     description(i) { return `Description for tag ${i}.`; },
     visibility: 'public',
+    schema: 'article',
     featureImage(i) { return `/content/images/2015/10/tag-${i}.jpg`; },
     metaDescription(i) { return `Meta description for tag ${i}.`; },
     metaTitle(i) { return `Meta Title for tag ${i}`; },

--- a/ghost/admin/mirage/factories/tier.js
+++ b/ghost/admin/mirage/factories/tier.js
@@ -7,6 +7,7 @@ export default Factory.extend({
     slug(i) { return `tier-${i}`;},
     type: 'paid',
     visibility: 'none',
+    schema: 'article',
     currency: 'usd',
     monthly_price: 500,
     yearly_price: 5000

--- a/ghost/core/core/frontend/meta/schema.js
+++ b/ghost/core/core/frontend/meta/schema.js
@@ -85,31 +85,62 @@ function getPostSchema(metaData, data) {
 
     const context = data.page ? 'page' : 'post';
 
-    schema = {
-        '@context': 'https://schema.org',
-        '@type': 'Article',
-        publisher: schemaPublisherObject(metaData),
-        author: {
-            '@type': 'Person',
-            name: escapeExpression(data[context].primary_author.name),
-            image: schemaImageObject(metaData.authorImage),
-            url: metaData.authorUrl,
-            sameAs: trimSameAs(data, context),
-            description: data[context].primary_author.metaDescription ?
-                escapeExpression(data[context].primary_author.metaDescription) :
-                null
-        },
-        headline: escapeExpression(metaData.metaTitle),
-        url: metaData.url,
-        datePublished: metaData.publishedDate,
-        dateModified: metaData.modifiedDate,
-        image: schemaImageObject(metaData.coverImage),
-        keywords: metaData.keywords && metaData.keywords.length > 0 ?
-            metaData.keywords.join(', ') : null,
-        description: description,
-        mainEntityOfPage: metaData.url
+    const schemaAuthor = {
+        '@type': 'Person',
+        name: escapeExpression(data[context].primary_author.name),
+        image: schemaImageObject(metaData.authorImage),
+        url: metaData.authorUrl,
+        sameAs: trimSameAs(data, context),
+        description: data[context].primary_author.metaDescription ?
+            escapeExpression(data[context].primary_author.metaDescription) :
+            null
     };
-    schema.author = trimSchema(schema.author);
+
+    switch (metaData.schema) {
+    case 'newsArticle':
+        schema = {
+            '@context': 'https://schema.org',
+            '@type': 'NewsArticle',
+            mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': metaData.url
+            },
+            // completed after
+            author: null,
+            headline: escapeExpression(metaData.metaTitle).substring(0, 100),
+            alternativeHeadline: description,
+            description: description,
+            image: schemaImageObject(metaData.coverImage),
+            datePublished: metaData.publishedDate,
+            dateModified: metaData.modifiedDate,
+            keywords: metaData.keywords && metaData.keywords.length > 0 ?
+                metaData.keywords.join(', ') : null,
+            publisher: schemaPublisherObject(metaData),
+            articleBody: data.post.excerpt,
+            articleSection: data.post.primary_tag ? data.post.primary_tag.name : null
+        };
+        break;
+    default:
+        schema = {
+            '@context': 'https://schema.org',
+            '@type': 'Article',
+            publisher: schemaPublisherObject(metaData),
+            // completed after
+            author: null,
+            headline: escapeExpression(metaData.metaTitle),
+            url: metaData.url,
+            datePublished: metaData.publishedDate,
+            dateModified: metaData.modifiedDate,
+            image: schemaImageObject(metaData.coverImage),
+            keywords: metaData.keywords && metaData.keywords.length > 0 ?
+                metaData.keywords.join(', ') : null,
+            description: description,
+            mainEntityOfPage: metaData.url
+        };
+        break;
+    }
+
+    schema.author = trimSchema(schemaAuthor);
     return trimSchema(schema);
 }
 

--- a/ghost/core/core/server/data/migrations/versions/5.64/2023-09-20-10-50-10-add-schema-column-to-post.js
+++ b/ghost/core/core/server/data/migrations/versions/5.64/2023-09-20-10-50-10-add-schema-column-to-post.js
@@ -1,0 +1,11 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('posts', 'schema', {
+    type: 'string',
+    maxlength: 50,
+    nullable: false,
+    defaultTo: 'article',
+    validations: {
+        isIn: [['article', 'newsArticle']]
+    }
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -69,6 +69,12 @@ module.exports = {
             nullable: false,
             defaultTo: 'public'
         },
+        schema: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'article'
+        },
         email_recipient_filter: {
             type: 'text',
             maxlength: 1000000000,

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '38fa7cfe8d74659ec75a5963b13cb4eb';
+    const currentSchemaHash = '83a8e9293205c85889c0536beba1895f';
     const currentFixturesHash = '6e8d5e89044320656de4900dd0529e68';
     const currentSettingsHash = '3a7ca0aa6a06cba47e3e898aef7029c2';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/posts-service/lib/PostsExporter.js
+++ b/ghost/posts-service/lib/PostsExporter.js
@@ -91,6 +91,7 @@ class PostsExporter {
                 featured: post.get('featured'),
                 tags: post.related('tags').map(tag => tag.get('name')).join(', '),
                 post_access: this.postAccessToString(post),
+                post_schema: this.postSchemaToString(post),
                 email_recipients: email ? this.humanReadableEmailRecipientFilter(email?.get('recipient_filter'), labels, tiers) : null,
                 newsletter_name: newsletters.length > 1 && post.get('newsletter_id') && email ? newsletters.find(newsletter => newsletter.get('id') === post.get('newsletter_id'))?.get('name') : null,
                 sends: email?.get('email_count') ?? null,
@@ -187,6 +188,18 @@ class PostsExporter {
         }
 
         return visibility;
+    }
+
+    postSchemaToString(post) {
+        const schema = post.get('schema');
+        switch (schema) {
+        case 'article':
+            return 'Article';
+        case 'newsArticle':
+            return 'News Article';
+        default:
+            return 'Article';
+        }
     }
 
     /**

--- a/ghost/posts-service/lib/PostsService.js
+++ b/ghost/posts-service/lib/PostsService.js
@@ -16,6 +16,7 @@ const {
 const messages = {
     invalidVisibilityFilter: 'Invalid visibility filter.',
     invalidVisibility: 'Invalid visibility value.',
+    invalidSchema: 'Invalid schema value.',
     invalidTiers: 'Invalid tiers value.',
     invalidTags: 'Invalid tags value.',
     invalidEmailSegment: 'The email segment parameter doesn\'t contain a valid filter',
@@ -257,6 +258,13 @@ class PostsService {
             DomainEvents.dispatch(PostsBulkUnfeaturedEvent.create(updateResult.editIds));
 
             return updateResult;
+        }
+        if (data.action === 'schema') {
+            if (!['article', 'newsArticle'].includes(data.meta.schema)) {
+                throw new errors.IncorrectUsageError({
+                    message: tpl(messages.invalidSchema)
+                });
+            }
         }
         if (data.action === 'access') {
             if (!['public', 'members', 'paid', 'tiers'].includes(data.meta.visibility)) {


### PR DESCRIPTION
Hello 👋 

According to this [documentation](https://gatsby.ghost.org/publishing-options/), Ghost automatically handles the `Article` schema for each post, which is great. However, it is not possible to customize it to use something different from `Article`.

The use case here is to have the [NewsArticle](https://schema.org/NewsArticle) schema. Here is what I suggest in that PR:

- Allow a new setting in the post settings, so that the user can choose the `NewsArticle` schema instead of the default `article`.
- Use that flag in `schema.js` to create a dedicated `NewsArticle` schema for that post.

I tried to make things work correctly, but I am not able to save the update. When I change the dropdown value and click on `Update`, I receive a success message (PUT 200) about the post being updated, but it still uses the previous value. What did I miss here?
Thanks in advance for your support.

Note: The dropdown was a good choice for me since it can easily be extended to other schemas, like `Recipe` for cooking blogs.

<img width="519" alt="Screenshot 2023-09-20 at 14 34 14" src="https://github.com/TryGhost/Ghost/assets/10224453/0cd50069-10cd-4515-bf99-1b08cfd8b6c6">

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9e50a7</samp>

This pull request adds a new feature to Ghost that allows users to select a schema type for their posts, either 'article' or 'newsArticle'. The schema type is a metadata attribute that affects how the posts are displayed and indexed by search engines and social media platforms. The pull request modifies the post model, validator, service, exporter, and schema helper to support the new attribute, and adds a new component and a migration to handle the user interface and the database changes. The pull request also updates the tests and the mock server to reflect the new feature.
