### PR TITLE
Switch to 4-core runners for browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,8 @@ jobs:
   job_browser-tests:
     name: Browser tests
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-latest-4-cores
     needs: [job_get_metadata, job_install_deps]
     if: needs.job_get_metadata.outputs.is_main == 'true' || needs.job_get_metadata.outputs.has_browser_tests_label == 'true'
     concurrency:


### PR DESCRIPTION
refs: https://github.com/TryGhost/DevOps/issues/78

This number of cores has been approved, will test with 1 browser per core, and 1 browser for every two cores
