### PR TITLE
Temporarily increased timeout for saving Offer in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
       if: always()
       with:
         name: browser-tests-playwright-report
-        path: ${{ github.workspace }}/ghost/core/playwright-report
+        path: ghost/core/playwright-report
         retention-days: 30
 
   job_unit-tests:

--- a/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
+++ b/ghost/core/test/e2e-browser/utils/e2e-browser-utils.js
@@ -333,7 +333,7 @@ const createOffer = async (page, {name, tierName, offerType, amount, discountTyp
     // Wait for the "Saved" button, ensures that next clicks don't trigger the unsaved work modal
     await page.getByRole('button', {name: 'Saved'}).waitFor({
         state: 'visible',
-        timeout: 1000
+        timeout: 10000
     });
     await page.locator('.gh-nav a[href="#/offers/"]').click();
 


### PR DESCRIPTION
- if Stripe is slow, this might take longer than we expect to finish
- this helps prevent flaky tests in CI

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 090eca9</samp>

This pull request fixes a path inconsistency in the CI workflow and increases a timeout value in the browser tests. These changes aim to improve the reliability and consistency of the testing process.
