### PR TITLE
Fixed "Cannot read properties of null (reading 'off')" noise in tests

### DIFF
--- a/ghost/core/core/server/services/lexical-multiplayer/service.js
+++ b/ghost/core/core/server/services/lexical-multiplayer/service.js
@@ -93,7 +93,7 @@ module.exports = {
 
         _disable = async () => {
             logging.info('Stopping lexical multiplayer websockets service');
-            ghostServer.httpServer.off('upgrade', handleUpgrade);
+            ghostServer.httpServer?.off('upgrade', handleUpgrade);
 
             if (wss) {
                 _isClosing = true;


### PR DESCRIPTION
no issue

- the lexical multiplayer experiment was causing noise in e2e tests because it tried to use `ghostServer.httpServer` which doesn't exist
