### PR TITLE
Moved `monobundle` into monorepo

### DIFF
--- a/ghost/core/.npmignore
+++ b/ghost/core/.npmignore
@@ -62,7 +62,7 @@ renovate.json
 !core/server/services/mail/templates/**
 bower_components/**
 .editorconfig
-gulpfile.js
+monobundle.js
 !content/themes/casper/gulpfile.js
 !content/themes/source/gulpfile.js
 package-lock.json

--- a/ghost/core/monobundle.js
+++ b/ghost/core/monobundle.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+const exec = util.promisify(require('node:child_process').exec);
+
+const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const findRoot = require('find-root');
+const {flattenDeep} = require('lodash');
+const glob = require('glob');
+
+const DETECT_TRAILING_WHITESPACE = /\s+$/;
+
+const jsonFiles = new Map();
+
+class JSONFile {
+    /**
+     * @param {string} filePath
+     * @returns {JSONFile}
+     */
+    static for(filePath) {
+        if (jsonFiles.has(filePath)) {
+            return jsonFiles.get(filePath);
+        }
+
+        let jsonFile = new this(filePath);
+        jsonFiles.set(filePath, jsonFile);
+
+        return jsonFile;
+    }
+
+    /**
+     * @param {string} filename
+     */
+    constructor(filename) {
+        this.filename = filename;
+        this.reload();
+    }
+
+    reload() {
+        const contents = fs.readFileSync(this.filename, {encoding: 'utf8'});
+
+        this.pkg = JSON.parse(contents);
+        this.lineEndings = detectNewline(contents);
+        this.indent = detectIndent(contents).amount;
+
+        let trailingWhitespace = DETECT_TRAILING_WHITESPACE.exec(contents);
+        this.trailingWhitespace = trailingWhitespace ? trailingWhitespace : '';
+    }
+
+    write() {
+        let contents = JSON.stringify(this.pkg, null, this.indent).replace(/\n/g, this.lineEndings);
+
+        fs.writeFileSync(this.filename, contents + this.trailingWhitespace, {encoding: 'utf8'});
+    }
+}
+
+/**
+ * @param {object} packageJson
+ */
+function getPackages(packageJson) {
+    if (!('workspaces' in packageJson)) {
+        return null;
+    }
+    const {workspaces} = packageJson;
+    if (Array.isArray(workspaces)) {
+        return workspaces;
+    }
+    return workspaces.packages || null;
+}
+
+/**
+ * @param {string} from
+ * @returns {string[]}
+ */
+function getWorkspaces(from) {
+    const root = findRoot(from, (dir) => {
+        const pkg = path.join(dir, 'package.json');
+        return fs.existsSync(pkg) && getPackages(require(pkg)) !== null;
+    });
+
+    const packages = getPackages(require(path.join(root, 'package.json')));
+    return flattenDeep(packages.map(name => glob.sync(path.join(root, `${name}/`))));
+}
+
+(async () => {
+    const cwd = process.cwd();
+    const nearestPkgJson = findRoot(cwd);
+    console.log('nearestPkgJson', nearestPkgJson);
+    const pkgInfo = JSONFile.for(path.join(nearestPkgJson, 'package.json'));
+
+    if (pkgInfo.pkg.name !== 'ghost') {
+        console.log('This script must be run from the `ghost` npm package directory');
+        process.exit(1);
+    }
+
+    const bundlePath = './components';
+    if (!fs.existsSync(bundlePath)){
+        fs.mkdirSync(bundlePath);
+    }
+
+    const workspaces = getWorkspaces(cwd)
+        .filter(w => !w.startsWith(cwd) && fs.existsSync(path.join(w, 'package.json')))
+        .filter(w => !w.includes('apps/'))
+        .filter(w => !w.includes('ghost/admin'));
+
+    console.log('workspaces', workspaces);
+    console.log('\n-------------------------\n');
+
+    for (const w of workspaces) {
+        const workspacePkgInfo = JSONFile.for(path.join(w, 'package.json'));
+
+        if (!workspacePkgInfo.pkg.private) {
+            continue;
+        }
+
+        console.log(`packaging ${w}\n`);
+
+        workspacePkgInfo.pkg.version = pkgInfo.pkg.version;
+        workspacePkgInfo.write();
+
+        const slugifiedName = workspacePkgInfo.pkg.name.replace(/@/g, '').replace(/\//g, '-');
+        const packedFilename = `file:` + path.join(bundlePath, `${slugifiedName}-${workspacePkgInfo.pkg.version}.tgz`);
+
+        if (pkgInfo.pkg.dependencies[workspacePkgInfo.pkg.name]) {
+            console.log(`- dependencies override for ${workspacePkgInfo.pkg.name} to ${packedFilename}`);
+            pkgInfo.pkg.dependencies[workspacePkgInfo.pkg.name] = packedFilename;
+        }
+
+        if (pkgInfo.pkg.devDependencies[workspacePkgInfo.pkg.name]) {
+            console.log(`- devDependencies override for ${workspacePkgInfo.pkg.name} to ${packedFilename}`);
+            pkgInfo.pkg.devDependencies[workspacePkgInfo.pkg.name] = packedFilename;
+        }
+
+        if (pkgInfo.pkg.optionalDependencies[workspacePkgInfo.pkg.name]) {
+            console.log(`- optionalDependencies override for ${workspacePkgInfo.pkg.name} to ${packedFilename}`);
+            pkgInfo.pkg.optionalDependencies[workspacePkgInfo.pkg.name] = packedFilename;
+        }
+
+        console.log(`- resolution override for ${workspacePkgInfo.pkg.name} to ${packedFilename}\n`);
+        pkgInfo.pkg.resolutions[workspacePkgInfo.pkg.name] = packedFilename;
+
+        const command = `npm pack --pack-destination ../core/components`;
+        console.log(`running '${command}' in ${w}\n`);
+
+        const {stdout, stderr} = await exec(command, {cwd: w});
+        console.log('stdout', stdout);
+        console.log('stderr', stderr);
+        console.log('\n-------------------------\n');
+    }
+
+    pkgInfo.write();
+
+    const filesToCopy = [
+        'README.md',
+        'LICENSE',
+        'PRIVACY.md',
+        'yarn.lock'
+    ];
+
+    for (const file of filesToCopy) {
+        console.log(`copying ../../${file} to ${file}`);
+        fs.copyFileSync(path.join('../../', file), file);
+    }
+})();

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -50,7 +50,7 @@
     "lint:test": "eslint -c test/.eslintrc.js --ignore-path test/.eslintignore 'test/**/*.js' --cache",
     "lint:code": "yarn lint:server && yarn lint:shared && yarn lint:frontend",
     "lint": "yarn lint:server && yarn lint:shared && yarn lint:frontend && yarn lint:test",
-    "prepack": "monobundle"
+    "prepack": "node monobundle.js"
   },
   "engines": {
     "node": "^18.12.1",
@@ -237,14 +237,16 @@
     "c8": "8.0.1",
     "cli-progress": "3.12.0",
     "cssnano": "6.0.1",
+    "detect-indent": "6.1.0",
+    "detect-newline": "3.1.0",
     "expect": "29.3.1",
+    "find-root": "1.1.0",
     "form-data": "4.0.0",
     "inquirer": "8.2.6",
     "jwks-rsa": "3.1.0",
     "mocha": "10.2.0",
     "mocha-slow-test-reporter": "0.1.2",
     "mock-knex": "TryGhost/mock-knex#d8b93b1c20d4820323477f2c60db016ab3e73192",
-    "monobundle": "TryGhost/monobundle#811679e94b75f82a0fb1d00a11e6e0b9f6e5e44a",
     "nock": "13.3.3",
     "papaparse": "5.3.2",
     "postcss": "8.4.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9621,13 +9621,6 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
-ansi-split@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-split/-/ansi-split-1.0.1.tgz#3cab03754ab6f1d64d4ad13cd10f22fc36db4a45"
-  integrity sha512-RRxQym4DFtDNmHIkW6aeFVvrXURb11lGAEPXNiryjCe8bK8RsANjzJ0M2aGOkvBYwP4Bl/xZ8ijtr6D3j1x/eg==
-  dependencies:
-    ansi-regex "^3.0.0"
-
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -18654,17 +18647,6 @@ glob@7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
-  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
-
 glob@8.1.0, glob@^8.0.3, glob@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
@@ -18709,7 +18691,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.4, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+glob@^7.0.4, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -19660,7 +19642,7 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha512-DUNFN5j7Tln0D+TxzloUjKB+CtVu6myn0JEFak6dG18mNt9YkQ6lzGCdafwofISZ1lLF3xRHJ98VKy9ynkcFaA==
 
-ignore@5.2.4, ignore@^5.0.4, ignore@^5.1.1, ignore@^5.1.8, ignore@^5.2.0, ignore@^5.2.4:
+ignore@5.2.4, ignore@^5.0.4, ignore@^5.1.1, ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -21254,7 +21236,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.1, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3:
+json5@^2.1.1, json5@^2.1.2, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -22130,11 +22112,6 @@ lodash.flatten@^4.2.0, lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==
-
-lodash.flattendeep@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-  integrity sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==
 
 lodash.foreach@^4.3.0, lodash.foreach@^4.5.0:
   version "4.5.0"
@@ -23064,11 +23041,6 @@ methods@^1.1.2, methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
-micro-memoize@^4.0.9:
-  version "4.0.14"
-  resolved "https://registry.yarnpkg.com/micro-memoize/-/micro-memoize-4.0.14.tgz#d1239ce2e5831125ac518509f5a23b54e7ca3e17"
-  integrity sha512-2tzWP1w2Hh+r7kCYa4f//jpBEA6dAueiuLco38NxfjF9Py3KCCI7wVOTdCvOhmTC043t+ulclVBdl3v+s+UJIQ==
-
 micromatch@4.0.5, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
@@ -23574,17 +23546,6 @@ moment@2.24.0, moment@2.27.0, moment@2.29.1, moment@2.29.3, moment@2.29.4, "mome
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
-monobundle@TryGhost/monobundle#811679e94b75f82a0fb1d00a11e6e0b9f6e5e44a:
-  version "0.1.0"
-  resolved "https://codeload.github.com/TryGhost/monobundle/tar.gz/811679e94b75f82a0fb1d00a11e6e0b9f6e5e44a"
-  dependencies:
-    detect-indent "6.1.0"
-    detect-newline "3.1.0"
-    find-root "1.1.0"
-    glob "8.0.3"
-    lodash.flattendeep "4.4.0"
-    ultra-runner "3.10.5"
 
 moo@^0.5.0, moo@^0.5.1:
   version "0.5.2"
@@ -24242,13 +24203,6 @@ npm-package-arg@^8.1.0:
     semver "^7.3.4"
     validate-npm-package-name "^3.0.0"
 
-npm-run-path@4.0.1, npm-run-path@^4.0.0, npm-run-path@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
-  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
-  dependencies:
-    path-key "^3.0.0"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -24260,6 +24214,13 @@ npm-run-path@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5"
   integrity sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==
+  dependencies:
+    path-key "^3.0.0"
+
+npm-run-path@^4.0.0, npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
 
@@ -25181,11 +25142,6 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.0, picomatc
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-pid-cwd@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pid-cwd/-/pid-cwd-1.2.0.tgz#c14c03d812b1d23f97aee27767957fc16272c979"
-  integrity sha512-8QQzIdBmy4bd2l1NKWON1X8flO5TQQRzU2uRDua/XaxSC0iJ+rgbDrlX76t0W3DaJ7OevTYpftyvQ6oMe3hclQ==
 
 pidtree@0.6.0:
   version "0.6.0"
@@ -26647,11 +26603,6 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==
-
-ps-list@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/ps-list/-/ps-list-7.2.0.tgz#3d110e1de8249a4b178c9b1cf2a215d1e4e42fc0"
-  integrity sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ==
 
 pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
@@ -28412,11 +28363,6 @@ shell-quote@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
-
-shellwords-ts@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/shellwords-ts/-/shellwords-ts-3.0.1.tgz#7c2ed81ea6d0804705a95a5625682363972600e2"
-  integrity sha512-GabK4ApLMqHFRGlpgNqg8dmtHTnYHt0WUUJkIeMd3QaDrUUBEDXHSSNi3I0PzMimg8W+I0EN4TshQxsnHv1cwg==
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -30424,11 +30370,6 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
-
 tslib@^1.11.1, tslib@^1.13.0, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -30500,7 +30441,7 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-type-fest@^0.21.2, type-fest@^0.21.3:
+type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
@@ -30590,30 +30531,6 @@ uid-safe@~2.1.5:
   integrity sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==
   dependencies:
     random-bytes "~1.0.0"
-
-ultra-runner@3.10.5:
-  version "3.10.5"
-  resolved "https://registry.yarnpkg.com/ultra-runner/-/ultra-runner-3.10.5.tgz#7a723b64326642a6d4649ca4cd51a9900c7eccd2"
-  integrity sha512-0U2OPII7sbvtbu9rhDlUUkP4Au/DPz2Tzbnawd/XwDuUruDqd+t/Bmel3cLJxl3yMLHf0OY0TMcIx9zzxdlAZw==
-  dependencies:
-    ansi-split "^1.0.1"
-    chalk "^4.1.0"
-    cross-spawn "^7.0.3"
-    fast-glob "^3.2.5"
-    globrex "^0.1.2"
-    ignore "^5.1.8"
-    json5 "^2.2.0"
-    micro-memoize "^4.0.9"
-    npm-run-path "4.0.1"
-    pid-cwd "^1.2.0"
-    ps-list "^7.2.0"
-    shellwords-ts "^3.0.0"
-    string-width "^4.2.0"
-    tslib "2.1.0"
-    type-fest "^0.21.2"
-    wrap-ansi "^7.0.0"
-    yamljs "^0.3.0"
-    yargs "^16.2.0"
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -32006,14 +31923,6 @@ yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yamljs@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
-  integrity sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==
-  dependencies:
-    argparse "^1.0.7"
-    glob "^7.0.5"
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/99

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5ea7fd</samp>

This pull request removes the `monobundle` dependency and replaces it with a custom script that creates a bundled package of the Ghost core and its private workspaces. This improves the publishing and installation process of the Ghost package by reducing the number of dependencies and files. It also updates the `package.json` and `.npmignore` files accordingly.
