### PR TITLE
Added sourceRoot key to admin sourcemaps

### DIFF
--- a/ghost/admin/lib/sourcemap-postprocess/index.js
+++ b/ghost/admin/lib/sourcemap-postprocess/index.js
@@ -1,0 +1,27 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  name: require('./package').name,
+
+  isDevelopingAddon() {
+    return true;
+  },
+
+  postBuild: function (results) {
+    const fs = this.project.require('fs-extra');
+
+    // read all .map files in the /assets directory
+    const assets = fs.readdirSync(path.join(results.directory, 'assets'));
+    const mapFiles = assets.filter((file) => file.endsWith('.map'));
+
+    // loop over the mapfiles and add a "sourceRoot" key to each one
+    mapFiles.forEach((file) => {
+      const mapFilePath = path.join(results.directory, 'assets', file);
+      const mapFile = JSON.parse(fs.readFileSync(mapFilePath, 'utf8'));
+      mapFile.sourceRoot = '../';
+      fs.writeFileSync(mapFilePath, JSON.stringify(mapFile));
+    });
+  }
+};

--- a/ghost/admin/lib/sourcemap-postprocess/index.js
+++ b/ghost/admin/lib/sourcemap-postprocess/index.js
@@ -1,27 +1,27 @@
+/* eslint-disable */
 'use strict';
+
 const fs = require('fs');
 const path = require('path');
 
 module.exports = {
-  name: require('./package').name,
+    name: 'sourcemap-postprocess',
 
-  isDevelopingAddon() {
-    return true;
-  },
+    isDevelopingAddon() {
+        return true;
+    },
 
-  postBuild: function (results) {
-    const fs = this.project.require('fs-extra');
+    postBuild: function (results) {
+        // read all .map files in the /assets directory
+        const assets = fs.readdirSync(path.join(results.directory, 'assets'));
+        const mapFiles = assets.filter((file) => file.endsWith('.map'));
 
-    // read all .map files in the /assets directory
-    const assets = fs.readdirSync(path.join(results.directory, 'assets'));
-    const mapFiles = assets.filter((file) => file.endsWith('.map'));
-
-    // loop over the mapfiles and add a "sourceRoot" key to each one
-    mapFiles.forEach((file) => {
-      const mapFilePath = path.join(results.directory, 'assets', file);
-      const mapFile = JSON.parse(fs.readFileSync(mapFilePath, 'utf8'));
-      mapFile.sourceRoot = '../';
-      fs.writeFileSync(mapFilePath, JSON.stringify(mapFile));
-    });
-  }
+        // loop over the mapfiles and add a "sourceRoot" key to each one
+        mapFiles.forEach((file) => {
+            const mapFilePath = path.join(results.directory, 'assets', file);
+            const mapFile = JSON.parse(fs.readFileSync(mapFilePath, 'utf8'));
+            mapFile.sourceRoot = '../';
+            fs.writeFileSync(mapFilePath, JSON.stringify(mapFile));
+        });
+    }
 };

--- a/ghost/admin/lib/sourcemap-postprocess/package.json
+++ b/ghost/admin/lib/sourcemap-postprocess/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "sourcemap-postprocess",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -150,8 +150,9 @@
   "ember-addon": {
     "paths": [
       "lib/asset-delivery",
+      "lib/ember-power-calendar-moment",
       "lib/ember-power-calendar-utils",
-      "lib/ember-power-calendar-moment"
+      "lib/sourcemap-postprocess"
     ]
   },
   "resolutions": {


### PR DESCRIPTION
no issue

- The sourcemaps generated for the admin app use relative links to the source code files e.g. `assets/ghost.js`
- Since the sourcemaps themselves are hosted at `/assets` already, this was leading to issues with sourcemaps in Sentry and in the browser looking for the sources at `/assets/assets/ghost.js`
- This commit adds a `sourceRoot` key to the sourcemaps, which should allow Sentry and the Browser to find the source code files at `../assets/ghost.js` instead of `assets/ghost.js`
- We may need to iterate on this — not 100% sure if this is the best way to do this without trying it in staging. If the `../` doesn't work in all environments, we can try including the CDN url directly