### PR TITLE
Added e2e tests for creating+saving pages containing collection cards

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
@@ -1488,3 +1488,360 @@ Object {
   "x-powered-by": "Express",
 }
 `;
+
+exports[`Pages API Update Works with featured collection card 1: [body] 1`] = `
+Object {
+  "pages": Array [
+    Object {
+      "authors": Any<Array>,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "comment_id": Any<String>,
+      "count": Object {
+        "negative_feedback": 0,
+        "paid_conversions": 0,
+        "positive_feedback": 0,
+        "signups": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "custom_excerpt": null,
+      "custom_template": null,
+      "excerpt": "
+
+
+Featured
+
+
+
+
+
+
+
+
+Not so short, bit complex
+
+
+* Lorem
+* Aliquam
+* Tortor
+* Morbi
+* Praesent
+* Pellentesque
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
+
+1234abcdefghijkl
+
+Definition listConsectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et d",
+      "feature_image": null,
+      "feature_image_alt": null,
+      "feature_image_caption": null,
+      "featured": false,
+      "frontmatter": null,
+      "html": "<div class=\\"kg-card kg-collection-card kg-width-wide\\" data-kg-collection-slug=\\"featured\\" data-kg-collection-limit=\\"3\\">
+            <h4 class=\\"kg-collection-card-title\\">Featured</h4>
+            <div class=\\"kg-collection-card-feed kg-collection-card-grid columns-3\\">
+                <a href=\\"http://127.0.0.1:2369/not-so-short-bit-complex/\\" class=\\"kg-collection-card-post-wrapper\\">
+            <div class=\\"kg-collection-card-post\\">
+                
+                <div class=\\"kg-collection-card-content\\">
+                    <h2 class=\\"kg-collection-card-post-title\\">Not so short, bit complex</h2>
+                    <p class=\\"kg-collection-card-post-excerpt\\"> * Lorem
+ * Aliquam
+ * Tortor
+ * Morbi
+ * Praesent
+ * Pellentesque
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.
+
+1234abcdefghijkl
+
+Definition listConsectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim venia</p>
+                    <div class=\\"kg-collection-card-post-meta\\">
+                        <p>4 Jan 2015</p>
+                        <p>&nbsp;· 1 min</p>
+                    </div>
+                </div>
+            </div>
+        </a><a href=\\"http://127.0.0.1:2369/short-and-sweet/\\" class=\\"kg-collection-card-post-wrapper\\">
+            <div class=\\"kg-collection-card-post\\">
+                <div class=\\"kg-collection-card-img\\">
+                        <img class=\\"aspect-[3/2]\\" src=\\"http://placekitten.com/500/200\\" alt=\\"Short and Sweet\\">
+                    </div>
+                <div class=\\"kg-collection-card-content\\">
+                    <h2 class=\\"kg-collection-card-post-title\\">Short and Sweet</h2>
+                    <p class=\\"kg-collection-card-post-excerpt\\">testing
+
+
+mctesters
+
+
+ * test
+ * line
+ * items
+</p>
+                    <div class=\\"kg-collection-card-post-meta\\">
+                        <p>3 Jan 2015</p>
+                        
+                    </div>
+                </div>
+            </div>
+        </a>
+            </div>
+        </div><p>Testing</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "lexical": "{\\"root\\":{\\"children\\":[{\\"type\\":\\"collection\\",\\"version\\":1,\\"collection\\":\\"featured\\",\\"postCount\\":3,\\"layout\\":\\"grid\\",\\"columns\\":3,\\"header\\":\\"Featured\\"},{\\"children\\":[{\\"detail\\":0,\\"format\\":0,\\"mode\\":\\"normal\\",\\"style\\":\\"\\",\\"text\\":\\"Testing\\",\\"type\\":\\"text\\",\\"version\\":1}],\\"direction\\":\\"ltr\\",\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"paragraph\\",\\"version\\":1}],\\"direction\\":null,\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"root\\",\\"version\\":1}}",
+      "meta_description": null,
+      "meta_title": null,
+      "mobiledoc": null,
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "post_revisions": Any<Array>,
+      "primary_author": Any<Object>,
+      "primary_tag": Any<Object>,
+      "published_at": null,
+      "reading_time": 1,
+      "show_title_and_feature_image": Any<Boolean>,
+      "slug": "latest-collection-card-test-2",
+      "status": "draft",
+      "tags": Any<Array>,
+      "tiers": Array [
+        Object {
+          "active": true,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "currency": null,
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "monthly_price": null,
+          "monthly_price_id": null,
+          "name": "Free",
+          "slug": "free",
+          "trial_days": 0,
+          "type": "free",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "public",
+          "welcome_page_url": null,
+          "yearly_price": null,
+          "yearly_price_id": null,
+        },
+        Object {
+          "active": true,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "currency": "usd",
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "monthly_price": 500,
+          "monthly_price_id": null,
+          "name": "Default Product",
+          "slug": "default-product",
+          "trial_days": 0,
+          "type": "paid",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "public",
+          "welcome_page_url": null,
+          "yearly_price": 5000,
+          "yearly_price_id": null,
+        },
+      ],
+      "title": "Latest Collection Card Test",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "url": Any<String>,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "visibility": "public",
+    },
+  ],
+}
+`;
+
+exports[`Pages API Update Works with latest collection card 1: [body] 1`] = `
+Object {
+  "pages": Array [
+    Object {
+      "authors": Any<Array>,
+      "canonical_url": null,
+      "codeinjection_foot": null,
+      "codeinjection_head": null,
+      "comment_id": Any<String>,
+      "count": Object {
+        "negative_feedback": 0,
+        "paid_conversions": 0,
+        "positive_feedback": 0,
+        "signups": 0,
+      },
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "custom_excerpt": null,
+      "custom_template": null,
+      "excerpt": "
+
+
+Latest
+
+
+
+
+
+
+
+
+
+
+Start here for a quick overview of everything you need to know
+
+
+We've crammed the most important information to help you get started with Ghost into this one post. It's your cheat-sheet to get started, and your shortcut to advanced features.
+
+
+
+25 Sep 2023
+
+
+ · 2 min
+
+
+
+
+
+
+
+
+
+
+
+
+Customizing your brand and design settings
+
+
+How to tweak a few settings in Ghost to transform your site from a generic template to a custom brand with style and personality.
+
+
+
+25 Sep 2023
+
+
+ · 3 mi",
+      "feature_image": null,
+      "feature_image_alt": null,
+      "feature_image_caption": null,
+      "featured": false,
+      "frontmatter": null,
+      "html": "<div class=\\"kg-card kg-collection-card kg-width-wide\\" data-kg-collection-slug=\\"latest\\" data-kg-collection-limit=\\"3\\">
+            <h4 class=\\"kg-collection-card-title\\">Latest</h4>
+            <div class=\\"kg-collection-card-feed kg-collection-card-grid columns-3\\">
+                <a href=\\"http://127.0.0.1:2369/welcome/\\" class=\\"kg-collection-card-post-wrapper\\">
+            <div class=\\"kg-collection-card-post\\">
+                <div class=\\"kg-collection-card-img\\">
+                        <img class=\\"aspect-[3/2]\\" src=\\"https://static.ghost.org/v4.0.0/images/welcome-to-ghost.png\\" alt=\\"Start here for a quick overview of everything you need to know\\">
+                    </div>
+                <div class=\\"kg-collection-card-content\\">
+                    <h2 class=\\"kg-collection-card-post-title\\">Start here for a quick overview of everything you need to know</h2>
+                    <p class=\\"kg-collection-card-post-excerpt\\">We've crammed the most important information to help you get started with Ghost into this one post. It's your cheat-sheet to get started, and your shortcut to advanced features.</p>
+                    <div class=\\"kg-collection-card-post-meta\\">
+                        <p>25 Sep 2023</p>
+                        <p>&nbsp;· 2 min</p>
+                    </div>
+                </div>
+            </div>
+        </a><a href=\\"http://127.0.0.1:2369/design/\\" class=\\"kg-collection-card-post-wrapper\\">
+            <div class=\\"kg-collection-card-post\\">
+                <div class=\\"kg-collection-card-img\\">
+                        <img class=\\"aspect-[3/2]\\" src=\\"https://static.ghost.org/v4.0.0/images/publishing-options.png\\" alt=\\"Customizing your brand and design settings\\">
+                    </div>
+                <div class=\\"kg-collection-card-content\\">
+                    <h2 class=\\"kg-collection-card-post-title\\">Customizing your brand and design settings</h2>
+                    <p class=\\"kg-collection-card-post-excerpt\\">How to tweak a few settings in Ghost to transform your site from a generic template to a custom brand with style and personality.</p>
+                    <div class=\\"kg-collection-card-post-meta\\">
+                        <p>25 Sep 2023</p>
+                        <p>&nbsp;· 3 min</p>
+                    </div>
+                </div>
+            </div>
+        </a><a href=\\"http://127.0.0.1:2369/write/\\" class=\\"kg-collection-card-post-wrapper\\">
+            <div class=\\"kg-collection-card-post\\">
+                <div class=\\"kg-collection-card-img\\">
+                        <img class=\\"aspect-[3/2]\\" src=\\"https://static.ghost.org/v4.0.0/images/writing-posts-with-ghost.png\\" alt=\\"Writing and managing content in Ghost, an advanced guide\\">
+                    </div>
+                <div class=\\"kg-collection-card-content\\">
+                    <h2 class=\\"kg-collection-card-post-title\\">Writing and managing content in Ghost, an advanced guide</h2>
+                    <p class=\\"kg-collection-card-post-excerpt\\">A full overview of all the features built into the Ghost editor, including powerful workflow automations to speed up your creative process.</p>
+                    <div class=\\"kg-collection-card-post-meta\\">
+                        <p>25 Sep 2023</p>
+                        <p>&nbsp;· 5 min</p>
+                    </div>
+                </div>
+            </div>
+        </a>
+            </div>
+        </div><p>Testing</p>",
+      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+      "lexical": "{\\"root\\":{\\"children\\":[{\\"type\\":\\"collection\\",\\"version\\":1,\\"collection\\":\\"latest\\",\\"postCount\\":3,\\"layout\\":\\"grid\\",\\"columns\\":3,\\"header\\":\\"Latest\\"},{\\"children\\":[{\\"detail\\":0,\\"format\\":0,\\"mode\\":\\"normal\\",\\"style\\":\\"\\",\\"text\\":\\"Testing\\",\\"type\\":\\"text\\",\\"version\\":1}],\\"direction\\":\\"ltr\\",\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"paragraph\\",\\"version\\":1}],\\"direction\\":null,\\"format\\":\\"\\",\\"indent\\":0,\\"type\\":\\"root\\",\\"version\\":1}}",
+      "meta_description": null,
+      "meta_title": null,
+      "mobiledoc": null,
+      "og_description": null,
+      "og_image": null,
+      "og_title": null,
+      "post_revisions": Any<Array>,
+      "primary_author": Any<Object>,
+      "primary_tag": Any<Object>,
+      "published_at": null,
+      "reading_time": 1,
+      "show_title_and_feature_image": Any<Boolean>,
+      "slug": "latest-collection-card-test",
+      "status": "draft",
+      "tags": Any<Array>,
+      "tiers": Array [
+        Object {
+          "active": true,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "currency": null,
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "monthly_price": null,
+          "monthly_price_id": null,
+          "name": "Free",
+          "slug": "free",
+          "trial_days": 0,
+          "type": "free",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "public",
+          "welcome_page_url": null,
+          "yearly_price": null,
+          "yearly_price_id": null,
+        },
+        Object {
+          "active": true,
+          "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "currency": "usd",
+          "description": null,
+          "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
+          "monthly_price": 500,
+          "monthly_price_id": null,
+          "name": "Default Product",
+          "slug": "default-product",
+          "trial_days": 0,
+          "type": "paid",
+          "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+          "visibility": "public",
+          "welcome_page_url": null,
+          "yearly_price": 5000,
+          "yearly_price_id": null,
+        },
+      ],
+      "title": "Latest Collection Card Test",
+      "twitter_description": null,
+      "twitter_image": null,
+      "twitter_title": null,
+      "updated_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
+      "url": Any<String>,
+      "uuid": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "visibility": "public",
+    },
+  ],
+}
+`;


### PR DESCRIPTION
no issue

- act as regression tests for internal collection code changes
- useful to test as we've hit missing transaction passthrough for sqlite a couple of times that wasn't caught
