### PR TITLE
Made new recommendation email more flexible

### DIFF
--- a/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
+++ b/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
@@ -347,6 +347,13 @@ exports[`Incoming Recommendation Emails Sends an email if we receive a recommend
         padding-left: 20px;
         border-left: 3px solid #DDE1E5;
       }
+      .recommendation-card--outlook {
+    	margin: 0;
+        padding: 0;
+        width: 100%;
+        border: 1px solid #F9F9FA;
+        background: #F9F9FA;
+      }
     </style>
   </head>
   <body style=\\"background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;\\">
@@ -371,35 +378,33 @@ exports[`Incoming Recommendation Emails Sends an email if we receive a recommend
                           <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 16px;\\">Other Ghost Site is <strong>recommending you</strong> to their audience. Now, every time someone new signs up on their site, they’ll see an option to check out Ghost as well.</p>
 
                         <!--[if !mso !vml]-->
-                        <figure style=\\"margin:0 0 1.5em;padding:0;width:100%;\\">
-                          <a style=\\"display:flex;min-height:110px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none\\" href=\\"https://www.otherghostsite.com/\\">
+                        <figure style=\\"margin:0 0 1.5em;padding:0;width:100%;background:#F9F9FA;\\">
+                          <a style=\\"display:flex;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none\\" href=\\"https://www.otherghostsite.com/\\">
                             <div style=\\"display:inline-block; width:100%; padding:20px\\">
                               <div style=\\"color:#15212a;font-size:13px;font-weight:400\\">
                                 
                                 <div style=\\"color:#15212a;font-size:16px;line-height:1.3em;font-weight:600\\">Other Ghost Site</div>
                               </div>
-                              <div class=\\"kg-bookmark-description\\" style=\\"display:-webkit-box;overflow-y:hidden;margin-top:6px;max-height:40px;color:#738a94;font-size:13px;line-height:1.5em;font-weight:400;-webkit-line-clamp: 2; -webkit-box-orient: vertical;\\"></div>
                             </div>
                           </a>
                         </figure>
                         <!--[endif]-->
 
                         <!--[if vml]>
-                        <table style=\\"border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; border: 1px solid #f9f9fa; background: #f9f9fa; font-family: -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Oxygen, Ubuntu, Cantarell, \\"Open Sans\\", \\"Helvetica Neue\\", sans-serif;\\">
+                        <table style=\\"border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; border: 1px solid #F9F9FA; font-family: -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Oxygen, Ubuntu, Cantarell, \\"Open Sans\\", \\"Helvetica Neue\\", sans-serif; background-color:#F9F9FA;\\" class=\\"recommendation-card--outlook\\">
                             <tr>
                                 <td width=\\"100%\\" style=\\"padding: 20px;background-color:#F9F9FA;\\">
                                     <table style=\\"margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;\\">
                                         <tr>
-                                            <td style=\\"padding-bottom: 12px;\\">
+                                            <td>
                                               <table style=\\"margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;\\">
                                                   <tr>
-                                                      <td><a style=\\"color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600; text-decoration: none;\\" href=\\"\\"></a></td>
+                                                      <td><a style=\\"color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600; text-decoration: none;\\" href=\\"https://www.otherghostsite.com/\\">Other Ghost Site</a></td>
                                                   </tr>
                                               </table>
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td><div><a href=\\"\\" style=\\"margin-top: 12px; color: #738a94; font-size: 13px; line-height: 1.5em; font-weight: 400;text-decoration: none;\\"></a></div></td>
                                         </tr>
                                     </table>
                                 </td>
@@ -568,6 +573,13 @@ exports[`Incoming Recommendation Emails Sends an email if we receive a recommend
         padding-left: 20px;
         border-left: 3px solid #DDE1E5;
       }
+      .recommendation-card--outlook {
+    	margin: 0;
+        padding: 0;
+        width: 100%;
+        border: 1px solid #F9F9FA;
+        background: #F9F9FA;
+      }
     </style>
   </head>
   <body style=\\"background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;\\">
@@ -592,35 +604,33 @@ exports[`Incoming Recommendation Emails Sends an email if we receive a recommend
                           <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 16px;\\">Other Ghost Site is <strong>recommending you</strong> to their audience. Now, every time someone new signs up on their site, they’ll see an option to check out Ghost as well.</p>
 
                         <!--[if !mso !vml]-->
-                        <figure style=\\"margin:0 0 1.5em;padding:0;width:100%;\\">
-                          <a style=\\"display:flex;min-height:110px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none\\" href=\\"https://www.otherghostsite.com/\\">
+                        <figure style=\\"margin:0 0 1.5em;padding:0;width:100%;background:#F9F9FA;\\">
+                          <a style=\\"display:flex;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none\\" href=\\"https://www.otherghostsite.com/\\">
                             <div style=\\"display:inline-block; width:100%; padding:20px\\">
                               <div style=\\"color:#15212a;font-size:13px;font-weight:400\\">
                                 
                                 <div style=\\"color:#15212a;font-size:16px;line-height:1.3em;font-weight:600\\">Other Ghost Site</div>
                               </div>
-                              <div class=\\"kg-bookmark-description\\" style=\\"display:-webkit-box;overflow-y:hidden;margin-top:6px;max-height:40px;color:#738a94;font-size:13px;line-height:1.5em;font-weight:400;-webkit-line-clamp: 2; -webkit-box-orient: vertical;\\"></div>
                             </div>
                           </a>
                         </figure>
                         <!--[endif]-->
 
                         <!--[if vml]>
-                        <table style=\\"border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; border: 1px solid #f9f9fa; background: #f9f9fa; font-family: -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Oxygen, Ubuntu, Cantarell, \\"Open Sans\\", \\"Helvetica Neue\\", sans-serif;\\">
+                        <table style=\\"border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; border: 1px solid #F9F9FA; font-family: -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Oxygen, Ubuntu, Cantarell, \\"Open Sans\\", \\"Helvetica Neue\\", sans-serif; background-color:#F9F9FA;\\" class=\\"recommendation-card--outlook\\">
                             <tr>
                                 <td width=\\"100%\\" style=\\"padding: 20px;background-color:#F9F9FA;\\">
                                     <table style=\\"margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;\\">
                                         <tr>
-                                            <td style=\\"padding-bottom: 12px;\\">
+                                            <td>
                                               <table style=\\"margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;\\">
                                                   <tr>
-                                                      <td><a style=\\"color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600; text-decoration: none;\\" href=\\"\\"></a></td>
+                                                      <td><a style=\\"color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600; text-decoration: none;\\" href=\\"https://www.otherghostsite.com/\\">Other Ghost Site</a></td>
                                                   </tr>
                                               </table>
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td><div><a href=\\"\\" style=\\"margin-top: 12px; color: #738a94; font-size: 13px; line-height: 1.5em; font-weight: 400;text-decoration: none;\\"></a></div></td>
                                         </tr>
                                     </table>
                                 </td>

--- a/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
+++ b/ghost/core/test/e2e-server/services/__snapshots__/recommendation-emails.test.js.snap
@@ -108,6 +108,13 @@ exports[`Incoming Recommendation Emails Sends a different email if we receive a 
         padding-left: 20px;
         border-left: 3px solid #DDE1E5;
       }
+      .recommendation-card--outlook {
+    	margin: 0;
+        padding: 0;
+        width: 100%;
+        border: 1px solid #F9F9FA;
+        background: #F9F9FA;
+      }
     </style>
   </head>
   <body style=\\"background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;\\">
@@ -132,35 +139,33 @@ exports[`Incoming Recommendation Emails Sends a different email if we receive a 
                           <p style=\\"font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 16px;\\">A site you’re recommending is now <strong>recommending you back</strong>:</p>
 
                         <!--[if !mso !vml]-->
-                        <figure style=\\"margin:0 0 1.5em;padding:0;width:100%;\\">
-                          <a style=\\"display:flex;min-height:110px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none\\" href=\\"https://www.otherghostsite.com/\\">
+                        <figure style=\\"margin:0 0 1.5em;padding:0;width:100%;background:#F9F9FA;\\">
+                          <a style=\\"display:flex;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none\\" href=\\"https://www.otherghostsite.com/\\">
                             <div style=\\"display:inline-block; width:100%; padding:20px\\">
                               <div style=\\"color:#15212a;font-size:13px;font-weight:400\\">
                                 
                                 <div style=\\"color:#15212a;font-size:16px;line-height:1.3em;font-weight:600\\">Other Ghost Site</div>
                               </div>
-                              <div class=\\"kg-bookmark-description\\" style=\\"display:-webkit-box;overflow-y:hidden;margin-top:6px;max-height:40px;color:#738a94;font-size:13px;line-height:1.5em;font-weight:400;-webkit-line-clamp: 2; -webkit-box-orient: vertical;\\"></div>
                             </div>
                           </a>
                         </figure>
                         <!--[endif]-->
 
                         <!--[if vml]>
-                        <table style=\\"border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; border: 1px solid #f9f9fa; background: #f9f9fa; font-family: -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Oxygen, Ubuntu, Cantarell, \\"Open Sans\\", \\"Helvetica Neue\\", sans-serif;\\">
+                        <table style=\\"border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; border: 1px solid #F9F9FA; font-family: -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Oxygen, Ubuntu, Cantarell, \\"Open Sans\\", \\"Helvetica Neue\\", sans-serif; background-color:#F9F9FA;\\" class=\\"recommendation-card--outlook\\">
                             <tr>
                                 <td width=\\"100%\\" style=\\"padding: 20px;background-color:#F9F9FA;\\">
                                     <table style=\\"margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;\\">
                                         <tr>
-                                            <td style=\\"padding-bottom: 12px;\\">
+                                            <td>
                                               <table style=\\"margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;\\">
                                                   <tr>
-                                                      <td><a style=\\"color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600; text-decoration: none;\\" href=\\"\\"></a></td>
+                                                      <td><a style=\\"color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600; text-decoration: none;\\" href=\\"https://www.otherghostsite.com/\\">Other Ghost Site</a></td>
                                                   </tr>
                                               </table>
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td><div><a href=\\"\\" style=\\"margin-top: 12px; color: #738a94; font-size: 13px; line-height: 1.5em; font-weight: 400;text-decoration: none;\\"></a></div></td>
                                         </tr>
                                     </table>
                                 </td>

--- a/ghost/staff-service/lib/email-templates/partials/styles.hbs
+++ b/ghost/staff-service/lib/email-templates/partials/styles.hbs
@@ -99,4 +99,11 @@
     padding-left: 20px;
     border-left: 3px solid #DDE1E5;
   }
+  .recommendation-card--outlook {
+	margin: 0;
+    padding: 0;
+    width: 100%;
+    border: 1px solid #F9F9FA;
+    background: #F9F9FA;
+  }
 </style>

--- a/ghost/staff-service/lib/email-templates/recommendation-received.hbs
+++ b/ghost/staff-service/lib/email-templates/recommendation-received.hbs
@@ -33,14 +33,16 @@
                         {{/if}}
 
                         <!--[if !mso !vml]-->
-                        <figure style="margin:0 0 1.5em;padding:0;width:100%;">
-                          <a style="display:flex;min-height:110px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none" href="{{recommendation.url}}">
+                        <figure style="margin:0 0 1.5em;padding:0;width:100%;background:#F9F9FA;">
+                          <a style="display:flex;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;background:#F9F9FA;border-radius:3px;border:1px solid #F9F9FA;color:#15171a;text-decoration:none" href="{{recommendation.url}}">
                             <div style="display:inline-block; width:100%; padding:20px">
                               <div style="color:#15212a;font-size:13px;font-weight:400">
                                 {{#if recommendation.favicon}}<img style="border:none;max-width:100%;margin-right:8px;margin-bottom:8px;width:20px;height:20px" src="{{recommendation.favicon}}" alt="">{{/if}}
                                 <div style="color:#15212a;font-size:16px;line-height:1.3em;font-weight:600">{{recommendation.title}}</div>
                               </div>
-                              <div class="kg-bookmark-description" style="display:-webkit-box;overflow-y:hidden;margin-top:6px;max-height:40px;color:#738a94;font-size:13px;line-height:1.5em;font-weight:400;-webkit-line-clamp: 2; -webkit-box-orient: vertical;">{{recommendation.excerpt}}</div>
+                              {{#if recommendation.excerpt}}
+                                <div class="kg-bookmark-description" style="display:-webkit-box;overflow-y:hidden;margin-top:6px;max-height:40px;color:#738a94;font-size:13px;line-height:1.5em;font-weight:400;-webkit-line-clamp: 2; -webkit-box-orient: vertical;">{{recommendation.excerpt}}</div>
+                              {{/if}}
                             </div>
                             {{#if recommendation.featuredImage}}
                               <div style="min-width: 140px; max-width: 180px; background-repeat: no-repeat; background-size: cover; background-position: center; border-radius: 0 2px 2px 0;background-image: url('{{recommendation.featuredImage}}')" class="new-mention-thumbnail">
@@ -52,26 +54,30 @@
                         <!--[endif]-->
 
                         <!--[if vml]>
-                        <table style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; border: 1px solid #f9f9fa; background: #f9f9fa; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;">
+                        <table style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; border: 1px solid #F9F9FA; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif; background-color:#F9F9FA;" class="recommendation-card--outlook">
                             <tr>
                                 <td width="100%" style="padding: 20px;background-color:#F9F9FA;">
                                     <table style="margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;">
                                         <tr>
-                                            <td style="padding-bottom: 12px;">
+                                            <td>
                                               <table style="margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;">
+                                                  {{#if recommendation.favicon}}
+                                                    <tr>
+                                                        <td valign="middle" style="padding-bottom: 8px; font-size: 0; line-height: 1.5em">
+                                                            <a href="{{recommendation.url}}" style="color: #15212A; text-decoration: none;"><img src="{{recommendation.favicon}}" width="20" height="20" alt=" "></a>
+                                                        </td>
+                                                    </tr>
+                                                  {{/if}}
                                                   <tr>
-                                                      {{#if sourceFavicon}}
-                                                          <td valign="middle" style="padding-right: 8px; font-size: 0; line-height: 1.5em">
-                                                              <a href="{{sourceUrl}}" style="color: #15212A; text-decoration: none;"><img src="{{sourceFavicon}}" width="20" height="20" alt=" "></a>
-                                                          </td>
-                                                      {{/if}}
-                                                      <td><a style="color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600; text-decoration: none;" href="{{sourceUrl}}">{{sourceTitle}}</a></td>
+                                                      <td><a style="color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600; text-decoration: none;" href="{{recommendation.url}}">{{recommendation.title}}</a></td>
                                                   </tr>
                                               </table>
                                             </td>
                                         </tr>
                                         <tr>
-                                            <td><div><a href="{{sourceUrl}}" style="margin-top: 12px; color: #738a94; font-size: 13px; line-height: 1.5em; font-weight: 400;text-decoration: none;">{{sourceExcerpt}}</a></div></td>
+                                          {{#if recommendation.excerpt}}
+                                            <td style="padding-top: 12px;"><div><a href="{{recommendation.url}}" style="color: #738a94; font-size: 13px; line-height: 1.5em; font-weight: 400;text-decoration: none;">{{recommendation.excerpt}}</a></div></td>
+                                          {{/if}}
                                         </tr>
                                     </table>
                                 </td>


### PR DESCRIPTION
- Removes `min-height` of the card in order to make the template more flexible half-empty states look better (missing description, short description, featured image...)
- Fixes wrong variables used in Outlook-specific template 
