### PR TITLE
Updated search keywords in AdminX

### DIFF
--- a/apps/admin-x-settings/src/admin-x-ds/settings/SettingNavSection.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/settings/SettingNavSection.tsx
@@ -19,7 +19,7 @@ const SettingNavSection: React.FC<Props> = ({title, keywords, children}) => {
         <>
             {title && <SettingSectionHeader title={title} />}
             {children &&
-                <ul className="mb-10 mt-[-8px]">
+                <ul className="-mt-1 mb-10">
                     {children}
                 </ul>
             }

--- a/apps/admin-x-settings/src/components/Sidebar.tsx
+++ b/apps/admin-x-settings/src/components/Sidebar.tsx
@@ -120,9 +120,10 @@ const Sidebar: React.FC = () => {
                     <SettingNavItem keywords={advancedSearchKeywords.history} navid='history' title="History" onClick={handleSectionClick} />
                 </SettingNavSection>
 
-                <Button className='mb-10 !font-normal' label='About Ghost' link onClick={() => {
+                {!filter && <Button className='mb-10 !font-normal' label='About Ghost' link onClick={() => {
                     updateRoute('about');
-                }} />
+                }} />}
+
             </div>
         </div>
     );

--- a/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/AdvancedSettings.tsx
@@ -6,10 +6,10 @@ import React from 'react';
 import SettingSection from '../../../admin-x-ds/settings/SettingSection';
 
 export const searchKeywords = {
-    integrations: ['integrations', 'zapier', 'slack', 'amp', 'unsplash', 'first promoter', 'firstpromoter', 'pintura', 'disqus', 'analytics', 'ulysses', 'typeform', 'buffer', 'plausible', 'github'],
-    codeInjection: ['code injection', 'head', 'footer'],
-    labs: ['labs', 'alpha', 'beta', 'flag', 'import', 'export', 'migrate', 'routes', 'redirect', 'translation', 'delete', 'content', 'editor', 'substack', 'migration', 'portal'],
-    history: ['history', 'log', 'events', 'user events', 'staff']
+    integrations: ['advanced', 'integrations', 'zapier', 'slack', 'amp', 'unsplash', 'first promoter', 'firstpromoter', 'pintura', 'disqus', 'analytics', 'ulysses', 'typeform', 'buffer', 'plausible', 'github'],
+    codeInjection: ['advanced', 'code injection', 'head', 'footer'],
+    labs: ['advanced', 'labs', 'alpha', 'beta', 'flag', 'import', 'export', 'migrate', 'routes', 'redirect', 'translation', 'delete', 'content', 'editor', 'substack', 'migration', 'portal'],
+    history: ['advanced', 'history', 'log', 'events', 'user events', 'staff']
 };
 
 const AdvancedSettings: React.FC = () => {

--- a/apps/admin-x-settings/src/components/settings/email/EmailSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/EmailSettings.tsx
@@ -8,10 +8,10 @@ import {getSettingValues} from '../../../api/settings';
 import {useGlobalData} from '../../providers/GlobalDataProvider';
 
 export const searchKeywords = {
-    enableNewsletters: ['newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off'],
+    enableNewsletters: ['emails', 'newsletters', 'newsletter sending', 'enable', 'disable', 'turn on', 'turn off'],
     newsletters: ['newsletters', 'emails'],
     defaultRecipients: ['newsletters', 'default recipients', 'emails'],
-    mailgun: ['mailgun', 'emails', 'newsletters']
+    mailgun: ['emails', 'mailgun', 'emails', 'newsletters']
 };
 
 const EmailSettings: React.FC = () => {

--- a/apps/admin-x-settings/src/components/settings/general/GeneralSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/GeneralSettings.tsx
@@ -12,15 +12,15 @@ import Twitter from './Twitter';
 import Users from './Users';
 
 export const searchKeywords = {
-    titleAndDescription: ['title and description', 'site title', 'site description', 'title & description'],
-    timeZone: ['time', 'date', 'site timezone', 'time zone'],
-    publicationLanguage: ['publication language', 'locale'],
-    metadata: ['metadata', 'title', 'description', 'search', 'engine', 'google', 'meta data'],
-    twitter: ['twitter card', 'structured data', 'rich cards', 'x card'],
-    facebook: ['facebook card', 'structured data', 'rich cards'],
-    socialAccounts: ['social accounts', 'facebook', 'twitter', 'structured data', 'rich cards'],
-    lockSite: ['password', 'lock site', 'make this site private'],
-    users: ['users and permissions', 'roles', 'staff']
+    titleAndDescription: ['general', 'title and description', 'site title', 'site description', 'title & description'],
+    timeZone: ['general', 'time', 'date', 'site timezone', 'time zone'],
+    publicationLanguage: ['general', 'publication language', 'locale'],
+    metadata: ['general', 'metadata', 'title', 'description', 'search', 'engine', 'google', 'meta data'],
+    twitter: ['general', 'twitter card', 'structured data', 'rich cards', 'x card'],
+    facebook: ['general', 'facebook card', 'structured data', 'rich cards'],
+    socialAccounts: ['general', 'social accounts', 'facebook', 'twitter', 'structured data', 'rich cards'],
+    lockSite: ['general', 'password', 'lock site', 'make this site private'],
+    users: ['general', 'users and permissions', 'roles', 'staff']
 };
 
 const GeneralSettings: React.FC = () => {

--- a/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
@@ -10,13 +10,13 @@ import TipsOrDonations from './TipsOrDonations';
 import useFeatureFlag from '../../../hooks/useFeatureFlag';
 
 export const searchKeywords = {
-    portal: ['portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership'],
-    access: ['default', 'access', 'subscription', 'post', 'membership'],
-    tiers: ['tiers', 'payment', 'paid', 'stripe'],
-    tips: ['tip', 'donation', 'one time', 'payment'],
-    embedSignupForm: ['embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up'],
-    recommendations: ['recommendations', 'recommend', 'blogroll'],
-    analytics: ['analytics', 'tracking', 'privacy', 'membership']
+    portal: ['membership', 'portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account'],
+    access: ['membership', 'default', 'access', 'subscription', 'post'],
+    tiers: ['membership', 'tiers', 'payment', 'paid', 'stripe'],
+    tips: ['membership', 'tip', 'donation', 'one time', 'payment'],
+    embedSignupForm: ['membership', 'embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up'],
+    recommendations: ['membership', 'recommendations', 'recommend', 'blogroll'],
+    analytics: ['membership', 'analytics', 'tracking', 'privacy']
 };
 
 const MembershipSettings: React.FC = () => {

--- a/apps/admin-x-settings/src/components/settings/site/SiteSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/SiteSettings.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 import SettingSection from '../../../admin-x-ds/settings/SettingSection';
 
 export const searchKeywords = {
-    design: ['logo', 'cover', 'colors', 'fonts', 'background', 'themes', 'appearance', 'style', 'design & branding', 'design and branding'],
-    navigation: ['navigation', 'menus', 'primary', 'secondary', 'links'],
-    announcementBar: ['announcement bar', 'important', 'banner']
+    design: ['site', 'logo', 'cover', 'colors', 'fonts', 'background', 'themes', 'appearance', 'style', 'design & branding', 'design and branding'],
+    navigation: ['site', 'navigation', 'menus', 'primary', 'secondary', 'links'],
+    announcementBar: ['site', 'announcement bar', 'important', 'banner']
 };
 
 const SiteSettings: React.FC = () => {


### PR DESCRIPTION
refs. https://github.com/TryGhost/Product/issues/3949

- keywords didn't contain the setting group so far, so it was not possible to filter settings for a single group
