### PR TITLE
Updated editor shortcuts menu

### DIFF
--- a/ghost/admin/app/components/gh-post-settings-menu.hbs
+++ b/ghost/admin/app/components/gh-post-settings-menu.hbs
@@ -265,8 +265,9 @@
                                     <div class="gh-shortcut">
                                         <div><s>Strike through</s></div>
                                         <div class="gh-keys">
-                                            <GhPostSettingsMenu::CtrlOrCmd />
-                                            <span class="gh-key mono">X</span>
+                                            <GhPostSettingsMenu::CtrlOrSymbol />
+                                            <GhPostSettingsMenu::OptionOrAlt />
+                                            <span class="gh-key mono">U</span>
                                         </div>
                                     </div>
                                     <div class="gh-shortcut">
@@ -318,15 +319,16 @@
                                         <div>H2</div>
                                         <div class="gh-keys">
                                             <GhPostSettingsMenu::CtrlOrSymbol />
-                                            <span class="gh-key mono">H</span>
+                                            <GhPostSettingsMenu::OptionOrAlt />
+                                            <span class="gh-key mono">2</span>
                                         </div>
                                     </div>
                                     <div class="gh-shortcut">
                                         <div>H3</div>
                                         <div class="gh-keys">
                                             <GhPostSettingsMenu::CtrlOrSymbol />
-                                            <span class="gh-key mono">H</span>
-                                            <span class="gh-key mono clear">2x</span>
+                                            <GhPostSettingsMenu::OptionOrAlt />
+                                            <span class="gh-key mono">3</span>
                                         </div>
                                     </div>
                                 </GhFormGroup>


### PR DESCRIPTION
refs TryGhost/Product#4160
- updated header to be ctrl+option/alt+1-5 for header to avoid conflict with os behaviour
- updated strike to be ctrl+option/alt+u to avoid view source browser behaviour