### PR TITLE
Fixed error caused by uploading empty redirects YAML file

### DIFF
--- a/ghost/core/core/server/services/custom-redirects/CustomRedirectsAPI.js
+++ b/ghost/core/core/server/services/custom-redirects/CustomRedirectsAPI.js
@@ -9,7 +9,7 @@ const errors = require('@tryghost/errors');
 const messages = {
     jsonParse: 'Could not parse JSON: {context}.',
     yamlParse: 'Could not parse YAML: {context}.',
-    yamlPlainString: 'YAML input cannot be a plain string. Check the format of your YAML file.',
+    yamlInvalid: 'YAML input is invalid. Check the contents of your YAML file.',
     redirectsHelp: 'https://ghost.org/docs/themes/routing/#redirects',
     redirectsRegister: 'Could not register custom redirects.'
 };
@@ -78,13 +78,9 @@ const parseRedirectsFile = (content, ext) => {
             });
         }
 
-        // yaml.load passes almost every yaml code.
-        // Because of that, it's hard to detect if there's an error in the file.
-        // But one of the obvious errors is the plain string output.
-        // Here we check if the user made this mistake.
-        if (typeof configYaml === 'string') {
+        if (typeof configYaml !== 'object' || configYaml === null) {
             throw new errors.BadRequestError({
-                message: tpl(messages.yamlPlainString),
+                message: tpl(messages.yamlInvalid),
                 help: tpl(messages.redirectsHelp)
             });
         }

--- a/ghost/core/test/unit/server/services/custom-redirects/api.test.js
+++ b/ghost/core/test/unit/server/services/custom-redirects/api.test.js
@@ -116,7 +116,20 @@ describe('UNIT: redirects CustomRedirectsAPI class', function () {
                 should.fail('setFromFilePath did not throw');
             } catch (err) {
                 should.exist(err);
-                err.message.should.eql('YAML input cannot be a plain string. Check the format of your YAML file.');
+                err.message.should.eql('YAML input is invalid. Check the contents of your YAML file.');
+            }
+        });
+
+        it('throws a syntax error when setting invalid (empty) YAML redirects file', async function () {
+            const invalidFilePath = path.join(__dirname, '/invalid/redirects/yaml.json');
+            fs.readFile.withArgs(invalidFilePath, 'utf-8').resolves('');
+
+            try {
+                await customRedirectsAPI.setFromFilePath(invalidFilePath, '.yaml');
+                should.fail('setFromFilePath did not throw');
+            } catch (err) {
+                should.exist(err);
+                err.message.should.eql('YAML input is invalid. Check the contents of your YAML file.');
             }
         });
 


### PR DESCRIPTION
no refs

Fixed error caused by uploading empty redirects YAML file:

```
Cannot read properties of undefined (reading '302')
```

This error was occurring due to `yaml.load` returning `undefined` when the provided yaml file was empty. I've made the check on the return value of `yaml.load` stricter (i.e we only want an `object`) to prevent this error from occurring.