### PR TITLE
Fixed site title syncing from AdminX to Ember

### DIFF
--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -318,6 +318,11 @@ export default class AdminXSettings extends Component {
         } else {
             this.store.pushPayload(type, response);
         }
+
+        if (dataType === 'SettingsResponseType') {
+            // Blog title is based on settings, but the one stored in config is used instead in various places
+            this.config.blogTitle = response.settings.find(setting => setting.key === 'title').value;
+        }
     };
 
     onInvalidate = (dataType) => {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3832

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6fc491b</samp>

Refactor settings management to use `config` service and sync blog title with server. Update `ghost/admin/app/components/admin-x/settings.js` to fetch and set `blogTitle` from settings.
