### PR TITLE
🐛 Fixed potential invalid nesting of elements within heading nodes in editor

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -45,7 +45,7 @@
     "@tryghost/helpers": "1.1.77",
     "@tryghost/kg-clean-basic-html": "3.0.36",
     "@tryghost/kg-converters": "0.0.19",
-    "@tryghost/koenig-lexical": "0.5.6",
+    "@tryghost/koenig-lexical": "0.5.7",
     "@tryghost/limit-service": "1.2.10",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7888,10 +7888,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@0.5.6":
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-0.5.6.tgz#964c5f525b5d1a02605667d125b96a9afee0c1bf"
-  integrity sha512-MuCGfDSdPphgjUnBL3KTsr0GZcLK8nbDTPDvKiUWJ3nCRAO29YcV9848haeU//GTJd86yL0/VLcMsiv7Q4+TVQ==
+"@tryghost/koenig-lexical@0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-0.5.7.tgz#72543bba032a5fc608e0873d7317b8f5cd9646fa"
+  integrity sha512-1fAJtx2hn5cQWfLERlkWwcHcDx9MmB3Ta7AugpBK6JQZ5aXXAMex73dfo2XjzK2ZwhWVlsMUlH0jCl5WvYNtOQ==
 
 "@tryghost/limit-service@1.2.10", "@tryghost/limit-service@^1.2.10":
   version "1.2.10"


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3538

- bumps `@tryghost/koenig-lexical` with version that extends our de-nesting transforms to include non-Paragraph element nodes
