### PR TITLE
Fixed metadata for recommendations from private sites

### DIFF
--- a/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
+++ b/ghost/core/core/frontend/apps/private-blogging/lib/views/private.hbs
@@ -6,7 +6,34 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
         <title>{{@site.title}}</title>
+        <meta property="og:type" content="website">
+        <meta property="og:site_name" content="{{@site.title}}">
+        <meta property="og:title" content="{{@site.title}}">
+        <meta name="twitter:title" content="{{@site.title}}">
 
+        <link rel="canonical" href="{{@site.url}}">
+        <meta property="og:url" content="{{@site.url}}">
+        <meta name="twitter:url" content="{{@site.url}}">
+
+        {{#if @site.icon}}
+            <link rel="icon" href="{{img_url @site.icon absolute="true"}}" type="image/png">
+        {{/if}}
+
+        {{#if @site.description}}
+            <meta name="description" content="{{@site.description}}">
+            <meta property="og:description" content="{{@site.description}}">
+            <meta name="twitter:description" content="{{@site.description}}">
+        {{/if}}
+
+        {{#if @site.cover_image}}
+            <meta property="og:image" content="{{img_url @site.cover_image absolute="true"}}">
+            <meta name="twitter:image" content="{{img_url @site.cover_image absolute="true"}}">
+        {{/if}}
+
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:site" content="@ghost">
+        <meta property="article:publisher" content="https://www.facebook.com/ghost">
+        <meta name="referrer" content="no-referrer-when-downgrade">
         <meta name="HandheldFriendly" content="True">
         <meta name="MobileOptimized" content="320">
         <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4098
- added basic metadata (title, description, image, url) on the password wall for private sites
- when a private site recommends me, I can now see the usual metadata
