### PR TITLE
Fixed edit a recommendation on page 2 or more

### DIFF
--- a/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
@@ -56,7 +56,7 @@ const modalPaths: {[key: string]: ModalName} = {
     'integrations/add': 'AddIntegrationModal',
     'integrations/show/:id': 'CustomIntegrationModal',
     'recommendations/add': 'AddRecommendationModal',
-    'recommendations/:id': 'EditRecommendationModal',
+    'recommendations/edit': 'EditRecommendationModal',
     'announcement-bar/edit': 'AnnouncementBarModal',
     'embed-signup-form/show': 'EmbedSignupFormModal'
 };

--- a/apps/admin-x-settings/src/components/providers/routing/modals.tsx
+++ b/apps/admin-x-settings/src/components/providers/routing/modals.tsx
@@ -47,9 +47,10 @@ const modals = {
     ZapierModal,
     AnnouncementBarModal,
     EmbedSignupFormModal
-} satisfies {[key: string]: ModalComponent};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+} satisfies {[key: string]: ModalComponent<any>};
 
 export default modals;
 
 export type ModalName = keyof typeof modals;
-export type ModalComponent = React.FC<NiceModalHocProps & RoutingModalProps>
+export type ModalComponent<Props = object> = React.FC<NiceModalHocProps & RoutingModalProps & Props>;

--- a/apps/admin-x-settings/src/components/settings/site/recommendations/EditRecommendationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/recommendations/EditRecommendationModal.tsx
@@ -5,17 +5,17 @@ import React from 'react';
 import RecommendationReasonForm from './RecommendationReasonForm';
 import useForm from '../../../../hooks/useForm';
 import useRouting from '../../../../hooks/useRouting';
-import {Recommendation, useBrowseRecommendations, useDeleteRecommendation, useEditRecommendation} from '../../../../api/recommendations';
+import {Recommendation, useDeleteRecommendation, useEditRecommendation} from '../../../../api/recommendations';
 import {RoutingModalProps} from '../../../providers/RoutingProvider';
 import {showToast} from '../../../../admin-x-ds/global/Toast';
 import {toast} from 'react-hot-toast';
 
-interface AddRecommendationModalProps {
+interface EditRecommendationModalProps {
     recommendation: Recommendation,
     animate?: boolean
 }
 
-const EditRecommendationModalConfirm: React.FC<AddRecommendationModalProps> = ({recommendation, animate}) => {
+const EditRecommendationModal: React.FC<RoutingModalProps & EditRecommendationModalProps> = ({recommendation, animate}) => {
     const modal = useModal();
     const {updateRoute} = useRouting();
     const {mutateAsync: editRecommendation} = useEditRecommendation();
@@ -112,17 +112,6 @@ const EditRecommendationModalConfirm: React.FC<AddRecommendationModalProps> = ({
     >
         <RecommendationReasonForm errors={errors} formState={formState} showURL={true} updateForm={updateForm as any}/>
     </Modal>;
-};
-
-const EditRecommendationModal: React.FC<RoutingModalProps> = ({params}) => {
-    const {data: {recommendations} = {}} = useBrowseRecommendations();
-    const recommendation = recommendations?.find(({id}) => id === params?.id);
-
-    if (recommendation) {
-        return <EditRecommendationModalConfirm recommendation={recommendation} />;
-    } else {
-        return null;
-    }
 };
 
 export default NiceModal.create(EditRecommendationModal);

--- a/apps/admin-x-settings/src/components/settings/site/recommendations/RecommendationList.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/recommendations/RecommendationList.tsx
@@ -4,6 +4,8 @@ import RecommendationIcon from './RecommendationIcon';
 import Table from '../../../../admin-x-ds/global/Table';
 import TableCell from '../../../../admin-x-ds/global/TableCell';
 // import TableHead from '../../../../admin-x-ds/global/TableHead';
+import EditRecommendationModal from './EditRecommendationModal';
+import NiceModal from '@ebay/nice-modal-react';
 import TableRow from '../../../../admin-x-ds/global/TableRow';
 import useRouting from '../../../../hooks/useRouting';
 import {PaginationData} from '../../../../hooks/usePagination';
@@ -16,10 +18,16 @@ interface RecommendationListProps {
 }
 
 const RecommendationItem: React.FC<{recommendation: Recommendation}> = ({recommendation}) => {
-    const {updateRoute} = useRouting();
+    const {route} = useRouting();
 
+    // Navigate to the edit page, without changing the route
+    // This helps to avoid fetching the recommendation
     const showDetails = () => {
-        updateRoute({route: `recommendations/${recommendation.id}`});
+        NiceModal.show(EditRecommendationModal, {
+            pathName: route,
+            animate: false,
+            recommendation: recommendation
+        });
     };
 
     const showSubscribes = recommendation.one_click_subscribe && (recommendation.count?.subscribers || recommendation.count?.clicks === 0);


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3903

- we do not update the route when opening "Edit a recommendation" anymore. By doing so, we can pass the recommendation object to the edit page, without having to refetch it from the database
