### PR TITLE
Removed assets/ from sources in admin sourcemaps

### DIFF
--- a/ghost/admin/lib/sourcemap-postprocess/index.js
+++ b/ghost/admin/lib/sourcemap-postprocess/index.js
@@ -20,7 +20,10 @@ module.exports = {
         mapFiles.forEach((file) => {
             const mapFilePath = path.join(results.directory, 'assets', file);
             const mapFile = JSON.parse(fs.readFileSync(mapFilePath, 'utf8'));
-            mapFile.sourceRoot = '../';
+            const sources = mapFile.sources;
+            for (let i = 0; i < sources.length; i++) {
+                sources[i] = sources[i].replace('assets/', '');
+            }
             fs.writeFileSync(mapFilePath, JSON.stringify(mapFile));
         });
     }


### PR DESCRIPTION
no issue

- Follow up to https://github.com/TryGhost/Ghost/pull/18825
- Adding the sourceRoot key didn't seem to work, so I'm just removing the `assets/` prefix from all the sources to hopefully correct the issue
