### PR TITLE
Cleaned up old re-auth code in editor route/template

### DIFF
--- a/ghost/admin/app/routes/lexical-editor.js
+++ b/ghost/admin/app/routes/lexical-editor.js
@@ -39,7 +39,8 @@ export default AuthenticatedRoute.extend({
         },
 
         authorizationFailed() {
-            this.controller.send('toggleReAuthenticateModal');
+            // noop - re-auth is handled by controller save
+            return;
         },
 
         willTransition(transition) {

--- a/ghost/admin/app/templates/lexical-editor.hbs
+++ b/ghost/admin/app/templates/lexical-editor.hbs
@@ -123,11 +123,6 @@
         {{/if}}
     </button>
 
-    {{#if this.showReAuthenticateModal}}
-        <GhFullscreenModal @modal="re-authenticate"
-            @close={{this.toggleReAuthenticateModal}}
-            @modifier="action wide" />
-    {{/if}}
     {{#if this.showPostHistory}}
         <GhFullscreenModal
             @modal="post-history"


### PR DESCRIPTION
no issue

- brings the lexical editor in line with the previous editor
