### PR TITLE
Reduced size of social metadata images

### DIFF
--- a/ghost/core/core/frontend/helpers/img_url.js
+++ b/ghost/core/core/frontend/helpers/img_url.js
@@ -7,18 +7,20 @@
 // Returns the URL for the current object scope i.e. If inside a post scope will return image permalink
 // `absolute` flag outputs absolute URL, else URL is relative.
 const {urlUtils} = require('../services/proxy');
+const {
+    detectInternalImage,
+    getImageWithSize,
+    getUnsplashImage,
+    detectUnsplashImage
+} = require('../utils/images');
 
-const url = require('url');
 const _ = require('lodash');
 const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
-const imageTransform = require('@tryghost/image-transform');
 
 const messages = {
     attrIsRequired: 'Attribute is required e.g. {{img_url feature_image}}'
 };
-
-const STATIC_IMAGE_URL_PREFIX = `${urlUtils.STATIC_IMAGE_URL_PREFIX}`;
 
 module.exports = function imgUrl(requestedImageUrl, options) {
     // CASE: if no url is passed, e.g. `{{img_url}}` we show a warning
@@ -46,7 +48,7 @@ module.exports = function imgUrl(requestedImageUrl, options) {
 
     if (!isInternalImage) {
         // Detect Unsplash width and format
-        const isUnsplashImage = /images\.unsplash\.com/.test(requestedImageUrl);
+        const isUnsplashImage = detectUnsplashImage(requestedImageUrl);
         if (isUnsplashImage) {
             try {
                 return getUnsplashImage(requestedImageUrl, sizeOptions);
@@ -98,96 +100,4 @@ function getImageSizeOptions(options) {
         imageSizes,
         requestedFormat
     };
-}
-
-function detectInternalImage(requestedImageUrl) {
-    const siteUrl = urlUtils.getSiteUrl();
-    const isAbsoluteImage = /https?:\/\//.test(requestedImageUrl);
-    const isAbsoluteInternalImage = isAbsoluteImage && requestedImageUrl.startsWith(siteUrl);
-
-    // CASE: imagePath is a "protocol relative" url e.g. "//www.gravatar.com/ava..."
-    //       by resolving the the imagePath relative to the blog url, we can then
-    //       detect if the imagePath is external, or internal.
-    const isRelativeInternalImage = !isAbsoluteImage && url.resolve(siteUrl, requestedImageUrl).startsWith(siteUrl);
-
-    return isAbsoluteInternalImage || isRelativeInternalImage;
-}
-
-function getUnsplashImage(imagePath, sizeOptions) {
-    const parsedUrl = new URL(imagePath);
-    const {requestedSize, imageSizes, requestedFormat} = sizeOptions;
-
-    if (requestedFormat) {
-        const supportedFormats = ['avif', 'gif', 'jpg', 'png', 'webp'];
-        if (supportedFormats.includes(requestedFormat)) {
-            parsedUrl.searchParams.set('fm', requestedFormat);
-        } else if (requestedFormat === 'jpeg') {
-            // Map to alias
-            parsedUrl.searchParams.set('fm', 'jpg');
-        }
-    }
-
-    if (!imageSizes || !imageSizes[requestedSize]) {
-        return parsedUrl.toString();
-    }
-
-    const {width, height} = imageSizes[requestedSize];
-
-    if (!width && !height) {
-        return parsedUrl.toString();
-    }
-
-    parsedUrl.searchParams.delete('w');
-    parsedUrl.searchParams.delete('h');
-
-    if (width) {
-        parsedUrl.searchParams.set('w', width);
-    }
-    if (height) {
-        parsedUrl.searchParams.set('h', height);
-    }
-    return parsedUrl.toString();
-}
-
-/**
- *
- * @param {string} imagePath
- * @param {Object} sizeOptions
- * @param {string} sizeOptions.requestedSize
- * @param {Object[]} sizeOptions.imageSizes
- * @param {string} [sizeOptions.requestedFormat]
- * @returns
- */
-function getImageWithSize(imagePath, sizeOptions) {
-    const hasLeadingSlash = imagePath[0] === '/';
-
-    if (hasLeadingSlash) {
-        return '/' + getImageWithSize(imagePath.slice(1), sizeOptions);
-    }
-    const {requestedSize, imageSizes, requestedFormat} = sizeOptions;
-
-    if (!requestedSize) {
-        return imagePath;
-    }
-
-    if (!imageSizes || !imageSizes[requestedSize]) {
-        return imagePath;
-    }
-
-    const {width, height} = imageSizes[requestedSize];
-
-    if (!width && !height) {
-        return imagePath;
-    }
-
-    const [imgBlogUrl, imageName] = imagePath.split(STATIC_IMAGE_URL_PREFIX);
-
-    const sizeDirectoryName = prefixIfPresent('w', width) + prefixIfPresent('h', height);
-    const formatPrefix = requestedFormat && imageTransform.canTransformToFormat(requestedFormat) ? `/format/${requestedFormat}` : '';
-
-    return [imgBlogUrl, STATIC_IMAGE_URL_PREFIX, `/size/${sizeDirectoryName}`, formatPrefix, imageName].join('');
-}
-
-function prefixIfPresent(prefix, string) {
-    return string ? prefix + string : '';
 }

--- a/ghost/core/core/frontend/utils/images.js
+++ b/ghost/core/core/frontend/utils/images.js
@@ -1,0 +1,100 @@
+const url = require('url');
+const imageTransform = require('@tryghost/image-transform');
+const urlUtils = require('../../shared/url-utils');
+
+module.exports.detectInternalImage = function detectInternalImage(requestedImageUrl) {
+    const siteUrl = urlUtils.getSiteUrl();
+    const isAbsoluteImage = /https?:\/\//.test(requestedImageUrl);
+    const isAbsoluteInternalImage = isAbsoluteImage && requestedImageUrl.startsWith(siteUrl);
+
+    // CASE: imagePath is a "protocol relative" url e.g. "//www.gravatar.com/ava..."
+    //       by resolving the the imagePath relative to the blog url, we can then
+    //       detect if the imagePath is external, or internal.
+    const isRelativeInternalImage = !isAbsoluteImage && url.resolve(siteUrl, requestedImageUrl).startsWith(siteUrl);
+
+    return isAbsoluteInternalImage || isRelativeInternalImage;
+};
+
+module.exports.detectUnsplashImage = function detectUnsplashImage(requestedImageUrl) {
+    const isUnsplashImage = /images\.unsplash\.com/.test(requestedImageUrl);
+    return isUnsplashImage;
+};
+
+module.exports.getUnsplashImage = function getUnsplashImage(imagePath, sizeOptions) {
+    const parsedUrl = new URL(imagePath);
+    const {requestedSize, imageSizes, requestedFormat} = sizeOptions;
+
+    if (requestedFormat) {
+        const supportedFormats = ['avif', 'gif', 'jpg', 'png', 'webp'];
+        if (supportedFormats.includes(requestedFormat)) {
+            parsedUrl.searchParams.set('fm', requestedFormat);
+        } else if (requestedFormat === 'jpeg') {
+            // Map to alias
+            parsedUrl.searchParams.set('fm', 'jpg');
+        }
+    }
+
+    if (!imageSizes || !imageSizes[requestedSize]) {
+        return parsedUrl.toString();
+    }
+
+    const {width, height} = imageSizes[requestedSize];
+
+    if (!width && !height) {
+        return parsedUrl.toString();
+    }
+
+    parsedUrl.searchParams.delete('w');
+    parsedUrl.searchParams.delete('h');
+
+    if (width) {
+        parsedUrl.searchParams.set('w', width);
+    }
+    if (height) {
+        parsedUrl.searchParams.set('h', height);
+    }
+    return parsedUrl.toString();
+};
+
+/**
+ *
+ * @param {string} imagePath
+ * @param {Object} sizeOptions
+ * @param {string} sizeOptions.requestedSize
+ * @param {Object[]} sizeOptions.imageSizes
+ * @param {string} [sizeOptions.requestedFormat]
+ * @returns
+ */
+module.exports.getImageWithSize = function getImageWithSize(imagePath, sizeOptions) {
+    const hasLeadingSlash = imagePath[0] === '/';
+
+    if (hasLeadingSlash) {
+        return '/' + getImageWithSize(imagePath.slice(1), sizeOptions);
+    }
+    const {requestedSize, imageSizes, requestedFormat} = sizeOptions;
+
+    if (!requestedSize) {
+        return imagePath;
+    }
+
+    if (!imageSizes || !imageSizes[requestedSize]) {
+        return imagePath;
+    }
+
+    const {width, height} = imageSizes[requestedSize];
+
+    if (!width && !height) {
+        return imagePath;
+    }
+
+    const [imgBlogUrl, imageName] = imagePath.split(urlUtils.STATIC_IMAGE_URL_PREFIX);
+
+    const sizeDirectoryName = prefixIfPresent('w', width) + prefixIfPresent('h', height);
+    const formatPrefix = requestedFormat && imageTransform.canTransformToFormat(requestedFormat) ? `/format/${requestedFormat}` : '';
+
+    return [imgBlogUrl, urlUtils.STATIC_IMAGE_URL_PREFIX, `/size/${sizeDirectoryName}`, formatPrefix, imageName].join('');
+};
+
+function prefixIfPresent(prefix, string) {
+    return string ? prefix + string : '';
+}

--- a/ghost/core/core/shared/config/overrides.json
+++ b/ghost/core/core/shared/config/overrides.json
@@ -124,7 +124,8 @@
             "signup-form-icon": {"width": 192, "height": 192},
             "email-header-image": {"width": 1200},
             "email-latest-posts-image": {"width": 200, "height": 200},
-            "email-latest-posts-image-mobile": {"width": 1200, "height": 960}
+            "email-latest-posts-image-mobile": {"width": 1200, "height": 960},
+            "social-image": {"width": 1200}
         }
     }
 }


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4140

- added `social-image` image size to our `internalImagesSizes` list with a max-width of 1200
- extracted image utils from `{{img_url}}` helper to a utils file for re-use
- updated `getImageDimensions` method that reads image dimensions and modifies the finalised `metaData` object before use to adjust dimensions and associated URLs to match max width of 1200px
