### PR TITLE
Added `DOCTYPE` HTML tag to admin-auth iframe

### DIFF
--- a/ghost/core/core/frontend/src/admin-auth/index.html
+++ b/ghost/core/core/frontend/src/admin-auth/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <script src="admin-auth.min.js"></script>


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [X] There's a clear use-case for this code change, explained below
- [X] Commit message has a short title & references relevant issues
- [X] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

Recently I ran a Lighthouse report on my ghost blog and I discover that the brosser found an issue.

The issue is "Page layout may be unexpected due to Quirks Mode"

This is because the iframe that inject the admin-auth html page doesn't have a DOCTYPE tag.


<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b71476d</samp>

Add `<!DOCTYPE html>` declaration to `admin-auth/index.html` to improve HTML validity and browser compatibility.
