### PR TITLE
Fixed Mailgun API key link

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/Mailgun.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/Mailgun.tsx
@@ -59,7 +59,7 @@ const MailGun: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 
     const apiKeysHint = (
-        <>Find your Mailgun API keys <Link href="https://app.mailgun.com/app/account/security/api_keys" rel="noopener noreferrer" target="_blank">here</Link></>
+        <>Find your Mailgun API keys <Link href="https://app.mailgun.com/settings/api_security" rel="noopener noreferrer" target="_blank">here</Link></>
     );
     const inputs = (
         <SettingGroupContent>


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/18630

- the previous link was incorrect/outdated

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97c4467</samp>

Updated the link to Mailgun API keys page in `Mailgun.tsx` component. This change helps users configure their email settings more easily.
