### PR TITLE
Recommendations stats improvements

### DIFF
--- a/apps/admin-x-settings/src/admin-x-ds/global/Hint.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/Hint.tsx
@@ -23,7 +23,7 @@ const Hint: React.FC<HintProps> = ({children, color, className, ...props}) => {
     }
 
     className = clsx(
-        'mt-2 inline-block text-xs',
+        'mt-1 inline-block text-xs',
         colorClassName,
         className
     );

--- a/apps/admin-x-settings/src/admin-x-ds/global/Table.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/global/Table.tsx
@@ -38,12 +38,14 @@ const OptionalPagination = ({pagination}: {pagination?: PaginationData}) => {
 };
 
 const OptionalShowMore = ({showMore}: {showMore?: ShowMoreData}) => {
-    if (!showMore || !showMore.hasMore) {
+    if (!showMore) {
         return null;
+    } else if (!showMore.hasMore) {
+        return <div></div>;
     }
 
     return (
-        <div className={`mt-2 flex items-center gap-2 text-sm font-bold text-green hover:text-green-400`}>
+        <div className={`mt-1 flex items-center gap-2 text-sm font-bold text-green hover:text-green-400`}>
             <button type='button' onClick={showMore.loadMore}>Show all</button>
         </div>
     );
@@ -52,7 +54,7 @@ const OptionalShowMore = ({showMore}: {showMore?: ShowMoreData}) => {
 const Table: React.FC<TableProps> = ({header, children, borderTop, hint, hintSeparator, pageTitle, className, pagination, showMore, isLoading}) => {
     const tableClasses = clsx(
         (borderTop || pageTitle) && 'border-t border-grey-300',
-        'w-full',
+        'w-full overflow-x-auto',
         pageTitle ? 'mb-0 mt-14' : 'my-0',
         className
     );
@@ -111,7 +113,7 @@ const Table: React.FC<TableProps> = ({header, children, borderTop, hint, hintSep
 
     return (
         <>
-            <div className='w-full overflow-x-auto'>
+            <div className='w-full'>
                 {pageTitle && <Heading>{pageTitle}</Heading>}
 
                 <table className={tableClasses}>
@@ -130,7 +132,7 @@ const Table: React.FC<TableProps> = ({header, children, borderTop, hint, hintSep
                 {(hint || pagination || showMore) &&
                 <div className="-mt-px">
                     {(hintSeparator || pagination) && <Separator />}
-                    <div className="flex flex-col-reverse items-start justify-between gap-1 pt-2 md:flex-row md:items-center md:gap-0 md:pt-0">
+                    <div className="mt-1 flex flex-col-reverse items-start justify-between gap-1 pt-2 md:flex-row md:items-center md:gap-0 md:pt-0">
                         <OptionalShowMore showMore={showMore} />
                         <Hint>{hint ?? ' '}</Hint>
                         <OptionalPagination pagination={pagination} />

--- a/apps/admin-x-settings/src/components/settings/site/recommendations/IncomingRecommendationList.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/recommendations/IncomingRecommendationList.tsx
@@ -9,6 +9,7 @@ import useRouting from '../../../../hooks/useRouting';
 import {IncomingRecommendation} from '../../../../api/recommendations';
 import {PaginationData} from '../../../../hooks/usePagination';
 import {ReferrerHistoryItem} from '../../../../api/referrers';
+import {numberWithCommas} from '../../../../utils/helpers';
 
 interface IncomingRecommendationListProps {
     incomingRecommendations: IncomingRecommendation[],
@@ -67,10 +68,19 @@ const IncomingRecommendationItem: React.FC<{incomingRecommendation: IncomingReco
                     </div>
                 </div>
             </TableCell>
-            <TableCell className='hidden align-middle md:!visible md:!table-cell' onClick={showDetails}>
-                {signups === 0 ? <span className="text-grey-500">-</span> : (<div className='-mt-px flex grow items-end gap-1'><span>{signups}</span><span className='-mb-px whitespace-nowrap text-sm lowercase text-grey-700'>{freeMembersLabel}</span></div>)}
+
+            <TableCell className='hidden !pr-1 pl-0 text-right align-middle md:!visible md:!table-cell' onClick={showDetails}>
+                {(signups === 0) ? (<span className="text-grey-500 dark:text-grey-900">-</span>) : (<div className='-mt-px text-right'>
+                    <span className='text-right'>{numberWithCommas(signups)}</span>
+                </div>)}
             </TableCell>
-            {incomingRecommendation.recommending_back && <TableCell className='group-hover/table-row:visible md:invisible'><div className='mt-1 whitespace-nowrap text-right text-sm leading-[1.8] text-grey-700'>Recommending back</div></TableCell>}
+            <TableCell className='hidden align-middle md:!visible md:!table-cell' onClick={showDetails}>
+                {(signups === 0) ? (null) : (<div className='-mt-px text-left'>
+                    <span className='-mb-px inline-block min-w-[60px] whitespace-nowrap text-left text-sm lowercase text-grey-700'>{freeMembersLabel}</span>
+                </div>)}
+            </TableCell>
+
+            {incomingRecommendation.recommending_back && <TableCell className='group-hover/table-row:visible md:invisible'><div className='mt-1 whitespace-nowrap text-right text-sm text-grey-700'>Recommending back</div></TableCell>}
         </TableRow>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/site/recommendations/RecommendationList.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/recommendations/RecommendationList.tsx
@@ -1,19 +1,19 @@
+import Button from '../../../../admin-x-ds/global/Button';
+import EditRecommendationModal from './EditRecommendationModal';
+import Link from '../../../../admin-x-ds/global/Link';
+import NiceModal from '@ebay/nice-modal-react';
 import NoValueLabel from '../../../../admin-x-ds/global/NoValueLabel';
 import React, {useState} from 'react';
 import RecommendationIcon from './RecommendationIcon';
 import Table, {ShowMoreData} from '../../../../admin-x-ds/global/Table';
 import TableCell from '../../../../admin-x-ds/global/TableCell';
-// import TableHead from '../../../../admin-x-ds/global/TableHead';
-import Button from '../../../../admin-x-ds/global/Button';
-import EditRecommendationModal from './EditRecommendationModal';
-import Link from '../../../../admin-x-ds/global/Link';
-import NiceModal from '@ebay/nice-modal-react';
 import TableRow from '../../../../admin-x-ds/global/TableRow';
 import Tooltip from '../../../../admin-x-ds/global/Tooltip';
 import useRouting from '../../../../hooks/useRouting';
 import useSettingGroup from '../../../../hooks/useSettingGroup';
 import {PaginationData} from '../../../../hooks/usePagination';
 import {Recommendation} from '../../../../api/recommendations';
+import {numberWithCommas} from '../../../../utils/helpers';
 
 interface RecommendationListProps {
     recommendations: Recommendation[],
@@ -53,10 +53,14 @@ const RecommendationItem: React.FC<{recommendation: Recommendation}> = ({recomme
                     </div>
                 </div>
             </TableCell>
-            <TableCell className='hidden w-8 align-middle md:!visible md:!table-cell' onClick={showDetails}>
-                {(count === 0) ? (<span className="text-grey-500 dark:text-grey-900">-</span>) : (<div className='-mt-px flex grow items-end gap-1'>
-                    <span>{count}</span>
-                    <span className='-mb-px whitespace-nowrap text-sm lowercase text-grey-700'>{showSubscribers ? newMembers : clicks}</span>
+            <TableCell className='hidden !pr-1 pl-0 text-right align-middle md:!visible md:!table-cell' onClick={showDetails}>
+                {(count === 0) ? (<span className="text-grey-500 dark:text-grey-900">-</span>) : (<div className='-mt-px items-end gap-1 text-right'>
+                    <span className='text-right'>{numberWithCommas(count)}</span>
+                </div>)}
+            </TableCell>
+            <TableCell className='hidden align-middle md:!visible md:!table-cell' onClick={showDetails}>
+                {(count === 0) ? (null) : (<div className='-mt-px items-end gap-1 text-left'>
+                    <span className='-mb-px inline-block min-w-[60px] whitespace-nowrap text-left text-sm lowercase text-grey-700'>{showSubscribers ? newMembers : clicks}</span>
                 </div>)}
             </TableCell>
         </TableRow>


### PR DESCRIPTION
- Fixes regression which made all `Hint`s have a top margin too big
- Improves formatting of recommendation stats
- Fixes issues with `Table` wrapper having overflow set to `auto`, and moves it to the table instead