### PR TITLE
Masked post and page IDs in Ember Data errors

### DIFF
--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -191,6 +191,13 @@ export default Route.extend(ShortcutsRoute, {
                         return null;
                     }
 
+                    // if the error value includes a model id then overwrite it to improve grouping
+                    if (event.exception.values && event.exception.values.length > 0) {
+                        const pattern = /<(post|page):[a-f0-9]+>/;
+                        const replacement = "<$1:ID>";
+                        event.exception.values[0].value = event.exception.values[0].value.replace(pattern, replacement);
+                    }
+
                     // ajax errors — improve logging and add context for debugging
                     if (isAjaxError(exception)) {
                         const error = exception.payload.errors[0];

--- a/ghost/admin/app/routes/application.js
+++ b/ghost/admin/app/routes/application.js
@@ -194,7 +194,7 @@ export default Route.extend(ShortcutsRoute, {
                     // if the error value includes a model id then overwrite it to improve grouping
                     if (event.exception.values && event.exception.values.length > 0) {
                         const pattern = /<(post|page):[a-f0-9]+>/;
-                        const replacement = "<$1:ID>";
+                        const replacement = '<$1:ID>';
                         event.exception.values[0].value = event.exception.values[0].value.replace(pattern, replacement);
                     }
 


### PR DESCRIPTION
no issue

- The standard error message from Ember Data includes post/page ids in the error message
- This causes Sentry to treat each instance as a unique issue and results in many duplicate issues for the same error
- This change should mask the ids and allow Sentry to group the errors correctly