### PR TITLE
Updated minimum CLI version to 1.25.0

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -56,7 +56,7 @@
   },
   "engines": {
     "node": "^16.14.0 || ^18.12.1",
-    "cli": "^1.17.0"
+    "cli": "^1.25.0"
   },
   "dependencies": {
     "@extractus/oembed-extractor": "3.2.1",


### PR DESCRIPTION
no issue

- Updated minimum ghost-cli version to 1.25.0 to accommodate shipping multiple builtin themes
