### PR TITLE
Improved performance of redis cache purge

### DIFF
--- a/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
+++ b/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
@@ -154,10 +154,10 @@ class AdapterCacheRedis extends BaseCacheAdapter {
      */
     async reset() {
         try {
+            const p0 = new Date();
             const keys = await this.#getKeys();
-            for (const key of keys) {
-                await this.cache.del(key);
-            }
+            await this.cache.del(keys);
+            logging.info(`Purged ${keys.length} keys in ${new Date() - p0}ms`);
         } catch (err) {
             logging.error(err);
         }


### PR DESCRIPTION
no issue

- When purging  the redis cache, we were looping over all the keys and sending a `del` command for each key.
- Redis can accept an array of keys in a single `del` command, so we can send all the keys in a single command which reduces the number of round trips to redis.
- In a basic local benchmark test, looping over 3390 keys took 55ms to purge, and sending all the keys in a single command took 21ms to purge.