### PR TITLE
Prevented handled errors from being sent to Sentry

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -185,6 +185,12 @@ export default Route.extend(ShortcutsRoute, {
                     event.tags = event.tags || {};
                     event.tags.shown_to_user = event.tags.shown_to_user || false;
                     event.tags.grammarly = !!document.querySelector('[data-gr-ext-installed]');
+
+                    // Do not report "handled" errors to Sentry
+                    if (event.tags.shown_to_user === true) {
+                        return null;
+                    }
+
                     return event;
                 },
                 // TransitionAborted errors surface from normal application behaviour


### PR DESCRIPTION
no refs

As part of the reduce Sentry noise work we decided to temporarily prevent the submission of "handled" errors to Sentry. This is a temporary measure to reduce noise while we work on improving the quality of the error reporting / alerting