### PR TITLE
Fixed reporting a user's role to Sentry from Admin

### DIFF
--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -60,7 +60,7 @@ export default class SessionService extends ESASessionService {
                         resolve({
                             ...event,
                             release: `ghost@${this.config.version}`,
-                            user:  {
+                            user: {
                                 role: this.user.role.name
                             }
                         });

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -60,7 +60,9 @@ export default class SessionService extends ESASessionService {
                         resolve({
                             ...event,
                             release: `ghost@${this.config.version}`,
-                            'user.role': this.user.role.name
+                            user:  {
+                                role: this.user.role.name
+                            }
                         });
                     });
                 });


### PR DESCRIPTION
refs TryGhost/Product#4064

- In Sentry we were seeing the error "Discarded unknown attribute 'user.role'" for most events sent from admin
- This small change removes this error in Sentry and restores the user.role tag for error events in admin
