### PR TITLE
Moved GitHub context logging to job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 env:
   FORCE_COLOR: 1
   HEAD_COMMIT: ${{ github.sha }}
-  GITHUB_CONTEXT: ${{ toJson(github) }}
   CACHED_DEPENDENCY_PATHS: |
     ${{ github.workspace }}/node_modules
     ${{ github.workspace }}/apps/*/node_modules
@@ -42,6 +41,11 @@ jobs:
         with:
           ref: ${{ env.HEAD_COMMIT }}
           fetch-depth: 2
+
+      - name: Output GitHub context
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Get metadata (push)
         if: github.event_name == 'push'


### PR DESCRIPTION
- this stops the entire context from being output in the env vars, so it cleans up the output at the top of each job

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 033711e</samp>

This pull request improves the `build` job in the GitHub Actions workflow `.github/workflows/ci.yml` by removing unused code and adding a diagnostic step.
