### PR TITLE
🐛 Fixed staff emails eventually having invalid styles

### DIFF
--- a/ghost/core/core/server/services/comments/CommentsServiceEmails.js
+++ b/ghost/core/core/server/services/comments/CommentsServiceEmails.js
@@ -15,7 +15,7 @@ class CommentsServiceEmails {
         this.urlService = urlService;
         this.urlUtils = urlUtils;
 
-        this.Handlebars = require('handlebars');
+        this.Handlebars = require('handlebars').create();
     }
 
     async notifyPostAuthors(comment) {

--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -668,7 +668,7 @@ class EmailRenderer {
     }
 
     async renderTemplate(data) {
-        this.#handlebars = require('handlebars');
+        this.#handlebars = require('handlebars').create();
 
         // Helpers
         this.#handlebars.registerHelper('if', function (conditional, options) {

--- a/ghost/staff-service/lib/StaffServiceEmails.js
+++ b/ghost/staff-service/lib/StaffServiceEmails.js
@@ -13,8 +13,9 @@ class StaffServiceEmails {
         this.urlUtils = urlUtils;
         this.labs = labs;
 
-        this.Handlebars = require('handlebars');
+        this.Handlebars = require('handlebars').create();
         this.registerPartials();
+        this.registerHelpers();
     }
 
     async notifyFreeMemberSignup({
@@ -478,10 +479,7 @@ class StaffServiceEmails {
         });
     }
 
-    async renderHTML(templateName, data) {
-        const htmlTemplateSource = await fs.readFile(path.join(__dirname, './email-templates/', `${templateName}.hbs`), 'utf8');
-        const htmlTemplate = this.Handlebars.compile(Buffer.from(htmlTemplateSource).toString());
-
+    registerHelpers() {
         this.Handlebars.registerHelper('eq', function (arg, value, options) {
             if (arg === value) {
                 return options.fn(this);
@@ -496,6 +494,11 @@ class StaffServiceEmails {
             }
             return array.slice(0,limit);
         });
+    }
+
+    async renderHTML(templateName, data) {
+        const htmlTemplateSource = await fs.readFile(path.join(__dirname, './email-templates/', `${templateName}.hbs`), 'utf8');
+        const htmlTemplate = this.Handlebars.compile(Buffer.from(htmlTemplateSource).toString());
 
         let sharedData = {};
         if (data.recipient) {


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/17937

- We used a global Handlebars instance, which means it was reused across Ghost
- Partials are different between parts of Ghost, that means the partials were overwritten every time a normal Mailgun email was send
- All staff emails send after a normal newsletter would have invalid styles because the partials for styles were overwritten