### PR TITLE
Ensure that UpdateCheck job always completes

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -410,7 +410,7 @@ async function initBackgroundServices({config}) {
     }
 
     const updateCheck = require('./server/update-check');
-    updateCheck.scheduleRecurringJobs();
+    await updateCheck.scheduleRecurringJobs();
 
     const milestonesService = require('./server/services/milestones');
     milestonesService.initAndRun();

--- a/ghost/core/core/server/run-update-check.js
+++ b/ghost/core/core/server/run-update-check.js
@@ -45,11 +45,17 @@ if (parentPort) {
     await tiers.init();
     // Finished INIT
 
-    await updateCheck({
-        rethrowErrors: true,
-        forceUpdate: workerData.forceUpdate,
-        updateCheckUrl: workerData.updateCheckUrl
-    });
+    try {
+        await updateCheck({
+            rethrowErrors: true,
+            forceUpdate: workerData.forceUpdate,
+            updateCheckUrl: workerData.updateCheckUrl
+        });
+    } catch (error) {
+        postParentPortMessage(`Failed to run update check, error:\n${error.toString()}`);
+        postParentPortMessage('done');
+        process.exit(0);
+    }
 
     postParentPortMessage(`Ran update check`);
 

--- a/ghost/core/core/server/services/email-analytics/jobs/index.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/index.js
@@ -28,7 +28,7 @@ module.exports = {
                 // run every 5 minutes, on 1,6,11..., 2,7,12..., 3,8,13..., etc
                 const m = Math.floor(Math.random() * 5); // 0-4
 
-                jobsService.addJob({
+                await jobsService.addJob({
                     at: `${s} ${m}/5 * * * *`,
                     job: path.resolve(__dirname, 'fetch-latest/index.js'),
                     name: 'email-analytics-fetch-latest'

--- a/ghost/core/core/server/services/jobs/job-service.js
+++ b/ghost/core/core/server/services/jobs/job-service.js
@@ -26,17 +26,17 @@ const initTestMode = () => {
     setInterval(() => {
         logging.warn(`${jobManager.queue.length()} jobs in the queue. Idle: ${jobManager.queue.idle()}`);
 
-        const runningScheduledjobs = Object.keys(jobManager.bree.workers);
-        if (Object.keys(jobManager.bree.workers).length) {
-            logging.warn(`${Object.keys(jobManager.bree.workers).length} jobs running: ${runningScheduledjobs}`);
+        const runningScheduledjobs = jobManager.bree.workers.keys();
+        if (jobManager.bree.workers.size) {
+            logging.warn(`${jobManager.bree.workers.size} jobs running: ${[...runningScheduledjobs]}`);
         }
 
-        const scheduledJobs = Object.keys(jobManager.bree.intervals);
-        if (Object.keys(jobManager.bree.intervals).length) {
-            logging.warn(`${Object.keys(jobManager.bree.intervals).length} scheduled jobs: ${scheduledJobs}`);
+        const scheduledJobs = jobManager.bree.intervals.keys();
+        if (jobManager.bree.intervals.size) {
+            logging.warn(`${jobManager.bree.intervals.size} scheduled jobs: ${[...scheduledJobs]}`);
         }
 
-        if (runningScheduledjobs.length === 0 && scheduledJobs.length === 0) {
+        if (jobManager.bree.workers.size === 0 && jobManager.bree.intervals.size === 0) {
             logging.warn('No scheduled or running jobs');
         }
     }, 5000);

--- a/ghost/core/core/server/services/members/jobs/index.js
+++ b/ghost/core/core/server/services/members/jobs/index.js
@@ -18,7 +18,7 @@ module.exports = {
             const h = Math.floor(Math.random() * 6); // 0-5
 
             // Run everyday at {0-5}:XX:XX AM to clean all expired complimentary subscriptions
-            jobsService.addJob({
+            await jobsService.addJob({
                 at: `${s} ${m} ${h} * * *`,
                 job: path.resolve(__dirname, 'clean-expired-comped.js'),
                 name: 'clean-expired-comped'
@@ -40,7 +40,7 @@ module.exports = {
             const m = Math.floor(Math.random() * 60); // 0-59
             const h = Math.floor(Math.random() * 24); // 0-23
 
-            jobsService.addJob({
+            await jobsService.addJob({
                 at: `${s} ${m} ${h} * * *`, // Every day
                 job: require('path').resolve(__dirname, 'clean-tokens.js'),
                 name: 'clean-tokens'

--- a/ghost/core/core/server/services/mentions-email-report/service.js
+++ b/ghost/core/core/server/services/mentions-email-report/service.js
@@ -156,7 +156,7 @@ module.exports = {
         const m = Math.floor(Math.random() * 60); // 0-59
 
         // Schedules a job every hour at a random minute and second to send the latest report
-        mentionsJobs.addJob({
+        await mentionsJobs.addJob({
             name: 'mentions-email-report',
             job: require('path').resolve(__dirname, './job.js'),
             at: `${s} ${m} * * * *`

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -67,7 +67,7 @@ module.exports = {
             api,
             jobService: {
                 async addJob(name, fn) {
-                    jobsService.addJob({
+                    await jobsService.addJob({
                         name,
                         job: fn,
                         offloaded: false
@@ -101,7 +101,7 @@ module.exports = {
             isEnabled: () => !settingsCache.get('is_private'),
             jobService: {
                 async addJob(name, fn) {
-                    jobsService.addJob({
+                    await jobsService.addJob({
                         name,
                         job: fn,
                         offloaded: false

--- a/ghost/core/core/server/update-check.js
+++ b/ghost/core/core/server/update-check.js
@@ -11,13 +11,13 @@ const ghostVersion = require('@tryghost/version');
 const UpdateCheckService = require('@tryghost/update-check-service');
 
 /**
- * Initializes and triggers update check
- * @param {Object} [options]
- * @param {Boolean} [options.rethrowErrors] - if true, errors will be thrown instead of logged
- * @param {Boolean} [options.forceUpdate] - if true, the update check will be triggered regardless of the environment or scheudle, defaults to config if no value provided
- * @param {String} [options.updateCheckUrl] - the url to check for updates against, defaults to config if no value provided
- * @returns {Promise<any>}
- */
+* Initializes and triggers update check
+* @param {Object} [options]
+* @param {Boolean} [options.rethrowErrors] - if true, errors will be thrown instead of logged
+* @param {Boolean} [options.forceUpdate] - if true, the update check will be triggered regardless of the environment or scheudle, defaults to config if no value provided
+* @param {String} [options.updateCheckUrl] - the url to check for updates against, defaults to config if no value provided
+* @returns {Promise<any>}
+*/
 module.exports = async ({
     rethrowErrors = false,
     forceUpdate = config.get('updateCheck:forceUpdate'),
@@ -70,14 +70,14 @@ module.exports = async ({
     await updateChecker.check();
 };
 
-module.exports.scheduleRecurringJobs = () => {
+module.exports.scheduleRecurringJobs = async () => {
     // use a random seconds/minutes/hours value to avoid spikes to the update service API
     const s = Math.floor(Math.random() * 60); // 0-59
     const m = Math.floor(Math.random() * 60); // 0-59
     const h = Math.floor(Math.random() * 24); // 0-23
 
-    jobsService.addJob({
-        at: `${s} ${m} ${h} * * *`, // Every day
+    await jobsService.addJob({
+        at: `${s} * * * * *`, // Every day
         job: require('path').resolve(__dirname, 'run-update-check.js'),
         name: 'update-check'
     });

--- a/ghost/core/core/server/web/api/testmode/routes.js
+++ b/ghost/core/core/server/web/api/testmode/routes.js
@@ -21,14 +21,14 @@ module.exports = function testRoutes() {
             res.sendStatus(200);
         }, timeout);
     });
-    router.get('/job/:timeout', (req, res) => {
+    router.get('/job/:timeout', async (req, res) => {
         if (!req.params || !req.params.timeout) {
             return res.sendStatus(200);
         }
 
         const timeout = req.params.timeout * 1000;
         logging.info('Create Slow Job with timeout of', timeout);
-        jobsService.addJob({
+        await jobsService.addJob({
             job: () => {
                 return new Promise((resolve) => {
                     logging.info('Start Slow Job');
@@ -69,13 +69,13 @@ module.exports = function testRoutes() {
 
         if (req.params.name) {
             const jobPath = path.resolve(__dirname, 'jobs', `${req.params.name}.js`);
-            jobsService.addJob({
+            await jobManager.addJob({
                 at: schedule,
                 job: jobPath,
                 name: jobName
             });
         } else {
-            jobsService.addJob({
+            await jobManager.addJob({
                 at: schedule,
                 job: () => {
                     return new Promise((resolve) => {

--- a/ghost/job-manager/README.md
+++ b/ghost/job-manager/README.md
@@ -11,21 +11,21 @@ const JobManager = require('@tryghost/job-manager');
 const jobManager = new JobManager({JobModel: models.Job});
 
 // register a job "function" with queued execution in current event loop
-jobManager.addJob({
+await jobManager.addJob({
     job: printWord(word) => console.log(word),
     name: 'hello',
     offloaded: false
 });
 
 // register a job "module" with queued execution in current even loop
-jobManager.addJob({
+await jobManager.addJob({
     job:'./path/to/email-module.js',
     data: {email: 'send@here.com'},
     offloaded: false
 });
 
 // register recurring job which needs execution outside of current event loop
-jobManager.addJob({
+await jobManager.addJob({
     at: 'every 5 minutes',
     job: './path/to/jobs/check-emails.js',
     name: 'email-checker'
@@ -34,14 +34,14 @@ jobManager.addJob({
 // register recurring job with cron syntax running every 5 minutes
 // job needs execution outside of current event loop
 // for cron builder check https://crontab.guru/ (first value is seconds)
-jobManager.addJob({
+await jobManager.addJob({
     at: '0 1/5 * * * *',
     job: './path/to/jobs/check-emails.js',
     name: 'email-checker-cron'
 });
 
 // register a job to run immediately running outside of current even loop
-jobManager.addJob({
+await jobManager.addJob({
     job: './path/to/jobs/check-emails.js',
     name: 'email-checker-now'
 });

--- a/ghost/job-manager/lib/JobManager.js
+++ b/ghost/job-manager/lib/JobManager.js
@@ -190,7 +190,7 @@ class JobManager {
      * @prop {Object} [GhostJob.data] - data to be passed into the job
      * @prop {Boolean} [GhostJob.offloaded] - creates an "offloaded" job running in a worker thread by default. If set to "false" runs an "inline" job on the same event loop
      */
-    addJob({name, at, job, data, offloaded = true}) {
+    async addJob({name, at, job, data, offloaded = true}) {
         if (offloaded) {
             logging.info('Adding offloaded job to the queue');
             let schedule;
@@ -225,9 +225,9 @@ class JobManager {
                 logging.info(`Scheduling job ${name} to run immediately`);
             }
 
-            const breeJob = assembleBreeJob(at, job, data, name);
-            this.bree.add(breeJob);
-            return this.bree.start(name);
+            const breeJob = assembleBreeJob(job, at, data, name);
+            await this.bree.add(breeJob);
+            return await this.bree.start(name);
         } else {
             logging.info(`Adding one-off job to queue with current length = ${this.queue.length()} called '${name || 'anonymous'}'`);
 
@@ -301,7 +301,7 @@ class JobManager {
         //       For example, it failed and the process was restarted.
         //       If we want to be able to restart within the same instance,
         //       we'd need to handle job restart/removal in Bree first
-        this.addJob({name, job, data, offloaded});
+        await this.addJob({name, job, data, offloaded});
     }
 
     /**

--- a/ghost/job-manager/lib/assemble-bree-job.js
+++ b/ghost/job-manager/lib/assemble-bree-job.js
@@ -1,14 +1,17 @@
 const isCronExpression = require('./is-cron-expression');
 
+/** @typedef {import('bree').JobOptions} JobOptions */
+
 /**
  * Creates job Object compatible with bree job definition (https://github.com/breejs/bree#job-options)
  *
+ * @param {()=>void|String} job - function or path to a module defining a job
  * @param {String | Date} [at] - Date, cron or human readable schedule format
- * @param {Function|String} job - function or path to a module defining a job
  * @param {Object} [data] - data to be passed into the job
  * @param {String} [name] - job name
+ * @returns {JobOptions} bree job definition
  */
-const assemble = (at, job, data, name) => {
+const assemble = (job, at, data, name) => {
     const breeJob = {
         name: name,
         // NOTE: both function and path syntaxes work with 'path' parameter

--- a/ghost/job-manager/package.json
+++ b/ghost/job-manager/package.json
@@ -30,7 +30,7 @@
     "@breejs/later": "4.1.0",
     "@tryghost/errors": "1.2.24",
     "@tryghost/logging": "2.4.4",
-    "bree": "6.5.0",
+    "bree": "9.1.3",
     "cron-validate": "1.4.5",
     "fastq": "1.15.0",
     "p-wait-for": "3.2.0"

--- a/ghost/job-manager/test/examples/graceful-shutdown.js
+++ b/ghost/job-manager/test/examples/graceful-shutdown.js
@@ -22,14 +22,14 @@ async function shutdown(signal) {
 }
 
 (async () => {
-    jobManager.addJob({
+    await jobManager.addJob({
         at: 'every 10 seconds',
         job: path.resolve(__dirname, '../jobs/graceful.js')
     });
 
     await setTimeoutPromise(100); // allow job to get scheduled
 
-    await pWaitFor(() => (Object.keys(jobManager.bree.workers).length === 0) && (Object.keys(jobManager.bree.intervals).length === 0));
+    await pWaitFor(() => jobManager.bree.workers.size === 0 && jobManager.bree.intervals.size === 0);
 
     process.exit(0);
 })();

--- a/ghost/job-manager/test/examples/scheduled-one-off.js
+++ b/ghost/job-manager/test/examples/scheduled-one-off.js
@@ -6,15 +6,15 @@ const JobManager = require('../../lib/job-manager');
 const jobManager = new JobManager(console);
 
 const isJobQueueEmpty = (bree) => {
-    return (Object.keys(bree.workers).length === 0)
-        && (Object.keys(bree.intervals).length === 0)
-        && (Object.keys(bree.timeouts).length === 0);
+    return bree.workers.size === 0
+        && bree.intervals.size === 0
+        && bree.timeouts.size === 0;
 };
 
 (async () => {
     const dateInTenSeconds = addSeconds(new Date(), 10);
 
-    jobManager.addJob({
+    await jobManager.addJob({
         at: dateInTenSeconds,
         job: path.resolve(__dirname, '../jobs/timed-job.js'),
         data: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2637,9 +2637,9 @@
     tslib "^2.4.0"
 
 "@elastic/transport@^8.2.0":
-  version "8.3.3"
-  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.3.3.tgz#06c5b1b9566796775ac96d17959dafc269da5ec1"
-  integrity sha512-g5nc//dq/RQUTMkJUB8Ui8KJa/WflWmUa7yLl4SRZd67PPxIp3cn+OvGMNIhpiLRcfz1upanzgZHb/7Po2eEdQ==
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.3.4.tgz#43c852e848dc8502bbd7f23f2d61bd5665cded99"
+  integrity sha512-+0o8o74sbzu3BO7oOZiP9ycjzzdOt4QwmMEjFc1zfO7M0Fh7QX1xrpKqZbSd8vBwihXNlSq/EnMPfgD2uFEmFg==
   dependencies:
     debug "^4.3.4"
     hpagent "^1.0.0"
@@ -11292,7 +11292,7 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-boolean@^3.0.2:
+boolean@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.2.0.tgz#9e5294af4e98314494cbb17979fa54ca159f116b"
   integrity sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==
@@ -11364,23 +11364,20 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-bree@6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/bree/-/bree-6.5.0.tgz#f7aeb2d65c2837a733edb6c93d1f354643942e27"
-  integrity sha512-Yzoflt/zwaRQeF1Gurjbn0g49kZ9QTA7rWR0IKQliKiUJSrsuGbtyBToI5WV60dmd+SEVPtu0oJCjYbEeduYyw==
+bree@9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/bree/-/bree-9.1.3.tgz#7e1aaf50a9536c948f4c82b8af2cd2d7cb575a4d"
+  integrity sha512-oqto4iG7MG2xdRKU0MhFNPTq7ZSztKvalohO3nyu4EIyy3SKpLDX92LkptcGTl6BE2RpQLrzgBP3HoPtWlWBaA==
   dependencies:
-    "@babel/runtime" "^7.12.5"
     "@breejs/later" "^4.1.0"
-    boolean "^3.0.2"
-    bthreads "^0.5.1"
+    boolean "^3.2.0"
     combine-errors "^3.0.3"
-    cron-validate "^1.4.1"
-    debug "^4.3.1"
-    human-interval "^2.0.0"
+    cron-validate "^1.4.3"
+    human-interval "^2.0.1"
     is-string-and-not-blank "^0.0.2"
     is-valid-path "^0.1.1"
-    ms "^2.1.2"
-    p-wait-for "3.1.0"
+    ms "^2.1.3"
+    p-wait-for "3"
     safe-timers "^1.1.0"
 
 broccoli-amd-funnel@^2.0.1:
@@ -12174,13 +12171,6 @@ bson-objectid@2.0.4:
   resolved "https://registry.yarnpkg.com/bson-objectid/-/bson-objectid-2.0.4.tgz#339211572ef97dc98f2d68eaee7b99b7be59a089"
   integrity sha512-vgnKAUzcDoa+AeyYwXCoHyF2q6u/8H46dxu5JN+4/TZeq/Dlinn0K6GvxsCLb3LHUJl0m/TLiEK31kUwtgocMQ==
 
-bthreads@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/bthreads/-/bthreads-0.5.1.tgz#c7a4dacc2d159c50de08b37b1e2a7da836171063"
-  integrity sha512-nK7Jo9ll+r1FRMNPWEFRTZMQrX6HhX8JjPAofxmbTNILHqWVIJPmWzCi9JlX/K0DL5AKZTFZg2Qser5C6gVs9A==
-  dependencies:
-    bufio "~1.0.5"
-
 buffer-crc32@^0.2.1, buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -12235,11 +12225,6 @@ buffer@^6.0.3:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
-
-bufio@~1.0.5:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/bufio/-/bufio-1.0.7.tgz#b7f63a1369a0829ed64cc14edf0573b3e382a33e"
-  integrity sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==
 
 builtin-modules@^3.3.0:
   version "3.3.0"
@@ -13679,7 +13664,7 @@ crelt@^1.0.0, crelt@^1.0.5:
   resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.6.tgz#7cc898ea74e190fb6ef9dae57f8f81cf7302df72"
   integrity sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==
 
-cron-validate@1.4.5, cron-validate@^1.4.1:
+cron-validate@1.4.5, cron-validate@^1.4.3:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/cron-validate/-/cron-validate-1.4.5.tgz#eceb221f7558e6302e5f84c7b3a454fdf4d064c3"
   integrity sha512-nKlOJEnYKudMn/aNyNH8xxWczlfpaazfWV32Pcx/2St51r2bxWbGhZD7uwzMcRhunA/ZNL+Htm/i0792Z59UMQ==
@@ -19578,7 +19563,7 @@ https@^1.0.0:
   resolved "https://registry.yarnpkg.com/https/-/https-1.0.0.tgz#3c37c7ae1a8eeb966904a2ad1e975a194b7ed3a4"
   integrity sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==
 
-human-interval@^2.0.0:
+human-interval@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/human-interval/-/human-interval-2.0.1.tgz#655baf606c7067bb26042dcae14ec777b099af15"
   integrity sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==
@@ -23664,7 +23649,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2, ms@^2.1.3:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -24810,14 +24795,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-p-wait-for@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-wait-for/-/p-wait-for-3.1.0.tgz#9da568a2adda3ea8175a3c43f46a5317e28c0e47"
-  integrity sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==
-  dependencies:
-    p-timeout "^3.0.0"
-
-p-wait-for@3.2.0:
+p-wait-for@3, p-wait-for@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/p-wait-for/-/p-wait-for-3.2.0.tgz#640429bcabf3b0dd9f492c31539c5718cb6a3f1f"
   integrity sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==


### PR DESCRIPTION
refs: https://github.com/TryGhost/Product/issues/3782

When Ghost runs a job, all exceptions must be handled so that the job can report "done" (as in finished) - regardless of whether the job has succeeded.

This patch is one solution, the other would be to introduce semantics for "failing" a job in a way which would also remove it from the queue, allowing Ghost to shut down / the worker to be terminated.

Here's the remaining issue, whilst it seems like Ghost is shutting down happily at this point, it has moved the shutdown time from the call to stop Bree into the call to process.exit(0) from the main thread. It seems like some network resources aren't being released by Node.js, causing a delay before the application can exit. I'm hopeful that the environment of Ghost (Pro) is going to be more efficient at tidying up these resources than it would have been with the original slow-down.
If nothing else, this now feels semantically correct in that Bree thinks the job is done, kills the worker and thinks that all the resources are tidied up.

Edit: This also contains an update to the latest version of Bree @ version 9.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 956a1de</samp>

Handle update check errors in worker script. The change adds error handling to `run-update-check.js` to avoid unhandled rejections and worker crashes, and to notify the parent process of the failure.
