### PR TITLE
Added unit tests for AdminX API hooks

### DIFF
--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -68,6 +68,7 @@
     "@storybook/testing-library": "0.2.2",
     "@tailwindcss/forms": "0.5.6",
     "@tailwindcss/line-clamp": "0.4.4",
+    "@testing-library/react": "^14.0.0",
     "@types/react": "18.2.28",
     "@types/react-dom": "18.2.13",
     "@types/validator": "13.11.3",

--- a/apps/admin-x-settings/test/unit/hooks/useForm.test.ts
+++ b/apps/admin-x-settings/test/unit/hooks/useForm.test.ts
@@ -1,0 +1,75 @@
+import * as assert from 'assert/strict';
+import useForm from '../../../src/hooks/useForm';
+import {act, renderHook} from '@testing-library/react';
+
+describe('useForm', function () {
+    describe('formState', () => {
+        it('returns the initial form state', function () {
+            const {result} = renderHook(() => useForm({
+                initialState: {a: 1},
+                onSave: () => {}
+            }));
+
+            assert.deepStrictEqual(result.current.formState, {a: 1});
+        });
+    });
+
+    describe('updateForm', () => {
+        it('updates the form state', function () {
+            const {result} = renderHook(() => useForm({
+                initialState: {a: 1},
+                onSave: () => {}
+            }));
+
+            act(() => result.current.updateForm(state => ({...state, b: 2})));
+
+            assert.deepStrictEqual(result.current.formState, {a: 1, b: 2});
+        });
+
+        it('sets the saveState to unsaved', function () {
+            const {result} = renderHook(() => useForm({
+                initialState: {a: 1},
+                onSave: () => {}
+            }));
+
+            act(() => result.current.updateForm(state => ({...state, a: 2})));
+
+            assert.deepStrictEqual(result.current.saveState, 'unsaved');
+        });
+    });
+
+    describe('handleSave', () => {
+        it('does nothing when the state has not changed', async function () {
+            let onSaveCalled = false;
+
+            const {result} = renderHook(() => useForm({
+                initialState: {a: 1},
+                onSave: () => {
+                    onSaveCalled = true;
+                }
+            }));
+
+            assert.equal(await act(() => result.current.handleSave()), true);
+
+            assert.equal(result.current.saveState, '');
+            assert.equal(onSaveCalled, false);
+        });
+
+        it('calls the onSave callback when the state has changed', async function () {
+            let onSaveCalled = false;
+
+            const {result} = renderHook(() => useForm({
+                initialState: {a: 1},
+                onSave: () => {
+                    onSaveCalled = true;
+                }
+            }));
+
+            act(() => result.current.updateForm(state => ({...state, a: 2})));
+            assert.equal(await act(() => result.current.handleSave()), true);
+
+            assert.equal(result.current.saveState, 'saved');
+            assert.equal(onSaveCalled, true);
+        });
+    });
+});

--- a/apps/admin-x-settings/test/unit/utils/api/hooks.test.tsx
+++ b/apps/admin-x-settings/test/unit/utils/api/hooks.test.tsx
@@ -1,0 +1,479 @@
+import React, {ReactNode} from 'react';
+import {InfiniteData, QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {MockContext, vi} from 'vitest';
+import {ServicesProvider} from '../../../../src/components/providers/ServiceProvider';
+import {act, renderHook, waitFor} from '@testing-library/react';
+import {createInfiniteQuery, createMutation, createPaginatedQuery, createQuery, createQueryWithId} from '../../../../src/utils/api/hooks';
+
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            retry: false
+        }
+    }
+});
+
+const wrapper: React.FC<{ children: ReactNode }> = ({children}) => (
+    <ServicesProvider
+        fetchKoenigLexical={async () => {}}
+        ghostVersion='5.x'
+        officialThemes={[]}
+        sentryDSN=''
+        unsplashConfig={{
+            Authorization: '',
+            'Accept-Version': '',
+            'Content-Type': '',
+            'App-Pragma': '',
+            'X-Unsplash-Cache': true
+        }}
+        zapierTemplates={[]}
+        onDelete={() => {}}
+        onInvalidate={() => {}}
+        onUpdate={() => {}}
+    >
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    </ServicesProvider>
+);
+
+let originalFetch = global.fetch;
+
+type FetchArgs = Parameters<typeof global.fetch>;
+
+const withMockFetch = async (
+    {json = {}, headers = {}, status = 200, ok = true}: {json?: unknown; headers?: Record<string, string>; status?: number; ok?: boolean},
+    callback: (mock: MockContext<FetchArgs, Promise<Response>>) => void | Promise<void>
+) => {
+    const mockFetch = vi.fn<FetchArgs, Promise<Response>>(() => Promise.resolve({
+        json: () => Promise.resolve(json),
+        headers: new Headers(headers),
+        status,
+        ok
+    } as Response));
+
+    global.fetch = mockFetch as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    await callback(mockFetch.mock);
+
+    global.fetch = originalFetch;
+};
+
+describe('createQuery', () => {
+    afterEach(() => {
+        queryClient.clear();
+    });
+
+    it('makes an API request', async () => {
+        await withMockFetch({
+            json: {test: 1}
+        }, async (mock) => {
+            const useTestQuery = createQuery({
+                dataType: 'test',
+                path: '/test/'
+            });
+
+            const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(result.current.data).toEqual({test: 1});
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0]).toEqual(['http://localhost:3000/ghost/api/admin/test/', {
+                credentials: 'include',
+                headers: {
+                    'app-pragma': 'no-cache',
+                    'x-ghost-version': '5.x'
+                },
+                method: 'GET',
+                mode: 'cors',
+                signal: expect.any(AbortSignal)
+            }]);
+        });
+    });
+
+    it('sends default query params', async () => {
+        await withMockFetch({}, async (mock) => {
+            const useTestQuery = createQuery({
+                dataType: 'test',
+                path: '/test/',
+                defaultSearchParams: {a: '?'}
+            });
+
+            const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?a=%3F');
+        });
+    });
+
+    it('can override default query params', async () => {
+        await withMockFetch({}, async (mock) => {
+            const useTestQuery = createQuery({
+                dataType: 'test',
+                path: '/test/',
+                defaultSearchParams: {a: '?'}
+            });
+
+            const {result} = renderHook(() => useTestQuery({searchParams: {b: '1'}}), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?b=1');
+        });
+    });
+
+    it('can transform return data', async () => {
+        await withMockFetch({json: {test: 1}}, async () => {
+            const useTestQuery = createQuery({
+                dataType: 'test',
+                path: '/test/',
+                returnData: data => (data as {test: number}).test + 1
+            });
+
+            const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(result.current.data).toEqual(2);
+        });
+    });
+});
+
+describe('createPaginatedQuery', () => {
+    afterEach(() => {
+        queryClient.clear();
+    });
+
+    it('makes a paginated API request', async () => {
+        await withMockFetch({
+            json: {test: 1}
+        }, async (mock) => {
+            const useTestQuery = createPaginatedQuery({
+                dataType: 'test',
+                path: '/test/'
+            });
+
+            const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(result.current.data).toEqual({test: 1});
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0]).toEqual(['http://localhost:3000/ghost/api/admin/test/?page=1', {
+                credentials: 'include',
+                headers: {
+                    'app-pragma': 'no-cache',
+                    'x-ghost-version': '5.x'
+                },
+                method: 'GET',
+                mode: 'cors',
+                signal: expect.any(AbortSignal)
+            }]);
+        });
+    });
+
+    it('sends default query params', async () => {
+        await withMockFetch({}, async (mock) => {
+            const useTestQuery = createPaginatedQuery({
+                dataType: 'test',
+                path: '/test/',
+                defaultSearchParams: {a: '?'}
+            });
+
+            const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?a=%3F&page=1');
+        });
+    });
+
+    it('can override default query params', async () => {
+        await withMockFetch({}, async (mock) => {
+            const useTestQuery = createPaginatedQuery({
+                dataType: 'test',
+                path: '/test/',
+                defaultSearchParams: {a: '?'}
+            });
+
+            const {result} = renderHook(() => useTestQuery({searchParams: {b: '1'}}), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?b=1&page=1');
+        });
+    });
+
+    it('can transform return data', async () => {
+        await withMockFetch({json: {test: 1}}, async () => {
+            const useTestQuery = createPaginatedQuery({
+                dataType: 'test',
+                path: '/test/',
+                returnData: data => ({test: (data as {test: number}).test + 1, meta: undefined})
+            });
+
+            const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(result.current.data).toEqual({test: 2});
+        });
+    });
+
+    it('exposes pagination metadata', async () => {
+        await withMockFetch({json: {meta: {pagination: {pages: 2, total: 100}}}}, async () => {
+            const useTestQuery = createPaginatedQuery({
+                dataType: 'test',
+                path: '/test/',
+                defaultSearchParams: {limit: '15'}
+            });
+
+            const {result} = renderHook(() => useTestQuery({}), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(result.current.pagination.limit).toEqual(15);
+            expect(result.current.pagination.page).toEqual(1);
+            expect(result.current.pagination.pages).toEqual(2);
+            expect(result.current.pagination.total).toEqual(100);
+        });
+    });
+
+    it('supports navigating pages', async () => {
+        await withMockFetch({json: {meta: {pagination: {pages: 2}}}}, async (mock) => {
+            const useTestQuery = createPaginatedQuery({
+                dataType: 'test',
+                path: '/test/'
+            });
+
+            const {result} = renderHook(() => useTestQuery({}), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?page=1');
+
+            act(() => result.current.pagination.nextPage());
+
+            await waitFor(() => expect(mock.calls.length).toBe(2));
+
+            expect(mock.calls[1][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?page=2');
+
+            act(() => result.current.pagination.prevPage());
+
+            await waitFor(() => expect(mock.calls.length).toBe(3));
+
+            expect(mock.calls[2][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?page=1');
+
+            act(() => result.current.pagination.setPage(5));
+
+            await waitFor(() => expect(mock.calls.length).toBe(4));
+
+            expect(mock.calls[3][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?page=5');
+        });
+    });
+});
+
+describe('createInfiniteQuery', () => {
+    afterEach(() => {
+        queryClient.clear();
+    });
+
+    it('makes a paginated API request', async () => {
+        await withMockFetch({
+            json: {test: 1, pagination: {next: 2}}
+        }, async (mock) => {
+            const useTestQuery = createInfiniteQuery({
+                dataType: 'test',
+                path: '/test/',
+                defaultNextPageParams: (lastPage, otherParams) => ({
+                    ...otherParams,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    page: ((lastPage as any).pagination.next || 1).toString()
+                }),
+                returnData: (originalData) => {
+                    const {pages} = originalData as InfiniteData<{test: number}>;
+                    return pages.map(page => page.test);
+                }
+            });
+
+            const {result} = renderHook(() => useTestQuery(), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(result.current.data).toEqual([1]);
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0]).toEqual(['http://localhost:3000/ghost/api/admin/test/', {
+                credentials: 'include',
+                headers: {
+                    'app-pragma': 'no-cache',
+                    'x-ghost-version': '5.x'
+                },
+                method: 'GET',
+                mode: 'cors',
+                signal: expect.any(AbortSignal)
+            }]);
+
+            await act(() => result.current.fetchNextPage());
+
+            await waitFor(() => expect(mock.calls.length).toBe(2));
+            expect(mock.calls[1][0]).toEqual('http://localhost:3000/ghost/api/admin/test/?page=2');
+
+            await waitFor(() => expect(result.current.data).toEqual([1, 1]));
+        });
+    });
+});
+
+describe('createQueryWithId', () => {
+    afterEach(() => {
+        queryClient.clear();
+    });
+
+    it('fills in the ID in the request', async () => {
+        await withMockFetch({
+            json: {test: 1}
+        }, async (mock) => {
+            const useTestQuery = createQueryWithId({
+                dataType: 'test',
+                path: '/test/:id/'
+            });
+
+            const {result} = renderHook(() => useTestQuery('1'), {wrapper});
+
+            await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+            expect(result.current.data).toEqual({test: 1});
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0][0]).toEqual('http://localhost:3000/ghost/api/admin/test/1/');
+        });
+    });
+});
+
+describe('createMutation', () => {
+    afterEach(() => {
+        queryClient.clear();
+    });
+
+    it('makes a request', async () => {
+        await withMockFetch({
+            json: {test: 1}
+        }, async (mock) => {
+            const useTestMutation = createMutation({
+                path: () => '/test/',
+                method: 'PUT'
+            });
+
+            const {result} = renderHook(() => useTestMutation(), {wrapper});
+
+            expect(await result.current.mutateAsync({})).toEqual({test: 1});
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0]).toEqual(['http://localhost:3000/ghost/api/admin/test/', {
+                credentials: 'include',
+                headers: {
+                    'app-pragma': 'no-cache',
+                    'x-ghost-version': '5.x'
+                },
+                method: 'PUT',
+                mode: 'cors',
+                body: undefined,
+                signal: expect.any(AbortSignal)
+            }]);
+        });
+    });
+
+    it('computes path, body, searchParams', async () => {
+        await withMockFetch({
+            json: {test: 1}
+        }, async (mock) => {
+            const useTestMutation = createMutation({
+                path: payload => `/test/${payload}/`,
+                searchParams: payload => ({a: `${payload}`}),
+                body: payload => ({b: `${payload}`}),
+                method: 'POST'
+            });
+
+            const {result} = renderHook(() => useTestMutation(), {wrapper});
+
+            expect(await result.current.mutateAsync('hello')).toEqual({test: 1});
+
+            expect(mock.calls.length).toBe(1);
+            expect(mock.calls[0]).toEqual(['http://localhost:3000/ghost/api/admin/test/hello/?a=hello', {
+                credentials: 'include',
+                headers: {
+                    'app-pragma': 'no-cache',
+                    'content-type': 'application/json',
+                    'x-ghost-version': '5.x'
+                },
+                method: 'POST',
+                mode: 'cors',
+                body: '{"b":"hello"}',
+                signal: expect.any(AbortSignal)
+            }]);
+        });
+    });
+
+    it('can invalidate queries in the cache', async () => {
+        await withMockFetch({
+            json: {test: 1}
+        }, async (mock) => {
+            queryClient.setQueryData(['MyDataType', '1'], {test: 1});
+            queryClient.setQueryData(['MyDataType', '2'], {test: 2});
+
+            const useTestMutation = createMutation({
+                path: () => '/test/',
+                method: 'PUT',
+                invalidateQueries: {dataType: 'MyDataType'}
+            });
+
+            const {result} = renderHook(() => useTestMutation(), {wrapper});
+
+            await result.current.mutateAsync({});
+
+            expect(mock.calls.length).toBe(1);
+
+            expect(queryClient.getQueryState(['MyDataType', '1'])?.isInvalidated).toBe(true);
+            expect(queryClient.getQueryState(['MyDataType', '2'])?.isInvalidated).toBe(true);
+        });
+    });
+
+    it('can update queries in the cache', async () => {
+        await withMockFetch({
+            json: {test: 10}
+        }, async (mock) => {
+            queryClient.setQueryData(['MyDataType', '1'], {test: 1});
+            queryClient.setQueryData(['MyDataType', '2'], {test: 2});
+
+            const useTestMutation = createMutation({
+                path: () => '/test/',
+                method: 'PUT',
+                updateQueries: {
+                    emberUpdateType: 'skip',
+                    dataType: 'MyDataType',
+                    update: (newData, currentData) => {
+                        return {test: (newData as {test: number}).test + (currentData as {test: number}).test};
+                    }
+                }
+            });
+
+            const {result} = renderHook(() => useTestMutation(), {wrapper});
+
+            await result.current.mutateAsync({});
+
+            expect(mock.calls.length).toBe(1);
+
+            expect(queryClient.getQueryData(['MyDataType', '1'])).toEqual({test: 11});
+            expect(queryClient.getQueryData(['MyDataType', '2'])).toEqual({test: 12});
+        });
+    });
+});

--- a/apps/admin-x-settings/test/unit/utils/api/updateQueries.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/api/updateQueries.test.ts
@@ -1,0 +1,95 @@
+import {deleteFromQueryCache, insertToQueryCache, updateQueryCache} from '../../../../src/utils/api/updateQueries';
+
+describe('insertToQueryCache', () => {
+    it('appends records from the new data', () => {
+        const newData = {
+            posts: [{id: '2'}]
+        };
+
+        const currentData = {
+            posts: [{id: '1'}]
+        };
+
+        const result = insertToQueryCache('posts')(newData, currentData);
+
+        expect(result).toEqual({
+            posts: [{id: '1'}, {id: '2'}]
+        });
+    });
+
+    it('appends to the last page for paginated queries', () => {
+        const newData = {
+            posts: [{id: '3'}]
+        };
+
+        const currentData = {
+            pages: [{posts: [{id: '1'}]}, {posts: [{id: '2'}]}]
+        };
+
+        const result = insertToQueryCache('posts')(newData, currentData);
+
+        expect(result).toEqual({
+            pages: [{posts: [{id: '1'}]}, {posts: [{id: '2'}, {id: '3'}]}]
+        });
+    });
+});
+
+describe('updateQueryCache', () => {
+    it('updates based on the ID', () => {
+        const newData = {
+            posts: [{id: '2', title: 'New Title'}]
+        };
+
+        const currentData = {
+            posts: [{id: '1'}, {id: '2', title: 'Old Title'}]
+        };
+
+        const result = updateQueryCache('posts')(newData, currentData);
+
+        expect(result).toEqual({
+            posts: [{id: '1'}, {id: '2', title: 'New Title'}]
+        });
+    });
+
+    it('updates nested records in paginated queries', () => {
+        const newData = {
+            posts: [{id: '2', title: 'New Title'}]
+        };
+
+        const currentData = {
+            pages: [{posts: [{id: '1'}]}, {posts: [{id: '2', title: 'Old Title'}]}]
+        };
+
+        const result = updateQueryCache('posts')(newData, currentData);
+
+        expect(result).toEqual({
+            pages: [{posts: [{id: '1'}]}, {posts: [{id: '2', title: 'New Title'}]}]
+        });
+    });
+});
+
+describe('deleteFromQueryCache', () => {
+    it('deletes based on the ID', () => {
+        const currentData = {
+            posts: [{id: '1'}, {id: '2'}]
+        };
+
+        const result = deleteFromQueryCache('posts')(null, currentData, '2');
+
+        expect(result).toEqual({
+            posts: [{id: '1'}]
+        });
+    });
+
+    it('deletes nested records in paginated queries', () => {
+        const currentData = {
+            pages: [{posts: [{id: '1'}]}, {posts: [{id: '2'}]}]
+        };
+
+        const result = deleteFromQueryCache('posts')(null, currentData, '2');
+
+        expect(result).toEqual({
+            pages: [{posts: [{id: '1'}]}, {posts: []}]
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
   "license": "MIT",
-  "workspaces": [
-    "ghost/*",
-    "apps/*"
-  ],
+  "workspaces": {
+    "packages": [
+        "ghost/*",
+        "apps/*"
+    ],
+    "nohoist": ["**/@testing-library/react"]
+  },
   "monorepo": {
     "public": false,
     "internalPackages": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7401,6 +7401,15 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
+"@testing-library/react@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.0.0.tgz#59030392a6792450b9ab8e67aea5f3cc18d6347c"
+  integrity sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^9.0.0"
+    "@types/react-dom" "^18.0.0"
+
 "@testing-library/user-event@14.4.3":
   version "14.4.3"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
@@ -8685,6 +8694,13 @@
   integrity sha512-PiYG40pnQRdPHnlf7tZnp0aQ6q9tspYr72vD61saO6zFCybLfMqwUCN0va1/P+86DXn18ZWeW30Bk7xlC5eEAQ==
   dependencies:
     "@types/react" "^17"
+
+"@types/react-dom@^18.0.0":
+  version "18.2.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.11.tgz#4332c315544698a0875dfdb6e320dda59e1b3d58"
+  integrity sha512-zq6Dy0EiCuF9pWFW6I6k6W2LdpUixLE4P6XjXU1QHLfak3GPACQfLwEuHzY5pOYa4hzj1d0GxX/P141aFjZsyg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-transition-group@^4.4.0":
   version "4.4.6"


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/3831

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b39e813</samp>

This pull request refactors the `createMutation` and `mutate` hooks in the `admin-x-settings` app to simplify the mutation options and fetch logic. It also adds the `@testing-library/react` dependency and unit tests for the custom hooks and the query cache update functions. The goal of these changes is to improve the code quality and test coverage of the app.
