### PR TITLE
Fixed minor Node deprecation warning

### DIFF
--- a/ghost/core/test/unit/frontend/services/card-assets.test.js
+++ b/ghost/core/test/unit/frontend/services/card-assets.test.js
@@ -25,7 +25,7 @@ describe('Card Asset Service', function () {
     });
 
     after(async function () {
-        await fs.rmdir(testDir, {recursive: true});
+        await fs.rm(testDir, {recursive: true});
     });
 
     it('can load nothing', async function () {


### PR DESCRIPTION
- resolves `DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead` in tests

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7820c5c</samp>

Update `fs.rmdir` calls to `fs.rm` with `recursive` option in `card-assets.test.js`. This improves compatibility with Node.js 14.
