### PR TITLE
Removed NODE_ENV env var from perf tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
 
       - name: Run hyperfine on boot
         working-directory: ghost/core
-        run: hyperfine --warmup 3 'NODE_ENV=production GHOST_CI_SHUTDOWN_AFTER_BOOT=1 node index.js' --export-json boot-perf.json
+        run: hyperfine --show-output --warmup 3 'GHOST_CI_SHUTDOWN_AFTER_BOOT=1 node index.js' --export-json boot-perf.json
 
       - name: Convert data
         working-directory: ghost/core


### PR DESCRIPTION
- this seems to break things, will investigate once this is merged

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1decc36</samp>

Removed `NODE_ENV=production` from hyperfine command in `.github/workflows/ci.yml` to fix boot performance benchmark bug. This was part of a pull request to improve performance tests.
