### PR TITLE
Modified getLocalTime to add timeonly option

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/TimeZone.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/TimeZone.tsx
@@ -18,11 +18,11 @@ interface HintProps {
 }
 
 const Hint: React.FC<HintProps> = ({timezone}) => {
-    const [currentTime, setCurrentTime] = useState(getLocalTime(timezone));
+    const [currentTime, setCurrentTime] = useState(getLocalTime(timezone, 'timeOnly'));
 
     useEffect(() => {
         const timer = setInterval(() => {
-            setCurrentTime(getLocalTime(timezone));
+            setCurrentTime(getLocalTime(timezone, 'timeOnly'));
         }, 1000);
 
         return () => {

--- a/apps/admin-x-settings/src/utils/helpers.ts
+++ b/apps/admin-x-settings/src/utils/helpers.ts
@@ -22,9 +22,14 @@ export function resolveAsset(assetPath: string, relativeTo: string) {
     return `${relativeTo}${assetPath}`;
 }
 
-export function getLocalTime(timeZone: string) {
+export function getLocalTime(timeZone: string, format?:string) {
     const date = new Date();
     const options = {timeZone: timeZone};
+    if (format && format === 'timeOnly') {
+        const localTime = date.toLocaleString('en-US', options);
+        const timeOnly = localTime.split(',')[1];
+        return timeOnly;
+    }
     const localTime = date.toLocaleString('en-US', options);
     return localTime;
 }


### PR DESCRIPTION
no issue

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e288b3</samp>

Added a `format` parameter to the `getLocalTime` function and used it in the `Hint` component to show only the time part of the local time in the time zone setting. This improved the user experience of the Ghost admin panel.
