### PR TITLE
Disabled babel sourcemaps in admin build

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -83,8 +83,7 @@ module.exports = function (defaults) {
         babel: {
             plugins: [
                 require.resolve('babel-plugin-transform-react-jsx')
-            ],
-            sourceMaps: true
+            ]
         },
         'ember-cli-babel': {
             optional: ['es6.spec.symbols'],


### PR DESCRIPTION
no issue

- Reverting https://github.com/TryGhost/Ghost/commit/a96224a152c1b90f2b619760dccea67cf6cd67c3 because it didn't help but made admin builds slower
