### PR TITLE
Updated old admin acceptance tests to E2E with AdminX

### DIFF
--- a/ghost/admin/tests/acceptance/editor-test.js
+++ b/ghost/admin/tests/acceptance/editor-test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import {authenticateSession, invalidateSession} from 'ember-simple-auth/test-support';
 import {beforeEach, describe, it} from 'mocha';
 import {blur, click, currentRouteName, currentURL, fillIn, find, findAll, triggerEvent, typeIn} from '@ember/test-helpers';
+import {datepickerSelect} from 'ember-power-datepicker/test-support';
 import {expect} from 'chai';
 import {selectChoose} from 'ember-power-select/test-support';
 import {setupApplicationTest} from 'ember-mocha';
@@ -117,6 +118,70 @@ describe('Acceptance: Editor', function () {
             this.server.loadFixtures('settings');
 
             return await authenticateSession();
+        });
+
+        describe('post settings menu', function () {
+            it('can set publish date', async function () {
+                let [post1] = this.server.createList('post', 2, {authors: [author]});
+                let futureTime = moment().tz('Etc/UTC').add(10, 'minutes');
+
+                // sanity check
+                expect(
+                    moment(post1.publishedAt).tz('Etc/UTC').format('YYYY-MM-DD HH:mm:ss'),
+                    'initial publishedAt sanity check')
+                    .to.equal('2015-12-19 16:25:07');
+
+                // post id 1 is a draft, checking for draft behaviour now
+                await visit('/editor/post/1');
+
+                // open post settings menu
+                await click('[data-test-psm-trigger]');
+
+                // should error, if the publish time is in the wrong format
+                await fillIn('[data-test-date-time-picker-time-input]', 'foo');
+                await blur('[data-test-date-time-picker-time-input]');
+
+                expect(find('[data-test-date-time-picker-error]').textContent.trim(), 'inline error response for invalid time')
+                    .to.equal('Must be in format: "15:00"');
+
+                // should error, if the publish time is in the future
+                // NOTE: date must be selected first, changing the time first will save
+                // with the new time
+                await fillIn('[data-test-date-time-picker-datepicker] input', moment.tz('Etc/UTC').add(1, 'day').format('YYYY-MM-DD'));
+                await blur('[data-test-date-time-picker-datepicker] input');
+                await fillIn('[data-test-date-time-picker-time-input]', futureTime.format('HH:mm'));
+                await blur('[data-test-date-time-picker-time-input]');
+
+                expect(find('[data-test-date-time-picker-error]').textContent.trim(), 'inline error response for future time')
+                    .to.equal('Must be in the past');
+
+                // closing the PSM will reset the invalid date/time
+                await click('[data-test-psm-trigger]');
+                await click('[data-test-psm-trigger]');
+
+                expect(
+                    find('[data-test-date-time-picker-error]'),
+                    'date picker error after closing PSM'
+                ).to.not.exist;
+
+                expect(
+                    find('[data-test-date-time-picker-date-input]').value,
+                    'PSM date value after closing with invalid date'
+                ).to.equal(moment(post1.publishedAt).tz('Etc/UTC').format('YYYY-MM-DD'));
+
+                expect(
+                    find('[data-test-date-time-picker-time-input]').value,
+                    'PSM time value after closing with invalid date'
+                ).to.equal(moment(post1.publishedAt).tz('Etc/UTC').format('HH:mm'));
+
+                // saves the post with the new date
+                let validTime = moment('2017-04-09 12:00');
+                await fillIn('[data-test-date-time-picker-time-input]', validTime.format('HH:mm'));
+                await blur('[data-test-date-time-picker-time-input]');
+                await datepickerSelect('[data-test-date-time-picker-datepicker]', validTime.toDate());
+
+                expect(moment(post1.publishedAt).tz('Etc/UTC').format('YYYY-MM-DD HH:mm:ss')).to.equal('2017-04-09 12:00:00');
+            });
         });
 
         it.skip('handles title validation errors correctly', async function () {

--- a/ghost/admin/tests/acceptance/editor/publish-flow-test.js
+++ b/ghost/admin/tests/acceptance/editor/publish-flow-test.js
@@ -431,41 +431,6 @@ describe('Acceptance: Publish flow', function () {
         it('can publish');
         it('can schedule publish');
 
-        // TODO: Update to E2E test
-        // it('respects default recipient settings - usually nobody', async function () {
-        //     // switch to "usually nobody" setting
-        //     // - doing it this way so we're not testing potentially stale mocked setting keys/values
-        //     await loginAsRole('Administrator', this.server);
-        //     await visit('/settings/newsletters');
-        //     await click('[data-test-toggle-membersemail]');
-        //     await selectChoose('[data-test-select="default-recipients"]', 'Usually nobody');
-        //     await click('[data-test-button="save-members-settings"]');
-
-        //     const post = this.server.create('post', {status: 'draft'});
-        //     await visit(`/editor/post/${post.id}`);
-        //     await click('[data-test-button="publish-flow"]');
-
-        //     expect(
-        //         find('[data-test-setting="publish-type"] [data-test-setting-title]'), 'publish type title'
-        //     ).to.have.trimmed.rendered.text('Publish');
-
-        //     expect(
-        //         find('[data-test-setting="email-recipients"] [data-test-setting-title]'), 'recipients title'
-        //     ).to.have.trimmed.rendered.text('Not sent as newsletter');
-
-        //     await click('[data-test-setting="publish-type"] [data-test-setting-title]');
-
-        //     // email-related options are enabled
-        //     expect(find('[data-test-publish-type="publish+send"]')).to.not.have.attribute('disabled');
-        //     expect(find('[data-test-publish-type="send"]')).to.not.have.attribute('disabled');
-
-        //     await click('[data-test-publish-type="publish+send"]');
-
-        //     expect(
-        //         find('[data-test-setting="email-recipients"] [data-test-setting-title]'), 'recipients title'
-        //     ).to.have.trimmed.rendered.text('All 7 subscribers');
-        // });
-
         it('handles Mailgun not being set up', async function () {
             disableMailgun(this.server);
 

--- a/ghost/core/test/e2e-browser/admin/publishing.spec.js
+++ b/ghost/core/test/e2e-browser/admin/publishing.spec.js
@@ -554,4 +554,82 @@ test.describe('Updating post access', () => {
         await expect(frontendPage.locator('.gh-post-upgrade-cta-content')).not.toBeVisible();
         await expect(frontendPage.locator('.gh-content.gh-canvas > p')).toHaveText('Only gold members can see this');
     });
+
+    test('publish time in timezone', async ({page}) => {
+        await page.goto('/ghost');
+
+        await createPostDraft(page, {title: 'Published in timezones', body: 'Published in timezones'});
+        await openPostSettingsMenu(page);
+
+        // saves the post with the new date
+        await page.locator('[data-test-date-time-picker-datepicker]').click();
+        await page.locator('.ember-power-calendar-nav-control--previous').click();
+        await page.locator('.ember-power-calendar-day', {hasText: '15'}).click();
+        await page.locator('[data-test-date-time-picker-time-input]').fill('12:00');
+
+        await publishPost(page);
+        await closePublishFlow(page);
+
+        // go to settings and change the timezone
+        await page.locator('[data-test-link="posts"]').click();
+        await page.locator('[data-test-nav="settings"]').click();
+        await expect(page.getByTestId('timezone')).toContainText('UTC');
+
+        await page.getByTestId('timezone').getByRole('button', {name: 'Edit'}).click();
+        await page.getByTestId('timezone-select').click();
+        await page.locator('[data-testid="select-option"]', {hasText: 'Kamchatka'}).click();
+
+        await page.getByTestId('timezone').getByRole('button', {name: 'Save'}).click();
+        await expect(page.getByTestId('timezone-select')).toBeHidden();
+        await expect(page.getByTestId('timezone')).toContainText('Pacific/Fiji');
+
+        await page.getByTestId('exit-settings').click();
+        await page.locator('[data-test-nav="posts"]').click();
+        await page.locator('[data-test-post-id]', {hasText: /Published in timezones/}).click();
+
+        await openPostSettingsMenu(page);
+
+        await expect(page.locator('[data-test-date-time-picker-date-input]')).toHaveValue(/-16$/);
+        await expect(page.locator('[data-test-date-time-picker-time-input]')).toHaveValue('00:00');
+        await expect(page.locator('[data-test-date-time-picker-timezone]')).toHaveText('+12');
+    });
+
+    test('default recipient settings - usually nobody', async ({page}) => {
+        // switch to "usually nobody" setting
+        await page.goto('/ghost/settings/newsletters');
+        await page.getByTestId('default-recipients').getByRole('button', {name: 'Edit'}).click();
+        await page.getByTestId('default-recipients-select').click();
+        await page.locator('[data-testid="select-option"]', {hasText: /Usually nobody/}).click();
+        await page.getByTestId('default-recipients').getByRole('button', {name: 'Save'}).click();
+
+        await expect(page.getByTestId('default-recipients-select')).toBeHidden();
+        await expect(page.getByTestId('default-recipients')).toContainText('Usually nobody');
+
+        await page.goto('/ghost');
+
+        await createMember(page, {
+            name: 'Test Member Recipient',
+            email: 'test@recipient.com'
+        });
+
+        // go to publish a post
+        await createPostDraft(page, {title: 'Published in timezones', body: 'Published in timezones'});
+        await page.locator('[data-test-button="publish-flow"]').click();
+
+        await expect(page.locator('[data-test-setting="publish-type"] [data-test-setting-title]')).toContainText('Publish');
+
+        await expect(page.locator('[data-test-setting="email-recipients"] [data-test-setting-title]')).toContainText('Not sent as newsletter');
+
+        await page.locator('[data-test-setting="publish-type"] [data-test-setting-title]').click();
+
+        // email-related options are enabled
+        await expect(page.locator('[data-test-publish-type="publish+send"]')).not.toBeDisabled();
+        await expect(page.locator('[data-test-publish-type="send"]')).not.toBeDisabled();
+
+        await page.locator('label[for="publish-type-publish+send"]').click();
+
+        await expect(
+            page.locator('[data-test-setting="email-recipients"] [data-test-setting-title]')
+        ).toContainText(/\d+\s* subscriber/m);
+    });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3831

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5af23a9</samp>

This pull request updates and adds some test cases for the editor and the publishing flow in Ghost. It uses a helper function to test the date picker component in the editor, and removes a redundant test case from the `publish-flow-test.js` file. It also adds two test cases to the `publishing.spec.js` file, using the Playwright framework, to check the publish time and the newsletter settings of a post.
