### PR TITLE
🎨 Improved headers layout in post editor and post settings side panel

### DIFF
--- a/ghost/admin/app/styles/components/koenig.css
+++ b/ghost/admin/app/styles/components/koenig.css
@@ -15,7 +15,7 @@
 
 /* Padded container housing title + editor canvas, scrollable content */
 .gh-koenig-editor-pane {
-    padding: 11vw 92px;
+    padding: calc(11vw - 94px) 92px 11vw 92px;
 }
 
 @media (min-width: 500px) and (max-width: 960px) {

--- a/ghost/admin/app/styles/components/settings-menu.css
+++ b/ghost/admin/app/styles/components/settings-menu.css
@@ -120,10 +120,10 @@
 /* ---------------------------------------------------------- */
 
 .settings-menu-header {
-    position: fixed;
+    position: sticky;
+    top: 0;
     display: flex;
     width: 100%;
-    max-width: 364px;
     padding: 36px 24px 24px;
     justify-content: space-between;
     align-items: center;
@@ -207,7 +207,7 @@
 }
 
 .settings-menu-content {
-    padding: 92px 0 0;
+    padding: 8px 0 0;
 }
 
 .gh-post-settings {
@@ -216,7 +216,7 @@
 
 @media (max-width: 1024px) {
     .settings-menu-content {
-        padding-top: 72px;
+        padding-top: 5px;
     }
 }
 

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -327,9 +327,15 @@
 
 @media (max-width: 1024px) {
     .gh-editor-header {
-        padding: 0 0 0 15px;
+        padding: 15px 0 0 15px;
         background-color: var(--white);
         border-radius: 0;
+    }
+}
+
+@media (max-width: 447px) {
+    .gh-editor-header {
+        padding: 0 0 0 15px;
     }
 }
 

--- a/ghost/admin/app/styles/layouts/editor.css
+++ b/ghost/admin/app/styles/layouts/editor.css
@@ -283,6 +283,14 @@
 /* NEW editor
 /* ---------------------------------------------------------- */
 
+.gh-main {
+    height: 100dvh;
+}
+
+.gh-main > .flex-row {
+    height: 100%;
+}
+
 .gh-main > section.gh-editor-fullscreen {
     position: fixed;
     top: 0;
@@ -304,26 +312,22 @@
 }
 
 .gh-editor-header {
-    position: absolute;
+    height: auto;
+    position: sticky;
     top: 0;
     right: 0;
     left: 0;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    height: 34px;
-    padding: 0;
-    margin: 30px;
+    padding: 30px;
+    margin: 0;
     z-index: 799;
 }
 
 @media (max-width: 1024px) {
     .gh-editor-header {
-        z-index: 100;
-        height: 64px;
-        margin: 0;
-        padding: 0;
-        padding-left: 15px;
+        padding: 0 0 0 15px;
         background-color: var(--white);
         border-radius: 0;
     }


### PR DESCRIPTION
- fixes #18690
- This change makes the headers for post editor main section and post settings side panel use `sticky` position instead of `absolute`/`fixed` respectively. This allows to solve the following 2 problems:
1. The published post actions wrapping over the "Add feature image" button (see #18690).
2. The header of the post settings section having incorrect width, and causing the underlying content to be visible on the right edge.

Problem 1 - before:

![Peek 2023-10-19 12-19](https://github.com/TryGhost/Ghost/assets/56583786/b099f95a-135e-470e-9092-dccecd2a1da6)

Problem 1 - after:

![Peek 2023-10-19 12-21](https://github.com/TryGhost/Ghost/assets/56583786/dd3e73c2-e134-45d9-ad95-27e38e0c54dc)

Problem 2 - before:

![Peek 2023-10-19 12-20](https://github.com/TryGhost/Ghost/assets/56583786/89b7ac83-fd04-47f0-9313-d9aac3c5ac61)

Problem 2 - after:

![Peek 2023-10-19 12-22](https://github.com/TryGhost/Ghost/assets/56583786/45702a08-b07e-4f40-a25a-0c6b4207101f)

- [x] There's a clear use-case for this code change, explained above
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)