### PR TITLE
Fixed emoji picker labs flag not being passed through to editor

### DIFF
--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -77,7 +77,7 @@ export default class FeatureService extends Service {
     @feature('tipsAndDonations') tipsAndDonations;
     @feature('recommendations') recommendations;
     @feature('lexicalIndicators') lexicalIndicators;
-    @feature('editorEmojiPicker') lexicalEmojiPicker;
+    @feature('editorEmojiPicker') editorEmojiPicker;
 
     _user = null;
 


### PR DESCRIPTION
no issue

- fixed `editor`/`lexical` typo in the feature flag name inside Admin
