### PR TITLE
Removed `assets/` from sources in admin sourcemaps

### DIFF
--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -68,11 +68,12 @@ module.exports = {
             ignore: ['icons']
         });
 
-        // loop over any sourcemaps and add a "sourceRoot" key to each one before copying
+        // loop over any sourcemaps and remove `assets/` key from each one
         assets.filter((file) => file.endsWith('.map')).forEach((file) => {
             const mapFilePath = `${results.directory}/assets/${file}`;
             const mapFile = JSON.parse(fs.readFileSync(mapFilePath, 'utf8'));
-            mapFile.sourceRoot = '../';
+            // loop over the sources and remove `assets/` from each one
+            mapFile.sources = mapFile.sources.map((source) => source.replace('assets/', ''));
             fs.writeFileSync(mapFilePath, JSON.stringify(mapFile));
         });
 


### PR DESCRIPTION
no issue

- Follow up to https://github.com/TryGhost/Ghost/commit/85fca5891f2d5e23878b4258a789bae469da36bc
- With the `sourceRoot` key added in the commit above, the sourcemaps were still failing validation (https://sourcemaps.io/report/1698954693695_https%3A%2F%2Fassets.ghostfoundation.org%2Fadmin%2F1603%2Fassets%2Fchunk.143.ab029856ba6d72733dfa.js)
- With the `sourceRoot` key, the maps were pointing to '<CDN_URL>/assets/../assets/...' which is invalid
- This change simply strips the leading `assets/` from any sources in the sourcemaps