### PR TITLE
Added test to test default theme against linked gscan version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,6 +591,8 @@ jobs:
     name: Regression tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-node@v4
         env:
           FORCE_COLOR: 0

--- a/ghost/admin/mirage/fixtures/settings.js
+++ b/ghost/admin/mirage/fixtures/settings.js
@@ -49,7 +49,7 @@ export default [
     setting('site', 'twitter_description', null),
 
     // THEME
-    setting('theme', 'active_theme', 'Source'),
+    setting('theme', 'active_theme', 'source'),
 
     // PRIVATE
     setting('private', 'is_private', false),

--- a/ghost/core/test/regression/site/default-theme.test.js
+++ b/ghost/core/test/regression/site/default-theme.test.js
@@ -7,8 +7,8 @@ it('Default theme passes linked gscan version', async function () {
     const themeService = require('../../../core/server/services/themes');
 
     // Set active theme name
-    mockSetting('active_theme', 'Source');
+    mockSetting('active_theme', 'source');
     await themeService.init();
-    const theme = await themeService.api.getThemeErrors('Source');
+    const theme = await themeService.api.getThemeErrors('source');
     assert.deepEqual(theme.errors, [], 'Default theme should have no errors');
 });

--- a/ghost/core/test/regression/site/default-theme.test.js
+++ b/ghost/core/test/regression/site/default-theme.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert/strict');
+const {mockSetting} = require('../../utils/e2e-framework-mock-manager');
+
+// This test checks if the default theme passes the current gscan version
+// If this test fails, check the used gscan version in Ghost
+it('Default theme passes linked gscan version', async function () {
+    const themeService = require('../../../core/server/services/themes');
+
+    // Set active theme name
+    mockSetting('active_theme', 'Source');
+    await themeService.init();
+    const theme = await themeService.api.getThemeErrors('Source');
+    assert.deepEqual(theme.errors, [], 'Default theme should have no errors');
+});


### PR DESCRIPTION
fixes GRO-32

If we ever introduce errors in the linked source theme and linked gscan version combination, this test will catch it.