### PR TITLE
Updated logic for whether a site is recommending you back

### DIFF
--- a/ghost/recommendations/src/IncomingRecommendationService.ts
+++ b/ghost/recommendations/src/IncomingRecommendationService.ts
@@ -97,10 +97,8 @@ export class IncomingRecommendationService {
             const url = new URL(mention.source.toString().replace(/\/.well-known\/recommendations\.json$/, ''));
 
             // Check if we are also recommending this URL
-            const existing = await this.#recommendationService.countRecommendations({
-                filter: `url:~'${url}'`
-            });
-            const recommendingBack = existing > 0;
+            const existing = await this.#recommendationService.readRecommendationByUrl(url);
+            const recommendingBack = !!existing;
 
             return {
                 title: mention.sourceTitle,

--- a/ghost/recommendations/src/RecommendationService.ts
+++ b/ghost/recommendations/src/RecommendationService.ts
@@ -258,4 +258,13 @@ export class RecommendationService {
         const subscribeEvent = SubscribeEvent.create({recommendationId: id, memberId});
         await this.subscribeEventRepository.save(subscribeEvent);
     }
+
+    async readRecommendationByUrl(url: URL): Promise<RecommendationPlain|null> {
+        const recommendation = await this.repository.getByUrl(url);
+
+        if (!recommendation) {
+            return null;
+        }
+        return recommendation.plain;
+    }
 }


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3958

- `url:~a.com` matches a.com, sub.a.com and a.com/path
- added a stricter check based on hostname and pathname, but that ignores www, protocol, query parameters and hash fragments
