### PR TITLE
Fixed Stripe connect display name key

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/stripe/StripeConnectModal.tsx
@@ -153,7 +153,7 @@ const Connect: React.FC = () => {
 
 const Connected: React.FC<{onClose?: () => void}> = ({onClose}) => {
     const {settings} = useGlobalData();
-    const [stripeConnectAccountName, stripeConnectLivemode] = getSettingValues(settings, ['stripe_connect_account_name', 'stripe_connect_livemode']);
+    const [stripeConnectAccountName, stripeConnectLivemode] = getSettingValues(settings, ['stripe_connect_display_name', 'stripe_connect_livemode']);
 
     const {refetch: fetchMembers, isFetching: isFetchingMembers} = useBrowseMembers({
         searchParams: {filter: 'status:paid', limit: '0'},

--- a/apps/admin-x-settings/test/acceptance/membership/stripe.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/stripe.test.ts
@@ -6,7 +6,7 @@ test.describe('Stripe settings', async () => {
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
             editSettings: {method: 'PUT', path: '/settings/', response: updatedSettingsResponse([
-                {key: 'stripe_connect_account_name', value: 'Dummy'},
+                {key: 'stripe_connect_display_name', value: 'Dummy'},
                 {key: 'stripe_connect_livemode', value: false},
                 {key: 'stripe_connect_account_id', value: 'acct_123'},
                 {key: 'stripe_connect_publishable_key', value: 'pk_test_123'},


### PR DESCRIPTION
no issue

- the stripe value is saved under the `stripe_connect_display_name` column, yet Admin X was querying `stripe_connect_account_name` causing it to be undefined.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0e6cb6</samp>

Renamed `stripe_connect_account_name` setting to `stripe_connect_display_name` in the admin-x-settings app. This improves clarity and consistency for the Stripe integration in the membership settings.
