### PR TITLE
Added Beta label to recommendations settings

### DIFF
--- a/apps/admin-x-settings/src/admin-x-ds/settings/SettingGroup.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/settings/SettingGroup.tsx
@@ -18,6 +18,7 @@ interface SettingGroupProps {
     saveState?: SaveState;
     customHeader?: React.ReactNode;
     customButtons?: React.ReactNode;
+    beta?: boolean;
     children?: React.ReactNode;
     hideEditButton?: boolean;
     alwaysShowSaveButton?: boolean;
@@ -52,6 +53,7 @@ const SettingGroup: React.FC<SettingGroupProps> = ({
     saveState,
     customHeader,
     customButtons,
+    beta = false,
     children,
     hideEditButton,
     alwaysShowSaveButton = true,
@@ -178,7 +180,7 @@ const SettingGroup: React.FC<SettingGroupProps> = ({
         <div className={containerClasses} data-testid={testId}>
             <div ref={ref} className='absolute' id={navid && navid}></div>
             {customHeader ? customHeader :
-                <SettingGroupHeader description={description} title={title!}>
+                <SettingGroupHeader beta={beta} description={description} title={title!}>
                     {customButtons ? customButtons :
                         (onEditingChange && <ButtonGroup buttons={isEditing ? editButtons : viewButtons} link linkWithPadding />)}
                 </SettingGroupHeader>

--- a/apps/admin-x-settings/src/admin-x-ds/settings/SettingGroupHeader.tsx
+++ b/apps/admin-x-settings/src/admin-x-ds/settings/SettingGroupHeader.tsx
@@ -5,17 +5,18 @@ import {useSearch} from '../../components/providers/ServiceProvider';
 interface Props {
     title?: string;
     description?: React.ReactNode;
+    beta?: boolean;
     children?: React.ReactNode;
 }
 
-const SettingGroupHeader: React.FC<Props> = ({title, description, children}) => {
+const SettingGroupHeader: React.FC<Props> = ({title, description, children, beta = false}) => {
     const {highlightKeywords} = useSearch();
 
     return (
         <div className="flex items-start justify-between gap-4">
             {(title || description) &&
                 <div>
-                    <Heading level={5}>{highlightKeywords(title || '')}</Heading>
+                    <Heading level={5}>{highlightKeywords(title || '')}{beta && <sup className='ml-0.5 text-[10px] font-semibold uppercase tracking-wide'>Beta</sup>}</Heading>
                     {description && <p className="mt-1 hidden max-w-lg group-[.is-not-editing]/setting-group:!visible group-[.is-not-editing]/setting-group:!block md:!visible md:!block">{highlightKeywords(description)}</p>}
                 </div>
             }

--- a/apps/admin-x-settings/src/components/settings/membership/Recommendations.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/Recommendations.tsx
@@ -122,6 +122,7 @@ const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     return (
         <SettingGroup
+            beta={true}
             customButtons={buttons}
             description={groupDescription}
             keywords={keywords}


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4068

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 92687d7</samp>

This pull request adds a beta label feature to the `SettingGroup` and `SettingGroupHeader` components in the `admin-x-settings` app, and applies it to the recommendations feature for the membership settings. This helps to indicate that the recommendations feature is still experimental and subject to change.
