### PR TITLE
Fixed popover "right" position in AdminX

### DIFF
--- a/apps/admin-x-settings/src/admin-x-ds/global/Popover.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/Popover.tsx
@@ -36,7 +36,7 @@ const Popover: React.FC<PopoverProps> = ({
             x -= parentRect.x;
             y -= parentRect.y;
 
-            const finalX = (position === 'left') ? x : x - width;
+            const finalX = (position === 'left') ? x : window.innerWidth - (x + width);
             setOpen(true);
             setPositionX(finalX);
             setPositionY(y + height);
@@ -46,9 +46,14 @@ const Popover: React.FC<PopoverProps> = ({
     };
 
     const style: React.CSSProperties = {
-        top: `${positionY}px`,
-        left: `${positionX}px`
+        top: `${positionY}px`
     };
+
+    if (position === 'left') {
+        style.left = `${positionX}px`;
+    } else {
+        style.right = `${positionX}px`;
+    }
 
     const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
         if (e.target === e.currentTarget) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3832

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at babb461</samp>

This pull request enhances the popover component in the `admin-x-settings` app. It fixes a bug with the alignment of the popover and refactors the style object for better readability and maintainability.
