### PR TITLE
Fixed AdminX loading failure screen layout

### DIFF
--- a/ghost/admin/app/components/admin-x/admin-x-component.js
+++ b/ghost/admin/app/components/admin-x/admin-x-component.js
@@ -236,7 +236,7 @@ export default class AdminXComponent extends Component {
     ReactComponent = () => {
         const fallback = (
             <div className="admin-x-settings-container--loading" style={{
-                width: '100vw',
+                width: '100%',
                 height: '100vh',
                 display: 'flex',
                 alignItems: 'center',

--- a/ghost/admin/app/styles/layouts/main.css
+++ b/ghost/admin/app/styles/layouts/main.css
@@ -2212,7 +2212,7 @@ section.gh-ds h2 {
 }
 
 .admin-x-container-error {
-    height: 100%;
+    height: 100vh;
     width: 100%;
     display: flex;
     align-items: center;
@@ -2226,7 +2226,7 @@ section.gh-ds h2 {
     flex-direction: column;
     align-items: flex-start;
     gap: 20px;
-    background: white;
+    background: var(--white);
     box-shadow: var(--box-shadow-m);
     border-radius: 20px;
     padding: 5vmin;


### PR DESCRIPTION
no issue

This was broken when adding the AdminX demo app - it would no longer display at full height.