### PR TITLE
Fixed default theme button in theme settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/theme/ThemePreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/ThemePreview.tsx
@@ -72,7 +72,7 @@ const ThemePreview: React.FC<{
 
     if (isInstalling) {
         installButtonLabel = 'Installing...';
-    } else if (selectedTheme.ref === 'default') {
+    } else if (selectedTheme.ref === 'default' && !installedTheme?.active) {
         installButtonLabel = `Activate ${selectedTheme.name}`;
     } else if (installedTheme) {
         installButtonLabel = `Update ${selectedTheme.name}`;


### PR DESCRIPTION
no issue

- the default theme (currently Source) showed Activate despite being active already, which may lead to confusion.
- This fix checks whether it's already to more accurately display the wording of the button

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fd443c</samp>

Fix theme preview button label for default theme. Hide the activate button for the default theme if it is already active in `ThemePreview.tsx`.
