### PR TITLE
Fixed admin sourcemap fingerprinting for chunk files

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -121,7 +121,8 @@ module.exports = function (defaults) {
                 'woff2',
                 'mp4',
                 'ico'
-            ]
+            ],
+            exclude: ['**/chunk*.map']
         },
         minifyJS: {
             options: {


### PR DESCRIPTION
no issue

- The fingerprinting on chunk files was happening twice (once by ember and once by webpack), resulting in the .js file and the .map file not matching
- This change prevents ember from fingerprinting the chunk.*.map files, so the resulting .map and .js files will have the same basename
- No real functional difference here, just a bit easier to find the corresponding .map file for a given .js file