### PR TITLE
Added `sourcesContent` key to admin sourcemaps

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -95,6 +95,9 @@ module.exports = function (defaults) {
         'ember-promise-modals': {
             excludeCSS: true
         },
+        'ember-cli-terser': {
+            enabled: true,
+        },
         outputPaths: {
             app: {
                 js: 'assets/ghost.js',
@@ -205,6 +208,7 @@ module.exports = function (defaults) {
         autoImport: {
             publicAssetURL,
             webpack: {
+                devtool: 'source-map',
                 resolve: {
                     fallback: {
                         util: require.resolve('util'),

--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -95,9 +95,6 @@ module.exports = function (defaults) {
         'ember-promise-modals': {
             excludeCSS: true
         },
-        'ember-cli-terser': {
-            enabled: true,
-        },
         outputPaths: {
             app: {
                 js: 'assets/ghost.js',


### PR DESCRIPTION
no issue

- The sourcemaps currently generated by the admin build do not include the `sourcesContent` key
- This commit is to experiment with this change, in particular to see if it improves the stacktraces available in Sentry from errors in the admin app
- Currently the stacktraces in admin show the minified code — hopefully this change will make the stacktraces show the original source code to make it easier to debug issues from within Sentry