### PR TITLE
Removed `path` tags from Sentry

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -92,7 +92,6 @@ export default Route.extend(ShortcutsRoute, {
             // Need a tiny delay here to allow the router to update to the current route
             later(() => {
                 Sentry.setTag('route', this.router.currentRouteName);
-                Sentry.setTag('path', this.router.currentURL);
             }, 2);
         },
 


### PR DESCRIPTION
no issues

- The `path` tags aren't super useful, since they often include e.g. a post id in the path, which isn't super useful for filtering/grouping
- We already have a `route` tag which can be used to filter to a particular route, which renders the `path` tags unnecessary