### PR TITLE
Improved Sentry error messages for SQL errors

### DIFF
--- a/ghost/mw-error-handler/lib/mw-error-handler.js
+++ b/ghost/mw-error-handler/lib/mw-error-handler.js
@@ -87,6 +87,15 @@ module.exports.prepareError = (err, req, res, next) => {
                 message: err.message,
                 statusCode: err.statusCode
             });
+        // Catch database errors and create a generic 500 error with the context set to the errno & code from the db
+        } else if (err.sql && err.errno && err.code) {
+            err = new errors.InternalServerError({
+                err: err,
+                message: tpl(messages.genericError),
+                context: `SQL Error ${err.errno}: ${err.code}`,
+                statusCode: err.statusCode,
+                code: 'UNEXPECTED_ERROR'
+            });
         // For everything else, create a generic 500 error, with context set to the original error message
         } else {
             err = new errors.InternalServerError({

--- a/ghost/mw-error-handler/test/mw-error-handler.test.js
+++ b/ghost/mw-error-handler/test/mw-error-handler.test.js
@@ -109,7 +109,7 @@ describe('Prepare Error', function () {
         let error = new Error('select * from posts where published_at > \'23424234234234\'');
 
         error.sql = 'select * from posts where published_at > \'23424234234234\'';
-        error.errno = 1525
+        error.errno = 1525;
         error.code = 'ER_WRONG_VALUE';
 
         prepareError(error, {}, {

--- a/ghost/mw-error-handler/test/mw-error-handler.test.js
+++ b/ghost/mw-error-handler/test/mw-error-handler.test.js
@@ -104,6 +104,24 @@ describe('Prepare Error', function () {
             done();
         });
     });
+
+    it('Correctly prepares a SQL error', function (done) {
+        let error = new Error('select * from posts where published_at > \'23424234234234\'');
+
+        error.sql = 'select * from posts where published_at > \'23424234234234\'';
+        error.errno = 1525
+        error.code = 'ER_WRONG_VALUE';
+
+        prepareError(error, {}, {
+            set: () => {}
+        }, (err) => {
+            err.statusCode.should.eql(500);
+            err.name.should.eql('InternalServerError');
+            err.message.should.eql('An unexpected error occurred, please try again.');
+            err.context.should.eql('SQL Error 1525: ER_WRONG_VALUE');
+            done();
+        });
+    });
 });
 
 describe('Prepare Stack', function () {


### PR DESCRIPTION
no issue

- In the catch-all 'UNEXPECTED ERROR' handler, we set the error context to the full text of the failing SQL query. This text is then sent to Sentry, with the query as the event type, which messes up issue grouping because it includes all the parameters, which are dynamic.
- This (admittedly hacky) solution adds special handling for SQL query errors that aren't caught elsewhere to improve the error message that is sent to Sentry. There shouldn't be any change to end users, who will still receive a generic 500 UNEXPECTED ERROR message. 
- Ideally we should handle SQL query errors much further up the stack, but this change should at least surface these errors in a more consolidated and manageable way.