### PR TITLE
✨ Added option to unsubscribe in one-click from emails

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -48,10 +48,6 @@ const features = [{
     description: 'Enables publishers to collect one-time payments',
     flag: 'tipsAndDonations'
 },{
-    title: 'List-Unsubscribe header',
-    description: 'Set the List-Unsubscribe header in emails',
-    flag: 'listUnsubscribeHeader'
-},{
     title: 'AdminX Offers',
     description: 'Enables the new offers UI in AdminX settings',
     flag: 'adminXOffers'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -21,7 +21,8 @@ const GA_FEATURES = [
     'announcementBar',
     'signupForm',
     'recommendations',
-    'editorEmojiPicker'
+    'editorEmojiPicker',
+    'listUnsubscribeHeader'
 ];
 
 // NOTE: this allowlist is meant to be used to filter out any unexpected
@@ -43,7 +44,6 @@ const ALPHA_FEATURES = [
     'tipsAndDonations',
     'importMemberTier',
     'lexicalIndicators',
-    'listUnsubscribeHeader',
     'editorEmojiPicker',
     'adminXOffers',
     'filterEmailDisabled'

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -758,7 +758,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4307",
+  "content-length": "4338",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4051
- added a `List-Unsubscribe` header to emails, in compliance with the RFC 8058 requirements
- Gmail, Apple Mail, Yahoo Mail, and other popular email clients offer an option to unsubscribe in one-click, based on the `List-Unsubscribe` header. Some require an HTTPS endpoint, some a mailto address; both options are provided in the List-Unsubscribe header

Co-authored-by: Simon Backx <simon@ghost.org>
Co-authored-by: Djordje Vlaisavljevic <dzvlais@gmail.com>