### PR TITLE
Reverted ember-cli-terser to 4.0.1

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -84,7 +84,7 @@
     "ember-cli-postcss": "6.0.1",
     "ember-cli-shims": "1.2.0",
     "ember-cli-string-helpers": "6.1.0",
-    "ember-cli-terser": "4.0.2",
+    "ember-cli-terser": "4.0.1",
     "ember-cli-test-loader": "3.1.0",
     "ember-composable-helpers": "5.0.0",
     "ember-concurrency": "2.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15361,10 +15361,10 @@ ember-cli-string-utils@^1.0.0, ember-cli-string-utils@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz#39b677fc2805f55173735376fcef278eaa4452a1"
   integrity sha512-PlJt4fUDyBrC/0X+4cOpaGCiMawaaB//qD85AXmDRikxhxVzfVdpuoec02HSiTGTTB85qCIzWBIh8lDOiMyyFg==
 
-ember-cli-terser@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-terser/-/ember-cli-terser-4.0.2.tgz#c436a9e4159f76a615b051cba0584844652b7dcd"
-  integrity sha512-Ej77K+YhCZImotoi/CU2cfsoZaswoPlGaM5TB3LvjvPDlVPRhxUHO2RsaUVC5lsGeRLRiHCOxVtoJ6GyqexzFA==
+ember-cli-terser@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-terser/-/ember-cli-terser-4.0.1.tgz#0da0b8f2b09989e8c992b207553ddec1bbb65915"
+  integrity sha512-vvp0uVl8reYeW9EZjSXRPR3Bq7y4u9CYlUdI7j/WzMPDj3/gUHU4Z7CHYOCrftrClQvFfqO2eXmHwDA6F7SLug==
   dependencies:
     broccoli-terser-sourcemap "^4.1.0"
 


### PR DESCRIPTION
no issue

- ember-cli-terser 4.0.2 apparently has a regression that breaks the sourcemap generation for the admin ember app
- this reverts the package to 4.0.1, which fixes the sourcemaps and should generate much more readable stack traces in Sentry
- Validating the sourcemaps locally succeeded, but will need to test this on staging to confirm everything is working properly in CI and with the CDN.