### PR TITLE
Combine Offer views to a single modal

### DIFF
--- a/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
+++ b/apps/admin-x-settings/src/components/providers/RoutingProvider.tsx
@@ -63,8 +63,8 @@ const modalPaths: {[key: string]: ModalName} = {
     'announcement-bar/edit': 'AnnouncementBarModal',
     'embed-signup-form/show': 'EmbedSignupFormModal',
     'offers/edit': 'OffersModal',
-    'offers/new': 'AddOfferModal',
-    'offers/:id': 'EditOfferModal',
+    // 'offers/new': 'AddOfferModal',
+    // 'offers/:id': 'EditOfferModal',
     about: 'AboutModal'
 };
 

--- a/apps/admin-x-settings/src/components/providers/routing/modals.tsx
+++ b/apps/admin-x-settings/src/components/providers/routing/modals.tsx
@@ -4,13 +4,13 @@ import type {RoutingModalProps} from '../RoutingProvider';
 import AboutModal from '../../settings/general/About';
 import AddIntegrationModal from '../../settings/advanced/integrations/AddIntegrationModal';
 import AddNewsletterModal from '../../settings/email/newsletters/AddNewsletterModal';
-import AddOfferModal from '../../settings/membership/offers/AddOfferModal';
+// import AddOfferModal from '../../settings/membership/offers/AddOfferModal';
 import AddRecommendationModal from '../../settings/membership/recommendations/AddRecommendationModal';
 import AmpModal from '../../settings/advanced/integrations/AmpModal';
 import AnnouncementBarModal from '../../settings/site/AnnouncementBarModal';
 import CustomIntegrationModal from '../../settings/advanced/integrations/CustomIntegrationModal';
 import DesignAndThemeModal from '../../settings/site/DesignAndThemeModal';
-import EditOfferModal from '../../settings/membership/offers/EditOfferModal';
+// import EditOfferModal from '../../settings/membership/offers/EditOfferModal';
 import EditRecommendationModal from '../../settings/membership/recommendations/EditRecommendationModal';
 import EmbedSignupFormModal from '../../settings/membership/embedSignup/EmbedSignupFormModal';
 import FirstpromoterModal from '../../settings/advanced/integrations/FirstPromoterModal';
@@ -52,8 +52,8 @@ const modals = {
     AnnouncementBarModal,
     EmbedSignupFormModal,
     OffersModal,
-    AddOfferModal,
-    EditOfferModal,
+    // AddOfferModal,
+    // EditOfferModal,
     AboutModal
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } satisfies {[key: string]: ModalComponent<any>};

--- a/apps/admin-x-settings/src/components/settings/membership/offers/AddOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/offers/AddOfferModal.tsx
@@ -1,4 +1,3 @@
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import PortalFrame from '../portal/PortalFrame';
 import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import useRouting from '../../../../hooks/useRouting';
@@ -186,7 +185,11 @@ const parseData = (input: string): { id: string; period: string; currency: strin
     return {id, period, currency};
 };
 
-const AddOfferModal = () => {
+type AddOfferModalProps = {
+    onBack: (view: 'list') => void;
+};
+
+const AddOfferModal: React.FC<AddOfferModalProps> = ({onBack}) => {
     const {siteData} = useGlobalData();
     const typeOptions = [
         {title: 'Discount', description: 'Offer a special reduced price', value: 'percent'},
@@ -200,7 +203,7 @@ const AddOfferModal = () => {
     ];
 
     const [href, setHref] = useState<string>('');
-    const modal = useModal();
+    // const modal = useModal();
     const {updateRoute} = useRouting();
     const hasOffers = useFeatureFlag('adminXOffers');
     const {data: {tiers} = {}} = useBrowseTiers();
@@ -340,17 +343,23 @@ const AddOfferModal = () => {
         });
     };
 
+    // useEffect(() => {
+    //     if (!hasOffers) {
+    //         modal.remove();
+    //         updateRoute('');
+    //     }
+    // }, [hasOffers, modal, updateRoute]);
+
+    // const cancelAddOffer = () => {
+    //     modal.remove();
+    //     updateRoute('offers/edit');
+    // };
+
     useEffect(() => {
         if (!hasOffers) {
-            modal.remove();
             updateRoute('');
         }
-    }, [hasOffers, modal, updateRoute]);
-
-    const cancelAddOffer = () => {
-        modal.remove();
-        updateRoute('offers/edit');
-    };
+    }, [updateRoute, hasOffers]);
 
     useEffect(() => {
         const newHref = getOfferPortalPreviewUrl(overrides, siteData.url);
@@ -377,7 +386,9 @@ const AddOfferModal = () => {
         href={href}
     />;
 
-    return <PreviewModalContent cancelLabel='Cancel' deviceSelector={false} okLabel='Publish' preview={iframe} sidebar={sidebar} size='full' title='Offer' onCancel={cancelAddOffer} />;
+    return <PreviewModalContent cancelLabel='Cancel' deviceSelector={false} okLabel='Publish' preview={iframe} sidebar={sidebar} size='full' title='Offer' onCancel={() => {
+        onBack('list');
+    }} />;
 };
 
-export default NiceModal.create(AddOfferModal);
+export default AddOfferModal;

--- a/apps/admin-x-settings/src/components/settings/membership/offers/EditOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/offers/EditOfferModal.tsx
@@ -1,11 +1,11 @@
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
+// import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import useForm, {ErrorMessages} from '../../../../hooks/useForm';
 import useHandleError from '../../../../utils/api/handleError';
 import useRouting from '../../../../hooks/useRouting';
 import {Button, Form, PreviewModalContent, TextArea, TextField, showToast} from '@tryghost/admin-x-design-system';
 import {Offer, useBrowseOffersById, useEditOffer} from '../../../../api/offers';
-import {RoutingModalProps} from '../../../providers/RoutingProvider';
+// import {RoutingModalProps} from '../../../providers/RoutingProvider';
 import {getHomepageUrl} from '../../../../api/site';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '../../../providers/GlobalDataProvider';
@@ -86,8 +86,13 @@ const Sidebar: React.FC<{
             );
         };
 
-const EditOfferModal: React.FC<RoutingModalProps> = ({params}) => {
-    const modal = useModal();
+type EditOfferProps = {
+    id: string,
+    onBack: (view: 'list') => void;
+};
+
+const EditOfferModal: React.FC<EditOfferProps> = ({id, onBack}) => {
+    // const modal = useModal();
     const {updateRoute} = useRouting();
     const handleError = useHandleError();
     const hasOffers = useFeatureFlag('adminXOffers');
@@ -95,12 +100,12 @@ const EditOfferModal: React.FC<RoutingModalProps> = ({params}) => {
 
     useEffect(() => {
         if (!hasOffers) {
-            modal.remove();
+            // modal.remove();
             updateRoute('');
         }
-    }, [hasOffers, modal, updateRoute]);
+    }, [hasOffers, updateRoute]);
 
-    const {data: {offers: offerById = []} = {}} = useBrowseOffersById(params?.id ? params?.id : '');
+    const {data: {offers: offerById = []} = {}} = useBrowseOffersById(id ? id : '');
 
     const {formState, saveState, updateForm, setFormState, handleSave, validate, errors, clearError, okProps} = useForm({
         initialState: offerById[0],
@@ -126,7 +131,7 @@ const EditOfferModal: React.FC<RoutingModalProps> = ({params}) => {
 
     useEffect(() => {
         setFormState(() => offerById[0]);
-    }, [setFormState, offerById[0]]);
+    }, [setFormState, offerById]);
 
     const updateOffer = (fields: Partial<Offer>) => {
         updateForm(state => ({...state, ...fields}));
@@ -149,8 +154,8 @@ const EditOfferModal: React.FC<RoutingModalProps> = ({params}) => {
         testId='offer-update-modal'
         title='Offer'
         onCancel={() => {
-            modal.remove();
-            updateRoute('offers/edit');
+            // modal.remove();
+            onBack('list');
         }}
         onOk={async () => {
             if (!(await handleSave({fakeWhenUnchanged: true}))) {
@@ -162,4 +167,4 @@ const EditOfferModal: React.FC<RoutingModalProps> = ({params}) => {
         }} /> : null;
 };
 
-export default NiceModal.create(EditOfferModal);
+export default EditOfferModal;

--- a/apps/admin-x-settings/src/components/settings/membership/offers/OffersList.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/offers/OffersList.tsx
@@ -1,0 +1,71 @@
+import {Button, Tab, TabView} from '@tryghost/admin-x-design-system';
+import {OfferCardProps} from './OffersModal';
+import {getPaidActiveTiers, useBrowseTiers} from '../../../../api/tiers';
+import {useBrowseOffers} from '../../../../api/offers';
+import {useState} from 'react';
+
+export type OfferType = 'percent' | 'fixed' | 'trial';
+
+export const OffersList: React.FC<{ OfferCard: React.ComponentType<OfferCardProps>, ToggleViewState: (state: 'list' | 'add' | 'edit') => void, SelectOffer: (id: string) => void }> = ({OfferCard, ToggleViewState, SelectOffer}) => {
+    let offersTabs: Tab[] = [
+        {id: 'active', title: 'Active'},
+        {id: 'archived', title: 'Archived'}
+    ];
+    const [selectedTab, setSelectedTab] = useState('active');
+
+    const {data: {offers: allOffers = []} = {}} = useBrowseOffers({
+        searchParams: {
+            limit: 'all'
+        }
+    });
+    const {data: {tiers: allTiers} = {}} = useBrowseTiers();
+    const paidActiveTiers = getPaidActiveTiers(allTiers || []);
+
+    return (
+        <div className='pt-6'>
+            <header>
+                <div className='flex items-center justify-between'>
+                    <TabView
+                        border={false}
+                        selectedTab={selectedTab}
+                        tabs={offersTabs}
+                        width='wide'
+                        onTabChange={setSelectedTab}
+                    />
+                    <Button color='green' icon='add' iconColorClass='green' label='New offer' link={true} size='sm' onClick={() => {
+                        ToggleViewState('add');
+                    }} />
+                </div>
+                <h1 className='mt-12 border-b border-b-grey-300 pb-2.5 text-3xl'>{offersTabs.find(tab => tab.id === selectedTab)?.title} offers</h1>
+            </header>
+            <div className='mt-8 grid grid-cols-3 gap-6'>
+                {allOffers.filter(offer => offer.status === selectedTab).map((offer) => {
+                    const offerTier = paidActiveTiers.find(tier => tier.id === offer?.tier.id);
+
+                    if (!offerTier) {
+                        return null;
+                    }
+
+                    return (
+                        <OfferCard
+                            key={offer?.id}
+                            amount={offer?.amount}
+                            cadence={offer?.cadence}
+                            currency={offer?.currency || 'USD'}
+                            duration={offer?.duration}
+                            name={offer?.name}
+                            offerId={offer?.id}
+                            offerTier={offerTier}
+                            redemptionCount={offer?.redemption_count}
+                            type={offer?.type as OfferType}
+                            onClick={() => {
+                                SelectOffer(offer?.id);
+                                ToggleViewState('edit');
+                            }}
+                        />
+                    );
+                })}
+            </div>
+        </div>
+    );
+};


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4138

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 630ddfc</samp>

This pull request refactors the offers modal in the membership settings to use a tabbed view and a preview modal instead of a separate modal for each offer. It removes the modal logic and dependencies from the `AddOfferModal` and `EditOfferModal` components and replaces them with prop functions and types. It also disables the modal-based navigation for the offer routes in the `RoutingProvider.tsx` file and comments out unused code related to offer modals in `modals.tsx`. It adds a new component `OffersList.tsx` that renders a list of offers based on the selected tab and allows the user to add or edit an offer.
