### PR TITLE
Recommendations settings tests wip

### DIFF
--- a/apps/admin-x-settings/src/admin-x-ds/global/Button.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/Button.tsx
@@ -24,6 +24,7 @@ export interface ButtonProps extends Omit<HTMLProps<HTMLButtonElement>, 'label' 
     loading?: boolean;
     loadingIndicatorSize?: LoadingIndicatorSize;
     loadingIndicatorColor?: LoadingIndicatorColor;
+    testId?: string;
     onClick?: (e?:React.MouseEvent<HTMLElement>) => void;
 }
 
@@ -43,6 +44,7 @@ const Button: React.FC<ButtonProps> = ({
     tag = 'button',
     loading = false,
     loadingIndicatorColor,
+    testId,
     onClick,
     ...props
 }) => {
@@ -132,6 +134,7 @@ const Button: React.FC<ButtonProps> = ({
 
     const buttonElement = React.createElement(tag, {className: className,
         disabled: disabled,
+        'data-testid': testId,
         type: 'button',
         onClick: onClick,
         ...props}, buttonChildren);

--- a/apps/admin-x-settings/src/admin-x-ds/global/form/Toggle.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/form/Toggle.tsx
@@ -18,6 +18,7 @@ interface ToggleProps {
     separator?: boolean;
     direction?: ToggleDirections;
     hint?: React.ReactNode;
+    testId?: string;
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -33,6 +34,7 @@ const Toggle: React.FC<ToggleProps> = ({
     error,
     checked,
     disabled,
+    testId,
     onChange
 }) => {
     const id = useId();
@@ -83,21 +85,21 @@ const Toggle: React.FC<ToggleProps> = ({
     return (
         <div>
             <div className={`group flex items-start gap-2 dark:text-white ${direction === 'rtl' && 'justify-between'} ${separator && 'pb-2'}`}>
-                <input checked={checked}
-                    className={clsx(
-                        toggleBgClass,
-                        'appearance-none rounded-full bg-grey-300 transition dark:bg-grey-800',
-                        `after:absolute after:ml-0.5 after:mt-0.5 after:rounded-full after:border-none after:bg-white after:transition-[background-color_0.2s,transform_0.2s] after:content-['']`,
-                        `checked:after:absolute checked:after:rounded-full checked:after:border-none checked:after:bg-white checked:after:transition-[background-color_0.2s,transform_0.2s] checked:after:content-['']`,
-                        'enabled:hover:cursor-pointer disabled:opacity-40 enabled:group-hover:opacity-80',
-                        sizeStyles,
-                        direction === 'rtl' && ' order-2'
-                    )}
-                    disabled={disabled}
-                    id={id}
-                    role="switch"
-                    type="checkbox"
-                    onChange={onChange} />
+                <input checked={checked} className={clsx(
+                    toggleBgClass,
+                    'appearance-none rounded-full bg-grey-300 transition dark:bg-grey-800',
+                    `after:absolute after:ml-0.5 after:mt-0.5 after:rounded-full after:border-none after:bg-white after:transition-[background-color_0.2s,transform_0.2s] after:content-['']`,
+                    `checked:after:absolute checked:after:rounded-full checked:after:border-none checked:after:bg-white checked:after:transition-[background-color_0.2s,transform_0.2s] checked:after:content-['']`,
+                    'enabled:hover:cursor-pointer disabled:opacity-40 enabled:group-hover:opacity-80',
+                    sizeStyles,
+                    direction === 'rtl' && ' order-2'
+                )}
+                data-testid={testId}
+                disabled={disabled}
+                id={id}
+                role="switch"
+                type="checkbox"
+                onChange={onChange} />
                 {label &&
                     <label className={`flex grow flex-col hover:cursor-pointer ${direction === 'rtl' && 'order-1'} ${labelStyles}`} htmlFor={id}>
                         {

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/FeatureToggle.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/FeatureToggle.tsx
@@ -13,7 +13,7 @@ const FeatureToggle: React.FC<{ flag: string; }> = ({flag}) => {
     const client = useQueryClient();
     const {toggleFeatureFlag} = useServices();
 
-    return <Toggle checked={labs[flag]} onChange={async () => {
+    return <Toggle checked={labs[flag]} testId={`${flag}-lab-item`} onChange={async () => {
         const newValue = !labs[flag];
         await editSettings([{
             key: 'labs',

--- a/apps/admin-x-settings/src/components/settings/site/Recommendations.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/Recommendations.tsx
@@ -66,7 +66,7 @@ const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
             onSave={handleSave}
         >
             <div className='flex justify-center rounded border border-green px-4 py-2 md:hidden'>
-                <Button color='green' label='Add recommendation' link onClick={() => {
+                <Button color='green' data-testid='add-recommendation-button' label='Add recommendation' link onClick={() => {
                     openAddNewRecommendationModal();
                 }} />
             </div>

--- a/apps/admin-x-settings/src/components/settings/site/Recommendations.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/Recommendations.tsx
@@ -66,7 +66,7 @@ const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
             onSave={handleSave}
         >
             <div className='flex justify-center rounded border border-green px-4 py-2 md:hidden'>
-                <Button color='green' data-testid='add-recommendation-button' label='Add recommendation' link onClick={() => {
+                <Button color='green' label='Add recommendation' testId='add-recommendation-button' link onClick={() => {
                     openAddNewRecommendationModal();
                 }} />
             </div>

--- a/apps/admin-x-settings/test/e2e/membership/recommendations.test.ts
+++ b/apps/admin-x-settings/test/e2e/membership/recommendations.test.ts
@@ -13,7 +13,7 @@ test.describe('Recommendations settings', async () => {
         await mockApi({page, requests: {
             ...globalDataRequests,
             browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
-            browseTiers: {method: 'GET', path: '/recommendations/?limit=all', response: responseFixtures.recommendations}
+            browseRecommendations: {method: 'GET', path: '/recommendations/?limit=all', response: responseFixtures.recommendations}
         }});
 
         await page.goto('');
@@ -21,7 +21,7 @@ test.describe('Recommendations settings', async () => {
         // Find recommendations
         const recommendationsSection = page.getByTestId('recommendations');
 
-        await recommendationsSection.getByTestId('add-recommendation-button').click();
+        // await recommendationsSection.getByTestId('add-recommendation-button').click();
 
         await recommendationsSection.getByRole('button', {name: 'Add recommendation'}).click();
 

--- a/apps/admin-x-settings/test/e2e/membership/recommendations.test.ts
+++ b/apps/admin-x-settings/test/e2e/membership/recommendations.test.ts
@@ -1,12 +1,29 @@
 import {expect, test} from '@playwright/test';
+import {globalDataRequests, mockApi, responseFixtures, updatedSettingsResponse} from '../../utils/e2e';
+
+const settingsWithStripe = updatedSettingsResponse([
+    {key: 'stripe_connect_publishable_key', value: 'pk_test_123'},
+    {key: 'stripe_connect_secret_key', value: 'sk_test_123'},
+    {key: 'stripe_connect_display_name', value: 'Dummy'},
+    {key: 'stripe_connect_account_id', value: 'acct_123'}
+]);
 
 test.describe('Recommendations settings', async () => {
-    test('Supports creating a new recommendation', async ({page}) => {
-        await page.goto('/');
+    test.only('Supports creating a new recommendation', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseSettings: {...globalDataRequests.browseSettings, response: settingsWithStripe},
+            browseTiers: {method: 'GET', path: '/recommendations/?limit=all', response: responseFixtures.recommendations}
+        }});
 
-        const section = page.getByTestId('recommendations');
+        await page.goto('');
+        
+        // Find recommendations
+        const recommendationsSection = page.getByTestId('recommendations');
 
-        await section.getByRole('button', {name: 'Add recommendation'}).click();
+        await recommendationsSection.getByTestId('add-recommendation-button').click();
+
+        await recommendationsSection.getByRole('button', {name: 'Add recommendation'}).click();
 
         const modal = page.getByTestId('add-recommendation-modal');
 

--- a/apps/admin-x-settings/test/e2e/membership/recommendations.test.ts
+++ b/apps/admin-x-settings/test/e2e/membership/recommendations.test.ts
@@ -1,0 +1,30 @@
+import {expect, test} from '@playwright/test';
+
+test.describe('Recommendations settings', async () => {
+    test('Supports creating a new recommendation', async ({page}) => {
+        await page.goto('/');
+
+        const section = page.getByTestId('recommendations');
+
+        await section.getByRole('button', {name: 'Add recommendation'}).click();
+
+        const modal = page.getByTestId('add-recommendation-modal');
+
+        await modal.getByRole('button', {name: 'Next'}).click();
+
+        await expect(modal).toHaveText(/Please enter a valid URL./);
+
+        await modal.getByLabel('URL').fill('https://main.ghost.org');
+
+        await modal.getByRole('button', {name: 'Next'}).click();
+
+        await expect(modal).toHaveText(/Preview/);
+        
+        await expect(modal.getByLabel('Title')).toHaveText(/Main X/);
+        await expect(modal.getByLabel('Short description')).toHaveText(/Main X/);
+
+        await modal.getByRole('button', {name: 'Add'}).click();
+
+        await expect(page.getByTestId('toast')).toHaveText(/Successfully added a recommendation/);
+    });
+});

--- a/apps/admin-x-settings/test/utils/e2e.ts
+++ b/apps/admin-x-settings/test/utils/e2e.ts
@@ -6,6 +6,7 @@ import {LabelsResponseType} from '../../src/api/labels';
 import {Locator, Page} from '@playwright/test';
 import {NewslettersResponseType} from '../../src/api/newsletters';
 import {OffersResponseType} from '../../src/api/offers';
+import {RecommendationResponseType} from '../../src/api/recommendations';
 import {RolesResponseType} from '../../src/api/roles';
 import {SettingsResponseType} from '../../src/api/settings';
 import {SiteResponseType} from '../../src/api/site';
@@ -44,6 +45,7 @@ export const responseFixtures = {
     themes: JSON.parse(readFileSync(`${__dirname}/responses/themes.json`).toString()) as ThemesResponseType,
     newsletters: JSON.parse(readFileSync(`${__dirname}/responses/newsletters.json`).toString()) as NewslettersResponseType,
     actions: JSON.parse(readFileSync(`${__dirname}/responses/actions.json`).toString()) as ActionsResponseType,
+    recommendations: JSON.parse(readFileSync(`${__dirname}/responses/recommendations.json`).toString()) as RecommendationResponseType,
     latestPost: {posts: [{id: '1', url: `${siteFixture.site.url}/test-post/`}]}
 };
 

--- a/apps/admin-x-settings/test/utils/responses/config.json
+++ b/apps/admin-x-settings/test/utils/responses/config.json
@@ -5,7 +5,9 @@
         "database": "sqlite3",
         "mail": "SMTP",
         "useGravatar": true,
-        "labs": {},
+        "labs": {
+            "recommendations": true
+        },
         "clientExtensions": {},
         "enableDeveloperExperiments": true,
         "stripeDirect": false,

--- a/apps/admin-x-settings/test/utils/responses/recommendations.json
+++ b/apps/admin-x-settings/test/utils/responses/recommendations.json
@@ -4,7 +4,7 @@
             "id": "645453f4d254799990dd0e21",
             "title": "Fake Site 1",
             "excerpt": "Fake excerpt 1",
-            "url": "www.google.com",
+            "url": "https://main.ghost.org",
             "active": true,
             "created_at": "2023-05-05T00:55:16.000Z",
             "updated_at": "2023-05-05T01:14:35.000Z",

--- a/apps/admin-x-settings/test/utils/responses/recommendations.json
+++ b/apps/admin-x-settings/test/utils/responses/recommendations.json
@@ -1,0 +1,29 @@
+{
+    "recommendations": [
+        {
+            "id": "645453f4d254799990dd0e21",
+            "title": "Fake Site 1",
+            "excerpt": "Fake excerpt 1",
+            "url": "www.google.com",
+            "active": true,
+            "created_at": "2023-05-05T00:55:16.000Z",
+            "updated_at": "2023-05-05T01:14:35.000Z",
+            "favicon": "https://images.unsplash.com/photo-1695193984598-2cbfd23c6b0c?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=3540&q=80",
+            "featured_image": "https://images.unsplash.com/photo-1695193984598-2cbfd23c6b0c?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=3540&q=80",
+            "one_click_subscribe": false,
+            "reason": "Fake reason 1",
+            "visibility": "public",
+            "count": []
+        }
+    ],
+    "meta": {
+        "pagination": {
+            "page": 1,
+            "pages": 1,
+            "limit": 2,
+            "total": 2,
+            "prev": null,
+            "next": null
+        }
+    }
+}

--- a/apps/admin-x-settings/test/utils/responses/settings.json
+++ b/apps/admin-x-settings/test/utils/responses/settings.json
@@ -242,7 +242,7 @@
         },
         {
             "key": "labs",
-            "value": "{}"
+            "value": "{\"recommendations\":true}"
         },
         {
             "key": "slack_url",


### PR DESCRIPTION
---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83a424c</samp>

This pull request adds support for testing the recommendations feature in the admin-x-settings app. It enhances the `Toggle` and `Button` components to use `data-testid` attributes for testing, and adds a new test file `recommendations.test.ts` that uses Playwright to verify the functionality of adding a new recommendation. It also updates the mock data for the settings and recommendations endpoints to enable the feature flag and provide a fake recommendation.
