### PR TITLE
🐛 Fixed member search ignoring filters

### DIFF
--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -373,8 +373,10 @@ const Member = ghostBookshelf.Model.extend({
     },
 
     searchQuery: function searchQuery(queryBuilder, query) {
-        queryBuilder.where('members.name', 'like', `%${query}%`);
-        queryBuilder.orWhere('members.email', 'like', `%${query}%`);
+        queryBuilder.where(function () {
+            this.where('members.name', 'like', `%${query}%`)
+                .orWhere('members.email', 'like', `%${query}%`);
+        });
     },
 
     orderRawQuery(field, direction) {


### PR DESCRIPTION
fixes TryGhost/Product#3792

- Previously, if you had a filter set in the members list (e.g. `status=paid`), then you searched for a member by email address, the original filter would be ignored, and any members matching the search would be returned, regardless of whether they matched the filters. Effectively, the logic was `member matches filters OR member matches search`. To make this worse, the UI still showed both the filters and the search query, leading to confusing results.
- This small change to the backend logic changes the behavior to only return members that match the filter AND the search query, so if you search for a member that does not meet the current filters, they will not be returned.
