### PR TITLE
Configured submodules to clone in performance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,8 @@ jobs:
     name: Performance tests
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-node@v4
         env:
           FORCE_COLOR: 0


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/105

- we should include submodules in the checkout so the Ghost boot is representative of booting Ghost with a theme

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10ba72f</samp>

Enable checkout action to fetch submodules in CI workflow. This fixes the build of the `Ghost-Admin` submodule in `.github/workflows/ci.yml`.
