### PR TITLE
Removed RewriteFrames Sentry integration from admin

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -7,7 +7,6 @@ import ShortcutsRoute from 'ghost-admin/mixins/shortcuts-route';
 import ctrlOrCmd from 'ghost-admin/utils/ctrl-or-cmd';
 import windowProxy from 'ghost-admin/utils/window-proxy';
 import {Debug} from '@sentry/integrations';
-import {RewriteFrames} from '@sentry/integrations';
 import {importSettings} from '../components/admin-x/settings';
 import {inject} from 'ghost-admin/decorators/inject';
 import {
@@ -211,26 +210,10 @@ export default Route.extend(ShortcutsRoute, {
                 },
                 // TransitionAborted errors surface from normal application behaviour
                 // - https://github.com/emberjs/ember.js/issues/12505
-                ignoreErrors: [/^TransitionAborted$/],
-                integrations: [
-                    // Stack frames in production are rewritten to remove the version identifier
-                    // from the path. This makes grouping by stack trace not work.
-                    // Before: /admin/1633/assets/path/to/file.js
-                    // After: /admin/assets/path/to/file.js
-                    new RewriteFrames({
-                        iteratee: (frame) => {
-                            if (frame.filename) {
-                                // Check if the frame.filename matches /admin/1633/assets
-                                // and rewrite it to /admin/assets
-                                frame.filename = frame.filename.replace(/\/admin\/\d+\/assets/, '/admin/assets');
-                            }
-                            return frame;
-                        }
-                    })
-                ]
+                ignoreErrors: [/^TransitionAborted$/]
             };
             if (this.config.sentry_env === 'development') {
-                sentryConfig.integrations.push(new Debug());
+                sentryConfig.integrations = [new Debug()];
             }
             Sentry.init(sentryConfig);
         }


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/5f7c7a82dc7d18a0e0dfed39fdb5c4de7195306b

- The goal of the RewriteFrames plugin was to remove version identifiers from the stack traces sent to Sentry, to improve the stack trace grouping. That sort of worked, but it ended up breaking the sourcemaps so the stack traces were ugly and hard to read within Sentry.
- This change removes the RewriteFrames plugin to fix the stack traces again. Instead, planning to use Sentry's stack trace rules built into the UI to fix the grouping.