### PR TITLE
Implemented filename fingerprinting to Admin-X Settings and Koenig-Lexical

### DIFF
--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -224,12 +224,12 @@ export const importSettings = async () => {
     }
 
     const baseUrl = (config.cdnUrl ? `${config.cdnUrl}assets/` : ghostPaths().assetRootWithHost);
-    const url = new URL(`${baseUrl}admin-x-settings/admin-x-settings.js`);
+    const url = new URL(`${baseUrl}admin-x-settings/${config.adminXSettingsFilename}?v=${config.adminXSettingsHash}`);
 
     if (url.protocol === 'http:') {
-        window['@tryghost/admin-x-settings'] = await import(`http://${url.host}${url.pathname}`);
+        window['@tryghost/admin-x-settings'] = await import(`http://${url.host}${url.pathname}${url.search}`);
     } else {
-        window['@tryghost/admin-x-settings'] = await import(`https://${url.host}${url.pathname}`);
+        window['@tryghost/admin-x-settings'] = await import(`https://${url.host}${url.pathname}${url.search}`);
     }
 
     return window['@tryghost/admin-x-settings'];

--- a/ghost/admin/app/utils/fetch-koenig-lexical.js
+++ b/ghost/admin/app/utils/fetch-koenig-lexical.js
@@ -10,12 +10,12 @@ export default async function fetchKoenigLexical() {
     // Else, if we pass a CDN URL, use that
     // Else, use the asset root from the ghostPaths util
     const baseUrl = (config.editorUrl || (config.cdnUrl ? `${config.cdnUrl}assets/koenig-lexical/` : `${ghostPaths().assetRootWithHost}koenig-lexical/`));
-    const url = new URL(`${baseUrl}koenig-lexical.umd.js`);
+    const url = new URL(`${baseUrl}${config.editorFilename}?v=${config.editorHash}`);
 
     if (url.protocol === 'http:') {
-        await import(`http://${url.host}${url.pathname}`);
+        await import(`http://${url.host}${url.pathname}${url.search}`);
     } else {
-        await import(`https://${url.host}${url.pathname}`);
+        await import(`https://${url.host}${url.pathname}${url.search}`);
     }
 
     return window['@tryghost/koenig-lexical'];


### PR DESCRIPTION
fixes https://github.com/TryGhost/DevOps/issues/86

- this will now hash the files and use these filenames where appropriate, which helps with cache busting

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f40717f</samp>

This pull request improves the asset delivery of the admin-x-settings and koenig-lexical scripts by using hashed filenames instead of hardcoded ones. This allows the scripts to be cached by the browser and invalidated when they are updated. The filenames are dynamically generated and imported by the `asset-delivery` module and the respective components and utils that use the scripts.
