### PR TITLE
Prevented background click closing members import modal

### DIFF
--- a/ghost/admin/.lint-todo
+++ b/ghost/admin/.lint-todo
@@ -589,3 +589,7 @@ remove|ember-template-lint|no-unused-block-params|1|0|1|0|e25f7866ab4ee682b08edf
 remove|ember-template-lint|no-invalid-interactive|7|32|7|32|508e64575a985432d0588f3291a126c4b62e68d8|1688342400000|1698714000000|1703898000000|app/components/gh-nav-menu/design.hbs
 add|ember-template-lint|no-invalid-interactive|7|32|7|32|2da5baf637c4f17f4acd498968b6022ffc0f3105|1692316800000|1702688400000|1707872400000|app/components/gh-nav-menu/design.hbs
 add|ember-template-lint|no-unknown-arguments-for-builtin-components|99|93|99|93|156670ca427c49c51f0a94f862b286ccc9466d92|1694649600000|1705021200000|1710205200000|app/components/gh-nav-menu/footer.hbs
+add|ember-template-lint|no-action|2|45|2|45|55b33496610b2f4ef6b9fe62713f4b4ddee37f19|1695340800000|1705712400000|1710896400000|app/components/gh-fullscreen-modal.hbs
+add|ember-template-lint|no-invalid-interactive|2|45|2|45|918fdec8490009c6197091e319d6ec52ee95b983|1695340800000|1705712400000|1710896400000|app/components/gh-fullscreen-modal.hbs
+remove|ember-template-lint|no-action|2|45|2|45|a9d29fae15800842d0e7b8f32b035ee22a23f4cb|1688342400000|1698714000000|1703898000000|app/components/gh-fullscreen-modal.hbs
+remove|ember-template-lint|no-invalid-interactive|2|45|2|45|b6693259da29d433264b59abc9a7c7ac846a4bf6|1688342400000|1698714000000|1703898000000|app/components/gh-fullscreen-modal.hbs

--- a/ghost/admin/app/components/gh-fullscreen-modal.hbs
+++ b/ghost/admin/app/components/gh-fullscreen-modal.hbs
@@ -1,5 +1,5 @@
 <LiquidWormhole @class="fullscreen-modal-container">
-    <div class="fullscreen-modal-background" {{action "clickOverlay"}}></div>
+    <div class="fullscreen-modal-background" {{action "clickOverlay" "background"}}></div>
     <div class={{this.modalClasses}}>
         {{#if (has-block)}}
           {{yield}}

--- a/ghost/admin/app/components/gh-fullscreen-modal.js
+++ b/ghost/admin/app/components/gh-fullscreen-modal.js
@@ -48,7 +48,7 @@ const FullScreenModalComponent = Component.extend({
         },
 
         clickOverlay() {
-            this.send('close');
+            this.send('close', ...arguments);
         }
     },
 

--- a/ghost/admin/app/controllers/members/import.js
+++ b/ghost/admin/app/controllers/members/import.js
@@ -17,7 +17,11 @@ export default class ImportController extends Controller {
     }
 
     @action
-    close() {
+    close(from) {
+        if (from === 'background') {
+            return;
+        }
+
         this.router.transitionTo('members');
     }
 }


### PR DESCRIPTION
no issue

- we don't want accidental background clicks closing this modal as it contains complex UI rather than a simple notification
- the members import modal is still using the old/outdated modal pattern so there was no option for disabling background click, went with a quick-fix for now rather than updating everything to our modern modal patterns
  - added passthrough of arguments to the `close` action on `<GhFullscreenModal>`
  - updated `<GhFullscreenModal>` background click handler to pass "background" as an action argument
  - updated the action used for handling members import modal closing to skip closing when it receives "background" as the first argument
