### PR TITLE
Fixed title for incoming recommendations from private sites

### DIFF
--- a/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
@@ -5,7 +5,7 @@
         <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
-        <title>{{@site.title}} - Private Site Access</title>
+        <title>{{@site.title}}</title>
 
         <meta name="HandheldFriendly" content="True">
         <meta name="MobileOptimized" content="320">


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4098
- when a site is private, the metadata title is "My Site — Private Site Access". When fetching the metadata via oembed, we get "Private Site Access" as publisher, and "My Site — Private Site Access" as title
- this fix removes "- Private Site Access" from the metadata title when a Ghost site is private
