### PR TITLE
Disabled Nx daemon

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -10,6 +10,7 @@
                     "test",
                     "test:unit"
                 ],
+                "useDaemonProcess": false,
                 "cacheDirectory": ".nxcache"
             }
         }


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/102

- we've been seeing various bugs relating to the Nx daemon, and when it crashes it nukes the entire dev command, which we'd like to avoid
- this should disable the daemon until some of these issues are fixed

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b1c27f6</samp>

Add `useDaemonProcess` option to `nx` configuration in `nx.json`. This option allows users to disable the daemon process that `nx` uses by default for better performance, but which can cause problems with some CI environments or tools.
