### PR TITLE
Added ember-cli-terser to ignoreDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
       "validator",
       "codemirror",
       "faker",
-      "ember-cli-code-coverage"
+      "ember-cli-code-coverage",
+      "ember-cli-terser"
     ],
     "ignorePaths": [
       "test",


### PR DESCRIPTION
no issue

- ember-cli-terser v4.0.2 has a regression that breaks our sourcemaps
- In a previous commit, I reverted to v4.0.1, but I didn't add the package to ignoreDeps
- This change is to prevent rennovate from upgrading to v4.0.2 again