### PR TITLE
Added flags helper for Acceptance Tests in AdminX

### DIFF
--- a/apps/admin-x-settings/test/utils/acceptance.ts
+++ b/apps/admin-x-settings/test/utils/acceptance.ts
@@ -47,6 +47,33 @@ export const responseFixtures = {
     latestPost: {posts: [{id: '1', url: `${siteFixture.site.url}/test-post/`}]}
 };
 
+let defaultLabFlags = {
+    adminXSettings: false,
+    recommendations: false,
+    audienceFeedback: false,
+    collections: false,
+    themeErrorsNotification: false,
+    outboundLinkTagging: false,
+    announcementBar: false,
+    signupForm: false,
+    lexicalEditor: false,
+    members: false
+};
+
+// Inject defaultLabFlags into responseFixtures.settings
+let labsSetting = responseFixtures.settings.settings.find(s => s.key === 'labs');
+
+if (!labsSetting) {
+    // If 'labs' key doesn't exist, create it
+    responseFixtures.settings.settings.push({
+        key: 'labs',
+        value: JSON.stringify(defaultLabFlags)
+    });
+} else {
+    // If 'labs' key exists, update its value
+    labsSetting.value = JSON.stringify(defaultLabFlags);
+}
+
 export const globalDataRequests = {
     browseSettings: {method: 'GET', path: /^\/settings\/\?group=/, response: responseFixtures.settings},
     browseConfig: {method: 'GET', path: '/config/', response: responseFixtures.config},
@@ -150,4 +177,31 @@ export async function mockSitePreview({page, url, response}: {page: Page, url: s
 export async function chooseOptionInSelect(select: Locator, optionText: string | RegExp) {
     await select.click();
     await select.page().locator('[data-testid="select-option"]', {hasText: optionText}).click();
+}
+
+interface LabsSettings {
+    [key: string]: boolean;
+}
+
+export function toggleLabsFlag(flag: string, value: boolean) {
+    labsSetting = responseFixtures.settings.settings.find(s => s.key === 'labs');
+
+    if (!labsSetting) {
+        throw new Error('Labs settings not found');
+    }
+
+    if (typeof labsSetting.value !== 'string') {
+        throw new Error('Labs settings value is not a string');
+    }
+
+    let labs: LabsSettings;
+    try {
+        labs = JSON.parse(labsSetting.value);
+    } catch (e) {
+        throw new Error('Failed to parse labs settings');
+    }
+  
+    labs[flag] = value;
+  
+    labsSetting.value = JSON.stringify(labs);
 }

--- a/apps/admin-x-settings/test/utils/acceptance.ts
+++ b/apps/admin-x-settings/test/utils/acceptance.ts
@@ -200,8 +200,8 @@ export function toggleLabsFlag(flag: string, value: boolean) {
     } catch (e) {
         throw new Error('Failed to parse labs settings');
     }
-  
+
     labs[flag] = value;
-  
+
     labsSetting.value = JSON.stringify(labs);
 }


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C0568LN2CGJ/p1696495250115289

Adds a new helper function `toggleLabsFlag` that allows toggling of lab flags within tests. This function can be used directly inside a test case or within `beforeEach` or `beforeAll` hooks to set the initial state before tests run.

Usage:
- To toggle a flag within a test: `toggleLabsFlag('recommendations', false);`
- To set initial state in a hook: 
  ```javascript
  beforeEach(() => {
    toggleLabsFlag('recommendations', true);
  });

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e138d58</samp>

This change adds a utility module for acceptance testing of experimental features in Ghost. It allows tests to mock and change the labs settings using `defaultLabFlags` and `toggleLabsFlag`.
