### PR TITLE
Added indexes to `members_created_events` and  `members_subscription_created_events`

### DIFF
--- a/ghost/core/core/server/data/migrations/utils/schema.js
+++ b/ghost/core/core/server/data/migrations/utils/schema.js
@@ -98,6 +98,22 @@ function createSetNullableMigration(table, column, options = {}) {
 
 /**
  * @param {string} table
+ * @param {string[]|string} columns One or multiple columns (in case the index should be for multiple columns)
+ * @returns {Migration}
+ */
+function createAddIndexMigration(table, columns) {
+    return createTransactionalMigration(
+        async function up(knex) {
+            await commands.addIndex(table, columns, knex);
+        },
+        async function down(knex) {
+            await commands.dropIndex(table, columns, knex);
+        }
+    );
+}
+
+/**
+ * @param {string} table
  * @param {string} from
  * @param {string} to
  *
@@ -163,7 +179,8 @@ module.exports = {
     createDropColumnMigration,
     createSetNullableMigration,
     createDropNullableMigration,
-    createRenameColumnMigration
+    createRenameColumnMigration,
+    createAddIndexMigration
 };
 
 /**

--- a/ghost/core/core/server/data/migrations/versions/5.72/2023-10-31-11-06-00-members-created-attribution-id-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.72/2023-10-31-11-06-00-members-created-attribution-id-index.js
@@ -1,0 +1,3 @@
+const {createAddIndexMigration} = require('../../utils');
+
+module.exports = createAddIndexMigration('members_created_events', ['attribution_id']);

--- a/ghost/core/core/server/data/migrations/versions/5.72/2023-10-31-11-06-01-members-subscription-created-attribution-id-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.72/2023-10-31-11-06-01-members-subscription-created-attribution-id-index.js
@@ -1,0 +1,3 @@
+const {createAddIndexMigration} = require('../../utils');
+
+module.exports = createAddIndexMigration('members_subscription_created_events', ['attribution_id']);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -523,7 +523,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         created_at: {type: 'dateTime', nullable: false},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-        attribution_id: {type: 'string', maxlength: 24, nullable: true},
+        attribution_id: {type: 'string', maxlength: 24, nullable: true, index: true},
         attribution_type: {
             type: 'string', maxlength: 50, nullable: true, validations: {
                 isIn: [['url', 'post', 'page', 'author', 'tag']]
@@ -538,10 +538,7 @@ module.exports = {
                 isIn: [['member', 'import', 'system', 'api', 'admin']]
             }
         },
-        batch_id: {type: 'string', maxlength: 24, nullable: true},
-        '@@INDEXES@@': [
-            ['attribution_id']
-        ]
+        batch_id: {type: 'string', maxlength: 24, nullable: true}
     },
     members_cancel_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
@@ -712,7 +709,7 @@ module.exports = {
         created_at: {type: 'dateTime', nullable: false},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
         subscription_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_stripe_customers_subscriptions.id', cascadeDelete: true},
-        attribution_id: {type: 'string', maxlength: 24, nullable: true},
+        attribution_id: {type: 'string', maxlength: 24, nullable: true, index: true},
         attribution_type: {
             type: 'string', maxlength: 50, nullable: true, validations: {
                 isIn: [['url', 'post', 'page', 'author', 'tag']]
@@ -722,10 +719,7 @@ module.exports = {
         referrer_source: {type: 'string', maxlength: 191, nullable: true},
         referrer_medium: {type: 'string', maxlength: 191, nullable: true},
         referrer_url: {type: 'string', maxlength: 2000, nullable: true},
-        batch_id: {type: 'string', maxlength: 24, nullable: true},
-        '@@INDEXES@@': [
-            ['attribution_id']
-        ]
+        batch_id: {type: 'string', maxlength: 24, nullable: true}
     },
     offer_redemptions: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -538,7 +538,10 @@ module.exports = {
                 isIn: [['member', 'import', 'system', 'api', 'admin']]
             }
         },
-        batch_id: {type: 'string', maxlength: 24, nullable: true}
+        batch_id: {type: 'string', maxlength: 24, nullable: true},
+        '@@INDEXES@@': [
+            ['attribution_id']
+        ]
     },
     members_cancel_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
@@ -719,7 +722,10 @@ module.exports = {
         referrer_source: {type: 'string', maxlength: 191, nullable: true},
         referrer_medium: {type: 'string', maxlength: 191, nullable: true},
         referrer_url: {type: 'string', maxlength: 2000, nullable: true},
-        batch_id: {type: 'string', maxlength: 24, nullable: true}
+        batch_id: {type: 'string', maxlength: 24, nullable: true},
+        '@@INDEXES@@': [
+            ['attribution_id']
+        ]
     },
     offer_redemptions: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '013334f4f51aae785b9afd345861c06a';
+    const currentSchemaHash = '6d07db2e996e4b97724d1c54ba1ece6c';
     const currentFixturesHash = '4db87173699ad9c9d8a67ccab96dfd2d';
     const currentSettingsHash = '3128d4ec667a50049486b0c21f04be07';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '6d07db2e996e4b97724d1c54ba1ece6c';
+    const currentSchemaHash = '1c1f476e830ce01a0167229697bd4523';
     const currentFixturesHash = '4db87173699ad9c9d8a67ccab96dfd2d';
     const currentSettingsHash = '3128d4ec667a50049486b0c21f04be07';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/4085

Increases the performance for the post analytics export by adding new indexes. These indexes are used when counting the amount of (paid) subscribers that were attributed to a given post. With the indexes, the time required to export 700 posts with 300k members decreases from 40s to 0.6s.

Tests show that adding these indexes should be very fast (< 1 s) if the tables contain up to 300k rows. 
