### PR TITLE
✨ Enabled emoji picker in editor

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -52,10 +52,6 @@ const features = [{
     description: 'Set the List-Unsubscribe header in emails',
     flag: 'listUnsubscribeHeader'
 },{
-    title: 'Editor emoji picker',
-    description: <>Trigger an emoji picker when typing <code>{':{search}'}</code> in the editor</>,
-    flag: 'editorEmojiPicker'
-},{
     title: 'AdminX Offers',
     description: 'Enables the new offers UI in AdminX settings',
     flag: 'adminXOffers'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -20,7 +20,8 @@ const GA_FEATURES = [
     'outboundLinkTagging',
     'announcementBar',
     'signupForm',
-    'recommendations'
+    'recommendations',
+    'editorEmojiPicker'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -43,7 +44,6 @@ const ALPHA_FEATURES = [
     'importMemberTier',
     'lexicalIndicators',
     'listUnsubscribeHeader',
-    'editorEmojiPicker',
     'adminXOffers'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -758,7 +758,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4280",
+  "content-length": "4307",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
closes TryGhost/Product#4107
- emoji picker is now available for inline emoji insertion
- open the menu with typing a : (colon), e.g. :sparkles: