### PR TITLE
Updated AdminX to sync data changes to Ember

### DIFF
--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -17,10 +17,11 @@ interface AppProps {
     officialThemes: OfficialTheme[];
     zapierTemplates: ZapierTemplate[];
     externalNavigate: (link: ExternalLink) => void;
-    toggleFeatureFlag: (flag: string, enabled: boolean) => void;
     darkMode?: boolean;
     unsplashConfig: DefaultHeaderTypes
     sentryDSN: string | null;
+    onUpdate: (dataType: string, response: unknown) => void;
+    onInvalidate: (dataType: string) => void;
 }
 
 const queryClient = new QueryClient({
@@ -41,7 +42,7 @@ function SentryErrorBoundary({children}: {children: React.ReactNode}) {
     );
 }
 
-function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, toggleFeatureFlag, darkMode = false, unsplashConfig, sentryDSN}: AppProps) {
+function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, darkMode = false, unsplashConfig, sentryDSN, onUpdate, onInvalidate}: AppProps) {
     const appClassName = clsx(
         'admin-x-settings h-[100vh] w-full overflow-y-auto overflow-x-hidden',
         darkMode && 'dark'
@@ -50,7 +51,7 @@ function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, t
     return (
         <SentryErrorBoundary>
             <QueryClientProvider client={queryClient}>
-                <ServicesProvider ghostVersion={ghostVersion} officialThemes={officialThemes} sentryDSN={sentryDSN} toggleFeatureFlag={toggleFeatureFlag} unsplashConfig={unsplashConfig} zapierTemplates={zapierTemplates}>
+                <ServicesProvider ghostVersion={ghostVersion} officialThemes={officialThemes} sentryDSN={sentryDSN} unsplashConfig={unsplashConfig} zapierTemplates={zapierTemplates} onInvalidate={onInvalidate} onUpdate={onUpdate}>
                     <GlobalDataProvider>
                         <RoutingProvider externalNavigate={externalNavigate}>
                             <GlobalDirtyStateProvider>

--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -22,6 +22,7 @@ interface AppProps {
     sentryDSN: string | null;
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
+    onDelete: (dataType: string, id: string) => void;
 }
 
 const queryClient = new QueryClient({
@@ -42,7 +43,7 @@ function SentryErrorBoundary({children}: {children: React.ReactNode}) {
     );
 }
 
-function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, darkMode = false, unsplashConfig, sentryDSN, onUpdate, onInvalidate}: AppProps) {
+function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, darkMode = false, unsplashConfig, sentryDSN, onUpdate, onInvalidate, onDelete}: AppProps) {
     const appClassName = clsx(
         'admin-x-settings h-[100vh] w-full overflow-y-auto overflow-x-hidden',
         darkMode && 'dark'
@@ -51,7 +52,7 @@ function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, d
     return (
         <SentryErrorBoundary>
             <QueryClientProvider client={queryClient}>
-                <ServicesProvider ghostVersion={ghostVersion} officialThemes={officialThemes} sentryDSN={sentryDSN} unsplashConfig={unsplashConfig} zapierTemplates={zapierTemplates} onInvalidate={onInvalidate} onUpdate={onUpdate}>
+                <ServicesProvider ghostVersion={ghostVersion} officialThemes={officialThemes} sentryDSN={sentryDSN} unsplashConfig={unsplashConfig} zapierTemplates={zapierTemplates} onDelete={onDelete} onInvalidate={onInvalidate} onUpdate={onUpdate}>
                     <GlobalDataProvider>
                         <RoutingProvider externalNavigate={externalNavigate}>
                             <GlobalDirtyStateProvider>

--- a/apps/admin-x-settings/src/api/apiKeys.ts
+++ b/apps/admin-x-settings/src/api/apiKeys.ts
@@ -23,6 +23,7 @@ export const useRefreshAPIKey = createMutation<IntegrationsResponseType, {integr
     path: ({integrationId, apiKeyId}) => `/integrations/${integrationId}/api_key/${apiKeyId}/refresh/`,
     body: ({integrationId}) => ({integrations: [{id: integrationId}]}),
     updateQueries: {
+        emberUpdateType: 'createOrUpdate',
         dataType: integrationsDataType,
         update: (newData, currentData) => (currentData && {
             ...(currentData as IntegrationsResponseType),

--- a/apps/admin-x-settings/src/api/customThemeSettings.ts
+++ b/apps/admin-x-settings/src/api/customThemeSettings.ts
@@ -40,6 +40,7 @@ export const useEditCustomThemeSettings = createMutation<CustomThemeSettingsResp
     body: settings => ({custom_theme_settings: settings}),
 
     updateQueries: {
+        emberUpdateType: 'skip',
         dataType,
         update: newData => newData
     }

--- a/apps/admin-x-settings/src/api/emailVerification.ts
+++ b/apps/admin-x-settings/src/api/emailVerification.ts
@@ -16,6 +16,7 @@ export const verifyEmailToken = createMutation<EmailVerificationResponseType, em
     body: ({token}) => ({token}),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: newData => ({
             ...newData,
             settings: newData.settings

--- a/apps/admin-x-settings/src/api/integrations.ts
+++ b/apps/admin-x-settings/src/api/integrations.ts
@@ -41,6 +41,7 @@ export const useCreateIntegration = createMutation<IntegrationsResponseType, Par
     searchParams: () => ({include: 'api_keys,webhooks'}),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: (newData, currentData) => (currentData && {
             ...(currentData as IntegrationsResponseType),
             integrations: (currentData as IntegrationsResponseType).integrations.concat(newData.integrations)
@@ -55,6 +56,7 @@ export const useEditIntegration = createMutation<IntegrationsResponseType, Integ
     searchParams: () => ({include: 'api_keys,webhooks'}),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: (newData, currentData) => (currentData && {
             ...(currentData as IntegrationsResponseType),
             integrations: (currentData as IntegrationsResponseType).integrations.map((integration) => {
@@ -70,6 +72,7 @@ export const useDeleteIntegration = createMutation<unknown, string>({
     path: id => `/integrations/${id}/`,
     updateQueries: {
         dataType,
+        emberUpdateType: 'delete',
         update: (_, currentData, id) => ({
             ...(currentData as IntegrationsResponseType),
             integrations: (currentData as IntegrationsResponseType).integrations.filter(user => user.id !== id)

--- a/apps/admin-x-settings/src/api/invites.ts
+++ b/apps/admin-x-settings/src/api/invites.ts
@@ -37,6 +37,7 @@ export const useAddInvite = createMutation<InvitesResponseType, {email: string, 
     }),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         // Assume that all invite queries should include this new one
         update: (newData, currentData) => (currentData && {
             ...(currentData as InvitesResponseType),
@@ -53,6 +54,7 @@ export const useDeleteInvite = createMutation<unknown, string>({
     method: 'DELETE',
     updateQueries: {
         dataType,
+        emberUpdateType: 'delete',
         update: (_, currentData, id) => ({
             ...(currentData as InvitesResponseType),
             invites: (currentData as InvitesResponseType).invites.filter(invite => invite.id !== id)

--- a/apps/admin-x-settings/src/api/newsletters.ts
+++ b/apps/admin-x-settings/src/api/newsletters.ts
@@ -76,6 +76,7 @@ export const useAddNewsletter = createMutation<NewslettersResponseType, Partial<
     searchParams: payload => ({opt_in_existing: payload.opt_in_existing.toString(), include: 'count.active_members,count.posts'}),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: insertToQueryCache('newsletters')
     }
 });
@@ -91,6 +92,7 @@ export const useEditNewsletter = createMutation<NewslettersEditResponseType, New
     defaultSearchParams: {include: 'count.active_members,count.posts'},
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: updateQueryCache('newsletters')
     }
 });

--- a/apps/admin-x-settings/src/api/settings.ts
+++ b/apps/admin-x-settings/src/api/settings.ts
@@ -35,6 +35,7 @@ export const useEditSettings = createMutation<SettingsResponseType, Setting[]>({
     body: settings => ({settings: settings.map(({key, value}) => ({key, value}))}),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: newData => ({
             ...newData,
             settings: newData.settings

--- a/apps/admin-x-settings/src/api/themes.ts
+++ b/apps/admin-x-settings/src/api/themes.ts
@@ -54,6 +54,7 @@ export const useActivateTheme = createMutation<ThemesResponseType, string>({
     path: name => `/themes/${name}/activate/`,
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: (newData: ThemesResponseType, currentData: unknown) => ({
             ...(currentData as ThemesResponseType),
             themes: (currentData as ThemesResponseType).themes.map((theme) => {
@@ -77,6 +78,7 @@ export const useDeleteTheme = createMutation<unknown, string>({
     path: name => `/themes/${name}/`,
     updateQueries: {
         dataType,
+        emberUpdateType: 'delete',
         update: (_, currentData, name) => ({
             ...(currentData as ThemesResponseType),
             themes: (currentData as ThemesResponseType).themes.filter(theme => theme.name !== name)
@@ -90,6 +92,7 @@ export const useInstallTheme = createMutation<ThemesInstallResponseType, string>
     searchParams: repo => ({source: 'github', ref: repo}),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         // Assume that all invite queries should include this new one
         update: (newData, currentData) => (currentData && {
             ...(currentData as ThemesResponseType),
@@ -111,6 +114,7 @@ export const useUploadTheme = createMutation<ThemesInstallResponseType, {file: F
     },
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         // Assume that all invite queries should include this new one
         update: (newData, currentData) => (currentData && {
             ...(currentData as ThemesResponseType),

--- a/apps/admin-x-settings/src/api/tiers.ts
+++ b/apps/admin-x-settings/src/api/tiers.ts
@@ -65,6 +65,7 @@ export const useEditTier = createMutation<TiersResponseType, Tier>({
     body: tier => ({tiers: [tier]}),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: updateQueryCache('tiers')
     }
 });

--- a/apps/admin-x-settings/src/api/users.ts
+++ b/apps/admin-x-settings/src/api/users.ts
@@ -98,6 +98,7 @@ export const useEditUser = createMutation<UsersResponseType, User>({
     searchParams: () => ({include: 'roles'}),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: updateQueryCache('users')
     }
 });
@@ -107,6 +108,7 @@ export const useDeleteUser = createMutation<DeleteUserResponse, string>({
     path: id => `/users/${id}/`,
     updateQueries: {
         dataType,
+        emberUpdateType: 'delete',
         update: deleteFromQueryCache('users')
     }
 });
@@ -134,6 +136,7 @@ export const useMakeOwner = createMutation<UsersResponseType, string>({
     }),
     updateQueries: {
         dataType,
+        emberUpdateType: 'createOrUpdate',
         update: updateQueryCache('users')
     }
 });

--- a/apps/admin-x-settings/src/api/webhooks.ts
+++ b/apps/admin-x-settings/src/api/webhooks.ts
@@ -31,6 +31,7 @@ export const useCreateWebhook = createMutation<WebhooksResponseType, Partial<Web
     body: webhook => ({webhooks: [webhook]}),
     updateQueries: {
         dataType: integrationsDataType,
+        emberUpdateType: 'createOrUpdate',
         update: (newData, currentData) => (currentData && {
             ...(currentData as IntegrationsResponseType),
             integrations: (currentData as IntegrationsResponseType).integrations.map((integration) => {
@@ -52,6 +53,7 @@ export const useEditWebhook = createMutation<WebhooksResponseType, Webhook>({
     body: webhook => ({webhooks: [webhook]}),
     updateQueries: {
         dataType: integrationsDataType,
+        emberUpdateType: 'createOrUpdate',
         update: (newData, currentData) => (currentData && {
             ...(currentData as IntegrationsResponseType),
             integrations: (currentData as IntegrationsResponseType).integrations.map(integration => ({
@@ -69,6 +71,7 @@ export const useDeleteWebhook = createMutation<unknown, string>({
     path: id => `/webhooks/${id}/`,
     updateQueries: {
         dataType: integrationsDataType,
+        emberUpdateType: 'createOrUpdate',
         update: (_, currentData, id) => ({
             ...(currentData as IntegrationsResponseType),
             integrations: (currentData as IntegrationsResponseType).integrations.map(integration => ({

--- a/apps/admin-x-settings/src/components/providers/ServiceProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/ServiceProvider.tsx
@@ -18,8 +18,9 @@ interface ServicesContextProps {
     zapierTemplates: ZapierTemplate[];
     search: SearchService;
     unsplashConfig: DefaultHeaderTypes;
-    toggleFeatureFlag: (flag: string, enabled: boolean) => void;
     sentryDSN: string | null;
+    onUpdate: (dataType: string, response: unknown) => void;
+    onInvalidate: (dataType: string) => void;
 }
 
 interface ServicesProviderProps {
@@ -27,9 +28,10 @@ interface ServicesProviderProps {
     ghostVersion: string;
     zapierTemplates: ZapierTemplate[];
     officialThemes: OfficialTheme[];
-    toggleFeatureFlag: (flag: string, enabled: boolean) => void;
     unsplashConfig: DefaultHeaderTypes;
     sentryDSN: string | null;
+    onUpdate: (dataType: string, response: unknown) => void;
+    onInvalidate: (dataType: string) => void;
 }
 
 const ServicesContext = createContext<ServicesContextProps>({
@@ -37,7 +39,6 @@ const ServicesContext = createContext<ServicesContextProps>({
     officialThemes: [],
     zapierTemplates: [],
     search: {filter: '', setFilter: () => {}, checkVisible: () => true},
-    toggleFeatureFlag: () => {},
     unsplashConfig: {
         Authorization: '',
         'Accept-Version': '',
@@ -45,10 +46,12 @@ const ServicesContext = createContext<ServicesContextProps>({
         'App-Pragma': '',
         'X-Unsplash-Cache': true
     },
-    sentryDSN: null
+    sentryDSN: null,
+    onUpdate: () => {},
+    onInvalidate: () => {}
 });
 
-const ServicesProvider: React.FC<ServicesProviderProps> = ({children, ghostVersion, zapierTemplates, officialThemes, toggleFeatureFlag, unsplashConfig, sentryDSN}) => {
+const ServicesProvider: React.FC<ServicesProviderProps> = ({children, ghostVersion, zapierTemplates, officialThemes, unsplashConfig, sentryDSN, onUpdate, onInvalidate}) => {
     const search = useSearchService();
 
     return (
@@ -58,8 +61,9 @@ const ServicesProvider: React.FC<ServicesProviderProps> = ({children, ghostVersi
             zapierTemplates,
             search,
             unsplashConfig,
-            toggleFeatureFlag,
-            sentryDSN
+            sentryDSN,
+            onUpdate,
+            onInvalidate
         }}>
             {children}
         </ServicesContext.Provider>

--- a/apps/admin-x-settings/src/components/providers/ServiceProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/ServiceProvider.tsx
@@ -21,6 +21,7 @@ interface ServicesContextProps {
     sentryDSN: string | null;
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
+    onDelete: (dataType: string, id: string) => void;
 }
 
 interface ServicesProviderProps {
@@ -32,6 +33,7 @@ interface ServicesProviderProps {
     sentryDSN: string | null;
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
+    onDelete: (dataType: string, id: string) => void;
 }
 
 const ServicesContext = createContext<ServicesContextProps>({
@@ -48,10 +50,11 @@ const ServicesContext = createContext<ServicesContextProps>({
     },
     sentryDSN: null,
     onUpdate: () => {},
-    onInvalidate: () => {}
+    onInvalidate: () => {},
+    onDelete: () => {}
 });
 
-const ServicesProvider: React.FC<ServicesProviderProps> = ({children, ghostVersion, zapierTemplates, officialThemes, unsplashConfig, sentryDSN, onUpdate, onInvalidate}) => {
+const ServicesProvider: React.FC<ServicesProviderProps> = ({children, ghostVersion, zapierTemplates, officialThemes, unsplashConfig, sentryDSN, onUpdate, onInvalidate, onDelete}) => {
     const search = useSearchService();
 
     return (
@@ -63,7 +66,8 @@ const ServicesProvider: React.FC<ServicesProviderProps> = ({children, ghostVersi
             unsplashConfig,
             sentryDSN,
             onUpdate,
-            onInvalidate
+            onInvalidate,
+            onDelete
         }}>
             {children}
         </ServicesContext.Provider>

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/FeatureToggle.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/FeatureToggle.tsx
@@ -5,14 +5,12 @@ import {ConfigResponseType, configDataType} from '../../../../api/config';
 import {getSettingValue, useEditSettings} from '../../../../api/settings';
 import {useGlobalData} from '../../../providers/GlobalDataProvider';
 import {useQueryClient} from '@tanstack/react-query';
-import {useServices} from '../../../providers/ServiceProvider';
 
 const FeatureToggle: React.FC<{ flag: string; }> = ({flag}) => {
     const {settings} = useGlobalData();
     const labs = JSON.parse(getSettingValue<string>(settings, 'labs') || '{}');
     const {mutateAsync: editSettings} = useEditSettings();
     const client = useQueryClient();
-    const {toggleFeatureFlag} = useServices();
 
     return <Toggle checked={labs[flag]} onChange={async () => {
         const newValue = !labs[flag];
@@ -21,7 +19,6 @@ const FeatureToggle: React.FC<{ flag: string; }> = ({flag}) => {
                 key: 'labs',
                 value: JSON.stringify({...labs, [flag]: newValue})
             }]);
-            toggleFeatureFlag(flag, newValue);
             client.setQueriesData([configDataType], current => ({
                 config: {
                     ...(current as ConfigResponseType).config,

--- a/apps/admin-x-settings/src/main.tsx
+++ b/apps/admin-x-settings/src/main.tsx
@@ -33,6 +33,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
             sentryDSN={'' as string | null}
             unsplashConfig={{} as DefaultHeaderTypes}
             zapierTemplates={[]}
+            onDelete={() => {}}
             onInvalidate={() => {}}
             onUpdate={() => {}}
         />

--- a/apps/admin-x-settings/src/main.tsx
+++ b/apps/admin-x-settings/src/main.tsx
@@ -31,9 +31,10 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
                 image: 'assets/img/themes/Edition.png'
             }]}
             sentryDSN={'' as string | null}
-            toggleFeatureFlag={() => {}}
             unsplashConfig={{} as DefaultHeaderTypes}
             zapierTemplates={[]}
+            onInvalidate={() => {}}
+            onUpdate={() => {}}
         />
     </React.StrictMode>
 );

--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -5,6 +5,7 @@ import config from 'ghost-admin/config/environment';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {action} from '@ember/object';
 import {inject} from 'ghost-admin/decorators/inject';
+import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 import {tracked} from '@glimmer/tracking';
 
@@ -250,6 +251,19 @@ const fetchSettings = function () {
     return {read};
 };
 
+const emberDataTypeMapping = {
+    ConfigResponseType: {ignore: true},
+    CustomThemeSettingsResponseType: {type: 'custom-theme-setting'},
+    IntegrationsResponseType: {type: 'integration'},
+    InvitesResponseType: {type: 'invite'},
+    NewslettersResponseType: {type: 'newsletter'},
+    RecommendationsResponseType: {type: 'recommendation'},
+    SettingsResponseType: {type: 'setting', singleton: true},
+    ThemesResponseType: {type: 'theme'},
+    TiersResponseType: {type: 'tier'},
+    UsersResponseType: {type: 'user'}
+};
+
 export default class AdminXSettings extends Component {
     @service ajax;
     @service feature;
@@ -279,12 +293,53 @@ export default class AdminXSettings extends Component {
         // don't rethrow, app should attempt to gracefully recover
     }
 
-    externalNavigate = ({route, models = []}) => {
-        this.router.transitionTo(route, ...models);
+    onUpdate = (dataType, response) => {
+        if (!emberDataTypeMapping[dataType]) {
+            throw new Error(`A mutation updating ${dataType} succeeded in AdminX but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
+        }
+
+        const {skip, type, singleton} = emberDataTypeMapping[dataType];
+
+        if (skip) {
+            return;
+        }
+
+        if (singleton) {
+            // Special singleton objects like settings don't work with pushPayload, we need to add the ID explicitly
+            this.store.push(this.store.serializerFor(type).normalizeSingleResponse(
+                this.store,
+                this.store.modelFor(type),
+                response,
+                null,
+                'queryRecord'
+            ));
+        } else {
+            this.store.pushPayload(type, response);
+        }
     };
 
-    toggleFeatureFlag = (flag, value) => {
-        this.feature.set(flag, value);
+    onInvalidate = (dataType) => {
+        if (!emberDataTypeMapping[dataType]) {
+            throw new Error(`A mutation invalidating ${dataType} succeeded in AdminX but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
+        }
+
+        const {skip, type, singleton} = emberDataTypeMapping[dataType];
+
+        if (skip) {
+            return;
+        }
+
+        if (singleton) {
+            // eslint-disable-next-line no-console
+            console.warn(`An AdminX mutation invalidated ${dataType}, but this is is marked as a singleton and cannot be reloaded in Ember. You probably wanted to use updateQueries instead of invalidateQueries`);
+            return;
+        }
+
+        run(() => this.store.unloadAll(type));
+    };
+
+    externalNavigate = ({route, models = []}) => {
+        this.router.transitionTo(route, ...models);
     };
 
     editorResource = fetchSettings();
@@ -322,10 +377,11 @@ export default class AdminXSettings extends Component {
                             officialThemes={officialThemes}
                             zapierTemplates={zapierTemplates}
                             externalNavigate={this.externalNavigate}
-                            toggleFeatureFlag={this.toggleFeatureFlag}
                             darkMode={this.feature.nightShift}
                             unsplashConfig={defaultUnsplashHeaders}
                             sentryDSN={this.config.sentry_dsn}
+                            onUpdate={this.onUpdate}
+                            onInvalidate={this.onInvalidate}
                         />
                     </Suspense>
                 </ErrorHandler>

--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -252,8 +252,6 @@ const fetchSettings = function () {
 };
 
 const emberDataTypeMapping = {
-    ConfigResponseType: {ignore: true},
-    CustomThemeSettingsResponseType: {type: 'custom-theme-setting'},
     IntegrationsResponseType: {type: 'integration'},
     InvitesResponseType: {type: 'invite'},
     NewslettersResponseType: {type: 'newsletter'},
@@ -298,11 +296,7 @@ export default class AdminXSettings extends Component {
             throw new Error(`A mutation updating ${dataType} succeeded in AdminX but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
         }
 
-        const {skip, type, singleton} = emberDataTypeMapping[dataType];
-
-        if (skip) {
-            return;
-        }
+        const {type, singleton} = emberDataTypeMapping[dataType];
 
         if (singleton) {
             // Special singleton objects like settings don't work with pushPayload, we need to add the ID explicitly
@@ -323,11 +317,7 @@ export default class AdminXSettings extends Component {
             throw new Error(`A mutation invalidating ${dataType} succeeded in AdminX but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
         }
 
-        const {skip, type, singleton} = emberDataTypeMapping[dataType];
-
-        if (skip) {
-            return;
-        }
+        const {type, singleton} = emberDataTypeMapping[dataType];
 
         if (singleton) {
             // eslint-disable-next-line no-console
@@ -336,6 +326,20 @@ export default class AdminXSettings extends Component {
         }
 
         run(() => this.store.unloadAll(type));
+    };
+
+    onDelete = (dataType, id) => {
+        if (!emberDataTypeMapping[dataType]) {
+            throw new Error(`A mutation deleting ${dataType} succeeded in AdminX but there is no mapping to an Ember type. Add one to emberDataTypeMapping`);
+        }
+
+        const {type} = emberDataTypeMapping[dataType];
+
+        const record = this.store.peekRecord(type, id);
+
+        if (record) {
+            record.unloadRecord();
+        }
     };
 
     externalNavigate = ({route, models = []}) => {
@@ -382,6 +386,7 @@ export default class AdminXSettings extends Component {
                             sentryDSN={this.config.sentry_dsn}
                             onUpdate={this.onUpdate}
                             onInvalidate={this.onInvalidate}
+                            onDelete={this.onDelete}
                         />
                     </Suspense>
                 </ErrorHandler>

--- a/ghost/admin/app/serializers/setting.js
+++ b/ghost/admin/app/serializers/setting.js
@@ -23,7 +23,7 @@ export default class Setting extends ApplicationSerializer {
     }
 
     serializeAttribute(snapshot, json, key, attributes) {
-        // Only serialize attributes that have changed and 
+        // Only serialize attributes that have changed and
         // send a partial update to the API to avoid conflicts
         // with different screens using the same model
         // See https://github.com/TryGhost/Ghost/issues/15470


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3832

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a91ba3</samp>

This pull request enables data synchronization between the Ember app and the React app for the settings module. It passes `onUpdate` and `onInvalidate` functions as props from the Ember app to the React app through the `ReactApp` component and the `ServicesContext`. It also removes unused code and adds some debugging logs in the `setting` serializer and the `settings` service.
