### PR TITLE
Scoped cache purging to be more domain specific

### DIFF
--- a/ghost/core/core/server/services/posts-public/service.js
+++ b/ghost/core/core/server/services/posts-public/service.js
@@ -1,3 +1,5 @@
+const logging = require('@tryghost/logging');
+
 class PostsPublicServiceWrapper {
     async init() {
         if (this.api) {
@@ -15,8 +17,22 @@ class PostsPublicServiceWrapper {
         if (config.get('hostSettings:postsPublicCache:enabled')) {
             const cache = adapterManager.getAdapter('cache:postsPublic');
             postsCache = new EventAwareCacheWrapper({
-                cache: cache,
-                resetEvents: ['site.changed'],
+                cache,
+                logging,
+                resetEvents: [
+                    'post.deleted',
+                    'post.published',
+                    'post.published.edited',
+                    'post.unpublished',
+                    'page.deleted',
+                    'page.published',
+                    'page.published.edited',
+                    'page.unpublished',
+                    'post.tag.attached',
+                    'post.tag.detached',
+                    'page.tag.attached',
+                    'page.tag.detached'
+                ],
                 eventRegistry: EventRegistry
             });
         }

--- a/ghost/core/core/server/services/posts-public/service.js
+++ b/ghost/core/core/server/services/posts-public/service.js
@@ -31,7 +31,11 @@ class PostsPublicServiceWrapper {
                     'post.tag.attached',
                     'post.tag.detached',
                     'page.tag.attached',
-                    'page.tag.detached'
+                    'page.tag.detached',
+                    'tag.edited',
+                    'tag.deleted',
+                    'user.edited',
+                    'user.deleted'
                 ],
                 eventRegistry: EventRegistry
             });

--- a/ghost/core/core/server/services/tags-public/service.js
+++ b/ghost/core/core/server/services/tags-public/service.js
@@ -1,3 +1,5 @@
+const logging = require('@tryghost/logging');
+
 class TagsPublicServiceWrapper {
     async init() {
         if (this.api) {
@@ -16,7 +18,12 @@ class TagsPublicServiceWrapper {
             let tagsPublicCache = adapterManager.getAdapter('cache:tagsPublic');
             tagsCache = new EventAwareCacheWrapper({
                 cache: tagsPublicCache,
-                resetEvents: ['site.changed'],
+                logging,
+                resetEvents: [
+                    'tag.added',
+                    'tag.edited',
+                    'tag.deleted'
+                ],
                 eventRegistry: EventRegistry
             });
         }

--- a/ghost/event-aware-cache-wrapper/lib/EventAwareCacheWrapper.js
+++ b/ghost/event-aware-cache-wrapper/lib/EventAwareCacheWrapper.js
@@ -1,13 +1,17 @@
 class EventAwareCacheWrapper {
     #cache;
+    #logging;
+
     /**
      * @param {Object} deps
      * @param {Object} deps.cache - cache instance extending adapter-base-cache
+     * @param {Object} deps.logging - logging instance
      * @param {Object} [deps.eventRegistry] - event registry instance
-     * @param {String[]} [deps.resetEvents] - event to listen to triggering reset
+     * @param {String[]} [deps.resetEvents] - events that should trigger a cache reset
      */
     constructor(deps) {
         this.#cache = deps.cache;
+        this.#logging = deps.logging;
 
         if (deps.resetEvents && deps.eventRegistry) {
             this.#initListeners(deps.eventRegistry, deps.resetEvents);
@@ -17,6 +21,8 @@ class EventAwareCacheWrapper {
     #initListeners(eventRegistry, eventsToResetOn) {
         eventsToResetOn.forEach((event) => {
             eventRegistry.on(event, () => {
+                this.#logging.info(`Purging cache entries prefixed with "${this.#cache.keyPrefix}" due to event: ${event}`);
+
                 this.reset();
             });
         });

--- a/ghost/event-aware-cache-wrapper/test/EventAwareCacheWrapper.test.js
+++ b/ghost/event-aware-cache-wrapper/test/EventAwareCacheWrapper.test.js
@@ -7,8 +7,12 @@ const {EventEmitter} = require('stream');
 describe('EventAwareCacheWrapper', function () {
     it('Can initialize', function () {
         const cache = new InMemoryCache();
+        const logging = {
+            info: () => {}
+        };
         const wrappedCache = new EventAwareCacheWrapper({
-            cache
+            cache,
+            logging
         });
         assert.ok(wrappedCache);
     });
@@ -16,8 +20,12 @@ describe('EventAwareCacheWrapper', function () {
     describe('get', function () {
         it('calls a wrapped cache with extra key', async function () {
             const cache = new InMemoryCache();
+            const logging = {
+                info: () => {}
+            };
             const wrapper = new EventAwareCacheWrapper({
-                cache: cache
+                cache,
+                logging
             });
 
             await wrapper.set('a', 'b');
@@ -29,10 +37,13 @@ describe('EventAwareCacheWrapper', function () {
     describe('listens to reset events', function () {
         it('resets the cache when reset event is triggered', async function () {
             const cache = new InMemoryCache();
-
+            const logging = {
+                info: () => {}
+            };
             const eventRegistry = new EventEmitter();
             const wrapper = new EventAwareCacheWrapper({
-                cache: cache,
+                cache,
+                logging,
                 resetEvents: ['site.changed'],
                 eventRegistry: eventRegistry
             });


### PR DESCRIPTION
no refs

Caches were being cleared whenever the `site.changed` event was published, which happens whenever a model is added/edited/deleted. This was causing not just all caches to be purged, but also caches unrelated to the model being added/edit/deleted. As the cache system is expanded to include more domain specific caches, this approach will need to be revisited due to interdependencies between the caches, but for now this should be sufficient.