### PR TITLE
Wired up redemption filter to OfferCards

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/offers/OffersModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/offers/OffersModal.tsx
@@ -8,6 +8,11 @@ import {useEffect} from 'react';
 
 export type OfferType = 'percent' | 'fixed' | 'trial';
 
+const createRedemptionFilterUrl = (id: string): string => {
+    const baseHref = '/ghost/#/members';
+    return `${baseHref}?filter=${encodeURIComponent('offer_redemptions:' + id)}`;
+};
+
 const OfferCard: React.FC<{name: string, type: OfferType, onClick: ()=>void}> = ({name, type, onClick}) => {
     let discountColor = '';
 
@@ -36,7 +41,8 @@ const OfferCard: React.FC<{name: string, type: OfferType, onClick: ()=>void}> = 
         </div>
         <div className='flex flex-col items-center text-xs'>
             <span className='font-medium'>Bronze monthly — First payment</span>
-            <a className='text-grey-700 hover:underline' href="/ghost/#/members">4 redemptions</a>
+            {/* TODO: pass in actual offer ID */}
+            <a className='text-grey-700 hover:underline' href={createRedemptionFilterUrl('fda10d177a4f5be094fb4a84')}>4 redemptions</a>
         </div>
     </div>;
 };
@@ -83,6 +89,7 @@ const OffersModal = () => {
                 <h1 className='mt-12 border-b border-b-grey-300 pb-2.5 text-3xl'>Active offers</h1>
             </header>
             <div className='mt-8 grid grid-cols-3 gap-6'>
+                {/* TODO replace 123 with actual offer ID */}
                 <OfferCard name='Black friday' type='percent' onClick={() => handleOfferEdit('123')} />
                 <OfferCard name='Buy this right now' type='fixed' onClick={() => handleOfferEdit('123')} />
                 <OfferCard name='Desperate Sale!' type='trial' onClick={() => handleOfferEdit('123')} />


### PR DESCRIPTION
no issue

- added a function to generate links that takes you to a pre-filtered list of members by redeemed offers.

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af3622c</samp>

Add dynamic links for filtering members by offer redemptions in the `OffersModal` component. Use a placeholder function for generating the URLs until the real offer IDs are available.
