### PR TITLE
Fixed icon not updating on Ember from AdminX

### DIFF
--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -324,6 +324,8 @@ export default class AdminXSettings extends Component {
         if (dataType === 'SettingsResponseType') {
             // Blog title is based on settings, but the one stored in config is used instead in various places
             this.config.blogTitle = response.settings.find(setting => setting.key === 'title').value;
+
+            this.settings.reload();
         }
 
         if (dataType === 'TiersResponseType') {


### PR DESCRIPTION
refs https://www.notion.so/ghost/df5bdea8f7ea4aca9d25eceb6a1bf34c?v=be2f15b6b58b4c27a0e11374282bead0&p=bafc80a9ad644fb18fe338f89500ff36&pm=s

- we now reload ember's settings data when settings data updated, to keep certain data synced, such as the icon in the sidebar.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 572a569</samp>

Refactor settings component to use Ember Octane and reload settings model after saving. This improves the UI and code quality of the `admin-x` component.
