### PR TITLE
Updated browser tests to use class names from Source theme

### DIFF
--- a/ghost/core/test/e2e-browser/admin/members.spec.js
+++ b/ghost/core/test/e2e-browser/admin/members.spec.js
@@ -305,7 +305,7 @@ test.describe('Admin', () => {
             await page.goto(link);
 
             // click the paid-only post
-            await page.locator('.post-card-image-link[href="/sell/"]').click();
+            await page.locator('.gh-card-link[href="/sell/"]').click();
 
             // check for content CTA and expect it to be zero
             await expect(page.locator('.gh-post-upgrade-cta')).toHaveCount(0);

--- a/ghost/core/test/e2e-browser/admin/private-site.spec.js
+++ b/ghost/core/test/e2e-browser/admin/private-site.spec.js
@@ -53,7 +53,7 @@ test.describe('Site Settings', () => {
 
             // check the site is publicly accessible
             await frontendPage.goto('/');
-            await expect(frontendPage.locator('.site-title')).toHaveText('The Local Test');
+            await expect(frontendPage.locator('.gh-navigation-brand')).toHaveText('The Local Test');
         });
     });
 });

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -55,7 +55,7 @@ const checkPostPublished = async (page, {slug, title, body}) => {
     expect(response.status()).toBe(200);
 
     // Check if the title and body are present on this page
-    await expect(page.locator('.gh-canvas .article-title')).toHaveText(title);
+    await expect(page.locator('.gh-article-title')).toHaveText(title);
     await expect(page.locator('.gh-content.gh-canvas > p')).toHaveText(body);
 };
 


### PR DESCRIPTION
no issue

- After updating the default theme to be Source instead of Casper, the browser tests broke because they depended on the class names in Casper, which have changed
- This fixes that by updating the classes to be compatible with the Source theme
