### PR TITLE
Moved labs unit test to correct folder

### DIFF
--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -62,6 +62,11 @@ module.exports.getAll = () => {
         labs[gaKey] = true;
     });
 
+    const labsConfig = config.get('labs') || {};
+    Object.keys(labsConfig).forEach((key) => {
+        labs[key] = labsConfig[key];
+    });
+
     labs.members = settingsCache.get('members_signup_access') !== 'none';
 
     return labs;

--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -1,9 +1,9 @@
 const should = require('should');
 const sinon = require('sinon');
 
-const configUtils = require('../../../utils/configUtils');
-const labs = require('../../../../core/shared/labs');
-const settingsCache = require('../../../../core/shared/settings-cache');
+const configUtils = require('../../utils/configUtils');
+const labs = require('../../../core/shared/labs');
+const settingsCache = require('../../../core/shared/settings-cache');
 
 function expectedLabsObject(obj) {
     const withGA = Object.assign({}, obj);

--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -1,4 +1,4 @@
-const should = require('should');
+const assert = require('assert/strict');
 const sinon = require('sinon');
 
 const configUtils = require('../../utils/configUtils');
@@ -22,7 +22,7 @@ describe('Labs Service', function () {
     });
 
     it('can getAll, even if empty with enabled members', function () {
-        labs.getAll().should.eql(expectedLabsObject({
+        assert.deepEqual(labs.getAll(), expectedLabsObject({
             members: true
         }));
     });
@@ -32,18 +32,18 @@ describe('Labs Service', function () {
         sinon.stub(process.env, 'NODE_ENV').value('production');
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('labs').returns({
-            oauthLogin: true
+            urlCache: true
         });
 
         // NOTE: this test should be rewritten to test the alpha flag independently of the internal ALPHA_FEATURES list
         //       otherwise we end up in the endless maintenance loop and need to update it every time a feature graduates from alpha
-        labs.getAll().should.eql(expectedLabsObject({
-            oauthLogin: true,
+        assert.deepEqual(labs.getAll(), expectedLabsObject({
+            urlCache: true,
             members: true
         }));
 
-        labs.isSet('members').should.be.true;
-        labs.isSet('oauthLogin').should.be.true;
+        assert.equal(labs.isSet('members'), true);
+        assert.equal(labs.isSet('urlCache'), true);
     });
 
     it('returns a falsy alpha flag when dev experiments in NOT toggled', function () {
@@ -51,29 +51,28 @@ describe('Labs Service', function () {
         sinon.stub(process.env, 'NODE_ENV').value('production');
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('labs').returns({
-            oauthLogin: true
+            urlCache: true
         });
 
         // NOTE: this test should be rewritten to test the alpha flag independently of the internal ALPHA_FEATURES list
         //       otherwise we end up in the endless maintenance loop and need to update it every time a feature graduates from alpha
-        labs.getAll().should.eql(expectedLabsObject({
-            oauthLogin: true,
+        assert.deepEqual(labs.getAll(), expectedLabsObject({
             members: true
         }));
 
-        labs.isSet('members').should.be.true;
-        labs.isSet('oauthLogin').should.be.false;
+        assert.equal(labs.isSet('members'), true);
+        assert.equal(labs.isSet('urlCache'), false);
     });
 
     it('members flag is true when members_signup_access setting is "all"', function () {
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('members_signup_access').returns('all');
 
-        labs.getAll().should.eql(expectedLabsObject({
+        assert.deepEqual(labs.getAll(), expectedLabsObject({
             members: true
         }));
 
-        labs.isSet('members').should.be.true;
+        assert.equal(labs.isSet('members'), true);
     });
 
     it('returns other allowlisted flags along with members', function () {
@@ -83,32 +82,32 @@ describe('Labs Service', function () {
             activitypub: false
         });
 
-        labs.getAll().should.eql(expectedLabsObject({
+        assert.deepEqual(labs.getAll(), expectedLabsObject({
             members: true,
             activitypub: false
         }));
 
-        labs.isSet('members').should.be.true;
-        labs.isSet('activitypub').should.be.false;
+        assert.equal(labs.isSet('members'), true);
+        assert.equal(labs.isSet('activitypub'), false);
     });
 
     it('members flag is false when members_signup_access setting is "none"', function () {
         sinon.stub(settingsCache, 'get');
         settingsCache.get.withArgs('members_signup_access').returns('none');
 
-        labs.getAll().should.eql(expectedLabsObject({
+        assert.deepEqual(labs.getAll(), expectedLabsObject({
             members: false
         }));
 
-        labs.isSet('members').should.be.false;
+        assert.equal(labs.isSet('members'), false);
     });
 
     it('isSet returns false for undefined', function () {
-        labs.isSet('bar').should.be.false;
+        assert.equal(labs.isSet('bar'), false);
     });
 
     it('isSet always returns false for deprecated', function () {
-        labs.isSet('subscribers').should.be.false;
-        labs.isSet('publicAPI').should.be.false;
+        assert.equal(labs.isSet('subscribers'), false);
+        assert.equal(labs.isSet('publicAPI'), false);
     });
 });


### PR DESCRIPTION
refs TryGhost/DevOps#72

- labs.js is in the shared folder, so I've moved it to the corresponding
  folder to make understanding the tests easier

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b6045b</samp>

This pull request improves the testing and configuration of the `labs.js` module, which handles the feature flags for experimental or in-development features in Ghost. It renames and updates the test file, changes the assertion style, and adds new test cases. It also adds a new logic to merge the config flags with the database flags, allowing more flexibility and control over the labs features.
