### PR TITLE
Fixed Stripe thumbnail src

### DIFF
--- a/ghost/admin/app/components/settings/members/stripe-settings-form.hbs
+++ b/ghost/admin/app/components/settings/members/stripe-settings-form.hbs
@@ -93,7 +93,7 @@
                             </div>
                         </div>
                         <div class="gh-stripe-guide-image">
-                            <img src="https://ghost.org/resources/content/images/2013-2023/02/Stripe---Home.jpg" alt="Stripe guide on Ghost Resources"/>
+                            <img src="https://ghost.org/resources/content/images/2022/02/Stripe---Home.jpg" alt="Stripe guide on Ghost Resources"/>
                         </div>
                     </a>
                 </div>


### PR DESCRIPTION
Search and replace for copyright messed up the `img` src so it had a bad link, it's fixed now.

[Slack thread](https://ghost.slack.com/archives/C025584CA/p1696512790406669)