### PR TITLE
🐛 Fixed URL paste over selected text removing text rather than converting to link in Firefox

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -48,7 +48,7 @@
     "@tryghost/kg-converters": "0.0.18",
     "@tryghost/kg-parser-plugins": "3.0.36",
     "@tryghost/kg-simplemde": "1.11.2",
-    "@tryghost/koenig-lexical": "0.5.1",
+    "@tryghost/koenig-lexical": "0.5.3",
     "@tryghost/limit-service": "1.2.10",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/mobiledoc-kit": "0.12.5-ghost.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7933,10 +7933,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-0.5.1.tgz#a67607d09929c4cf7beff3051476c1a98f1ce465"
-  integrity sha512-jhssuje5P5HGC4RPbeOkPhFgxNAi3l+8S4cYtK7DVdC0/vq9wyU5Z/uJR+XSH7wDZAlR5O32DVYTsBtOHV7N2w==
+"@tryghost/koenig-lexical@0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-0.5.3.tgz#0e1462199c605625c2ef16cbc2f1a2d0f936d95c"
+  integrity sha512-78hJkg0n/SO4WzAGTNjJYFHWMA8C5RzP2FlK1MwRQK6pu8Pmugs8OmuC9N1gtWVXnWDSU0JfAadllrBj5D6TOw==
 
 "@tryghost/limit-service@1.2.10", "@tryghost/limit-service@^1.2.10":
   version "1.2.10"


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/18569

- bumps Koenig including...
  - fix for Firefox link pasting
  - addition of `Ctrl/Cmd+Alt+H` for toggling highlight formatting
