### PR TITLE
Added console logs to debug Sentry stack traces in Admin

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -184,6 +184,8 @@ export default Route.extend(ShortcutsRoute, {
                 integrations: [
                     new RewriteFrames({
                         iteratee: (frame) => {
+                            console.log('frame: ', frame); // eslint-disable-line no-console
+                            console.log('cdnUrl: ', appConfig.cdnUrl); // eslint-disable-line no-console
                             // Remove duplicate `assets/` from CDN file paths (unsure why this occurs though)
                             if (frame.filename?.startsWith(appConfig.cdnUrl) && frame.filename?.includes('assets/assets/')) {
                                 frame.filename = frame.filename.replace('assets/assets/', 'assets/');


### PR DESCRIPTION
no issue

- Our stack traces in Sentry are pointing to the wrong location for source code files. We attempted to fix this [here](https://github.com/TryGhost/Ghost/pull/18773) but this didn't work as expected in staging for some reason
- This commit just adds a few console logs to help with debugging in staging so we can figure out what's going wrong