### PR TITLE
🐛 Fixed incorrect subscription status text when subscription is comped

### DIFF
--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -91,8 +91,9 @@ export function allowCompMemberUpgrade({member}) {
 }
 
 export function getCompExpiry({member}) {
-    if (member?.subscriptions?.[0]?.tier?.expiry_at) {
-        return getDateString(member.subscriptions[0].tier.expiry_at);
+    const subscription = getMemberSubscription({member});
+    if (subscription?.tier?.expiry_at) {
+        return getDateString(subscription.tier.expiry_at);
     }
     return '';
 }

--- a/apps/portal/src/utils/helpers.test.js
+++ b/apps/portal/src/utils/helpers.test.js
@@ -1,4 +1,4 @@
-import {getAllProductsForSite, getAvailableProducts, getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getUrlHistory, hasMultipleProducts, isActiveOffer, isInviteOnlySite, isPaidMember, isSameCurrency, transformApiTiersData, isSigninAllowed, isSignupAllowed} from './helpers';
+import {getAllProductsForSite, getAvailableProducts, getCurrencySymbol, getFreeProduct, getMemberName, getMemberSubscription, getPriceFromSubscription, getPriceIdFromPageQuery, getSupportAddress, getUrlHistory, hasMultipleProducts, isActiveOffer, isInviteOnlySite, isPaidMember, isSameCurrency, transformApiTiersData, isSigninAllowed, isSignupAllowed, getCompExpiry} from './helpers';
 import * as Fixtures from './fixtures-generator';
 import {site as FixturesSite, member as FixtureMember, offer as FixtureOffer, transformTierFixture as TransformFixtureTiers} from '../utils/test-fixtures';
 import {isComplimentaryMember} from '../utils/helpers';
@@ -402,6 +402,50 @@ describe('Helpers - ', () => {
             });
 
             expect(actual.length).toBe(0);
+        });
+    });
+
+    describe('getCompExpiry', () => {
+        let member = {};
+
+        beforeEach(() => {
+            member = {
+                paid: true,
+                subscriptions: [
+                    {
+                        status: 'active',
+                        price: {
+                            amount: 0
+                        },
+                        tier: {
+                            expiry_at: '2023-10-13T00:00:00.000Z'
+                        }
+                    }
+                ]
+            };
+        });
+
+        it('returns the expiry date of a comped subscription', () => {
+            expect(getCompExpiry({member})).toEqual('13 Oct 2023');
+        });
+
+        it('returns the expiry date of a comped subscription if the member has multiple subscriptions', () => {
+            member.subscriptions.push({
+                status: 'cancelled',
+                price: {
+                    amount: 1234
+                },
+                tier: {
+                    expiry_at: '2023-10-14T00:00:00.000Z'
+                }
+            });
+            expect(getCompExpiry({member})).toEqual('13 Oct 2023');
+        });
+
+        it('returns an empty string if the subscription has no expiry date', () => {
+            delete member.subscriptions[0].tier.expiry_at;
+
+            expect(getCompExpiry({member})).toEqual('');
         });
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3963

The subscription status text was incorrect when a subscription was comped and a member had multiple subscriptions (i.e a cancelled sub and a comped sub). This was because the methods used to determine the status of a subscription only took into account the status of the first subscription associated with a member.