### PR TITLE
Added an email rendering test for all Koenig cards

### DIFF
--- a/ghost/core/test/integration/services/email-service/README.md
+++ b/ghost/core/test/integration/services/email-service/README.md
@@ -1,0 +1,12 @@
+# What is a golden post?
+The golden post is a single lexical post that has at least one example of every card that is available in the Koenig editor (with a few exceptions for cards that should never make it into an email). We have run into problems in the past where a small change to a particular card or to the EmailRenderer itself results in seriously mangled email rendering in one or more clients (usually Outlook).
+
+# How do I update the golden post to include a new card?
+If you're seeing a failing test like `The golden post does not contain the ${card} card`, that means that you (or someone else) has added a new node to `@tryghost/kg-default-nodes` that is not currently represented in the golden post. This test is here to trigger a review of the rendered email of the new card, to make sure it doesn't break the formatting in email clients. To update this test properly, please do the following:
+
+1. Create a card in the lexical editor, either at `koenig.ghost.org` or in your local Koenig repo
+2. Use the JSON Output in the bottom right of the demo to copy the lexical payload for the new card
+3. Paste the lexical payload for the card as a top level child of the `root` node in the golden post fixture at `ghost/core/test/utils/fixtures/email-service/golden-post.json`
+4. Re-run your tests with `UPDATE_SNAPSHOT=1` set to update the snapshot to include the new card
+5. Update (or recreate) the Golden Post on `main.ghost.org` using the `golden-post.json` string.
+6. Send a test email to Litmus and examine the rendered output to ensure everything looks right on different clients.

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -1660,14 +1660,14 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                         <tr class=\\"post-content-row\\">
                                             <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #000000; padding-bottom: 20px; border-bottom: 1px solid #e5eff5; border-bottom: 1px solid rgba(0, 0, 0, 0.12); max-width: 600px;\\" valign=\\"top\\">
                                                 <!-- POST CONTENT START -->
-                                                <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">This is just a simple paragraph, no frills.</p><blockquote style=\\"margin: 2em 0 2em 0; padding: 0 25px 0 25px; border-left: #FF1A75 2px solid; color: #000000; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\">This is block quote</blockquote><blockquote class=\\"kg-blockquote-alt\\" style=\\"margin: 2em 0 2em 0; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px; border-left: 0 none; padding: 0 50px 0 50px; text-align: center; font-size: 1.2em; font-style: italic; color: #000000; color: rgba(0, 0, 0, 0.5);\\">This is a...different block quote</blockquote><h2 id=\\"this-is-a-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">This is a heading!</h2><h3 id=\\"heres-a-smaller-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 26px;\\">Here&#39;s a smaller heading.</h3><div class=\\"kg-card kg-image-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1952-1.jpeg\\" class=\\"kg-image\\" alt=\\"A beautiful tree, indeed.\\" loading=\\"lazy\\" width=\\"600\\" height=\\"450\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: block; margin: 0 auto; width: auto; height: auto;\\"><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><span style=\\"white-space: pre-wrap;\\">A beautiful tree.</span></div></div><h1 id=\\"a-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 42px; font-weight: 700;\\">A heading</h1>
+                                                <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">This is just a simple paragraph, no frills.</p><blockquote style=\\"margin: 2em 0 2em 0; padding: 0 25px 0 25px; border-left: #FF1A75 2px solid; color: #000000; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\">This is block quote</blockquote><blockquote class=\\"kg-blockquote-alt\\" style=\\"margin: 2em 0 2em 0; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px; border-left: 0 none; padding: 0 50px 0 50px; text-align: center; font-size: 1.2em; font-style: italic; color: #000000; color: rgba(0, 0, 0, 0.5);\\">This is a...different block quote</blockquote><h2 id=\\"this-is-a-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">This is a heading!</h2><h3 id=\\"heres-a-smaller-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 26px;\\">Here&#39;s a smaller heading.</h3><div class=\\"kg-card kg-image-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><img src=\\"https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg/1920px-Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg\\" class=\\"kg-image\\" alt=\\"Cows eat grass.\\" loading=\\"lazy\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: block; margin: 0 auto; width: auto; height: auto;\\" width=\\"auto\\" height=\\"auto\\"><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><span style=\\"white-space: pre-wrap;\\">A lovely cow</span></div></div><h1 id=\\"a-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 42px; font-weight: 700;\\">A heading</h1>
 <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">and a paragraph (in markdown!)</p>
 
 <!--kg-card-begin: html-->
 <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">A paragraph inside an HTML card.</p>
 <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">And another one, with some <b>bold</b> text.</p>
 <!--kg-card-end: html-->
-<div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1952-6.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1873.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1868-2.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1478.jpeg\\" width=\\"600\\" height=\\"800\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_3917.jpeg\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A tree, a meerkat, and a terrier.</span></p></div></div><hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e5eff5; border-top: 1px solid rgba(0, 0, 0, 0.12);\\"><div>
+<hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e5eff5; border-top: 1px solid rgba(0, 0, 0, 0.12);\\"><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&amp;w=2070&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A gallery.</span></p></div></div><div>
         <!--[if !mso !vml]-->
             <div class=\\"kg-card kg-bookmark-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0; width: 100%; background: #ffffff;\\">
                 <a class=\\"kg-bookmark-container\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"display: flex; min-height: 148px; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Oxygen, Ubuntu, Cantarell, &#39;Open Sans&#39;, &#39;Helvetica Neue&#39;, sans-serif; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12); overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\">
@@ -1737,7 +1737,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
         <![endif]--></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Hey </span><span>Vinz</span><span style=\\"white-space: pre-wrap;\\">,</span></p><!--members-only--><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"></p><div class=\\"btn btn-accent\\" style=\\"box-sizing: border-box; width: 100%; display: table;\\"><table border=\\"0\\" cellspacing=\\"0\\" cellpadding=\\"0\\" align=\\"center\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;\\" width=\\"auto\\"><tr><td align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; border-radius: 5px; text-align: center; background-color: #FF1A75;\\" valign=\\"top\\" bgcolor=\\"#FF1A75\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; background-color: #FF1A75; color: #FFFFFF; border-color: #FF1A75;\\" target=\\"_blank\\">Click me, I&#39;m a button!</a></td></tr></table></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"></p><div class=\\"kg-card kg-callout-card kg-callout-card-blue\\" style=\\"display: flex; margin: 0 0 1.5em 0; padding: 20px 28px; border-radius: 3px; background: #E9F6FB;\\"><div class=\\"kg-callout-emoji\\" style=\\"padding-right: 12px; font-size: 20px;\\">&#x1F4A1;</div><div class=\\"kg-callout-text\\" style=\\"color: #15212A;\\">I had an idea...</div></div><div style=\\"background: transparent;
         border: 1px solid rgba(124, 139, 154, 0.25); border-radius: 4px; padding: 20px; margin-bottom: 1.5em;\\">
             <h4 style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top: 0px;\\"><span style=\\"white-space: pre-wrap;\\">Spoiler alert!</span></h4>
-            <div style=\\"font-size: 1rem; line-height: 1.5; margin-bottom: -1.5em;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Just kidding</span></p></div>
+            <div style=\\"font-size: 1rem; line-height: 1.5; margin-bottom: -1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Just kidding</span></p></div>
         </div><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" class=\\"kg-audio-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\">
                 <tbody><tr>
                     <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
@@ -1781,7 +1781,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
             </tbody></table><div class=\\"kg-card kg-video-card kg-width-regular kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\">
             <!--[if !mso !vml]-->
             <a class=\\"kg-video-preview\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" aria-label=\\"Play video\\" style=\\"background-color: #1d1f21; background-image: radial-gradient(circle at center, #5b5f66, #1d1f21); display: block; overflow-wrap: anywhere; color: #FF1A75; mso-hide: all; text-decoration: none;\\" target=\\"_blank\\">
-                <table cellpadding=\\"0\\" cellspacing=\\"0\\" border=\\"0\\" width=\\"100%\\" background=\\"https://main.ghost.org/content/media/2023/11/sample_640x360_thumb.jpg\\" role=\\"presentation\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-size: cover; min-height: 200px; background: url(&#39;https://main.ghost.org/content/media/2023/11/sample_640x360_thumb.jpg&#39;) left top / cover; mso-hide: all;\\">
+                <table cellpadding=\\"0\\" cellspacing=\\"0\\" border=\\"0\\" width=\\"100%\\" background=\\"https://main.ghost.org/content/media/2023/12/sample_640x360_thumb.jpg\\" role=\\"presentation\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-size: cover; min-height: 200px; background: url(&#39;https://main.ghost.org/content/media/2023/12/sample_640x360_thumb.jpg&#39;) left top / cover; mso-hide: all;\\">
                     <tbody><tr style=\\"mso-hide: all\\">
                         <td width=\\"25%\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; visibility: hidden; mso-hide: all;\\" valign=\\"top\\">
                             <img src=\\"https://img.spacergif.org/v1/150x338/0a/spacer.png\\" alt width=\\"100%\\" border=\\"0\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; height: auto; opacity: 0; visibility: hidden; mso-hide: all;\\" height=\\"auto\\">
@@ -1797,24 +1797,24 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
 
             <!--[if vml]>
             <v:group xmlns:v=\\"urn:schemas-microsoft-com:vml\\" xmlns:w=\\"urn:schemas-microsoft-com:office:word\\" coordsize=\\"600,338\\" coordorigin=\\"0,0\\" href=\\"http://127.0.0.1:2369/404/\\" style=\\"width:600px;height:338px;\\">
-                <v:rect fill=\\"t\\" stroked=\\"f\\" style=\\"position:absolute;width:600;height:338;\\"><v:fill src=\\"https://main.ghost.org/content/media/2023/11/sample_640x360_thumb.jpg\\" type=\\"frame\\"/></v:rect>
+                <v:rect fill=\\"t\\" stroked=\\"f\\" style=\\"position:absolute;width:600;height:338;\\"><v:fill src=\\"https://main.ghost.org/content/media/2023/12/sample_640x360_thumb.jpg\\" type=\\"frame\\"/></v:rect>
                 <v:oval fill=\\"t\\" strokecolor=\\"white\\" strokeweight=\\"4px\\" style=\\"position:absolute;left:261;top:130;width:78;height:78\\"><v:fill color=\\"black\\" opacity=\\"30%\\" /></v:oval>
                 <v:shape coordsize=\\"24,32\\" path=\\"m,l,32,24,16,xe\\" fillcolor=\\"white\\" stroked=\\"f\\" style=\\"position:absolute;left:289;top:152;width:30;height:34;\\" />
             </v:group>
             <![endif]-->
 
-            <div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A video card.</span></p></div>
+            <div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A lovely video of a woman on the beach doing nothing.</span></p></div>
         </div><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding: 20px; border: 1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;\\" width=\\"100%\\">
             
                 <tbody><tr>
                     <td align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;\\" valign=\\"top\\">
-                        <img src=\\"https://main.ghost.org/content/images/2023/11/71124418043__F5E7A067-CA69-4E5F-91D8-938EC4A12B20.jpeg\\" width=\\"560\\" height=\\"747\\" style=\\"-ms-interpolation-mode: bicubic; display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;\\" border=\\"0\\">
+                        <img src=\\"https://main.ghost.org/content/images/2023/12/ghost-logo.png\\" width=\\"560\\" height=\\"180\\" style=\\"-ms-interpolation-mode: bicubic; display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;\\" border=\\"0\\">
                     </td>
                 </tr>
             
             <tr>
                 <td valign=\\"top\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\">
-                    <h4 style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-weight: 700; font-size: 22px; margin-top: 0; margin-bottom: 0;\\"><span style=\\"white-space: pre-wrap;\\">Care for a refreshment?</span></h4>
+                    <h4 style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-weight: 700; font-size: 22px; margin-top: 0; margin-bottom: 0;\\"><span style=\\"white-space: pre-wrap;\\">Make a blog!</span></h4>
                 </td>
             </tr>
             
@@ -1826,14 +1826,14 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
             
             <tr>
                 <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;\\" valign=\\"top\\">
-                    <div style=\\"padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">It&#39;s what plants crave.</span></p></div>
+                    <div style=\\"padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">with Ghost</span></p></div>
                 </td>
             </tr>
             
                 <tr>
                     <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;\\" valign=\\"top\\">
                         <div class=\\"btn btn-accent\\" style=\\"box-sizing: border-box; display: table; width: 100%; padding-top: 16px;\\">
-                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"background-color: #FF1A75; overflow-wrap: anywhere; border: solid 1px; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 0; text-decoration: none; color: #FFFFFF; width: 100%; text-align: center; border-color: #FF1A75;\\" target=\\"_blank\\"><span style=\\"display: block;padding: 12px 25px;\\">$98 at Amazon</span></a>
+                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"background-color: #FF1A75; overflow-wrap: anywhere; border: solid 1px; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 0; text-decoration: none; color: #FFFFFF; width: 100%; text-align: center; border-color: #FF1A75;\\" target=\\"_blank\\"><span style=\\"display: block;padding: 12px 25px;\\">Click here</span></a>
                         </div>
                     </td>
                 </tr>
@@ -1867,7 +1867,7 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                 <v:oval fill=\\"t\\" strokecolor=\\"white\\" strokeweight=\\"4px\\" style=\\"position:absolute;left:261;top:186;width:78;height:78\\"><v:fill color=\\"black\\" opacity=\\"30%\\" /></v:oval>
                 <v:shape coordsize=\\"24,32\\" path=\\"m,l,32,24,16,xe\\" fillcolor=\\"white\\" stroked=\\"f\\" style=\\"position:absolute;left:289;top:208;width:30;height:34;\\" />
             </v:group>
-            <![endif]--></div><div></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Some text.</p><blockquote style=\\"margin: 2em 0 2em 0; padding: 0 25px 0 25px; border-left: #FF1A75 2px solid; color: #000000; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\">A blockquote</blockquote><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Some more text.</p><div class=\\"kg-card kg-code-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2em; color: #ffffff;\\"><code class=\\"language-javascript\\" style=\\"font-size: 0.9em;\\">console.log(&#39;Hello world!&#39;);</code></pre><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A tiny little script.</span></p></div></div><table cellspacing=\\"0\\" cellpadding=\\"4\\" border=\\"0\\" class=\\"kg-file-card\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; margin: 0 0 1.5em 0; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12);\\">
+            <![endif]--></div><div></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Some text.</p><blockquote style=\\"margin: 2em 0 2em 0; padding: 0 25px 0 25px; border-left: #FF1A75 2px solid; color: #000000; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\">A blockquote</blockquote><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Some more text.</p><div class=\\"kg-card kg-code-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2em; color: #ffffff;\\"><code class=\\"language-javascript\\" style=\\"font-size: 0.9em;\\">console.log(&#39;Hello world!&#39;);</code></pre><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A tiny little script.</span></p></div></div><table cellspacing=\\"0\\" cellpadding=\\"4\\" border=\\"0\\" class=\\"kg-file-card\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; margin: 0 0 1.5em 0; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12);\\">
             <tbody><tr>
                 <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
                     <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
@@ -2030,7 +2030,7 @@ This is a heading!
 
 Here's a smaller heading.
 
-A beautiful tree.
+A lovely cow
 
 
 A heading
@@ -2048,9 +2048,9 @@ And another one, with some bold text.
 
 
 
-A tree, a meerkat, and a terrier.
-
 ----------------------------------------
+
+A gallery.
 
 
 
@@ -2163,7 +2163,7 @@ http://127.0.0.1:2369/r/xxxxxx?m=member-uuid
 
 
 
-A video card.
+A lovely video of a woman on the beach doing nothing.
 
 
 
@@ -2178,7 +2178,7 @@ A video card.
 
 
 
-Care for a refreshment?
+Make a blog!
 
 
 
@@ -2192,7 +2192,7 @@ Care for a refreshment?
 
 
 
-It's what plants crave.
+with Ghost
 
 
 
@@ -2201,7 +2201,7 @@ It's what plants crave.
 
 
 
-$98 at Amazon [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+Click here [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -1564,53 +1564,35 @@ table.body h2 span {
 </style>
     </head>
     <body style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; -webkit-font-smoothing: antialiased; font-size: 18px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; color: #000000;\\">
-        <span class=\\"preheader\\" style=\\"color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;\\">Here&#39;s a paragraph
+        <span class=\\"preheader\\" style=\\"color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;\\">This is just a simple paragraph, no frills.
 
-Here&#39;s a block quote
+This is block quote
 
-Here&#39;s some text.
-
-
-Images
+This is a...different block quote
 
 
-Markdown
+This is a heading!
 
 
-A heading!
+Here&#39;s a smaller heading.
 
 
-And a paragraph
+A heading
 
 
-
-HTML
-
-
-
-A paragraph!
-
-
-And another paragraph, with bold test.
+and a paragraph (in markdown!)
 
 
 
 
-Gallery
+A paragraph inside an HTML card.
 
 
-Divider
+And another one, with some bold text.
 
 
-Bookmark
 
-Ghost: Independent technology for modern publishingBeautiful, modern publishing with newsletters and premium subscriptions built-in. Used by Sky, 404Media, Lever News, Tangle, The Browser, and thousands more.Ghost - The Professional Publishing Platform
-
-
-Email content
-
-
-Email call to actio</span>
+Ghost: Independent technology for modern publishingBeautiful, modern publishing with newsletters and premium subscriptions built-in. Used by Sky, 404Media, Lever News, Tangle, The Browser, and thousands more.Ghost - The Profes</span>
         <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"body\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
             <!-- Outlook doesn't respect max-width so we need an extra centered table -->
             <!--[if mso]>
@@ -1678,14 +1660,14 @@ Email call to actio</span>
                                         <tr class=\\"post-content-row\\">
                                             <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #000000; padding-bottom: 20px; border-bottom: 1px solid #e5eff5; border-bottom: 1px solid rgba(0, 0, 0, 0.12); max-width: 600px;\\" valign=\\"top\\">
                                                 <!-- POST CONTENT START -->
-                                                <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Here&#39;s a paragraph</p><blockquote style=\\"margin: 2em 0 2em 0; padding: 0 25px 0 25px; border-left: #FF1A75 2px solid; color: #000000; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\">Here&#39;s a block quote</blockquote><blockquote class=\\"kg-blockquote-alt\\" style=\\"margin: 2em 0 2em 0; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px; border-left: 0 none; padding: 0 50px 0 50px; text-align: center; font-size: 1.2em; font-style: italic; color: #000000; color: rgba(0, 0, 0, 0.5);\\">Here&#39;s some text.</blockquote><h2 id=\\"images\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Images</h2><div class=\\"kg-card kg-image-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1873-1.jpeg\\" class=\\"kg-image\\" alt=\\"A small dog.\\" loading=\\"lazy\\" width=\\"600\\" height=\\"450\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: block; margin: 0 auto; width: auto; height: auto;\\"><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><span style=\\"white-space: pre-wrap;\\">A small dog playing in the grass.</span></div></div><h2 id=\\"markdown\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Markdown</h2><h1 id=\\"a-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 42px; font-weight: 700;\\">A heading!</h1>
-<p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">And a paragraph</p>
-<h2 id=\\"html\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">HTML</h2>
+                                                <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">This is just a simple paragraph, no frills.</p><blockquote style=\\"margin: 2em 0 2em 0; padding: 0 25px 0 25px; border-left: #FF1A75 2px solid; color: #000000; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\">This is block quote</blockquote><blockquote class=\\"kg-blockquote-alt\\" style=\\"margin: 2em 0 2em 0; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px; border-left: 0 none; padding: 0 50px 0 50px; text-align: center; font-size: 1.2em; font-style: italic; color: #000000; color: rgba(0, 0, 0, 0.5);\\">This is a...different block quote</blockquote><h2 id=\\"this-is-a-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">This is a heading!</h2><h3 id=\\"heres-a-smaller-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 26px;\\">Here&#39;s a smaller heading.</h3><div class=\\"kg-card kg-image-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1952-1.jpeg\\" class=\\"kg-image\\" alt=\\"A beautiful tree, indeed.\\" loading=\\"lazy\\" width=\\"600\\" height=\\"450\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: block; margin: 0 auto; width: auto; height: auto;\\"><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><span style=\\"white-space: pre-wrap;\\">A beautiful tree.</span></div></div><h1 id=\\"a-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 42px; font-weight: 700;\\">A heading</h1>
+<p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">and a paragraph (in markdown!)</p>
+
 <!--kg-card-begin: html-->
-<p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">A paragraph!</p>
-<p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">And another paragraph, with <em>bold</em> test.</p>
+<p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">A paragraph inside an HTML card.</p>
+<p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">And another one, with some <b>bold</b> text.</p>
 <!--kg-card-end: html-->
-<h2 id=\\"gallery\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Gallery</h2><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1873-2.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1865.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1861.jpeg\\" width=\\"600\\" height=\\"800\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1862.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A small dog playing and sitting in the grass.</span></p></div></div><h2 id=\\"divider\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Divider</h2><hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e5eff5; border-top: 1px solid rgba(0, 0, 0, 0.12);\\"><h2 id=\\"bookmark\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Bookmark</h2><div>
+<div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1952-6.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1873.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1868-2.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_1478.jpeg\\" width=\\"600\\" height=\\"800\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"https://main.ghost.org/content/images/2023/11/IMG_3917.jpeg\\" width=\\"600\\" height=\\"400\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A tree, a meerkat, and a terrier.</span></p></div></div><hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e5eff5; border-top: 1px solid rgba(0, 0, 0, 0.12);\\"><div>
         <!--[if !mso !vml]-->
             <div class=\\"kg-card kg-bookmark-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0; width: 100%; background: #ffffff;\\">
                 <a class=\\"kg-bookmark-container\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"display: flex; min-height: 148px; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Oxygen, Ubuntu, Cantarell, &#39;Open Sans&#39;, &#39;Helvetica Neue&#39;, sans-serif; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12); overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\">
@@ -1701,7 +1683,7 @@ Email call to actio</span>
                     <div class=\\"kg-bookmark-thumbnail\\" style=\\"min-width: 140px; max-width: 180px; background-repeat: no-repeat; background-size: cover; background-position: center; border-radius: 0 2px 2px 0; background-image: url(&#39;https://ghost.org/images/meta/ghost.png&#39;);\\">
                         <img src=\\"https://ghost.org/images/meta/ghost.png\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: none;\\"></div>
                 </a>
-                <div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Ghost&#39;s homepage</span></p></div>
+                <div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">My favorite website.</span></p></div>
             </div>
         <!--[endif]-->
         <!--[if vml]>
@@ -1752,11 +1734,11 @@ Email call to actio</span>
                 </tr>
             </table>
             <div class=\\"kg-bookmark-spacer--outlook\\" style=\\"height: 1.5em;\\">&nbsp;</div>
-        <![endif]--></div><h2 id=\\"email-content\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Email content</h2><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Hey </span><span>Vinz</span><span style=\\"white-space: pre-wrap;\\">,</span></p><h2 id=\\"email-call-to-action\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Email call to action</h2><h2 id=\\"public-preview\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Public preview</h2><!--members-only--><h2 id=\\"button\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Button</h2><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"></p><div class=\\"btn btn-accent\\" style=\\"box-sizing: border-box; width: 100%; display: table;\\"><table border=\\"0\\" cellspacing=\\"0\\" cellpadding=\\"0\\" align=\\"center\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;\\" width=\\"auto\\"><tr><td align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; border-radius: 5px; text-align: center; background-color: #FF1A75;\\" valign=\\"top\\" bgcolor=\\"#FF1A75\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; background-color: #FF1A75; color: #FFFFFF; border-color: #FF1A75;\\" target=\\"_blank\\">Click me!</a></td></tr></table></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"></p><h2 id=\\"callout\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Callout</h2><div class=\\"kg-card kg-callout-card kg-callout-card-purple\\" style=\\"display: flex; margin: 0 0 1.5em 0; padding: 20px 28px; border-radius: 3px; background: #F2EDFC;\\"><div class=\\"kg-callout-emoji\\" style=\\"padding-right: 12px; font-size: 20px;\\">&#x1F4A1;</div><div class=\\"kg-callout-text\\" style=\\"color: #15212A;\\">Don&#39;t forget!</div></div><h2 id=\\"toggle\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Toggle</h2><div style=\\"background: transparent;
+        <![endif]--></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Hey </span><span>Vinz</span><span style=\\"white-space: pre-wrap;\\">,</span></p><!--members-only--><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"></p><div class=\\"btn btn-accent\\" style=\\"box-sizing: border-box; width: 100%; display: table;\\"><table border=\\"0\\" cellspacing=\\"0\\" cellpadding=\\"0\\" align=\\"center\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;\\" width=\\"auto\\"><tr><td align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; border-radius: 5px; text-align: center; background-color: #FF1A75;\\" valign=\\"top\\" bgcolor=\\"#FF1A75\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; background-color: #FF1A75; color: #FFFFFF; border-color: #FF1A75;\\" target=\\"_blank\\">Click me, I&#39;m a button!</a></td></tr></table></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"></p><div class=\\"kg-card kg-callout-card kg-callout-card-blue\\" style=\\"display: flex; margin: 0 0 1.5em 0; padding: 20px 28px; border-radius: 3px; background: #E9F6FB;\\"><div class=\\"kg-callout-emoji\\" style=\\"padding-right: 12px; font-size: 20px;\\">&#x1F4A1;</div><div class=\\"kg-callout-text\\" style=\\"color: #15212A;\\">I had an idea...</div></div><div style=\\"background: transparent;
         border: 1px solid rgba(124, 139, 154, 0.25); border-radius: 4px; padding: 20px; margin-bottom: 1.5em;\\">
-            <h4 style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top: 0px;\\"><span style=\\"white-space: pre-wrap;\\">Here&#39;s a spoiler!</span></h4>
-            <div style=\\"font-size: 1rem; line-height: 1.5; margin-bottom: -1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Jk jk no spoilers here</span></p></div>
-        </div><h2 id=\\"audio\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Audio</h2><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" class=\\"kg-audio-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\">
+            <h4 style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top: 0px;\\"><span style=\\"white-space: pre-wrap;\\">Spoiler alert!</span></h4>
+            <div style=\\"font-size: 1rem; line-height: 1.5; margin-bottom: -1.5em;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Just kidding</span></p></div>
+        </div><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" class=\\"kg-audio-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\">
                 <tbody><tr>
                     <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
                         <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
@@ -1796,13 +1778,13 @@ Email call to actio</span>
                         </tbody></table>
                     </td>
                 </tr>
-            </tbody></table><h2 id=\\"video\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Video</h2><div class=\\"kg-card kg-video-card kg-width-regular\\" style=\\"margin: 0 0 1.5em; padding: 0;\\">
+            </tbody></table><div class=\\"kg-card kg-video-card kg-width-regular kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\">
             <!--[if !mso !vml]-->
             <a class=\\"kg-video-preview\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" aria-label=\\"Play video\\" style=\\"background-color: #1d1f21; background-image: radial-gradient(circle at center, #5b5f66, #1d1f21); display: block; overflow-wrap: anywhere; color: #FF1A75; mso-hide: all; text-decoration: none;\\" target=\\"_blank\\">
-                <table cellpadding=\\"0\\" cellspacing=\\"0\\" border=\\"0\\" width=\\"100%\\" background=\\"http://127.0.0.1:2369/content/media/2023/11/video_thumb.jpg\\" role=\\"presentation\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-size: cover; min-height: 200px; background: url(&#39;http://127.0.0.1:2369/content/media/2023/11/video_thumb.jpg&#39;) left top / cover; mso-hide: all;\\">
+                <table cellpadding=\\"0\\" cellspacing=\\"0\\" border=\\"0\\" width=\\"100%\\" background=\\"https://main.ghost.org/content/media/2023/11/sample_640x360_thumb.jpg\\" role=\\"presentation\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-size: cover; min-height: 200px; background: url(&#39;https://main.ghost.org/content/media/2023/11/sample_640x360_thumb.jpg&#39;) left top / cover; mso-hide: all;\\">
                     <tbody><tr style=\\"mso-hide: all\\">
                         <td width=\\"25%\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; visibility: hidden; mso-hide: all;\\" valign=\\"top\\">
-                            <img src=\\"https://img.spacergif.org/v1/150x615/0a/spacer.png\\" alt width=\\"100%\\" border=\\"0\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; height: auto; opacity: 0; visibility: hidden; mso-hide: all;\\" height=\\"auto\\">
+                            <img src=\\"https://img.spacergif.org/v1/150x338/0a/spacer.png\\" alt width=\\"100%\\" border=\\"0\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; height: auto; opacity: 0; visibility: hidden; mso-hide: all;\\" height=\\"auto\\">
                         </td>
                         <td width=\\"50%\\" align=\\"center\\" valign=\\"middle\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; vertical-align: middle; mso-hide: all;\\">
                             <div class=\\"kg-video-play-button\\" style=\\"height: 2em; width: 3em; margin: 0 auto; border-radius: 10px; padding: 1em 0.8em 0.6em 1em; font-size: 1em; background-color: rgba(0,0,0,0.85); mso-hide: all;\\"><div style=\\"display: block; width: 0; height: 0; margin: 0 auto; line-height: 0px; border-color: transparent transparent transparent white; border-style: solid; border-width: 0.8em 0 0.8em 1.5em; mso-hide: all;\\"></div></div>
@@ -1814,80 +1796,56 @@ Email call to actio</span>
             <!--[endif]-->
 
             <!--[if vml]>
-            <v:group xmlns:v=\\"urn:schemas-microsoft-com:vml\\" xmlns:w=\\"urn:schemas-microsoft-com:office:word\\" coordsize=\\"600,615\\" coordorigin=\\"0,0\\" href=\\"http://127.0.0.1:2369/404/\\" style=\\"width:600px;height:615px;\\">
-                <v:rect fill=\\"t\\" stroked=\\"f\\" style=\\"position:absolute;width:600;height:615;\\"><v:fill src=\\"http://127.0.0.1:2369/content/media/2023/11/video_thumb.jpg\\" type=\\"frame\\"/></v:rect>
-                <v:oval fill=\\"t\\" strokecolor=\\"white\\" strokeweight=\\"4px\\" style=\\"position:absolute;left:261;top:269;width:78;height:78\\"><v:fill color=\\"black\\" opacity=\\"30%\\" /></v:oval>
-                <v:shape coordsize=\\"24,32\\" path=\\"m,l,32,24,16,xe\\" fillcolor=\\"white\\" stroked=\\"f\\" style=\\"position:absolute;left:289;top:291;width:30;height:34;\\" />
+            <v:group xmlns:v=\\"urn:schemas-microsoft-com:vml\\" xmlns:w=\\"urn:schemas-microsoft-com:office:word\\" coordsize=\\"600,338\\" coordorigin=\\"0,0\\" href=\\"http://127.0.0.1:2369/404/\\" style=\\"width:600px;height:338px;\\">
+                <v:rect fill=\\"t\\" stroked=\\"f\\" style=\\"position:absolute;width:600;height:338;\\"><v:fill src=\\"https://main.ghost.org/content/media/2023/11/sample_640x360_thumb.jpg\\" type=\\"frame\\"/></v:rect>
+                <v:oval fill=\\"t\\" strokecolor=\\"white\\" strokeweight=\\"4px\\" style=\\"position:absolute;left:261;top:130;width:78;height:78\\"><v:fill color=\\"black\\" opacity=\\"30%\\" /></v:oval>
+                <v:shape coordsize=\\"24,32\\" path=\\"m,l,32,24,16,xe\\" fillcolor=\\"white\\" stroked=\\"f\\" style=\\"position:absolute;left:289;top:152;width:30;height:34;\\" />
             </v:group>
             <![endif]-->
 
-            
-        </div><h2 id=\\"file\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">File</h2><table cellspacing=\\"0\\" cellpadding=\\"4\\" border=\\"0\\" class=\\"kg-file-card\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; margin: 0 0 1.5em 0; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12);\\">
-            <tbody><tr>
-                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
-                    <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
-                        <tbody><tr>
-                            <td valign=\\"middle\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; vertical-align: middle;\\">
-                                
-                                <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
-                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-title\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 8px; font-size: 17px; font-weight: bold; line-height: 1.3em; overflow-wrap: anywhere; text-decoration: none; color: #000000;\\" target=\\"_blank\\">package</a>
-                                </td></tr></tbody></table>
-                                
-                                
-                                <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
-                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-meta\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 4px; padding-bottom: 8px; font-size: 13px; line-height: 1.4em; overflow-wrap: anywhere; text-decoration: none; color: #000000; color: rgba(0, 0, 0, 0.5);\\" target=\\"_blank\\"><span class=\\"kg-file-name\\" style=\\"font-weight: 500; color: #000000;\\">package.json</span> &#x2022; 3 Bytes</a>
-                                </td></tr></tbody></table>
-                            </td>
-                            <td width=\\"80\\" valign=\\"middle\\" class=\\"kg-file-thumbnail\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; position: relative; vertical-align: middle; text-align: center; border-radius: 2px; background: #FF1A75;\\" align=\\"center\\">
-                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline; position: absolute; display: block; top: 0; right: 0; bottom: 0; left: 0;\\" target=\\"_blank\\"></a>
-                                <img src=\\"https://static.ghost.org/v4.0.0/images/download-icon-darkmode.png\\" style=\\"border: none; -ms-interpolation-mode: bicubic; margin-top: 6px; height: 24px; width: 24px; max-width: 24px;\\" width=\\"24\\" height=\\"24\\">
-                            </td>
-                        </tr>
-                    </tbody></table>
-                </td>
-            </tr>
-        </tbody></table><h2 id=\\"product\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Product</h2><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding: 20px; border: 1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;\\" width=\\"100%\\">
+            <div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A video card.</span></p></div>
+        </div><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding: 20px; border: 1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;\\" width=\\"100%\\">
             
                 <tbody><tr>
                     <td align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;\\" valign=\\"top\\">
-                        <img src=\\"http://127.0.0.1:2369/content/images/2023/11/IMG_1870.jpeg\\" width=\\"560\\" height=\\"420\\" style=\\"-ms-interpolation-mode: bicubic; display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;\\" border=\\"0\\">
+                        <img src=\\"https://main.ghost.org/content/images/2023/11/71124418043__F5E7A067-CA69-4E5F-91D8-938EC4A12B20.jpeg\\" width=\\"560\\" height=\\"747\\" style=\\"-ms-interpolation-mode: bicubic; display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;\\" border=\\"0\\">
                     </td>
                 </tr>
             
             <tr>
                 <td valign=\\"top\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\">
-                    <h4 style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-weight: 700; font-size: 22px; margin-top: 0; margin-bottom: 0;\\"><span style=\\"white-space: pre-wrap;\\">Free dog</span></h4>
+                    <h4 style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-weight: 700; font-size: 22px; margin-top: 0; margin-bottom: 0;\\"><span style=\\"white-space: pre-wrap;\\">Care for a refreshment?</span></h4>
                 </td>
             </tr>
             
                 <tr style=\\"padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;\\">
                     <td valign=\\"top\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\">
-                        <img src=\\"https://static.ghost.org/v4.0.0/images/star-rating-3.png\\" style=\\"-ms-interpolation-mode: bicubic; max-width: 100%; border: none; width: 96px;\\" border=\\"0\\" width=\\"96\\">
+                        <img src=\\"https://static.ghost.org/v4.0.0/images/star-rating-5.png\\" style=\\"-ms-interpolation-mode: bicubic; max-width: 100%; border: none; width: 96px;\\" border=\\"0\\" width=\\"96\\">
                     </td>
                 </tr>
             
             <tr>
                 <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;\\" valign=\\"top\\">
-                    <div style=\\"padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">He&#39;s cute but he&#39;s mean</span></p></div>
+                    <div style=\\"padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">It&#39;s what plants crave.</span></p></div>
                 </td>
             </tr>
             
                 <tr>
                     <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;\\" valign=\\"top\\">
                         <div class=\\"btn btn-accent\\" style=\\"box-sizing: border-box; display: table; width: 100%; padding-top: 16px;\\">
-                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"background-color: #FF1A75; overflow-wrap: anywhere; border: solid 1px; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 0; text-decoration: none; color: #FFFFFF; width: 100%; text-align: center; border-color: #FF1A75;\\" target=\\"_blank\\"><span style=\\"display: block;padding: 12px 25px;\\">Buy now</span></a>
+                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"background-color: #FF1A75; overflow-wrap: anywhere; border: solid 1px; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 0; text-decoration: none; color: #FFFFFF; width: 100%; text-align: center; border-color: #FF1A75;\\" target=\\"_blank\\"><span style=\\"display: block;padding: 12px 25px;\\">$98 at Amazon</span></a>
                         </div>
                     </td>
                 </tr>
             
-        </tbody></table><h2 id=\\"header\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Header</h2><div class=\\"kg-header-card kg-v2\\" style=\\"margin: 0 0 1.5em 0; padding: 110px 35px 110px 35px; color: #FFFFFF; text-align: center; background-color: #000000;\\">
+        </tbody></table><div class=\\"kg-header-card kg-v2\\" style=\\"margin: 0 0 1.5em 0; padding: 110px 35px 110px 35px; color: #FFFFFF; text-align: center; background-color: #000000;\\">
             
             <div class=\\"kg-header-card-content\\" style>
                 <h2 class=\\"kg-header-card-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; font-size: 3em; font-weight: 700; line-height: 1.1em; margin: 0 0 0.125em; color: #FFFFFF;\\"><span style=\\"white-space: pre-wrap;\\">Good news everyone!</span></h2>
-                <p class=\\"kg-header-card-subheading\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #FFFFFF;\\"><span style=\\"white-space: pre-wrap;\\">We&#39;re going to be okay.</span></p>
+                <p class=\\"kg-header-card-subheading\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #FFFFFF;\\"><span style=\\"white-space: pre-wrap;\\">This header renders properly in </span><i><em class=\\"italic\\" style=\\"white-space: pre-wrap;\\">all</em></i><span style=\\"white-space: pre-wrap;\\"> email clients!</span></p>
                 
             </div>
-        </div><h2 id=\\"embeds\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Embeds</h2><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
+        </div><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
             <a class=\\"kg-video-preview\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" aria-label=\\"Play video\\" style=\\"background-color: #1d1f21; background-image: radial-gradient(circle at center, #5b5f66, #1d1f21); display: block; overflow-wrap: anywhere; color: #FF1A75; mso-hide: all; text-decoration: none;\\" target=\\"_blank\\">
                 <table cellpadding=\\"0\\" cellspacing=\\"0\\" border=\\"0\\" width=\\"100%\\" background=\\"https://i.ytimg.com/vi/jfKfPfyJRdk/hqdefault.jpg\\" role=\\"presentation\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-size: cover; min-height: 200px; background: url(&#39;https://i.ytimg.com/vi/jfKfPfyJRdk/hqdefault.jpg&#39;) left top / cover; mso-hide: all;\\">
                     <tbody><tr style=\\"mso-hide: all\\">
@@ -1909,7 +1867,35 @@ Email call to actio</span>
                 <v:oval fill=\\"t\\" strokecolor=\\"white\\" strokeweight=\\"4px\\" style=\\"position:absolute;left:261;top:186;width:78;height:78\\"><v:fill color=\\"black\\" opacity=\\"30%\\" /></v:oval>
                 <v:shape coordsize=\\"24,32\\" path=\\"m,l,32,24,16,xe\\" fillcolor=\\"white\\" stroked=\\"f\\" style=\\"position:absolute;left:289;top:208;width:30;height:34;\\" />
             </v:group>
-            <![endif]--></div><h2 id=\\"signup-card\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Signup Card</h2><div></div><h2 id=\\"codeblock\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Codeblock</h2><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2em; color: #ffffff;\\"><code class=\\"language-javascript\\" style=\\"font-size: 0.9em;\\">const fs = require(&#39;fs-extra&#39;);</code></pre><h1 id=\\"the-aside-element\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 42px; font-weight: 700;\\">The aside element</h1><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">My family and I visited The Epcot center this summer. The weather was nice, and Epcot was amazing! I had a great summer together with my family!</p><h4 id=\\"epcot-center\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; font-size: 21px; line-height: 1.2em;\\">Epcot Center</h4><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Epcot is a theme park at Walt Disney World Resort featuring exciting attractions, international pavilions, award-winning fireworks and seasonal special events.</p>
+            <![endif]--></div><div></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Some text.</p><blockquote style=\\"margin: 2em 0 2em 0; padding: 0 25px 0 25px; border-left: #FF1A75 2px solid; color: #000000; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\">A blockquote</blockquote><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Some more text.</p><div class=\\"kg-card kg-code-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2em; color: #ffffff;\\"><code class=\\"language-javascript\\" style=\\"font-size: 0.9em;\\">console.log(&#39;Hello world!&#39;);</code></pre><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p dir=\\"ltr\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A tiny little script.</span></p></div></div><table cellspacing=\\"0\\" cellpadding=\\"4\\" border=\\"0\\" class=\\"kg-file-card\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; margin: 0 0 1.5em 0; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12);\\">
+            <tbody><tr>
+                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                    <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                        <tbody><tr>
+                            <td valign=\\"middle\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; vertical-align: middle;\\">
+                                
+                                <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-title\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 8px; font-size: 17px; font-weight: bold; line-height: 1.3em; overflow-wrap: anywhere; text-decoration: none; color: #000000;\\" target=\\"_blank\\">test</a>
+                                </td></tr></tbody></table>
+                                
+                                
+                                <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-description\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 2px; font-size: 15px; line-height: 1.4em; overflow-wrap: anywhere; text-decoration: none; color: #000000; color: rgba(0, 0, 0, 0.5);\\" target=\\"_blank\\">A tiny text file.</a>
+                                </td></tr></tbody></table>
+                                
+                                <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-meta\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 4px; padding-bottom: 8px; font-size: 13px; line-height: 1.4em; overflow-wrap: anywhere; text-decoration: none; color: #000000; color: rgba(0, 0, 0, 0.5);\\" target=\\"_blank\\"><span class=\\"kg-file-name\\" style=\\"font-weight: 500; color: #000000;\\">test.txt</span> &#x2022; 16 Bytes</a>
+                                </td></tr></tbody></table>
+                            </td>
+                            <td width=\\"80\\" valign=\\"middle\\" class=\\"kg-file-thumbnail\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; position: relative; vertical-align: middle; text-align: center; border-radius: 2px; background: #FF1A75;\\" align=\\"center\\">
+                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline; position: absolute; display: block; top: 0; right: 0; bottom: 0; left: 0;\\" target=\\"_blank\\"></a>
+                                <img src=\\"https://static.ghost.org/v4.0.0/images/download-icon-darkmode.png\\" style=\\"border: none; -ms-interpolation-mode: bicubic; margin-top: 6px; height: 24px; width: 24px; max-width: 24px;\\" width=\\"24\\" height=\\"24\\">
+                            </td>
+                        </tr>
+                    </tbody></table>
+                </td>
+            </tr>
+        </tbody></table>
                                                 <!-- POST CONTENT END -->
 
                                             </td>
@@ -2032,51 +2018,39 @@ View in browser [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
-Here's a paragraph
+This is just a simple paragraph, no frills.
 
-> Here's a block quote
+> This is block quote
 
-> Here's some text.
-
-
-Images
-
-A small dog playing in the grass.
+> This is a...different block quote
 
 
-Markdown
+This is a heading!
 
 
-A heading!
+Here's a smaller heading.
+
+A beautiful tree.
 
 
-And a paragraph
+A heading
 
 
-
-HTML
-
-
-
-A paragraph!
-
-
-And another paragraph, with bold test.
+and a paragraph (in markdown!)
 
 
 
 
-Gallery
-
-A small dog playing and sitting in the grass.
+A paragraph inside an HTML card.
 
 
-Divider
+And another one, with some bold text.
+
+
+
+A tree, a meerkat, and a terrier.
 
 ----------------------------------------
-
-
-Bookmark
 
 
 
@@ -2096,48 +2070,27 @@ Ghost - The Professional Publishing Platform
 [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
-Ghost's homepage
+My favorite website.
 
 
 
-
-
-Email content
 
 Hey Vinz,
 
 
-Email call to action
 
-
-Public preview
-
-
-Button
+Click me, I'm a button! [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
-Click me! [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+💡I had an idea...
 
 
+Spoiler alert!
 
 
-Callout
+Just kidding
 
-💡Don't forget!
-
-
-Toggle
-
-
-Here's a spoiler!
-
-
-Jk jk no spoilers here
-
-
-
-Audio
 
 
 
@@ -2188,9 +2141,6 @@ http://127.0.0.1:2369/r/xxxxxx?m=member-uuid
 
 
 
-Video
-
-
 
 
 
@@ -2213,10 +2163,7 @@ Video
 
 
 
-
-
-File
-
+A video card.
 
 
 
@@ -2229,14 +2176,106 @@ File
 
 
 
-package [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+Care for a refreshment?
 
 
 
 
 
 
-package.json • 3 Bytes [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+
+It's what plants crave.
+
+
+
+
+
+
+
+
+$98 at Amazon [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+
+
+
+
+Good news everyone!
+
+
+This header renders properly in all email clients!
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+[http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+Some text.
+
+> A blockquote
+
+Some more text.
+
+console.log('Hello world!');
+
+A tiny little script.
+
+
+
+
+
+
+
+
+
+
+
+
+
+test [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+A tiny text file. [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+test.txt • 16 Bytes [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
@@ -2250,106 +2289,6 @@ http://127.0.0.1:2369/r/xxxxxx?m=member-uuid
 
 
 
-
-
-Product
-
-
-
-
-
-
-
-
-
-
-
-
-
-Free dog
-
-
-
-
-
-
-
-
-
-
-
-
-
-He's cute but he's mean
-
-
-
-
-
-
-
-
-Buy now [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
-
-
-
-
-
-
-
-Header
-
-
-
-
-
-Good news everyone!
-
-
-We're going to be okay.
-
-
-
-
-
-Embeds
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-[http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
-
-
-
-
-
-Signup Card
-
-
-Codeblock
-
-const fs = require('fs-extra');
-
-
-The aside element
-
-My family and I visited The Epcot center this summer. The weather was nice, and Epcot was amazing! I had a great summer together with my family!
-
-Epcot Center
-
-Epcot is a theme park at Walt Disney World Resort featuring exciting attractions, international pavilions, award-winning fireworks and seasonal special events.
 
 
 

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -1199,3 +1199,1197 @@ http://127.0.0.1:2369/r/xxxxxx?m=member-uuid
 ",
 }
 `;
+
+exports[`Can send cards via email renders the golden post correctly 1 1`] = `
+Object {
+  "html": "<!doctype html>
+<html>
+    <head>
+        <meta name=\\"viewport\\" content=\\"width=device-width\\">
+        <meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\">
+        <!--[if mso]><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch><o:AllowPNG/></o:OfficeDocumentSettings></xml><![endif]-->
+        <title>A random test post</title>
+        <style>
+.post-title-link {
+  display: block;
+  text-align: center;
+  margin-top: 50px;
+  text-decoration: none !important;
+  color: #000000;
+}
+.post-title-link-left {
+  text-align: left;
+}
+.comment-link {
+  color: #000000;
+  color: rgba(0, 0, 0, 0.5);
+  font-size: 13px;
+  letter-spacing: 0.1px;
+  text-decoration: none;
+}
+.comment-link img {
+  width: 16px;
+  height: 16px;
+  margin-bottom: 1px;
+  vertical-align: middle;
+}
+.view-online-link {
+  word-wrap: none;
+  white-space: nowrap;
+  color: #000000;
+  color: rgba(0, 0, 0, 0.5);
+}
+.kg-nft-link {
+  display: block;
+  text-decoration: none !important;
+  color: #000000 !important;
+  font-family: inherit !important;
+  font-size: 14px;
+  line-height: 1.3em;
+  padding-top: 4px;
+  padding-right: 20px;
+  padding-left: 20px;
+  padding-bottom: 4px;
+}
+.kg-twitter-link {
+  display: block;
+  text-decoration: none !important;
+  color: #15212A !important;
+  font-family: inherit !important;
+  font-size: 15px;
+  padding: 8px;
+  line-height: 1.3em;
+}
+.kg-audio-link {
+  text-decoration: none !important;
+  color: #000000;
+  color: rgba(0, 0, 0, 0.5);
+}
+@media only screen and (max-width: 620px) {
+  table.body {
+    width: 100%;
+    min-width: 100%;
+    padding: 8px 4px;
+    background-color: #ffffff;
+  }
+
+  .hide-mobile {
+    display: none;
+  }
+
+  .mobile-only {
+    display: initial !important;
+  }
+
+  table.body p,
+table.body ul,
+table.body ol,
+table.body td {
+    font-size: 16px !important;
+  }
+
+  table.body pre {
+    white-space: pre-wrap !important;
+    word-break: break-word !important;
+  }
+
+  table.body .content {
+    padding: 0 !important;
+  }
+
+  table.body .container {
+    padding: 0 !important;
+    width: 100% !important;
+  }
+
+  table.body .main {
+    border-spacing: 10px 0 !important;
+    border-left-width: 0 !important;
+    border-radius: 0 !important;
+    border-right-width: 0 !important;
+  }
+
+  table.body .btn table {
+    width: 100% !important;
+  }
+
+  table.body .btn a {
+    width: 100% !important;
+  }
+
+  table.body .img-responsive {
+    height: auto !important;
+    max-width: 100% !important;
+    width: auto !important;
+  }
+
+  table.body .site-icon img {
+    width: 40px !important;
+    height: 40px !important;
+  }
+
+  table.body .site-url a {
+    font-size: 14px !important;
+    padding-bottom: 15px !important;
+  }
+
+  table.body .post-meta,
+table.body .post-meta-date {
+    white-space: normal !important;
+    font-size: 12px !important;
+    line-height: 1.5em;
+  }
+
+  table.body .post-meta,
+table.body .view-online {
+    width: 100% !important;
+  }
+
+  table.body .post-meta-left,
+table.body .post-meta-left.view-online {
+    width: 100% !important;
+    text-align: left !important;
+  }
+
+  table.body .post-meta.view-online-mobile {
+    display: table-row !important;
+  }
+
+  table.body .post-meta-left.view-online-mobile,
+table.body .post-meta-left.view-online-mobile .view-online {
+    text-align: left !important;
+  }
+
+  table.body .post-meta.view-online.desktop {
+    display: none !important;
+  }
+
+  table.body .view-online {
+    text-decoration: underline;
+  }
+
+  table.body .view-online-link,
+table.body .comment-link,
+table.body .footer,
+table.body .footer a {
+    font-size: 12px !important;
+  }
+
+  table.body .post-title a {
+    font-size: 32px !important;
+    line-height: 1.15em !important;
+  }
+
+  table.feedback-buttons {
+    display: none !important;
+  }
+
+  table.feedback-buttons-mobile {
+    display: table !important;
+    width: 100% !important;
+    max-width: 390px;
+  }
+
+  table.feedback-buttons-mobile a,
+table.body .feedback-button-mobile-text {
+    text-decoration: none !important;
+  }
+
+  table.body .feedback-button-mobile-text {
+    font-size: 13px !important;
+  }
+
+  table.body .latest-posts-header {
+    font-size: 12px !important;
+  }
+
+  table.body .latest-post-title {
+    display: inline-block !important;
+    width: 100%;
+    padding-right: 8px !important;
+  }
+
+  table.body .latest-post h4,
+table.body .latest-post h4 span {
+    padding: 4px 0 6px !important;
+    font-size: 15px !important;
+  }
+
+  table.body .latest-post-excerpt,
+table.body .latest-post-excerpt a,
+table.body .latest-post-excerpt span {
+    font-size: 13px !important;
+    line-height: 1.2 !important;
+  }
+
+  table.body .latest-post-excerpt span {
+    display: none !important;
+  }
+
+  table.body .subscription-box h3 {
+    font-size: 14px !important;
+  }
+
+  table.body .subscription-box p,
+table.body .subscription-box p span {
+    font-size: 13px !important;
+  }
+
+  table.body .subscription-details,
+table.body .manage-subscription {
+    display: inline-block;
+    width: 100%;
+    text-align: left !important;
+    font-size: 13px !important;
+  }
+
+  table.body .subscription-details {
+    padding-bottom: 12px;
+  }
+
+  table.body .kg-bookmark-card {
+    width: 90vw;
+  }
+
+  table.body .kg-bookmark-thumbnail {
+    display: none !important;
+  }
+
+  table.body .kg-bookmark-metadata span {
+    font-size: 13px !important;
+  }
+
+  table.body .kg-embed-card {
+    max-width: 90vw !important;
+  }
+
+  table.body h1 {
+    font-size: 32px !important;
+    line-height: 1.3em !important;
+  }
+
+  table.body h2,
+table.body h2 span {
+    font-size: 26px !important;
+    line-height: 1.22em !important;
+  }
+
+  table.body h3 {
+    font-size: 21px !important;
+    line-height: 1.25em !important;
+  }
+
+  table.body h4 {
+    font-size: 19px !important;
+    line-height: 1.3em !important;
+  }
+
+  table.body h5 {
+    font-size: 16px !important;
+    line-height: 1.4em !important;
+  }
+
+  table.body h6 {
+    font-size: 16px !important;
+    line-height: 1.4em !important;
+  }
+
+  table.body blockquote {
+    font-size: 17px;
+    line-height: 1.6em;
+    margin-bottom: 0;
+    padding-left: 15px;
+  }
+
+  table.body blockquote.kg-blockquote-alt {
+    border-left: 0 none !important;
+    margin: 0 0 2.5em 0 !important;
+    padding: 0 50px 0 50px !important;
+    font-size: 1.2em;
+  }
+
+  table.body blockquote + * {
+    margin-top: 1.5em !important;
+  }
+
+  table.body hr {
+    margin: 2em 0 !important;
+  }
+}
+@media all {
+  .subscription-details p.hidden {
+    display: none !important;
+  }
+
+  .ExternalClass {
+    width: 100%;
+  }
+
+  .ExternalClass,
+.ExternalClass p,
+.ExternalClass span,
+.ExternalClass font,
+.ExternalClass td,
+.ExternalClass div {
+    line-height: 100%;
+  }
+
+  .apple-link a {
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: none !important;
+  }
+
+  #MessageViewBody a {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+  }
+
+  .btn-primary table td:hover {
+    background-color: #34495e !important;
+  }
+
+  .btn-primary a:hover {
+    background-color: #34495e !important;
+    border-color: #34495e !important;
+  }
+}
+</style>
+    </head>
+    <body style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; -webkit-font-smoothing: antialiased; font-size: 18px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; color: #000000;\\">
+        <span class=\\"preheader\\" style=\\"color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;\\">Here&#39;s a paragraph
+
+Here&#39;s a block quote
+
+Here&#39;s some text.
+
+
+Images
+
+
+Markdown
+
+
+A heading!
+
+
+And a paragraph
+
+
+
+HTML
+
+
+
+A paragraph!
+
+
+And another paragraph, with bold test.
+
+
+
+
+Gallery
+
+
+Divider
+
+
+Bookmark
+
+Ghost: Independent technology for modern publishingBeautiful, modern publishing with newsletters and premium subscriptions built-in. Used by Sky, 404Media, Lever News, Tangle, The Browser, and thousands more.Ghost - The Professional Publishing Platform
+
+
+Email content
+
+
+Email call to actio</span>
+        <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" class=\\"body\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+            <!-- Outlook doesn't respect max-width so we need an extra centered table -->
+            <!--[if mso]>
+            <tr>
+                <td>
+                    <center>
+                        <table border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"600\\">
+            <![endif]-->
+            <tr>
+                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">&#xA0;</td>
+                <td class=\\"container\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; display: block; padding: 12px; max-width: 600px; background-color: #ffffff; color: #000000; margin: 0 auto;\\" valign=\\"top\\" bgcolor=\\"#ffffff\\">
+                    <div class=\\"content\\" style=\\"box-sizing: border-box; display: block; margin: 0 auto; max-width: 600px;\\">
+                        <!-- START CENTERED WHITE CONTAINER -->
+                        <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"20\\" class=\\"main\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-radius: 3px; border-spacing: 20px 0; width: 100%; background: #ffffff;\\">
+
+                            <!-- START MAIN CONTENT AREA -->
+                            <tr>
+                                <td class=\\"wrapper\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; box-sizing: border-box;\\" valign=\\"top\\">
+                                    <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                                            <tr class=\\"header-image-row\\">
+                                                <td class=\\"header-image\\" width=\\"100%\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 24px;\\" valign=\\"top\\">
+                                                    <img src=\\"http://127.0.0.1:2369/content/images/2022/05/test.jpg\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%;\\">
+                                                </td>
+                                            </tr>
+
+                                            <tr>
+                                                <td class=\\"site-info-bordered\\" width=\\"100%\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 50px; border-bottom: 1px solid #e5eff5; border-bottom: 1px solid rgba(0, 0, 0, 0.12);\\" valign=\\"top\\">
+                                                    <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
+                                                            <tr>
+                                                                <td class=\\"site-url \\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; vertical-align: top; color: #000000; font-size: 16px; letter-spacing: -0.1px; font-weight: 700; text-transform: uppercase; text-align: center;\\" valign=\\"top\\" align=\\"center\\"><div style=\\"width: 100% !important;\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"site-title\\" style=\\"color: #000000; overflow-wrap: anywhere; text-decoration: none;\\" target=\\"_blank\\">Ghost</a></div></td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td class=\\"site-url site-url-bottom-padding\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; vertical-align: top; color: #000000; font-size: 16px; letter-spacing: -0.1px; font-weight: 700; text-transform: uppercase; text-align: center; padding-bottom: 50px;\\" valign=\\"top\\" align=\\"center\\"><div style=\\"width: 100% !important;\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"site-subtitle\\" style=\\"color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 14px; font-weight: 400; text-transform: none; overflow-wrap: anywhere; text-decoration: none;\\" target=\\"_blank\\">Daily newsletter</a></div></td>
+                                                            </tr>
+
+                                                    </table>
+                                                </td>
+                                            </tr>
+
+                                            <tr>
+                                                <td class=\\"post-title post-title-serif\\" style=\\"vertical-align: top; color: #000000; padding-bottom: 16px; font-size: 42px; line-height: 1.1em; font-weight: 700; text-align: center; font-family: Georgia, serif; letter-spacing: -0.01em;\\" valign=\\"top\\" align=\\"center\\">
+                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"display: block; text-align: center; margin-top: 50px; color: #000000; overflow-wrap: anywhere; text-decoration: none;\\" target=\\"_blank\\">A random test post</a>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; width: 100%;\\" width=\\"100%\\" valign=\\"top\\">
+                                                    <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-bottom: 48px;\\">
+                                                        <tr>
+                                                            <td height=\\"20\\" class=\\"post-meta post-meta-center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; vertical-align: top; color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 13px; letter-spacing: 0.1px; text-align: center; padding: 0;\\" valign=\\"top\\" align=\\"center\\">
+                                                                By Joe Bloggs &#x2022; <span class=\\"post-meta-date\\" style=\\"white-space: nowrap;\\">date </span>
+                                                            </td>
+                                                            <td class=\\"post-meta post-meta-center view-online desktop\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; vertical-align: top; color: rgba(0, 0, 0, 0.5); font-size: 13px; letter-spacing: 0.1px; text-align: center; display: none;\\" valign=\\"top\\" align=\\"center\\">
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"view-online-link\\" style=\\"text-decoration: none; word-wrap: none; white-space: nowrap; color: #000000; color: rgba(0, 0, 0, 0.5); overflow-wrap: anywhere;\\" target=\\"_blank\\">View in browser</a>
+                                                            </td>
+                                                        </tr>
+                                                        <tr class=\\"post-meta post-meta-center view-online-mobile\\" style=\\"color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 13px; letter-spacing: 0.1px; text-align: center;\\" align=\\"center\\">
+                                                            <td height=\\"20\\" class=\\"view-online\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; vertical-align: top; color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 13px; letter-spacing: 0.1px; text-align: center; text-decoration: underline;\\" valign=\\"top\\" align=\\"center\\">
+                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"view-online-link\\" style=\\"word-wrap: none; white-space: nowrap; color: #000000; color: rgba(0, 0, 0, 0.5); overflow-wrap: anywhere; text-decoration: underline;\\" target=\\"_blank\\">View in browser</a>
+                                                            </td>
+                                                        </tr>
+                                                    </table>
+                                                </td>
+                                            </tr>
+
+                                        <tr class=\\"post-content-row\\">
+                                            <td class=\\"post-content\\" style=\\"vertical-align: top; font-family: Georgia, serif; font-size: 18px; line-height: 1.5em; color: #000000; padding-bottom: 20px; border-bottom: 1px solid #e5eff5; border-bottom: 1px solid rgba(0, 0, 0, 0.12); max-width: 600px;\\" valign=\\"top\\">
+                                                <!-- POST CONTENT START -->
+                                                <p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Here&#39;s a paragraph</p><blockquote style=\\"margin: 2em 0 2em 0; padding: 0 25px 0 25px; border-left: #FF1A75 2px solid; color: #000000; font-size: 17px; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px;\\">Here&#39;s a block quote</blockquote><blockquote class=\\"kg-blockquote-alt\\" style=\\"margin: 2em 0 2em 0; font-weight: 500; line-height: 1.6em; letter-spacing: -0.2px; border-left: 0 none; padding: 0 50px 0 50px; text-align: center; font-size: 1.2em; font-style: italic; color: #000000; color: rgba(0, 0, 0, 0.5);\\">Here&#39;s some text.</blockquote><h2 id=\\"images\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Images</h2><div class=\\"kg-card kg-image-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1873-1.jpeg\\" class=\\"kg-image\\" alt=\\"A small dog.\\" loading=\\"lazy\\" width=\\"600\\" height=\\"450\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: block; margin: 0 auto; width: auto; height: auto;\\"><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><span style=\\"white-space: pre-wrap;\\">A small dog playing in the grass.</span></div></div><h2 id=\\"markdown\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Markdown</h2><h1 id=\\"a-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 42px; font-weight: 700;\\">A heading!</h1>
+<p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">And a paragraph</p>
+<h2 id=\\"html\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">HTML</h2>
+<!--kg-card-begin: html-->
+<p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">A paragraph!</p>
+<p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">And another paragraph, with <em>bold</em> test.</p>
+<!--kg-card-end: html-->
+<h2 id=\\"gallery\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Gallery</h2><div class=\\"kg-card kg-gallery-card kg-width-wide kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><div class=\\"kg-gallery-container\\" style=\\"margin-top: -20px;\\"><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1873-2.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1865.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div><div class=\\"kg-gallery-row\\"><div class=\\"kg-gallery-image\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1861.jpeg\\" width=\\"600\\" height=\\"800\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div><div class=\\"kg-gallery-image\\"><img src=\\"http://127.0.0.1:2369/content/images/size/w1600/2023/11/IMG_1862.jpeg\\" width=\\"600\\" height=\\"450\\" loading=\\"lazy\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; padding-top: 20px; width: 100%; height: auto;\\"></div></div></div><div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">A small dog playing and sitting in the grass.</span></p></div></div><h2 id=\\"divider\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Divider</h2><hr style=\\"position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e5eff5; border-top: 1px solid rgba(0, 0, 0, 0.12);\\"><h2 id=\\"bookmark\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Bookmark</h2><div>
+        <!--[if !mso !vml]-->
+            <div class=\\"kg-card kg-bookmark-card kg-card-hascaption\\" style=\\"margin: 0 0 1.5em; padding: 0; width: 100%; background: #ffffff;\\">
+                <a class=\\"kg-bookmark-container\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"display: flex; min-height: 148px; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Oxygen, Ubuntu, Cantarell, &#39;Open Sans&#39;, &#39;Helvetica Neue&#39;, sans-serif; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12); overflow-wrap: anywhere; color: #FF1A75; text-decoration: none;\\" target=\\"_blank\\">
+                    <div class=\\"kg-bookmark-content\\" style=\\"display: inline-block; width: 100%; padding: 20px;\\">
+                        <div class=\\"kg-bookmark-title\\" style=\\"color: #000000; font-size: 15px; line-height: 1.5em; font-weight: 600;\\">Ghost: Independent technology for modern publishing</div>
+                        <div class=\\"kg-bookmark-description\\" style=\\"display: -webkit-box; overflow-y: hidden; margin-top: 12px; max-height: 40px; color: #000000; color: rgba(0, 0, 0, 0.5); font-size: 13px; line-height: 1.5em; font-weight: 400; -webkit-line-clamp: 2; -webkit-box-orient: vertical;\\">Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by Sky, 404Media, Lever News, Tangle, The Browser, and thousands more.</div>
+                        <div class=\\"kg-bookmark-metadata\\" style=\\"display: flex; flex-wrap: wrap; align-items: center; margin-top: 14px; color: #000000; font-size: 13px; font-weight: 400;\\">
+                            <img class=\\"kg-bookmark-icon\\" src=\\"https://ghost.org/favicon.ico\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; margin-right: 8px; width: 22px; height: 22px;\\" width=\\"22\\" height=\\"22\\">
+                            <span class=\\"kg-bookmark-author\\" src=\\"Ghost - The Professional Publishing Platform\\" style=\\"line-height: 1.5em;\\">Ghost - The Professional Publishing Platform</span>
+                            
+                        </div>
+                    </div>
+                    <div class=\\"kg-bookmark-thumbnail\\" style=\\"min-width: 140px; max-width: 180px; background-repeat: no-repeat; background-size: cover; background-position: center; border-radius: 0 2px 2px 0; background-image: url(&#39;https://ghost.org/images/meta/ghost.png&#39;);\\">
+                        <img src=\\"https://ghost.org/images/meta/ghost.png\\" alt style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; display: none;\\"></div>
+                </a>
+                <div style=\\"text-align: center; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 13px; padding-top: 5px; line-height: 1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Ghost&#39;s homepage</span></p></div>
+            </div>
+        <!--[endif]-->
+        <!--[if vml]>
+            <table class=\\"kg-card kg-bookmark-card--outlook\\" style=\\"margin: 0; padding: 0; width: 100%; border: 1px solid #e5eff5; background: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif; border-collapse: collapse; border-spacing: 0;\\" width=\\"100%\\">
+                <tr>
+                    <td width=\\"100%\\" style=\\"padding: 20px;\\">
+                        <table style=\\"margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;\\">
+                            <tr>
+                                <td class=\\"kg-bookmark-title--outlook\\">
+                                    <a href=\\"https://ghost.org\\" style=\\"text-decoration: none; color: #15212A; font-size: 15px; line-height: 1.5em; font-weight: 600;\\">
+                                        Ghost: Independent technology for modern publishing
+                                    </a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <div class=\\"kg-bookmark-description--outlook\\">
+                                        <a href=\\"https://ghost.org\\" style=\\"text-decoration: none; margin-top: 12px; color: #738a94; font-size: 13px; line-height: 1.5em; font-weight: 400;\\">
+                                            Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by Sky, 404Media, Lever News, Tangle, The Browser, and thousands more.
+                                        </a>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class=\\"kg-bookmark-metadata--outlook\\" style=\\"padding-top: 14px; color: #15212A; font-size: 13px; font-weight: 400; line-height: 1.5em;\\">
+                                    <table style=\\"margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;\\">
+                                        <tr>
+                                            
+                                                <td valign=\\"middle\\" class=\\"kg-bookmark-icon--outlook\\" style=\\"padding-right: 8px; font-size: 0; line-height: 1.5em;\\">
+                                                    <a href=\\"https://ghost.org\\" style=\\"text-decoration: none; color: #15212A;\\">
+                                                        <img src=\\"https://ghost.org/favicon.ico\\" width=\\"22\\" height=\\"22\\" alt=\\" \\">
+                                                    </a>
+                                                </td>
+                                            
+                                            <td valign=\\"middle\\" class=\\"kg-bookmark-byline--outlook\\">
+                                                <a href=\\"https://ghost.org\\" style=\\"text-decoration: none; color: #15212A;\\">
+                                                    Ghost - The Professional Publishing Platform
+                                                    
+                                                    
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+            <div class=\\"kg-bookmark-spacer--outlook\\" style=\\"height: 1.5em;\\">&nbsp;</div>
+        <![endif]--></div><h2 id=\\"email-content\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Email content</h2><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Hey </span><span>Vinz</span><span style=\\"white-space: pre-wrap;\\">,</span></p><h2 id=\\"email-call-to-action\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Email call to action</h2><h2 id=\\"public-preview\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Public preview</h2><!--members-only--><h2 id=\\"button\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Button</h2><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"></p><div class=\\"btn btn-accent\\" style=\\"box-sizing: border-box; width: 100%; display: table;\\"><table border=\\"0\\" cellspacing=\\"0\\" cellpadding=\\"0\\" align=\\"center\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;\\" width=\\"auto\\"><tr><td align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; border-radius: 5px; text-align: center; background-color: #FF1A75;\\" valign=\\"top\\" bgcolor=\\"#FF1A75\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; background-color: #FF1A75; color: #FFFFFF; border-color: #FF1A75;\\" target=\\"_blank\\">Click me!</a></td></tr></table></div><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"></p><h2 id=\\"callout\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Callout</h2><div class=\\"kg-card kg-callout-card kg-callout-card-purple\\" style=\\"display: flex; margin: 0 0 1.5em 0; padding: 20px 28px; border-radius: 3px; background: #F2EDFC;\\"><div class=\\"kg-callout-emoji\\" style=\\"padding-right: 12px; font-size: 20px;\\">&#x1F4A1;</div><div class=\\"kg-callout-text\\" style=\\"color: #15212A;\\">Don&#39;t forget!</div></div><h2 id=\\"toggle\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Toggle</h2><div style=\\"background: transparent;
+        border: 1px solid rgba(124, 139, 154, 0.25); border-radius: 4px; padding: 20px; margin-bottom: 1.5em;\\">
+            <h4 style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-size: 1.375rem; font-weight: 600; margin-bottom: 8px; margin-top: 0px;\\"><span style=\\"white-space: pre-wrap;\\">Here&#39;s a spoiler!</span></h4>
+            <div style=\\"font-size: 1rem; line-height: 1.5; margin-bottom: -1.5em;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">Jk jk no spoilers here</span></p></div>
+        </div><h2 id=\\"audio\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Audio</h2><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" class=\\"kg-audio-card\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto; width: 100%; margin: 0 auto 1.5em; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12);\\" width=\\"100%\\">
+                <tbody><tr>
+                    <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                        <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                            <tbody><tr>
+                                <td width=\\"60\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline; display: block; width: 60px; height: 60px; padding-top: 4px; padding-right: 16px; padding-bottom: 4px; padding-left: 4px; border-radius: 2px;\\" target=\\"_blank\\">
+                                        
+                                        <img src=\\"https://static.ghost.org/v4.0.0/images/audio-file-icon.png\\" class=\\"kg-audio-thumbnail placeholder\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; width: 24px; height: 24px; padding: 18px; border-radius: 2px; background: #FF1A75;\\" width=\\"24\\" height=\\"24\\">
+                                        
+                                    </a>
+                                </td>
+                                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; position: relative; vertical-align: center;\\" valign=\\"center\\">
+                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline; position: absolute; display: block; top: 0; right: 0; bottom: 0; left: 0;\\" target=\\"_blank\\"></a>
+                                    <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                                        <tbody><tr>
+                                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-audio-title\\" style=\\"display: block; padding-right: 20px; padding-bottom: 4px; padding-top: 4px; font-size: 16px; font-weight: 600; line-height: 18px; overflow-wrap: anywhere; text-decoration: none; color: #000000;\\" target=\\"_blank\\">Sample</a>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                                                <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                                                    <tbody><tr>
+                                                        <td width=\\"24\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; vertical-align: middle;\\" valign=\\"middle\\">
+                                                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-audio-play-button\\" style=\\"display: block; box-sizing: border-box; width: 16px; height: 16px; border-style: solid; border-width: 8px 0px 8px 16px; border-color: transparent transparent transparent currentColor; overflow-wrap: anywhere; text-decoration: underline; color: #000000;\\" target=\\"_blank\\"></a>
+                                                        </td>
+                                                        <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; vertical-align: middle;\\" valign=\\"middle\\">
+                                                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-audio-duration\\" style=\\"display: block; font-size: 13px; overflow-wrap: anywhere; text-decoration: none; color: #000000;\\" target=\\"_blank\\">1:45<span class=\\"kg-audio-link\\" style=\\"color: #000000; color: rgba(0, 0, 0, 0.5); text-decoration: none;\\"> &#x2022; Click to play audio</span></a>
+                                                        </td>
+                                                    </tr>
+                                                </tbody></table>
+                                            </td>
+                                        </tr>
+                                    </tbody></table>
+                                </td>
+                            </tr>
+                        </tbody></table>
+                    </td>
+                </tr>
+            </tbody></table><h2 id=\\"video\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Video</h2><div class=\\"kg-card kg-video-card kg-width-regular\\" style=\\"margin: 0 0 1.5em; padding: 0;\\">
+            <!--[if !mso !vml]-->
+            <a class=\\"kg-video-preview\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" aria-label=\\"Play video\\" style=\\"background-color: #1d1f21; background-image: radial-gradient(circle at center, #5b5f66, #1d1f21); display: block; overflow-wrap: anywhere; color: #FF1A75; mso-hide: all; text-decoration: none;\\" target=\\"_blank\\">
+                <table cellpadding=\\"0\\" cellspacing=\\"0\\" border=\\"0\\" width=\\"100%\\" background=\\"http://127.0.0.1:2369/content/media/2023/11/video_thumb.jpg\\" role=\\"presentation\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-size: cover; min-height: 200px; background: url(&#39;http://127.0.0.1:2369/content/media/2023/11/video_thumb.jpg&#39;) left top / cover; mso-hide: all;\\">
+                    <tbody><tr style=\\"mso-hide: all\\">
+                        <td width=\\"25%\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; visibility: hidden; mso-hide: all;\\" valign=\\"top\\">
+                            <img src=\\"https://img.spacergif.org/v1/150x615/0a/spacer.png\\" alt width=\\"100%\\" border=\\"0\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; height: auto; opacity: 0; visibility: hidden; mso-hide: all;\\" height=\\"auto\\">
+                        </td>
+                        <td width=\\"50%\\" align=\\"center\\" valign=\\"middle\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; vertical-align: middle; mso-hide: all;\\">
+                            <div class=\\"kg-video-play-button\\" style=\\"height: 2em; width: 3em; margin: 0 auto; border-radius: 10px; padding: 1em 0.8em 0.6em 1em; font-size: 1em; background-color: rgba(0,0,0,0.85); mso-hide: all;\\"><div style=\\"display: block; width: 0; height: 0; margin: 0 auto; line-height: 0px; border-color: transparent transparent transparent white; border-style: solid; border-width: 0.8em 0 0.8em 1.5em; mso-hide: all;\\"></div></div>
+                        </td>
+                        <td width=\\"25%\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; mso-hide: all;\\" valign=\\"top\\">&#xA0;</td>
+                    </tr>
+                </tbody></table>
+            </a>
+            <!--[endif]-->
+
+            <!--[if vml]>
+            <v:group xmlns:v=\\"urn:schemas-microsoft-com:vml\\" xmlns:w=\\"urn:schemas-microsoft-com:office:word\\" coordsize=\\"600,615\\" coordorigin=\\"0,0\\" href=\\"http://127.0.0.1:2369/404/\\" style=\\"width:600px;height:615px;\\">
+                <v:rect fill=\\"t\\" stroked=\\"f\\" style=\\"position:absolute;width:600;height:615;\\"><v:fill src=\\"http://127.0.0.1:2369/content/media/2023/11/video_thumb.jpg\\" type=\\"frame\\"/></v:rect>
+                <v:oval fill=\\"t\\" strokecolor=\\"white\\" strokeweight=\\"4px\\" style=\\"position:absolute;left:261;top:269;width:78;height:78\\"><v:fill color=\\"black\\" opacity=\\"30%\\" /></v:oval>
+                <v:shape coordsize=\\"24,32\\" path=\\"m,l,32,24,16,xe\\" fillcolor=\\"white\\" stroked=\\"f\\" style=\\"position:absolute;left:289;top:291;width:30;height:34;\\" />
+            </v:group>
+            <![endif]-->
+
+            
+        </div><h2 id=\\"file\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">File</h2><table cellspacing=\\"0\\" cellpadding=\\"4\\" border=\\"0\\" class=\\"kg-file-card\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; margin: 0 0 1.5em 0; border-radius: 3px; border: 1px solid #e5eff5; border: 1px solid rgba(0, 0, 0, 0.12);\\">
+            <tbody><tr>
+                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                    <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\">
+                        <tbody><tr>
+                            <td valign=\\"middle\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; vertical-align: middle;\\">
+                                
+                                <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-title\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 8px; font-size: 17px; font-weight: bold; line-height: 1.3em; overflow-wrap: anywhere; text-decoration: none; color: #000000;\\" target=\\"_blank\\">package</a>
+                                </td></tr></tbody></table>
+                                
+                                
+                                <table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\"><tbody><tr><td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">
+                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"kg-file-meta\\" style=\\"display: block; width: 100%; padding-left: 12px; padding-top: 4px; padding-bottom: 8px; font-size: 13px; line-height: 1.4em; overflow-wrap: anywhere; text-decoration: none; color: #000000; color: rgba(0, 0, 0, 0.5);\\" target=\\"_blank\\"><span class=\\"kg-file-name\\" style=\\"font-weight: 500; color: #000000;\\">package.json</span> &#x2022; 3 Bytes</a>
+                                </td></tr></tbody></table>
+                            </td>
+                            <td width=\\"80\\" valign=\\"middle\\" class=\\"kg-file-thumbnail\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; position: relative; vertical-align: middle; text-align: center; border-radius: 2px; background: #FF1A75;\\" align=\\"center\\">
+                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"overflow-wrap: anywhere; color: #FF1A75; text-decoration: underline; position: absolute; display: block; top: 0; right: 0; bottom: 0; left: 0;\\" target=\\"_blank\\"></a>
+                                <img src=\\"https://static.ghost.org/v4.0.0/images/download-icon-darkmode.png\\" style=\\"border: none; -ms-interpolation-mode: bicubic; margin-top: 6px; height: 24px; width: 24px; max-width: 24px;\\" width=\\"24\\" height=\\"24\\">
+                            </td>
+                        </tr>
+                    </tbody></table>
+                </td>
+            </tr>
+        </tbody></table><h2 id=\\"product\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Product</h2><table cellspacing=\\"0\\" cellpadding=\\"0\\" border=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding: 20px; border: 1px solid #E9E9E9; border-radius: 5px; margin: 0 0 1.5em; width: 100%;\\" width=\\"100%\\">
+            
+                <tbody><tr>
+                    <td align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;\\" valign=\\"top\\">
+                        <img src=\\"http://127.0.0.1:2369/content/images/2023/11/IMG_1870.jpeg\\" width=\\"560\\" height=\\"420\\" style=\\"-ms-interpolation-mode: bicubic; display: block; width: 100%; height: auto; max-width: 100%; border: none; padding-bottom: 16px;\\" border=\\"0\\">
+                    </td>
+                </tr>
+            
+            <tr>
+                <td valign=\\"top\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\">
+                    <h4 style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; line-height: 1.2em; font-weight: 700; font-size: 22px; margin-top: 0; margin-bottom: 0;\\"><span style=\\"white-space: pre-wrap;\\">Free dog</span></h4>
+                </td>
+            </tr>
+            
+                <tr style=\\"padding-top:0; padding-bottom:0; margin-bottom:0; padding-bottom:0;\\">
+                    <td valign=\\"top\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\">
+                        <img src=\\"https://static.ghost.org/v4.0.0/images/star-rating-3.png\\" style=\\"-ms-interpolation-mode: bicubic; max-width: 100%; border: none; width: 96px;\\" border=\\"0\\" width=\\"96\\">
+                    </td>
+                </tr>
+            
+            <tr>
+                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;\\" valign=\\"top\\">
+                    <div style=\\"padding-top: 8px; opacity: 0.7; font-size: 17px; line-height: 1.4; margin-bottom: -24px;\\"><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\"><span style=\\"white-space: pre-wrap;\\">He&#39;s cute but he&#39;s mean</span></p></div>
+                </td>
+            </tr>
+            
+                <tr>
+                    <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; padding-top: 0; padding-bottom: 0; margin-bottom: 0; padding-bottom: 0;\\" valign=\\"top\\">
+                        <div class=\\"btn btn-accent\\" style=\\"box-sizing: border-box; display: table; width: 100%; padding-top: 16px;\\">
+                            <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"background-color: #FF1A75; overflow-wrap: anywhere; border: solid 1px; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 0; text-decoration: none; color: #FFFFFF; width: 100%; text-align: center; border-color: #FF1A75;\\" target=\\"_blank\\"><span style=\\"display: block;padding: 12px 25px;\\">Buy now</span></a>
+                        </div>
+                    </td>
+                </tr>
+            
+        </tbody></table><h2 id=\\"header\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Header</h2><div class=\\"kg-header-card kg-v2\\" style=\\"margin: 0 0 1.5em 0; padding: 110px 35px 110px 35px; color: #FFFFFF; text-align: center; background-color: #000000;\\">
+            
+            <div class=\\"kg-header-card-content\\" style>
+                <h2 class=\\"kg-header-card-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; text-rendering: optimizeLegibility; font-size: 3em; font-weight: 700; line-height: 1.1em; margin: 0 0 0.125em; color: #FFFFFF;\\"><span style=\\"white-space: pre-wrap;\\">Good news everyone!</span></h2>
+                <p class=\\"kg-header-card-subheading\\" style=\\"margin: 0 0 1.5em 0; line-height: 1.6em; color: #FFFFFF;\\"><span style=\\"white-space: pre-wrap;\\">We&#39;re going to be okay.</span></p>
+                
+            </div>
+        </div><h2 id=\\"embeds\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Embeds</h2><div class=\\"kg-card kg-embed-card\\" style=\\"margin: 0 0 1.5em; padding: 0;\\"><!--[if !mso !vml]-->
+            <a class=\\"kg-video-preview\\" href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" aria-label=\\"Play video\\" style=\\"background-color: #1d1f21; background-image: radial-gradient(circle at center, #5b5f66, #1d1f21); display: block; overflow-wrap: anywhere; color: #FF1A75; mso-hide: all; text-decoration: none;\\" target=\\"_blank\\">
+                <table cellpadding=\\"0\\" cellspacing=\\"0\\" border=\\"0\\" width=\\"100%\\" background=\\"https://i.ytimg.com/vi/jfKfPfyJRdk/hqdefault.jpg\\" role=\\"presentation\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-size: cover; min-height: 200px; background: url(&#39;https://i.ytimg.com/vi/jfKfPfyJRdk/hqdefault.jpg&#39;) left top / cover; mso-hide: all;\\">
+                    <tbody><tr style=\\"mso-hide: all\\">
+                        <td width=\\"25%\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; visibility: hidden; mso-hide: all;\\" valign=\\"top\\">
+                            <img src=\\"https://img.spacergif.org/v1/150x450/0a/spacer.png\\" alt width=\\"100%\\" border=\\"0\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; height: auto; opacity: 0; visibility: hidden; mso-hide: all;\\" height=\\"auto\\">
+                        </td>
+                        <td width=\\"50%\\" align=\\"center\\" valign=\\"middle\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; color: #000000; vertical-align: middle; mso-hide: all;\\">
+                            <div class=\\"kg-video-play-button\\" style=\\"height: 2em; width: 3em; margin: 0 auto; border-radius: 10px; padding: 1em 0.8em 0.6em 1em; font-size: 1em; background-color: rgba(0,0,0,0.85); mso-hide: all;\\"><div style=\\"display: block; width: 0; height: 0; margin: 0 auto; line-height: 0px; border-color: transparent transparent transparent white; border-style: solid; border-width: 0.8em 0 0.8em 1.5em; mso-hide: all;\\"></div></div>
+                        </td>
+                        <td width=\\"25%\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; mso-hide: all;\\" valign=\\"top\\">&#xA0;</td>
+                    </tr>
+                </tbody></table>
+            </a>
+            <!--[endif]-->
+
+            <!--[if vml]>
+            <v:group xmlns:v=\\"urn:schemas-microsoft-com:vml\\" xmlns:w=\\"urn:schemas-microsoft-com:office:word\\" coordsize=\\"600,450\\" coordorigin=\\"0,0\\" href=\\"https://www.youtube.com/watch?v=jfKfPfyJRdk\\" style=\\"width:600px;height:450px;\\">
+                <v:rect fill=\\"t\\" stroked=\\"f\\" style=\\"position:absolute;width:600;height:450;\\"><v:fill src=\\"https://i.ytimg.com/vi/jfKfPfyJRdk/hqdefault.jpg\\" type=\\"frame\\"/></v:rect>
+                <v:oval fill=\\"t\\" strokecolor=\\"white\\" strokeweight=\\"4px\\" style=\\"position:absolute;left:261;top:186;width:78;height:78\\"><v:fill color=\\"black\\" opacity=\\"30%\\" /></v:oval>
+                <v:shape coordsize=\\"24,32\\" path=\\"m,l,32,24,16,xe\\" fillcolor=\\"white\\" stroked=\\"f\\" style=\\"position:absolute;left:289;top:208;width:30;height:34;\\" />
+            </v:group>
+            <![endif]--></div><h2 id=\\"signup-card\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Signup Card</h2><div></div><h2 id=\\"codeblock\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 32px;\\">Codeblock</h2><pre style=\\"white-space: pre-wrap; overflow: auto; background: #15212A; padding: 15px; border-radius: 3px; line-height: 1.2em; color: #ffffff;\\"><code class=\\"language-javascript\\" style=\\"font-size: 0.9em;\\">const fs = require(&#39;fs-extra&#39;);</code></pre><h1 id=\\"the-aside-element\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; line-height: 1.11em; text-rendering: optimizeLegibility; color: #000000; margin: 1.5em 0 0.5em 0; font-size: 42px; font-weight: 700;\\">The aside element</h1><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">My family and I visited The Epcot center this summer. The weather was nice, and Epcot was amazing! I had a great summer together with my family!</p><h4 id=\\"epcot-center\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-weight: 700; text-rendering: optimizeLegibility; color: #000000; margin: 1.8em 0 0.5em 0; font-size: 21px; line-height: 1.2em;\\">Epcot Center</h4><p style=\\"margin: 0 0 1.5em 0; line-height: 1.6em;\\">Epcot is a theme park at Walt Disney World Resort featuring exciting attractions, international pavilions, award-winning fireworks and seasonal special events.</p>
+                                                <!-- POST CONTENT END -->
+
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+
+                            <!-- END MAIN CONTENT AREA -->
+
+
+
+
+                            <tr>
+                                <td class=\\"wrapper\\" align=\\"center\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; box-sizing: border-box;\\" valign=\\"top\\">
+                                    <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" width=\\"100%\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; padding-top: 40px; padding-bottom: 30px;\\">
+                                        <tr>
+                                            <td class=\\"footer\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; vertical-align: top; color: #000000; color: rgba(0, 0, 0, 0.5); margin-top: 20px; text-align: center; font-size: 13px; padding-bottom: 10px; padding-top: 10px; padding-left: 30px; padding-right: 30px; line-height: 1.5em;\\" valign=\\"top\\" align=\\"center\\">Ghost &#xA9; 2023 &#x2013; <a href=\\"http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&newsletter=requested-newsletter-uuid\\" style=\\"overflow-wrap: anywhere; color: #000000; color: rgba(0, 0, 0, 0.5); text-decoration: underline;\\" target=\\"_blank\\">Unsubscribe</a></td>
+                                        </tr>
+
+                                            <tr>
+                                                <td class=\\"footer-powered\\" style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000; text-align: center; padding-top: 70px; padding-bottom: 40px;\\" valign=\\"top\\" align=\\"center\\"><a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" style=\\"color: #FF1A75; text-decoration: none; overflow-wrap: anywhere;\\" target=\\"_blank\\"><img src=\\"https://static.ghost.org/v4.0.0/images/powered.png\\" border=\\"0\\" width=\\"142\\" height=\\"30\\" class=\\"gh-powered\\" alt=\\"Powered by Ghost\\" style=\\"border: none; -ms-interpolation-mode: bicubic; max-width: 100%; width: 142px; height: 30px;\\"></a></td>
+                                            </tr>
+                                    </table>
+                                </td>
+                            </tr>
+
+                        </table>
+                        <!-- END CENTERED WHITE CONTAINER -->
+                    </div>
+                </td>
+                <td style=\\"font-family: -apple-system, BlinkMacSystemFont, &#39;Segoe UI&#39;, Roboto, Helvetica, Arial, sans-serif, &#39;Apple Color Emoji&#39;, &#39;Segoe UI Emoji&#39;, &#39;Segoe UI Symbol&#39;; font-size: 18px; vertical-align: top; color: #000000;\\" valign=\\"top\\">&#xA0;</td>
+            </tr>
+
+            <!--[if mso]>
+                            </table>
+                        </center>
+                    </td>
+                </tr>
+            <![endif]-->
+        </table>
+    </body>
+</html>
+",
+  "plaintext": "
+
+
+
+
+
+
+
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ghost [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+
+
+
+
+A random test post [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+
+
+
+By Joe Bloggs • date
+
+
+View in browser [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+View in browser [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+
+
+
+
+
+Here's a paragraph
+
+> Here's a block quote
+
+> Here's some text.
+
+
+Images
+
+A small dog playing in the grass.
+
+
+Markdown
+
+
+A heading!
+
+
+And a paragraph
+
+
+
+HTML
+
+
+
+A paragraph!
+
+
+And another paragraph, with bold test.
+
+
+
+
+Gallery
+
+A small dog playing and sitting in the grass.
+
+
+Divider
+
+----------------------------------------
+
+
+Bookmark
+
+
+
+
+
+
+Ghost: Independent technology for modern publishing
+Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by Sky, 404Media, Lever News, Tangle, The Browser, and thousands more.
+
+
+Ghost - The Professional Publishing Platform
+
+
+
+
+
+[http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+Ghost's homepage
+
+
+
+
+
+Email content
+
+Hey Vinz,
+
+
+Email call to action
+
+
+Public preview
+
+
+Button
+
+
+
+Click me! [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+Callout
+
+💡Don't forget!
+
+
+Toggle
+
+
+Here's a spoiler!
+
+
+Jk jk no spoilers here
+
+
+
+Audio
+
+
+
+
+
+
+
+
+
+
+
+
+
+http://127.0.0.1:2369/r/xxxxxx?m=member-uuid
+
+
+http://127.0.0.1:2369/r/xxxxxx?m=member-uuid
+
+
+
+
+
+Sample [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+
+
+
+http://127.0.0.1:2369/r/xxxxxx?m=member-uuid
+
+
+1:45 • Click to play audio [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Video
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+[http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+
+
+File
+
+
+
+
+
+
+
+
+
+
+
+
+
+package [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+package.json • 3 Bytes [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+http://127.0.0.1:2369/r/xxxxxx?m=member-uuid
+
+
+
+
+
+
+
+
+
+Product
+
+
+
+
+
+
+
+
+
+
+
+
+
+Free dog
+
+
+
+
+
+
+
+
+
+
+
+
+
+He's cute but he's mean
+
+
+
+
+
+
+
+
+Buy now [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+
+
+Header
+
+
+
+
+
+Good news everyone!
+
+
+We're going to be okay.
+
+
+
+
+
+Embeds
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+[http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
+
+
+
+
+Signup Card
+
+
+Codeblock
+
+const fs = require('fs-extra');
+
+
+The aside element
+
+My family and I visited The Epcot center this summer. The weather was nice, and Epcot was amazing! I had a great summer together with my family!
+
+Epcot Center
+
+Epcot is a theme park at Walt Disney World Resort featuring exciting attractions, international pavilions, award-winning fireworks and seasonal special events.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ghost © 2023 – Unsubscribe [http://127.0.0.1:2369/unsubscribe/?uuid=member-uuid&newsletter=requested-newsletter-uuid]
+
+
+
+http://127.0.0.1:2369/r/xxxxxx?m=member-uuid
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+",
+}
+`;

--- a/ghost/core/test/integration/services/email-service/cards.test.js
+++ b/ghost/core/test/integration/services/email-service/cards.test.js
@@ -5,8 +5,7 @@ const configUtils = require('../../../utils/configUtils');
 const {sendEmail, matchEmailSnapshot} = require('../../../utils/batch-email-utils');
 const cheerio = require('cheerio');
 const fs = require('fs-extra');
-const { DEFAULT_NODES } = require('@tryghost/kg-default-nodes');
-const CommentsController = require('../../../../core/server/services/comments/CommentsController');
+const {DEFAULT_NODES} = require('@tryghost/kg-default-nodes');
 
 const goldenPost = fs.readJsonSync('./test/utils/fixtures/email-service/golden-post.json');
 
@@ -149,8 +148,6 @@ describe('Can send cards via email', function () {
             lexical: JSON.stringify(goldenPost)
         });
 
-
-
         splitPreheader(data);
 
         await matchEmailSnapshot();
@@ -165,8 +162,8 @@ describe('Can send cards via email', function () {
             'collection', // only used in pages, will never be emailed
             'extended-text', // not a card
             'extended-quote', // not a card
-            'extended-heading', // not a card
-        ]
+            'extended-heading' // not a card
+        ];
 
         const cardsInDefaultNodes = DEFAULT_NODES.map((node) => {
             try {
@@ -178,7 +175,7 @@ describe('Can send cards via email', function () {
             return card !== null && !excludedCards.includes(card); // don't include extended versions of regular text type nodes, we only want the cards (decorator nodes)
         });
 
-
+        // Check that every card in DEFAULT_NODES are present in the golden post (with the exception of the excludedCards above)
         for (const card of cardsInDefaultNodes) {
             assert.ok(cardsInGoldenPost.includes(card), `The golden post does not contain the ${card} card`);
         }

--- a/ghost/core/test/integration/services/email-service/cards.test.js
+++ b/ghost/core/test/integration/services/email-service/cards.test.js
@@ -154,6 +154,12 @@ describe('Can send cards via email', function () {
     });
 
     it('renders all of the default nodes in the golden post', async function () {
+        // This test checks that all of the default nodes from @tryghost/kg-default-nodes are present in the golden post
+        // This is to ensure that if we add new cards to Koenig, they will be included in the golden post
+        // This is important because the golden post is used to test the email rendering of the cards after
+        // they have gone through the Email Renderer, which can change the HTML/CSS of the cards
+        // See the README.md in this same directory for more information.
+
         const cardsInGoldenPost = goldenPost.root.children.map((child) => {
             return child.type;
         });
@@ -162,7 +168,8 @@ describe('Can send cards via email', function () {
             'collection', // only used in pages, will never be emailed
             'extended-text', // not a card
             'extended-quote', // not a card
-            'extended-heading' // not a card
+            'extended-heading', // not a card
+            'tk' // shouldn't be present in published posts / emails
         ];
 
         const cardsInDefaultNodes = DEFAULT_NODES.map((node) => {

--- a/ghost/core/test/utils/fixtures/email-service/golden-post.json
+++ b/ghost/core/test/utils/fixtures/email-service/golden-post.json
@@ -8,7 +8,7 @@
                         "format": 0,
                         "mode": "normal",
                         "style": "",
-                        "text": "Here's a paragraph",
+                        "text": "This is just a simple paragraph, no frills.",
                         "type": "extended-text",
                         "version": 1
                     }
@@ -26,7 +26,7 @@
                         "format": 0,
                         "mode": "normal",
                         "style": "",
-                        "text": "Here's a block quote",
+                        "text": "This is block quote",
                         "type": "extended-text",
                         "version": 1
                     }
@@ -44,7 +44,7 @@
                         "format": 0,
                         "mode": "normal",
                         "style": "",
-                        "text": "Here's some text.",
+                        "text": "This is a...different block quote",
                         "type": "extended-text",
                         "version": 1
                     }
@@ -62,7 +62,7 @@
                         "format": 0,
                         "mode": "normal",
                         "style": "",
-                        "text": "Images",
+                        "text": "This is a heading!",
                         "type": "extended-text",
                         "version": 1
                     }
@@ -73,85 +73,47 @@
                 "type": "heading",
                 "version": 1,
                 "tag": "h2"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Here's a smaller heading.",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h3"
             },
             {
                 "type": "image",
                 "version": 1,
-                "src": "__GHOST_URL__/content/images/2023/11/IMG_1873-1.jpeg",
+                "src": "https://main.ghost.org/content/images/2023/11/IMG_1952-1.jpeg",
                 "width": 4032,
                 "height": 3024,
                 "title": "",
-                "alt": "A small dog.",
-                "caption": "<span style=\"white-space: pre-wrap;\">A small dog playing in the grass.</span>",
+                "alt": "A beautiful tree, indeed.",
+                "caption": "<span style=\"white-space: pre-wrap;\">A beautiful tree.</span>",
                 "cardWidth": "regular",
                 "href": ""
             },
             {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Markdown",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
-            },
-            {
                 "type": "markdown",
                 "version": 1,
-                "markdown": "# A heading!\nAnd a paragraph"
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "HTML",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
+                "markdown": "# A heading\nand a paragraph (in markdown!)"
             },
             {
                 "type": "html",
                 "version": 1,
-                "html": "<p>A paragraph!</p>\n<p>And another paragraph, with <em>bold</em> test.</p>"
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Gallery",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
+                "html": "<p>A paragraph inside an HTML card.</p>\n<p>And another one, with some <b>bold</b> text.</p>"
             },
             {
                 "type": "gallery",
@@ -159,76 +121,45 @@
                 "images": [
                     {
                         "row": 0,
-                        "src": "__GHOST_URL__/content/images/2023/11/IMG_1873-2.jpeg",
+                        "src": "https://main.ghost.org/content/images/2023/11/IMG_1952-6.jpeg",
+                        "width": 4032,
+                        "height": 3024,
+                        "fileName": "IMG_1952.jpeg"
+                    },
+                    {
+                        "row": 0,
+                        "src": "https://main.ghost.org/content/images/2023/11/IMG_1873.jpeg",
                         "width": 4032,
                         "height": 3024,
                         "fileName": "IMG_1873.jpeg"
                     },
                     {
                         "row": 0,
-                        "src": "__GHOST_URL__/content/images/2023/11/IMG_1865.jpeg",
+                        "src": "https://main.ghost.org/content/images/2023/11/IMG_1868-2.jpeg",
                         "width": 4032,
                         "height": 3024,
-                        "fileName": "IMG_1865.jpeg"
-                    },
-                    {
-                        "row": 0,
-                        "src": "__GHOST_URL__/content/images/2023/11/IMG_1861.jpeg",
-                        "width": 3024,
-                        "height": 4032,
-                        "fileName": "IMG_1861.jpeg"
+                        "fileName": "IMG_1868.jpeg"
                     },
                     {
                         "row": 1,
-                        "src": "__GHOST_URL__/content/images/2023/11/IMG_1862.jpeg",
-                        "width": 4032,
-                        "height": 3024,
-                        "fileName": "IMG_1862.jpeg"
-                    }
-                ],
-                "caption": "<p><span style=\"white-space: pre-wrap;\">A small dog playing and sitting in the grass.</span></p>"
-            },
-            {
-                "children": [
+                        "src": "https://main.ghost.org/content/images/2023/11/IMG_1478.jpeg",
+                        "width": 3024,
+                        "height": 4032,
+                        "fileName": "IMG_1478.jpeg"
+                    },
                     {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Divider",
-                        "type": "extended-text",
-                        "version": 1
+                        "row": 1,
+                        "src": "https://main.ghost.org/content/images/2023/11/IMG_3917.jpeg",
+                        "width": 5184,
+                        "height": 3456,
+                        "fileName": "IMG_3917.jpeg"
                     }
                 ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
+                "caption": "<p><span style=\"white-space: pre-wrap;\">A tree, a meerkat, and a terrier.</span></p>"
             },
             {
                 "type": "horizontalrule",
                 "version": 1
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Bookmark",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
             },
             {
                 "type": "bookmark",
@@ -242,26 +173,7 @@
                     "publisher": "Ghost - The Professional Publishing Platform",
                     "thumbnail": "https://ghost.org/images/meta/ghost.png"
                 },
-                "caption": "<p><span style=\"white-space: pre-wrap;\">Ghost's homepage</span></p>"
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Email content",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
+                "caption": "<p><span style=\"white-space: pre-wrap;\">My favorite website.</span></p>"
             },
             {
                 "type": "email",
@@ -269,277 +181,79 @@
                 "html": "<p><span style=\"white-space: pre-wrap;\">Hey </span><code spellcheck=\"false\" style=\"white-space: pre-wrap;\"><span>{first_name, \"there\"}</span></code><span style=\"white-space: pre-wrap;\">,</span></p>"
             },
             {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Email call to action",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
-            },
-            {
                 "type": "email-cta",
                 "version": 1,
                 "alignment": "left",
                 "buttonText": "",
                 "buttonUrl": "",
-                "html": "<p><span style=\"white-space: pre-wrap;\">Subscribe now!</span></p>",
+                "html": "<p><span style=\"white-space: pre-wrap;\">Hello there, fellow users of electronic mail.</span></p>",
                 "segment": "status:free",
                 "showButton": false,
                 "showDividers": true
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Public preview",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
             },
             {
                 "type": "paywall",
                 "version": 1
             },
             {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Button",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
-            },
-            {
                 "type": "button",
                 "version": 1,
-                "buttonText": "Click me!",
+                "buttonText": "Click me, I'm a button!",
                 "alignment": "center",
-                "buttonUrl": "__GHOST_URL__/"
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Callout",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
+                "buttonUrl": "https://ghost.org"
             },
             {
                 "type": "callout",
                 "version": 1,
-                "calloutText": "<p><span style=\"white-space: pre-wrap;\">Don't forget!</span></p>",
+                "calloutText": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">I had an idea...</span></p>",
                 "calloutEmoji": "💡",
-                "backgroundColor": "purple"
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Toggle",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
+                "backgroundColor": "blue"
             },
             {
                 "type": "toggle",
                 "version": 1,
-                "heading": "<span style=\"white-space: pre-wrap;\">Here's a spoiler!</span>",
-                "content": "<p><span style=\"white-space: pre-wrap;\">Jk jk no spoilers here</span></p>"
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Audio",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
+                "heading": "<span style=\"white-space: pre-wrap;\">Spoiler alert!</span>",
+                "content": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">Just kidding</span></p>"
             },
             {
                 "type": "audio",
                 "version": 1,
                 "duration": 105.822041,
                 "mimeType": "audio/mpeg",
-                "src": "__GHOST_URL__/content/media/2023/11/sample.mp3",
+                "src": "https://main.ghost.org/content/media/2023/11/sample.mp3",
                 "title": "Sample",
                 "thumbnailSrc": ""
             },
             {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Video",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
-            },
-            {
                 "type": "video",
                 "version": 1,
-                "src": "__GHOST_URL__/content/media/2023/11/video.mp4",
-                "caption": "",
-                "fileName": "video.mp4",
+                "src": "https://main.ghost.org/content/media/2023/11/sample_640x360.mp4",
+                "caption": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">A video card.</span></p>",
+                "fileName": "sample_640x360.mp4",
                 "mimeType": "video/mp4",
-                "width": 158,
-                "height": 162,
-                "duration": 4.066667,
-                "thumbnailSrc": "__GHOST_URL__/content/media/2023/11/video_thumb.jpg",
+                "width": 640,
+                "height": 360,
+                "duration": 13.346667,
+                "thumbnailSrc": "https://main.ghost.org/content/media/2023/11/sample_640x360_thumb.jpg",
                 "customThumbnailSrc": "",
-                "thumbnailWidth": 158,
-                "thumbnailHeight": 162,
+                "thumbnailWidth": 640,
+                "thumbnailHeight": 360,
                 "cardWidth": "regular",
                 "loop": false
             },
             {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "File",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
-            },
-            {
-                "type": "file",
-                "src": "__GHOST_URL__/content/files/2023/11/package.json",
-                "fileTitle": "package",
-                "fileCaption": "",
-                "fileName": "package.json",
-                "fileSize": 3
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Product",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
-            },
-            {
                 "type": "product",
                 "version": 1,
-                "productImageSrc": "__GHOST_URL__/content/images/2023/11/IMG_1870.jpeg",
-                "productImageWidth": 4032,
-                "productImageHeight": 3024,
-                "productTitle": "<span style=\"white-space: pre-wrap;\">Free dog</span>",
-                "productDescription": "<p><span style=\"white-space: pre-wrap;\">He's cute but he's mean</span></p>",
+                "productImageSrc": "https://main.ghost.org/content/images/2023/11/71124418043__F5E7A067-CA69-4E5F-91D8-938EC4A12B20.jpeg",
+                "productImageWidth": 3024,
+                "productImageHeight": 4032,
+                "productTitle": "<span style=\"white-space: pre-wrap;\">Care for a refreshment?</span>",
+                "productDescription": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">It's what plants crave.</span></p>",
                 "productRatingEnabled": true,
-                "productStarRating": 3,
+                "productStarRating": 5,
                 "productButtonEnabled": true,
-                "productButton": "Buy now",
-                "productUrl": "http://localhost:2368/"
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Header",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
+                "productButton": "$98 at Amazon",
+                "productUrl": "https://ghost.org"
             },
             {
                 "type": "header",
@@ -550,9 +264,9 @@
                 "buttonUrl": "",
                 "buttonText": "",
                 "header": "<span style=\"white-space: pre-wrap;\">Good news everyone!</span>",
-                "subheader": "<span style=\"white-space: pre-wrap;\">We're going to be okay.</span>",
+                "subheader": "<span style=\"white-space: pre-wrap;\">This header renders properly in </span><i><em class=\"italic\" style=\"white-space: pre-wrap;\">all</em></i><span style=\"white-space: pre-wrap;\"> email clients!</span>",
                 "backgroundImageSrc": "",
-                "accentColor": "#FF1A75",
+                "accentColor": "#14171b",
                 "alignment": "center",
                 "backgroundColor": "#000000",
                 "backgroundImageWidth": null,
@@ -563,25 +277,6 @@
                 "buttonTextColor": "#000000",
                 "layout": "full",
                 "swapped": false
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Embeds",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
             },
             {
                 "type": "embed",
@@ -607,25 +302,6 @@
                 "caption": ""
             },
             {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "Signup Card",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
-            },
-            {
                 "type": "signup",
                 "version": 1,
                 "alignment": "left",
@@ -637,10 +313,10 @@
                 "buttonTextColor": "#FFFFFF",
                 "buttonText": "Subscribe",
                 "disclaimer": "<span style=\"white-space: pre-wrap;\">No spam. Unsubscribe anytime.</span>",
-                "header": "<span style=\"white-space: pre-wrap;\">Sign up for Dev</span>",
+                "header": "<span style=\"white-space: pre-wrap;\">Sign up for This Is The Main</span>",
                 "labels": [],
                 "layout": "wide",
-                "subheader": "<span style=\"white-space: pre-wrap;\">Thoughts, stories and ideas.</span>",
+                "subheader": "<span style=\"white-space: pre-wrap;\">The testing and tweaking of Ghost, now with extra long description for the same price of epic staging</span>",
                 "successMessage": "Email sent! Check your inbox to complete your signup.",
                 "swapped": false
             },
@@ -651,52 +327,7 @@
                         "format": 0,
                         "mode": "normal",
                         "style": "",
-                        "text": "Codeblock",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h2"
-            },
-            {
-                "type": "codeblock",
-                "version": 1,
-                "code": "const fs = require('fs-extra');",
-                "language": "javascript",
-                "caption": ""
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "The aside element",
-                        "type": "extended-text",
-                        "version": 1
-                    }
-                ],
-                "direction": "ltr",
-                "format": "",
-                "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h1"
-            },
-            {
-                "children": [
-                    {
-                        "detail": 0,
-                        "format": 0,
-                        "mode": "normal",
-                        "style": "",
-                        "text": "My family and I visited The Epcot center this summer. The weather was nice, and Epcot was amazing! I had a great summer together with my family!",
+                        "text": "Some text.",
                         "type": "extended-text",
                         "version": 1
                     }
@@ -714,7 +345,7 @@
                         "format": 0,
                         "mode": "normal",
                         "style": "",
-                        "text": "Epcot Center",
+                        "text": "A blockquote",
                         "type": "extended-text",
                         "version": 1
                     }
@@ -722,9 +353,8 @@
                 "direction": "ltr",
                 "format": "",
                 "indent": 0,
-                "type": "heading",
-                "version": 1,
-                "tag": "h4"
+                "type": "extended-quote",
+                "version": 1
             },
             {
                 "children": [
@@ -733,12 +363,35 @@
                         "format": 0,
                         "mode": "normal",
                         "style": "",
-                        "text": "Epcot is a theme park at Walt Disney World Resort featuring exciting attractions, international pavilions, award-winning fireworks and seasonal special events.",
+                        "text": "Some more text.",
                         "type": "extended-text",
                         "version": 1
                     }
                 ],
                 "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "paragraph",
+                "version": 1
+            },
+            {
+                "type": "codeblock",
+                "version": 1,
+                "code": "console.log('Hello world!');",
+                "language": "javascript",
+                "caption": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">A tiny little script.</span></p>"
+            },
+            {
+                "type": "file",
+                "src": "https://main.ghost.org/content/files/2023/11/test.txt",
+                "fileTitle": "test",
+                "fileCaption": "A tiny text file.",
+                "fileName": "test.txt",
+                "fileSize": 16
+            },
+            {
+                "children": [],
+                "direction": null,
                 "format": "",
                 "indent": 0,
                 "type": "paragraph",

--- a/ghost/core/test/utils/fixtures/email-service/golden-post.json
+++ b/ghost/core/test/utils/fixtures/email-service/golden-post.json
@@ -1,0 +1,754 @@
+{
+    "root": {
+        "children": [
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Here's a paragraph",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "paragraph",
+                "version": 1
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Here's a block quote",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "quote",
+                "version": 1
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Here's some text.",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "aside",
+                "version": 1
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Images",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "image",
+                "version": 1,
+                "src": "__GHOST_URL__/content/images/2023/11/IMG_1873-1.jpeg",
+                "width": 4032,
+                "height": 3024,
+                "title": "",
+                "alt": "A small dog.",
+                "caption": "<span style=\"white-space: pre-wrap;\">A small dog playing in the grass.</span>",
+                "cardWidth": "regular",
+                "href": ""
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Markdown",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "markdown",
+                "version": 1,
+                "markdown": "# A heading!\nAnd a paragraph"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "HTML",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "html",
+                "version": 1,
+                "html": "<p>A paragraph!</p>\n<p>And another paragraph, with <em>bold</em> test.</p>"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Gallery",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "gallery",
+                "version": 1,
+                "images": [
+                    {
+                        "row": 0,
+                        "src": "__GHOST_URL__/content/images/2023/11/IMG_1873-2.jpeg",
+                        "width": 4032,
+                        "height": 3024,
+                        "fileName": "IMG_1873.jpeg"
+                    },
+                    {
+                        "row": 0,
+                        "src": "__GHOST_URL__/content/images/2023/11/IMG_1865.jpeg",
+                        "width": 4032,
+                        "height": 3024,
+                        "fileName": "IMG_1865.jpeg"
+                    },
+                    {
+                        "row": 0,
+                        "src": "__GHOST_URL__/content/images/2023/11/IMG_1861.jpeg",
+                        "width": 3024,
+                        "height": 4032,
+                        "fileName": "IMG_1861.jpeg"
+                    },
+                    {
+                        "row": 1,
+                        "src": "__GHOST_URL__/content/images/2023/11/IMG_1862.jpeg",
+                        "width": 4032,
+                        "height": 3024,
+                        "fileName": "IMG_1862.jpeg"
+                    }
+                ],
+                "caption": "<p><span style=\"white-space: pre-wrap;\">A small dog playing and sitting in the grass.</span></p>"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Divider",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "horizontalrule",
+                "version": 1
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Bookmark",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "bookmark",
+                "version": 1,
+                "url": "https://ghost.org",
+                "metadata": {
+                    "icon": "https://ghost.org/favicon.ico",
+                    "title": "Ghost: Independent technology for modern publishing",
+                    "description": "Beautiful, modern publishing with newsletters and premium subscriptions built-in. Used by Sky, 404Media, Lever News, Tangle, The Browser, and thousands more.",
+                    "author": "",
+                    "publisher": "Ghost - The Professional Publishing Platform",
+                    "thumbnail": "https://ghost.org/images/meta/ghost.png"
+                },
+                "caption": "<p><span style=\"white-space: pre-wrap;\">Ghost's homepage</span></p>"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Email content",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "email",
+                "version": 1,
+                "html": "<p><span style=\"white-space: pre-wrap;\">Hey </span><code spellcheck=\"false\" style=\"white-space: pre-wrap;\"><span>{first_name, \"there\"}</span></code><span style=\"white-space: pre-wrap;\">,</span></p>"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Email call to action",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "email-cta",
+                "version": 1,
+                "alignment": "left",
+                "buttonText": "",
+                "buttonUrl": "",
+                "html": "<p><span style=\"white-space: pre-wrap;\">Subscribe now!</span></p>",
+                "segment": "status:free",
+                "showButton": false,
+                "showDividers": true
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Public preview",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "paywall",
+                "version": 1
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Button",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "button",
+                "version": 1,
+                "buttonText": "Click me!",
+                "alignment": "center",
+                "buttonUrl": "__GHOST_URL__/"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Callout",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "callout",
+                "version": 1,
+                "calloutText": "<p><span style=\"white-space: pre-wrap;\">Don't forget!</span></p>",
+                "calloutEmoji": "💡",
+                "backgroundColor": "purple"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Toggle",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "toggle",
+                "version": 1,
+                "heading": "<span style=\"white-space: pre-wrap;\">Here's a spoiler!</span>",
+                "content": "<p><span style=\"white-space: pre-wrap;\">Jk jk no spoilers here</span></p>"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Audio",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "audio",
+                "version": 1,
+                "duration": 105.822041,
+                "mimeType": "audio/mpeg",
+                "src": "__GHOST_URL__/content/media/2023/11/sample.mp3",
+                "title": "Sample",
+                "thumbnailSrc": ""
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Video",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "video",
+                "version": 1,
+                "src": "__GHOST_URL__/content/media/2023/11/video.mp4",
+                "caption": "",
+                "fileName": "video.mp4",
+                "mimeType": "video/mp4",
+                "width": 158,
+                "height": 162,
+                "duration": 4.066667,
+                "thumbnailSrc": "__GHOST_URL__/content/media/2023/11/video_thumb.jpg",
+                "customThumbnailSrc": "",
+                "thumbnailWidth": 158,
+                "thumbnailHeight": 162,
+                "cardWidth": "regular",
+                "loop": false
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "File",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "file",
+                "src": "__GHOST_URL__/content/files/2023/11/package.json",
+                "fileTitle": "package",
+                "fileCaption": "",
+                "fileName": "package.json",
+                "fileSize": 3
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Product",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "product",
+                "version": 1,
+                "productImageSrc": "__GHOST_URL__/content/images/2023/11/IMG_1870.jpeg",
+                "productImageWidth": 4032,
+                "productImageHeight": 3024,
+                "productTitle": "<span style=\"white-space: pre-wrap;\">Free dog</span>",
+                "productDescription": "<p><span style=\"white-space: pre-wrap;\">He's cute but he's mean</span></p>",
+                "productRatingEnabled": true,
+                "productStarRating": 3,
+                "productButtonEnabled": true,
+                "productButton": "Buy now",
+                "productUrl": "http://localhost:2368/"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Header",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "header",
+                "version": 2,
+                "size": "small",
+                "style": "dark",
+                "buttonEnabled": false,
+                "buttonUrl": "",
+                "buttonText": "",
+                "header": "<span style=\"white-space: pre-wrap;\">Good news everyone!</span>",
+                "subheader": "<span style=\"white-space: pre-wrap;\">We're going to be okay.</span>",
+                "backgroundImageSrc": "",
+                "accentColor": "#FF1A75",
+                "alignment": "center",
+                "backgroundColor": "#000000",
+                "backgroundImageWidth": null,
+                "backgroundImageHeight": null,
+                "backgroundSize": "cover",
+                "textColor": "#FFFFFF",
+                "buttonColor": "#ffffff",
+                "buttonTextColor": "#000000",
+                "layout": "full",
+                "swapped": false
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Embeds",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "embed",
+                "version": 1,
+                "url": "https://www.youtube.com/watch?v=jfKfPfyJRdk",
+                "embedType": "video",
+                "html": "<iframe width=\"200\" height=\"150\" src=\"https://www.youtube.com/embed/jfKfPfyJRdk?feature=oembed\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen title=\"lofi hip hop radio 📚 - beats to relax/study to\"></iframe>",
+                "metadata": {
+                    "title": "lofi hip hop radio 📚 - beats to relax/study to",
+                    "author_name": "Lofi Girl",
+                    "author_url": "https://www.youtube.com/@LofiGirl",
+                    "type": "video",
+                    "height": 150,
+                    "width": 200,
+                    "version": "1.0",
+                    "provider_name": "YouTube",
+                    "provider_url": "https://www.youtube.com/",
+                    "thumbnail_height": 360,
+                    "thumbnail_width": 480,
+                    "thumbnail_url": "https://i.ytimg.com/vi/jfKfPfyJRdk/hqdefault.jpg",
+                    "html": "<iframe width=\"200\" height=\"150\" src=\"https://www.youtube.com/embed/jfKfPfyJRdk?feature=oembed\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" allowfullscreen title=\"lofi hip hop radio 📚 - beats to relax/study to\"></iframe>"
+                },
+                "caption": ""
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Signup Card",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "signup",
+                "version": 1,
+                "alignment": "left",
+                "backgroundColor": "#F0F0F0",
+                "backgroundImageSrc": "",
+                "backgroundSize": "cover",
+                "textColor": "#000000",
+                "buttonColor": "accent",
+                "buttonTextColor": "#FFFFFF",
+                "buttonText": "Subscribe",
+                "disclaimer": "<span style=\"white-space: pre-wrap;\">No spam. Unsubscribe anytime.</span>",
+                "header": "<span style=\"white-space: pre-wrap;\">Sign up for Dev</span>",
+                "labels": [],
+                "layout": "wide",
+                "subheader": "<span style=\"white-space: pre-wrap;\">Thoughts, stories and ideas.</span>",
+                "successMessage": "Email sent! Check your inbox to complete your signup.",
+                "swapped": false
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Codeblock",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h2"
+            },
+            {
+                "type": "codeblock",
+                "version": 1,
+                "code": "const fs = require('fs-extra');",
+                "language": "javascript",
+                "caption": ""
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "The aside element",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h1"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "My family and I visited The Epcot center this summer. The weather was nice, and Epcot was amazing! I had a great summer together with my family!",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "paragraph",
+                "version": 1
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Epcot Center",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "heading",
+                "version": 1,
+                "tag": "h4"
+            },
+            {
+                "children": [
+                    {
+                        "detail": 0,
+                        "format": 0,
+                        "mode": "normal",
+                        "style": "",
+                        "text": "Epcot is a theme park at Walt Disney World Resort featuring exciting attractions, international pavilions, award-winning fireworks and seasonal special events.",
+                        "type": "extended-text",
+                        "version": 1
+                    }
+                ],
+                "direction": "ltr",
+                "format": "",
+                "indent": 0,
+                "type": "paragraph",
+                "version": 1
+            }
+        ],
+        "direction": "ltr",
+        "format": "",
+        "indent": 0,
+        "type": "root",
+        "version": 1
+    }
+}

--- a/ghost/core/test/utils/fixtures/email-service/golden-post.json
+++ b/ghost/core/test/utils/fixtures/email-service/golden-post.json
@@ -34,7 +34,7 @@
                 "direction": "ltr",
                 "format": "",
                 "indent": 0,
-                "type": "quote",
+                "type": "extended-quote",
                 "version": 1
             },
             {
@@ -70,7 +70,7 @@
                 "direction": "ltr",
                 "format": "",
                 "indent": 0,
-                "type": "heading",
+                "type": "extended-heading",
                 "version": 1,
                 "tag": "h2"
             },
@@ -89,19 +89,19 @@
                 "direction": "ltr",
                 "format": "",
                 "indent": 0,
-                "type": "heading",
+                "type": "extended-heading",
                 "version": 1,
                 "tag": "h3"
             },
             {
                 "type": "image",
                 "version": 1,
-                "src": "https://main.ghost.org/content/images/2023/11/IMG_1952-1.jpeg",
-                "width": 4032,
-                "height": 3024,
+                "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg/1920px-Cow_%28Fleckvieh_breed%29_Oeschinensee_Slaunger_2009-07-07.jpg",
+                "width": null,
+                "height": null,
                 "title": "",
-                "alt": "A beautiful tree, indeed.",
-                "caption": "<span style=\"white-space: pre-wrap;\">A beautiful tree.</span>",
+                "alt": "Cows eat grass.",
+                "caption": "<span style=\"white-space: pre-wrap;\">A lovely cow</span>",
                 "cardWidth": "regular",
                 "href": ""
             },
@@ -116,50 +116,42 @@
                 "html": "<p>A paragraph inside an HTML card.</p>\n<p>And another one, with some <b>bold</b> text.</p>"
             },
             {
+                "type": "horizontalrule",
+                "version": 1
+            },
+            {
                 "type": "gallery",
                 "version": 1,
                 "images": [
                     {
                         "row": 0,
-                        "src": "https://main.ghost.org/content/images/2023/11/IMG_1952-6.jpeg",
-                        "width": 4032,
-                        "height": 3024,
-                        "fileName": "IMG_1952.jpeg"
+                        "src": "https://images.unsplash.com/photo-1702352461386-15dcf064708a?q=80&w=2128&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                        "width": null,
+                        "height": null,
+                        "alt": "",
+                        "caption": "",
+                        "fileName": "photo-1702352461386-15dcf064708a"
                     },
                     {
                         "row": 0,
-                        "src": "https://main.ghost.org/content/images/2023/11/IMG_1873.jpeg",
-                        "width": 4032,
-                        "height": 3024,
-                        "fileName": "IMG_1873.jpeg"
+                        "src": "https://images.unsplash.com/photo-1702377168432-ac8b5e387998?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                        "width": null,
+                        "height": null,
+                        "alt": "",
+                        "caption": "",
+                        "fileName": "photo-1702377168432-ac8b5e387998"
                     },
                     {
                         "row": 0,
-                        "src": "https://main.ghost.org/content/images/2023/11/IMG_1868-2.jpeg",
-                        "width": 4032,
-                        "height": 3024,
-                        "fileName": "IMG_1868.jpeg"
-                    },
-                    {
-                        "row": 1,
-                        "src": "https://main.ghost.org/content/images/2023/11/IMG_1478.jpeg",
-                        "width": 3024,
-                        "height": 4032,
-                        "fileName": "IMG_1478.jpeg"
-                    },
-                    {
-                        "row": 1,
-                        "src": "https://main.ghost.org/content/images/2023/11/IMG_3917.jpeg",
-                        "width": 5184,
-                        "height": 3456,
-                        "fileName": "IMG_3917.jpeg"
+                        "src": "https://plus.unsplash.com/premium_photo-1700558685152-81f821a40724?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                        "width": 2070,
+                        "height": 1380,
+                        "alt": "",
+                        "caption": "",
+                        "fileName": "premium_photo-1700558685152-81f821a40724"
                     }
                 ],
-                "caption": "<p><span style=\"white-space: pre-wrap;\">A tree, a meerkat, and a terrier.</span></p>"
-            },
-            {
-                "type": "horizontalrule",
-                "version": 1
+                "caption": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">A gallery.</span></p>"
             },
             {
                 "type": "bookmark",
@@ -205,7 +197,7 @@
             {
                 "type": "callout",
                 "version": 1,
-                "calloutText": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">I had an idea...</span></p>",
+                "calloutText": "<p><span style=\"white-space: pre-wrap;\">I had an idea...</span></p>",
                 "calloutEmoji": "💡",
                 "backgroundColor": "blue"
             },
@@ -213,46 +205,46 @@
                 "type": "toggle",
                 "version": 1,
                 "heading": "<span style=\"white-space: pre-wrap;\">Spoiler alert!</span>",
-                "content": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">Just kidding</span></p>"
+                "content": "<p><span style=\"white-space: pre-wrap;\">Just kidding</span></p>"
             },
             {
                 "type": "audio",
                 "version": 1,
                 "duration": 105.822041,
                 "mimeType": "audio/mpeg",
-                "src": "https://main.ghost.org/content/media/2023/11/sample.mp3",
+                "src": "https://main.ghost.org/content/media/2023/12/sample.mp3",
                 "title": "Sample",
                 "thumbnailSrc": ""
             },
             {
                 "type": "video",
                 "version": 1,
-                "src": "https://main.ghost.org/content/media/2023/11/sample_640x360.mp4",
-                "caption": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">A video card.</span></p>",
+                "src": "https://main.ghost.org/content/media/2023/12/sample_640x360.mp4",
+                "caption": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">A lovely video of a woman on the beach doing nothing.</span></p>",
                 "fileName": "sample_640x360.mp4",
                 "mimeType": "video/mp4",
                 "width": 640,
                 "height": 360,
                 "duration": 13.346667,
-                "thumbnailSrc": "https://main.ghost.org/content/media/2023/11/sample_640x360_thumb.jpg",
+                "thumbnailSrc": "https://main.ghost.org/content/media/2023/12/sample_640x360_thumb.jpg",
                 "customThumbnailSrc": "",
                 "thumbnailWidth": 640,
                 "thumbnailHeight": 360,
                 "cardWidth": "regular",
-                "loop": false
+                "loop": true
             },
             {
                 "type": "product",
                 "version": 1,
-                "productImageSrc": "https://main.ghost.org/content/images/2023/11/71124418043__F5E7A067-CA69-4E5F-91D8-938EC4A12B20.jpeg",
-                "productImageWidth": 3024,
-                "productImageHeight": 4032,
-                "productTitle": "<span style=\"white-space: pre-wrap;\">Care for a refreshment?</span>",
-                "productDescription": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">It's what plants crave.</span></p>",
+                "productImageSrc": "https://main.ghost.org/content/images/2023/12/ghost-logo.png",
+                "productImageWidth": 800,
+                "productImageHeight": 257,
+                "productTitle": "<span style=\"white-space: pre-wrap;\">Make a blog!</span>",
+                "productDescription": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">with Ghost</span></p>",
                 "productRatingEnabled": true,
                 "productStarRating": 5,
                 "productButtonEnabled": true,
-                "productButton": "$98 at Amazon",
+                "productButton": "Click here",
                 "productUrl": "https://ghost.org"
             },
             {
@@ -379,7 +371,7 @@
                 "version": 1,
                 "code": "console.log('Hello world!');",
                 "language": "javascript",
-                "caption": "<p dir=\"ltr\"><span style=\"white-space: pre-wrap;\">A tiny little script.</span></p>"
+                "caption": "<p><span style=\"white-space: pre-wrap;\">A tiny little script.</span></p>"
             },
             {
                 "type": "file",
@@ -388,14 +380,6 @@
                 "fileCaption": "A tiny text file.",
                 "fileName": "test.txt",
                 "fileSize": 16
-            },
-            {
-                "children": [],
-                "direction": null,
-                "format": "",
-                "indent": 0,
-                "type": "paragraph",
-                "version": 1
             }
         ],
         "direction": "ltr",


### PR DESCRIPTION
refs TryGhost/Product#4125

This PR adds two new integration tests to ensure all our Koenig cards are rendered properly after going through the EmailRenderer. Although we have thorough tests for the cards themselves in the Koenig repo, the EmailRenderer does post-processing on the rendered HTML, such as inlining CSS, which can adversely impact the rendered output of our cards in email clients (usually Outlook).

Since email newsletters are a core feature of Ghost, these bugs are typically fairly urgent, and since it is email, they are also quite difficult to troubleshoot and fix. These two tests are intended to prevent bugs of this sort, which in the past have been created by seemingly harmless changes like bumping dependencies that are used in the EmailRenderer.

The idea is to create a 'Golden Post' which has at least 1 of every card from Koenig, run that post through the EmailRenderer, and take a snapshot of the rendered HTML. In the future, if we make any changes to the EmailRenderer or the Koenig cards themselves, this will trigger us to carefully consider the changes, and it provides an 'expected' output to compare our changes against.

Additionally, the second test simply checks that all cards from `kg-default-nodes` are included in the 'Golden Post'. This protects against any new cards that we will add in the future — as soon as we add them to Koenig and bump `kg-default-nodes` in Ghost, this test will fail, prompting us to add the new card to the Golden Post and update the snapshots.

We should also run the 'Golden Post' through a test in Litmus, which allows us to visually inspect the rendered email across many different email clients. Ideally we would create a process to review the output of the 'Golden Post' in Litmus whenever we update the snapshot as well.


