### PR TITLE
Removed sticker option from Pintura

### DIFF
--- a/apps/admin-x-settings/src/hooks/usePinturaEditor.ts
+++ b/apps/admin-x-settings/src/hooks/usePinturaEditor.ts
@@ -35,7 +35,6 @@ declare global {
                 enableTransparencyGrid: boolean;
                 util: string;
                 utils: string[];
-                stickerStickToImage: boolean;
                 frameOptions: [FrameOptionType, (locale: PinturaLocale) => string][];
                 cropSelectPresetFilter: string;
                 cropSelectPresetOptions: [number | undefined, string][];
@@ -164,10 +163,8 @@ export default function usePinturaEditor({
                         'redact',
                         'annotate',
                         'trim',
-                        'frame',
-                        'sticker'
+                        'frame'
                     ],
-                    stickerStickToImage: true,
                     frameOptions: [
                         // No frame
                         [undefined, locale => locale.labelNone],

--- a/ghost/admin/app/components/koenig-image-editor.js
+++ b/ghost/admin/app/components/koenig-image-editor.js
@@ -158,10 +158,8 @@ export default class KoenigImageEditor extends Component {
                     'redact',
                     'annotate',
                     'trim',
-                    'frame',
-                    'sticker'
+                    'frame'
                 ],
-                stickerStickToImage: true,
                 frameOptions: [
                     // No frame
                     [undefined, locale => locale.labelNone],


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change, explained below
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f8cbd76</samp>

Removed the sticker feature from the image editor component in both the new and the legacy admin apps. This simplifies the UI and the code of the `usePinturaEditor.ts` and `koenig-image-editor.js` files.
