### PR TITLE
🐛 Fixed highlight formatting not showing in rendered posts

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -104,7 +104,7 @@
     "@tryghost/kg-default-cards": "9.1.9",
     "@tryghost/kg-default-nodes": "0.2.10",
     "@tryghost/kg-html-to-lexical": "0.1.11",
-    "@tryghost/kg-lexical-html-renderer": "0.3.48",
+    "@tryghost/kg-lexical-html-renderer": "0.3.49",
     "@tryghost/kg-mobiledoc-html-renderer": "6.0.15",
     "@tryghost/limit-service": "1.2.12",
     "@tryghost/link-redirects": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7858,10 +7858,10 @@
     jsdom "^22.1.0"
     lexical "^0.12.2"
 
-"@tryghost/kg-lexical-html-renderer@0.3.48":
-  version "0.3.48"
-  resolved "https://registry.yarnpkg.com/@tryghost/kg-lexical-html-renderer/-/kg-lexical-html-renderer-0.3.48.tgz#88ed8b58f9b028c9e6930b04b95611f83acb318b"
-  integrity sha512-DJs4pEwzGfnnGl8hLdV4hI/AXlKqQahAX7msS86l31EOTgyl4xNYGz5y8uERorlGycKSNlndGbgYSVcw/Cgcdg==
+"@tryghost/kg-lexical-html-renderer@0.3.49":
+  version "0.3.49"
+  resolved "https://registry.yarnpkg.com/@tryghost/kg-lexical-html-renderer/-/kg-lexical-html-renderer-0.3.49.tgz#2947ce8d85987d98a4eb0d30f58776d2e6632f27"
+  integrity sha512-lyZ5XKhT5OIP6RcTuFUurRf1VSin7r9715Rttj3IGg1VOdfAjhkmNzvvMpF/Ni7kzAT+tkak+Yz8sSezxZONew==
   dependencies:
     "@lexical/clipboard" "^0.12.2"
     "@lexical/code" "^0.12.2"


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4144

- bumped `@tryghost/kg-lexical-html-renderer` which adds highlight/`<mark>` support
