### PR TITLE
Fixed deleting session when requesting identity for invalid session

### DIFF
--- a/ghost/members-ssr/lib/members-ssr.js
+++ b/ghost/members-ssr/lib/members-ssr.js
@@ -267,7 +267,7 @@ class MembersSSR {
      * @returns {Promise<void>}
      */
     async deleteSession(req, res) {
-        if (req.body.all) {
+        if (req.body && typeof req.body === 'object' && req.body.all) {
             // Update transient_id to invalidate all sessions
             const member = await this.getMemberDataFromSession(req, res);
             if (member) {
@@ -303,7 +303,7 @@ class MembersSSR {
         const transientId = this._getSessionCookies(req, res);
         const token = await this._getMemberIdentityToken(transientId);
         if (!token) {
-            this.deleteSession(req, res);
+            await this.deleteSession(req, res);
             throw new BadRequestError({
                 message: 'Invalid session, could not get identity token'
             });


### PR DESCRIPTION
ref https://ghost.slack.com/archives/C02G9E68C/p1700129928489809

- When the GET /api/session endpoint is called, the session is deleted if it is invalid
- We don't have a body parser for this GET endoint, and the request object was passed to the deleteSession handler. This caused a type error (cannot read properties of undefined)
- We had dangling promise because deleteSession is async and wasn't awaited, causing random errors in tests
- Added a test that would have caught this earlier