### PR TITLE
Wired up tkReminders flag in Admin+editor

### DIFF
--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -293,7 +293,8 @@ export default class KoenigLexicalEditor extends Component {
             feature: {
                 collectionsCard: this.feature.get('collectionsCard'),
                 collections: this.feature.get('collections'),
-                emojiPicker: this.feature.get('editorEmojiPicker')
+                emojiPicker: this.feature.get('editorEmojiPicker'),
+                tkReminders: this.feature.get('tkReminders')
             },
             depreciated: {
                 headerV1: true // if false, shows header v1 in the menu

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -80,6 +80,7 @@ export default class FeatureService extends Service {
     @feature('editorEmojiPicker') editorEmojiPicker;
     @feature('filterEmailDisabled') filterEmailDisabled;
     @feature('adminXDemo') adminXDemo;
+    @feature('tkReminders') tkReminders;
 
     _user = null;
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/19057

- the flag and toggle UI had been added but we were missing the final part of wiring up the feature in Admin and passthrough to the editor
