### PR TITLE
Fixed posts list hrefs showing "mobiledoc-editor" and added "editor-beta" redirects

### DIFF
--- a/ghost/admin/app/components/posts-list/list-item.hbs
+++ b/ghost/admin/app/components/posts-list/list-item.hbs
@@ -45,7 +45,7 @@
             {{/unless}}
         </a>
     {{else}}
-        <LinkTo @route="editor.edit" @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-title">
+        <LinkTo @route="lexical-editor.edit" @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-title">
             <h3 class="gh-content-entry-title">
                 {{#if @post.featured}}
                     {{svg-jar "star-fill" class="gh-featured-post"}}
@@ -206,7 +206,7 @@
                 </span>
             </a>
         {{else}}
-            <LinkTo @route="editor.edit" @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-button" title="">
+            <LinkTo @route="lexical-editor.edit" @models={{array this.post.displayName this.post.id}} class="permalink gh-list-data gh-post-list-button" title="">
                 <span class="gh-post-list-cta edit {{if this.isHovered "is-hovered"}}" title="Go to Editor" data-ignore-select>
                     {{svg-jar "pen" title="Go to Editor"}}
                 </span>

--- a/ghost/admin/app/routes/error404.js
+++ b/ghost/admin/app/routes/error404.js
@@ -1,8 +1,27 @@
 import Route from '@ember/routing/route';
+import {inject as service} from '@ember/service';
 
 export default class Error404Route extends Route {
     controllerName = 'error';
     templateName = 'error';
+
+    @service router;
+
+    beforeModel(transition) {
+        // handle redirects for old routes
+        if (transition.to?.params?.path?.startsWith?.('editor-beta')) {
+            const [, type, postId] = transition.to.params.path.split('/');
+
+            const route = postId ? 'lexical-editor.edit' : 'lexical-editor.new';
+            const models = [type];
+
+            if (postId) {
+                models.push(postId);
+            }
+
+            return this.router.transitionTo(route, ...models);
+        }
+    }
 
     model() {
         return {


### PR DESCRIPTION
no issue

- switched posts list over to using the `lexical-editor.edit` route so it uses the `/editor/` href rather than `/mobiledoc-editor/`
- added redirect handling for the `/editor-beta/*` urls to our generic 404 route so anyone upgrading with the beta URLs still open in tabs or saved won't hit a 404
