### PR TITLE
Fixed duration options for yearly cadence

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
@@ -74,6 +74,15 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
     handleNameInput,
     handleTextAreaInput,
     amountOptions}) => {
+    const getFilteredDurationOptions = () => {
+        // Check if the selected tier's cadence is 'yearly'
+        if (selectedTier?.label?.includes('Yearly')) {
+            // Filter out 'repeating' from duration options
+            return durationOptions.filter(option => option.value !== 'repeating');
+        }
+        return durationOptions;
+    };
+    const filteredDurationOptions = getFilteredDurationOptions();
     return (
         <div className='pt-7'>
             <Form>
@@ -124,8 +133,8 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
                                 </div>
                             </div>
                             <Select
-                                options={durationOptions}
-                                selectedOption={overrides.duration === 'once' ? durationOptions[0] : overrides.duration === 'repeating' ? durationOptions[1] : durationOptions[2]}
+                                options={filteredDurationOptions}
+                                selectedOption={filteredDurationOptions.find(option => option.value === overrides.duration)}
                                 title='Duration'
                                 onSelect={e => handleDurationChange(e?.value || '')}
                             />


### PR DESCRIPTION
no issue

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b84f2a0</samp>

This change improves the offer creation modal by filtering the duration options based on the tier's cadence. This avoids showing irrelevant or invalid options to the user and simplifies the selection process.
