### PR TITLE
Fixed Sentry ajax error tags

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -197,13 +197,11 @@ export default Route.extend(ShortcutsRoute, {
                         event.exception.values[0].type = `${error.type}: ${error.context}`;
                         event.exception.values[0].value = error.message;
                         event.exception.values[0].context = error.context;
-                        event.tags.isAjaxError = true;
                     } else {
-                        event.tags.isAjaxError = false;
                         delete event.contexts.ajax;
-                        delete event.tags.ajaxStatus;
-                        delete event.tags.ajaxMethod;
-                        delete event.tags.ajaxUrl;
+                        delete event.tags.ajax_status;
+                        delete event.tags.ajax_method;
+                        delete event.tags.ajax_url;
                     }
 
                     return event;

--- a/ghost/admin/app/services/ajax.js
+++ b/ghost/admin/app/services/ajax.js
@@ -306,7 +306,7 @@ class ajaxService extends AjaxService {
             status
         });
         Sentry.setTag('ajax_status', status);
-        Sentry.setTag('ajax_url', request.url);
+        Sentry.setTag('ajax_url', request.url.slice(0, 200)); // the max length of a tag value is 200 characters
         Sentry.setTag('ajax_method', request.method);
 
         if (headers['content-version']) {


### PR DESCRIPTION
no issue

- Fixed an issue where the ajax_url tag was exceeding the allowed length of tags in Sentry
- Fixed the mechanism for deleting the ajax tags when the error is not an ajax error
- Removed the isAjaxError tag, since we can use the other ajax tags to filter for ajax errors now