### PR TITLE
Implemented Sentry Replays in admin

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -5,7 +5,7 @@ import Route from '@ember/routing/route';
 import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import windowProxy from 'ghost-admin/utils/window-proxy';
-import {InitSentryForEmber} from '@sentry/ember';
+import {InitSentryForEmber, Replay} from '@sentry/ember';
 import {importSettings} from '../components/admin-x/settings';
 import {inject} from 'ghost-admin/decorators/inject';
 import {
@@ -173,6 +173,8 @@ export default Route.extend(ShortcutsRoute, {
                 dsn: this.config.sentry_dsn,
                 environment: this.config.sentry_env,
                 release: `ghost@${this.config.version}`,
+                integrations: [new Replay()],
+                replaysOnErrorSampleRate: 1.0,
                 beforeSend(event) {
                     event.tags = event.tags || {};
                     event.tags.shown_to_user = event.tags.shown_to_user || false;


### PR DESCRIPTION
refs TryGhost/Product#4064

- More info on Sentry Replays here: https://docs.sentry.io/product/session-replay/
- Basically it records the app's DOM in the moments before an error occurs and allows you to 'play it back' from within Sentry
- You can inspect the DOM as if you were in the browser with them when the error occurred
- Note: Text and images are obfuscated, so it visually isn't that impressive, but being able to inspect the DOM is a game changer for debugging I think
