### PR TITLE
Disabled reporting compressed gzip size

### DIFF
--- a/apps/admin-x-design-system/vite.config.ts
+++ b/apps/admin-x-design-system/vite.config.ts
@@ -19,6 +19,7 @@ export default (function viteConfig() {
             port: 4174
         },
         build: {
+            reportCompressedSize: false,
             minify: false,
             sourcemap: true,
             outDir: 'es',

--- a/apps/admin-x-framework/vite.config.ts
+++ b/apps/admin-x-framework/vite.config.ts
@@ -1,7 +1,7 @@
 import react from '@vitejs/plugin-react';
 import glob from 'glob';
-import { resolve } from 'path';
-import { defineConfig } from 'vitest/config';
+import {resolve} from 'path';
+import {defineConfig} from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default (function viteConfig() {
@@ -17,6 +17,7 @@ export default (function viteConfig() {
             port: 4174
         },
         build: {
+            reportCompressedSize: false,
             minify: false,
             sourcemap: true,
             outDir: 'es',

--- a/apps/admin-x-settings/vite.config.ts
+++ b/apps/admin-x-settings/vite.config.ts
@@ -54,6 +54,7 @@ export default (function viteConfig() {
             port: 4174
         },
         build: {
+            reportCompressedSize: false,
             minify: true,
             sourcemap: true,
             lib: {

--- a/apps/announcement-bar/vite.config.js
+++ b/apps/announcement-bar/vite.config.js
@@ -45,6 +45,7 @@ export default defineConfig((config) => {
         build: {
             outDir: resolve(__dirname, 'umd'),
             emptyOutDir: true,
+            reportCompressedSize: false,
             minify: true,
             sourcemap: true,
             cssCodeSplit: true,

--- a/apps/comments-ui/vite.config.ts
+++ b/apps/comments-ui/vite.config.ts
@@ -31,6 +31,7 @@ export default (function viteConfig() {
             port: 5368
         },
         build: {
+            reportCompressedSize: false,
             outDir: resolve(__dirname, 'umd'),
             emptyOutDir: true,
             minify: true,

--- a/apps/portal/vite.config.js
+++ b/apps/portal/vite.config.js
@@ -53,6 +53,7 @@ export default defineConfig((config) => {
         build: {
             outDir: resolve(__dirname, 'umd'),
             emptyOutDir: true,
+            reportCompressedSize: false,
             minify: true,
             sourcemap: true,
             cssCodeSplit: false,

--- a/apps/signup-form/vite.config.ts
+++ b/apps/signup-form/vite.config.ts
@@ -29,6 +29,7 @@ export default (function viteConfig() {
         },
         build: {
             outDir: resolve(__dirname, 'umd'),
+            reportCompressedSize: false,
             emptyOutDir: true,
             minify: true,
             sourcemap: true,

--- a/apps/sodo-search/vite.config.js
+++ b/apps/sodo-search/vite.config.js
@@ -50,6 +50,7 @@ export default defineConfig((config) => {
         },
         build: {
             outDir: resolve(__dirname, 'umd'),
+            reportCompressedSize: false,
             emptyOutDir: true,
             minify: true,
             sourcemap: true,


### PR DESCRIPTION
refs https://vitejs.dev/config/build-options.html#build-reportcompressedsize

- this should make building a little bit quicker because it doesn't have to calculate the gzip size (I don't think we're likely to hit this because we don't have large projects, but it's still nice to clean up the output)

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77dbddb</samp>

This pull request disables the reporting of compressed size for several apps that use `vite` as a build tool. This is done to improve the build performance and reduce the noise in the output.
