### PR TITLE
Handled unhandled ember ajax errors

### DIFF
--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -43,7 +43,7 @@ export function isVersionMismatchError(errorOrStatus, payload) {
 
 export class DataImportError extends AjaxError {
     constructor(payload) {
-        super(payload, 'he server encountered an error whilst importing data.');
+        super(payload, 'The server encountered an error whilst importing data.');
     }
 }
 

--- a/ghost/admin/app/services/notifications.js
+++ b/ghost/admin/app/services/notifications.js
@@ -34,6 +34,8 @@ const GENERIC_ERROR_NAMES = [
     'SyntaxError',
     'TypeError',
     'URIError',
+    // ember-ajax errors - https://github.com/ember-cli/ember-ajax/blob/master/addon/errors.ts
+    'AjaxError',
     'ServerError'
 ];
 


### PR DESCRIPTION
no refs

Handled unhandled ember ajax errors (i.e `406`) so that a friendly error message can be displayed to the user.