### PR TITLE
Handled `ServerError` to show a custom error message in the admin

### DIFF
--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -178,22 +178,6 @@ export function isEmailError(errorOrStatus, payload) {
     }
 }
 
-/* Gateway timeout error */
-
-export class GatewayTimeoutError extends AjaxError {
-    constructor(payload) {
-        super(payload, 'Server is currently unavailable, please wait a moment then retry.', 504);
-    }
-}
-
-export function isGatewayTimeoutError(errorOrStatus) {
-    if (isAjaxError(errorOrStatus)) {
-        return errorOrStatus instanceof GatewayTimeoutError;
-    } else {
-        return errorOrStatus === 504;
-    }
-}
-
 /* end: custom error types */
 
 export class AcceptedResponse {
@@ -342,8 +326,6 @@ class ajaxService extends AjaxService {
             return new EmailError(payload);
         } else if (this.isAcceptedResponse(status)) {
             return new AcceptedResponse(payload);
-        } else if (this.isGatewayTimeoutError(status)) {
-            return new GatewayTimeoutError(payload);
         }
 
         let isGhostRequest = GHOST_REQUEST.test(request.url);
@@ -420,10 +402,6 @@ class ajaxService extends AjaxService {
 
     isEmailError(status, headers, payload) {
         return isEmailError(status, payload);
-    }
-
-    isGatewayTimeoutError(status) {
-        return isGatewayTimeoutError(status);
     }
 
     isAcceptedResponse(status) {

--- a/ghost/admin/app/services/notifications.js
+++ b/ghost/admin/app/services/notifications.js
@@ -33,7 +33,8 @@ const GENERIC_ERROR_NAMES = [
     'ReferenceError',
     'SyntaxError',
     'TypeError',
-    'URIError'
+    'URIError',
+    'ServerError'
 ];
 
 export const GENERIC_ERROR_MESSAGE = 'An unexpected error occurred, please try again.';
@@ -176,7 +177,10 @@ export default class NotificationsService extends Service {
 
         let msg = options.defaultErrorText || GENERIC_ERROR_MESSAGE;
 
-        if (resp?.name && GENERIC_ERROR_NAMES.includes(resp.name)) {
+        if (
+            resp?.name && GENERIC_ERROR_NAMES.includes(resp.name) ||
+            resp?.constructor && GENERIC_ERROR_NAMES.includes(resp.constructor.name)
+        ) {
             msg = GENERIC_ERROR_MESSAGE;
         } else if (resp instanceof String) {
             msg = resp;

--- a/ghost/admin/tests/acceptance/error-handling-test.js
+++ b/ghost/admin/tests/acceptance/error-handling-test.js
@@ -103,7 +103,7 @@ describe('Acceptance: Error Handling', function () {
 
             expect(findAll('.gh-alert').length).to.equal(1);
             expect(find('.gh-alert').textContent).to.not.match(/html>/);
-            expect(find('.gh-alert').textContent).to.match(/Server is currently unavailable, please wait a moment then retry./);
+            expect(find('.gh-alert').textContent).to.match(/An unexpected error occurred, please try again./);
         });
 
         it('handles ember-ajax HTML response', async function () {
@@ -118,7 +118,7 @@ describe('Acceptance: Error Handling', function () {
 
             expect(findAll('.gh-alert').length).to.equal(1);
             expect(find('.gh-alert').textContent).to.not.match(/html>/);
-            expect(find('.gh-alert').textContent).to.match(/Server is currently unavailable, please wait a moment then retry./);
+            expect(find('.gh-alert').textContent).to.match(/An unexpected error occurred, please try again./);
         });
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4040

Handled `ServerError` to show a custom error message in the admin when an unhandled server error occurs (i.e 504). Supersedes https://github.com/TryGhost/Ghost/pull/18703