### PR TITLE
🐛 Fixed showing recommendations on custom welcome pages

### DIFF
--- a/ghost/core/core/server/services/members/middleware.js
+++ b/ghost/core/core/server/services/members/middleware.js
@@ -265,7 +265,15 @@ const createSessionFromMagicLink = async function createSessionFromMagicLink(req
                 const ensureEndsWith = (string, endsWith) => (string.endsWith(endsWith) ? string : string + endsWith);
                 const removeLeadingSlash = string => string.replace(/^\//, '');
 
+                // Add query parameters so the frontend can detect that the signup went fine
+
                 const redirectUrl = new URL(removeLeadingSlash(ensureEndsWith(customRedirect, '/')), ensureEndsWith(baseUrl, '/'));
+
+                if (urlUtils.isSiteUrl(redirectUrl)) {
+                    // Add only for non-external URLs
+                    redirectUrl.searchParams.set('success', 'true');
+                    redirectUrl.searchParams.set('action', 'signup');
+                }
 
                 return res.redirect(redirectUrl.href);
             }

--- a/ghost/core/test/e2e-api/members/signin.test.js
+++ b/ghost/core/test/e2e-api/members/signin.test.js
@@ -64,7 +64,7 @@ describe('Members Signin', function () {
 
         await membersAgent.get(`/?token=${token}&action=signup`)
             .expectStatus(302)
-            .expectHeader('Location', /\/welcome-free\/$/)
+            .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
             .expectHeader('Set-Cookie', /members-ssr.*/);
     });
 
@@ -75,7 +75,7 @@ describe('Members Signin', function () {
 
         await membersAgent.get(`/?token=${token}&action=signup-paid`)
             .expectStatus(302)
-            .expectHeader('Location', /\/welcome-paid\/$/)
+            .expectHeader('Location', /\/welcome-paid\/\?success=true&action=signup$/)
             .expectHeader('Set-Cookie', /members-ssr.*/);
     });
 
@@ -86,7 +86,7 @@ describe('Members Signin', function () {
 
         await membersAgent.get(`/?token=${token}&action=subscribe`)
             .expectStatus(302)
-            .expectHeader('Location', /\/welcome-free\/$/)
+            .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
             .expectHeader('Set-Cookie', /members-ssr.*/);
     });
 
@@ -98,7 +98,7 @@ describe('Members Signin', function () {
 
         await membersAgent.get(`/?token=${token}&action=signup`)
             .expectStatus(302)
-            .expectHeader('Location', /\/welcome-free\/$/)
+            .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
             .expectHeader('Set-Cookie', /members-ssr.*/);
 
         const member = await getMemberByEmail(email);
@@ -129,7 +129,7 @@ describe('Members Signin', function () {
 
         await membersAgent.get(`/?token=${token}&action=signup`)
             .expectStatus(302)
-            .expectHeader('Location', /\/welcome-free\/$/)
+            .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
             .expectHeader('Set-Cookie', /members-ssr.*/);
     });
 
@@ -173,7 +173,7 @@ describe('Members Signin', function () {
             // Use a first time
             await membersAgent.get(`/?token=${token}&action=signup`)
                 .expectStatus(302)
-                .expectHeader('Location', /\/welcome-free\/$/)
+                .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
                 .expectHeader('Set-Cookie', /members-ssr.*/);
 
             // Fetch token in the database
@@ -189,7 +189,7 @@ describe('Members Signin', function () {
 
             await membersAgent.get(`/?token=${token}&action=signup`)
                 .expectStatus(302)
-                .expectHeader('Location', /\/welcome-free\/$/)
+                .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
                 .expectHeader('Set-Cookie', /members-ssr.*/);
 
             await model.refresh();
@@ -226,17 +226,17 @@ describe('Members Signin', function () {
             // Use a first time
             await membersAgent.get(`/?token=${token}&action=signup`)
                 .expectStatus(302)
-                .expectHeader('Location', /\/welcome-free\/$/)
+                .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
                 .expectHeader('Set-Cookie', /members-ssr.*/);
 
             await membersAgent.get(`/?token=${token}&action=signup`)
                 .expectStatus(302)
-                .expectHeader('Location', /\/welcome-free\/$/)
+                .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
                 .expectHeader('Set-Cookie', /members-ssr.*/);
 
             await membersAgent.get(`/?token=${token}&action=signup`)
                 .expectStatus(302)
-                .expectHeader('Location', /\/welcome-free\/$/)
+                .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
                 .expectHeader('Set-Cookie', /members-ssr.*/);
 
             // Fetch token in the database
@@ -534,7 +534,7 @@ describe('Members Signin', function () {
 
             await membersAgent.get(`/?token=${token}&action=signup`)
                 .expectStatus(302)
-                .expectHeader('Location', /\/welcome-free\/$/)
+                .expectHeader('Location', /\/welcome-free\/\?success=true&action=signup$/)
                 .expectHeader('Set-Cookie', /members-ssr.*/);
 
             const member = await getMemberByEmail(email);


### PR DESCRIPTION
no issue

When a custom welcome page is set for a tier, the recommendations modal didn't show. If recommendations were disabled, there was also no toast to confirm the sign up.

To fix this, we'll need to set the success and action query parameters on the welcome page, but only if it is not an external site.