### PR TITLE
Improved modal save handling in Admin X

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/CustomIntegrationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/CustomIntegrationModal.tsx
@@ -98,7 +98,7 @@ const CustomIntegrationModalContent: React.FC<{integration: Integration}> = ({in
         stickyFooter
         onOk={async () => {
             toast.remove();
-            if (!(await handleSave())) {
+            if (!(await handleSave({fakeWhenUnchanged: true}))) {
                 showToast({
                     type: 'pageError',
                     message: 'Can\'t save integration, please double check that you\'ve filled all mandatory fields.'

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/CustomIntegrationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/CustomIntegrationModal.tsx
@@ -27,10 +27,16 @@ const CustomIntegrationModalContent: React.FC<{integration: Integration}> = ({in
     const {mutateAsync: uploadImage} = useUploadImage();
     const handleError = useHandleError();
 
-    const {formState, updateForm, handleSave, saveState, errors, clearError, validate} = useForm({
+    const {formState, updateForm, handleSave, saveState, errors, clearError, validate, okProps} = useForm({
         initialState: integration,
+        savingDelay: 500,
+        savedDelay: 500,
         onSave: async () => {
             await editIntegration(formState);
+        },
+        onSavedStateReset: () => {
+            modal.remove();
+            updateRoute('integrations');
         },
         onSaveError: handleError,
         onValidate: () => {
@@ -82,19 +88,17 @@ const CustomIntegrationModalContent: React.FC<{integration: Integration}> = ({in
         afterClose={() => {
             updateRoute('integrations');
         }}
+        buttonsDisabled={okProps.disabled}
         dirty={saveState === 'unsaved'}
-        okColor='black'
-        okLabel='Save & close'
+        okColor={okProps.color}
+        okLabel={okProps.label || 'Save & close'}
         size='md'
         testId='custom-integration-modal'
         title={formState.name}
         stickyFooter
         onOk={async () => {
             toast.remove();
-            if (await handleSave()) {
-                modal.remove();
-                updateRoute('integrations');
-            } else {
+            if (!(await handleSave())) {
                 showToast({
                     type: 'pageError',
                     message: 'Can\'t save integration, please double check that you\'ve filled all mandatory fields.'

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -438,8 +438,9 @@ const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: b
     const {updateRoute} = useRouting();
     const handleError = useHandleError();
 
-    const {formState, saveState, updateForm, setFormState, handleSave, validate, errors, clearError} = useForm({
+    const {formState, saveState, updateForm, setFormState, handleSave, validate, errors, clearError, okProps} = useForm({
         initialState: newsletter,
+        savingDelay: 500,
         onSave: async () => {
             const {newsletters, meta} = await editNewsletter(formState);
             if (meta?.sent_email_verification) {
@@ -489,12 +490,12 @@ const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: b
 
     return <PreviewModalContent
         afterClose={() => updateRoute('newsletters')}
-        buttonsDisabled={saveState === 'saving'}
+        buttonsDisabled={okProps.disabled}
         cancelLabel='Close'
         deviceSelector={false}
         dirty={saveState === 'unsaved'}
-        okColor={saveState === 'saved' ? 'green' : 'black'}
-        okLabel={saveState === 'saved' ? 'Saved' : (saveState === 'saving' ? 'Saving...' : 'Save')}
+        okColor={okProps.color}
+        okLabel={okProps.label || 'Save'}
         preview={preview}
         previewBgColor={'grey'}
         previewToolbar={false}
@@ -503,7 +504,7 @@ const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: b
         testId='newsletter-modal'
         title='Newsletter'
         onOk={async () => {
-            if (!(await handleSave())) {
+            if (!(await handleSave({fakeWhenUnchanged: true}))) {
                 showToast({
                     type: 'pageError',
                     message: 'Can\'t save newsletter, please double check that you\'ve filled all mandatory fields.'

--- a/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/UserDetailModal.tsx
@@ -110,6 +110,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
     const {formState, setFormState, saveState, handleSave, updateForm, errors, setErrors, clearError, okProps} = useForm({
         initialState: user,
         savingDelay: 500,
+        savedDelay: 500,
         onValidate: (values) => {
             return Object.entries(validators).reduce<ErrorMessages>((newErrors, [key, validate]) => {
                 const error = validate(values);
@@ -121,6 +122,10 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
         },
         onSave: async (values) => {
             await updateUser?.(values);
+        },
+        onSavedStateReset: () => {
+            mainModal.remove();
+            navigateOnClose();
         },
         onSaveError: handleError
     });
@@ -162,15 +167,6 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             updateRoute({isExternal: true, route: 'dashboard'});
         }
     }, [currentUser, updateRoute]);
-
-    useEffect(() => {
-        if (saveState === 'saved') {
-            setTimeout(() => {
-                mainModal.remove();
-                navigateOnClose();
-            }, 500);
-        }
-    }, [mainModal, navigateOnClose, saveState, updateRoute]);
 
     const confirmSuspend = async (_user: User) => {
         if (_user.status === 'inactive' && _user.roles[0].name !== 'Contributor') {
@@ -370,6 +366,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             afterClose={navigateOnClose}
             animate={canAccessSettings(currentUser)}
             backDrop={canAccessSettings(currentUser)}
+            buttonsDisabled={okProps.disabled}
             dirty={saveState === 'unsaved'}
             okColor={okProps.color}
             okLabel={okProps.label || 'Save & close'}

--- a/apps/admin-x-settings/src/components/settings/general/users/ProfileBasics.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/ProfileBasics.tsx
@@ -7,7 +7,7 @@ import {UserDetailProps} from '../UserDetailModal';
 import {hasAdminAccess} from '../../../../api/users';
 import {useGlobalData} from '../../../providers/GlobalDataProvider';
 
-const BasicInputs: React.FC<UserDetailProps> = ({errors, validators, clearError, user, setUserData}) => {
+const BasicInputs: React.FC<UserDetailProps> = ({errors, validateField, clearError, user, setUserData}) => {
     const {currentUser} = useGlobalData();
 
     return (
@@ -18,7 +18,7 @@ const BasicInputs: React.FC<UserDetailProps> = ({errors, validators, clearError,
                 title="Full name"
                 value={user.name}
                 onBlur={(e) => {
-                    validators.name({name: e.target.value});
+                    validateField('name', e.target.value);
                 }}
                 onChange={(e) => {
                     setUserData({...user, name: e.target.value});
@@ -31,7 +31,7 @@ const BasicInputs: React.FC<UserDetailProps> = ({errors, validators, clearError,
                 title="Email"
                 value={user.email}
                 onBlur={(e) => {
-                    validators.email({email: e.target.value});
+                    validateField('email', e.target.value);
                 }}
                 onChange={(e) => {
                     setUserData({...user, email: e.target.value});

--- a/apps/admin-x-settings/src/components/settings/general/users/ProfileDetails.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/ProfileDetails.tsx
@@ -7,7 +7,7 @@ import {UserDetailProps} from '../UserDetailModal';
 import {facebookHandleToUrl, facebookUrlToHandle, twitterHandleToUrl, twitterUrlToHandle, validateFacebookUrl, validateTwitterUrl} from '../../../../utils/socialUrls';
 import {useState} from 'react';
 
-export const DetailsInputs: React.FC<UserDetailProps> = ({errors, clearError, validators, user, setUserData}) => {
+export const DetailsInputs: React.FC<UserDetailProps> = ({errors, clearError, validateField, user, setUserData}) => {
     const [facebookUrl, setFacebookUrl] = useState(user.facebook ? facebookHandleToUrl(user.facebook) : '');
     const [twitterUrl, setTwitterUrl] = useState(user.twitter ? twitterHandleToUrl(user.twitter) : '');
 
@@ -19,7 +19,7 @@ export const DetailsInputs: React.FC<UserDetailProps> = ({errors, clearError, va
                 title="Location"
                 value={user.location || ''}
                 onBlur={(e) => {
-                    validators.location({location: e.target.value});
+                    validateField('location', e.target.value);
                 }}
                 onChange={(e) => {
                     setUserData({...user, location: e.target.value});
@@ -31,7 +31,7 @@ export const DetailsInputs: React.FC<UserDetailProps> = ({errors, clearError, va
                 title="Website"
                 value={user.website || ''}
                 onBlur={(e) => {
-                    validators.url({url: e.target.value});
+                    validateField('url', e.target.value);
                 }}
                 onChange={(e) => {
                     setUserData({...user, website: e.target.value});
@@ -43,7 +43,7 @@ export const DetailsInputs: React.FC<UserDetailProps> = ({errors, clearError, va
                 title="Facebook profile"
                 value={facebookUrl}
                 onBlur={(e) => {
-                    if (validators.facebook({facebook: e.target.value})) {
+                    if (validateField('facebook', e.target.value)) {
                         const url = validateFacebookUrl(e.target.value);
                         setFacebookUrl(url);
                         setUserData({...user, facebook: facebookUrlToHandle(url)});
@@ -59,7 +59,7 @@ export const DetailsInputs: React.FC<UserDetailProps> = ({errors, clearError, va
                 title="X (formerly Twitter) profile"
                 value={twitterUrl}
                 onBlur={(e) => {
-                    if (validators.twitter({twitter: e.target.value})) {
+                    if (validateField('twitter', e.target.value)) {
                         const url = validateTwitterUrl(e.target.value);
                         setTwitterUrl(url);
                         setUserData({...user, twitter: twitterUrlToHandle(url)});
@@ -75,7 +75,7 @@ export const DetailsInputs: React.FC<UserDetailProps> = ({errors, clearError, va
                 title="Bio"
                 value={user.bio || ''}
                 onBlur={(e) => {
-                    validators.bio({bio: e.target.value});
+                    validateField('bio', e.target.value);
                 }}
                 onChange={(e) => {
                     setUserData({...user, bio: e.target.value});

--- a/apps/admin-x-settings/src/components/settings/membership/portal/PortalModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/PortalModal.tsx
@@ -115,11 +115,13 @@ const PortalModal: React.FC = () => {
         }
     }, [handleError, verifyEmail, verifyToken]);
 
-    const {formState, setFormState, saveState, handleSave, updateForm} = useForm({
+    const {formState, setFormState, saveState, handleSave, updateForm, okProps} = useForm({
         initialState: {
             settings: settings as Dirtyable<Setting>[],
             tiers: allTiers as Dirtyable<Tier>[] || []
         },
+
+        savingDelay: 500,
 
         onSave: async () => {
             await Promise.all(formState.tiers.filter(({dirty}) => dirty).map(tier => editTier(tier)));
@@ -204,12 +206,6 @@ const PortalModal: React.FC = () => {
         {id: 'account', title: 'Account page'},
         {id: 'links', title: 'Links'}
     ];
-    let okLabel = 'Save';
-    if (saveState === 'saving') {
-        okLabel = 'Saving...';
-    } else if (saveState === 'saved') {
-        okLabel = 'Saved';
-    }
 
     return <PreviewModalContent
         afterClose={() => {
@@ -218,8 +214,8 @@ const PortalModal: React.FC = () => {
         cancelLabel='Close'
         deviceSelector={false}
         dirty={saveState === 'unsaved'}
-        okColor={saveState === 'saved' ? 'green' : 'black'}
-        okLabel={okLabel}
+        okColor={okProps.color}
+        okLabel={okProps.label || 'Save'}
         preview={preview}
         previewBgColor={selectedPreviewTab === 'links' ? 'white' : 'greygradient'}
         previewToolbarTabs={previewTabs}

--- a/apps/admin-x-settings/src/components/settings/membership/portal/PortalModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/PortalModal.tsx
@@ -211,6 +211,7 @@ const PortalModal: React.FC = () => {
         afterClose={() => {
             updateRoute('portal');
         }}
+        buttonsDisabled={okProps.disabled}
         cancelLabel='Close'
         deviceSelector={false}
         dirty={saveState === 'unsaved'}

--- a/apps/admin-x-settings/src/components/settings/membership/recommendations/EditRecommendationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/recommendations/EditRecommendationModal.tsx
@@ -22,12 +22,16 @@ const EditRecommendationModal: React.FC<RoutingModalProps & EditRecommendationMo
     const {mutateAsync: deleteRecommendation} = useDeleteRecommendation();
     const handleError = useHandleError();
 
-    const {formState, updateForm, handleSave, saveState, errors, clearError, setErrors} = useForm({
+    const {formState, updateForm, handleSave, errors, clearError, setErrors, okProps} = useForm({
         initialState: {
             ...recommendation
         },
+        savingDelay: 500,
+        savedDelay: 500,
         onSave: async (state) => {
             await editRecommendation(state);
+        },
+        onSavedStateReset: () => {
             modal.remove();
             updateRoute('recommendations');
         },
@@ -45,14 +49,6 @@ const EditRecommendationModal: React.FC<RoutingModalProps & EditRecommendationMo
             return newErrors;
         }
     });
-
-    let okLabel = 'Save';
-
-    if (saveState === 'saving') {
-        okLabel = 'Saving...';
-    } else if (saveState === 'saved') {
-        okLabel = 'Saved';
-    }
 
     let leftButtonProps = {
         label: 'Delete',
@@ -94,20 +90,16 @@ const EditRecommendationModal: React.FC<RoutingModalProps & EditRecommendationMo
         }}
         animate={animate ?? true}
         backDropClick={false}
+        buttonsDisabled={okProps.disabled}
         cancelLabel={'Cancel'}
         leftButtonProps={leftButtonProps}
-        okColor='black'
-        okLabel={okLabel}
+        okColor={okProps.color}
+        okLabel={okProps.label || 'Save & close'}
         size='sm'
         testId='edit-recommendation-modal'
         title={'Edit recommendation'}
         stickyFooter
         onOk={async () => {
-            if (saveState === 'saving') {
-                // Already saving
-                return;
-            }
-
             dismissAllToasts();
             try {
                 await handleSave({force: true});

--- a/apps/admin-x-settings/src/components/settings/membership/tiers/TierDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/tiers/TierDetailModal.tsx
@@ -82,8 +82,6 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
             } else {
                 await createTier(values);
             }
-
-            modal.remove();
         },
         onSavedStateReset: () => {
             modal.remove();

--- a/apps/admin-x-settings/src/components/settings/membership/tiers/TierDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/tiers/TierDetailModal.tsx
@@ -6,14 +6,14 @@ import Heading from '../../../../admin-x-ds/global/Heading';
 import Icon from '../../../../admin-x-ds/global/Icon';
 import Modal from '../../../../admin-x-ds/global/modal/Modal';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef} from 'react';
 import Select from '../../../../admin-x-ds/global/form/Select';
 import SortableList from '../../../../admin-x-ds/global/SortableList';
 import TextField from '../../../../admin-x-ds/global/form/TextField';
 import TierDetailPreview from './TierDetailPreview';
 import Toggle from '../../../../admin-x-ds/global/form/Toggle';
 import URLTextField from '../../../../admin-x-ds/global/form/URLTextField';
-import useForm from '../../../../hooks/useForm';
+import useForm, {ErrorMessages} from '../../../../hooks/useForm';
 import useHandleError from '../../../../utils/api/handleError';
 import useRouting from '../../../../hooks/useRouting';
 import useSettingGroup from '../../../../hooks/useSettingGroup';
@@ -41,20 +41,30 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
     const {localSettings, siteData} = useSettingGroup();
     const siteTitle = getSettingValues(localSettings, ['title']) as string[];
 
-    const [errors, setErrors] = useState<{ [key in keyof Tier]?: string }>({}); // eslint-disable-line no-unused-vars
-
-    const setError = (field: keyof Tier, error: string | undefined) => {
-        setErrors(errs => ({...errs, [field]: error}));
-        return error;
+    const validators: {[key in keyof Tier]?: () => string | undefined} = {
+        name: () => (formState.name ? undefined : 'You must specify a name'),
+        monthly_price: () => (formState.type !== 'free' ? validateCurrencyAmount(formState.monthly_price || 0, formState.currency, {allowZero: false}) : undefined),
+        yearly_price: () => (formState.type !== 'free' ? validateCurrencyAmount(formState.yearly_price || 0, formState.currency, {allowZero: false}) : undefined)
     };
 
-    const {formState, saveState, updateForm, handleSave} = useForm<TierFormState>({
+    const {formState, saveState, updateForm, handleSave, errors, setErrors, clearError, okProps} = useForm<TierFormState>({
         initialState: {
             ...(tier || {}),
             trial_days: tier?.trial_days?.toString() || '',
             currency: tier?.currency || currencies[0].isoCode,
             visibility: tier?.visibility || 'none',
             welcome_page_url: tier?.welcome_page_url || null
+        },
+        savingDelay: 500,
+        savedDelay: 500,
+        onValidate: () => {
+            const newErrors: ErrorMessages = {};
+
+            Object.entries(validators).forEach(([key, validator]) => {
+                newErrors[key as keyof Tier] = validator?.();
+            });
+
+            return newErrors;
         },
         onSave: async () => {
             const {trial_days: trialDays, currency, ...rest} = formState;
@@ -75,13 +85,21 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
 
             modal.remove();
         },
+        onSavedStateReset: () => {
+            modal.remove();
+            updateRoute('tiers');
+        },
         onSaveError: handleError
     });
 
-    const validators = {
-        name: () => setError('name', formState.name ? undefined : 'You must specify a name'),
-        monthly_price: () => formState.type !== 'free' && setError('monthly_price', validateCurrencyAmount(formState.monthly_price || 0, formState.currency, {allowZero: false})),
-        yearly_price: () => formState.type !== 'free' && setError('yearly_price', validateCurrencyAmount(formState.yearly_price || 0, formState.currency, {allowZero: false}))
+    const validateField = (key: string) => {
+        const error = validators[key as keyof Tier]?.();
+
+        if (error) {
+            setErrors({...errors, [key]: error});
+        } else {
+            clearError(key);
+        }
     };
 
     const benefits = useSortableIndexedList({
@@ -105,8 +123,8 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
     const didInitialRender = useRef(false);
     useEffect(() => {
         if (didInitialRender.current) {
-            validators.monthly_price();
-            validators.yearly_price();
+            validators.monthly_price?.();
+            validators.yearly_price?.();
         }
 
         didInitialRender.current = true;
@@ -164,9 +182,11 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
         afterClose={() => {
             updateRoute('tiers');
         }}
+        buttonsDisabled={okProps.disabled}
         dirty={saveState === 'unsaved'}
         leftButtonProps={leftButtonProps}
-        okLabel='Save & close'
+        okColor={okProps.color}
+        okLabel={okProps.label || 'Save & close'}
         size='lg'
         testId='tier-detail-modal'
         title={(tier ? (tier.active ? 'Edit tier' : 'Edit archived tier') : 'New tier')}
@@ -174,21 +194,12 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
         onOk={async () => {
             toast.remove();
 
-            if (Object.values(validators).filter(validator => validator()).length) {
+            if (!await handleSave({fakeWhenUnchanged: true})) {
                 showToast({
                     type: 'pageError',
                     message: 'Can\'t save tier, please double check that you\'ve filled all mandatory fields.'
                 });
                 return;
-            }
-
-            if (saveState !== 'unsaved') {
-                updateRoute('tiers');
-                modal.remove();
-            }
-
-            if (await handleSave()) {
-                updateRoute('tiers');
             }
         }}
     >
@@ -203,7 +214,7 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
                         title='Name'
                         value={formState.name || ''}
                         autoFocus
-                        onBlur={() => validators.name()}
+                        onBlur={() => validateField('name')}
                         onChange={e => updateForm(state => ({...state, name: e.target.value}))}
                     />}
                     <TextField
@@ -243,7 +254,7 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
                                         title='Monthly price'
                                         valueInCents={formState.monthly_price || ''}
                                         hideTitle
-                                        onBlur={() => validators.monthly_price()}
+                                        onBlur={() => validateField('monthly_price')}
                                         onChange={price => updateForm(state => ({...state, monthly_price: price}))}
                                     />
                                     <CurrencyField
@@ -254,7 +265,7 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
                                         title='Yearly price'
                                         valueInCents={formState.yearly_price || ''}
                                         hideTitle
-                                        onBlur={() => validators.yearly_price()}
+                                        onBlur={() => validateField('yearly_price')}
                                         onChange={price => updateForm(state => ({...state, yearly_price: price}))}
                                     />
                                 </div>

--- a/apps/admin-x-settings/src/components/settings/site/AnnouncementBarModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/AnnouncementBarModal.tsx
@@ -115,7 +115,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
 const AnnouncementBarModal: React.FC = () => {
     const {siteData} = useGlobalData();
-    const {localSettings, updateSetting, handleSave} = useSettingGroup();
+    const {localSettings, updateSetting, handleSave, okProps} = useSettingGroup({savingDelay: 500});
     const [announcementContent] = getSettingValues<string>(localSettings, ['announcement_content']);
     const [accentColor] = getSettingValues<string>(localSettings, ['accent_color']);
     const [announcementBackgroundColor] = getSettingValues<string>(localSettings, ['announcement_background']);
@@ -208,10 +208,12 @@ const AnnouncementBarModal: React.FC = () => {
         afterClose={() => {
             updateRoute('announcement-bar');
         }}
+        buttonsDisabled={okProps.disabled}
         cancelLabel='Close'
         deviceSelector={true}
         dirty={false}
-        okLabel='Save'
+        okColor={okProps.color}
+        okLabel={okProps.label || 'Save'}
         preview={preview}
         previewBgColor='greygradient'
         previewToolbarTabs={previewTabs}
@@ -221,8 +223,7 @@ const AnnouncementBarModal: React.FC = () => {
         title='Announcement'
         titleHeadingLevel={5}
         onOk={async () => {
-            if (!(await handleSave())) {
-                updateRoute('announcement-bar');
+            if (!(await handleSave({fakeWhenUnchanged: true}))) {
                 showToast({
                     type: 'pageError',
                     message: 'An error occurred while saving your changes. Please try again.'

--- a/apps/admin-x-settings/src/components/settings/site/DesignModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/DesignModal.tsx
@@ -111,12 +111,12 @@ const DesignModal: React.FC = () => {
         onSave: async () => {
             if (formState.themeSettings?.some(setting => setting.dirty)) {
                 const response = await editThemeSettings(formState.themeSettings);
-                updateForm(state => ({...state, themeSettings: response.custom_theme_settings}));
+                setFormState(state => ({...state, themeSettings: response.custom_theme_settings}));
             }
 
             if (formState.settings.some(setting => setting.dirty)) {
                 const {settings: newSettings} = await editSettings(formState.settings.filter(setting => setting.dirty));
-                updateForm(state => ({...state, settings: newSettings}));
+                setFormState(state => ({...state, settings: newSettings}));
             }
         },
         onSaveError: handleError

--- a/apps/admin-x-settings/src/components/settings/site/DesignModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/DesignModal.tsx
@@ -1,6 +1,4 @@
 import BrandSettings, {BrandSettingValues} from './designAndBranding/BrandSettings';
-// import Button from '../../../admin-x-ds/global/Button';
-// import ChangeThemeModal from './ThemeModal';
 import Icon from '../../../admin-x-ds/global/Icon';
 import React, {useEffect, useState} from 'react';
 import StickyFooter from '../../../admin-x-ds/global/StickyFooter';
@@ -102,12 +100,14 @@ const DesignModal: React.FC = () => {
         saveState,
         handleSave,
         updateForm,
-        setFormState
+        setFormState,
+        okProps
     } = useForm({
         initialState: {
             settings: settings as Array<Setting & { dirty?: boolean }>,
             themeSettings: themeSettings ? (themeSettings.custom_theme_settings as Array<CustomThemeSetting & { dirty?: boolean }>) : undefined
         },
+        savingDelay: 500,
         onSave: async () => {
             if (formState.themeSettings?.some(setting => setting.dirty)) {
                 const response = await editThemeSettings(formState.themeSettings);
@@ -215,12 +215,12 @@ const DesignModal: React.FC = () => {
         afterClose={() => {
             updateRoute('design');
         }}
-        buttonsDisabled={saveState === 'saving'}
+        buttonsDisabled={okProps.disabled}
         cancelLabel='Close'
         defaultTab='homepage'
         dirty={saveState === 'unsaved'}
-        okColor={saveState === 'saved' ? 'green' : 'black'}
-        okLabel={saveState === 'saved' ? 'Saved' : (saveState === 'saving' ? 'Saving...' : 'Save')}
+        okColor={okProps.color}
+        okLabel={okProps.label || 'Save'}
         preview={previewContent}
         previewToolbarTabs={previewTabs}
         selectedURL={selectedPreviewTab}
@@ -231,7 +231,7 @@ const DesignModal: React.FC = () => {
         testId='design-modal'
         title='Design'
         onOk={async () => {
-            await handleSave();
+            await handleSave({fakeWhenUnchanged: true});
         }}
         onSelectURL={onSelectURL}
     />;

--- a/apps/admin-x-settings/src/components/settings/site/NavigationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/NavigationModal.tsx
@@ -45,6 +45,7 @@ const NavigationModal = NiceModal.create(() => {
             }}
             buttonsDisabled={saveState === 'saving'}
             dirty={localSettings.some(setting => setting.dirty)}
+            okLabel={saveState === 'saving' ? 'Saving...' : 'OK'}
             scrolling={true}
             size='lg'
             stickyFooter={true}

--- a/apps/admin-x-settings/src/hooks/useSettingGroup.tsx
+++ b/apps/admin-x-settings/src/hooks/useSettingGroup.tsx
@@ -38,7 +38,7 @@ const useSettingGroup = ({savingDelay, onValidate}: {savingDelay?: number; onVal
 
     const [isEditing, setEditing] = useState(false);
 
-    const {formState: localSettings, saveState, handleSave, updateForm, reset, validate, errors, clearError, okProps} = useForm<LocalSetting[]>({
+    const {formState: localSettings, saveState, handleSave, updateForm, setFormState, reset, validate, errors, clearError, okProps} = useForm<LocalSetting[]>({
         initialState: settings || [],
         savingDelay,
         onSave: async () => {
@@ -63,7 +63,7 @@ const useSettingGroup = ({savingDelay, onValidate}: {savingDelay?: number; onVal
     // reset the local state when there's a new settings API response, unless currently editing
     useEffect(() => {
         if (!isEditing || saveState === 'saving') {
-            reset();
+            setFormState(() => settings);
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [settings]);

--- a/apps/admin-x-settings/src/hooks/useSettingGroup.tsx
+++ b/apps/admin-x-settings/src/hooks/useSettingGroup.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, useState} from 'react';
-import useForm, {ErrorMessages, SaveState} from './useForm';
+import useForm, {ErrorMessages, OkProps, SaveHandler, SaveState} from './useForm';
 import useGlobalDirtyState from './useGlobalDirtyState';
 import useHandleError from '../utils/api/handleError';
 import {Setting, SettingValue, useEditSettings} from '../api/settings';
@@ -18,16 +18,17 @@ export interface SettingGroupHook {
     saveState: SaveState;
     siteData: SiteData | null;
     focusRef: React.RefObject<HTMLInputElement>;
-    handleSave: () => Promise<boolean>;
+    handleSave: SaveHandler;
     handleCancel: () => void;
     updateSetting: (key: string, value: SettingValue) => void;
     handleEditingChange: (newState: boolean) => void;
     validate: () => boolean;
     errors: ErrorMessages;
     clearError: (key: string) => void;
+    okProps: OkProps;
 }
 
-const useSettingGroup = ({onValidate}: {onValidate?: () => ErrorMessages} = {}): SettingGroupHook => {
+const useSettingGroup = ({savingDelay, onValidate}: {savingDelay?: number; onValidate?: () => ErrorMessages} = {}): SettingGroupHook => {
     // create a ref to focus the input field
     const focusRef = useRef<HTMLInputElement>(null);
 
@@ -37,8 +38,9 @@ const useSettingGroup = ({onValidate}: {onValidate?: () => ErrorMessages} = {}):
 
     const [isEditing, setEditing] = useState(false);
 
-    const {formState: localSettings, saveState, handleSave, updateForm, reset, validate, errors, clearError} = useForm<LocalSetting[]>({
+    const {formState: localSettings, saveState, handleSave, updateForm, reset, validate, errors, clearError, okProps} = useForm<LocalSetting[]>({
         initialState: settings || [],
+        savingDelay,
         onSave: async () => {
             await editSettings?.(changedSettings());
         },
@@ -124,7 +126,8 @@ const useSettingGroup = ({onValidate}: {onValidate?: () => ErrorMessages} = {}):
         handleEditingChange,
         validate,
         errors,
-        clearError
+        clearError,
+        okProps
     };
 };
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4060

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55149bc</samp>

Refactored various settings forms and modals in the admin app to use the updated `useForm` hook, which simplifies the form state management, validation, and saving logic. Improved the UI and UX of the modal ok buttons by using the `okProps` object and the `saveState` from the hook. Added options to save the forms without changes and to fake the saving when unchanged. Fixed some bugs and removed unused code.
