### PR TITLE
🐛 Fixed custom setting image upload not working for multiple images

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/designAndBranding/ThemeSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/designAndBranding/ThemeSettings.tsx
@@ -76,7 +76,7 @@ const ThemeSetting: React.FC<{
             <Heading useLabelTag>{humanizeSettingKey(setting.key)}</Heading>
             <ImageUpload
                 height={setting.value ? '100px' : '32px'}
-                id='cover-image'
+                id={`custom-${setting.key}`}
                 imageURL={setting.value || ''}
                 onDelete={() => setSetting(null)}
                 onUpload={file => handleImageUpload(file)}


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/18718

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6fc7040</samp>

Refactored the `id` prop of the `ImageUpload` component in `ThemeSettings.tsx` to avoid duplication and follow naming convention. This is part of improving the theme settings UI and functionality.
