### PR TITLE
Added support for Ghost sites hosted on a subdirectory, when adding a rec

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/recommendations/AddRecommendationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/recommendations/AddRecommendationModal.tsx
@@ -48,8 +48,15 @@ const AddRecommendationModal: React.FC<RoutingModalProps & AddRecommendationModa
                 throw new AlreadyExistsError('A recommendation with this URL already exists.');
             }
 
-            // Check if it s a Ghost site or not
-            let externalGhostSite = validatedUrl.protocol === 'https:' ? (await queryExternalGhostSite('https://' + validatedUrl.host)) : null;
+            // Check if it's a Ghost site or not:
+            // 1. Check the full path first. This is the most common use case, and also helps to cover Ghost sites that are hosted on a subdirectory
+            // 2. If needed, check the origin. This helps to cover cases where the recommendation URL is a subpage or a post URL of the Ghost site
+            let externalGhostSite = null;
+            externalGhostSite = await queryExternalGhostSite(validatedUrl.toString());
+
+            if (!externalGhostSite && validatedUrl.pathname !== '' && validatedUrl.pathname !== '/') {
+                externalGhostSite = await queryExternalGhostSite(validatedUrl.origin);
+            }
 
             // Use the hostname as fallback title
             const defaultTitle = validatedUrl.hostname.replace('www.', '');


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/3915
- when adding a recommendation, we now ping the pull path first to check whether it's a Ghost site. This is the most common case and also helps to cover Ghost sites that are hosted on a subdirectory.
- if needed, we ping the origin path to perform the same check. This helps to cover the case where the recommended URL is a subpage or post of a Ghost site
- we now have 4 networks calls in the worst case when adding a recommendation: uniqueness validation, two checks to determine whether it's a Ghost site, read metadata from oembed. Each of these have a timeout of 5 seconds, so there's a max. waiting time of 20 sec in the worst case
