### PR TITLE
Updated toast testid to prevent conflicts in tests

### DIFF
--- a/apps/admin-x-settings/src/admin-x-ds/global/Toast.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/Toast.tsx
@@ -45,7 +45,7 @@ const Toast: React.FC<ToastProps> = ({
     );
 
     return (
-        <div className={classNames} data-testid='toast'>
+        <div className={classNames} data-testid={`toast-${props?.type}`}>
             <div className='flex items-start gap-3'>
                 {props?.icon && (typeof props.icon === 'string' ?
                     <div className='mt-0.5'><Icon className='grow' colorClass={props.type === 'success' ? 'text-green' : 'text-white'} name={props.icon} size='sm' /></div> : props.icon)}

--- a/apps/admin-x-settings/test/e2e/advanced/integrations/slack.test.ts
+++ b/apps/admin-x-settings/test/e2e/advanced/integrations/slack.test.ts
@@ -55,7 +55,7 @@ test.describe('Slack integration', async () => {
         await slackModal.getByLabel('Username').fill('My site');
         await slackModal.getByRole('button', {name: 'Send test notification'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/Check your Slack channel for the test message/);
+        await expect(page.getByTestId('toast-neutral')).toHaveText(/Check your Slack channel for the test message/);
 
         expect(lastApiRequests.editSettings?.body).toEqual({
             settings: [

--- a/apps/admin-x-settings/test/e2e/email/newsletters.test.ts
+++ b/apps/admin-x-settings/test/e2e/email/newsletters.test.ts
@@ -26,7 +26,7 @@ test.describe('Newsletter settings', async () => {
         const modal = page.getByTestId('add-newsletter-modal');
         await modal.getByRole('button', {name: 'Create'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/Can't save newsletter/);
+        await expect(page.getByTestId('toast-error')).toHaveText(/Can't save newsletter/);
         await expect(modal).toHaveText(/Please enter a name/);
 
         // Shouldn't be necessary, but without these Playwright doesn't click Create the second time for some reason
@@ -69,7 +69,7 @@ test.describe('Newsletter settings', async () => {
         await modal.getByPlaceholder('Weekly Roundup').fill('');
         await modal.getByRole('button', {name: 'Save'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/Can't save newsletter/);
+        await expect(page.getByTestId('toast-error')).toHaveText(/Can't save newsletter/);
         await expect(modal).toHaveText(/Please enter a name/);
 
         await modal.getByPlaceholder('Weekly Roundup').fill('Updated newsletter');

--- a/apps/admin-x-settings/test/e2e/general/users/actions.test.ts
+++ b/apps/admin-x-settings/test/e2e/general/users/actions.test.ts
@@ -126,7 +126,7 @@ test.describe('User actions', async () => {
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Delete user'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/User deleted/);
+        await expect(page.getByTestId('toast-success')).toHaveText(/User deleted/);
         await expect(activeTab.getByTestId('user-list-item')).toHaveCount(0);
 
         expect(lastApiRequests.deleteUser?.url).toMatch(new RegExp(`/users/${authorUser.id}`));
@@ -189,7 +189,7 @@ test.describe('User actions', async () => {
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Yep — I\'m sure'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/Ownership transferred/);
+        await expect(page.getByTestId('toast-success')).toHaveText(/Ownership transferred/);
 
         await expect(section.getByTestId('owner-user')).toHaveText(/administrator@test\.com/);
 

--- a/apps/admin-x-settings/test/e2e/general/users/invite.test.ts
+++ b/apps/admin-x-settings/test/e2e/general/users/invite.test.ts
@@ -38,7 +38,7 @@ test.describe('User invitations', async () => {
         await modal.locator('input[value=author]').check();
         await modal.getByRole('button', {name: 'Send invitation now'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/Invitation successfully sent to newuser@test\.com/);
+        await expect(page.getByTestId('toast-success')).toHaveText(/Invitation successfully sent to newuser@test\.com/);
 
         await section.getByRole('tab', {name: 'Invited'}).click();
 
@@ -77,7 +77,7 @@ test.describe('User invitations', async () => {
 
         await listItem.getByRole('button', {name: 'Resend'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/Invitation resent! \(invitee@test\.com\)/);
+        await expect(page.getByTestId('toast-success')).toHaveText(/Invitation resent! \(invitee@test\.com\)/);
 
         // Resending works by deleting and re-adding the invite
 
@@ -112,7 +112,7 @@ test.describe('User invitations', async () => {
 
         await listItem.getByRole('button', {name: 'Revoke'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/Invitation revoked \(invitee@test\.com\)/);
+        await expect(page.getByTestId('toast-success')).toHaveText(/Invitation revoked \(invitee@test\.com\)/);
 
         expect(lastApiRequests.deleteInvite?.url).toMatch(new RegExp(`/invites/${responseFixtures.invites.invites[0].id}`));
     });

--- a/apps/admin-x-settings/test/e2e/membership/tiers.test.ts
+++ b/apps/admin-x-settings/test/e2e/membership/tiers.test.ts
@@ -26,7 +26,7 @@ test.describe('Tier settings', async () => {
 
         await modal.getByRole('button', {name: 'Save & close'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/Can't save tier/);
+        await expect(page.getByTestId('toast-error')).toHaveText(/Can't save tier/);
         await expect(modal).toHaveText(/You must specify a name/);
         await expect(modal).toHaveText(/Amount must be at least \$1/);
 
@@ -104,7 +104,7 @@ test.describe('Tier settings', async () => {
         await modal.getByLabel('Name').fill('');
         await modal.getByRole('button', {name: 'Save & close'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/Can't save tier/);
+        await expect(page.getByTestId('toast-error')).toHaveText(/Can't save tier/);
         await expect(modal).toHaveText(/You must specify a name/);
 
         await modal.getByLabel('Name').fill('Supporter updated');

--- a/apps/admin-x-settings/test/e2e/site/theme.test.ts
+++ b/apps/admin-x-settings/test/e2e/site/theme.test.ts
@@ -56,7 +56,7 @@ test.describe('Theme settings', async () => {
 
         await page.getByRole('button', {name: 'Activate'}).click();
 
-        await expect(page.getByTestId('toast')).toHaveText(/headline is now your active theme/);
+        await expect(page.getByTestId('toast-success')).toHaveText(/headline is now your active theme/);
 
         expect(lastApiRequests.installTheme?.url).toMatch(/\?source=github&ref=TryGhost%2FHeadline/);
     });


### PR DESCRIPTION
no issue

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3084199</samp>

Updated the e2e tests and the toast component in the `admin-x-settings` app to use consistent and descriptive identifiers. This improves the test reliability and readability, and allows for better feedback messages. Changed the `data-testid` attribute of the `Toast.tsx` component and the corresponding test selectors.
