### PR TITLE
Fixed infinite save loop due to missing post_revisions include on saves

### DIFF
--- a/ghost/admin/app/adapters/page.js
+++ b/ghost/admin/app/adapters/page.js
@@ -1,7 +1,8 @@
 import ApplicationAdapter from 'ghost-admin/adapters/application';
+import {ALL_POST_INCLUDES} from './post';
 
 export default class Page extends ApplicationAdapter {
-    // posts and pages now include everything by default
+    // posts and pages now include everything except post_revisions by default
     buildIncludeURL(store, modelName, id, snapshot, requestType, query) {
         const url = this.buildURL(modelName, id, snapshot, requestType, query);
         const parsedUrl = new URL(url);
@@ -14,6 +15,13 @@ export default class Page extends ApplicationAdapter {
         if (snapshot?.adapterOptions?.convertToLexical) {
             const convertToLexical = snapshot.adapterOptions.convertToLexical;
             parsedUrl.searchParams.append('convert_to_lexical', convertToLexical);
+        }
+
+        // on create/update we need to explicitly request post_revisions to be included
+        // so we can compare and create a new one later if needed but that means we
+        // have to specify every post include option
+        if (requestType === 'createRecord' || requestType === 'updateRecord') {
+            parsedUrl.searchParams.append('include', ALL_POST_INCLUDES);
         }
 
         return parsedUrl.toString();

--- a/ghost/admin/app/adapters/post.js
+++ b/ghost/admin/app/adapters/post.js
@@ -1,5 +1,17 @@
 import ApplicationAdapter from 'ghost-admin/adapters/application';
 
+export const ALL_POST_INCLUDES = [
+    'tags',
+    'authors',
+    'authors.roles',
+    'email',
+    'tiers',
+    'newsletter',
+    'count.clicks',
+    'post_revisions',
+    'post_revisions.author'
+].join(',');
+
 export default class Post extends ApplicationAdapter {
     buildIncludeURL(store, modelName, id, snapshot, requestType, query) {
         const url = this.buildURL(modelName, id, snapshot, requestType, query);
@@ -29,7 +41,14 @@ export default class Post extends ApplicationAdapter {
             const convertToLexical = snapshot.adapterOptions.convertToLexical;
             parsedUrl.searchParams.append('convert_to_lexical', convertToLexical);
         }
-        
+
+        // on create/update we need to explicitly request post_revisions to be included
+        // so we can compare and create a new one later if needed but that means we
+        // have to specify every post include option
+        if (requestType === 'createRecord' || requestType === 'updateRecord') {
+            parsedUrl.searchParams.append('include', ALL_POST_INCLUDES);
+        }
+
         return parsedUrl.toString();
     }
 

--- a/ghost/admin/app/routes/lexical-editor/edit.js
+++ b/ghost/admin/app/routes/lexical-editor/edit.js
@@ -1,4 +1,5 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
+import {ALL_POST_INCLUDES} from '../../adapters/post';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
 export default class EditRoute extends AuthenticatedRoute {
@@ -28,7 +29,9 @@ export default class EditRoute extends AuthenticatedRoute {
         let query = {
             // eslint-disable-next-line camelcase
             id: post_id,
-            include: 'tags,authors,authors.roles,email,tiers,newsletter,count.clicks,post_revisions,post_revisions.author'
+            // we need to explicitly request post_revisions which means we need
+            // to specify every post include option
+            include: ALL_POST_INCLUDES
         };
 
         const records = await this.store.query(modelName, query);


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/edcd6caf2bf90991c0840e8176890413da12904d
refs https://github.com/TryGhost/Ghost/commit/56f283275494076bfae9aa06a2d5df0d8d8f9b5d

- although we added an include for `post_revisions` when fetching a post for editing we didn't have the same `include` param added to saves meaning our revisions list was wiped from the store on each update
- on leaving the editor we check the last post revision to see if anything has changed and we need to save again, but with it being wiped and not being re-populated on save it meant the check always failed leading to an infinite loop of saves
- updated the posts and pages adapters to use the full includes param on create/update requests so we don't lose what we're trying to compare against
