### PR TITLE
Wired up date-created to Offer Analytics

### DIFF
--- a/apps/admin-x-framework/src/api/offers.ts
+++ b/apps/admin-x-framework/src/api/offers.ts
@@ -19,7 +19,8 @@ export type Offer = {
     tier: {
         id: string;
         name?: string;
-    }
+    },
+    created_at?: string;
 }
 
 export type PartialNewOffer = Omit<Offer, 'redemption_count'>;

--- a/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
@@ -11,6 +11,15 @@ import {useGlobalData} from '../../../providers/GlobalDataProvider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
+function formatTimestamp(timestamp: string): string {
+    const date = new Date(timestamp);
+    return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+    });
+}
+
 const Sidebar: React.FC<{
         clearError: (field: string) => void,
         errors: ErrorMessages,
@@ -88,7 +97,7 @@ const Sidebar: React.FC<{
                             <div className='flex flex-col gap-5 rounded-md border border-grey-300 p-4 pb-3.5'>
                                 <div className='flex flex-col gap-1.5'>
                                     <span className='text-xs font-semibold leading-none text-grey-700'>Created at</span>
-                                    <span>June 14, 2023</span>
+                                    <span>{formatTimestamp(offer?.created_at ? offer.created_at : '')}</span>
                                 </div>
                                 <div className='flex flex-col gap-1.5'>
                                     <span className='text-xs font-semibold leading-none text-grey-700'>Total redemptions</span>


### PR DESCRIPTION
no issue

---

<!-- Leave the line below if you'd like GitHub Copilot to generate a summary from your commit -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c7304ac</samp>

This pull request adds the `created_at` property to the `Offer` type and displays it in the `EditOfferModal` component. This allows the admin to see when an offer was created.
