### PR TITLE
Hide SVG icon titles globally

### DIFF
--- a/apps/admin-x-design-system/src/global/Icon.tsx
+++ b/apps/admin-x-design-system/src/global/Icon.tsx
@@ -62,7 +62,7 @@ const Icon: React.FC<IconProps> = ({name, size = 'md', colorClass = '', classNam
 
     if (SvgComponent) {
         return (
-            <SvgComponent className={`${styles} ${className}`} />
+            <SvgComponent className={`pointer-events-none ${styles} ${className}`} />
         );
     }
     return null;


### PR DESCRIPTION
no issues

- when svg icons include title tag, the titles are displayed on hover
- this adds a global tailwind class pointer-events-none to the Icon component to hide the titles globally


