### PR TITLE
Misc Sentry tweaks

### DIFF
--- a/apps/admin-x-design-system/src/global/ErrorBoundary.tsx
+++ b/apps/admin-x-design-system/src/global/ErrorBoundary.tsx
@@ -24,7 +24,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
 
     componentDidCatch(error: unknown, info: ErrorInfo) {
         Sentry.withScope((scope) => {
-            scope.setTag('adminX settings component-', info.componentStack);
+            scope.setTag('adminx_settings_component', info.componentStack);
             Sentry.captureException(error);
         });
         // eslint-disable-next-line no-console

--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -695,7 +695,6 @@ export default class LexicalEditorController extends Controller {
                     scope.setTag('post_type', post.isPage ? 'page' : 'post');
                     scope.setTag('save_revision', options.adapterOptions?.saveRevision);
                     scope.setTag('email_segment', options.adapterOptions?.emailSegment);
-                    scope.setTag('save_revision', options.adapterOptions?.saveRevision);
                     scope.setTag('convert_to_lexical', options.adapterOptions?.convertToLexical);
                 });
             }
@@ -708,7 +707,6 @@ export default class LexicalEditorController extends Controller {
                     scope.setTag('post_type', post.isPage ? 'page' : 'post');
                     scope.setTag('save_revision', options.adapterOptions?.saveRevision);
                     scope.setTag('email_segment', options.adapterOptions?.emailSegment);
-                    scope.setTag('save_revision', options.adapterOptions?.saveRevision);
                     scope.setTag('convert_to_lexical', options.adapterOptions?.convertToLexical);
                 });
             }

--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -305,9 +305,9 @@ class ajaxService extends AjaxService {
             method: request.method,
             status
         });
-        Sentry.setTag('ajaxStatus', status);
-        Sentry.setTag('ajaxUrl', request.url);
-        Sentry.setTag('ajaxMethod', request.method);
+        Sentry.setTag('ajax_status', status);
+        Sentry.setTag('ajax_url', request.url);
+        Sentry.setTag('ajax_method', request.method);
 
         if (headers['content-version']) {
             const contentVersion = semverCoerce(headers['content-version']);

--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -39,7 +39,7 @@ if (sentryConfig && !sentryConfig.disabled) {
                 event.tags.type = exception.errorType;
                 event.tags.code = exception.code;
                 event.tags.id = exception.id;
-                event.tags.statusCode = exception.statusCode;
+                event.tags.status_code = exception.statusCode;
             }
             return event;
         }


### PR DESCRIPTION
no refs

- Removed redundant duplicated `save_revision` tag when capturing slow saves
- Standardised Sentry tags casing (`snake_case`)
- Renamed tag `adminX settings component-` to `adminx_settings_component`