### PR TITLE
✨ Added "startsWith" check to the match helper

### DIFF
--- a/ghost/core/core/frontend/helpers/match.js
+++ b/ghost/core/core/frontend/helpers/match.js
@@ -57,6 +57,9 @@ const handleMatch = (data, operator, value) => {
     case '<=':
         result = data <= value;
         break;
+    case 'startsWith':
+        result = _.isString(data) && _.isString(value) && data.startsWith(value);
+        break;
     default:
         result = data === value;
     }

--- a/ghost/core/test/unit/frontend/helpers/match.test.js
+++ b/ghost/core/test/unit/frontend/helpers/match.test.js
@@ -246,6 +246,38 @@ describe('Match helper', function () {
             }, hash);
         });
 
+        describe('Explicit Starts With', function () {
+            runTests({
+                // Using string values
+                '{{match empty "startsWith" ""}}': 'true',
+                '{{match empty "startsWith" " "}}': 'false',
+                '{{match string "startsWith" "Hello"}}': 'true',
+                '{{match string "startsWith" "World"}}': 'false',
+                '{{match string_true "startsWith" "tr"}}': 'true',
+                '{{match string_false "startsWith" "tr"}}': 'false',
+                '{{match safestring_string_false "startsWith" "fa"}}': 'true',
+                '{{match safestring_string_true "startsWith" "fa"}}': 'false',
+                '{{match string_five "startsWith" "5"}}': 'true',
+                '{{match string_five "startsWith" "6"}}': 'false',
+                '{{match object.foo "startsWith" "fo"}}': 'true',
+                '{{match object.foo "startsWith" "ba"}}': 'false',
+                '{{match array.[0] "startsWith" "fo"}}': 'true',
+                '{{match array.[0] "startsWith" "ba"}}': 'false',
+
+                // Using non-string values
+                '{{match zero "startsWith" 0}}': 'false',
+                '{{match zero "startsWith" "0"}}': 'false',
+                '{{match "1" "startsWith" one}}': 'false',
+                '{{match null "startsWith" "null"}}': 'false',
+                '{{match truthy_bool "startsWith" "tr"}}': 'false',
+                '{{match safestring_bool_false "startsWith" "fa"}}': 'false',
+                '{{match undefined "startsWith" "undefined"}}': 'false',
+                '{{match unknown "startsWith" "unknown" }}': 'false',
+                '{{match object "startsWith" "object" }}': 'false',
+                '{{match array "startsWith" "array" }}': 'false'
+            }, hash);
+        });
+
         // SafeStrings represent the original value as an object for example:
         // SafeString { string: true } vs SafeString { string: 'true' }
         // allows us to know if the original value was a boolean or a string


### PR DESCRIPTION
Added "startsWith" string comparison to the match helper. 

I think this simple check will unlock and simplify a lot of use cases for theme developers:

**Group logic when dealing with similar custom settings**:
```handlebars
{{!-- Suppose layout could be: "List full", "List narrow", "Grid 2 cols", "Grid 3 cols", "Grid masonry" --}}
{{#match @custom.layout "startsWith" "Grid"}} 
    has-grid
{{/match}}
```

**Check if a URL is external**:
```handlebars
{{^match (url absolute="true") "startsWith" @site.url }} 
    is-external
{{/match}}
```

**Simulate nested tags**:
```handlebars
{{#match slug "startsWith" "hash-parent-tag-" }} 
    {{> template-parent }}
{{/match}}
```

**Help implementing nested navigation**:
```handlebars
{{#match label "startsWith" "--" }} 
    is-child-nav-item
{{/match}}
```

**Add a badge to a navigation item**:
```handlebars
{{#match label "startsWith" "[NEW]" }} 
    <span>{{t "NEW"}}</span>
{{/match}}
```

---

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 082c4f9</samp>

This pull request adds support for the `startsWith` operator to the `match` template helper, which allows matching data values against string prefixes. It also adds unit tests for the new operator in the `match.test.js` file.
