### PR TITLE
Fixed issues with wrong button color in dark mode

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/APIKeys.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/APIKeys.tsx
@@ -27,9 +27,9 @@ const APIKeyField: React.FC<APIKeyFieldProps> = ({label, text = '', hint, onRege
         <div className={containerClasses}>
             <span>{text}</span>
             {hint}
-            <div className='visible absolute right-0 top-1/2 flex translate-y-[-50%] gap-1 pl-1 text-sm group-hover/api-keys:visible dark:bg-black md:invisible'>
-                {onRegenerate && <Button className='!bg-white' color='outline' label='Regenerate' size='sm' onClick={onRegenerate} />}
-                <Button className='!bg-white' color='outline' label={copied ? 'Copied' : 'Copy'} size='sm' onClick={copyText} />
+            <div className='visible absolute right-0 top-1/2 flex translate-y-[-50%] gap-1 bg-white pl-1 text-sm group-hover/api-keys:visible dark:bg-black md:invisible'>
+                {onRegenerate && <Button color='outline' label='Regenerate' size='sm' onClick={onRegenerate} />}
+                <Button color='outline' label={copied ? 'Copied' : 'Copy'} size='sm' onClick={copyText} />
             </div>
         </div>
     </div>;


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4166

Fixes an issue with APIKeys component used in integration modals where they don’t have the correct color in dark mode.