### PR TITLE
Log long requests during application shutdown

### DIFF
--- a/ghost/core/core/server/GhostServer.js
+++ b/ghost/core/core/server/GhostServer.js
@@ -145,6 +145,7 @@ class GhostServer {
 
         try {
             this.isShuttingDown = true;
+            this.rootApp.set('shutdown-started', Date.now());
             logging.warn(tpl(messages.ghostIsShuttingDown));
             await this.stop();
             setTimeout(() => {


### PR DESCRIPTION
refs: https://github.com/TryGhost/DevOps/issues/64

This introduces new middleware that is activated on shutdown, logging any request which is still in flight, 15 seconds after the app begins to shutdown.

If a request is still in flight 60 seconds after shutdown, then the app will shutdown and the request will be lost. Ghost already has a 60 second timeout for requests, so the chance that a request would be lost like this is extremely unlikely.