### PR TITLE
Updated Koenig-Lexical bundling

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -132,9 +132,9 @@ if (DASH_DASH_ARGS.includes('lexical')) {
         //        reverse_proxy http://127.0.0.1:4173
         //    }
 
-        COMMAND_GHOST.env['editor__url'] = 'https://localhost:41730/koenig-lexical.umd.js';
+        COMMAND_ADMIN.env['EDITOR_URL'] = 'https://localhost:41730/';
     } else {
-        COMMAND_GHOST.env['editor__url'] = 'http://localhost:4173/koenig-lexical.umd.js';
+        COMMAND_ADMIN.env['EDITOR_URL'] = 'http://localhost:4173/';
     }
 }
 

--- a/ghost/admin/app/routes/lexical-editor.js
+++ b/ghost/admin/app/routes/lexical-editor.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
-import {inject} from 'ghost-admin/decorators/inject';
 import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 
@@ -11,14 +10,6 @@ export default AuthenticatedRoute.extend({
     ui: service(),
 
     classNames: ['editor'],
-
-    config: inject(),
-
-    beforeModel() {
-        if (!this.config.editor?.url) {
-            return this.router.transitionTo('posts');
-        }
-    },
 
     activate() {
         this._super(...arguments);

--- a/ghost/admin/app/utils/fetch-koenig-lexical.js
+++ b/ghost/admin/app/utils/fetch-koenig-lexical.js
@@ -1,16 +1,16 @@
+import config from 'ghost-admin/config/environment';
+import ghostPaths from 'ghost-admin/utils/ghost-paths';
+
 export default async function fetchKoenigLexical() {
     if (window['@tryghost/koenig-lexical']) {
         return window['@tryghost/koenig-lexical'];
     }
 
-    // the manual specification of the protocol in the import template string is
-    // required to work around ember-auto-import complaining about an unknown dynamic import
-    // during the build step
-    const GhostAdmin = window.GhostAdmin || window.Ember.Namespace.NAMESPACES.find(ns => ns.name === 'ghost-admin');
-    const urlTemplate = GhostAdmin.__container__.lookup('config:main').editor?.url;
-    const urlVersion = GhostAdmin.__container__.lookup('config:main').editor?.version;
-
-    const url = new URL(urlTemplate.replace('{version}', urlVersion));
+    // If we pass an editor URL (the env var from the dev script), use that
+    // Else, if we pass a CDN URL, use that
+    // Else, use the asset root from the ghostPaths util
+    const baseUrl = (config.editorUrl || (config.cdnUrl ? `${config.cdnUrl}assets/koenig-lexical/` : `${ghostPaths().assetRootWithHost}koenig-lexical/`));
+    const url = new URL(`${baseUrl}koenig-lexical.umd.js`);
 
     if (url.protocol === 'http:') {
         await import(`http://${url.host}${url.pathname}`);

--- a/ghost/admin/config/environment.js
+++ b/ghost/admin/config/environment.js
@@ -6,6 +6,7 @@ module.exports = function (environment) {
         modulePrefix: 'ghost-admin',
         environment,
         cdnUrl: process.env.GHOST_CDN_URL || '',
+        editorUrl: process.env.EDITOR_URL || '',
         rootURL: '',
         locationType: 'trailing-hash',
         EmberENV: {

--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -59,5 +59,18 @@ module.exports = {
         } else  {
             console.log('Admin-X-Settings folder not found');
         }
+
+        // if we are passed a URL for Koenig-Lexical dev server, we don't need to copy the assets
+        if (!process.env.EDITOR_URL) {
+            // copy the @tryghost/koenig-lexical assets
+            const koenigLexicalPath = path.dirname(require.resolve('@tryghost/koenig-lexical'));
+            const assetsKoenigLexicalPath = `${assetsOut}/assets/koenig-lexical`;
+
+            if (fs.existsSync(koenigLexicalPath)) {
+                fs.copySync(koenigLexicalPath, assetsKoenigLexicalPath, {overwrite: true, dereference: true});
+            } else {
+                console.log('Koenig-Lexical folder not found');
+            }
+        }
     }
 };

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -48,6 +48,7 @@
     "@tryghost/kg-converters": "0.0.14",
     "@tryghost/kg-parser-plugins": "3.0.35",
     "@tryghost/kg-simplemde": "1.11.2",
+    "@tryghost/koenig-lexical": "0.4.20",
     "@tryghost/limit-service": "1.2.10",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/mobiledoc-kit": "0.12.5-ghost.2",

--- a/ghost/admin/tests/acceptance/editor/lexical-test.js
+++ b/ghost/admin/tests/acceptance/editor/lexical-test.js
@@ -15,11 +15,6 @@ describe('Acceptance: Lexical editor', function () {
     beforeEach(async function () {
         this.server.loadFixtures();
 
-        // ensure required config is in place for external lexical editor to load
-        const config = this.server.schema.configs.find(1);
-        config.attrs.editor = {url: 'https://cdn.pkg/editor.js'};
-        config.save();
-
         enableLabsFlag(this.server, 'lexicalEditor');
 
         // stub loaded external module to avoid loading of external dep
@@ -34,18 +29,7 @@ describe('Acceptance: Lexical editor', function () {
         expect(currentURL(), 'currentURL').to.equal('/signin');
     });
 
-    it('redirects to posts screen if editor.url config is missing', async function () {
-        const config = this.server.schema.configs.find(1);
-        config.attrs.editor = undefined;
-        config.save();
-
-        await loginAsRole('Administrator', this.server);
-        await visit('/editor-beta/post/');
-
-        expect(currentURL(), 'currentURL').to.equal('/posts');
-    });
-
-    it('loads when editor.url is present', async function () {
+    it('loads editor', async function () {
         await loginAsRole('Administrator', this.server);
         await visit('/editor-beta/post/');
         expect(currentURL(), 'currentURL').to.equal('/editor-beta/post/');

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
@@ -19,7 +19,6 @@ module.exports = {
             'emailAnalytics',
             'hostSettings',
             'tenor',
-            'editor',
             'pintura',
             'signupForm'
         ];

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -197,10 +197,6 @@
         "url": "https://cdn.jsdelivr.net/ghost/comments-ui@~{version}/umd/comments-ui.min.js",
         "version": "0.13"
     },
-    "editor": {
-        "url": "https://cdn.jsdelivr.net/ghost/koenig-lexical@~{version}/dist/koenig-lexical.umd.js",
-        "version": "0.4"
-    },
     "signupForm": {
         "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",
         "version": "0.1"

--- a/ghost/core/test/e2e-api/admin/utils.js
+++ b/ghost/core/test/e2e-api/admin/utils.js
@@ -41,7 +41,6 @@ const expectedProperties = {
         'emailAnalytics',
         'tenor',
         'mailgunIsConfigured',
-        'editor',
         'signupForm'
     ],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7932,6 +7932,11 @@
   dependencies:
     semver "^7.3.5"
 
+"@tryghost/koenig-lexical@0.4.20":
+  version "0.4.20"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-0.4.20.tgz#3f4b461ddb9016f1f8b2a7de68956e2ec2953151"
+  integrity sha512-knzpjtrBeliaXPhD8IwMPPgXniOx9Sb9tdCiwCOXlf/lZ6z/B2ug2D9bvdGpx1aWBqJAQsbeAFXaov6gtergYA==
+
 "@tryghost/limit-service@1.2.10", "@tryghost/limit-service@^1.2.10":
   version "1.2.10"
   resolved "https://registry.yarnpkg.com/@tryghost/limit-service/-/limit-service-1.2.10.tgz#9e1c8b21eddc3de8c5b8a9b029ba4915ec1ac625"


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/83

- this will now continue use the dev server assets if we tell it to,
  or copy the dependency package files to the built folder otherwise
- removes `editor` from config API because it's no longer needed
- removes dependency on `editor.url` in tests, as this no longer exists
- edits dev script to pass dev server URL as env var
- adds `@tryghost/koenig-lexical` dependency to Admin

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a68d78a</samp>

This pull request removes the `editor` property from the config files and endpoint, and adds a new dependency and asset delivery for the `@tryghost/koenig-lexical` module, which provides lexical analysis of editor content. It also simplifies and renames some variables and files related to the editor script URL.
