### PR TITLE
Fixed syncing tiers status between Ember and AdminX

### DIFF
--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -278,6 +278,7 @@ export default class AdminXSettings extends Component {
     @service store;
     @service settings;
     @service router;
+    @service membersUtils;
 
     @inject config;
 
@@ -322,6 +323,11 @@ export default class AdminXSettings extends Component {
         if (dataType === 'SettingsResponseType') {
             // Blog title is based on settings, but the one stored in config is used instead in various places
             this.config.blogTitle = response.settings.find(setting => setting.key === 'title').value;
+        }
+
+        if (dataType === 'TiersResponseType') {
+            // membersUtils has local state which needs to be updated
+            this.membersUtils.reload();
         }
     };
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3832

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ddea75</samp>

Added `membersUtils` service to `AdminXSettings` component to support tiers feature. Reloaded service after saving settings with `TiersResponseType`.
