### PR TITLE
Improved AdminX scrolling behaviour

### DIFF
--- a/apps/admin-x-settings/src/App.tsx
+++ b/apps/admin-x-settings/src/App.tsx
@@ -8,6 +8,7 @@ import {DefaultHeaderTypes} from './unsplash/UnsplashTypes';
 import {FetchKoenigLexical, OfficialTheme, ServicesProvider} from './components/providers/ServiceProvider';
 import {GlobalDirtyStateProvider} from './hooks/useGlobalDirtyState';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {ScrollSectionProvider} from './hooks/useScrollSection';
 import {ErrorBoundary as SentryErrorBoundary} from '@sentry/react';
 import {Toaster} from 'react-hot-toast';
 import {UpgradeStatusType} from './utils/globalTypes';
@@ -51,22 +52,24 @@ function App({ghostVersion, officialThemes, zapierTemplates, externalNavigate, d
             <QueryClientProvider client={queryClient}>
                 <ServicesProvider fetchKoenigLexical={fetchKoenigLexical} ghostVersion={ghostVersion} officialThemes={officialThemes} sentryDSN={sentryDSN} unsplashConfig={unsplashConfig} upgradeStatus={upgradeStatus} zapierTemplates={zapierTemplates} onDelete={onDelete} onInvalidate={onInvalidate} onUpdate={onUpdate}>
                     <GlobalDataProvider>
-                        <RoutingProvider externalNavigate={externalNavigate}>
-                            <GlobalDirtyStateProvider>
-                                <DesignSystemProvider>
-                                    <div className={appClassName} id="admin-x-root" style={{
-                                        height: '100vh',
-                                        width: '100%'
-                                    }}
-                                    >
-                                        <Toaster />
-                                        <NiceModal.Provider>
-                                            <MainContent />
-                                        </NiceModal.Provider>
-                                    </div>
-                                </DesignSystemProvider>
-                            </GlobalDirtyStateProvider>
-                        </RoutingProvider>
+                        <ScrollSectionProvider>
+                            <RoutingProvider externalNavigate={externalNavigate}>
+                                <GlobalDirtyStateProvider>
+                                    <DesignSystemProvider>
+                                        <div className={appClassName} id="admin-x-root" style={{
+                                            height: '100vh',
+                                            width: '100%'
+                                        }}
+                                        >
+                                            <Toaster />
+                                            <NiceModal.Provider>
+                                                <MainContent />
+                                            </NiceModal.Provider>
+                                        </div>
+                                    </DesignSystemProvider>
+                                </GlobalDirtyStateProvider>
+                            </RoutingProvider>
+                        </ScrollSectionProvider>
                     </GlobalDataProvider>
                 </ServicesProvider>
             </QueryClientProvider>

--- a/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
@@ -1,6 +1,6 @@
 import NiceModal from '@ebay/nice-modal-react';
 import React, {createContext, useCallback, useEffect, useState} from 'react';
-import {ScrollSectionProvider} from '../../hooks/useScrollSection';
+import {useScrollSectionContext} from '../../hooks/useScrollSection';
 import type {ModalComponent, ModalName} from './routing/modals';
 
 export type RouteParams = {[key: string]: string}
@@ -124,6 +124,7 @@ type RouteProviderProps = {
 const RoutingProvider: React.FC<RouteProviderProps> = ({externalNavigate, children}) => {
     const [route, setRoute] = useState<string | undefined>(undefined);
     const [loadingModal, setLoadingModal] = useState(false);
+    const {updateNavigatedSection, scrollToSection} = useScrollSectionContext();
 
     useEffect(() => {
         // Preload all the modals after initial render to avoid a delay when opening them
@@ -142,12 +143,14 @@ const RoutingProvider: React.FC<RouteProviderProps> = ({externalNavigate, childr
 
         const newPath = options.route;
 
-        if (newPath) {
+        if (newPath === route) {
+            scrollToSection(newPath.split('/')[0]);
+        } else if (newPath) {
             window.location.hash = `/settings/${newPath}`;
         } else {
             window.location.hash = `/settings`;
         }
-    }, [externalNavigate]);
+    }, [externalNavigate, route, scrollToSection]);
 
     useEffect(() => {
         const handleHashChange = () => {
@@ -172,6 +175,12 @@ const RoutingProvider: React.FC<RouteProviderProps> = ({externalNavigate, childr
         };
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+    useEffect(() => {
+        if (route !== undefined) {
+            updateNavigatedSection(route.split('/')[0]);
+        }
+    }, [route, updateNavigatedSection]);
+
     if (route === undefined) {
         return null;
     }
@@ -184,9 +193,7 @@ const RoutingProvider: React.FC<RouteProviderProps> = ({externalNavigate, childr
                 loadingModal
             }}
         >
-            <ScrollSectionProvider navigatedSection={route.split('/')[0]}>
-                {children}
-            </ScrollSectionProvider>
+            {children}
         </RouteContext.Provider>
     );
 };


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3832

Hopefully the scrolling finally works consistently

- Fixed a bug where clicking the navigated section wouldn't scroll to it
- Fixed a bug where the first click after opening settings wouldn't animate the scroll
- Fixed a bug where the sidebar would always animate scroll even on the initial page load

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0996b8b</samp>

This pull request improves the scrolling and navigation functionality of the settings page by using a custom hook and a context provider. It refactors the `RoutingProvider` and the `useScrollSection` hook to handle the route and sidebar changes more efficiently, and simplifies the code by removing unnecessary components and state. It also adds new functions to the scroll section context data to update and scroll to the desired section.
