### PR TITLE
🐛 Fixed outboundLinkTagging setting affected whether member sources are tracked

### DIFF
--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -79,7 +79,7 @@ async function signout({api, state}) {
 
 async function signin({data, api, state}) {
     try {
-        await api.member.sendMagicLink({...data, emailType: 'signin', outboundLinkTagging: state.site.outbound_link_tagging});
+        await api.member.sendMagicLink({...data, emailType: 'signin'});
         return {
             page: 'magiclink',
             lastPage: 'signin'
@@ -100,7 +100,7 @@ async function signup({data, state, api}) {
         let {plan, tierId, cadence, email, name, newsletters, offerId} = data;
 
         if (plan.toLowerCase() === 'free') {
-            await api.member.sendMagicLink({emailType: 'signup', ...data, outboundLinkTagging: state.site.outbound_link_tagging});
+            await api.member.sendMagicLink({emailType: 'signup', ...data});
         } else {
             if (tierId && cadence) {
                 await api.member.checkoutPlan({plan, tierId, cadence, email, name, newsletters, offerId});
@@ -487,15 +487,14 @@ async function oneClickSubscribe({data: {siteUrl}, state}) {
         name: member.name,
         email: member.email,
         autoRedirect: false,
-        outboundLinkTagging: state.site.outbound_link_tagging,
-        customUrlHistory: [
+        customUrlHistory: state.site.outbound_link_tagging ? [
             {
                 time: Date.now(),
                 referrerSource,
                 referrerMedium: 'Ghost Recommendations',
                 referrerUrl
             }
-        ]
+        ] : []
     });
 
     return {};

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -243,7 +243,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             });
         },
 
-        async sendMagicLink({email, emailType, labels, name, oldEmail, newsletters, redirect, customUrlHistory, outboundLinkTagging, autoRedirect = true}) {
+        async sendMagicLink({email, emailType, labels, name, oldEmail, newsletters, redirect, customUrlHistory, autoRedirect = true}) {
             const url = endpointFor({type: 'members', resource: 'send-magic-link'});
             const body = {
                 name,
@@ -257,7 +257,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 autoRedirect
             };
             const urlHistory = customUrlHistory ?? getUrlHistory();
-            if (urlHistory && outboundLinkTagging) {
+            if (urlHistory) {
                 body.urlHistory = urlHistory;
             }
 


### PR DESCRIPTION
no issue

- During the one click subscribe flow, the outboundLinkTagging should affect whether we send a history or not to the signup endpoint. But for internal history this is the members_track_sources setting. This happens in the backend normally.
- Do not send a (constructed) history to external sites (= one click subscribe flow in recommendations) if outboundLinkTagging is false
- Do always send a history internally for local signups (backend handles whether to store it based on the members_track_sources setting that is currently not exposed in the frontend). The history is not built if this setting is disabled, but we could have an old history entry if this setting was enabled in the past.