### PR TITLE
Added install from URL in AdminX

### DIFF
--- a/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
@@ -37,6 +37,8 @@ export type RoutingModalProps = {
 const modalPaths: {[key: string]: ModalName} = {
     'design/edit/themes': 'DesignAndThemeModal',
     'design/edit': 'DesignAndThemeModal',
+    // this is a special route, because it can install a theme directly from the Ghost Marketplace
+    'design/change-theme/install': 'DesignAndThemeModal',
     'navigation/edit': 'NavigationModal',
     'users/invite': 'InviteUserModal',
     'users/show/:slug': 'UserDetailModal',

--- a/apps/admin-x-settings/src/components/settings/site/DesignAndThemeModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/DesignAndThemeModal.tsx
@@ -10,6 +10,17 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
         return <DesignModal />;
     } else if (pathName === 'design/edit/themes') {
         return <ChangeThemeModal />;
+    } else if (pathName === 'design/change-theme/install') {
+        const url = window.location.href;
+        const fragment = url.split('#')[1];
+        const queryParams = fragment.split('?')[1];
+
+        const searchParams = new URLSearchParams(queryParams);
+
+        const ref = searchParams.get('ref') || null;
+        const source = searchParams.get('source') || null;
+
+        return <ChangeThemeModal source={source} themeRef={ref} />;
     } else {
         modal.remove();
     }

--- a/apps/admin-x-settings/src/components/settings/site/ThemeModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/ThemeModal.tsx
@@ -18,6 +18,7 @@ import useRouting from '../../../hooks/useRouting';
 import {HostLimitError, useLimiter} from '../../../hooks/useLimiter';
 import {InstalledTheme, Theme, ThemesInstallResponseType, useActivateTheme, useBrowseThemes, useInstallTheme, useUploadTheme} from '../../../api/themes';
 import {OfficialTheme} from '../../providers/ServiceProvider';
+import {showToast} from '../../../admin-x-ds/global/Toast';
 
 interface ThemeToolbarProps {
     selectedTheme: OfficialTheme|null;
@@ -293,6 +294,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
         setSelectedTheme(theme);
     };
 
+    // probably not the best place to handle the logic here, something for cleanup.
     useEffect(() => {
         // this grabs the theme ref from the url and installs it
         if (source && themeRef && !installedFromMarketplace) {
@@ -331,9 +333,13 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
                         data = await installTheme(themeRef);
                         if (data?.themes[0]) {
                             await activateTheme(data.themes[0].name);
+                            showToast({
+                                type: 'success',
+                                message: <div><span className='capitalize'>{data.themes[0].name}</span> is now your active theme.</div>
+                            });
                         }
                         confirmModal?.remove();
-                        updateRoute('design/edit/themes');
+                        updateRoute('design/edit');
                     } catch (e) {
                         handleError(e);
                     }


### PR DESCRIPTION
refs https://www.notion.so/ghost/AdminX-feedback-27fc7f549bbf4a53bfa2e7b6e5643963?p=6fc16caf7f0d42f2933e28e1519c3623&pm=s

- added ability to install a theme directly from the Ghost Marketplace.
- uses the existing URL pattern to ensure they remain compatible.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3b6f1b</samp>

This pull request enables users to install and activate themes from the Ghost Marketplace, a curated collection of themes for the Ghost platform. It adds a new route and modal component to handle the theme installation from a URL, and modifies the existing modal components to support the theme activation and confirmation. It affects the files `ThemeModal.tsx`, `RoutingProvider.tsx`, and `DesignAndThemeModal.tsx`.
