### PR TITLE
Filter members by email disabled

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -55,6 +55,10 @@ const features = [{
     title: 'AdminX Offers',
     description: 'Enables the new offers UI in AdminX settings',
     flag: 'adminXOffers'
+},{
+    title: 'Filter by email disabled',
+    description: 'Allows filtering members by email disabled',
+    flag: 'filterEmailDisabled'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/admin/app/components/members/filter.js
+++ b/ghost/admin/app/components/members/filter.js
@@ -178,18 +178,6 @@ export default class MembersFilter extends Component {
             return [filter];
         });
 
-        // find list of newsletters from store and add them to filter list if there are more than one newsletter
-        // it also removes the 'subscribed' filter from the list as that would unsubscribe members from all newsletters, instead replace it with a filter for each newsletter
-        // if (this.newsletters?.length > 1) {
-        //     // remove the 'subscribed' filter from the list
-        //     //availableFilters = availableFilters.filter(prop => prop.name !== 'subscribed');
-        //
-        //     // find the index of the 'basic' group and insert the 'multiple newsletters' filter after it
-        //     const indexes = availableFilters.map((obj, index) => (obj.group === 'Basic' ? index : null)).filter(i => i !== null);
-        //     const lastIndex = indexes.pop();
-        //     availableFilters.splice(lastIndex + 1, 0, ...NEWSLETTERS_FILTER(this.newsletters));
-        // }
-
         // only add the offers filter if there are any offers
         if (this.offers.length > 0) {
             availableFilters = availableFilters.concat(OFFERS_FILTER);

--- a/ghost/admin/app/components/members/filters/subscribed.js
+++ b/ghost/admin/app/components/members/filters/subscribed.js
@@ -3,12 +3,12 @@ import {MATCH_RELATION_OPTIONS} from './relation-options';
 export const SUBSCRIBED_FILTER = ({newsletters, feature, group}) => {
     if (feature.filterEmailDisabled) {
         return {
-            label: 'Newsletter subscription',
+            label: newsletters.length > 1 ? 'Newsletter subscriptions' : 'Newsletter subscription',
             name: 'subscribed',
             columnLabel: 'Subscribed',
             relationOptions: MATCH_RELATION_OPTIONS,
             valueType: 'options',
-            group,
+            group: newsletters.length > 1 ? 'Newsletters' : group,
             // Only show the filter for multiple newsletters if feature flag is enabled
             feature: newsletters.length > 1 ? 'filterEmailDisabled' : undefined,
             buildNqlFilter: (flt) => {
@@ -73,8 +73,10 @@ export const SUBSCRIBED_FILTER = ({newsletters, feature, group}) => {
                         };
                     }
 
-                    return {
-                        text: 'Email enabled'
+                    return member.newsletters.length > 0 ? {
+                        text: 'Subscribed'
+                    } : {
+                        text: 'Unsubscribed'
                     };
                 }
 

--- a/ghost/admin/app/components/members/filters/subscribed.js
+++ b/ghost/admin/app/components/members/filters/subscribed.js
@@ -1,61 +1,161 @@
 import {MATCH_RELATION_OPTIONS} from './relation-options';
 
-export const SUBSCRIBED_FILTER = {
-    label: 'Newsletter subscription',
-    name: 'subscribed',
-    columnLabel: 'Subscribed',
-    relationOptions: MATCH_RELATION_OPTIONS,
-    valueType: 'options',
-    buildNqlFilter: (flt) => {
-        const relation = flt.relation;
-        const value = flt.value;
-
-        return (relation === 'is' && value === 'true') || (relation === 'is-not' && value === 'false')
-            ? '(subscribed:true+email_disabled:0)'
-            : '(subscribed:false,email_disabled:1)';
-    },
-    parseNqlFilter: (flt) => {
-        const comparator = flt.$and || flt.$or;
-
-        if (!comparator || comparator.length !== 2) {
-            return;
-        }
-
-        if (comparator[0].subscribed === undefined || comparator[1].email_disabled === undefined) {
-            return;
-        }
-
-        const subscribed = comparator[0].subscribed;
-
+export const SUBSCRIBED_FILTER = ({newsletters, feature, group}) => {
+    if (feature.filterEmailDisabled) {
         return {
-            value: subscribed ? 'true' : 'false',
-            relation: 'is'
-        };
-    },
-    options: [
-        {label: 'Subscribed', name: 'true'},
-        {label: 'Unsubscribed', name: 'false'}
-    ],
-    getColumnValue: (member, flt) => {
-        const relation = flt.relation;
-        const value = flt.value;
+            label: 'Newsletter subscription',
+            name: 'subscribed',
+            columnLabel: 'Subscribed',
+            relationOptions: MATCH_RELATION_OPTIONS,
+            valueType: 'options',
+            group,
+            // Only show the filter for multiple newsletters if feature flag is enabled
+            feature: newsletters.length > 1 ? 'filterEmailDisabled' : undefined,
+            buildNqlFilter: (flt) => {
+                const relation = flt.relation;
+                const value = flt.value;
 
-        return {
-            text: (relation === 'is' && value === 'true') || (relation === 'is-not' && value === 'false')
-                ? 'Subscribed'
-                : 'Unsubscribed'
+                if (value === 'email-disabled') {
+                    if (relation === 'is') {
+                        return '(email_disabled:1)';
+                    }
+                    return '(email_disabled:0)';
+                }
+
+                return (relation === 'is' && value === 'subscribed') || (relation === 'is-not' && value === 'unsubscribed')
+                    ? '(subscribed:true+email_disabled:0)'
+                    : '(subscribed:false+email_disabled:0)';
+            },
+            parseNqlFilter: (flt) => {
+                const comparator = flt.$and || flt.$or; // $or for legacy filter backwards compatibility
+
+                if (!comparator || comparator.length !== 2) {
+                    const filter = flt.yg || flt;
+                    if (filter && filter.email_disabled !== undefined) {
+                        if (filter.email_disabled) {
+                            return {
+                                value: 'email-disabled',
+                                relation: 'is'
+                            };
+                        }
+                        return {
+                            value: 'email-disabled',
+                            relation: 'is-not'
+                        };
+                    }
+                    return;
+                }
+
+                if (comparator[0].subscribed === undefined || comparator[1].email_disabled === undefined) {
+                    return;
+                }
+
+                const subscribed = comparator[0].subscribed;
+
+                return {
+                    value: subscribed ? 'subscribed' : 'unsubscribed',
+                    relation: 'is'
+                };
+            },
+            options: [
+                {label: newsletters.length > 1 ? 'Subscribed to one or more' : 'Subscribed', name: 'subscribed'},
+                {label: newsletters.length > 1 ? 'Unsubscribed from all' : 'Unsubscribed', name: 'unsubscribed'},
+                {label: 'Email disabled', name: 'email-disabled'}
+            ],
+            getColumnValue: (member, flt) => {
+                const relation = flt.relation;
+                const value = flt.value;
+
+                if (value === 'email-disabled') {
+                    if (relation === 'is') {
+                        return {
+                            text: 'Email disabled'
+                        };
+                    }
+
+                    return {
+                        text: 'Email enabled'
+                    };
+                }
+
+                if (member.emailSuppression && member.emailSuppression.suppressed) {
+                    return {
+                        text: 'Email disabled'
+                    };
+                }
+
+                return {
+                    text: (relation === 'is' && value === 'subscribed') || (relation === 'is-not' && value === 'unsubscribed')
+                        ? 'Subscribed'
+                        : 'Unsubscribed'
+                };
+            }
         };
     }
+
+    if (newsletters.length > 1) {
+        // Disable
+        // Only show the filter for multiple newsletters if feature flag is enabled
+        return [];
+    }
+
+    return {
+        label: 'Newsletter subscription',
+        name: 'subscribed',
+        columnLabel: 'Subscribed',
+        relationOptions: MATCH_RELATION_OPTIONS,
+        valueType: 'options',
+        group: group,
+        buildNqlFilter: (flt) => {
+            const relation = flt.relation;
+            const value = flt.value;
+
+            return (relation === 'is' && value === 'true') || (relation === 'is-not' && value === 'false')
+                ? '(subscribed:true+email_disabled:0)'
+                : '(subscribed:false,email_disabled:1)';
+        },
+        parseNqlFilter: (flt) => {
+            const comparator = flt.$and || flt.$or;
+
+            if (!comparator || comparator.length !== 2) {
+                return;
+            }
+
+            if (comparator[0].subscribed === undefined || comparator[1].email_disabled === undefined) {
+                return;
+            }
+
+            const subscribed = comparator[0].subscribed;
+
+            return {
+                value: subscribed ? 'true' : 'false',
+                relation: 'is'
+            };
+        },
+        options: [
+            {label: 'Subscribed', name: 'true'},
+            {label: 'Unsubscribed', name: 'false'}
+        ],
+        getColumnValue: (member, flt) => {
+            const relation = flt.relation;
+            const value = flt.value;
+
+            return {
+                text: (relation === 'is' && value === 'true') || (relation === 'is-not' && value === 'false')
+                    ? 'Subscribed'
+                    : 'Unsubscribed'
+            };
+        }
+    };
 };
 
-export const NEWSLETTERS_FILTER = (newsletterList) => {
-    let newsletters = [];
-    newsletterList.forEach((newsletter) => {
-        const filter = {
+export const NEWSLETTERS_FILTERS = ({newsletters, group}) => {
+    return newsletters.map((newsletter) => {
+        return {
             label: newsletter.name,
             name: `newsletters.slug:${newsletter.slug}`,
             relationOptions: MATCH_RELATION_OPTIONS,
-            group: 'Newsletters',
+            group,
             valueType: 'options',
             buildNqlFilter: (flt) => {
                 const relation = flt.relation;
@@ -98,9 +198,24 @@ export const NEWSLETTERS_FILTER = (newsletterList) => {
             options: [
                 {label: 'Subscribed', name: 'true'},
                 {label: 'Unsubscribed', name: 'false'}
-            ]
+            ],
+            columnLabel: newsletter.name,
+            getColumnValue: (member, flt) => {
+                const relation = flt.relation;
+                const value = flt.value;
+
+                if (member.emailSuppression && member.emailSuppression.suppressed) {
+                    return {
+                        text: 'Email disabled'
+                    };
+                }
+
+                return {
+                    text: (relation === 'is' && value === 'subscribed') || (relation === 'is-not' && value === 'unsubscribed')
+                        ? 'Subscribed'
+                        : 'Unsubscribed'
+                };
+            }
         };
-        newsletters.push(filter);
     });
-    return newsletters;
 };

--- a/ghost/admin/app/components/members/filters/subscribed.js
+++ b/ghost/admin/app/components/members/filters/subscribed.js
@@ -144,6 +144,9 @@ export const SUBSCRIBED_FILTER = ({newsletters, feature, group}) => {
 };
 
 export const NEWSLETTERS_FILTERS = ({newsletters, group, feature}) => {
+    if (newsletters.length <= 1) {
+        return [];
+    }
     return newsletters.map((newsletter) => {
         return {
             label: newsletter.name,

--- a/ghost/admin/app/components/members/filters/subscribed.js
+++ b/ghost/admin/app/components/members/filters/subscribed.js
@@ -78,12 +78,6 @@ export const SUBSCRIBED_FILTER = ({newsletters, feature, group}) => {
                     };
                 }
 
-                if (member.emailSuppression && member.emailSuppression.suppressed) {
-                    return {
-                        text: 'Email disabled'
-                    };
-                }
-
                 return {
                     text: (relation === 'is' && value === 'subscribed') || (relation === 'is-not' && value === 'unsubscribed')
                         ? 'Subscribed'
@@ -149,7 +143,7 @@ export const SUBSCRIBED_FILTER = ({newsletters, feature, group}) => {
     };
 };
 
-export const NEWSLETTERS_FILTERS = ({newsletters, group}) => {
+export const NEWSLETTERS_FILTERS = ({newsletters, group, feature}) => {
     return newsletters.map((newsletter) => {
         return {
             label: newsletter.name,
@@ -204,14 +198,16 @@ export const NEWSLETTERS_FILTERS = ({newsletters, group}) => {
                 const relation = flt.relation;
                 const value = flt.value;
 
-                if (member.emailSuppression && member.emailSuppression.suppressed) {
-                    return {
-                        text: 'Email disabled'
-                    };
+                if (feature.filterEmailDisabled) {
+                    if (member.emailSuppression && member.emailSuppression.suppressed) {
+                        return {
+                            text: 'Email disabled'
+                        };
+                    }
                 }
 
                 return {
-                    text: (relation === 'is' && value === 'subscribed') || (relation === 'is-not' && value === 'unsubscribed')
+                    text: (relation === 'is' && value === 'true') || (relation === 'is-not' && value === 'false')
                         ? 'Subscribed'
                         : 'Unsubscribed'
                 };

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -78,6 +78,7 @@ export default class FeatureService extends Service {
     @feature('recommendations') recommendations;
     @feature('lexicalIndicators') lexicalIndicators;
     @feature('editorEmojiPicker') editorEmojiPicker;
+    @feature('filterEmailDisabled') filterEmailDisabled;
 
     _user = null;
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -44,7 +44,9 @@ const ALPHA_FEATURES = [
     'importMemberTier',
     'lexicalIndicators',
     'listUnsubscribeHeader',
-    'adminXOffers'
+    'editorEmojiPicker',
+    'adminXOffers',
+    'filterEmailDisabled'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/members-api/lib/services/MemberBREADService.js
+++ b/ghost/members-api/lib/services/MemberBREADService.js
@@ -242,7 +242,7 @@ module.exports = class MemberBREADService {
 
         const suppressionData = await this.emailSuppressionList.getSuppressionData(member.email);
         member.email_suppression = {
-            suppressed: suppressionData.suppressed,
+            suppressed: suppressionData.suppressed || !!model.get('email_disabled'),
             info: suppressionData.info
         };
 
@@ -401,11 +401,10 @@ module.exports = class MemberBREADService {
         const subscriptions = page.data.flatMap(model => model.related('stripeSubscriptions').slice());
         const offerMap = await this.fetchSubscriptionOffers(subscriptions);
 
-        const members = page.data.map(model => model.toJSON(options));
+        const bulkSuppressionData = await this.emailSuppressionList.getBulkSuppressionData(page.data.map(member => member.get('email')));
 
-        const bulkSuppressionData = await this.emailSuppressionList.getBulkSuppressionData(members.map(member => member.email));
-
-        const data = members.map((member, index) => {
+        const data = page.data.map((model, index) => {
+            const member = model.toJSON(options);
             member.subscriptions = member.subscriptions.filter(sub => !!sub.price);
             this.attachSubscriptionsToMember(member);
             this.attachOffersToSubscriptions(member, offerMap);
@@ -413,7 +412,7 @@ module.exports = class MemberBREADService {
                 delete member.products;
             }
             member.email_suppression = {
-                suppressed: bulkSuppressionData[index].suppressed,
+                suppressed: bulkSuppressionData[index].suppressed || !!model.get('email_disabled'),
                 info: bulkSuppressionData[index].info
             };
             return member;

--- a/ghost/members-api/test/unit/lib/services/member-bread.test.js
+++ b/ghost/members-api/test/unit/lib/services/member-bread.test.js
@@ -42,7 +42,10 @@ describe('MemberBreadService', function () {
             memberModelStub = {
                 id: MEMBER_ID,
                 related: sinon.stub().returns([]),
-                toJSON: sinon.stub().returns({...memberModelJSON})
+                toJSON: sinon.stub().returns({...memberModelJSON}),
+                get: function (key) {
+                    return this[key];
+                }
             };
             memberRepositoryStub = {
                 get: sinon.stub().resolves(null),


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/4108

- Updates filters behind a new alpha feature flag so you can also filter on members who have email disabled (because the email had a permanent bounce, they reported spam or the email address is invalid)
- When returning members, we now also use the email_disabled flag to set email_suppression.suppressed correctly (in case they are out of sync, which should normally never happen).
