### PR TITLE
Removed Admin X labs flags in email service

### DIFF
--- a/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
+++ b/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
@@ -197,7 +197,7 @@ exports[`Incoming Recommendation Emails Sends an email if we receive a recommend
                     </tr>
                     <tr>
                       <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 2px\\">
-                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings-x/users/show/joe-bloggs\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">here</a>.</p>
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">here</a>.</p>
                       </td>
                     </tr>
 
@@ -418,7 +418,7 @@ exports[`Incoming Recommendation Emails Sends an email if we receive a recommend
                     </tr>
                     <tr>
                       <td style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-top: 2px\\">
-                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings-x/users/show/smith-wellingsworth\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">here</a>.</p>
+                        <p class=\\"small\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 18px; font-size: 11px; color: #738A94; font-weight: normal; margin: 0; margin-bottom: 2px;\\">Don’t want to receive these emails? Manage your preferences <a class=\\"small\\" href=\\"http://127.0.0.1:2369/ghost/#/settings/staff/smith-wellingsworth\\" style=\\"text-decoration: underline; color: #738A94; font-size: 11px;\\">here</a>.</p>
                       </td>
                     </tr>
 
@@ -449,7 +449,7 @@ You have been recommended by Other Ghost Site.
 ---
 
 Sent to jbloggs@example.com from 127.0.0.1.
-If you would no longer like to receive these notifications you can adjust your settings at http://127.0.0.1:2369/ghost/#/settings-x/users/show/joe-bloggs.
+If you would no longer like to receive these notifications you can adjust your settings at http://127.0.0.1:2369/ghost/#/settings/staff/joe-bloggs.
     "
 `;
 

--- a/ghost/staff-service/lib/StaffServiceEmails.js
+++ b/ghost/staff-service/lib/StaffServiceEmails.js
@@ -37,10 +37,6 @@ class StaffServiceEmails {
 
             let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
 
-            if (this.labs.isSet('adminXSettings')) {
-                staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings-x/users/show/${user.slug}`);
-            }
-
             const templateData = {
                 memberData,
                 attributionTitle,
@@ -97,10 +93,6 @@ class StaffServiceEmails {
 
             let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
 
-            if (this.labs.isSet('adminXSettings')) {
-                staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings-x/users/show/${user.slug}`);
-            }
-
             const templateData = {
                 memberData,
                 attributionTitle,
@@ -154,10 +146,6 @@ class StaffServiceEmails {
 
             let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
 
-            if (this.labs.isSet('adminXSettings')) {
-                staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings-x/users/show/${user.slug}`);
-            }
-
             const templateData = {
                 memberData,
                 tierData,
@@ -189,10 +177,6 @@ class StaffServiceEmails {
      */
     async getSharedData(recipient) {
         let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${recipient.slug}`);
-
-        if (this.labs.isSet('adminXSettings')) {
-            staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings-x/users/show/${recipient.slug}`);
-        }
 
         return {
             siteTitle: this.settingsCache.get('title'),
@@ -237,9 +221,7 @@ class StaffServiceEmails {
             const to = user.email;
 
             let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
-            if (this.labs.isSet('adminXSettings')) {
-                staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings-x/users/show/${user.slug}`);
-            }
+
             const templateData = {
                 siteTitle: this.settingsCache.get('title'),
                 siteUrl: this.urlUtils.getSiteUrl(),
@@ -294,9 +276,6 @@ class StaffServiceEmails {
             const to = user.email;
 
             let staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings/staff/${user.slug}`);
-            if (this.labs.isSet('adminXSettings')) {
-                staffUrl = this.urlUtils.urlJoin(this.urlUtils.urlFor('admin', true), '#', `/settings-x/users/show/${user.slug}`);
-            }
 
             const templateData = {
                 siteTitle: this.settingsCache.get('title'),


### PR DESCRIPTION
no issue

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb0df07</samp>

Simplified staff URL generation for emails by removing unused feature flag and code. This affects the `StaffServiceEmails.js` file and the `adminXSettings` flag.
