### PR TITLE
Fixed tiers resetting in Ember when created in AdminX

### DIFF
--- a/ghost/admin/app/components/admin-x/settings.js
+++ b/ghost/admin/app/components/admin-x/settings.js
@@ -366,6 +366,11 @@ export default class AdminXSettings extends Component {
         }
 
         run(() => this.store.unloadAll(type));
+
+        if (dataType === 'TiersResponseType') {
+            // membersUtils has local state which needs to be updated
+            this.membersUtils.reload();
+        }
     };
 
     onDelete = (dataType, id) => {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3832

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3fbb5c5</samp>

Reload members data when tiers settings change. This ensures that the UI shows the correct counts and labels of the tiers after updating them in the settings component.
