### PR TITLE
🐛 Fixed escape handling for Pintura in Settings

### DIFF
--- a/apps/admin-x-settings/src/hooks/usePinturaEditor.ts
+++ b/apps/admin-x-settings/src/hooks/usePinturaEditor.ts
@@ -221,7 +221,8 @@ export default function usePinturaEditor({
                 });
 
                 editor.on('loaderror', () => {
-                    // TODO: log error message
+                    // TODO: log error message on Sentry
+                    Sentry.captureMessage('Pintura editor failed to load');
                 });
 
                 editor.on('process', (result) => {
@@ -236,6 +237,11 @@ export default function usePinturaEditor({
 
     // Only allow closing the modal if the close button was clicked
     useEffect(() => {
+        const handleEscapePress = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.stopPropagation();
+            }
+        };
         if (!isOpen) {
             return;
         }
@@ -247,9 +253,11 @@ export default function usePinturaEditor({
         };
 
         window.addEventListener('click', handleCloseClick, {capture: true});
+        window.addEventListener('keydown', handleEscapePress, {capture: true});
 
         return () => {
             window.removeEventListener('click', handleCloseClick, {capture: true});
+            window.removeEventListener('keydown', handleEscapePress, {capture: true});
         };
     }, [isOpen]);
 


### PR DESCRIPTION
refs https://www.notion.so/ghost/When-hitting-ESC-within-the-Pintura-editor-editing-cover-image-from-Design-Branding-it-would-e-b1c70064f2fd4f5cb830b095c2abd08e

- When escape was hit in within the Pintura editor in Settings, it cleared the modal underneath it, causing the close button to become unresponsive.
- A previous commit was made to disable the escape key altogether so that users don't accidentally quit Pintura and having all their changes discarded.
- This fixes a regression to make sure the background modal don't hide and Pintura can only be closed by mouse clicking the actual close button on the top left, if not saving it on the top right.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ed7f7e</samp>

This pull request enhances the Pintura editor integration by adding error reporting and escape key handling. It modifies the `usePinturaEditor` hook in `apps/admin-x-settings/src/hooks/usePinturaEditor.ts`.
