### PR TITLE
Updated links to old settings to link to AdminX

### DIFF
--- a/ghost/admin/app/components/gh-members-no-members.hbs
+++ b/ghost/admin/app/components/gh-members-no-members.hbs
@@ -9,8 +9,14 @@
         <p class="gh-members-empty-secondary-cta">Have members already? <LinkTo @route="member.new">Add them manually</LinkTo> or <LinkTo @route="members.import">import from CSV</LinkTo></p>
     {{else}}
         <p>Memberships have been disabled. Adjust your Subscription Access settings to start adding members.</p>
-        <LinkTo @route="settings.membership" class="gh-btn gh-btn-green">
-            <span>Membership settings</span>
-        </LinkTo>
+        {{#if (feature "adminXSettings")}}
+            <LinkTo @route="settings-x.settings-x" @model="access" class="gh-btn gh-btn-green">
+                <span>Membership settings</span>
+            </LinkTo>
+        {{else}}
+            <LinkTo @route="settings.membership" class="gh-btn gh-btn-green">
+                <span>Membership settings</span>
+            </LinkTo>
+        {{/if}}
     {{/if}}
 </div>

--- a/ghost/admin/app/templates/offers.hbs
+++ b/ghost/admin/app/templates/offers.hbs
@@ -30,9 +30,15 @@
                 <div class="gh-offers-list-cta missing-tiers">
                     {{svg-jar "discount-bubble" class="discount-bubble"}}
                     <h4>You must have an active tier to create offers</h4>
-                    <LinkTo @route="settings.membership" class="gh-btn gh-btn-green">
-                        <span>Manage tiers</span>
-                    </LinkTo>
+                    {{#if (feature "adminXSettings")}}
+                        <LinkTo @route="settings-x.settings-x" @model="tiers" class="gh-btn gh-btn-green">
+                            <span>Manage tiers</span>
+                        </LinkTo>
+                    {{else}}
+                        <LinkTo @route="settings.membership" class="gh-btn gh-btn-green">
+                            <span>Manage tiers</span>
+                        </LinkTo>
+                    {{/if}}
                 </div>
         {{else if (and this.offersExist this.filteredOffers.length)}}
             <table class="gh-list gh-offers-list" data-test-offers-list>


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3832

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at edc0b86</samp>

This pull request updates the empty states for members and offers to use a new settings route and model when the feature flag `adminXSettings` is enabled. It also extracts the common logic and UI for the empty states to a component `gh-members-no-members.hbs`.
