### PR TITLE
Updated AJAX error context sent to Sentry from admin

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -193,11 +193,18 @@ export default Route.extend(ShortcutsRoute, {
                     }
 
                     // ajax errors — improve logging and add context for debugging
-                    if (exception && exception.payload && isEmberArray(exception.payload.errors) && exception.payload.errors.length > 0) {
+                    if (isAjaxError(exception)) {
                         const error = exception.payload.errors[0];
                         event.exception.values[0].type = `${error.type}: ${error.context}`;
                         event.exception.values[0].value = error.message;
                         event.exception.values[0].context = error.context;
+                        event.tags.isAjaxError = true;
+                    } else {
+                        event.tags.isAjaxError = false;
+                        delete event.contexts.ajax;
+                        delete event.tags.ajaxStatus;
+                        delete event.tags.ajaxMethod;
+                        delete event.tags.ajaxUrl;
                     }
 
                     return event;

--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -305,9 +305,9 @@ class ajaxService extends AjaxService {
             method: request.method,
             status
         });
-        Sentry.setTag('ajax.status', status);
-        Sentry.setTag('ajax.url', request.url);
-        Sentry.setTag('ajax.method', request.method);
+        Sentry.setTag('ajaxStatus', status);
+        Sentry.setTag('ajaxUrl', request.url);
+        Sentry.setTag('ajaxMethod', request.method);
 
         if (headers['content-version']) {
             const contentVersion = semverCoerce(headers['content-version']);


### PR DESCRIPTION
no issues

- Added isAjaxError tag to all errors sent from admin with a true/false value
- Removed all Ajax context and tags if the error is not an Ajax error
- Updated names of Ajax tags to use camelcase instead of dot notation
