### PR TITLE
Fixed building `@tryghost/admin-x-demo` project before Admin

### DIFF
--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -40,8 +40,9 @@ module.exports = {
             }
 
             if (this.env === 'production') {
-                console.log('Admin-X Settings:', this.packageConfig['adminXSettingsFilename'], this.packageConfig['adminXSettingsHash']);
-                console.log('Koenig-Lexical:', this.packageConfig['editorFilename'], this.packageConfig['editorHash']);
+                for (const [key, value] of Object.entries(this.packageConfig)) {
+                    console.log(`Asset-Delivery: ${key} = ${value}`);
+                }
             }
 
             return this.packageConfig;

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -180,6 +180,7 @@
           "build:dev",
           {
             "projects": [
+              "@tryghost/admin-x-demo",
               "@tryghost/admin-x-settings"
             ],
             "target": "build"
@@ -191,6 +192,7 @@
           "build",
           {
             "projects": [
+              "@tryghost/admin-x-demo",
               "@tryghost/admin-x-settings"
             ],
             "target": "build"


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/a93c665d20e35513a7f357c37d60c7439559e91c

- this project needs to be built before Admin because Admin symlinks/copies the assets
