### PR TITLE
Improved error handling for SQL errors

### DIFF
--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -22,13 +22,25 @@ if (sentryConfig && !sentryConfig.disabled) {
                     event.exception.values[0].type = exception.context;
                 }
 
+                // This is a mysql2 error — add some additional context
+                if (exception.sql) {
+                    event.exception.values[0].type = `SQL Error ${exception.errno}: ${exception.sqlErrorCode}`;
+                    event.exception.values[0].value = exception.sqlMessage;
+                    event.contexts.mysql = {
+                        errno: exception.errno,
+                        code: exception.sqlErrorCode,
+                        sql: exception.sql,
+                        message: exception.sqlMessage,
+                        state: exception.sqlState
+                    };
+                }
+
                 // This is a Ghost Error, copy all our extra data to tags
                 event.tags.type = exception.errorType;
                 event.tags.code = exception.code;
                 event.tags.id = exception.id;
                 event.tags.statusCode = exception.statusCode;
             }
-
             return event;
         }
     });

--- a/ghost/mw-error-handler/test/mw-error-handler.test.js
+++ b/ghost/mw-error-handler/test/mw-error-handler.test.js
@@ -104,6 +104,29 @@ describe('Prepare Error', function () {
             done();
         });
     });
+
+    it('Correctly prepares a mysql2 error', function (done) {
+        let error = new Error('select anything from anywhere where something = anything;');
+
+        error.stack += '\n';
+        error.stack += path.join('node_modules', 'mysql2', 'lib');
+        error.code = 'ER_WRONG_VALUE';
+        error.sql = 'select anything from anywhere where something = anything;';
+        error.sqlMessage = 'Incorrect DATETIME value: 3234234234';
+
+        prepareError(error, {}, {
+            set: () => {}
+        }, (err) => {
+            err.statusCode.should.eql(500);
+            err.name.should.eql('InternalServerError');
+            err.message.should.eql('An unexpected error occurred, please try again.');
+            err.code.should.eql('UNEXPECTED_ERROR');
+            err.sqlErrorCode.should.eql('ER_WRONG_VALUE');
+            err.sql.should.eql('select anything from anywhere where something = anything;');
+            err.sqlMessage.should.eql('Incorrect DATETIME value: 3234234234');
+            done();
+        });
+    });
 });
 
 describe('Prepare Stack', function () {


### PR DESCRIPTION
refs TryGhost/Product#4083

- In the vast majority of cases, we shouldn't have SQL errors in our code. Due to some limitations with validating e.g. nql filters passed to the API, sometimes we don't catch these errors and they bubble up to the user.
- In these rare cases, Ghost was returning the raw SQL error from mysql which is not very user friendly and also exposes information about the database, which generally is not a good practice.
- To make things worse, Sentry was treating every instance of these errors as a unique issue, even when it was exactly the same query failing over and over.
- This change improves the error message returned from the API, and also makes sure that Sentry will group all these errors together, so we can easily see how many times they are happening and where.
- It also adds more specific context to the event that is sent to Sentry, including the mysql error number, code, and the SQL query itself.