### PR TITLE
Fixed default mail address using config.mail.from

### DIFF
--- a/ghost/core/core/server/services/mail/GhostMailer.js
+++ b/ghost/core/core/server/services/mail/GhostMailer.js
@@ -25,7 +25,7 @@ function getDomain() {
 function getFromAddress(requestedFromAddress) {
     const configAddress = config.get('mail') && config.get('mail').from;
 
-    const address = requestedFromAddress || configAddress;
+    const address = configAddress || requestedFromAddress;
     // If we don't have a from address at all
     if (!address) {
         // Default to noreply@[blog.url]


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `yarn test:all` and `yarn lint`)

We appreciate your contribution!

---

use config.mail.from as default mail address.

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5753d2c</samp>

Fixed a bug in `GhostMailer.js` that caused the from address of test emails to ignore the configured value. This change is part of a pull request to enhance the email settings UI and functionality.
