### PR TITLE
Updated Admin meta title to `Ghost Admin – [site title]`

### DIFF
--- a/ghost/admin/app/services/ui.js
+++ b/ghost/admin/app/services/ui.js
@@ -147,11 +147,7 @@ export default class UiService extends Service {
 
         let blogTitle = this.config.blogTitle;
 
-        if (!isEmpty(tokens)) {
-            window.document.title = `${tokens.join(' - ')} - ${blogTitle}`;
-        } else {
-            window.document.title = blogTitle;
-        }
+        window.document.title = `Ghost Admin - ${blogTitle}`;
     }
 
     @action

--- a/ghost/admin/app/services/ui.js
+++ b/ghost/admin/app/services/ui.js
@@ -6,7 +6,6 @@ import {
 } from '@tryghost/color-utils';
 import {action, get} from '@ember/object';
 import {inject} from 'ghost-admin/decorators/inject';
-import {isEmpty} from '@ember/utils';
 import {tracked} from '@glimmer/tracking';
 
 function collectMetadataClasses(transition, prop) {

--- a/ghost/admin/tests/acceptance/members-test.js
+++ b/ghost/admin/tests/acceptance/members-test.js
@@ -49,9 +49,6 @@ describe('Acceptance: Members', function () {
             // lands on correct page
             expect(currentURL(), 'currentURL').to.equal('/members');
 
-            // it has correct page title
-            expect(document.title, 'page title').to.equal('Members - Test Blog');
-
             // it lists all members
             expect(findAll('[data-test-list="members-list-item"]').length, 'members list count')
                 .to.equal(2);
@@ -104,9 +101,6 @@ describe('Acceptance: Members', function () {
 
             // lands on correct page
             expect(currentURL(), 'currentURL').to.equal('/members');
-
-            // it has correct page title
-            expect(document.title, 'page title').to.equal('Members - Test Blog');
 
             // it lists all members
             expect(findAll('[data-test-list="members-list-item"]').length, 'members list count')

--- a/ghost/admin/tests/acceptance/offers-test.js
+++ b/ghost/admin/tests/acceptance/offers-test.js
@@ -56,9 +56,6 @@ describe('Acceptance: Offers', function () {
             // lands on correct page
             expect(currentURL(), 'currentURL').to.equal('/offers');
 
-            // it has correct page title
-            expect(document.title, 'page title').to.equal('Offers - Test Blog');
-
             // it highlights active state in nav menu
             expect(
                 find('[data-test-nav="offers"]'),

--- a/ghost/admin/tests/acceptance/staff-test.js
+++ b/ghost/admin/tests/acceptance/staff-test.js
@@ -102,9 +102,6 @@
 //             // doesn't do any redirecting
 //             expect(currentURL(), 'currentURL').to.equal('/settings/staff');
 
-//             // it has correct page title
-//             expect(document.title, 'page title').to.equal('Staff - Test Blog');
-
 //             // it shows active users in active section
 //             expect(
 //                 findAll('[data-test-active-users] [data-test-user-id]').length,
@@ -133,9 +130,6 @@
 
 //             // url is correct
 //             expect(currentURL(), 'url after clicking user').to.equal(`/settings/staff/${user2.slug}`);
-
-//             // title is correct
-//             expect(document.title, 'title after clicking user').to.equal('Staff - User - Test Blog');
 
 //             // view title should exist and be linkable and active
 //             expect(

--- a/ghost/admin/tests/acceptance/tags-test.js
+++ b/ghost/admin/tests/acceptance/tags-test.js
@@ -59,9 +59,6 @@ describe('Acceptance: Tags', function () {
             // it loads tags list
             expect(currentURL(), 'currentURL').to.equal('tags');
 
-            // it has correct page title
-            expect(document.title, 'page title').to.equal('Tags - Test Blog');
-
             // it highlights nav menu
             expect(find('[data-test-nav="tags"]'), 'highlights nav menu item')
                 .to.have.class('active');


### PR DESCRIPTION
No ref
- In order to make it easier to distinguish between Admin and site in browser tabs, we've updated the meta title to include `Ghost Admin` in the title.