### PR TITLE
Removed relative path link

### DIFF
--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -1,6 +1,8 @@
 /* eslint-disable */
 'use strict';
 
+const path = require('path');
+
 module.exports = {
     name: 'asset-delivery',
 
@@ -22,7 +24,7 @@ module.exports = {
         const fs = this.project.require('fs-extra');
         const walkSync = this.project.require('walk-sync');
 
-        const assetsOut = `../core/core/built/admin`;
+        const assetsOut = path.join(path.dirname(require.resolve('ghost')), `core/built/admin`);
         fs.removeSync(assetsOut);
         fs.ensureDirSync(assetsOut);
 


### PR DESCRIPTION
- this helps maintainability in the future because Admin doesn't need to care where Core is, as we just resolve to the path where the `ghost` package is

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46b2cf6</samp>

Refactored the `asset-delivery` script to use dynamic paths based on the `path` module. This makes the script more robust and adaptable to different environments.
