### PR TITLE
Added custom theme type to emberdatatypemapping

### DIFF
--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -265,7 +265,9 @@ const emberDataTypeMapping = {
     SettingsResponseType: {type: 'setting', singleton: true},
     ThemesResponseType: {type: 'theme'},
     TiersResponseType: {type: 'tier'},
-    UsersResponseType: {type: 'user'}
+    UsersResponseType: {type: 'user'},
+    CustomThemeSettingsResponseType: {type: 'custom-theme-setting'}
+
 };
 
 export default class AdminXSettings extends Component {


### PR DESCRIPTION
no issue

- added a missing emberDataTypeMapping needed for theme uploads to be handled correctly

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 40647c6</samp>

Added support for custom theme settings API in Ember Data. Updated `settings.js` to map the new `CustomThemeSettingsResponseType` to the store.
