### PR TITLE
Fixed site description input field bug in settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/designAndBranding/BrandSettings.tsx
@@ -51,7 +51,6 @@ const BrandSettings: React.FC<{ values: BrandSettingValues, updateSetting: (key:
             <SettingGroupContent>
                 <TextField
                     key='site-description'
-                    clearBg={true}
                     hint='Used in your theme, meta data and search results'
                     title='Site description'
                     value={siteDescription}


### PR DESCRIPTION
refs. https://github.com/TryGhost/Product/issues/4060

- site description input field in design settings had a transparent background