### PR TITLE
Fixed max currency amount to only apply to donations

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/TipsOrDonations.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/TipsOrDonations.tsx
@@ -11,6 +11,9 @@ import {currencySelectGroups, getSymbol, validateCurrencyAmount} from '../../../
 import {getSettingValues} from '../../../api/settings';
 import {withErrorBoundary} from '../../../admin-x-ds/global/ErrorBoundary';
 
+// Stripe doesn't allow amounts over 10,000 as a preset amount
+const MAX_AMOUNT = 10_000;
+
 const TipsOrDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {
         localSettings,
@@ -28,7 +31,7 @@ const TipsOrDonations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     } = useSettingGroup({
         onValidate: () => {
             return {
-                donationsSuggestedAmount: validateCurrencyAmount(suggestedAmountInCents, donationsCurrency)
+                donationsSuggestedAmount: validateCurrencyAmount(suggestedAmountInCents, donationsCurrency, {maxAmount: MAX_AMOUNT})
             };
         }
     });

--- a/apps/admin-x-settings/src/utils/currency.ts
+++ b/apps/admin-x-settings/src/utils/currency.ts
@@ -203,10 +203,11 @@ export function minimumAmountForCurrency(currency: string) {
     }
 }
 
-// Stripe doesn't allow amounts over 10,000 as a preset amount
-const MAX_AMOUNT = 10_000;
-
-export function validateCurrencyAmount(cents: number | undefined, currency: string | undefined, {allowZero = true} = {}) {
+export function validateCurrencyAmount(
+    cents: number | undefined,
+    currency: string | undefined,
+    {allowZero = true, maxAmount}: {allowZero?: boolean; maxAmount?: number} = {}
+) {
     if (cents === undefined || !currency) {
         return;
     }
@@ -222,7 +223,7 @@ export function validateCurrencyAmount(cents: number | undefined, currency: stri
         return `Non-zero amount must be at least ${symbol}${minAmount}.`;
     }
 
-    if (cents !== 0 && cents > (MAX_AMOUNT * 100)) {
-        return `Suggested amount cannot be more than ${symbol}${MAX_AMOUNT}.`;
+    if (maxAmount && cents !== 0 && cents > (maxAmount * 100)) {
+        return `Suggested amount cannot be more than ${symbol}${maxAmount}.`;
     }
 }


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4044

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea09dec</samp>

This pull request improves the validation of suggested amounts for tips or donations in the membership settings. It adds a constant `MAX_AMOUNT` based on Stripe's limit and refactors the `validateCurrencyAmount` function to make it more reusable.
