### PR TITLE
Changed "latest posts" layout in email template on mobile

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
@@ -191,8 +191,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -308,35 +307,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -427,11 +421,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -736,7 +725,7 @@ exports[`Email Preview API Read can read post email preview with email card and 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "23946",
+  "content-length": "23765",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -841,8 +830,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -958,35 +946,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -1077,11 +1060,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -1406,7 +1384,7 @@ exports[`Email Preview API Read can read post email preview with fields 4: [head
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "28757",
+  "content-length": "28576",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1542,8 +1520,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -1659,35 +1636,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -1778,11 +1750,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -2094,7 +2061,7 @@ exports[`Email Preview API Read has custom content transformations for email com
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "23700",
+  "content-length": "23519",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2559,8 +2526,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -2676,35 +2642,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -2795,11 +2756,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -3121,7 +3077,7 @@ exports[`Email Preview API Read uses the newsletter provided through ?newsletter
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "24192",
+  "content-length": "24011",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3612,8 +3568,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -3729,35 +3684,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -3848,11 +3798,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -4174,7 +4119,7 @@ exports[`Email Preview API Read uses the posts newsletter by default 4: [headers
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "24192",
+  "content-length": "24011",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/integration/services/email-service/__snapshots__/batch-sending.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/batch-sending.test.js.snap
@@ -84,8 +84,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -201,35 +200,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -320,11 +314,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -709,8 +698,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -826,35 +814,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -945,11 +928,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -1320,8 +1298,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -1437,35 +1414,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -1556,11 +1528,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -1931,8 +1898,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -2048,35 +2014,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -2167,11 +2128,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -2542,8 +2498,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -2659,35 +2614,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -2778,11 +2728,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -3101,8 +3046,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -3218,35 +3162,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -3337,11 +3276,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -3712,8 +3646,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -3829,35 +3762,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -3948,11 +3876,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -4423,8 +4346,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -4540,35 +4462,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -4659,11 +4576,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -5090,8 +5002,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -5207,35 +5118,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -5326,11 +5232,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -5463,17 +5364,17 @@ table.body figcaption a {
 
                                 <tr>
                                     <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding: 24px 0; border-bottom: 1px solid #e5eff5; border-bottom: 1px solid rgba(0, 0, 0, 0.12);\\" valign=\\"top\\">
-                                        <h3 class=\\"latest-posts-header\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; text-rendering: optimizeLegibility; margin: 0; padding: 8px 0 16px; color: #000000; font-size: 14px; font-weight: 700; text-transform: uppercase;\\">Keep reading</h3>
+                                        <h3 class=\\"latest-posts-header\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; text-rendering: optimizeLegibility; margin: 0; padding: 8px 0 16px; color: #000000; font-size: 13px; font-weight: 700; text-transform: uppercase;\\">Keep reading</h3>
                                             <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                 <tr>
                                                     <td class=\\"latest-post\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding: 8px 0; max-width: 600px;\\" valign=\\"top\\">
                                                         <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                             <tr>
                                                                 <td valign=\\"top\\" align=\\"left\\" class=\\"latest-post-title\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-right: 12px;\\">
-                                                                    <h4 class style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; line-height: 1.2em; margin: 0; padding: 2px 0 4px; font-size: 19px; font-weight: 700;\\">
+                                                                    <h4 class style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; line-height: 1.2em; margin: 0; padding: 2px 0 4px; font-size: 18px; font-weight: 700;\\">
                                                                         <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; text-decoration: none; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
                                                                     </h4>
-                                                                        <p style=\\"line-height: 1.6em; margin: 0; padding: 0; color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 15px; font-weight: 400;\\">
+                                                                        <p class=\\"latest-post-excerpt\\" style=\\"line-height: 1.6em; margin: 0; padding: 0; color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 15px; font-weight: 400;\\">
                                                                             <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; text-decoration: none; color: #000000; color: rgba(0, 0, 0, 0.5);\\" target=\\"_blank\\">Hello world</a>
                                                                         </p>
                                                                 </td>
@@ -5488,10 +5389,10 @@ table.body figcaption a {
                                                         <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                             <tr>
                                                                 <td valign=\\"top\\" align=\\"left\\" class=\\"latest-post-title\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-right: 12px;\\">
-                                                                    <h4 class style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; line-height: 1.2em; margin: 0; padding: 2px 0 4px; font-size: 19px; font-weight: 700;\\">
+                                                                    <h4 class style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; line-height: 1.2em; margin: 0; padding: 2px 0 4px; font-size: 18px; font-weight: 700;\\">
                                                                         <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; text-decoration: none; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
                                                                     </h4>
-                                                                        <p style=\\"line-height: 1.6em; margin: 0; padding: 0; color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 15px; font-weight: 400;\\">
+                                                                        <p class=\\"latest-post-excerpt\\" style=\\"line-height: 1.6em; margin: 0; padding: 0; color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 15px; font-weight: 400;\\">
                                                                             <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; text-decoration: none; color: #000000; color: rgba(0, 0, 0, 0.5);\\" target=\\"_blank\\">Hello world</a>
                                                                         </p>
                                                                 </td>
@@ -5506,10 +5407,10 @@ table.body figcaption a {
                                                         <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                             <tr>
                                                                 <td valign=\\"top\\" align=\\"left\\" class=\\"latest-post-title\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-right: 12px;\\">
-                                                                    <h4 class style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; line-height: 1.2em; margin: 0; padding: 2px 0 4px; font-size: 19px; font-weight: 700;\\">
+                                                                    <h4 class style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; line-height: 1.2em; margin: 0; padding: 2px 0 4px; font-size: 18px; font-weight: 700;\\">
                                                                         <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; text-decoration: none; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
                                                                     </h4>
-                                                                        <p style=\\"line-height: 1.6em; margin: 0; padding: 0; color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 15px; font-weight: 400;\\">
+                                                                        <p class=\\"latest-post-excerpt\\" style=\\"line-height: 1.6em; margin: 0; padding: 0; color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 15px; font-weight: 400;\\">
                                                                             <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; text-decoration: none; color: #000000; color: rgba(0, 0, 0, 0.5);\\" target=\\"_blank\\">Hello world</a>
                                                                         </p>
                                                                 </td>
@@ -5846,8 +5747,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -5963,35 +5863,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -6082,11 +5977,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -6512,8 +6402,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -6629,35 +6518,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -6748,11 +6632,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -7178,8 +7057,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -7295,35 +7173,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -7414,11 +7287,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -7844,8 +7712,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -7961,35 +7828,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -8080,11 +7942,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -8510,8 +8367,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -8627,35 +8483,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -8746,11 +8597,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -9176,8 +9022,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -9293,35 +9138,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -9412,11 +9252,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -9789,8 +9624,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -9906,35 +9740,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -10025,11 +9854,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -84,8 +84,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -201,35 +200,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -320,11 +314,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {
@@ -695,8 +684,7 @@ Object {
   table.body p,
 table.body ul,
 table.body ol,
-table.body td,
-table.body span {
+table.body td {
     font-size: 16px !important;
   }
 
@@ -812,35 +800,30 @@ table.body .feedback-button-mobile-text {
   }
 
   table.body .latest-posts-header {
-    font-size: 14px !important;
-  }
-
-  table.body .latest-post-img {
-    display: none !important;
-  }
-
-  table.body .latest-post-img-mobile {
-    display: inline-block !important;
-    width: 100%;
+    font-size: 12px !important;
   }
 
   table.body .latest-post-title {
     display: inline-block !important;
     width: 100%;
-    padding-right: 0 !important;
-    padding-bottom: 8px !important;
+    padding-right: 8px !important;
   }
 
   table.body .latest-post h4,
 table.body .latest-post h4 span {
-    padding: 4px 0 !important;
-    font-size: 18px !important;
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
   }
 
-  table.body .latest-post p,
-table.body .latest-post p span {
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
     font-size: 13px !important;
-    line-height: 1.25em;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
   }
 
   table.body .subscription-box h3 {
@@ -931,11 +914,6 @@ table.body h2 span {
 
   table.body hr {
     margin: 2em 0 !important;
-  }
-
-  table.body figcaption,
-table.body figcaption a {
-    font-size: 13px !important;
   }
 }
 @media all {

--- a/ghost/email-service/lib/email-templates/partials/latest-posts.hbs
+++ b/ghost/email-service/lib/email-templates/partials/latest-posts.hbs
@@ -4,29 +4,12 @@
             <td class="latest-post">
                 <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                     <tr>
-                        {{#if ../latestPostsHasImages}}
-                            {{#if featureImage}}
-                                <td class="latest-post-img-mobile">
-                                    <a href="{{url}}">
-                                        <img
-                                            src="{{featureImageMobile.src}}"
-                                            {{#if featureImageMobile.width }}
-                                                width="{{featureImageMobile.width}}"
-                                            {{/if}}
-                                            {{#if featureImageMobile.height }}
-                                                height="{{featureImageMobile.height}}"
-                                            {{/if}}
-                                        />
-                                    </a>
-                                </td>
-                            {{/if}}
-                        {{/if}}
                         <td valign="top" align="left" class="latest-post-title">
                             <h4 class="{{#if ../latestPostsHasImages}}{{#if (not featureImage)}}no-image{{/if}}{{/if}}">
                                 <a href="{{url}}">{{{title}}}</a>
                             </h4>
                             {{#if excerpt}}
-                                <p>
+                                <p class="latest-post-excerpt">
                                     <a href="{{url}}">{{{excerpt}}}</a>
                                 </p>
                             {{/if}}

--- a/ghost/email-service/lib/email-templates/partials/styles-old.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles-old.hbs
@@ -268,7 +268,7 @@ figure {
 figcaption {
     text-align: center;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-    font-size: 14px;
+    font-size: 13px;
     padding-top: 5px;
     line-height: 1.5em;
 }
@@ -477,7 +477,7 @@ figure blockquote p {
     margin: 0;
     padding: 8px 0 16px;
     color: #15212A;
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 700;
     text-transform: uppercase;
 }
@@ -498,18 +498,8 @@ figure blockquote p {
     text-decoration: none;
 }
 
-.latest-post-img img,
-.latest-post-img-mobile img {
+.latest-post-img img {
     object-fit: cover;
-}
-
-.latest-post-img-mobile {
-    display: none;
-}
-
-.latest-post-img-mobile img {
-    width: 100% !important;
-    height: auto !important; /* Make sure CSS ignores the height that is defined in HTML, but keep the aspect ratio from the width/height in HTML */
 }
 
 .latest-post-title {
@@ -519,7 +509,7 @@ figure blockquote p {
 .latest-post h4 {
     margin: 0;
     padding: 2px 0 4px;
-    font-size: 19px;
+    font-size: 18px;
     font-weight: 700;
 }
 
@@ -1290,8 +1280,7 @@ a[data-flickr-embed] img {
     table.body p,
     table.body ul,
     table.body ol,
-    table.body td,
-    table.body span {
+    table.body td {
         font-size: 16px !important;
     }
 
@@ -1403,33 +1392,29 @@ a[data-flickr-embed] img {
     }
 
     table.body .latest-posts-header {
-        font-size: 14px !important;
-    }
-
-    table.body .latest-post-img {
-        display: none !important;
-    }
-
-    table.body .latest-post-img-mobile {
-        display: inline-block !important;
-        width: 100%;
+        font-size: 12px !important;
     }
 
     table.body .latest-post-title {
         display: inline-block !important;
         width: 100%;
-        padding-right: 0 !important;
-        padding-bottom: 8px !important;
+        padding-right: 8px !important;
     }
 
     table.body .latest-post h4, table.body .latest-post h4 span {
-        padding: 4px 0 !important;
-        font-size: 18px !important;
+        padding: 4px 0 6px !important;
+        font-size: 15px !important;
     }
 
-    table.body .latest-post p, table.body .latest-post p span {
+    table.body .latest-post-excerpt,
+    table.body .latest-post-excerpt a,
+    table.body .latest-post-excerpt span {
         font-size: 13px !important;
-        line-height: 1.25em;
+        line-height: 1.2 !important;
+    }
+
+    table.body .latest-post-excerpt span {
+        display: none !important;
     }
 
     table.body .subscription-box h3 {
@@ -1520,11 +1505,6 @@ a[data-flickr-embed] img {
 
     table.body hr {
         margin: 2em 0 !important;
-    }
-
-    table.body figcaption,
-    table.body figcaption a {
-        font-size: 13px !important;
     }
 
     table.body .kg-header-card.kg-v2 span {

--- a/ghost/email-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/email-service/lib/email-templates/partials/styles.hbs
@@ -293,7 +293,7 @@ figure {
 figcaption {
     text-align: center;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-    font-size: 14px;
+    font-size: 13px;
     padding-top: 5px;
     line-height: 1.5em;
 }
@@ -514,7 +514,7 @@ figure blockquote p {
     margin: 0;
     padding: 8px 0 16px;
     color: {{titleColor}};
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 700;
     text-transform: uppercase;
 }
@@ -536,18 +536,8 @@ figure blockquote p {
     text-decoration: none;
 }
 
-.latest-post-img img,
-.latest-post-img-mobile img {
+.latest-post-img img {
     object-fit: cover;
-}
-
-.latest-post-img-mobile {
-    display: none;
-}
-
-.latest-post-img-mobile img {
-    width: 100% !important;
-    height: auto !important; /* Make sure CSS ignores the height that is defined in HTML, but keep the aspect ratio from the width/height in HTML */
 }
 
 .latest-post-title {
@@ -557,7 +547,7 @@ figure blockquote p {
 .latest-post h4 {
     margin: 0;
     padding: 2px 0 4px;
-    font-size: 19px;
+    font-size: 18px;
     font-weight: 700;
 }
 
@@ -1367,8 +1357,7 @@ a[data-flickr-embed] img {
     table.body p,
     table.body ul,
     table.body ol,
-    table.body td,
-    table.body span {
+    table.body td {
         font-size: 16px !important;
     }
 
@@ -1485,33 +1474,29 @@ a[data-flickr-embed] img {
     }
 
     table.body .latest-posts-header {
-        font-size: 14px !important;
-    }
-
-    table.body .latest-post-img {
-        display: none !important;
-    }
-
-    table.body .latest-post-img-mobile {
-        display: inline-block !important;
-        width: 100%;
+        font-size: 12px !important;
     }
 
     table.body .latest-post-title {
         display: inline-block !important;
         width: 100%;
-        padding-right: 0 !important;
-        padding-bottom: 8px !important;
+        padding-right: 8px !important;
     }
 
     table.body .latest-post h4, table.body .latest-post h4 span {
-        padding: 4px 0 !important;
-        font-size: 18px !important;
+        padding: 4px 0 6px !important;
+        font-size: 15px !important;
     }
 
-    table.body .latest-post p, table.body .latest-post p span {
+    table.body .latest-post-excerpt,
+    table.body .latest-post-excerpt a,
+    table.body .latest-post-excerpt span {
         font-size: 13px !important;
-        line-height: 1.25em;
+        line-height: 1.2 !important;
+    }
+
+    table.body .latest-post-excerpt span {
+        display: none !important;
     }
 
     table.body .subscription-box h3 {
@@ -1603,12 +1588,6 @@ a[data-flickr-embed] img {
     table.body hr {
         margin: 2em 0 !important;
     }
-
-    table.body figcaption,
-    table.body figcaption a {
-        font-size: 13px !important;
-    }
-
 }
 
 /* -------------------------------------


### PR DESCRIPTION
Refs https://ghost.slack.com/archives/C019B1K4FAM/p1699127038805739

- Removed mobile styles so that latest posts are always in the same layout, instead of in a single column on mobile
- Fixed img caption font size rendering too large on mobile