### PR TITLE
Promotes Collections to GA

### DIFF
--- a/ghost/admin/app/components/gh-nav-menu/main.hbs
+++ b/ghost/admin/app/components/gh-nav-menu/main.hbs
@@ -96,9 +96,6 @@
                     {{#if this.showTagsNavigation}}
                         <li><LinkTo @route="tags" @current-when="tags tag tag.new" data-test-nav="tags">{{svg-jar "tag"}}Tags</LinkTo></li>
                     {{/if}}
-                    {{#if (and (gh-user-can-admin this.session.user) (feature "collections"))}}
-                        <li><LinkTo @route="collections" @current-when="collections collection collection.new" data-test-nav="collections">{{svg-jar "collections-bookmark"}}Collections</LinkTo></li>
-                    {{/if}}
                     {{#if (gh-user-can-admin this.session.user)}}
                         <li class="relative">
                             {{#if (eq this.router.currentRouteName "members.index")}}

--- a/ghost/core/core/server/services/collections/service.js
+++ b/ghost/core/core/server/services/collections/service.js
@@ -34,8 +34,12 @@ class CollectionsServiceWrapper {
         const config = require('../../../shared/config');
         const labs = require('../../../shared/labs');
 
-        // host setting OR labs "collections" flag has to be enabled to run collections service
-        if (config.get('hostSettings:collections:enabled') || labs.isSet('collections')) {
+        // CASE: emergency kill switch in case we need to disable collections outside of labs
+        if (config.get('hostSettings:collections:enabled') === false) {
+            return;
+        }
+
+        if (labs.isSet('collections')) {
             if (inited) {
                 return;
             }

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -15,6 +15,7 @@ const messages = {
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
     'audienceFeedback',
+    'collections',
     'themeErrorsNotification',
     'outboundLinkTagging',
     'announcementBar',
@@ -36,7 +37,6 @@ const ALPHA_FEATURES = [
     'websockets',
     'stripeAutomaticTax',
     'emailCustomization',
-    'collections',
     'adminXSettings',
     'mailEvents',
     'collectionsCard',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -758,7 +758,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4234",
+  "content-length": "4255",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/18287

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 50bcee7</samp>

This pull request enables the `collections` feature for all users via the labs UI, and adds a kill switch to disable it in case of emergencies. The pull request affects the `labs.js` and `service.js` files in the core module.
