### PR TITLE
Fixed post edit button URL

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -206,7 +206,7 @@
                 </span>
             </a>
         {{else}}
-            <LinkTo @route={{this.editorRoute}} @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-button" title="">
+            <LinkTo @route="editor.edit" @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-button" title="">
                 <span class="gh-post-list-cta edit {{if this.isHovered "is-hovered"}}" title="Go to Editor" data-ignore-select>
                     {{svg-jar "pen" title="Go to Editor"}}
                 </span>


### PR DESCRIPTION
no issues

- the edit button in the post list wasn't doing anything with an empty link
- now it has same URL as the post list item and it directs to its edit screen
