### PR TITLE
Refined cache invalidation when updating a user

### DIFF
--- a/ghost/core/core/server/api/endpoints/users.js
+++ b/ghost/core/core/server/api/endpoints/users.js
@@ -40,44 +40,38 @@ async function fetchOrCreatePersonalToken(userId) {
     return token;
 }
 
-const shouldInvalidateCacheAfterChange = (model) => {
-    // Model attributes that should not trigger cache invalidation when changed
-    // (because they have no effect on the frontend)
-    const privateAttrs = [
-        'id',
-        'password',
-        'email',
-        'accessibility',
+function shouldInvalidateCacheAfterChange(model) {
+    // Model attributes that should trigger cache invalidation when changed
+    // (because they affect the frontend)
+    const publicAttrs = [
+        'name',
+        'slug',
+        'profile_image',
+        'cover_image',
+        'bio',
+        'website',
+        'location',
+        'facebook',
+        'twitter',
         'status',
-        'locale',
         'visibility',
-        'last_seen',
-        'tour',
-        'comment_notifications',
-        'free_member_signup_notification',
-        'paid_subscription_started_notification',
-        'paid_subscription_canceled_notification',
-        'mention_notifications',
-        'recommendation_notifications',
-        'milestone_notifications',
-        'donation_notifications',
-        'updated_at',
-        'updated_by'
+        'meta_title',
+        'meta_description'
     ];
 
     if (model.wasChanged() === false) {
         return false;
     }
 
-    // Check if any of the changed attributes are not private
+    // Check if any of the changed attributes are public
     for (const attr of Object.keys(model._changed)) {
-        if (privateAttrs.includes(attr) === false) {
+        if (publicAttrs.includes(attr) === true) {
             return true;
         }
     }
 
     return false;
-};
+}
 
 module.exports = {
     docName: 'users',

--- a/ghost/core/core/server/api/endpoints/users.js
+++ b/ghost/core/core/server/api/endpoints/users.js
@@ -40,6 +40,45 @@ async function fetchOrCreatePersonalToken(userId) {
     return token;
 }
 
+const shouldInvalidateCacheAfterChange = (model) => {
+    // Model attributes that should not trigger cache invalidation when changed
+    // (because they have no effect on the frontend)
+    const privateAttrs = [
+        'id',
+        'password',
+        'email',
+        'accessibility',
+        'status',
+        'locale',
+        'visibility',
+        'last_seen',
+        'tour',
+        'comment_notifications',
+        'free_member_signup_notification',
+        'paid_subscription_started_notification',
+        'paid_subscription_canceled_notification',
+        'mention_notifications',
+        'recommendation_notifications',
+        'milestone_notifications',
+        'donation_notifications',
+        'updated_at',
+        'updated_by'
+    ];
+
+    if (model.wasChanged() === false) {
+        return false;
+    }
+
+    // Check if any of the changed attributes are not private
+    for (const attr of Object.keys(model._changed)) {
+        if (privateAttrs.includes(attr) === false) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
 module.exports = {
     docName: 'users',
 
@@ -137,11 +176,7 @@ module.exports = {
                         }));
                     }
 
-                    if (model.wasChanged()) {
-                        this.headers.cacheInvalidate = true;
-                    } else {
-                        this.headers.cacheInvalidate = false;
-                    }
+                    this.headers.cacheInvalidate = shouldInvalidateCacheAfterChange(model);
 
                     return model;
                 });

--- a/ghost/core/test/e2e-api/admin/users.test.js
+++ b/ghost/core/test/e2e-api/admin/users.test.js
@@ -274,6 +274,36 @@ describe('User API', function () {
         jsonResponse.users[0].roles[0].name.should.equal('Administrator');
     });
 
+    it('Does not trigger cache invalidation when a private attribute on a user has been changed', async function () {
+        const res = await request.put(localUtils.API.getApiQuery('users/me/'))
+            .set('Origin', config.get('url'))
+            .send({
+                users: [{
+                    comment_notifications: false
+                }]
+            })
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200);
+
+        should.equal(res.headers['x-cache-invalidate'], undefined);
+    });
+
+    it('Does not trigger cache invalidation when no attribute on a user has been changed', async function () {
+        const res = await request.put(localUtils.API.getApiQuery('users/me/'))
+            .set('Origin', config.get('url'))
+            .send({
+                users: [{
+                    facebook: null
+                }]
+            })
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200);
+
+        should.equal(res.headers['x-cache-invalidate'], undefined);
+    });
+
     it('Can destroy an active user and transfer posts to the owner', async function () {
         const userId = testUtils.getExistingData().users[1].id;
         const userSlug = testUtils.getExistingData().users[1].slug;


### PR DESCRIPTION
refs https://github.com/TryGhost/Arch/issues/101

Refined the cache invalidation logic so that when updating a user, we only invalidate the cache when an attribute of the user that is used on the frontend changes.