### PR TITLE
Fixed Admin sending all post revisions along with each post save request

### DIFF
--- a/ghost/admin/app/serializers/post.js
+++ b/ghost/admin/app/serializers/post.js
@@ -27,6 +27,7 @@ export default class PostSerializer extends ApplicationSerializer.extend(Embedde
         delete json.email_recipient_filter;
         delete json.email;
         delete json.newsletter;
+        delete json.post_revisions;
         // Deprecated property (replaced with data.authors)
         delete json.author;
         // Page-only properties


### PR DESCRIPTION
no issue

- deleted `post_revisions` from the serialized JSON string for posts
