### PR TITLE
🐛 Fixed cache key generation not taking into account array value

### DIFF
--- a/ghost/core/core/server/api/endpoints/posts-public.js
+++ b/ghost/core/core/server/api/endpoints/posts-public.js
@@ -26,8 +26,9 @@ const rejectPrivateFieldsTransformer = input => mapQuery(input, function (value,
 function generateOptionsData(frame, options) {
     return options.reduce((memo, option) => {
         let value = frame.options?.[option];
-        if (['include', 'fields', 'formats'].includes(option)) {
-            value = value?.split(',').sort();
+
+        if (['include', 'fields', 'formats'].includes(option) && typeof value === 'string') {
+            value = value.split(',').sort();
         }
 
         if (option === 'page') {


### PR DESCRIPTION
`generateOptionsData` was not taking into account the query params `include`, `fields` and `format` could also be an array if included in the request query like: `?fields[]=title&fields[]=slug` or `?fields=title&fields=slug`