### PR TITLE
Added well-known assetlinks.json to allowed files

### DIFF
--- a/ghost/core/core/frontend/web/middleware/static-theme.js
+++ b/ghost/core/core/frontend/web/middleware/static-theme.js
@@ -45,7 +45,7 @@ function isAllowedFile(file) {
 
     const normalizedFilePath = path.normalize(decodedFilePath);
 
-    const allowedFiles = ['manifest.json'];
+    const allowedFiles = ['manifest.json', 'assetlinks.json'];
     const allowedPath = '/assets/';
     const alwaysDeny = ['.hbs'];
 

--- a/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/static-theme.test.js
@@ -157,6 +157,23 @@ describe('staticTheme', function () {
         });
     });
 
+    it('should NOT skip if file is allowed even if nested', function (done) {
+        req.path = '/.well-known/assetlinks.json';
+
+        staticTheme()(req, res, function next() {
+            // Specifically gets called twice
+            activeThemeStub.calledTwice.should.be.true();
+            expressStaticStub.called.should.be.true();
+
+            // Check that express static gets called with the theme path + maxAge
+            should.exist(expressStaticStub.firstCall.args);
+            expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+            expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+
+            done();
+        });
+    });
+
     it('should NOT skip if file is in assets', function (done) {
         req.path = '/assets/whatever.json';
 


### PR DESCRIPTION
refs: https://github.com/google/digitalassetlinks/blob/master/well-known/specification.md
refs: https://github.com/google/digitalassetlinks/blob/master/well-known/details.md

- allow themes to include assetlinks.json files to comply with the Google digital asset links spec

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 628be3b</samp>

This pull request adds support for serving `assetlinks.json` files from the static theme middleware, which enables web app developers to use Ghost as a backend for their web apps. It also adds a test case to verify that the middleware works correctly with the `.well-known` folder convention.
