### PR TITLE
Switched `yarn workspace` to `yarn nx run ...`

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -108,6 +108,6 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: playwright-report
-        path: playwright-report/
+        name: browser-tests-playwright-report
+        path: ghost/core/playwright-report
         retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,8 +521,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: playwright-report
-          path: playwright-report
+          name: admin-x-settings-playwright-report
+          path: apps/admin-x-settings/playwright-report
           retention-days: 30
 
       - uses: tryghost/actions/actions/slack-build@main
@@ -574,8 +574,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: playwright-report
-          path: playwright-report
+          name: comments-ui-playwright-report
+          path: apps/comments-ui/playwright-report
           retention-days: 30
 
       - uses: tryghost/actions/actions/slack-build@main
@@ -627,8 +627,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: playwright-report
-          path: playwright-report
+          name: signup-form-playwright-report
+          path: apps/signup-form/playwright-report
           retention-days: 30
 
       - uses: tryghost/actions/actions/slack-build@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,7 +515,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps
 
-      - run: yarn workspace @tryghost/admin-x-settings run test:e2e
+      - run: yarn nx run @tryghost/admin-x-settings:test:e2e
 
       - name: Upload test results
         if: always()
@@ -568,7 +568,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps
 
-      - run: yarn workspace @tryghost/comments-ui run test
+      - run: yarn nx run @tryghost/comments-ui:test
 
       - name: Upload test results
         if: always()
@@ -621,7 +621,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps
 
-      - run: yarn workspace @tryghost/signup-form run test:e2e
+      - run: yarn nx run @tryghost/signup-form:test:e2e
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
- this switches to NX for more command-execution, which helps in the future because we can configure dependent tasks that are also cacheable

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ada6e34</samp>

Refactored the CI workflow to use Nx for running tests. This supports the migration of the Ghost monorepo to Nx.
