### PR TITLE
Fixed errors not displaying when uploading broken theme in Admin X

### DIFF
--- a/apps/admin-x-settings/src/api/themes.ts
+++ b/apps/admin-x-settings/src/api/themes.ts
@@ -15,7 +15,7 @@ export type Theme = {
 }
 
 export type InstalledTheme = Theme & {
-    errors?: ThemeProblem<'error'>[];
+    gscan_errors?: ThemeProblem<'error'>[];
     warnings?: ThemeProblem<'warning'>[];
 }
 

--- a/apps/admin-x-settings/src/components/settings/site/ThemeModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/ThemeModal.tsx
@@ -98,8 +98,8 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
             </>;
         }
 
-        if (uploadedTheme.errors?.length || uploadedTheme.warnings?.length) {
-            const hasErrors = uploadedTheme.errors?.length;
+        if (uploadedTheme?.gscan_errors?.length || uploadedTheme.warnings?.length) {
+            const hasErrors = uploadedTheme?.gscan_errors?.length;
 
             title = `Upload successful with ${hasErrors ? 'errors' : 'warnings'}`;
             prompt = <>
@@ -286,8 +286,8 @@ const ChangeThemeModal = () => {
                     </>;
                 }
 
-                if (newlyInstalledTheme.errors?.length || newlyInstalledTheme.warnings?.length) {
-                    const hasErrors = newlyInstalledTheme.errors?.length;
+                if (newlyInstalledTheme.gscan_errors?.length || newlyInstalledTheme.warnings?.length) {
+                    const hasErrors = newlyInstalledTheme.gscan_errors?.length;
 
                     title = `Installed with ${hasErrors ? 'errors' : 'warnings'}`;
                     prompt = <>

--- a/apps/admin-x-settings/src/components/settings/site/theme/ThemeInstalledModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/ThemeInstalledModal.tsx
@@ -49,10 +49,10 @@ const ThemeInstalledModal: React.FC<{
     const {mutateAsync: activateTheme} = useActivateTheme();
 
     let errorPrompt = null;
-    if (installedTheme.errors) {
+    if (installedTheme.gscan_errors) {
         errorPrompt = <div className="mt-6">
             <List hint={<>Highly recommended to fix, functionality <strong>could</strong> be restricted</>} title="Errors">
-                {installedTheme.errors?.map(error => <ThemeProblemView problem={error} />)}
+                {installedTheme.gscan_errors?.map(error => <ThemeProblemView problem={error} />)}
             </List>
         </div>;
     }
@@ -66,7 +66,7 @@ const ThemeInstalledModal: React.FC<{
         </div>;
     }
 
-    let okLabel = `Activate${installedTheme.errors?.length ? ' with errors' : ''}`;
+    let okLabel = `Activate${installedTheme.gscan_errors?.length ? ' with errors' : ''}`;
 
     if (installedTheme.active) {
         okLabel = 'OK';


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C0568LN2CGJ/p1695716107796769

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4bca3ee</samp>

Updated the theme modal and the theme installed modal to use the new `gscan_errors` property for theme validation. This improves the accuracy and consistency of the feedback given to users when they upload or activate themes.
