### PR TITLE
Fixed Pintura config on Admin X

### DIFF
--- a/apps/admin-x-settings/src/api/config.ts
+++ b/apps/admin-x-settings/src/api/config.ts
@@ -40,6 +40,10 @@ export type Config = {
         billing?: {
             enabled?: boolean
             url?: string
+        },
+        pintura?: {
+            js?: string
+            css?: string
         }
     }
 

--- a/apps/admin-x-settings/src/components/settings/general/Facebook.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Facebook.tsx
@@ -24,20 +24,16 @@ const Facebook: React.FC<{ keywords: string[] }> = ({keywords}) => {
     } = useSettingGroup();
 
     const {mutateAsync: uploadImage} = useUploadImage();
-    const [pintura] = getSettingValues<boolean>(localSettings, ['pintura']);
     // const [unsplashEnabled] = getSettingValues<boolean>(localSettings, ['unsplash']);
     const [pinturaJsUrl] = getSettingValues<string>(localSettings, ['pintura_js_url']);
     const [pinturaCssUrl] = getSettingValues<string>(localSettings, ['pintura_css_url']);
     // const [showUnsplash, setShowUnsplash] = useState<boolean>(false);
 
-    const pinturaEnabled = Boolean(pintura) && Boolean(pinturaJsUrl) && Boolean(pinturaCssUrl);
-
     const editor = usePinturaEditor(
         {config: {
             jsUrl: pinturaJsUrl || '',
             cssUrl: pinturaCssUrl || ''
-        },
-        disabled: !pinturaEnabled}
+        }}
     );
 
     const [
@@ -91,7 +87,7 @@ const Facebook: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         imageURL={facebookImage}
                         pintura={
                             {
-                                isEnabled: pinturaEnabled,
+                                isEnabled: editor.isEnabled,
                                 openEditor: async () => editor.openEditor({
                                     image: facebookImage || '',
                                     handleSave: async (file:File) => {

--- a/apps/admin-x-settings/src/components/settings/general/Twitter.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/Twitter.tsx
@@ -24,18 +24,15 @@ const Twitter: React.FC<{ keywords: string[] }> = ({keywords}) => {
     } = useSettingGroup();
 
     const {mutateAsync: uploadImage} = useUploadImage();
-    const [pintura] = getSettingValues<boolean>(localSettings, ['pintura']);
+
     const [pinturaJsUrl] = getSettingValues<string>(localSettings, ['pintura_js_url']);
     const [pinturaCssUrl] = getSettingValues<string>(localSettings, ['pintura_css_url']);
-
-    const pinturaEnabled = Boolean(pintura) && Boolean(pinturaJsUrl) && Boolean(pinturaCssUrl);
 
     const editor = usePinturaEditor(
         {config: {
             jsUrl: pinturaJsUrl || '',
             cssUrl: pinturaCssUrl || ''
-        },
-        disabled: !pinturaEnabled}
+        }}
     );
 
     const [
@@ -87,7 +84,7 @@ const Twitter: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         imageURL={twitterImage}
                         pintura={
                             {
-                                isEnabled: pinturaEnabled,
+                                isEnabled: editor.isEnabled,
                                 openEditor: async () => editor.openEditor({
                                     image: twitterImage || '',
                                     handleSave: async (file:File) => {

--- a/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
@@ -344,17 +344,14 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
 
     // Pintura integration
     const {settings} = useGlobalData();
-    const [pintura] = getSettingValues<boolean>(settings, ['pintura']);
     const [pinturaJsUrl] = getSettingValues<string>(settings, ['pintura_js_url']);
     const [pinturaCssUrl] = getSettingValues<string>(settings, ['pintura_css_url']);
-    const pinturaEnabled = Boolean(pintura) && Boolean(pinturaJsUrl) && Boolean(pinturaCssUrl);
 
     const editor = usePinturaEditor(
         {config: {
             jsUrl: pinturaJsUrl || '',
             cssUrl: pinturaCssUrl || ''
-        },
-        disabled: !pinturaEnabled}
+        }}
     );
 
     const navigateOnClose = useCallback(() => {
@@ -652,7 +649,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                         imageURL={userData.cover_image || ''}
                         pintura={
                             {
-                                isEnabled: pinturaEnabled,
+                                isEnabled: editor.isEnabled,
                                 openEditor: async () => editor.openEditor({
                                     image: userData.cover_image || '',
                                     handleSave: async (file:File) => {
@@ -684,7 +681,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                             imageURL={userData.profile_image}
                             pintura={
                                 {
-                                    isEnabled: pinturaEnabled,
+                                    isEnabled: editor.isEnabled,
                                     openEditor: async () => editor.openEditor({
                                         image: userData.profile_image || '',
                                         handleSave: async (file:File) => {

--- a/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
@@ -26,7 +26,6 @@ const BrandSettings: React.FC<{ values: BrandSettingValues, updateSetting: (key:
     const {mutateAsync: uploadImage} = useUploadImage();
     const [siteDescription, setSiteDescription] = useState(values.description);
     const {settings} = useGlobalData();
-    const [pintura] = getSettingValues<boolean>(settings, ['pintura']);
     const [unsplashEnabled] = getSettingValues<boolean>(settings, ['unsplash']);
     const [pinturaJsUrl] = getSettingValues<string>(settings, ['pintura_js_url']);
     const [pinturaCssUrl] = getSettingValues<string>(settings, ['pintura_css_url']);
@@ -39,17 +38,12 @@ const BrandSettings: React.FC<{ values: BrandSettingValues, updateSetting: (key:
         }, 500)
     );
 
-    const pinturaEnabled = Boolean(pintura) && Boolean(pinturaJsUrl) && Boolean(pinturaCssUrl);
-
     const editor = usePinturaEditor(
         {config: {
             jsUrl: pinturaJsUrl || '',
             cssUrl: pinturaCssUrl || ''
-        },
-        disabled: !pinturaEnabled}
+        }}
     );
-
-    // check if pintura !false and pintura_js_url and pintura_css_url are not '' or null or undefined
 
     return (
         <div className='mt-7'>
@@ -135,7 +129,7 @@ const BrandSettings: React.FC<{ values: BrandSettingValues, updateSetting: (key:
                         openUnsplash={() => setShowUnsplash(true)}
                         pintura={
                             {
-                                isEnabled: pinturaEnabled,
+                                isEnabled: editor.isEnabled,
                                 openEditor: async () => editor.openEditor({
                                     image: values.coverImage || '',
                                     handleSave: async (file:File) => {

--- a/apps/admin-x-settings/src/hooks/usePinturaEditor.ts
+++ b/apps/admin-x-settings/src/hooks/usePinturaEditor.ts
@@ -1,4 +1,6 @@
 import * as Sentry from '@sentry/react';
+import {Config} from '../api/config';
+import {Setting} from '../api/settings';
 import {getSettingValues} from '../api/settings';
 import {useCallback, useEffect, useState} from 'react';
 import {useGlobalData} from '../components/providers/GlobalDataProvider';
@@ -52,17 +54,18 @@ export default function usePinturaEditor({
 }: {
         config: PinturaEditorConfig;
     }) {
-    const {config: globalConfig, settings} = useGlobalData();
+    const {config: globalConfig, settings} = useGlobalData() as { config: Config, settings: Setting[] };
     const [pintura] = getSettingValues<boolean>(settings, ['pintura']);
     const [scriptLoaded, setScriptLoaded] = useState<boolean>(false);
     const [cssLoaded, setCssLoaded] = useState<boolean>(false);
 
     let isEnabled = pintura && scriptLoaded && cssLoaded || false;
+    const pinturaConfig = globalConfig?.pintura as { js?: string; css?: string };
 
     useEffect(() => {
         const pinturaJsUrl = () => {
-            if (globalConfig?.pintura?.js) {
-                return globalConfig?.pintura?.js;
+            if (pinturaConfig?.js) {
+                return pinturaConfig?.js;
             }
             return config?.jsUrl || null;
         };
@@ -92,12 +95,12 @@ export default function usePinturaEditor({
             Sentry.captureException(e);
             // Log script loading error
         }
-    }, [config?.jsUrl, globalConfig?.pintura?.js]);
+    }, [config?.jsUrl, pinturaConfig?.js]);
 
     useEffect(() => {
         const pinturaCssUrl = () => {
-            if (globalConfig?.pintura?.css) {
-                return globalConfig?.pintura?.css;
+            if (pinturaConfig?.css) {
+                return pinturaConfig?.css;
             }
             return config?.cssUrl;
         };
@@ -125,7 +128,7 @@ export default function usePinturaEditor({
             Sentry.captureException(e);
             // wire up to sentry
         }
-    }, [config?.cssUrl, globalConfig?.pintura?.css]);
+    }, [config?.cssUrl, pinturaConfig?.css]);
 
     const openEditor = useCallback(
         ({image, handleSave}: OpenEditorParams) => {


### PR DESCRIPTION
no issue

- We didn't take Pintura settings into account have the url's passed in via configs as opposed to the database entry.
- this checks for both now.
- We also now require less configuration to wire in the editor.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a85c114</samp>

This pull request removes the dependency on the `pintura` setting value for enabling the Pintura image editor in various components in the admin settings app. It uses a custom hook, `usePinturaEditor`, to get the editor configuration and availability from the global config and the settings API. It also adds error reporting and refactors the hook code for simplicity and consistency.
