### PR TITLE
Added pre-emptive fetch of editor module after logging in to Admin

### DIFF
--- a/ghost/admin/app/services/koenig.js
+++ b/ghost/admin/app/services/koenig.js
@@ -1,0 +1,54 @@
+import Service from '@ember/service';
+import fetchKoenigLexical from '../utils/fetch-koenig-lexical';
+import {task} from 'ember-concurrency';
+
+export default class Koenig extends Service {
+    get resource() {
+        let status = 'pending';
+        let response;
+
+        const suspender = this.fetch().then(
+            (res) => {
+                status = 'success';
+                response = res;
+            },
+            (err) => {
+                status = 'error';
+                response = err;
+            }
+        );
+
+        const read = () => {
+            switch (status) {
+            case 'pending':
+                throw suspender;
+            case 'error':
+                throw response;
+            default:
+                return response;
+            }
+        };
+
+        return {read};
+    }
+
+    async fetch() {
+        // avoid re-fetching whilst already fetching
+        if (this._fetchTask.isRunning) {
+            return await this._fetchTask.last;
+        }
+
+        // avoid re-fetching if we've already fetched successfully
+        if (this._fetchTask.lastSuccessful) {
+            return this._fetchTask.lastSuccessful.value;
+        }
+
+        // kick-off a new fetch
+        return await this._fetchTask.perform();
+    }
+
+    @task
+    *_fetchTask() {
+        return yield fetchKoenigLexical();
+    }
+}

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -12,6 +12,7 @@ export default class SessionService extends ESASessionService {
     @service configManager;
     @service('store') dataStore;
     @service feature;
+    @service koenig;
     @service notifications;
     @service router;
     @service frontend;
@@ -68,6 +69,9 @@ export default class SessionService extends ESASessionService {
 
         this.loadServerNotifications();
         this.whatsNew.fetchLatest.perform();
+
+        // pre-emptively load editor code in the background to avoid loading state when opening editor
+        this.koenig.fetch();
     }
 
     async handleAuthentication() {


### PR DESCRIPTION
no issue

Reduces likelihood of seeing the "Loading editor..." state when accessing the editor by fetching the editor module in the background after login.

- added `koenig` service
  - `.resource` getter for returning a React suspense resource object to reduce duplication across main editor and HTML input components
  - `.fetch()` method that fetches the Koenig module, avoids concurrent or repeated fetches by utilising an internal `._fetchTask` ember-concurrency task
- updated Koenig components to use the `koenig` service and associated resource for fetching the module
  - required setting up `editorResource` inside the component's class and passing it in as a prop to the suspense-aware components as we need access to Ember's dependency injection available in the class
- added `koenig.fetch()` call to our post-login code in the `session` service so the fetch is started before the editor is accessed
