### PR TITLE
Hide attribution table sort indicator when there are no paid tiers

### DIFF
--- a/ghost/admin/app/components/member-attribution/source-attribution-table.hbs
+++ b/ghost/admin/app/components/member-attribution/source-attribution-table.hbs
@@ -6,7 +6,7 @@
             class="gh-dashboard-list-title {{if (eq @sortColumn "signups") "sorted-by"}}"
             {{on "click" (fn @setSortColumn "signups")}}
         >
-            <span class="hide-when-small">Free </span>signups{{svg-jar "arrow-down-fill"}}
+            <span class="hide-when-small">Free </span>signups{{#if this.membersUtils.paidMembersEnabled}}{{svg-jar "arrow-down-fill"}}{{/if}}
         </div>
         {{#if this.membersUtils.paidMembersEnabled}}
             <div


### PR DESCRIPTION
no ref

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6127fa8</samp>

Fix UI issues with source attribution table in member attribution component. Hide arrow-down-fill icon for free signups column when paid members feature is disabled in `source-attribution-table.hbs`.
