### PR TITLE
Added individual settings fields to search keywords

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/GeneralSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/GeneralSettings.tsx
@@ -19,8 +19,8 @@ export const searchKeywords = {
     twitter: ['twitter card', 'structured data', 'rich cards', 'x card'],
     facebook: ['facebook card', 'structured data', 'rich cards'],
     socialAccounts: ['social accounts', 'facebook', 'twitter', 'structured data', 'rich cards'],
-    lockSite: ['password', 'lock site', 'make this site private'],
-    users: ['users and permissions', 'roles', 'staff']
+    lockSite: ['password protection', 'lock site', 'make this site private'],
+    users: ['users and permissions', 'roles', 'staff', 'invite people', 'contributors', 'editors', 'authors', 'administrators']
 };
 
 const GeneralSettings: React.FC = () => {

--- a/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
@@ -11,7 +11,7 @@ import useFeatureFlag from '../../../hooks/useFeatureFlag';
 
 export const searchKeywords = {
     portal: ['portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership'],
-    access: ['default', 'access', 'subscription', 'post', 'membership'],
+    access: ['default', 'access', 'subscription', 'post', 'membership', 'comments', 'commenting'],
     tiers: ['tiers', 'payment', 'paid', 'stripe'],
     tips: ['tip', 'donation', 'one time', 'payment'],
     embedSignupForm: ['embeddable signup form', 'embeddable form', 'embeddable sign up form', 'embeddable sign up'],


### PR DESCRIPTION
The goal of this commit is to make all the individual setting fields searchable by adding them to the keywords. This should significantly improve UX when trying to look for "comments", for example, which one might not suspect to be paired with "Access" settings in memberships.

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)