### PR TITLE
Refactored loading of Koenig-Lexical package

### DIFF
--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -5,8 +5,8 @@ import NiceModal from '@ebay/nice-modal-react';
 import RoutingProvider, {ExternalLink} from './components/providers/RoutingProvider';
 import clsx from 'clsx';
 import {DefaultHeaderTypes} from './utils/unsplash/UnsplashTypes';
+import {FetchKoenigLexical, OfficialTheme, ServicesProvider} from './components/providers/ServiceProvider';
 import {GlobalDirtyStateProvider} from './hooks/useGlobalDirtyState';
-import {OfficialTheme, ServicesProvider} from './components/providers/ServiceProvider';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {ErrorBoundary as SentryErrorBoundary} from '@sentry/react';
 import {Toaster} from 'react-hot-toast';
@@ -20,7 +20,7 @@ interface AppProps {
     darkMode?: boolean;
     unsplashConfig: DefaultHeaderTypes
     sentryDSN: string | null;
-    fetchKoenigLexical: any;
+    fetchKoenigLexical: FetchKoenigLexical;
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
@@ -51,7 +51,7 @@ function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, d
                     <GlobalDataProvider>
                         <RoutingProvider externalNavigate={externalNavigate}>
                             <GlobalDirtyStateProvider>
-                                <DesignSystemProvider fetchKoenigLexical={fetchKoenigLexical}>
+                                <DesignSystemProvider>
                                     <div className={appClassName} id="admin-x-root" style={{
                                         height: '100vh',
                                         width: '100%'

--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -20,6 +20,7 @@ interface AppProps {
     darkMode?: boolean;
     unsplashConfig: DefaultHeaderTypes
     sentryDSN: string | null;
+    fetchKoenigLexical: any;
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
@@ -37,7 +38,7 @@ const queryClient = new QueryClient({
     }
 });
 
-function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, darkMode = false, unsplashConfig, sentryDSN, onUpdate, onInvalidate, onDelete}: AppProps) {
+function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, darkMode = false, unsplashConfig, fetchKoenigLexical, sentryDSN, onUpdate, onInvalidate, onDelete}: AppProps) {
     const appClassName = clsx(
         'admin-x-settings h-[100vh] w-full overflow-y-auto overflow-x-hidden',
         darkMode && 'dark'
@@ -50,7 +51,7 @@ function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, d
                     <GlobalDataProvider>
                         <RoutingProvider externalNavigate={externalNavigate}>
                             <GlobalDirtyStateProvider>
-                                <DesignSystemProvider>
+                                <DesignSystemProvider fetchKoenigLexical={fetchKoenigLexical}>
                                     <div className={appClassName} id="admin-x-root" style={{
                                         height: '100vh',
                                         width: '100%'

--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -47,7 +47,7 @@ function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, d
     return (
         <SentryErrorBoundary>
             <QueryClientProvider client={queryClient}>
-                <ServicesProvider ghostVersion={ghostVersion} officialThemes={officialThemes} sentryDSN={sentryDSN} unsplashConfig={unsplashConfig} zapierTemplates={zapierTemplates} onDelete={onDelete} onInvalidate={onInvalidate} onUpdate={onUpdate}>
+                <ServicesProvider fetchKoenigLexical={fetchKoenigLexical} ghostVersion={ghostVersion} officialThemes={officialThemes} sentryDSN={sentryDSN} unsplashConfig={unsplashConfig} zapierTemplates={zapierTemplates} onDelete={onDelete} onInvalidate={onInvalidate} onUpdate={onUpdate}>
                     <GlobalDataProvider>
                         <RoutingProvider externalNavigate={externalNavigate}>
                             <GlobalDirtyStateProvider>

--- a/apps/admin-x-settings/src/admin-x-ds/global/form/HtmlEditor.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/form/HtmlEditor.tsx
@@ -1,7 +1,8 @@
 import * as Sentry from '@sentry/react';
 import ErrorBoundary from '../ErrorBoundary';
 import React, {Suspense, useCallback, useMemo} from 'react';
-import {fetchKoenigLexical, useFocusContext} from '../../providers/DesignSystemProvider';
+import {FetchKoenigLexical, useServices} from '../../../components/providers/ServiceProvider';
+import {useFocusContext} from '../../providers/DesignSystemProvider';
 
 export interface HtmlEditorProps {
     value?: string
@@ -17,7 +18,7 @@ declare global {
     }
 }
 
-const fetchKoenig = function () {
+const fetchKoenig = function (fetchKoenigLexical: FetchKoenigLexical) {
     let status = 'pending';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let response: any;
@@ -143,7 +144,8 @@ const HtmlEditor: React.FC<HtmlEditorProps & {
     className,
     ...props
 }) => {
-    const editorResource = fetchKoenig();
+    const {fetchKoenigLexical} = useServices();
+    const editorResource = useMemo(() => fetchKoenig(fetchKoenigLexical), [fetchKoenigLexical]);
 
     const {setFocusState} = useFocusContext();
     // this is not ideal, we need to add a focus plugin inside the Koenig editor package to handle this properly

--- a/apps/admin-x-settings/src/admin-x-ds/global/form/HtmlEditor.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/form/HtmlEditor.tsx
@@ -14,11 +14,12 @@ export interface HtmlEditorProps {
 
 declare global {
     interface Window {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         '@tryghost/koenig-lexical': any;
     }
 }
 
-const fetchKoenig = function (fetchKoenigLexical: FetchKoenigLexical) {
+const loadKoenig = function (fetchKoenigLexical: FetchKoenigLexical) {
     let status = 'pending';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let response: any;
@@ -48,7 +49,7 @@ const fetchKoenig = function (fetchKoenigLexical: FetchKoenigLexical) {
     return {read};
 };
 
-type EditorResource = ReturnType<typeof fetchKoenig>;
+type EditorResource = ReturnType<typeof loadKoenig>;
 
 const KoenigWrapper: React.FC<HtmlEditorProps & { editor: EditorResource }> = ({
     editor,
@@ -145,7 +146,7 @@ const HtmlEditor: React.FC<HtmlEditorProps & {
     ...props
 }) => {
     const {fetchKoenigLexical} = useServices();
-    const editorResource = useMemo(() => fetchKoenig(fetchKoenigLexical), [fetchKoenigLexical]);
+    const editorResource = useMemo(() => loadKoenig(fetchKoenigLexical), [fetchKoenigLexical]);
 
     const {setFocusState} = useFocusContext();
     // this is not ideal, we need to add a focus plugin inside the Koenig editor package to handle this properly

--- a/apps/admin-x-settings/src/admin-x-ds/global/form/HtmlField.stories.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/form/HtmlField.stories.tsx
@@ -5,15 +5,7 @@ import HtmlField from './HtmlField';
 const meta = {
     title: 'Global / Form / Htmlfield',
     component: HtmlField,
-    tags: ['autodocs'],
-    args: {
-        config: {
-            editor: {
-                url: 'https://cdn.jsdelivr.net/ghost/koenig-lexical@~{version}/dist/koenig-lexical.umd.js',
-                version: '0.3'
-            }
-        }
-    }
+    tags: ['autodocs']
 } satisfies Meta<typeof HtmlField>;
 
 export default meta;

--- a/apps/admin-x-settings/src/admin-x-ds/global/form/HtmlField.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/form/HtmlField.tsx
@@ -4,13 +4,7 @@ import HtmlEditor, {HtmlEditorProps} from './HtmlEditor';
 import React from 'react';
 import clsx from 'clsx';
 
-export type EditorConfig = { editor: { url: string; version: string; } }
-
 export type HtmlFieldProps = HtmlEditorProps & {
-    /**
-     * Should be passed the Ghost instance config to get the editor JS URL
-     */
-    config: EditorConfig;
     title?: string;
     hideTitle?: boolean;
     error?: boolean;

--- a/apps/admin-x-settings/src/admin-x-ds/providers/DesignSystemProvider.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/providers/DesignSystemProvider.tsx
@@ -4,7 +4,6 @@ import React, {createContext, useContext, useState} from 'react';
 interface DesignSystemContextType {
     isAnyTextFieldFocused: boolean;
     setFocusState: (value: boolean) => void;
-    fetchKoenigLexical: any;
 }
 
 const DesignSystemContext = createContext<DesignSystemContextType | undefined>(undefined);
@@ -18,11 +17,10 @@ export const useFocusContext = () => {
 };
 
 interface DesignSystemProviderProps {
-    fetchKoenigLexical: any;
     children: React.ReactNode;
 }
 
-const DesignSystemProvider: React.FC<DesignSystemProviderProps> = ({fetchKoenigLexical, children}) => {
+const DesignSystemProvider: React.FC<DesignSystemProviderProps> = ({children}) => {
     const [isAnyTextFieldFocused, setIsAnyTextFieldFocused] = useState(false);
 
     const setFocusState = (value: boolean) => {
@@ -30,7 +28,7 @@ const DesignSystemProvider: React.FC<DesignSystemProviderProps> = ({fetchKoenigL
     };
 
     return (
-        <DesignSystemContext.Provider value={{isAnyTextFieldFocused, fetchKoenigLexical, setFocusState}}>
+        <DesignSystemContext.Provider value={{isAnyTextFieldFocused, setFocusState}}>
             {children}
         </DesignSystemContext.Provider>
     );

--- a/apps/admin-x-settings/src/admin-x-ds/providers/DesignSystemProvider.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/providers/DesignSystemProvider.tsx
@@ -4,6 +4,7 @@ import React, {createContext, useContext, useState} from 'react';
 interface DesignSystemContextType {
     isAnyTextFieldFocused: boolean;
     setFocusState: (value: boolean) => void;
+    fetchKoenigLexical: any;
 }
 
 const DesignSystemContext = createContext<DesignSystemContextType | undefined>(undefined);
@@ -17,10 +18,11 @@ export const useFocusContext = () => {
 };
 
 interface DesignSystemProviderProps {
+    fetchKoenigLexical: any;
     children: React.ReactNode;
 }
 
-const DesignSystemProvider: React.FC<DesignSystemProviderProps> = ({children}) => {
+const DesignSystemProvider: React.FC<DesignSystemProviderProps> = ({fetchKoenigLexical, children}) => {
     const [isAnyTextFieldFocused, setIsAnyTextFieldFocused] = useState(false);
 
     const setFocusState = (value: boolean) => {
@@ -28,7 +30,7 @@ const DesignSystemProvider: React.FC<DesignSystemProviderProps> = ({children}) =
     };
 
     return (
-        <DesignSystemContext.Provider value={{isAnyTextFieldFocused, setFocusState}}>
+        <DesignSystemContext.Provider value={{isAnyTextFieldFocused, fetchKoenigLexical, setFocusState}}>
             {children}
         </DesignSystemContext.Provider>
     );

--- a/apps/admin-x-settings/src/components/providers/ServiceProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/ServiceProvider.tsx
@@ -12,6 +12,8 @@ export type OfficialTheme = {
     url?: string;
 };
 
+export type FetchKoenigLexical = () => Promise<any>
+
 interface ServicesContextProps {
     ghostVersion: string
     officialThemes: OfficialTheme[];
@@ -22,6 +24,7 @@ interface ServicesContextProps {
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
+    fetchKoenigLexical: FetchKoenigLexical;
 }
 
 interface ServicesProviderProps {
@@ -34,6 +37,7 @@ interface ServicesProviderProps {
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
+    fetchKoenigLexical: FetchKoenigLexical;
 }
 
 const ServicesContext = createContext<ServicesContextProps>({
@@ -51,10 +55,11 @@ const ServicesContext = createContext<ServicesContextProps>({
     sentryDSN: null,
     onUpdate: () => {},
     onInvalidate: () => {},
-    onDelete: () => {}
+    onDelete: () => {},
+    fetchKoenigLexical: async () => {}
 });
 
-const ServicesProvider: React.FC<ServicesProviderProps> = ({children, ghostVersion, zapierTemplates, officialThemes, unsplashConfig, sentryDSN, onUpdate, onInvalidate, onDelete}) => {
+const ServicesProvider: React.FC<ServicesProviderProps> = ({children, ghostVersion, zapierTemplates, officialThemes, unsplashConfig, sentryDSN, onUpdate, onInvalidate, onDelete, fetchKoenigLexical}) => {
     const search = useSearchService();
 
     return (
@@ -67,7 +72,8 @@ const ServicesProvider: React.FC<ServicesProviderProps> = ({children, ghostVersi
             sentryDSN,
             onUpdate,
             onInvalidate,
-            onDelete
+            onDelete,
+            fetchKoenigLexical
         }}>
             {children}
         </ServicesContext.Provider>

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -46,7 +46,7 @@ const Sidebar: React.FC<{
 }> = ({newsletter, onlyOne, updateNewsletter, validate, errors, clearError}) => {
     const {mutateAsync: editNewsletter} = useEditNewsletter();
     const limiter = useLimiter();
-    const {settings, siteData, config} = useGlobalData();
+    const {settings, siteData} = useGlobalData();
     const [membersSupportAddress, icon] = getSettingValues<string>(settings, ['members_support_address', 'icon']);
     const {mutateAsync: uploadImage} = useUploadImage();
     const [selectedTab, setSelectedTab] = useState('generalSettings');
@@ -406,7 +406,6 @@ const Sidebar: React.FC<{
                         />
                     </ToggleGroup>
                     <HtmlField
-                        config={config}
                         hint='Any extra information or legal text'
                         nodes='MINIMAL_NODES'
                         placeholder=' '

--- a/apps/admin-x-settings/src/components/settings/membership/portal/SignupOptions.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/SignupOptions.tsx
@@ -124,7 +124,6 @@ const SignupOptions: React.FC<{
         )}
 
         <HtmlField
-            config={config}
             error={Boolean(errors.portal_signup_terms_html)}
             hint={errors.portal_signup_terms_html || <>Recommended: <strong>115</strong> characters. You&apos;ve used <strong className="text-green">{signupTermsLength}</strong></>}
             nodes='MINIMAL_NODES'

--- a/apps/admin-x-settings/src/components/settings/site/AnnouncementBarModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/AnnouncementBarModal.tsx
@@ -38,8 +38,6 @@ const Sidebar: React.FC<SidebarProps> = ({
     paidMembersEnabled,
     onBlur
 }) => {
-    const {config} = useGlobalData();
-
     const visibilityCheckboxes = [
         {
             label: 'Logged out visitors',
@@ -70,7 +68,6 @@ const Sidebar: React.FC<SidebarProps> = ({
     return (
         <Form>
             <HtmlField
-                config={config}
                 nodes='MINIMAL_NODES'
                 placeholder='Highlight breaking news, offers or updates'
                 title='Announcement'
@@ -201,10 +198,10 @@ const AnnouncementBarModal: React.FC = () => {
         break;
     }
 
-    const preview = <AnnouncementBarPreview 
-        announcementBackgroundColor={announcementBackgroundColor} 
-        announcementContent={announcementContent} 
-        url={selectedTabURL} 
+    const preview = <AnnouncementBarPreview
+        announcementBackgroundColor={announcementBackgroundColor}
+        announcementContent={announcementContent}
+        url={selectedTabURL}
         visibility={visibilitySettings}
     />;
 

--- a/apps/admin-x-settings/src/main.tsx
+++ b/apps/admin-x-settings/src/main.tsx
@@ -8,6 +8,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>
         <App
             externalNavigate={() => {}}
+            fetchKoenigLexical={() => {}}
             ghostVersion='5.x'
             officialThemes={[{
                 name: 'Casper',

--- a/apps/admin-x-settings/src/main.tsx
+++ b/apps/admin-x-settings/src/main.tsx
@@ -8,7 +8,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>
         <App
             externalNavigate={() => {}}
-            fetchKoenigLexical={() => {}}
+            fetchKoenigLexical={() => {
+                return Promise.resolve();
+            }}
             ghostVersion='5.x'
             officialThemes={[{
                 name: 'Casper',

--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/ember';
 import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
 import config from 'ghost-admin/config/environment';
+import fetchKoenigLexical from 'ghost-admin/utils/fetch-koenig-lexical';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {action} from '@ember/object';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -413,6 +414,7 @@ export default class AdminXSettings extends Component {
                             darkMode={this.feature.nightShift}
                             unsplashConfig={defaultUnsplashHeaders}
                             sentry={this.config.sentry_dsn ? Sentry : undefined}
+                            fetchKoenigLexical={fetchKoenigLexical}
                             onUpdate={this.onUpdate}
                             onInvalidate={this.onInvalidate}
                             onDelete={this.onDelete}

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/ember';
 import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
 import fetch from 'fetch';
+import fetchKoenigLexical from 'ghost-admin/utils/fetch-koenig-lexical';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
 import {action} from '@ember/object';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -60,34 +61,11 @@ class ErrorHandler extends React.Component {
     }
 }
 
-const fetchKoenig = function () {
+const loadKoenig = function () {
     let status = 'pending';
     let response;
 
-    const fetchPackage = async () => {
-        if (window['@tryghost/koenig-lexical']) {
-            return window['@tryghost/koenig-lexical'];
-        }
-
-        // the manual specification of the protocol in the import template string is
-        // required to work around ember-auto-import complaining about an unknown dynamic import
-        // during the build step
-        const GhostAdmin = window.GhostAdmin || window.Ember.Namespace.NAMESPACES.find(ns => ns.name === 'ghost-admin');
-        const urlTemplate = GhostAdmin.__container__.lookup('config:main').editor?.url;
-        const urlVersion = GhostAdmin.__container__.lookup('config:main').editor?.version;
-
-        const url = new URL(urlTemplate.replace('{version}', urlVersion));
-
-        if (url.protocol === 'http:') {
-            await import(`http://${url.host}${url.pathname}`);
-        } else {
-            await import(`https://${url.host}${url.pathname}`);
-        }
-
-        return window['@tryghost/koenig-lexical'];
-    };
-
-    const suspender = fetchPackage().then(
+    const suspender = fetchKoenigLexical().then(
         (res) => {
             status = 'success';
             response = res;
@@ -112,7 +90,7 @@ const fetchKoenig = function () {
     return {read};
 };
 
-const editorResource = fetchKoenig();
+const editorResource = loadKoenig();
 
 const KoenigComposer = (props) => {
     const {KoenigComposer: _KoenigComposer} = editorResource.read();

--- a/ghost/admin/app/utils/fetch-koenig-lexical.js
+++ b/ghost/admin/app/utils/fetch-koenig-lexical.js
@@ -1,0 +1,22 @@
+export default async function fetchKoenigLexical() {
+    if (window['@tryghost/koenig-lexical']) {
+        return window['@tryghost/koenig-lexical'];
+    }
+
+    // the manual specification of the protocol in the import template string is
+    // required to work around ember-auto-import complaining about an unknown dynamic import
+    // during the build step
+    const GhostAdmin = window.GhostAdmin || window.Ember.Namespace.NAMESPACES.find(ns => ns.name === 'ghost-admin');
+    const urlTemplate = GhostAdmin.__container__.lookup('config:main').editor?.url;
+    const urlVersion = GhostAdmin.__container__.lookup('config:main').editor?.version;
+
+    const url = new URL(urlTemplate.replace('{version}', urlVersion));
+
+    if (url.protocol === 'http:') {
+        await import(`http://${url.host}${url.pathname}`);
+    } else {
+        await import(`https://${url.host}${url.pathname}`);
+    }
+
+    return window['@tryghost/koenig-lexical'];
+}


### PR DESCRIPTION
- DRY up all the fetching so we only do it from one place

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 21bd4cc</samp>

This pull request refactors the dynamic import of the `Koenig` editor package in various components that use the HtmlEditor component. It introduces a new utility function `fetchKoenigLexical` that returns the editor package and passes it as a prop to the HtmlEditor component. This improves code readability, maintainability, and testability, and avoids code duplication and hard-coded URLs.
