### PR TITLE
Added extra redis cache adapter configuration options

### DIFF
--- a/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
+++ b/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
@@ -13,6 +13,7 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      * @param {Number} [config.port] - redis port used in case no cache instance provided
      * @param {String} [config.password] - redis password used in case no cache instance provided
      * @param {Object} [config.clusterConfig] - redis cluster config used in case no cache instance provided
+     * @param {Object} [config.storeConfig] - extra redis client config used in case no cache instance provided
      * @param {Number} [config.ttl] - default cached value Time To Live (expiration) in *seconds*
      * @param {String} [config.keyPrefix] - prefix to use when building a unique cache key, e.g.: 'some_id:image-sizes:'
      * @param {Boolean} [config.reuseConnection] - specifies if the redis store/connection should be reused within the process
@@ -38,7 +39,9 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                 ttl: config.ttl,
                 host: config.host,
                 port: config.port,
+                username: config.username,
                 password: config.password,
+                ...config.storeConfig,
                 clusterConfig: config.clusterConfig
             };
             const store = redisStoreFactory.getRedisStore(storeOptions, config.reuseConnection);

--- a/ghost/adapter-cache-redis/test/adapter-cache-redis.test.js
+++ b/ghost/adapter-cache-redis/test/adapter-cache-redis.test.js
@@ -27,6 +27,20 @@ describe('Adapter Cache Redis', function () {
         assert.ok(cache);
     });
 
+    it('can initialize with storeConfig', async function () {
+        const cache = new RedisCache({
+            username: 'myusername',
+            storeConfig: {
+                retryStrategy: false,
+                lazyConnect: true
+            },
+            reuseConnection: false
+        });
+        assert.ok(cache);
+        assert.equal(cache.redisClient.options.username, 'myusername');
+        assert.equal(cache.redisClient.options.retryStrategy, false);
+    });
+
     describe('get', function () {
         it('can get a value from the cache', async function () {
             const redisCacheInstanceStub = {


### PR DESCRIPTION
no refs

- This enables supplying a username to connect to redis with when connection to an individual node rather than a cluster.
- It also allows for extra options to be given to the ioredis store used in the background.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e10635a</samp>

This change adds support for Redis 6 ACL authentication and custom ioredis options to the `AdapterCacheRedis` module. It allows users to connect to Redis servers with different usernames and passwords, and to fine-tune the Redis client behavior.
