### PR TITLE
🐛 Redirected email previews to /email/ route

### DIFF
--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -53,6 +53,11 @@ module.exports = function previewController(req, res, next) {
                 return urlUtils.redirect301(res, routerManager.getUrlByResourceId(post.id, {withSubdirectory: true}));
             }
 
+            // published content should only resolve to /:slug or /email/:uuid - /p/:uuid is for drafts only in lieu of an actual preview api
+            if (post.status !== 'published' && post.email_only === true) {
+                return urlUtils.redirect301(res, urlUtils.urlJoin('/email', post.uuid, '/'));
+            }
+
             post.access = !!post.html;
 
             return renderer.renderEntry(req, res)(post);

--- a/ghost/core/test/e2e-frontend/preview_routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview_routes.test.js
@@ -90,6 +90,23 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect(assertCorrectFrontendHeaders);
     });
 
+    it('should redirect sent email-only posts to /email/:uuid from /p/:uuid', async function () {
+        // difficult to build a sent newsletter using the data generator
+        const emailedPost = await testUtils.fixtures.insertPosts([{
+            title: 'test newsletter',
+            status: 'sent',
+            posts_meta: {
+                email_only: true
+            }
+        }]);
+
+        await request.get(`/p/${emailedPost[0].get('uuid')}/`)
+            .expect(301)
+            .expect('Location', `/email/${emailedPost[0].get('uuid')}/`)
+            .expect('Cache-Control', testUtils.cacheRules.year)
+            .expect(assertCorrectFrontendHeaders);
+    });
+
     it('404s unknown uuids', async function () {
         request.get('/p/aac6b4f6-e1f3-406c-9247-c94a0496d39f/')
             .expect(404)


### PR DESCRIPTION
closes TryGhost/Product#4136
- the `/p/` route is only intended for drafts, not published content (e.g. sent newsletters)
- email-only posts (newsletters) do not get assigned a slug, and could still be viewed at `/p/:uuid`, which didn't hide paid/member content