### PR TITLE
🐛 Fixed issue with settings being marked as dirty when visibility is changed

### DIFF
--- a/ghost/admin/app/services/custom-theme-settings.js
+++ b/ghost/admin/app/services/custom-theme-settings.js
@@ -100,6 +100,16 @@ export default class CustomThemeSettingsServices extends Service {
     updateSettingsVisibility() {
         this.settings.forEach((setting) => {
             setting.visible = this._isSettingVisible(setting);
+
+            // Updating the setting visibility will cause the setting to be marked as dirty so
+            // we need to compute whether the setting is actually dirty and set the flag manually
+            const changedProperties = Object.keys(setting.changedAttributes()).filter(key => key !== 'visible');
+
+            setting.hasDirtyAttributes = false;
+
+            if (changedProperties.length > 0) {
+                setting.hasDirtyAttributes = true;
+            }
         });
     }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3924

Settings were being marked as dirty when visibility was changed causing the confirm dialog to show when navigating away from the settings page. This change manually computes the dirtiness of the setting to ensure the visibility change is ignored