### PR TITLE
Fixed Sentry initialising twice

### DIFF
--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -47,19 +47,6 @@ function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, t
         'admin-x-settings h-[100vh] w-full overflow-y-auto overflow-x-hidden',
         darkMode && 'dark'
     );
-    
-    useEffect(() => {
-        if (sentryDSN) {
-            Sentry.init({
-                dsn: sentryDSN,
-                release: ghostVersion,
-                integrations: [
-                    new Sentry.BrowserTracing({
-                    })
-                ]
-            });
-        }
-    }, [sentryDSN, ghostVersion]);
 
     return (
         <SentryErrorBoundary>

--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import GlobalDataProvider from './components/providers/GlobalDataProvider';
 import MainContent from './MainContent';
 import NiceModal from '@ebay/nice-modal-react';
@@ -11,7 +10,6 @@ import {OfficialTheme, ServicesProvider} from './components/providers/ServicePro
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {Toaster} from 'react-hot-toast';
 import {ZapierTemplate} from './components/settings/advanced/integrations/ZapierModal';
-import {useEffect} from 'react';
 
 interface AppProps {
     ghostVersion: string;


### PR DESCRIPTION
no issue

- The second initialisation inside the React app isn't needed since it's being initialised by Ember and the required settings is being passed correctly to the Ember library inside React.
- The second initialisation caused Admin X to not report issues correctly.
- To test, add `"client_sentry": { "enabled": false, "dsn": "" }` to the `config.development.json` and write some bad code to trigger issues.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77bf93f</samp>

This change refactors the error handling and reporting logic in the `admin-x-settings` app by removing the redundant Sentry initialization from the `App` component and using the global instance instead. This avoids potential conflicts and performance issues with multiple Sentry instances.
