### PR TITLE
🐛 Fixed email rendering bug in Gmail for Android

### DIFF
--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -369,7 +369,8 @@ class EmailRenderer {
         }
 
         // Record the original image width and height attributes before inlining the styles with juice
-        // If any images have `width: auto` or `height: auto` set via CSS, juice will explicitly set the width/height to `auto` on the <img /> tag
+        // If any images have `width: auto` or `height: auto` set via CSS, 
+        // juice will explicitly set the width/height attributes to `auto` on the <img /> tag
         // This is not supported by Outlook, so we need to reset the width/height attributes to the original values
         // Other clients will ignore the width/height attributes and use the inlined CSS instead
         $ = cheerio.load(html);
@@ -390,12 +391,15 @@ class EmailRenderer {
         // Reset any `height="auto"` or `width="auto"` attributes to their original values before inlining CSS
         const imageTags = $('img').get();
         for (let i = 0; i < imageTags.length; i += 1) {
-            // if the newImage width or height is set to 'auto', reset to its original value
-            if (imageTags[i].attribs.width === 'auto' && originalImageSizes[i].width) {
-                imageTags[i].attribs.width = originalImageSizes[i].width;
-            }
-            if (imageTags[i].attribs.height === 'auto' && originalImageSizes[i].height) {
-                imageTags[i].attribs.height = originalImageSizes[i].height;
+            // There shouldn't be any issues with consistency between these two lists, but just in case...
+            if (imageTags[i].attribs.src === originalImageSizes[i].src) {
+                // if the image width or height is set to 'auto', reset to its original value
+                if (imageTags[i].attribs.width === 'auto' && originalImageSizes[i].width) {
+                    imageTags[i].attribs.width = originalImageSizes[i].width;
+                }
+                if (imageTags[i].attribs.height === 'auto' && originalImageSizes[i].height) {
+                    imageTags[i].attribs.height = originalImageSizes[i].height;
+                }
             }
         }
 

--- a/ghost/email-service/lib/email-templates/partials/styles-old.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles-old.hbs
@@ -638,6 +638,7 @@ a[data-flickr-embed] img {
     display: block;
     margin: 0 auto;
     height: auto;
+    width: auto;
 }
 
 .kg-bookmark-container {

--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -685,8 +685,8 @@ a[data-flickr-embed] img {
 .kg-image-card img {
     display: block;
     margin: 0 auto;
-    /* width: auto;
-    height: auto !important; */
+    width: auto;
+    height: auto !important;
 }
 
 .kg-bookmark-container {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/18587/files and https://github.com/TryGhost/Ghost/pull/17475/files

- In October 2022, `juice`, a library Ghost uses to inline CSS for email rendering, introduced a small change that began inlining `width: auto` and `height: auto` from CSS on image tags, resulting in `width="auto"` and `height="auto"` attributes being added to image tags in our email renderer. (https://github.com/Automattic/juice/commit/cb62062794e07cf4c0f30b16bd2c6b31b8144c41)
- This change in `juice` broke our email rendering in Outlook, which doesn't play well with `width="auto"` attributes. The first two attempts to workaround this new behavior in `juice` ended up fixing the issue in Outlook, but breaking the rendering in other renderers
- This commit stores the `height` and `width` attributes of all images _before_ inlining the CSS with `juice`, and resets them to their original values, only if they were set to `auto` 