### PR TITLE
Fixed toasts not disappearing after settings reload

### DIFF
--- a/apps/admin-x-settings/src/MainContent.tsx
+++ b/apps/admin-x-settings/src/MainContent.tsx
@@ -6,6 +6,7 @@ import Users from './components/settings/general/Users';
 import useRouting from './hooks/useRouting';
 import {ReactNode, useEffect} from 'react';
 import {canAccessSettings, isEditorUser} from './api/users';
+import {toast} from 'react-hot-toast';
 import {topLevelBackdropClasses} from './admin-x-ds/global/modal/Modal';
 import {useGlobalData} from './components/providers/GlobalDataProvider';
 
@@ -24,6 +25,11 @@ const Page: React.FC<{children: ReactNode}> = ({children}) => {
 const MainContent: React.FC = () => {
     const {currentUser} = useGlobalData();
     const {route, updateRoute, loadingModal} = useRouting();
+
+    useEffect(() => {
+        // resets any toasts that may have been left open on initial load
+        toast.remove();
+    }, []);
 
     useEffect(() => {
         if (!canAccessSettings(currentUser) && route !== `users/show/${currentUser.slug}`) {


### PR DESCRIPTION
refs https://www.notion.so/ghost/AdminX-feedback-27fc7f549bbf4a53bfa2e7b6e5643963?p=d8bb2da9a6534494ad5baf840bbfd785&pm=s

- The error state remains visible after navigating away from settings
- this fix resets the toast on initial load to ensure it doesn't persist if not needed
---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c91fe7</samp>

Improved notifications on settings page using `toast` function. Cleared old notifications on initial load to avoid confusion.
