### PR TITLE
Improved error message for `yarn dev`

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -214,6 +214,10 @@ async function handleStripe() {
     try {
         await result;
     } catch (err) {
-        console.error('\nExecuting dev command failed, ensure dependencies are up-to-date by running `yarn fix`\n');
+        console.error();
+        console.error(chalk.red(`Executing dev command failed:`) + `\n`);
+        console.error(chalk.red(`If you've recently done a \`yarn main\`, dependencies might be out of sync. Try running \`${chalk.green('yarn fix')}\` to fix this.`));
+        console.error(chalk.red(`If not, something else went wrong. Please report this to the Ghost team.`));
+        console.error();
     }
 })();


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/104

- added colors and better messages to help when the script fails

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8ec2f0</samp>

Improved error message for Stripe setup in `dev.js`. The message is more informative, colorful, and friendly, and helps developers troubleshoot and report issues.
