### PR TITLE
Removed usage of unquoted ids in filter strings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/HistoryModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/HistoryModal.tsx
@@ -174,7 +174,7 @@ const HistoryModal = NiceModal.create<RoutingModalProps>(({params}) => {
             filter: [
                 excludedEvents.length && `event:-[${excludedEvents.join(',')}]`,
                 excludedResources.length && `resource_type:-[${excludedResources.join(',')}]`,
-                params?.user && `actor_id:${params.user}`
+                params?.user && `actor_id:'${params.user}'`
             ].filter(Boolean).join('+')
         },
         getNextPageParams: (lastPage, otherParams) => ({

--- a/apps/comments-ui/src/utils/api.ts
+++ b/apps/comments-ui/src/utils/api.ts
@@ -144,7 +144,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}: {site
                 });
             },
             async replies({commentId, afterReplyId, limit}: {commentId: string; afterReplyId: string; limit?: number | 'all'}) {
-                const filter = encodeURIComponent(`id:>${afterReplyId}`);
+                const filter = encodeURIComponent(`id:>'${afterReplyId}'`);
                 const order = encodeURIComponent('created_at ASC, id ASC');
 
                 const url = endpointFor({type: 'members', resource: `comments/${commentId}/replies`, params: `?limit=${limit ?? 5}&order=${order}&filter=${filter}`});

--- a/ghost/admin/app/services/dashboard-stats.js
+++ b/ghost/admin/app/services/dashboard-stats.js
@@ -723,7 +723,7 @@ export default class DashboardStatsService extends Service {
         }
 
         const start30d = new Date(Date.now() - 30 * 86400 * 1000);
-        const result = yield this.store.query('email', {limit: 100, filter: 'submitted_at:>' + start30d.toISOString()});
+        const result = yield this.store.query('email', {limit: 100, filter: `submitted_at:>'${start30d.toISOString()}'`});
         this.emailsSent30d = result.reduce((c, email) => c + email.emailCount, 0);
     }
 

--- a/ghost/collections/src/CollectionsService.ts
+++ b/ghost/collections/src/CollectionsService.ts
@@ -609,7 +609,7 @@ export class CollectionsService {
     }
     async getCollectionsForPost(postId: string): Promise<CollectionDTO[]> {
         const collections = await this.collectionsRepository.getAll({
-            filter: `posts:${postId},slug:latest`
+            filter: `posts:'${postId}',slug:latest`
         });
 
         return Promise.all(collections.sort((a, b) => {

--- a/ghost/core/core/server/models/base/plugins/events.js
+++ b/ghost/core/core/server/models/base/plugins/events.js
@@ -7,6 +7,10 @@ const schema = require('../../../data/schema');
 // This wires up our model event system
 const events = require('../../../lib/common/events');
 
+// Run tests or development with NUMERIC_IDS=1 to enable numeric object IDs
+let forceNumericObjectIds = process.env.NODE_ENV !== 'production' && !!process.env.NUMERIC_IDS;
+let numberGenerator = 0;
+
 module.exports = function (Bookshelf) {
     Bookshelf.Model = Bookshelf.Model.extend({
         initializeEvents: function () {
@@ -39,7 +43,7 @@ module.exports = function (Bookshelf) {
          * no auto increment
          */
         setId: function setId() {
-            this.set('id', ObjectId().toHexString());
+            this.set('id', Bookshelf.Model.generateId());
         },
 
         /**
@@ -267,6 +271,21 @@ module.exports = function (Bookshelf) {
             Object.assign(model._changed, _.cloneDeep(model.changed));
 
             this.addAction(model, 'deleted', options);
+        }
+    }, {
+        generateId: function generateId() {
+            if (forceNumericObjectIds) {
+                numberGenerator = numberGenerator + 1;
+                const counter = numberGenerator.toString();
+
+                // 77777777 here are to make sure generated ids's are larger than naturally generated ones
+                const base = '777777770000000000000000';
+                const id = base.substring(0, base.length - counter.length) + counter;
+
+                //// This always generates a valid object ID that is fully numeric
+                return id;
+            }
+            return ObjectId().toHexString();
         }
     });
 };

--- a/ghost/core/test/e2e-api/admin/actions.test.js
+++ b/ghost/core/test/e2e-api/admin/actions.test.js
@@ -33,7 +33,7 @@ describe('Actions API', function () {
         postUpdatedAt = res.body.posts[0].updated_at;
 
         const res2 = await request
-            .get(localUtils.API.getApiQuery(`actions/?filter=resource_id:${postId}&include=actor`))
+            .get(localUtils.API.getApiQuery(`actions/?filter=${encodeURIComponent(`resource_id:'${postId}'`)}&include=actor`))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
@@ -73,7 +73,7 @@ describe('Actions API', function () {
         postUpdatedAt = res3.body.posts[0].updated_at;
 
         const res4 = await request
-            .get(localUtils.API.getApiQuery(`actions/?filter=resource_id:${postId}&include=actor`))
+            .get(localUtils.API.getApiQuery(`actions/?filter=${encodeURIComponent(`resource_id:'${postId}'`)}&include=actor`))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
@@ -113,7 +113,7 @@ describe('Actions API', function () {
             .expect(200);
 
         const res5 = await request
-            .get(localUtils.API.getApiQuery(`actions/?filter=resource_id:${postId}&include=actor`))
+            .get(localUtils.API.getApiQuery(`actions/?filter=${encodeURIComponent(`resource_id:'${postId}'`)}&include=actor`))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)

--- a/ghost/core/test/e2e-api/admin/activity-feed.test.js
+++ b/ghost/core/test/e2e-api/admin/activity-feed.test.js
@@ -9,7 +9,7 @@ const logging = require('@tryghost/logging');
 let agent;
 
 async function testPagination(skippedTypes, postId, totalExpected, limit) {
-    const postFilter = postId ? `+data.post_id:${postId}` : '';
+    const postFilter = postId ? `+data.post_id:'${postId}'` : '';
 
     // To make the test cover more edge cases, we test different limit configurations
     const {body: firstPage} = await agent
@@ -49,7 +49,7 @@ async function testPagination(skippedTypes, postId, totalExpected, limit) {
         const remaining = totalExpected - (page - 1) * limit;
 
         const {body: secondPage} = await agent
-            .get(`/members/events?filter=${encodeURIComponent(`type:-[${skippedTypes.join(',')}]${postFilter}+(data.created_at:<'${lastCreatedAt}',(data.created_at:'${lastCreatedAt}'+id:<${lastId}))`)}&limit=${limit}`)
+            .get(`/members/events?filter=${encodeURIComponent(`type:-[${skippedTypes.join(',')}]${postFilter}+(data.created_at:<'${lastCreatedAt}',(data.created_at:'${lastCreatedAt}'+id:<'${lastId}'))`)}&limit=${limit}`)
             .expectStatus(200)
             .matchHeaderSnapshot({
                 etag: anyEtag,
@@ -162,7 +162,7 @@ describe('Activity Feed API', function () {
             const memberId = fixtureManager.get('members', 0).id;
 
             await agent
-                .get(`/members/events?filter=${encodeURIComponent(`data.post_id:${postId},data.member_id:${memberId}`)}`)
+                .get(`/members/events?filter=${encodeURIComponent(`data.post_id:'${postId}',data.member_id:'${memberId}'`)}`)
                 .expectStatus(200)
                 .matchBodySnapshot({
                     events: new Array(10).fill({
@@ -180,7 +180,7 @@ describe('Activity Feed API', function () {
             const memberId = fixtureManager.get('members', 0).id;
 
             await agent
-                .get(`/members/events?filter=${encodeURIComponent(`(type:comment_event,type:click_event)+(data.post_id:${postId},data.member_id:${memberId})`)}`)
+                .get(`/members/events?filter=${encodeURIComponent(`(type:comment_event,type:click_event)+(data.post_id:'${postId}',data.member_id:'${memberId}')`)}`)
                 .expectStatus(200)
                 .matchBodySnapshot({
                     events: new Array(3).fill({
@@ -407,7 +407,7 @@ describe('Activity Feed API', function () {
         const postId = fixtureManager.get('posts', 0).id;
 
         await agent
-            .get(`/members/events?filter=data.post_id:${postId}&limit=20`)
+            .get(`/members/events?filter=data.post_id:'${postId}'&limit=20`)
             .expectStatus(200)
             .matchHeaderSnapshot({
                 etag: anyEtag,
@@ -441,7 +441,7 @@ describe('Activity Feed API', function () {
     it('Can limit events', async function () {
         const postId = fixtureManager.get('posts', 0).id;
         await agent
-            .get(`/members/events?filter=data.post_id:${postId}&limit=2`)
+            .get(`/members/events?filter=data.post_id:'${postId}'&limit=2`)
             .expectStatus(200)
             .matchHeaderSnapshot({
                 etag: anyEtag,

--- a/ghost/core/test/e2e-api/admin/integrations.test.js
+++ b/ghost/core/test/e2e-api/admin/integrations.test.js
@@ -262,7 +262,7 @@ describe('Integrations API', function () {
         should.equal(updatedIntegration.id, createdIntegration.id);
         updatedAdminApiKey.secret.should.not.eql(adminApiKey.secret);
 
-        const res3 = await request.get(localUtils.API.getApiQuery(`actions/?filter=resource_id:${adminApiKey.id}&include=actor`))
+        const res3 = await request.get(localUtils.API.getApiQuery(`actions/?filter=resource_id:'${adminApiKey.id}'&include=actor`))
             .set('Origin', config.get('url'))
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)

--- a/ghost/core/test/e2e-api/admin/links.test.js
+++ b/ghost/core/test/e2e-api/admin/links.test.js
@@ -50,7 +50,7 @@ describe('Links API', function () {
         });
         const postId = siteLink.post_id;
         const originalTo = siteLink.link.to;
-        const filter = `post_id:${postId}+to:'${originalTo}'`;
+        const filter = `post_id:'${postId}'+to:'${originalTo}'`;
 
         // Wait minimum 2 seconds
         clock.tick(2 * 1000);
@@ -122,7 +122,7 @@ describe('Links API', function () {
         });
         const postId = siteLink.post_id;
         const originalTo = siteLink.link.to;
-        const filter = `post_id:${postId}+to:'${originalTo}'`;
+        const filter = `post_id:'${postId}'+to:'${originalTo}'`;
 
         // Wait minimum 2 seconds
         clock.tick(2 * 1000);
@@ -187,7 +187,7 @@ describe('Links API', function () {
         });
         const postId = siteLink.post_id;
         const originalTo = 'https://empty.example.com';
-        const filter = `post_id:${postId}+to:'${originalTo}'`;
+        const filter = `post_id:'${postId}'+to:'${originalTo}'`;
         await agent
             .put(`links/bulk/?filter=${encodeURIComponent(filter)}`)
             .body({

--- a/ghost/core/test/e2e-api/admin/members-exporter.test.js
+++ b/ghost/core/test/e2e-api/admin/members-exporter.test.js
@@ -38,7 +38,7 @@ function basicAsserts(member, row) {
 async function testOutput(member, asserts, filters = []) {
     // Add default filters that always should match
     filters.push('limit=all');
-    filters.push(`filter=id:${member.id}`);
+    filters.push(`filter=id:'${member.id}'`);
 
     for (const filter of filters) {
         // Test all
@@ -61,7 +61,7 @@ async function testOutput(member, asserts, filters = []) {
 
         asserts(row);
 
-        if (filter === 'filter=id:${member.id}') {
+        if (filter === `filter=id:'${member.id}'`) {
             csv.data.length.should.eql(1);
         }
     }

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -1958,7 +1958,7 @@ describe('Members API', function () {
 
         // Check activity feed
         const {body: eventsBody} = await agent
-            .get(`/members/events?filter=data.member_id:${newMember.id}`)
+            .get(`/members/events?filter=data.member_id:'${newMember.id}'`)
             .body({members: [memberChanged]})
             .expectStatus(200)
             .matchHeaderSnapshot({
@@ -3037,7 +3037,7 @@ describe('Members API Bulk operations', function () {
         should(model.relations.newsletters.models.length).equal(newsletterCount, 'This test requires a member with 2 or more newsletters');
 
         await agent
-            .put(`/members/bulk/?filter=id:${member.id}`)
+            .put(`/members/bulk/?filter=id:'${member.id}'`)
             .body({bulk: {
                 action: 'unsubscribe'
             }})
@@ -3065,7 +3065,7 @@ describe('Members API Bulk operations', function () {
 
         // When we do it again, we should still receive a count of 1, because we unsubcribed one member (who happens to be already unsubscribed)
         await agent
-            .put(`/members/bulk/?filter=id:${member.id}`)
+            .put(`/members/bulk/?filter=id:'${member.id}'`)
             .body({bulk: {
                 action: 'unsubscribe'
             }})
@@ -3303,7 +3303,7 @@ describe('Members API Bulk operations', function () {
         should(model2.relations.labels.models.map(m => m.id)).match([firstId, secondId]);
 
         await agent
-            .put(`/members/bulk/?filter=id:${member1.id}`)
+            .put(`/members/bulk/?filter=id:'${member1.id}'`)
             .body({bulk: {
                 action: 'removeLabel',
                 meta: {

--- a/ghost/core/test/e2e-api/members-comments/comments.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments.test.js
@@ -213,7 +213,7 @@ describe('Comments API', function () {
 
             it('Can browse all comments of a post', async function () {
                 await membersAgent
-                    .get(`/api/comments/?filter=post_id:${postId}`)
+                    .get(`/api/comments/?filter=post_id:'${postId}'`)
                     .expectStatus(200)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -308,7 +308,7 @@ describe('Comments API', function () {
 
             it('Can browse all comments of a post', async function () {
                 await membersAgent
-                    .get(`/api/comments/?filter=post_id:${postId}`)
+                    .get(`/api/comments/?filter=post_id:'${postId}'`)
                     .expectStatus(200)
                     .matchHeaderSnapshot({
                         etag: anyEtag
@@ -679,7 +679,7 @@ describe('Comments API', function () {
                     }]});
 
                 const {body} = await membersAgent
-                    .get(`/api/comments/?filter=post_id:${anotherPostId}`);
+                    .get(`/api/comments/?filter=post_id:'${anotherPostId}'`);
 
                 assert(!body.comments.find(comment => comment.id === commentId), 'The comment should not have moved post');
             });

--- a/ghost/core/test/e2e-api/members/recommendations.test.js
+++ b/ghost/core/test/e2e-api/members/recommendations.test.js
@@ -6,13 +6,13 @@ const {Recommendation} = require('@tryghost/recommendations');
 
 async function testClicked({recommendationId, memberId}, test) {
     const before = await recommendationsService.clickEventRepository.getAll({
-        filter: 'recommendationId:' + recommendationId
+        filter: `recommendationId:'${recommendationId}'`
     });
 
     await test();
 
     const after = await recommendationsService.clickEventRepository.getAll({
-        filter: 'recommendationId:' + recommendationId
+        filter: `recommendationId:'${recommendationId}'`
     });
 
     assert.equal(after.length, before.length + 1);
@@ -40,11 +40,11 @@ async function testNotSubscribed(test) {
 
 async function testSubscribed({recommendationId, memberId}, test) {
     const before = await recommendationsService.subscribeEventRepository.getAll({
-        filter: 'recommendationId:' + recommendationId
+        filter: `recommendationId:'${recommendationId}'`
     });
     await test();
     const after = await recommendationsService.subscribeEventRepository.getAll({
-        filter: 'recommendationId:' + recommendationId
+        filter: `recommendationId:'${recommendationId}'`
     });
 
     assert.equal(after.length, before.length + 1);

--- a/ghost/core/test/e2e-server/click-tracking.test.js
+++ b/ghost/core/test/e2e-server/click-tracking.test.js
@@ -49,7 +49,7 @@ describe('Click Tracking', function () {
         await jobService.allSettled();
 
         const {body: {links}} = await agent.get(
-            `/links/?filter=post_id:${post.id}`
+            `/links/?filter=${encodeURIComponent(`post_id:'${post.id}'`)}`
         );
 
         /** @type {(url: string) => Promise<import('node-fetch').Response>} */
@@ -101,13 +101,13 @@ describe('Click Tracking', function () {
         await fetchWithoutFollowingRedirect(urlOfLinkToClick.href);
 
         const {body: {links: [clickedLink]}} = await agent.get(
-            `/links/?filter=post_id:${post.id}`
+            `/links/?filter=${encodeURIComponent(`post_id:'${post.id}'`)}`
         );
 
         const clickCount = clickedLink.count.clicks;
 
         const {body: {events: clickEvents}} = await agent.get(
-            `/members/events/?filter=data.member_id:${memberToClickLink.id}${encodeURIComponent('+')}type:click_event`
+            `/members/events/?filter=${encodeURIComponent(`data.member_id:'${memberToClickLink.id}'+type:click_event`)}`
         );
 
         const clickEvent = clickEvents.find((/** @type any */ event) => {

--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -54,7 +54,7 @@ async function testEmailBatches(settings, email_recipient_filter, expectedBatche
     assert.equal(emailModel.get('email_count'), expectedTotal, 'This email should have an email_count of ' + expectedTotal + ' recipients');
 
     // Did we create batches?
-    const batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
+    const batches = await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`});
     assert.equal(batches.models.length, expectedBatches.length);
     const remainingBatches = batches.models.slice();
     const emailRecipients = [];
@@ -74,7 +74,7 @@ async function testEmailBatches(settings, email_recipient_filter, expectedBatche
         assert.equal(firstBatch.get('error_data'), null);
 
         // Did we create recipients?
-        const emailRecipientsFirstBatch = await models.EmailRecipient.findAll({filter: `email_id:${emailModel.id}+batch_id:${firstBatch.id}`});
+        const emailRecipientsFirstBatch = await models.EmailRecipient.findAll({filter: `email_id:'${emailModel.id}'+batch_id:'${firstBatch.id}'`});
         assert.equal(emailRecipientsFirstBatch.models.length, expectedBatch.recipients);
 
         emailRecipients.push(...emailRecipientsFirstBatch.models);
@@ -142,7 +142,7 @@ describe('Batch sending tests', function () {
         assert.equal(emailModel.get('email_count'), 4);
 
         // Did we create batches?
-        const batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
+        const batches = await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`});
         assert.equal(batches.models.length, 1);
 
         // Check all batches are in send state
@@ -157,7 +157,7 @@ describe('Batch sending tests', function () {
         }
 
         // Did we create recipients?
-        const emailRecipients = await models.EmailRecipient.findAll({filter: `email_id:${emailModel.id}`});
+        const emailRecipients = await models.EmailRecipient.findAll({filter: `email_id:'${emailModel.id}'`});
         assert.equal(emailRecipients.models.length, 4);
 
         for (const recipient of emailRecipients.models) {
@@ -189,7 +189,7 @@ describe('Batch sending tests', function () {
         assert.equal(emailModel.get('email_count'), 4);
 
         // Did we create batches?
-        const batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
+        const batches = await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`});
         assert.equal(batches.models.length, 1);
     });
 
@@ -223,11 +223,11 @@ describe('Batch sending tests', function () {
         assert.equal(emailModel.get('email_count'), 4);
 
         // Did we create batches?
-        const batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
+        const batches = await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`});
         assert.equal(batches.models.length, 1);
 
         // Did we create recipients?
-        const emailRecipients = await models.EmailRecipient.findAll({filter: `email_id:${emailModel.id}`});
+        const emailRecipients = await models.EmailRecipient.findAll({filter: `email_id:'${emailModel.id}'`});
         assert.equal(emailRecipients.models.length, 4);
 
         for (const recipient of emailRecipients.models) {
@@ -238,7 +238,7 @@ describe('Batch sending tests', function () {
         // Create a new email and see if it is included now
         const {emailModel: emailModel2} = await sendEmail(agent);
         assert.equal(emailModel2.get('email_count'), 5);
-        const emailRecipients2 = await models.EmailRecipient.findAll({filter: `email_id:${emailModel2.id}`});
+        const emailRecipients2 = await models.EmailRecipient.findAll({filter: `email_id:'${emailModel2.id}'`});
         assert.equal(emailRecipients2.models.length, emailRecipients.models.length + 1);
     });
 
@@ -411,7 +411,7 @@ describe('Batch sending tests', function () {
         assert.equal(emailModel.get('email_count'), 5);
 
         // Did we create batches?
-        let batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
+        let batches = await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`});
         assert.equal(batches.models.length, 5);
 
         // sort batches by id because findAll doesn't have order option
@@ -449,7 +449,7 @@ describe('Batch sending tests', function () {
             assert.equal(batch.get('member_segment'), null);
 
             // Did we create recipients?
-            const batchRecipients = await models.EmailRecipient.findAll({filter: `email_id:${emailModel.id}+batch_id:${batch.id}`});
+            const batchRecipients = await models.EmailRecipient.findAll({filter: `email_id:'${emailModel.id}'+batch_id:'${batch.id}'`});
             assert.equal(batchRecipients.models.length, 1);
 
             emailRecipients.push(...batchRecipients.models);
@@ -463,7 +463,7 @@ describe('Batch sending tests', function () {
         await jobManager.allSettled();
 
         await emailModel.refresh();
-        batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
+        batches = await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`});
 
         // sort batches by provider_id (nullable) because findAll doesn't have order option
         batches.models.sort(sortBatches);
@@ -472,7 +472,7 @@ describe('Batch sending tests', function () {
         assert.equal(emailModel.get('email_count'), 5);
 
         // Did we keep the batches?
-        batches = await models.EmailBatch.findAll({filter: `email_id:${emailModel.id}`});
+        batches = await models.EmailBatch.findAll({filter: `email_id:'${emailModel.id}'`});
 
         // sort batches by provider_id (nullable) because findAll doesn't have order option
         batches.models.sort(sortBatches);
@@ -491,7 +491,7 @@ describe('Batch sending tests', function () {
             assert.equal(batch.get('error_data'), null);
 
             // Did we create recipients?
-            const batchRecipients = await models.EmailRecipient.findAll({filter: `email_id:${emailModel.id}+batch_id:${batch.id}`});
+            const batchRecipients = await models.EmailRecipient.findAll({filter: `email_id:'${emailModel.id}'+batch_id:'${batch.id}'`});
             assert.equal(batchRecipients.models.length, 1);
 
             emailRecipients.push(...batchRecipients.models);

--- a/ghost/core/test/integration/services/email-service/email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/email-event-storage.test.js
@@ -268,7 +268,7 @@ describe('EmailEventStorage', function () {
 
         // Check we have a stored permanent failure
         const permanentFailures = await models.EmailRecipientFailure.findAll({
-            filter: `email_recipient_id:${emailRecipient.id}`
+            filter: `email_recipient_id:'${emailRecipient.id}'`
         });
         assert.equal(permanentFailures.length, 1);
 
@@ -364,7 +364,7 @@ describe('EmailEventStorage', function () {
 
         // Check we have a stored permanent failure
         const permanentFailures = await models.EmailRecipientFailure.findAll({
-            filter: `email_recipient_id:${emailRecipient.id}`
+            filter: `email_recipient_id:'${emailRecipient.id}'`
         });
         assert.equal(permanentFailures.length, 1);
 
@@ -455,7 +455,7 @@ describe('EmailEventStorage', function () {
 
         // Check we have a stored permanent failure
         const permanentFailures = await models.EmailRecipientFailure.findAll({
-            filter: `email_recipient_id:${emailRecipient.id}`
+            filter: `email_recipient_id:'${emailRecipient.id}'`
         });
         assert.equal(permanentFailures.length, 1);
 
@@ -544,7 +544,7 @@ describe('EmailEventStorage', function () {
 
         // Check we have a stored permanent failure
         const permanentFailures = await models.EmailRecipientFailure.findAll({
-            filter: `email_recipient_id:${emailRecipient.id}`
+            filter: `email_recipient_id:'${emailRecipient.id}'`
         });
         assert.equal(permanentFailures.length, 1);
 
@@ -661,7 +661,7 @@ describe('EmailEventStorage', function () {
 
         // Check we have a stored temporary failure
         const failures = await models.EmailRecipientFailure.findAll({
-            filter: `email_recipient_id:${emailRecipient.id}`
+            filter: `email_recipient_id:'${emailRecipient.id}'`
         });
         assert.equal(failures.length, 1);
 
@@ -763,7 +763,7 @@ describe('EmailEventStorage', function () {
 
         // Check we have a stored temporary failure
         const failures = await models.EmailRecipientFailure.findAll({
-            filter: `email_recipient_id:${emailRecipient.id}`
+            filter: `email_recipient_id:'${emailRecipient.id}'`
         });
         assert.equal(failures.length, 1);
 
@@ -865,7 +865,7 @@ describe('EmailEventStorage', function () {
 
         // Check we have a stored temporary failure
         const failures = await models.EmailRecipientFailure.findAll({
-            filter: `email_recipient_id:${emailRecipient.id}`
+            filter: `email_recipient_id:'${emailRecipient.id}'`
         });
         assert.equal(failures.length, 1);
 
@@ -967,7 +967,7 @@ describe('EmailEventStorage', function () {
 
         // Check we have a stored temporary failure
         const failures = await models.EmailRecipientFailure.findAll({
-            filter: `email_recipient_id:${emailRecipient.id}`
+            filter: `email_recipient_id:'${emailRecipient.id}'`
         });
         assert.equal(failures.length, 1);
 
@@ -991,7 +991,7 @@ describe('EmailEventStorage', function () {
         const providerId = emailBatch.provider_id;
         const timestamp = new Date(2000, 0, 1);
         const eventsURI = '/members/events/?' + encodeURIComponent(
-            `filter=type:-[comment_event,aggregated_click_event]+data.member_id:${memberId}`
+            `filter=type:-[comment_event,aggregated_click_event]+data.member_id:'${memberId}'`
         );
 
         // Check not unsubscribed

--- a/ghost/core/test/regression/models/model_posts.test.js
+++ b/ghost/core/test/regression/models/model_posts.test.js
@@ -1501,7 +1501,7 @@ describe('Post Model', function () {
 
                     return models.MobiledocRevision
                         .findAll({
-                            filter: `post_id:${updatedPost.id}`
+                            filter: `post_id:'${updatedPost.id}'`
                         });
                 })
                 .then((mobiledocRevisions) => {
@@ -1536,7 +1536,7 @@ describe('Post Model', function () {
                 })
                 .then(() => models.MobiledocRevision
                     .findAll({
-                        filter: `post_id:${revisionedPost.id}`
+                        filter: `post_id:'${revisionedPost.id}'`
                     })
                 )
                 .then((mobiledocRevisions) => {
@@ -1566,7 +1566,7 @@ describe('Post Model', function () {
 
                     return models.MobiledocRevision
                         .findAll({
-                            filter: `post_id:${createdPost.id}`
+                            filter: `post_id:'${createdPost.id}'`
                         });
                 })
                 .then((mobiledocRevisions) => {
@@ -1582,7 +1582,7 @@ describe('Post Model', function () {
 
                     return models.MobiledocRevision
                         .findAll({
-                            filter: `post_id:${editedPost.id}`
+                            filter: `post_id:'${editedPost.id}'`
                         });
                 })
                 .then((mobiledocRevisions) => {

--- a/ghost/core/test/utils/fixtures/data-generator.js
+++ b/ghost/core/test/utils/fixtures/data-generator.js
@@ -1,9 +1,13 @@
 const _ = require('lodash');
 const uuid = require('uuid');
-const ObjectId = require('bson-objectid').default;
 const moment = require('moment');
 const constants = require('@tryghost/constants');
 const DataGenerator = {};
+const ghostBookshelf = require('../../../core/server/models/base');
+
+function generateId() {
+    return ghostBookshelf.Model.generateId();
+}
 
 DataGenerator.markdownToMobiledoc = function markdownToMobiledoc(content) {
     const mobiledoc = {
@@ -202,61 +206,61 @@ DataGenerator.Content = {
 
     permissions: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Browse posts',
             action_type: 'browse',
             object_type: 'post'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test',
             action_type: 'edit',
             object_type: 'post'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test',
             action_type: 'edit',
             object_type: 'tag'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test',
             action_type: 'edit',
             object_type: 'user'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test',
             action_type: 'edit',
             object_type: 'page'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test',
             action_type: 'add',
             object_type: 'post'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test',
             action_type: 'add',
             object_type: 'user'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test',
             action_type: 'add',
             object_type: 'page'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test',
             action_type: 'destroy',
             object_type: 'post'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test',
             action_type: 'destroy',
             object_type: 'user'
@@ -265,32 +269,32 @@ DataGenerator.Content = {
 
     roles: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Administrator',
             description: 'Administrators'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Editor',
             description: 'Editors'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Author',
             description: 'Authors'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Owner',
             description: 'Blog Owner'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Contributor',
             description: 'Contributors'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Admin Integration',
             description: 'External Apps'
         }
@@ -298,7 +302,7 @@ DataGenerator.Content = {
 
     members: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'member1@test.com',
             name: 'Mr Egg',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b340',
@@ -306,7 +310,7 @@ DataGenerator.Content = {
             email_disabled: false
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'member2@test.com',
             email_open_rate: 50,
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b341',
@@ -314,7 +318,7 @@ DataGenerator.Content = {
             email_disabled: false
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'paid@test.com',
             name: 'Egon Spengler',
             email_open_rate: 80,
@@ -323,7 +327,7 @@ DataGenerator.Content = {
             email_disabled: false
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'trialing@test.com',
             name: 'Ray Stantz',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b343',
@@ -331,7 +335,7 @@ DataGenerator.Content = {
             email_disabled: false
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'comped@test.com',
             name: 'Vinz Clortho',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b344',
@@ -339,7 +343,7 @@ DataGenerator.Content = {
             email_disabled: false
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'vip@test.com',
             name: 'Winston Zeddemore',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b345',
@@ -347,7 +351,7 @@ DataGenerator.Content = {
             email_disabled: false
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'vip-paid@test.com',
             name: 'Peter Venkman',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b346',
@@ -356,7 +360,7 @@ DataGenerator.Content = {
             email_disabled: false
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'with-product@test.com',
             name: 'Dana Barrett',
             uuid: 'f6f91461-d7d8-4a3f-aa5d-8e582c40b347',
@@ -368,7 +372,7 @@ DataGenerator.Content = {
 
     newsletters: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Daily newsletter',
             slug: 'daily-newsletter',
             description: '',
@@ -386,7 +390,7 @@ DataGenerator.Content = {
             header_image: '__GHOST_URL__/content/images/2022/05/test.jpg'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Weekly newsletter',
             slug: 'weekly-newsletter',
             description: '',
@@ -404,7 +408,7 @@ DataGenerator.Content = {
             header_image: '__GHOST_URL__/content/images/2022/05/test.jpg'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Old newsletter',
             slug: 'old-newsletter',
             description: '',
@@ -446,17 +450,17 @@ DataGenerator.Content = {
 
     labels: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Label 1',
             slug: 'label-1'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Label 2',
             slug: 'label-2'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'VIP',
             slug: 'vip'
         }
@@ -464,35 +468,35 @@ DataGenerator.Content = {
 
     members_stripe_customers: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: null, // relation added later
             customer_id: 'cus_HR3tBmNhx4QsZY',
             name: 'Egon Spengler',
             email: 'paid@test.com'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: null, // relation added later
             customer_id: 'cus_HR3tBmNhx4QsZZ',
             name: 'Ray Stantz',
             email: 'trialing@test.com'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: null, // relation added later
             customer_id: 'cus_HR3tBmNhx4QsZ0',
             name: 'Vinz Clortho',
             email: 'comped@test.com'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: null, // relation added later
             customer_id: 'cus_HR3tBmNhx4QsZ1',
             name: 'Peter Venkman',
             email: 'vip-paid@test.com'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: null, // relation added later
             customer_id: 'cus_HR3tBmNhx4QsZ2',
             name: 'Dana Barrett',
@@ -502,7 +506,7 @@ DataGenerator.Content = {
 
     members_paid_subscription_events: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             type: 'created',
             mrr_delta: 1000,
             currency: 'usd',
@@ -513,7 +517,7 @@ DataGenerator.Content = {
             from_plan: null,
             to_plan: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb8'
         }, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             type: 'created',
             mrr_delta: 0,
             currency: 'usd',
@@ -524,7 +528,7 @@ DataGenerator.Content = {
             from_plan: null,
             to_plan: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb9'
         }, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             type: 'created',
             mrr_delta: 0,
             currency: 'usd',
@@ -538,7 +542,7 @@ DataGenerator.Content = {
     ],
     members_stripe_customers_subscriptions: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             customer_id: 'cus_HR3tBmNhx4QsZY',
             subscription_id: 'sub_HR3tLNgGAHsa7b',
             plan_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb8',
@@ -555,7 +559,7 @@ DataGenerator.Content = {
             mrr: 1000
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             customer_id: 'cus_HR3tBmNhx4QsZZ',
             subscription_id: 'sub_HR3tLNgGAHsa7c',
             plan_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb9',
@@ -572,7 +576,7 @@ DataGenerator.Content = {
             mrr: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             customer_id: 'cus_HR3tBmNhx4QsZ0',
             subscription_id: 'sub_HR3tLNgGAHsa7d',
             plan_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730ba0',
@@ -591,7 +595,7 @@ DataGenerator.Content = {
     ],
     stripe_prices: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730b12',
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
             active: true,
@@ -602,7 +606,7 @@ DataGenerator.Content = {
             interval: 'month'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb8',
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
             active: true,
@@ -613,7 +617,7 @@ DataGenerator.Content = {
             interval: 'month'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730ba0',
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
             active: true,
@@ -624,7 +628,7 @@ DataGenerator.Content = {
             interval: 'year'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730bb9',
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
             active: true,
@@ -635,7 +639,7 @@ DataGenerator.Content = {
             interval: 'year'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             stripe_price_id: '173e16a1fffa7d232b398e4a9b08d266a456ae8f3d23e5f11cc608ced6730b13',
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d',
             active: true,
@@ -648,19 +652,19 @@ DataGenerator.Content = {
     ],
     stripe_products: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             product_id: '',
             stripe_product_id: '109c85c734fb9992e7bc30a26af66c22f5c94d8dc62e0a33cb797be902c06b2d'
         }
     ],
     webhooks: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             event: 'member.added',
             target_url: 'https://example.com/webhooks/subscriber-added'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             event: 'member.removed',
             target_url: 'https://example.com/webhooks/subscriber-removed'
         }
@@ -668,24 +672,24 @@ DataGenerator.Content = {
 
     integrations: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Test Integration',
             slug: 'test-integration'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Test Internal Integration',
             slug: 'test-internal-integration',
             type: 'internal'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Test Builtin Integration',
             slug: 'test-builtin-integration',
             type: 'builtin'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Test Core Integration',
             slug: 'test-core-integration',
             type: 'core'
@@ -694,31 +698,31 @@ DataGenerator.Content = {
 
     api_keys: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             type: 'admin',
             secret: _.repeat('a', 64)
             // integration_id: DataGenerator.Content.integrations[0].id
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             type: 'content',
             secret: _.repeat('c', 26)
             // integration_id: DataGenerator.Content.integrations[0].id
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             type: 'admin',
             secret: _.repeat('b', 64),
             integration_id: undefined // "internal"
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             type: 'admin',
             secret: _.repeat('d', 26),
             integration_id: undefined // "builtin"
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             type: 'admin',
             secret: _.repeat('e', 64),
             integration_id: undefined // "core"
@@ -727,7 +731,7 @@ DataGenerator.Content = {
 
     emails: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             uuid: '6b6afda6-4b5e-4893-bff6-f16859e8349a',
             status: 'submitted',
             email_count: 2,
@@ -740,7 +744,7 @@ DataGenerator.Content = {
             newsletter_id: null // newsletter[0] relation added later
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             uuid: '365daa11-4bf0-4614-ad43-6346387ffa00',
             status: 'failed',
             error: 'Everything went south',
@@ -756,7 +760,7 @@ DataGenerator.Content = {
 
     email_batches: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email_id: null, // emails[0] relation added later
             provider_id: 'email1@testing.mailgun.net',
             status: 'submitted'
@@ -765,7 +769,7 @@ DataGenerator.Content = {
 
     email_recipients: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email_id: null, // emails[0] relation added later
             member_id: null, // members[0] relation added later
             batch_id: null, // email_batches[0] relation added later
@@ -777,7 +781,7 @@ DataGenerator.Content = {
             member_name: 'Mr Egg'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email_id: null, // emails[0] relation added later
             member_id: null, // members[1] relation added later
             batch_id: null, // email_batches[0] relation added later
@@ -789,7 +793,7 @@ DataGenerator.Content = {
             member_name: null
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email_id: null, // emails[0] relation added later
             member_id: null, // members[2] relation added later
             batch_id: null, // email_batches[0] relation added later
@@ -801,7 +805,7 @@ DataGenerator.Content = {
             member_name: 'Mr Egg'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email_id: null, // emails[0] relation added later
             member_id: null, // members[3] relation added later
             batch_id: null, // email_batches[0] relation added later
@@ -813,7 +817,7 @@ DataGenerator.Content = {
             member_name: 'Mr Egg'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email_id: null, // emails[0] relation added later
             member_id: null, // members[4] relation added later
             batch_id: null, // email_batches[0] relation added later
@@ -826,7 +830,7 @@ DataGenerator.Content = {
             member_name: 'Mr Egg'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email_id: null, // emails[0] relation added later
             member_id: null, // members[5] relation added later
             batch_id: null, // email_batches[0] relation added later
@@ -842,7 +846,7 @@ DataGenerator.Content = {
 
     snippets: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Test snippet 1',
             mobiledoc: '{}'
         }
@@ -850,14 +854,14 @@ DataGenerator.Content = {
 
     custom_theme_settings: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             theme: 'casper',
             key: 'header_typography',
             type: 'select',
             value: 'Serif'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             theme: 'casper',
             key: 'footer_type',
             type: 'select',
@@ -881,21 +885,21 @@ DataGenerator.Content = {
 
     links: [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             from: '/r/70b0129a',
             to: '__GHOST_URL__/blog/email/01cd4df3-83fa-4921-83be-3bb9a465ef83/?ref=Test-newsletter&attribution_id=6343994e7216ffcbce491716&attribution_type=post',
             created_at: null,
             updated_at: null
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             from: '/r/a0b0129a',
             to: '__GHOST_URL__/blog/email/01cd4df3-83fa-4921-83be-3bb9a465ef83/?ref=Test-newsletter&attribution_id=6343994e7216ffcbce491716&attribution_type=post',
             created_at: null,
             updated_at: null
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             from: '/r/20b0129a',
             to: 'https://example.com/subscripe?ref=Test-newsletter',
             created_at: null,
@@ -917,21 +921,21 @@ DataGenerator.Content = {
         // sourceFavicon: metadata.favicon,
         // sourceFeaturedImage: metadata.image
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             source: 'https://source.com',
             target: 'https://target.com',
             sourceTitle: 'Title!',
             sourceExcerpt: 'Excerpt!'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             source: 'https://anothersource.com',
             target: 'https://anothertarget.com',
             sourceTitle: 'Another Title!',
             sourceExcerpt: 'Another Excerpt!'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             source: 'https://src.com',
             target: 'https://target.com',
             sourceTitle: 'Title goes here',
@@ -991,7 +995,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             created_by: DataGenerator.Content.users[0].id,
             created_at: new Date(),
             updated_by: DataGenerator.Content.users[0].id,
@@ -1003,7 +1007,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'tag',
             slug: 'slug',
             feature_image: null,
@@ -1034,7 +1038,7 @@ DataGenerator.forKnex = (function () {
         }
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             uuid: uuid.v4(),
             title: 'title',
             status: 'published',
@@ -1057,7 +1061,7 @@ DataGenerator.forKnex = (function () {
         locale = locale || null;
 
         return createPost({
-            id: ObjectId().toHexString(),
+            id: generateId(),
             title: 'Test Post ' + uniqueInteger,
             slug: 'ghost-from-fiction-to-function-' + uniqueInteger,
             mobiledoc: DataGenerator.markdownToMobiledoc('Three days ago I released a <a title="Ghost" href="http:\/\/john.onolan.org\/ghost\/">concept page<\/a> for a lite version of WordPress that I\'ve been thinking about for a long time, called Ghost. I think it\'s fair to say that I didn\'t quite anticipate how strong the reaction would be - and I\'ve hardly had time to catch my breath in the last 72 hours.\n\nThe response was overwhelming, and overwhelmingly positive. In the first 6 hours my site got 35,000 page views after hitting the number 1 slot on <a href="http:\/\/news.ycombinator.com\/item?id=4743245" onclick="javascript:_gaq.push([\'_trackEvent\',\'outbound-article\',\'http:\/\/news.ycombinator.com\']);">Hacker News<\/a>.&nbsp;As of right now, the traffic count is just over <a href="http:\/\/john.onolan.org\/wp-content\/uploads\/2012\/11\/Screen-Shot-2012-11-09-at-17.51.21.png" rel="lightbox" class="cboxElement">91,000 page views<\/a>&nbsp;- and Ghost has been featured all over the place. Notable mentions so far include Christina Warren from Mashable, who <a href="http:\/\/christina.is\/" onclick="javascript:_gaq.push([\'_trackEvent\',\'outbound-article\',\'http:\/\/christina.is\']);">wrote about it<\/a>. Michael Carney from PandoDaily <a href="http:\/\/pandodaily.com\/2012\/11\/07\/wordpress-guru-designs-a-concept-blogging-platform-that-doesnt-suck-gets-rave-reviews\/" onclick="javascript:_gaq.push([\'_trackEvent\',\'outbound-article\',\'http:\/\/pandodaily.com\']);">interviewed me about it<\/a>. Someone even <a href="http:\/\/www.voicens.com\/web\/?p=4425" onclick="javascript:_gaq.push([\'_trackEvent\',\'outbound-article\',\'http:\/\/www.voicens.com\']);">wrote about it in Chinese<\/a>. That\'s pretty cool.\n\n\nThe feedback has been amazing, and while it\'s impossible to reply to all of the messages individually, I\'m getting to as many of them as I can and I want to thank each and every one of you who took the time to send me a message or share the concept because you liked it. Now that the initial storm has died down a bit, I wanted to take some time to answer some of the more common questions and talk about what\'s next.\n<h2>FAQ - Continued...<\/h2>\n\nThe most common question, bizarrely:\n<h5><em><strong>Oh my god, why is that whole page made of images? What\'s wrong with you? \/\/ I can\'t take you seriously \/\/ Don\'t you know anything about the web? \/\/ You are literally Satan re-incarnate.<\/strong><\/em><\/h5>\n\nThis was really the only negativity I got in response to the post, and it surprised me. I put together the concept page as... just that... a concept. It was a way for me to get the ideas out of my head and "down on paper" - or so to speak. I used photoshop as a <em>tool<\/em> to write down my idea with text and images. If I used a sketchbook as a <em>tool&nbsp;<\/em>to create images and handwritten notes, then uploaded scans of it, I doubt anyone would complain. The concept page was never supposed to be a finished product because I had no idea if there would be any interest in it. I had no motivation to waste hours coding a custom layout for something might only ever be read by a few people and then forgotten.\n\nHardware manufacturers make hundreds of foam cutout prototypes of products before they build one with working buttons and screens. I\'m aware of all the usability problems with a web page made of images, and equally, foam cutouts without buttons or screens aren\'t particularly user friendly either. They\'re not supposed to be.\n\nLet\'s move on.\n<h5><em><strong>What? Why no comments? I need comments.<\/strong><\/em><\/h5>\n\nBecause comments add a layer of complexity that is beyond the core focus of this platform, which is publishing. Again, that\'s not to say you couldn\'t have any comments. This could easily be added with a dedicated plugin where you own the data or (as mentioned) there are third party providers such as Disqus, IntenseDebate, Livefyre and Facebook who all have great platforms. The point of this isn\'t to say "you can\'t have comments" - it\'s to say "comments aren\'t on by default". It\'s about simplicity, more than anything else.\n<h5><em><strong>Yeah, but WordPress are already going to revise their dashboard, WordPress.com is experimenting with a potential simplified version... so why bother with this?<\/strong><\/em><\/h5>\n\n<a href="http:\/\/john.onolan.org\/wp-content\/uploads\/2012\/11\/newwp.png" rel="lightbox[2102]" title="newwp" class="cboxElement"><img class="alignnone size-large wp-image-2117" title="newwp" src="http:\/\/john.onolan.org\/wp-content\/uploads\/2012\/11\/newwp-550x210.png" alt="" width="550" height="210"><\/a>\n\nSorry, but Tumblr already did this - it\'s not the future of blogging, it\'s the past.\n\nGhost isn\'t about sharing "Fuck Yeah [<a href="http:\/\/fuckyeahdogs.tumblr.com\/" onclick="javascript:_gaq.push([\'_trackEvent\',\'outbound-article\',\'http:\/\/fuckyeahdogs.tumblr.com\']);">Dogs<\/a>\/<a href="http:\/\/fuckyeahsharks.tumblr.com\/" onclick="javascript:_gaq.push([\'_trackEvent\',\'outbound-article\',\'http:\/\/fuckyeahsharks.tumblr.com\']);" rel="lightbox" class="cboxElement">Sharks<\/a>\/<a href="http:\/\/fuckyeahgirlswithtattoos.tumblr.com\/" onclick="javascript:_gaq.push([\'_trackEvent\',\'outbound-article\',\'http:\/\/fuckyeahgirlswithtattoos.tumblr.com\']);">Girls with Tattoos<\/a>]" - it\'s about publishing - which means writing - rather than mashing a few buttons to make sure that everyone can see and appreciate your latest funny picture\/status, which is surely the most funny picture\/status you\'ve ever posted.\n\nTumblr, Pinterest and Facebook already have this locked down.&nbsp;It\'s not the future.\n<h5><em><strong>So... are you actually going to build this thing?<\/strong><\/em><\/h5>\n\nThe concept page was a way for me to test demand and interest. To see if anyone actually agreed with my frustrations and, more importantly, my solutions. I plucked a random figure of "10,000 pageviews" out of the air before I hit the publish button. If it got less than 10,000 pageviews, I would surrender to the fact that it would only ever be an idea. I\'ve now exceeded that goal 9 times over, so yes, I\'m looking at how Ghost can now be made into a reality.\n<h5><em><strong>How can I find out when it\'s done? \/\/ SHUT UP AND TAKE MY MONEY<\/strong><\/em><\/h5>\n\nOk, ok - there\'s a holding page up on <a href="http:\/\/tryghost.org" onclick="javascript:_gaq.push([\'_trackEvent\',\'outbound-article\',\'http:\/\/tryghost.org\']);">http:\/\/TryGhost.org<\/a> - put your email address in.\n<hr>\n<h3>How are you going to do this?<\/h3>\n\nThere\'s three main ways of going about this, each has merits as well as drawbacks.\n\n<em><strong>1.) Build it from scratch<\/strong><\/em> - Many people (particularly the Hacker News crowd) expressed the sentiment that there was little point in forking WordPress. When you\'re going to strip out so much, you get to a point where you might as well start from scratch anyway. Take away the crutches of being stuck with older technologies and put together something which is as sophisticated in code as it is in UI\/UX.\n<ul>\n<li><em>Pros:<\/em> The idea of something completely new is exciting, opportunity to build something very sophisticated, complete control over everything.<\/li>\n<li><em>Cons:<\/em> Lose the &nbsp;WordPress ecosystem which includes millions of users and thousands of developers, potentially spend the next 6 months fighting over whether to use PHP\/RoR\/Django\/Python\/Node\/Whateverthefuck because everyone loves to evangelise the technology they know best.<\/li>\n<\/ul>\n\n<em><strong>2.) Fork WordPress<\/strong><\/em> - This was the original idea I put out. Take the WordPress codebase, as is, and modify it to turn it into something new. Initially the codebase is practically the same, which means developers already know it. Then it can change over time and evolve into its own thing.\n<ul>\n<li><em>Pros:<\/em> Easy start with existing codebase, potential to evolve, doesn\'t lose WordPress ecosystem initially.<\/li>\n<li><em>Cons:<\/em> Stuck with existing codebase - the good as well as the bad, &nbsp;eventually needs to be rewritten completely, less control, loses the WordPress ecosystem after a while anyway, makes it complicated to transition from legacy code to new code.<\/li>\n<\/ul>\n\n<em><strong>3.) Make it a plugin\/extension<\/strong><\/em> - Lots of people asked why Ghost couldn\'t just be a WordPress plugin. It would certainly be the easiest route of the 3, it\'s possible to completely remove \/wp-admin\/ and replace with with \/ghost\/ ... but I feel like it kind of misses the point. This route bolts Ghost on, but it\'s still WordPress under the hood. From a UI\/UX standpoint it would function - but it wouldn\'t revolutionise anything else. It makes WordPress itself about blogging again, rather than creating something new.\n<ul>\n<li><em>Pros:<\/em> Very easy development, very easy deployment, keeps WordPress ecosystem forever, doesn\'t force anyone to change.<\/li>\n<li><em>Cons:<\/em> The least exciting (for me, personally), much less control, it would be much harder to maintain something like this on a non-profit basis - which loses a piece of what Ghost is about.<\/li>\n<\/ul>\n<h3>What\'s the answer?<\/h3>\n\nI\'ve spoken to a lot of smart people over the last few days. The one thing that everyone seems to agree on is that a fork is the worst of both worlds. So the one thing that I suggested as a way of making this happen, is the least likely to work in reality. Remember the foam prototype metaphor earlier? Learning and iterating - that\'s what happening now.\n\nThat leaves a choice between WordPress plugin or fresh build. The answer? Both.\n\nA WordPress plugin will act as a proof of concept and a working prototype, initially, because it\'s easier to leverage the existing WordPress ecosystem to create it than to go into a cave for 6 months trying to build this amazing thing that everyone will have forgotten about.\n\nThe plugin will not be perfect. It will add the Ghost UI\/UX and as much functionality as we can cram into it. It will completely remove \/wp-admin\/ and replace it with \/ghost\/ - effectively using WordPress core as a basic foundation to build on top of. It will give people who don\'t want to switch away from WordPress access to the Ghost UX which they want to have, and it will give people who want the full Ghost platform a taste of what\'s to come.\n\nIt will allow us to develop and learn and iterate on the concept pretty rapidly, which has a great deal of value.\n\nThis is step one. Assuming the plugin is actually used by people - it would then justify exploring building the standalone version of Ghost from the ground up. The plugin would subsequently serve as a great marketing tool for the platform. Think of it as an upgrade path. But that\'s a long way away. Having the idea is the easy part. Making it happen is what counts.\n\nHappily - amongst the thousands of people talking about Ghost for the last few days - several have been talking about how they\'ve already built some working prototypes of my mockups and turned them into WordPress plugins or just local development sites. These will likely go on to be the starting point of the first Ghost plugin.<\/p>\n\nThere\'s a lot to do, and I\'m amazed by the number of people who have offered their help with this. In the next few days I\'ll be kicking off work on the plugin properly and start putting together a more organised structure which explains how you can get involved and contribute to the project if you\'re interested. So... watch this space - and thanks for all your support so far.\n\n<a href="http:\/\/twitter.com\/TryGhost" onclick="javascript:_gaq.push([\'_trackEvent\',\'outbound-article\',\'http:\/\/twitter.com\']);" class="twitter-follow-button">Follow @TryGhost<\/a>'),
@@ -1080,7 +1084,7 @@ DataGenerator.forKnex = (function () {
         }
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'name',
             email: 'test@ghost.org',
             bio: 'bio',
@@ -1104,7 +1108,7 @@ DataGenerator.forKnex = (function () {
         const basics = createBasic(newObj);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             uuid: uuid.v4(),
             secret: 'not_available',
             redirection_uri: 'http://localhost:9999',
@@ -1127,7 +1131,7 @@ DataGenerator.forKnex = (function () {
 
     function createPostsTags(postId, tagId) {
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: postId,
             tag_id: tagId
         };
@@ -1135,7 +1139,7 @@ DataGenerator.forKnex = (function () {
 
     function createUsersRoles(userId, roleId) {
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             user_id: userId,
             role_id: roleId
         };
@@ -1143,7 +1147,7 @@ DataGenerator.forKnex = (function () {
 
     function createPostsAuthors(postId, authorId, sort_order = 0) {
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             author_id: authorId,
             post_id: postId,
             sort_order: sort_order
@@ -1153,7 +1157,7 @@ DataGenerator.forKnex = (function () {
     function createNewsletter(overrides) {
         const newObj = _.cloneDeep(overrides);
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             uuid: uuid.v4(),
             slug: 'daily-newsletter',
             name: 'Daily Newsletter',
@@ -1175,7 +1179,7 @@ DataGenerator.forKnex = (function () {
     function createOffer(overrides) {
         const newObj = _.cloneDeep(overrides);
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'Black Friday',
             code: 'black-friday',
             display_title: 'Black Friday Sale!',
@@ -1195,7 +1199,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'member@ghost.org'
         });
     }
@@ -1204,7 +1208,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'member@ghost.org',
             newsletters: [{
                 id: 'newsletter-1'
@@ -1216,7 +1220,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email: 'member@ghost.org',
             products: [{
                 id: 'product-1'
@@ -1228,7 +1232,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'label',
             slug: 'slug',
             created_by: DataGenerator.Content.users[0].id,
@@ -1242,7 +1246,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'product',
             slug: 'gold',
             active: true,
@@ -1261,7 +1265,7 @@ DataGenerator.forKnex = (function () {
 
     function createMembersLabels(member_id, label_id, sort_order = 0) {
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id,
             label_id,
             sort_order
@@ -1270,7 +1274,7 @@ DataGenerator.forKnex = (function () {
 
     function createStripeProduct(product_id, stripe_product_id) {
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             product_id,
             stripe_product_id
         };
@@ -1280,7 +1284,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             uuid: '95ce1c53-69b0-4f5f-be91-d3aeb39046b5',
             key: 'title',
             value: null,
@@ -1296,7 +1300,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             token: uuid.v4(),
             expires: Date.now() + constants.ONE_DAY_MS
         });
@@ -1306,7 +1310,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             token: uuid.v4(),
             email: 'test@ghost.org',
             role_id: DataGenerator.Content.roles[0].id,
@@ -1321,7 +1325,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             event: 'test',
             target_url: 'https://example.com/hooks/test',
             created_by: DataGenerator.Content.users[0].id,
@@ -1335,7 +1339,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             name: 'test integration',
             slug: 'test-integration',
             created_by: DataGenerator.Content.users[0].id,
@@ -1356,7 +1360,7 @@ DataGenerator.forKnex = (function () {
     function createEmailBatch(overrides) {
         const newObj = _.cloneDeep(overrides);
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             created_at: new Date(),
             updated_at: new Date()
         });
@@ -1365,7 +1369,7 @@ DataGenerator.forKnex = (function () {
     function createEmailRecipient(overrides) {
         const newObj = _.cloneDeep(overrides);
         return _.defaults(newObj, {
-            id: ObjectId().toHexString()
+            id: generateId()
         });
     }
 
@@ -1376,7 +1380,7 @@ DataGenerator.forKnex = (function () {
         const newObj = _.cloneDeep(overrides);
 
         return _.defaults(newObj, {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[memberIndex].id,
             post_id: DataGenerator.Content.posts[0].id
         });
@@ -1436,35 +1440,35 @@ DataGenerator.forKnex = (function () {
     const roles_users = [
         {
             // owner
-            id: ObjectId().toHexString(),
+            id: generateId(),
             role_name: 'Owner',
             user_id: DataGenerator.Content.users[0].id,
             role_id: DataGenerator.Content.roles[3].id
         },
         {
             // admin
-            id: ObjectId().toHexString(),
+            id: generateId(),
             role_name: 'Administrator',
             user_id: DataGenerator.Content.users[1].id,
             role_id: DataGenerator.Content.roles[0].id
         },
         {
             // editor
-            id: ObjectId().toHexString(),
+            id: generateId(),
             role_name: 'Editor',
             user_id: DataGenerator.Content.users[2].id,
             role_id: DataGenerator.Content.roles[1].id
         },
         {
             // author
-            id: ObjectId().toHexString(),
+            id: generateId(),
             role_name: 'Author',
             user_id: DataGenerator.Content.users[3].id,
             role_id: DataGenerator.Content.roles[2].id
         },
         {
             // contributor
-            id: ObjectId().toHexString(),
+            id: generateId(),
             role_name: 'Contributor',
             user_id: DataGenerator.Content.users[7].id,
             role_id: DataGenerator.Content.roles[4].id
@@ -1473,12 +1477,12 @@ DataGenerator.forKnex = (function () {
 
     const posts_meta = [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[2].id,
             meta_description: 'meta description for short and sweet'
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[3].id,
             meta_description: 'meta description for draft post'
         }
@@ -1488,37 +1492,37 @@ DataGenerator.forKnex = (function () {
     // it relies on the created posts/tags
     const posts_tags = [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[0].id,
             tag_id: DataGenerator.Content.tags[0].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[0].id,
             tag_id: DataGenerator.Content.tags[1].id,
             sort_order: 1
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[1].id,
             tag_id: DataGenerator.Content.tags[0].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[1].id,
             tag_id: DataGenerator.Content.tags[1].id,
             sort_order: 1
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[2].id,
             tag_id: DataGenerator.Content.tags[2].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[3].id,
             tag_id: DataGenerator.Content.tags[3].id,
             sort_order: 0
@@ -1527,50 +1531,50 @@ DataGenerator.forKnex = (function () {
 
     const members_newsletters = [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[0].id,
             newsletter_id: DataGenerator.Content.newsletters[0].id
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[1].id,
             newsletter_id: DataGenerator.Content.newsletters[0].id
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[2].id,
             newsletter_id: DataGenerator.Content.newsletters[0].id
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[3].id,
             newsletter_id: DataGenerator.Content.newsletters[1].id
         },
         // Member index 4 (comped@test.com), subscribed to two active newsletters
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[4].id,
             newsletter_id: DataGenerator.Content.newsletters[0].id
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[4].id,
             newsletter_id: DataGenerator.Content.newsletters[1].id
         },
         // Member index 5 (vip@test.com), subscribed to an active and archived newsletter
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[5].id,
             newsletter_id: DataGenerator.Content.newsletters[1].id
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[5].id,
             newsletter_id: DataGenerator.Content.newsletters[2].id
         },
         // Member index 6 (vip-paid@test.com), subscribed to an archived newsletter
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: DataGenerator.Content.members[6].id,
             newsletter_id: DataGenerator.Content.newsletters[2].id
         }
@@ -1579,61 +1583,61 @@ DataGenerator.forKnex = (function () {
 
     const posts_authors = [
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[0].id,
             author_id: DataGenerator.Content.users[0].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[1].id,
             author_id: DataGenerator.Content.users[0].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[2].id,
             author_id: DataGenerator.Content.users[0].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[3].id,
             author_id: DataGenerator.Content.users[0].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[3].id,
             author_id: _.find(DataGenerator.Content.users, {email: 'jbOgendAth@example.com'}).id,
             sort_order: 1
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[4].id,
             author_id: DataGenerator.Content.users[0].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[4].id,
             author_id: _.find(DataGenerator.Content.users, {slug: 'slimer-mcectoplasm'}).id,
             sort_order: 1
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[5].id,
             author_id: DataGenerator.Content.users[0].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[6].id,
             author_id: DataGenerator.Content.users[0].id,
             sort_order: 0
         },
         {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             post_id: DataGenerator.Content.posts[7].id,
             author_id: DataGenerator.Content.users[0].id,
             sort_order: 0
@@ -1687,7 +1691,7 @@ DataGenerator.forKnex = (function () {
         if (recipient.failed_at === null) {
             if (recipient.delivered_at === null) {
                 return [{
-                    id: ObjectId().toHexString(),
+                    id: generateId(),
                     email_recipient_id: recipient.id,
                     email_id: recipient.email_id,
                     member_id: recipient.member_id,
@@ -1696,14 +1700,14 @@ DataGenerator.forKnex = (function () {
                     enhanced_code: '5.5.5',
                     severity: 'temporary',
                     failed_at: recipient.processed_at,
-                    event_id: 'event-id-' + ObjectId().toHexString()
+                    event_id: 'event-id-' + generateId()
                 }];
             }
 
             return [];
         }
         return [{
-            id: ObjectId().toHexString(),
+            id: generateId(),
             email_recipient_id: recipient.id,
             email_id: recipient.email_id,
             member_id: recipient.member_id,
@@ -1712,7 +1716,7 @@ DataGenerator.forKnex = (function () {
             enhanced_code: '5.5.5',
             severity: 'permanent',
             failed_at: recipient.failed_at,
-            event_id: 'event-id-' + ObjectId().toHexString()
+            event_id: 'event-id-' + generateId()
         }];
     });
 
@@ -1741,7 +1745,7 @@ DataGenerator.forKnex = (function () {
             }
         ];
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: member.id,
             source: 'system',
             attribution_type: 'post',
@@ -1826,7 +1830,7 @@ DataGenerator.forKnex = (function () {
             }
         ];
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: members[index].id,
             subscription_id: subscription.id,
             source: 'system',
@@ -1843,7 +1847,7 @@ DataGenerator.forKnex = (function () {
         createBasic(DataGenerator.Content.members_paid_subscription_events[2]),
         ...members_subscription_created_events.map((e) => {
             return {
-                id: ObjectId().toHexString(),
+                id: generateId(),
                 type: 'created',
                 mrr_delta: 1000,
                 currency: 'usd',
@@ -1858,7 +1862,7 @@ DataGenerator.forKnex = (function () {
 
     const redirects = posts.map((post, index) => {
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             from: '/r/' + index,
             to: 'https:://ghost.org',
             post_id: post.id,
@@ -1869,7 +1873,7 @@ DataGenerator.forKnex = (function () {
 
     const members_click_events = redirects.map((redirect, index) => {
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: members[index].id,
             redirect_id: redirect.id,
             created_at: new Date()
@@ -1878,7 +1882,7 @@ DataGenerator.forKnex = (function () {
 
     const members_feedback = posts.map((redirect, index) => {
         return {
-            id: ObjectId().toHexString(),
+            id: generateId(),
             member_id: members[index].id,
             post_id: redirect.id,
             score: index % 2,
@@ -2008,7 +2012,7 @@ DataGenerator.forModel = (function () {
     });
 
     roles = _.map(DataGenerator.Content.roles, function (role) {
-        return _.extend({}, role, {id: ObjectId().toHexString()});
+        return _.extend({}, role, {id: generateId()});
     });
 
     return {

--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -369,7 +369,7 @@ class EmailRenderer {
         }
 
         // Record the original image width and height attributes before inlining the styles with juice
-        // If any images have `width: auto` or `height: auto` set via CSS, 
+        // If any images have `width: auto` or `height: auto` set via CSS,
         // juice will explicitly set the width/height attributes to `auto` on the <img /> tag
         // This is not supported by Outlook, so we need to reset the width/height attributes to the original values
         // Other clients will ignore the width/height attributes and use the inlined CSS instead
@@ -984,7 +984,7 @@ class EmailRenderer {
         if (newsletter.get('show_latest_posts')) {
             // Fetch last 3 published posts
             const {data} = await this.#models.Post.findPage({
-                filter: 'status:published+id:-' + post.id,
+                filter: `status:published+id:-'${post.id}'`,
                 order: 'published_at DESC',
                 limit: 3
             });

--- a/ghost/webmentions/test/InMemoryMentionRepository.test.js
+++ b/ghost/webmentions/test/InMemoryMentionRepository.test.js
@@ -47,7 +47,7 @@ describe('InMemoryMentionRepository', function () {
         }
 
         const pageOne = await repository.getPage({
-            filter: `resource_id:${resourceId.toHexString()}`,
+            filter: `resource_id:'${resourceId.toHexString()}'`,
             limit: 2,
             page: 1
         });
@@ -57,7 +57,7 @@ describe('InMemoryMentionRepository', function () {
         assert(pageOne.meta.pagination.next === 2);
 
         const pageTwo = await repository.getPage({
-            filter: `resource_id:${resourceId.toHexString()}`,
+            filter: `resource_id:'${resourceId.toHexString()}'`,
             limit: 2,
             page: 2
         });
@@ -67,7 +67,7 @@ describe('InMemoryMentionRepository', function () {
         assert(pageTwo.meta.pagination.next === 3);
 
         const pageThree = await repository.getPage({
-            filter: `resource_id:${resourceId.toHexString()}`,
+            filter: `resource_id:'${resourceId.toHexString()}'`,
             limit: 2,
             page: 3
         });


### PR DESCRIPTION
fixes [GRO-34](https://linear.app/tryghost/issue/GRO-34/)
fixes [GRO-33](https://linear.app/tryghost/issue/GRO-33/)

This adds a new way to run all tests with enforced numeric ObjectIDs. These
numeric ids cause issues if they are used withing NQL filters. So they
surface tiny bugs in our codebase.

You can run tests using this option via:
NUMERIC_IDS=1 yarn test:e2e

Removed some defensive logic that could be explained by this discovered
issue.