### PR TITLE
🐛 Fix edge case resulting in duplicate emails for some recipients

### DIFF
--- a/ghost/email-service/lib/BatchSendingService.js
+++ b/ghost/email-service/lib/BatchSendingService.js
@@ -247,7 +247,7 @@ class BatchSendingService {
             while (!members || lastId) {
                 logging.info(`Fetching members batch for email ${email.id} segment ${segment}, lastId: ${lastId}`);
 
-                const filter = segmentFilter + `+id:<${lastId}`;
+                const filter = segmentFilter + `+id:<'${lastId}'`;
                 members = await this.#models.Member.getFilteredCollectionQuery({filter})
                     .orderByRaw('id DESC')
                     .select('members.id', 'members.uuid', 'members.email', 'members.name').limit(BATCH_SIZE + 1);

--- a/ghost/email-service/test/batch-sending-service.test.js
+++ b/ghost/email-service/test/batch-sending-service.test.js
@@ -298,6 +298,10 @@ describe('Batch Sending Service', function () {
                 }));
 
                 const q = nql(filter);
+                // Check that the filter id:<${lastId} is a string
+                // In rare cases when the object ID is numeric, the query returns unexpected results
+                assert.equal(typeof q.toJSON().$and[2].id.$lt, 'string');
+
                 const all = members.filter((member) => {
                     return q.queryJSON(member.toJSON());
                 });
@@ -394,6 +398,10 @@ describe('Batch Sending Service', function () {
 
             Member.getFilteredCollectionQuery = ({filter}) => {
                 const q = nql(filter);
+                // Check that the filter id:<${lastId} is a string
+                // In rare cases when the object ID is numeric, the query returns unexpected results
+                assert.equal(typeof q.toJSON().$and[2].id.$lt, 'string');
+
                 const all = members.filter((member) => {
                     return q.queryJSON(member.toJSON());
                 });
@@ -494,6 +502,10 @@ describe('Batch Sending Service', function () {
 
             Member.getFilteredCollectionQuery = ({filter}) => {
                 const q = nql(filter);
+                // Check that the filter id:<${lastId} is a string
+                // In rare cases when the object ID is numeric, the query returns unexpected results
+                assert.equal(typeof q.toJSON().$and[2].id.$lt, 'string');
+
                 const all = members.filter((member) => {
                     return q.queryJSON(member.toJSON());
                 });

--- a/ghost/email-service/test/batch-sending-service.test.js
+++ b/ghost/email-service/test/batch-sending-service.test.js
@@ -459,15 +459,42 @@ describe('Batch Sending Service', function () {
 
             const members = [
                 // will create ids 0-9
-                ...new Array(10).fill(0).map((i,index) => createModel({
-                    id: index,
+                createModel({
+                    id: '6457649752fe260001430e5d', // object id < member #3
                     email: `test@numericid.com`,
                     uuid: 12345,
                     status: 'free',
                     newsletters: [
                         newsletter
                     ]
-                }))
+                }),
+                createModel({
+                    id: '641ed866c32a4f003d78704a', // object id < member #3
+                    email: `test2@numericid.com`,
+                    uuid: 12346,
+                    status: 'free',
+                    newsletters: [
+                        newsletter
+                    ]
+                }),
+                createModel({ // member #3
+                    id: '650706040078550001536020', // numeric object id
+                    email: `test3@numericid.com`,
+                    uuid: 12347,
+                    status: 'free',
+                    newsletters: [
+                        newsletter
+                    ]
+                }),
+                createModel({
+                    id: '633c23615de215003dcf6671', // object id < member #3
+                    email: `test4@numericid.com`,
+                    uuid: 12348,
+                    status: 'free',
+                    newsletters: [
+                        newsletter
+                    ]
+                })
             ];
 
             const initialMembers = members.slice();
@@ -496,7 +523,7 @@ describe('Batch Sending Service', function () {
                 },
                 sendingService: {
                     getMaximumRecipients() {
-                        return 5;
+                        return 3; // pick a batch size that ends with a numeric member object id
                     }
                 },
                 emailSegmenter: {
@@ -507,7 +534,7 @@ describe('Batch Sending Service', function () {
                 db
             });
 
-            const email = createModel({id: 99999});
+            const email = createModel({});
 
             const batches = await service.createBatches({
                 email,
@@ -518,18 +545,19 @@ describe('Batch Sending Service', function () {
             assert.equal(batches.length, 2);
 
             const calls = insert.getCalls();
+            calls.forEach(call => console.log(`call.args[0]`,call.args[0]))
             assert.equal(calls.length, 2);
 
-            const insertedRecipients = calls.flatMap(call => call.args[0]);
+            // const insertedRecipients = calls.flatMap(call => call.args[0]);
             // assert.equal(insertedRecipients.length, 5);
 
-            console.log(`insertedRecipients`,insertedRecipients)
+            // console.log(`insertedRecipients`,insertedRecipients)
 
             // Check all recipients match initialMembers
-            assert.deepEqual(insertedRecipients.map(recipient => recipient.member_id).sort(), initialMembers.map(member => member.id).sort());
+            // assert.deepEqual(insertedRecipients.map(recipient => recipient.member_id).sort(), initialMembers.map(member => member.id).sort());
 
             // Check email_count set
-            assert.equal(email.get('email_count'), 5);
+            assert.equal(email.get('email_count'), 4);
         });
     });
 

--- a/ghost/email-service/test/batch-sending-service.test.js
+++ b/ghost/email-service/test/batch-sending-service.test.js
@@ -459,14 +459,14 @@ describe('Batch Sending Service', function () {
 
             const members = [
                 createModel({
-                    id: '61a55008a9d68c003baec6df', // object id < member #3
+                    id: '61a55008a9d68c003baec6df',
                     email: `test2@numericid.com`,
                     status: 'free',
                     newsletters: [
                         newsletter
                     ]
                 }),
-                createModel({ // member #3
+                createModel({
                     id: '650706040078550001536020', // numeric object id
                     email: `test3@numericid.com`,
                     status: 'free',
@@ -475,7 +475,7 @@ describe('Batch Sending Service', function () {
                     ]
                 }),
                 createModel({
-                    id: '65070957007855000153605b', // object id > member #3
+                    id: '65070957007855000153605b',
                     email: `test4@numericid.com`,
                     status: 'free',
                     newsletters: [

--- a/ghost/email-service/test/batch-sending-service.test.js
+++ b/ghost/email-service/test/batch-sending-service.test.js
@@ -269,7 +269,7 @@ describe('Batch Sending Service', function () {
         });
     });
 
-    describe.only('createBatches', function () {
+    describe('createBatches', function () {
         it('works even when new members are added', async function () {
             const Member = createModelClass({});
             const EmailBatch = createModelClass({});
@@ -300,7 +300,7 @@ describe('Batch Sending Service', function () {
                 const q = nql(filter);
                 // Check that the filter id:<${lastId} is a string
                 // In rare cases when the object ID is numeric, the query returns unexpected results
-                assert.equal(typeof q.toJSON().$and[2].id.$lt, 'string');
+                assert.equal(typeof q.toJSON().$and[1].id.$lt, 'string');
 
                 const all = members.filter((member) => {
                     return q.queryJSON(member.toJSON());

--- a/ghost/email-service/test/batch-sending-service.test.js
+++ b/ghost/email-service/test/batch-sending-service.test.js
@@ -460,7 +460,8 @@ describe('Batch Sending Service', function () {
             const members = [
                 createModel({
                     id: '61a55008a9d68c003baec6df',
-                    email: `test2@numericid.com`,
+                    email: `test1@numericid.com`,
+                    uuid: 'test1',
                     status: 'free',
                     newsletters: [
                         newsletter
@@ -468,7 +469,8 @@ describe('Batch Sending Service', function () {
                 }),
                 createModel({
                     id: '650706040078550001536020', // numeric object id
-                    email: `test3@numericid.com`,
+                    email: `test2@numericid.com`,
+                    uuid: 'test2',
                     status: 'free',
                     newsletters: [
                         newsletter
@@ -476,7 +478,8 @@ describe('Batch Sending Service', function () {
                 }),
                 createModel({
                     id: '65070957007855000153605b',
-                    email: `test4@numericid.com`,
+                    email: `test3@numericid.com`,
+                    uuid: 'test3',
                     status: 'free',
                     newsletters: [
                         newsletter
@@ -496,6 +499,8 @@ describe('Batch Sending Service', function () {
                 all.sort((a, b) => {
                     return b.id.localeCompare(a.id);
                 });
+
+                console.log(filter,all)
 
                 return createDb({
                     all: all.map(member => member.toJSON())
@@ -533,6 +538,7 @@ describe('Batch Sending Service', function () {
                 newsletter
             });
             assert.equal(batches.length, 2);
+            console.log(`batches`,batches)
 
             const calls = insert.getCalls();
             assert.equal(calls.length, 2);
@@ -540,7 +546,7 @@ describe('Batch Sending Service', function () {
             const insertedRecipients = calls.flatMap(call => call.args[0]);
             assert.equal(insertedRecipients.length, 3);
 
-            // console.log(`insertedRecipients`,insertedRecipients)
+            console.log(`insertedRecipients`,insertedRecipients)
 
             // Check all recipients match initialMembers
             assert.deepEqual(insertedRecipients.map(recipient => recipient.member_id).sort(), initialMembers.map(member => member.id).sort());

--- a/ghost/email-service/test/batch-sending-service.test.js
+++ b/ghost/email-service/test/batch-sending-service.test.js
@@ -458,20 +458,9 @@ describe('Batch Sending Service', function () {
             const newsletter = createModel({});
 
             const members = [
-                // will create ids 0-9
                 createModel({
-                    id: '6457649752fe260001430e5d', // object id < member #3
-                    email: `test@numericid.com`,
-                    uuid: 12345,
-                    status: 'free',
-                    newsletters: [
-                        newsletter
-                    ]
-                }),
-                createModel({
-                    id: '641ed866c32a4f003d78704a', // object id < member #3
+                    id: '61a55008a9d68c003baec6df', // object id < member #3
                     email: `test2@numericid.com`,
-                    uuid: 12346,
                     status: 'free',
                     newsletters: [
                         newsletter
@@ -480,16 +469,14 @@ describe('Batch Sending Service', function () {
                 createModel({ // member #3
                     id: '650706040078550001536020', // numeric object id
                     email: `test3@numericid.com`,
-                    uuid: 12347,
                     status: 'free',
                     newsletters: [
                         newsletter
                     ]
                 }),
                 createModel({
-                    id: '633c23615de215003dcf6671', // object id < member #3
+                    id: '65070957007855000153605b', // object id > member #3
                     email: `test4@numericid.com`,
-                    uuid: 12348,
                     status: 'free',
                     newsletters: [
                         newsletter
@@ -505,7 +492,11 @@ describe('Batch Sending Service', function () {
                     return q.queryJSON(member.toJSON());
                 });
 
-                console.log(filter,all)
+                // Sort all by id desc (string)
+                all.sort((a, b) => {
+                    return b.id.localeCompare(a.id);
+                });
+
                 return createDb({
                     all: all.map(member => member.toJSON())
                 });
@@ -523,7 +514,7 @@ describe('Batch Sending Service', function () {
                 },
                 sendingService: {
                     getMaximumRecipients() {
-                        return 3; // pick a batch size that ends with a numeric member object id
+                        return 2; // pick a batch size that ends with a numeric member object id
                     }
                 },
                 emailSegmenter: {
@@ -541,23 +532,21 @@ describe('Batch Sending Service', function () {
                 post: createModel({}),
                 newsletter
             });
-            console.log(`batches`,batches)
             assert.equal(batches.length, 2);
 
             const calls = insert.getCalls();
-            calls.forEach(call => console.log(`call.args[0]`,call.args[0]))
             assert.equal(calls.length, 2);
 
-            // const insertedRecipients = calls.flatMap(call => call.args[0]);
-            // assert.equal(insertedRecipients.length, 5);
+            const insertedRecipients = calls.flatMap(call => call.args[0]);
+            assert.equal(insertedRecipients.length, 3);
 
             // console.log(`insertedRecipients`,insertedRecipients)
 
             // Check all recipients match initialMembers
-            // assert.deepEqual(insertedRecipients.map(recipient => recipient.member_id).sort(), initialMembers.map(member => member.id).sort());
+            assert.deepEqual(insertedRecipients.map(recipient => recipient.member_id).sort(), initialMembers.map(member => member.id).sort());
 
             // Check email_count set
-            assert.equal(email.get('email_count'), 4);
+            assert.equal(email.get('email_count'), 3);
         });
     });
 


### PR DESCRIPTION
refs https://ghost.slack.com/archives/CTH5NDJMS/p1699359241142969

It's possible for `ObjectIDs` to have only numeric characters. We were previously letting the type be inferred, which created a very rare but possible edge case where the last recipient of an email batch had a numeric ObjectID, resulting in a numeric comparison against alphanumeric `ObjectIDs` in the database.
- updated the filter to add `'`'s around the `lastId` parameter
- updated tests to check for the type of the id filter parameter value
- can't fully test for numeric object IDs using what we have because javascript cannot handle numerics of that size; may be able to look at using fixture data loaded directly into the db