### PR TITLE
Added basic offers modal for design

### DIFF
--- a/apps/admin-x-settings/src/components/providers/SettingsRouter.tsx
+++ b/apps/admin-x-settings/src/components/providers/SettingsRouter.tsx
@@ -33,6 +33,7 @@ export const modalPaths: {[key: string]: ModalName} = {
     'embed-signup-form/show': 'EmbedSignupFormModal',
     'offers/edit': 'OffersModal',
     'offers/new': 'AddOfferModal',
+    'offers/success': 'OfferSuccess',
     'offers/:id': 'EditOfferModal',
     about: 'AboutModal'
 };

--- a/apps/admin-x-settings/src/components/providers/routing/modals.tsx
+++ b/apps/admin-x-settings/src/components/providers/routing/modals.tsx
@@ -18,6 +18,7 @@ import HistoryModal from '../../settings/advanced/HistoryModal';
 import InviteUserModal from '../../settings/general/InviteUserModal';
 import NavigationModal from '../../settings/site/NavigationModal';
 import NewsletterDetailModal from '../../settings/email/newsletters/NewsletterDetailModal';
+import OfferSuccess from '../../settings/growth/offers/OfferSuccess';
 import OffersModal from '../../settings/growth/offers/OffersModal';
 import PinturaModal from '../../settings/advanced/integrations/PinturaModal';
 import PortalModal from '../../settings/membership/portal/PortalModal';
@@ -54,7 +55,8 @@ const modals = {
     OffersModal,
     AddOfferModal,
     EditOfferModal,
-    AboutModal
+    AboutModal,
+    OfferSuccess
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } satisfies {[key: string]: ModalComponent<any>};
 

--- a/apps/admin-x-settings/src/components/settings/growth/offers/OfferSuccess.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/OfferSuccess.tsx
@@ -1,0 +1,15 @@
+import NiceModal from '@ebay/nice-modal-react';
+import {Modal} from '@tryghost/admin-x-design-system';
+
+const OfferSuccess = () => {
+    return <Modal
+        cancelLabel=''
+        header={false}
+        height='full'
+        size='lg'
+    >
+        <h1>Success</h1>
+    </Modal>;
+};
+
+export default NiceModal.create(OfferSuccess);


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4148

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e683919</samp>

This pull request adds a new modal component for showing a success message after creating or editing an offer in the growth settings. It updates the `modals.tsx`, `SettingsRouter.tsx`, and `OfferSuccess.tsx` files to implement the new component and its route.
