### PR TITLE
Fixed link to release in About modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/About.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/About.tsx
@@ -2,10 +2,11 @@ import Icon from '../../../admin-x-ds/global/Icon';
 import Modal from '../../../admin-x-ds/global/modal/Modal';
 import NiceModal from '@ebay/nice-modal-react';
 import Separator from '../../../admin-x-ds/global/Separator';
-import semverParse from 'semver/functions/parse';
 import useRouting from '../../../hooks/useRouting';
 import {ReactComponent as GhostLogo} from '../../../admin-x-ds/assets/images/ghost-logo.svg';
 import {RoutingModalProps} from '../../providers/RoutingProvider';
+import {linkToGitHubReleases} from '../../../utils/linkToGithubReleases';
+import {showDatabaseWarning} from '../../../utils/showDatabaseWarning';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
 import {useUpgradeStatus} from '../../providers/ServiceProvider';
 
@@ -14,24 +15,6 @@ const AboutModal = NiceModal.create<RoutingModalProps>(({}) => {
     const globalData = useGlobalData();
     let config = globalData.config;
     const upgradeStatus = useUpgradeStatus();
-
-    function linkToGitHubReleases():string {
-        if (config.version.includes('-pre.')) {
-            try {
-                const semverVersion = semverParse(config.version, {includePrerelease: true} as any);
-
-                if (semverVersion && semverVersion.build?.[0]) {
-                    return `https://github.com/TryGhost/Ghost/commit/${semverVersion.build[0]}`;
-                }
-
-                return '';
-            } catch (e) {
-                return '';
-            }
-        }
-
-        return `https://github.com/TryGhost/Ghost/releases/tag/v${config.version}`;
-    }
 
     function copyrightYear():number {
         const date = new Date();
@@ -53,23 +36,6 @@ const AboutModal = NiceModal.create<RoutingModalProps>(({}) => {
         }
 
         return true;
-    }
-
-    function showDatabaseWarning() : boolean {
-        const isProduction = !!config.environment.match?.(/production/i);
-        const database = config.database;
-
-        // Show a warning if we're in production and not using MySQL 8
-        if (isProduction && database !== 'mysql8') {
-            return true;
-        }
-
-        // Show a warning if we're in development and using MySQL 5
-        if (!isProduction && database === 'mysql5') {
-            return true;
-        }
-
-        return false;
     }
 
     return (
@@ -94,8 +60,8 @@ const AboutModal = NiceModal.create<RoutingModalProps>(({}) => {
                         )
                     }
                     {
-                        linkToGitHubReleases() && (
-                            <div><strong>Version:</strong> <a className='text-green' href={linkToGitHubReleases()} rel="noopener noreferrer" target="_blank">{config.version}</a></div>
+                        linkToGitHubReleases(config.version) && (
+                            <div><strong>Version:</strong> <a className='text-green' href={linkToGitHubReleases(config.version)} rel="noopener noreferrer" target="_blank">{config.version}</a></div>
                         ) || (
                             <div><strong>Version:</strong> {config.version}</div>
                         )
@@ -116,7 +82,7 @@ const AboutModal = NiceModal.create<RoutingModalProps>(({}) => {
                     }
 
                     {
-                        showSystemInfo() && showDatabaseWarning() && (
+                        showSystemInfo() && showDatabaseWarning(config.environment, config.database) && (
                             <div className='text-red-500 dark:text-red-400'>
                                  You are running an unsupported database in production. Please <a href="https://ghost.org/docs/faq/supported-databases/" rel="noopener noreferrer" target="_blank">upgrade to MySQL 8</a>.
                             </div>

--- a/apps/admin-x-settings/src/utils/linkToGithubReleases.ts
+++ b/apps/admin-x-settings/src/utils/linkToGithubReleases.ts
@@ -1,0 +1,20 @@
+import semverParse from 'semver/functions/parse';
+
+export function linkToGitHubReleases(version: string):string {
+    if (version.includes('-pre.')) {
+        try {
+            const semverVersion = semverParse(version, {includePrerelease: true} as any);
+
+            if (semverVersion && semverVersion.build?.[0]) {
+                return `https://github.com/TryGhost/Ghost/commit/${semverVersion.build[0]}`;
+            }
+
+            return '';
+        } catch (e) {
+            return '';
+        }
+    }
+    let cleanedVersion = version.replace('+moya', '');
+
+    return `https://github.com/TryGhost/Ghost/releases/tag/v${cleanedVersion}`;
+}

--- a/apps/admin-x-settings/src/utils/showDatabaseWarning.ts
+++ b/apps/admin-x-settings/src/utils/showDatabaseWarning.ts
@@ -1,0 +1,15 @@
+export function showDatabaseWarning(environment: string, database:string) : boolean {
+    const isProduction = !!environment.match?.(/production/i);
+
+    // Show a warning if we're in production and not using MySQL 8
+    if (isProduction && database !== 'mysql8') {
+        return true;
+    }
+
+    // Show a warning if we're in development and using MySQL 5
+    if (!isProduction && database === 'mysql5') {
+        return true;
+    }
+
+    return false;
+}

--- a/apps/admin-x-settings/test/unit/utils/linkToGithubReleases.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/linkToGithubReleases.test.ts
@@ -1,0 +1,16 @@
+import * as assert from 'assert/strict';
+import {linkToGitHubReleases} from '../../../src/utils/linkToGithubReleases';
+
+describe('linkToGithubRelease', function () {
+    it('generates a link to a release', function () {
+        let version = '5.69.0';
+        let link = linkToGitHubReleases(version);
+        assert.equal(link, 'https://github.com/TryGhost/Ghost/releases/tag/v5.69.0');
+    });
+
+    it('strips moya from the version', function () {
+        let version = '5.69.0+moya';
+        let link = linkToGitHubReleases(version);
+        assert.equal(link, 'https://github.com/TryGhost/Ghost/releases/tag/v5.69.0');
+    });
+});

--- a/apps/admin-x-settings/test/unit/utils/showDatabaseWarning.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/showDatabaseWarning.test.ts
@@ -1,0 +1,20 @@
+import * as assert from 'assert/strict';
+import {showDatabaseWarning} from '../../../src/utils/showDatabaseWarning';
+
+describe('showDatabaseWarning', function () {
+    it('shows a warning when in production and not using MySQL 8', function () {
+        assert.equal(showDatabaseWarning('production', 'mysql5'), true);
+    });
+
+    it('shows a warning when in development and using MySQL 5', function () {
+        assert.equal(showDatabaseWarning('development', 'mysql5'), true);
+    });
+
+    it('does not show a warning when in production and using MySQL 8', function () {
+        assert.equal(showDatabaseWarning('production', 'mysql8'), false);
+    });
+
+    it('does not show a warning when in development and using MySQL 8', function () {
+        assert.equal(showDatabaseWarning('development', 'mysql8'), false);
+    });
+});


### PR DESCRIPTION
no issue

- the link to the release has `-moya` added to it, which breaks the link to the github release. This ensures it gets removed should it be there to avoid broken links.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f13886c</samp>

Refactored the `About.tsx` component to extract some utility functions to separate modules. Added unit tests for the extracted functions in the `test/unit/utils` folder. The refactoring improves code organization and reusability, and the tests increase the code coverage and reliability.
