### PR TITLE
Fixed duplicate `/assets` in Sentry stacktrace filenames

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -184,11 +184,11 @@ export default Route.extend(ShortcutsRoute, {
                 integrations: [
                     new RewriteFrames({
                         iteratee: (frame) => {
-                            console.log('frame: ', frame); // eslint-disable-line no-console
-                            console.log('cdnUrl: ', appConfig.cdnUrl); // eslint-disable-line no-console
-                            // Remove duplicate `assets/` from CDN file paths (unsure why this occurs though)
-                            if (frame.filename?.startsWith(appConfig.cdnUrl) && frame.filename?.includes('assets/assets/')) {
-                                frame.filename = frame.filename.replace('assets/assets/', 'assets/');
+                            if (this.config.sentry_env === 'production') {
+                                // Remove duplicate `assets/` from CDN file paths (unsure why this occurs though)
+                                if (frame.filename?.startsWith(appConfig.cdnUrl) && frame.filename?.includes('assets/')) {
+                                    frame.filename = frame.filename.replace('assets/', '');
+                                }
                             }
 
                             return frame;


### PR DESCRIPTION
no issue

- For whatever reason, our Sentry stack traces are adding an extra `/assets` to the filenames in stacktraces from admin
- Attempted to fix this [here](https://github.com/TryGhost/Ghost/commit/3e9ee16ffb87bcf8e98c89a3213f8785fb8c19c0) but it didn't work because at this point the duplication hasn't occurred yet
- This change strips the `/assets` segment from the filenames, so when Sentry adds it back in, it doesn't duplicate anything. Would be good to get to the bottom of why this is happening, but this should hopefully improve our stacktraces in Sentry in the meantime.
