### PR TITLE
🐛 Fixed the post title writing issue using Japanese IME

### DIFF
--- a/ghost/admin/app/components/gh-koenig-editor-lexical.js
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.js
@@ -113,16 +113,16 @@ export default class GhKoenigEditorReactComponent extends Component {
             return;
         }
 
-        const {keyCode} = event;
+        const {key} = event;
         const {value, selectionStart} = event.target;
 
         const couldLeaveTitle = !value || selectionStart === value.length;
-        const arrowLeavingTitle = [39, 40].includes(keyCode) && couldLeaveTitle;
+        const arrowLeavingTitle = ['ArrowDown', 'ArrowRight'].includes(key) && couldLeaveTitle;
 
-        if (keyCode === 13 || keyCode === 9 || arrowLeavingTitle) {
+        if (key === 'Enter' || key === 'Tab' || arrowLeavingTitle) {
             event.preventDefault();
 
-            if (keyCode === 13 && !editorAPI.editorIsEmpty()) {
+            if (key === 'Enter' && !editorAPI.editorIsEmpty()) {
                 editorAPI.insertParagraphAtTop({focus: true});
             } else {
                 editorAPI.focusEditor({position: 'top'});

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.js
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.js
@@ -113,16 +113,16 @@ export default class GhKoenigEditorReactComponent extends Component {
             return;
         }
 
-        const {key} = event;
+        const {keyCode} = event;
         const {value, selectionStart} = event.target;
 
         const couldLeaveTitle = !value || selectionStart === value.length;
-        const arrowLeavingTitle = ['ArrowDown', 'ArrowRight'].includes(key) && couldLeaveTitle;
+        const arrowLeavingTitle = [39, 40].includes(keyCode) && couldLeaveTitle;
 
-        if (key === 'Enter' || key === 'Tab' || arrowLeavingTitle) {
+        if (keyCode === 13 || keyCode === 9 || arrowLeavingTitle) {
             event.preventDefault();
 
-            if (key === 'Enter' && !editorAPI.editorIsEmpty()) {
+            if (keyCode === 13 && !editorAPI.editorIsEmpty()) {
                 editorAPI.insertParagraphAtTop({focus: true});
             } else {
                 editorAPI.focusEditor({position: 'top'});

--- a/ghost/admin/app/components/gh-koenig-editor-lexical.js
+++ b/ghost/admin/app/components/gh-koenig-editor-lexical.js
@@ -109,7 +109,7 @@ export default class GhKoenigEditorReactComponent extends Component {
     onTitleKeydown(event) {
         const {editorAPI} = this;
 
-        if (!editorAPI) {
+        if (!editorAPI || event.originalEvent.isComposing) {
             return;
         }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/18949
- changed editor to control on a keyCode basis instead of key

behavior after this change:

https://github.com/TryGhost/Ghost/assets/10049972/beadc5f6-5223-4830-ac32-20ca2b7fbdc2


Please include a description of your change & check your PR against this list, thanks!

- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a912e7</samp>

Fixed a bug in the editor title input field that prevented keyboard navigation to the content area. Used `keyCode` instead of `key` in `gh-koenig-editor-lexical.js` to handle keyboard events consistently across browsers.
