### PR TITLE
Enabled babel sourcemaps in admin build

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -83,7 +83,8 @@ module.exports = function (defaults) {
         babel: {
             plugins: [
                 require.resolve('babel-plugin-transform-react-jsx')
-            ]
+            ],
+            sourceMaps: true
         },
         'ember-cli-babel': {
             optional: ['es6.spec.symbols'],


### PR DESCRIPTION
no issue

- Somewhere along the process of building the admin app, the sourcemaps are getting corrupted
- This commit is to test the theory that babel is the source of the corruption, because it isn't generating sourcemaps, so we are missing a step in the process