### PR TITLE
Disabled one-click subscribe when Portal checkbox is required

### DIFF
--- a/apps/admin-x-settings/src/api/external-ghost-site.ts
+++ b/apps/admin-x-settings/src/api/external-ghost-site.ts
@@ -7,7 +7,7 @@ export type GhostSiteResponse = {
         logo: URL | null,
         icon: URL | null,
         cover_image : URL | null,
-        allow_self_signup: boolean,
+        allow_external_signup: boolean,
         url: URL,
     }
 }
@@ -35,7 +35,20 @@ export const useExternalGhostSite = () => {
                 });
 
                 // We need to validate all data types here for extra safety
-                if (typeof result !== 'object' || !result.site || typeof result.site !== 'object' || typeof result.site.title !== 'string' || typeof result.site.allow_self_signup !== 'boolean' || typeof result.site.url !== 'string') {
+                if (typeof result !== 'object' || !result.site || typeof result.site !== 'object') {
+                    // eslint-disable-next-line no-console
+                    console.warn('Received invalid response from external Ghost site API', result);
+                    return null;
+                }
+
+                // Temporary mapping (should get removed!)
+                // allow_self_signup was replaced by allow_external_signup
+                if (typeof result.site.allow_self_signup === 'boolean' && typeof result.site.allow_external_signup !== 'boolean') {
+                    result.site.allow_external_signup = result.site.allow_self_signup;
+                }
+
+                // We need to validate all data types here for extra safety
+                if (typeof result.site.title !== 'string' || typeof result.site.allow_external_signup !== 'boolean' || typeof result.site.url !== 'string') {
                     // eslint-disable-next-line no-console
                     console.warn('Received invalid response from external Ghost site API', result);
                     return null;
@@ -74,7 +87,7 @@ export const useExternalGhostSite = () => {
                             logo: result.site.logo ? new URL(result.site.logo) : null,
                             icon: result.site.icon ? new URL(result.site.icon) : null,
                             cover_image: result.site.cover_image ? new URL(result.site.cover_image) : null,
-                            allow_self_signup: result.site.allow_self_signup,
+                            allow_external_signup: result.site.allow_external_signup,
                             url: new URL(result.site.url)
                         }
                     };

--- a/apps/admin-x-settings/src/components/settings/site/recommendations/AddRecommendationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/recommendations/AddRecommendationModal.tsx
@@ -58,7 +58,7 @@ const AddRecommendationModal: React.FC<RoutingModalProps & AddRecommendationModa
                 updatedRecommendation.excerpt = externalGhostSite.site.description ?? formState.excerpt ?? null;
                 updatedRecommendation.featured_image = externalGhostSite.site.cover_image?.toString() ?? formState.featured_image ?? null;
                 updatedRecommendation.favicon = externalGhostSite.site.icon?.toString() ?? externalGhostSite.site.logo?.toString() ?? formState.favicon ?? null;
-                updatedRecommendation.one_click_subscribe = externalGhostSite.site.allow_self_signup;
+                updatedRecommendation.one_click_subscribe = externalGhostSite.site.allow_external_signup;
             } else {
                 // For non-Ghost sites, we use the Oemebd API to fetch metadata
                 const oembed = await queryOembed({

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/site.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/site.js
@@ -16,7 +16,7 @@ module.exports = {
                 'locale',
                 'url',
                 'version',
-                'allow_self_signup',
+                'allow_external_signup',
                 'sentry_dsn',
                 'sentry_env'
             ])

--- a/ghost/core/core/server/services/public-config/site.js
+++ b/ghost/core/core/server/services/public-config/site.js
@@ -14,7 +14,7 @@ module.exports = function getSiteProperties() {
         locale: settingsCache.get('locale'),
         url: urlUtils.urlFor('home', true),
         version: ghostVersion.safe,
-        allow_self_signup: settingsCache.get('allow_self_signup')
+        allow_external_signup: settingsCache.get('allow_self_signup') && !(settingsCache.get('portal_signup_checkbox_required') && settingsCache.get('portal_signup_terms_html'))
     };
 
     if (config.get('client_sentry') && !config.get('client_sentry').disabled) {

--- a/ghost/core/test/e2e-api/admin/__snapshots__/site.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/site.test.js.snap
@@ -4,7 +4,7 @@ exports[`Site API can retrieve config and all expected properties 1: [body] 1`] 
 Object {
   "site": Object {
     "accent_color": "#FF1A75",
-    "allow_self_signup": true,
+    "allow_external_signup": true,
     "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
     "description": "Thoughts, stories and ideas",
     "icon": null,

--- a/ghost/core/test/e2e-api/members/__snapshots__/site.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/site.test.js.snap
@@ -4,7 +4,7 @@ exports[`Site Public Settings Can retrieve site pubic config 1: [body] 1`] = `
 Object {
   "site": Object {
     "accent_color": "#FF1A75",
-    "allow_self_signup": true,
+    "allow_external_signup": true,
     "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
     "description": "Thoughts, stories and ideas",
     "icon": null,
@@ -18,6 +18,64 @@ Object {
 `;
 
 exports[`Site Public Settings Can retrieve site pubic config 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Site Public Settings Sets allow_external_signup to false when members are invite only 1: [body] 1`] = `
+Object {
+  "site": Object {
+    "accent_color": "#FF1A75",
+    "allow_external_signup": false,
+    "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
+    "description": "Thoughts, stories and ideas",
+    "icon": null,
+    "locale": "en",
+    "logo": null,
+    "title": "Ghost",
+    "url": "http://127.0.0.1:2369/",
+    "version": StringMatching /\\\\d\\+\\\\\\.\\\\d\\+/,
+  },
+}
+`;
+
+exports[`Site Public Settings Sets allow_external_signup to false when members are invite only 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "*",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
+exports[`Site Public Settings Sets allow_external_signup to false when portal requires checkbox 1: [body] 1`] = `
+Object {
+  "site": Object {
+    "accent_color": "#FF1A75",
+    "allow_external_signup": false,
+    "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
+    "description": "Thoughts, stories and ideas",
+    "icon": null,
+    "locale": "en",
+    "logo": null,
+    "title": "Ghost",
+    "url": "http://127.0.0.1:2369/",
+    "version": StringMatching /\\\\d\\+\\\\\\.\\\\d\\+/,
+  },
+}
+`;
+
+exports[`Site Public Settings Sets allow_external_signup to false when portal requires checkbox 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "*",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",

--- a/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
+++ b/ghost/core/test/e2e-api/shared/__snapshots__/version.test.js.snap
@@ -4,7 +4,7 @@ exports[`API Versioning Admin API Does an internal rewrite for canary URLs with 
 Object {
   "site": Object {
     "accent_color": "#FF1A75",
-    "allow_self_signup": true,
+    "allow_external_signup": true,
     "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
     "description": "Thoughts, stories and ideas",
     "icon": null,
@@ -83,7 +83,7 @@ exports[`API Versioning Admin API allows invalid accept-version header 1: [body]
 Object {
   "site": Object {
     "accent_color": "#FF1A75",
-    "allow_self_signup": true,
+    "allow_external_signup": true,
     "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
     "description": "Thoughts, stories and ideas",
     "icon": null,
@@ -231,7 +231,7 @@ exports[`API Versioning Admin API responds with content version header even when
 Object {
   "site": Object {
     "accent_color": "#FF1A75",
-    "allow_self_signup": true,
+    "allow_external_signup": true,
     "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
     "description": "Thoughts, stories and ideas",
     "icon": null,
@@ -261,7 +261,7 @@ exports[`API Versioning Admin API responds with current content version header w
 Object {
   "site": Object {
     "accent_color": "#FF1A75",
-    "allow_self_signup": true,
+    "allow_external_signup": true,
     "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
     "description": "Thoughts, stories and ideas",
     "icon": null,
@@ -291,7 +291,7 @@ exports[`API Versioning Admin API responds with current content version header w
 Object {
   "site": Object {
     "accent_color": "#FF1A75",
-    "allow_self_signup": true,
+    "allow_external_signup": true,
     "cover_image": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
     "description": "Thoughts, stories and ideas",
     "icon": null,


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/3911

For now we decided that we don't want to enable one-click-subscribe in case a site has a required checkbox (which isn't shown during the one-click-subscribe flow)