### PR TITLE
Fixed "delete all content" modal not closing in AdminX

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/MigrationOptions.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/MigrationOptions.tsx
@@ -64,13 +64,14 @@ const MigrationOptions: React.FC = () => {
             prompt: 'This is permanent! No backups, no restores, no magic undo button. We warned you, k?',
             okColor: 'red',
             okLabel: 'Delete',
-            onOk: async () => {
+            onOk: async (modal) => {
                 try {
                     await deleteAllContent(null);
                     showToast({
                         type: 'success',
                         message: 'All content deleted from database.'
                     });
+                    modal?.remove();
                     await client.refetchQueries();
                 } catch (e) {
                     handleError(e);


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3831

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80778a0</samp>

Improved the user experience of deleting all content in the labs settings by closing the confirmation modal automatically. This involved modifying the `ConfirmModal` and `MigrationOptions` components in `apps/admin-x-settings`.
