### PR TITLE
🐛 Fixed searching for "Code Injection" in AdminX

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
@@ -7,7 +7,7 @@ import SettingSection from '../../../admin-x-ds/settings/SettingSection';
 
 export const searchKeywords = {
     integrations: ['integration', 'zapier', 'slack', 'amp', 'unsplash', 'first promoter', 'firstpromoter', 'pintura', 'disqus', 'analytics', 'ulysses', 'typeform', 'buffer', 'plausible', 'github'],
-    codeInjection: ['newsletter', 'enable', 'disable', 'turn on'],
+    codeInjection: ['code', 'injection'],
     labs: ['labs', 'alpha', 'beta', 'flag', 'import', 'export', 'migrate', 'routes', 'redirect', 'translation', 'delete', 'content', 'editor', 'substack', 'migration', 'portal'],
     history: ['history', 'log', 'events', 'user events', 'staff']
 };


### PR DESCRIPTION
Before, there was a "copy-paste-o" from email newsletter section.

Now the expected keywords can be used to search for code injection.

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)
