### PR TITLE
Fixed e2e-browser publishing tests

### DIFF
--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -76,6 +76,9 @@ const createPage = async (page, {title = 'Hello world', body = 'This is my post 
     await page.locator('[data-test-editor-title-input]').click();
     await page.locator('[data-test-editor-title-input]').fill(title);
 
+    // wait for editor to be ready
+    await expect(page.locator('[data-lexical-editor="true"]')).toBeVisible();
+
     // Continue to the body by pressing enter
     await page.keyboard.press('Enter');
 
@@ -281,7 +284,7 @@ test.describe('Publishing', () => {
 
     test.describe('Update post', () => {
         test.describe.configure({retries: 1});
-        
+
         test('Can update a published post', async ({page: adminPage}) => {
             await adminPage.goto('/ghost');
 

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -435,6 +435,9 @@ const createPostDraft = async (page, {title = 'Hello world', body = 'This is my 
     await page.locator('[data-test-editor-title-input]').click();
     await page.locator('[data-test-editor-title-input]').fill(title);
 
+    // wait for editor to be ready
+    await expect(page.locator('[data-lexical-editor="true"]')).toBeVisible();
+
     // Continue to the body by pressing enter
     await page.keyboard.press('Enter');
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/18422

- now that we're using the externally-loaded editor we need to wait for it to load and be ready before moving focus to it and starting to type
