### PR TITLE
Removed block styling for `<i>` elements in Admin

### DIFF
--- a/ghost/admin/app/styles/patterns/global.css
+++ b/ghost/admin/app/styles/patterns/global.css
@@ -591,10 +591,6 @@ button {
     line-height: inherit;
 }
 
-i {
-    display: block;
-}
-
 img,
 input[type="image"] {
     max-width: 100%;


### PR DESCRIPTION
no issue

- we don't use `<i>` elements anywhere in our own code and this styling was causing odd in-editor previews of HTML cards when their content contained `<i>`
