### PR TITLE
Added error boundaries to AdminX to avoid crashing the entire page

### DIFF
--- a/apps/admin-x-settings/src/admin-x-ds/global/ErrorBoundary.stories.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/ErrorBoundary.stories.tsx
@@ -1,0 +1,22 @@
+import ErrorBoundary from './ErrorBoundary';
+import type {Meta, StoryObj} from '@storybook/react';
+
+const meta = {
+    title: 'Global / Error Boundary',
+    component: ErrorBoundary,
+    tags: ['autodocs']
+} satisfies Meta<typeof ErrorBoundary>;
+
+export default meta;
+type Story = StoryObj<typeof ErrorBoundary>;
+
+const RaisesError = () => {
+    throw new Error('Something went wrong');
+};
+
+export const WithError: Story = {
+    args: {
+        name: 'Test Section',
+        children: <RaisesError />
+    }
+};

--- a/apps/admin-x-settings/src/admin-x-ds/global/ErrorBoundary.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import Banner from './Banner';
+import React, {ComponentType, ErrorInfo, ReactNode} from 'react';
+
+/**
+ * Catches errors in child components and displays a banner. Useful to prevent errors in one
+ * section from crashing the entire page
+ */
+class ErrorBoundary extends React.Component<{children: ReactNode, name: ReactNode}> {
+    state = {hasError: false};
+
+    constructor(props: {children: ReactNode, name: ReactNode}) {
+        super(props);
+    }
+
+    static getDerivedStateFromError() {
+        return {hasError: true};
+    }
+
+    componentDidCatch(error: unknown, info: ErrorInfo) {
+        // TODO: Log to Sentry
+        // eslint-disable-next-line no-console
+        console.error(error);
+        // eslint-disable-next-line no-console
+        console.error('In component:', info.componentStack);
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <Banner color='red'>
+                    An error occurred loading {this.props.name}. Please refresh and try again.
+                </Banner>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;
+
+export const withErrorBoundary = <Props extends Record<string, unknown>>(Component: ComponentType<Props>, name: string) => {
+    return function WithErrorBoundary(props: Props) {
+        return (
+            <ErrorBoundary name={name}>
+                <Component {...props} />
+            </ErrorBoundary>
+        );
+    };
+};

--- a/apps/admin-x-settings/src/components/settings/advanced/CodeInjection.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/CodeInjection.tsx
@@ -8,6 +8,7 @@ import TabView from '../../../admin-x-ds/global/TabView';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {ReactCodeMirrorRef} from '@uiw/react-codemirror';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const CodeInjection: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -93,4 +94,4 @@ const CodeInjection: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default CodeInjection;
+export default withErrorBoundary(CodeInjection, 'Code injection');

--- a/apps/admin-x-settings/src/components/settings/advanced/History.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/History.tsx
@@ -2,6 +2,7 @@ import Button from '../../../admin-x-ds/global/Button';
 import React from 'react';
 import SettingGroup from '../../../admin-x-ds/settings/SettingGroup';
 import useRouting from '../../../hooks/useRouting';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const History: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();
@@ -21,4 +22,4 @@ const History: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default History;
+export default withErrorBoundary(History, 'History');

--- a/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
@@ -19,6 +19,7 @@ import {ReactComponent as ZapierIcon} from '../../../assets/icons/zapier.svg';
 import {getSettingValues} from '../../../api/settings';
 import {showToast} from '../../../admin-x-ds/global/Toast';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 interface IntegrationItemProps {
     icon?: React.ReactNode,
@@ -236,4 +237,4 @@ const Integrations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Integrations;
+export default withErrorBoundary(Integrations, 'Integrations');

--- a/apps/admin-x-settings/src/components/settings/advanced/Labs.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/Labs.tsx
@@ -8,6 +8,7 @@ import SettingGroup from '../../../admin-x-ds/settings/SettingGroup';
 import SettingGroupHeader from '../../../admin-x-ds/settings/SettingGroupHeader';
 import TabView, {Tab} from '../../../admin-x-ds/global/TabView';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 type LabsTab = 'labs-migration-options' | 'labs-alpha-features' | 'labs-beta-features';
 
@@ -66,4 +67,4 @@ const Labs: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Labs;
+export default withErrorBoundary(Labs, 'Labs');

--- a/apps/admin-x-settings/src/components/settings/email/DefaultRecipients.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/DefaultRecipients.tsx
@@ -10,6 +10,7 @@ import {getSettingValues} from '../../../api/settings';
 import {useBrowseLabels} from '../../../api/labels';
 import {useBrowseOffers} from '../../../api/offers';
 import {useBrowseTiers} from '../../../api/tiers';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 type RefipientValueArgs = {
     defaultEmailRecipients: string;
@@ -206,4 +207,4 @@ const DefaultRecipients: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default DefaultRecipients;
+export default withErrorBoundary(DefaultRecipients, 'Default recipients');

--- a/apps/admin-x-settings/src/components/settings/email/EnableNewsletters.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/EnableNewsletters.tsx
@@ -7,6 +7,7 @@ import Toggle from '../../../admin-x-ds/global/form/Toggle';
 import useRouting from '../../../hooks/useRouting';
 import {Setting, getSettingValues, useEditSettings} from '../../../api/settings';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const EnableNewsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();
@@ -75,4 +76,4 @@ const EnableNewsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     </SettingGroup>);
 };
 
-export default EnableNewsletters;
+export default withErrorBoundary(EnableNewsletters, 'Newsletter sending');

--- a/apps/admin-x-settings/src/components/settings/email/Mailgun.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/Mailgun.tsx
@@ -7,6 +7,7 @@ import SettingGroupContent from '../../../admin-x-ds/settings/SettingGroupConten
 import TextField from '../../../admin-x-ds/global/form/TextField';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {getSettingValues, useEditSettings} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const MAILGUN_REGIONS = [
     {label: '🇺🇸 US', value: 'https://api.mailgun.net/v3'},
@@ -122,4 +123,4 @@ const MailGun: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default MailGun;
+export default withErrorBoundary(MailGun, 'Mailgun');

--- a/apps/admin-x-settings/src/components/settings/email/Newsletters.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/Newsletters.tsx
@@ -5,6 +5,7 @@ import SettingGroup from '../../../admin-x-ds/settings/SettingGroup';
 import TabView from '../../../admin-x-ds/global/TabView';
 import useRouting from '../../../hooks/useRouting';
 import {useBrowseNewsletters} from '../../../api/newsletters';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();
@@ -46,4 +47,4 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Newsletters;
+export default withErrorBoundary(Newsletters, 'Newsletters');

--- a/apps/admin-x-settings/src/components/settings/general/Facebook.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Facebook.tsx
@@ -7,6 +7,7 @@ import useSettingGroup from '../../../hooks/useSettingGroup';
 import {ReactComponent as FacebookLogo} from '../../../admin-x-ds/assets/images/facebook-logo.svg';
 import {getImageUrl, useUploadImage} from '../../../api/images';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const Facebook: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -113,4 +114,4 @@ const Facebook: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Facebook;
+export default withErrorBoundary(Facebook, 'Facebook card');

--- a/apps/admin-x-settings/src/components/settings/general/LockSite.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/LockSite.tsx
@@ -7,6 +7,7 @@ import TextField from '../../../admin-x-ds/global/form/TextField';
 import Toggle from '../../../admin-x-ds/global/form/Toggle';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const LockSite: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -108,4 +109,4 @@ const LockSite: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default LockSite;
+export default withErrorBoundary(LockSite, 'Make site private');

--- a/apps/admin-x-settings/src/components/settings/general/Metadata.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Metadata.tsx
@@ -7,6 +7,7 @@ import useSettingGroup from '../../../hooks/useSettingGroup';
 import {ReactComponent as GoogleLogo} from '../../../admin-x-ds/assets/images/google-logo.svg';
 import {ReactComponent as MagnifyingGlass} from '../../../admin-x-ds/assets/icons/magnifying-glass.svg';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 interface SearchEnginePreviewProps {
     title: string;
@@ -126,4 +127,4 @@ const Metadata: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Metadata;
+export default withErrorBoundary(Metadata, 'Meta data');

--- a/apps/admin-x-settings/src/components/settings/general/PublicationLanguage.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/PublicationLanguage.tsx
@@ -4,6 +4,7 @@ import SettingGroupContent from '../../../admin-x-ds/settings/SettingGroupConten
 import TextField from '../../../admin-x-ds/global/form/TextField';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const PublicationLanguage: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -71,4 +72,4 @@ const PublicationLanguage: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default PublicationLanguage;
+export default withErrorBoundary(PublicationLanguage, 'Publication language');

--- a/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
@@ -87,10 +87,10 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const twitterInputRef = useRef<HTMLInputElement>(null);
 
-    const [facebookHandle, twitterHandle] = getSettingValues(localSettings, ['facebook', 'twitter']) as string[];
+    const [facebookHandle, twitterHandle] = getSettingValues<string | null>(localSettings, ['facebook', 'twitter']);
 
-    const [facebookUrl, setFacebookUrl] = useState(facebookHandleToUrl(facebookHandle));
-    const [twitterUrl, setTwitterUrl] = useState(twitterHandleToUrl(twitterHandle));
+    const [facebookUrl, setFacebookUrl] = useState(facebookHandle ? facebookHandleToUrl(facebookHandle) : '');
+    const [twitterUrl, setTwitterUrl] = useState(twitterHandle ? twitterHandleToUrl(twitterHandle) : '');
 
     const values = (
         <SettingGroupContent

--- a/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/SocialAccounts.tsx
@@ -5,6 +5,7 @@ import TextField from '../../../admin-x-ds/global/form/TextField';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import validator from 'validator';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 function validateFacebookUrl(newUrl: string) {
     const errMessage = 'The URL must be in a format like https://www.facebook.com/yourPage';
@@ -199,4 +200,4 @@ const SocialAccounts: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default SocialAccounts;
+export default withErrorBoundary(SocialAccounts, 'Social accounts');

--- a/apps/admin-x-settings/src/components/settings/general/TimeZone.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/TimeZone.tsx
@@ -6,6 +6,7 @@ import timezoneData from '@tryghost/timezone-data';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {getLocalTime} from '../../../utils/helpers';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 interface TimezoneDataDropdownOption {
     name: string;
@@ -100,4 +101,4 @@ const TimeZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default TimeZone;
+export default withErrorBoundary(TimeZone, 'Site timezone');

--- a/apps/admin-x-settings/src/components/settings/general/TitleAndDescription.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/TitleAndDescription.tsx
@@ -4,6 +4,7 @@ import SettingGroupContent from '../../../admin-x-ds/settings/SettingGroupConten
 import TextField from '../../../admin-x-ds/global/form/TextField';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const TitleAndDescription: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -82,4 +83,4 @@ const TitleAndDescription: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default TitleAndDescription;
+export default withErrorBoundary(TitleAndDescription, 'Title & description');

--- a/apps/admin-x-settings/src/components/settings/general/Twitter.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Twitter.tsx
@@ -7,6 +7,7 @@ import useSettingGroup from '../../../hooks/useSettingGroup';
 import {ReactComponent as TwitterLogo} from '../../../admin-x-ds/assets/images/twitter-logo.svg';
 import {getImageUrl, useUploadImage} from '../../../api/images';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const Twitter: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -115,4 +116,4 @@ const Twitter: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Twitter;
+export default withErrorBoundary(Twitter, 'Twitter card');

--- a/apps/admin-x-settings/src/components/settings/general/Users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Users.tsx
@@ -14,6 +14,7 @@ import {UserInvite, useAddInvite, useDeleteInvite} from '../../../api/invites';
 import {generateAvatarColor, getInitials} from '../../../utils/helpers';
 import {showToast} from '../../../admin-x-ds/global/Toast';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 interface OwnerProps {
     user: User;
@@ -258,4 +259,4 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
     );
 };
 
-export default Users;
+export default withErrorBoundary(Users, 'Staff');

--- a/apps/admin-x-settings/src/components/settings/membership/Access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Access.tsx
@@ -8,6 +8,7 @@ import {GroupBase, MultiValue} from 'react-select';
 import {getOptionLabel} from '../../../utils/helpers';
 import {getSettingValues} from '../../../api/settings';
 import {useBrowseTiers} from '../../../api/tiers';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const MEMBERS_SIGNUP_ACCESS_OPTIONS = [
     {
@@ -190,4 +191,4 @@ const Access: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Access;
+export default withErrorBoundary(Access, 'Access');

--- a/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Analytics.tsx
@@ -6,6 +6,7 @@ import Toggle from '../../../admin-x-ds/global/form/Toggle';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {getSettingValues} from '../../../api/settings';
 import {usePostsExports} from '../../../api/posts';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -105,4 +106,4 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Analytics;
+export default withErrorBoundary(Analytics, 'Analytics');

--- a/apps/admin-x-settings/src/components/settings/membership/Portal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Portal.tsx
@@ -2,6 +2,7 @@ import Button from '../../../admin-x-ds/global/Button';
 import React from 'react';
 import SettingGroup from '../../../admin-x-ds/settings/SettingGroup';
 import useRouting from '../../../hooks/useRouting';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const Portal: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();
@@ -22,4 +23,4 @@ const Portal: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Portal;
+export default withErrorBoundary(Portal, 'Portal settings');

--- a/apps/admin-x-settings/src/components/settings/membership/Tiers.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Tiers.tsx
@@ -8,6 +8,7 @@ import useRouting from '../../../hooks/useRouting';
 import {Tier, getActiveTiers, getArchivedTiers, useBrowseTiers} from '../../../api/tiers';
 import {checkStripeEnabled} from '../../../api/settings';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const StripeConnectedButton: React.FC<{className?: string; onClick: () => void;}> = ({className, onClick}) => {
     className = clsx(
@@ -83,4 +84,4 @@ const Tiers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Tiers;
+export default withErrorBoundary(Tiers, 'Tiers');

--- a/apps/admin-x-settings/src/components/settings/membership/TipsOrDonations.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/TipsOrDonations.tsx
@@ -9,6 +9,7 @@ import useSettingGroup from '../../../hooks/useSettingGroup';
 import {confirmIfDirty} from '../../../utils/modals';
 import {currencySelectGroups, getSymbol, validateCurrencyAmount} from '../../../utils/currency';
 import {getSettingValues} from '../../../api/settings';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const TipsOrDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -132,4 +133,4 @@ const TipsOrDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default TipsOrDonations;
+export default withErrorBoundary(TipsOrDonations, 'Tips or donations');

--- a/apps/admin-x-settings/src/components/settings/site/AnnouncementBar.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/AnnouncementBar.tsx
@@ -2,6 +2,7 @@ import Button from '../../../admin-x-ds/global/Button';
 import React from 'react';
 import SettingGroup from '../../../admin-x-ds/settings/SettingGroup';
 import useRouting from '../../../hooks/useRouting';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const AnnouncementBar: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();
@@ -21,4 +22,4 @@ const AnnouncementBar: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default AnnouncementBar;
+export default withErrorBoundary(AnnouncementBar, 'Announcement bar');

--- a/apps/admin-x-settings/src/components/settings/site/DesignSetting.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/DesignSetting.tsx
@@ -2,6 +2,7 @@ import Button from '../../../admin-x-ds/global/Button';
 import React from 'react';
 import SettingGroup from '../../../admin-x-ds/settings/SettingGroup';
 import useRouting from '../../../hooks/useRouting';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const DesignSetting: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();
@@ -21,4 +22,4 @@ const DesignSetting: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default DesignSetting;
+export default withErrorBoundary(DesignSetting, 'Branding and design');

--- a/apps/admin-x-settings/src/components/settings/site/Navigation.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/Navigation.tsx
@@ -2,6 +2,7 @@ import Button from '../../../admin-x-ds/global/Button';
 import React from 'react';
 import SettingGroup from '../../../admin-x-ds/settings/SettingGroup';
 import useRouting from '../../../hooks/useRouting';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const Navigation: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();
@@ -21,4 +22,4 @@ const Navigation: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Navigation;
+export default withErrorBoundary(Navigation, 'Navigation');

--- a/apps/admin-x-settings/src/components/settings/site/Recommendations.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/Recommendations.tsx
@@ -8,6 +8,7 @@ import TabView from '../../../admin-x-ds/global/TabView';
 import useRouting from '../../../hooks/useRouting';
 import useSettingGroup from '../../../hooks/useSettingGroup';
 import {useBrowseRecommendations} from '../../../api/recommendations';
+import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
 const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
@@ -74,4 +75,4 @@ const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 };
 
-export default Recommendations;
+export default withErrorBoundary(Recommendations, 'Recommendations');


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3832

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da016c5</samp>

No summary available (Limit exceeded: required to process 65358 tokens, but only 50000 are allowed per call)
