### PR TITLE
🏗️ Repopulate featured collection records

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.64/2023-09-19-04-25-40-truncate-stale-built-in-collections-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.64/2023-09-19-04-25-40-truncate-stale-built-in-collections-posts.js
@@ -1,12 +1,10 @@
 const logging = require('@tryghost/logging');
-const {createNonTransactionalMigration} = require('../../utils');
 
-module.exports = createNonTransactionalMigration(
-    async function up(knex) {
-        logging.info('Clearing collections_posts table');
-        await knex('collections_posts').truncate();
+module.exports = {
+    async up() {
+        logging.warn('Skipping migration - noop');
     },
-    async function down() {
-        logging.info('Not doing anything - collections_posts table has been truncated');
+    async down() {
+        logging.warn('Skipping migration - noop');
     }
-);
+};

--- a/ghost/core/core/server/data/migrations/versions/5.64/2023-09-19-04-34-10-repopulate-built-in-collection-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.64/2023-09-19-04-34-10-repopulate-built-in-collection-posts.js
@@ -1,69 +1,10 @@
 const logging = require('@tryghost/logging');
-const {default: ObjectID} = require('bson-objectid');
-const {createTransactionalMigration} = require('../../utils');
 
-const insertPostCollections = async (knex, collectionId, postIds) => {
-    logging.warn(`Batch inserting ${postIds.length} collection posts for collection ${collectionId}`);
-
-    const collectionPosts = postIds.map((postId) => {
-        return {
-            id: (new ObjectID()).toHexString(),
-            collection_id: collectionId,
-            post_id: postId,
-            sort_order: 0
-        };
-    });
-
-    await knex.batchInsert('collections_posts', collectionPosts, 1000);
-};
-
-module.exports = createTransactionalMigration(
-    async function up(knex) {
-        logging.info('Populating built-in collections');
-
-        const existingLatestCollection = await knex('collections')
-            .where({
-                slug: 'latest'
-            })
-            .first();
-
-        if (!existingLatestCollection) {
-            logging.warn('Latest collection does not exists, skipping');
-        } else {
-            const latestPostsRows = await knex('posts')
-                .select('id')
-                .where({
-                    type: 'post'
-                });
-
-            const latestPostsIds = latestPostsRows.map(row => row.id);
-
-            await insertPostCollections(knex, existingLatestCollection.id, latestPostsIds);
-        }
-
-        const existingFeaturedCollection = await knex('collections')
-            .where({
-                slug: 'featured'
-            })
-            .first();
-
-        if (!existingFeaturedCollection) {
-            logging.warn('Featured collection does not exist, skipping');
-        } else {
-            const featuredPostsRows = await knex('posts')
-                .select('id')
-                .where({
-                    featured: true,
-                    type: 'post'
-                });
-
-            const featuredPostsIds = featuredPostsRows.map(row => row.id);
-
-            await insertPostCollections(knex, existingFeaturedCollection.id, featuredPostsIds);
-        }
+module.exports = {
+    async up() {
+        logging.warn('Skipping migration - noop');
     },
-    async function down(knex) {
-        logging.info('Clearing collections_posts table');
-        await knex('collections_posts').truncate();
+    async down() {
+        logging.warn('Skipping migration - noop');
     }
-);
+};

--- a/ghost/core/core/server/data/migrations/versions/5.65/2023-09-22-06-42-15-truncate-stale-built-in-collections-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.65/2023-09-22-06-42-15-truncate-stale-built-in-collections-posts.js
@@ -1,0 +1,12 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info('Clearing collections_posts table');
+        await knex('collections_posts').truncate();
+    },
+    async function down() {
+        logging.info('Not doing anything - collections_posts table has been truncated');
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/5.65/2023-09-22-06-42-55-repopulate-built-in-featured-collection-posts.js
+++ b/ghost/core/core/server/data/migrations/versions/5.65/2023-09-22-06-42-55-repopulate-built-in-featured-collection-posts.js
@@ -1,0 +1,49 @@
+const logging = require('@tryghost/logging');
+const {default: ObjectID} = require('bson-objectid');
+const {createTransactionalMigration} = require('../../utils');
+
+const insertPostCollections = async (knex, collectionId, postIds) => {
+    logging.warn(`Batch inserting ${postIds.length} collection posts for collection ${collectionId}`);
+
+    const collectionPosts = postIds.map((postId) => {
+        return {
+            id: (new ObjectID()).toHexString(),
+            collection_id: collectionId,
+            post_id: postId,
+            sort_order: 0
+        };
+    });
+
+    await knex.batchInsert('collections_posts', collectionPosts, 1000);
+};
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Populating built-in featured collection');
+
+        const existingFeaturedCollection = await knex('collections')
+            .where({
+                slug: 'featured'
+            })
+            .first();
+
+        if (!existingFeaturedCollection) {
+            logging.warn('Featured collection does not exist, skipping');
+        } else {
+            const featuredPostsRows = await knex('posts')
+                .select('id')
+                .where({
+                    featured: true,
+                    type: 'post'
+                });
+
+            const featuredPostsIds = featuredPostsRows.map(row => row.id);
+
+            await insertPostCollections(knex, existingFeaturedCollection.id, featuredPostsIds);
+        }
+    },
+    async function down(knex) {
+        logging.info('Clearing collections_posts table');
+        await knex('collections_posts').truncate();
+    }
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -977,20 +977,6 @@
         },
         {
             "from": {
-                "model": "Collection",
-                "match": "slug",
-                "relation": "posts"
-            },
-            "to": {
-                "model": "Post",
-                "match": "slug"
-            },
-            "entries": {
-                "latest": ["coming-soon"]
-            }
-        },
-        {
-            "from": {
                 "model": "User",
                 "match": "id",
                 "relation": "roles"

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '38fa7cfe8d74659ec75a5963b13cb4eb';
-    const currentFixturesHash = '6e8d5e89044320656de4900dd0529e68';
+    const currentFixturesHash = '4db87173699ad9c9d8a67ccab96dfd2d';
     const currentSettingsHash = '3a7ca0aa6a06cba47e3e898aef7029c2';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/95
refs https://github.com/TryGhost/Ghost/commit/00e5f84d88488a5b915d191093151e7dff208465

- Maintaining "latest" collection's static content is causing performance issues we are not able to overcome in a short period of time. Instead we leave it as a "dynamic" collection, which equals the contents of the Posts API. The "featured" collection will be saved in a "static" form as previously.
- This is roughly the same migration as in 5.64 version (see refed commit). It wipes out all of the stored collections data and only populates the featured collection.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58571c6</samp>

This pull request adds two migration scripts to the `versions/5.65` folder that update the `collections_posts` table to reflect the new built-in featured collection logic. The first script truncates the table to remove any stale data, and the second script repopulates it with the posts that have the `featured` flag set to true.
