### PR TITLE
Updated newsletter settings UI for managed email

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -71,3 +71,19 @@ export const useBrowseConfig = createQuery<ConfigResponseType>({
     dataType,
     path: '/config/'
 });
+
+// Helpers
+
+export const isManagedEmail = (config: Config) => {
+    return !!config?.hostSettings?.managedEmail?.enabled;
+};
+
+export const hasSendingDomain = (config: Config) => {
+    const isDomain = /[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
+    const sendingDomain = config?.hostSettings?.managedEmail?.sendingDomain;
+    return typeof sendingDomain === 'string' && isDomain.test(sendingDomain);
+};
+
+export const sendingDomain = (config: Config) => {
+    return config?.hostSettings?.managedEmail?.sendingDomain;
+};

--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -48,7 +48,11 @@ export type Config = {
         pintura?: {
             js?: string
             css?: string
-        }
+        },
+        managedEmail?: {
+            enabled?: boolean
+            sendingDomain?: string
+        },
     }
 
     // Config is relatively fluid, so we only type used properties above and still support arbitrary property access when needed

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -182,7 +182,7 @@ const Sidebar: React.FC<{
     const renderReplyToEmailField = () => {
         if (isManagedEmail(config)) {
             if (hasSendingDomain(config)) {
-                const replyToEmailUsername = newsletter.sender_reply_to?.split('@')[0];
+                const replyToEmailUsername = ['newsletter', 'support'].includes(newsletter.sender_reply_to) ? '' : newsletter.sender_reply_to?.split('@')[0];
                 return (
                     <TextField
                         error={Boolean(errors.sender_reply_to)}

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -4,7 +4,7 @@ import React, {useEffect, useState} from 'react';
 import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import useSettingGroup from '../../../../hooks/useSettingGroup';
 import validator from 'validator';
-import {Button, ButtonGroup, ColorPickerField, ConfirmationModal, Form, Heading, Hint, HtmlField, Icon, ImageUpload, LimitModal, PreviewModalContent, Select, SelectOption, Separator, Tab, TabView, TextArea, TextField, Toggle, ToggleGroup, showToast} from '@tryghost/admin-x-design-system';
+import {Button, ButtonGroup, ColorPickerField, ConfirmationModal, Form, Heading, Hint, HtmlField, Icon, ImageUpload, LimitModal, PreviewModalContent, Select, SelectOption, Separator, SettingGroupContent, Tab, TabView, TextArea, TextField, Toggle, ToggleGroup, showToast} from '@tryghost/admin-x-design-system';
 import {ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
 import {Newsletter, useBrowseNewsletters, useEditNewsletter} from '@tryghost/admin-x-framework/api/newsletters';
@@ -189,16 +189,28 @@ const Sidebar: React.FC<{
                 );
             } else {
                 return (
-                    <TextField
-                        error={Boolean(errors.sender_reply_to)}
-                        hint={errors.sender_reply_to}
-                        placeholder={fullEmailAddress(newsletter.sender_email || 'noreply', siteData)}
-                        title="Reply-to email"
-                        value={newsletter.sender_reply_to || ''}
-                        onBlur={validate}
-                        onChange={e => updateNewsletter({sender_reply_to: e.target.value})}
-                        onKeyDown={() => clearError('sender_reply_to')}
-                    />
+                    <>
+                        <TextField
+                            error={Boolean(errors.sender_reply_to)}
+                            hint={errors.sender_reply_to}
+                            placeholder={fullEmailAddress(newsletter.sender_email || 'noreply', siteData)}
+                            title="Reply-to email"
+                            value={newsletter.sender_reply_to || ''}
+                            onBlur={validate}
+                            onChange={e => updateNewsletter({sender_reply_to: e.target.value})}
+                            onKeyDown={() => clearError('sender_reply_to')}
+                        />
+                        <SettingGroupContent
+                            values={[
+                                {
+                                    heading: 'Sender email address',
+                                    key: 'sender-email-addresss',
+                                    value: 'rediverge@ghost.io',
+                                    hint: <span className="text-xs text-grey-700">To customize, you need to <a className="text-green" href="#">set up a custom sending domain</a></span>
+                                }
+                            ]}
+                        />
+                    </>
                 );
             }
         }

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -514,7 +514,7 @@ const Sidebar: React.FC<{
 
 const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: boolean;}> = ({newsletter, onlyOne}) => {
     const modal = useModal();
-    const {siteData, settings} = useGlobalData();
+    const {siteData, settings, config} = useGlobalData();
     const {mutateAsync: editNewsletter} = useEditNewsletter();
     const {updateRoute} = useRouting();
     const handleError = useHandleError();
@@ -572,6 +572,10 @@ const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: b
 
             if (formState.sender_email && !validator.isEmail(formState.sender_email)) {
                 newErrors.sender_email = 'Invalid email.';
+            }
+
+            if (isManagedEmail(config) && formState.sender_reply_to && (!validator.isEmail(formState.sender_reply_to))) {
+                newErrors.sender_reply_to = 'Invalid email.';
             }
 
             return newErrors;

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
@@ -4,6 +4,7 @@ import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import {Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
 import {fullEmailAddress} from '@tryghost/admin-x-framework/api/site';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {hasSendingDomain, isManagedEmail, sendingDomain} from '@tryghost/admin-x-framework/api/config';
 import {textColorForBackgroundColor} from '@tryghost/color-utils';
 import {useGlobalData} from '../../../providers/GlobalDataProvider';
 
@@ -91,24 +92,10 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
         secondaryTextColor
     } : {};
 
-    const isManagedEmail = () => {
-        return !!config?.hostSettings?.managedEmail?.enabled;
-    };
-
-    const hasSendingDomain = () => {
-        const isDomain = /[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
-        const sendingDomain = config?.hostSettings?.managedEmail?.sendingDomain;
-        return typeof sendingDomain === 'string' && isDomain.test(sendingDomain);
-    };
-
-    const sendingDomain = () => {
-        return config?.hostSettings?.managedEmail?.sendingDomain;
-    };
-
     const renderSenderEmail = () => {
-        if (isManagedEmail()) {
-            if (hasSendingDomain()) {
-                return newsletter.sender_email || 'noreply@' + sendingDomain();
+        if (isManagedEmail(config)) {
+            if (hasSendingDomain(config)) {
+                return newsletter.sender_email || 'noreply@' + sendingDomain(config);
             }
         }
 

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
@@ -91,6 +91,30 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
         secondaryTextColor
     } : {};
 
+    const isManagedEmail = () => {
+        return !!config?.hostSettings?.managedEmail?.enabled;
+    };
+
+    const hasSendingDomain = () => {
+        const isDomain = /[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
+        const sendingDomain = config?.hostSettings?.managedEmail?.sendingDomain;
+        return typeof sendingDomain === 'string' && isDomain.test(sendingDomain);
+    };
+
+    const sendingDomain = () => {
+        return config?.hostSettings?.managedEmail?.sendingDomain;
+    };
+
+    const renderSenderEmail = () => {
+        if (isManagedEmail()) {
+            if (hasSendingDomain()) {
+                return newsletter.sender_email || 'noreply@' + sendingDomain();
+            }
+        }
+
+        return fullEmailAddress(newsletter.sender_email || 'noreply', siteData);
+    };
+
     return <NewsletterPreviewContent
         authorPlaceholder={currentUser.name || currentUser.email}
         backgroundColor={colors.backgroundColor || '#ffffff'}
@@ -100,7 +124,7 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
         headerImage={newsletter.header_image}
         headerSubtitle={headerSubtitle}
         headerTitle={headerTitle}
-        senderEmail={fullEmailAddress(newsletter.sender_email || 'noreply', siteData)}
+        senderEmail={renderSenderEmail()}
         senderName={newsletter.sender_name || title}
         showBadge={newsletter.show_badge}
         showCommentCta={showCommentCta}

--- a/apps/admin-x-settings/test/acceptance/email/newsletters.test.ts
+++ b/apps/admin-x-settings/test/acceptance/email/newsletters.test.ts
@@ -91,80 +91,214 @@ test.describe('Newsletter settings', async () => {
         });
     });
 
-    test('Displays a prompt when email verification is required', async ({page}) => {
-        await mockApi({page, requests: {
-            ...globalDataRequests,
-            browseNewsletters: {method: 'GET', path: '/newsletters/?include=count.active_members%2Ccount.posts&limit=50', response: responseFixtures.newsletters},
-            editNewsletter: {method: 'PUT', path: `/newsletters/${responseFixtures.newsletters.newsletters[0].id}/?include=count.active_members%2Ccount.posts`, response: {
-                newsletters: [responseFixtures.newsletters.newsletters[0]],
-                meta: {
-                    sent_email_verification: ['sender_email']
-                }
-            }}
-        }});
+    test.describe('Email addresses', async () => {
+        test.describe('For self-hosters', async () => {
+            test('Displays a prompt when email verification is required', async ({page}) => {
+                await mockApi({page, requests: {
+                    ...globalDataRequests,
+                    browseNewsletters: {method: 'GET', path: '/newsletters/?include=count.active_members%2Ccount.posts&limit=50', response: responseFixtures.newsletters},
+                    editNewsletter: {method: 'PUT', path: `/newsletters/${responseFixtures.newsletters.newsletters[0].id}/?include=count.active_members%2Ccount.posts`, response: {
+                        newsletters: [responseFixtures.newsletters.newsletters[0]],
+                        meta: {
+                            sent_email_verification: ['sender_email']
+                        }
+                    }}
+                }});
 
-        await page.goto('/');
+                await page.goto('/');
 
-        const section = page.getByTestId('newsletters');
+                const section = page.getByTestId('newsletters');
 
-        await section.getByText('Awesome newsletter').click();
+                await section.getByText('Awesome newsletter').click();
 
-        const modal = page.getByTestId('newsletter-modal');
+                const modal = page.getByTestId('newsletter-modal');
 
-        await modal.getByLabel('Sender email').fill('not-an-email');
-        await modal.getByRole('button', {name: 'Save'}).click();
+                await modal.getByLabel('Sender email').fill('not-an-email');
+                await modal.getByRole('button', {name: 'Save'}).click();
 
-        await expect(page.getByTestId('toast-error')).toHaveText(/Can't save newsletter/);
-        await expect(modal).toHaveText(/Invalid email/);
+                await expect(page.getByTestId('toast-error')).toHaveText(/Can't save newsletter/);
+                await expect(modal).toHaveText(/Invalid email/);
 
-        await modal.getByLabel('Sender email').fill('test@test.com');
-        await modal.getByRole('button', {name: 'Save'}).click();
+                await modal.getByLabel('Sender email').fill('test@test.com');
+                await modal.getByRole('button', {name: 'Save'}).click();
 
-        await expect(page.getByTestId('confirmation-modal')).toHaveCount(1);
-        await expect(page.getByTestId('confirmation-modal')).toHaveText(/Confirm newsletter email address/);
-        await expect(page.getByTestId('confirmation-modal')).toHaveText(/default email address \(noreply@test.com\)/);
-    });
+                await expect(page.getByTestId('confirmation-modal')).toHaveCount(1);
+                await expect(page.getByTestId('confirmation-modal')).toHaveText(/Confirm newsletter email address/);
+                await expect(page.getByTestId('confirmation-modal')).toHaveText(/default email address \(noreply@test.com\)/);
+            });
 
-    test('Displays the current email when changing sender address', async ({page}) => {
-        const response = {
-            ...responseFixtures.newsletters,
-            newsletters: [{
-                ...responseFixtures.newsletters.newsletters[0],
-                sender_email: 'current@test.com'
-            }]
-        } satisfies NewslettersResponseType;
+            test('Displays the current email when changing sender address', async ({page}) => {
+                const response = {
+                    ...responseFixtures.newsletters,
+                    newsletters: [{
+                        ...responseFixtures.newsletters.newsletters[0],
+                        sender_email: 'current@test.com'
+                    }]
+                } satisfies NewslettersResponseType;
 
-        await mockApi({page, requests: {
-            ...globalDataRequests,
-            browseNewsletters: {method: 'GET', path: '/newsletters/?include=count.active_members%2Ccount.posts&limit=50', response},
-            editNewsletter: {method: 'PUT', path: `/newsletters/${responseFixtures.newsletters.newsletters[0].id}/?include=count.active_members%2Ccount.posts`, response: {
-                newsletters: response.newsletters,
-                meta: {
-                    sent_email_verification: ['sender_email']
-                }
-            }}
-        }});
+                await mockApi({page, requests: {
+                    ...globalDataRequests,
+                    browseNewsletters: {method: 'GET', path: '/newsletters/?include=count.active_members%2Ccount.posts&limit=50', response},
+                    editNewsletter: {method: 'PUT', path: `/newsletters/${responseFixtures.newsletters.newsletters[0].id}/?include=count.active_members%2Ccount.posts`, response: {
+                        newsletters: response.newsletters,
+                        meta: {
+                            sent_email_verification: ['sender_email']
+                        }
+                    }}
+                }});
 
-        await page.goto('/');
+                await page.goto('/');
 
-        const section = page.getByTestId('newsletters');
+                const section = page.getByTestId('newsletters');
 
-        await section.getByText('Awesome newsletter').click();
+                await section.getByText('Awesome newsletter').click();
 
-        const modal = page.getByTestId('newsletter-modal');
+                const modal = page.getByTestId('newsletter-modal');
 
-        await modal.getByLabel('Sender email').fill('not-an-email');
-        await modal.getByRole('button', {name: 'Save'}).click();
+                await modal.getByLabel('Sender email').fill('not-an-email');
+                await modal.getByRole('button', {name: 'Save'}).click();
 
-        await expect(page.getByTestId('toast-error')).toHaveText(/Can't save newsletter/);
-        await expect(modal).toHaveText(/Invalid email/);
+                await expect(page.getByTestId('toast-error')).toHaveText(/Can't save newsletter/);
+                await expect(modal).toHaveText(/Invalid email/);
 
-        await modal.getByLabel('Sender email').fill('test@test.com');
-        await modal.getByRole('button', {name: 'Save'}).click();
+                await modal.getByLabel('Sender email').fill('test@test.com');
+                await modal.getByRole('button', {name: 'Save'}).click();
 
-        await expect(page.getByTestId('confirmation-modal')).toHaveCount(1);
-        await expect(page.getByTestId('confirmation-modal')).toHaveText(/Confirm newsletter email address/);
-        await expect(page.getByTestId('confirmation-modal')).toHaveText(/previous email address \(current@test.com\)/);
+                await expect(page.getByTestId('confirmation-modal')).toHaveCount(1);
+                await expect(page.getByTestId('confirmation-modal')).toHaveText(/Confirm newsletter email address/);
+                await expect(page.getByTestId('confirmation-modal')).toHaveText(/previous email address \(current@test.com\)/);
+            });
+        });
+
+        test.describe('For Ghost (Pro) users without custom domain', () => {
+            test('Does not allow the Sender email address to be edited', async ({page}) => {
+                await mockApi({page, requests: {
+                    ...globalDataRequests,
+                    browseNewsletters: {method: 'GET', path: '/newsletters/?include=count.active_members%2Ccount.posts&limit=50', response: responseFixtures.newsletters},
+                    browseConfig: {
+                        ...globalDataRequests.browseConfig,
+                        response: {
+                            config: {
+                                ...responseFixtures.config.config,
+                                hostSettings: {
+                                    managedEmail: {
+                                        enabled: true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }});
+
+                await page.goto('/');
+                const section = page.getByTestId('newsletters');
+                await section.getByText('Awesome newsletter').click();
+                const modal = page.getByTestId('newsletter-modal');
+                const senderEmailField = modal.getByLabel('Sender email');
+
+                // Test that there is no input field near "Sender email"
+                const parentElementLocator = senderEmailField.locator('xpath=..');
+                const inputElementsNearby = await parentElementLocator.locator('input').count();
+
+                expect(inputElementsNearby).toBe(0);
+            });
+
+            test('Allow full customisation of the reply-to address', async ({page}) => {
+                await mockApi({page, requests: {
+                    ...globalDataRequests,
+                    browseNewsletters: {method: 'GET', path: '/newsletters/?include=count.active_members%2Ccount.posts&limit=50', response: responseFixtures.newsletters},
+                    editNewsletter: {method: 'PUT', path: `/newsletters/${responseFixtures.newsletters.newsletters[0].id}/?include=count.active_members%2Ccount.posts`, response: {
+                        newsletters: [responseFixtures.newsletters.newsletters[0]],
+                        meta: {
+                            sent_email_verification: ['sender_reply_to']
+                        }
+                    }},
+                    browseConfig: {
+                        ...globalDataRequests.browseConfig,
+                        response: {
+                            config: {
+                                ...responseFixtures.config.config,
+                                hostSettings: {
+                                    managedEmail: {
+                                        enabled: true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }});
+
+                await page.goto('/');
+                const section = page.getByTestId('newsletters');
+                await section.getByText('Awesome newsletter').click();
+                const modal = page.getByTestId('newsletter-modal');
+                const replyToEmail = modal.getByLabel('Reply-to email');
+
+                await replyToEmail.fill('not-an-email');
+                await modal.getByRole('button', {name: 'Save'}).click();
+
+                await expect(page.getByTestId('toast-error')).toHaveText(/Can't save newsletter/);
+                await expect(modal).toHaveText(/Invalid email/);
+
+                await replyToEmail.fill('test@test.com');
+                await modal.getByRole('button', {name: 'Save'}).click();
+
+                await expect(page.getByTestId('confirmation-modal')).toHaveCount(1);
+                await expect(page.getByTestId('confirmation-modal')).toHaveText(/Confirm reply-to address/);
+                await expect(page.getByTestId('confirmation-modal')).toHaveText(/previous reply-to address \(noreply@test.com\)/);
+            });
+        });
+
+        test.describe('For Ghost (Pro) users with custom domain', () => {
+            test('Allow sender and reply-to addresses to be changed without verification, but not their domain name', async ({page}) => {
+                await mockApi({page, requests: {
+                    ...globalDataRequests,
+                    browseNewsletters: {method: 'GET', path: '/newsletters/?include=count.active_members%2Ccount.posts&limit=50', response: responseFixtures.newsletters},
+                    editNewsletter: {method: 'PUT', path: `/newsletters/${responseFixtures.newsletters.newsletters[0].id}/?include=count.active_members%2Ccount.posts`, response: {
+                        newsletters: [responseFixtures.newsletters.newsletters[0]],
+                        meta: {
+                            sent_email_verification: []
+                        }
+                    }},
+                    browseConfig: {
+                        ...globalDataRequests.browseConfig,
+                        response: {
+                            config: {
+                                ...responseFixtures.config.config,
+                                hostSettings: {
+                                    managedEmail: {
+                                        enabled: true,
+                                        sendingDomain: 'customdomain.com'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }});
+
+                await page.goto('/');
+                const section = page.getByTestId('newsletters');
+                await section.getByText('Awesome newsletter').click();
+                const modal = page.getByTestId('newsletter-modal');
+                const senderEmail = modal.getByLabel('Sender email');
+                const replyToEmail = modal.getByLabel('Reply-to address');
+
+                // The sending domain is rendered as placeholder text
+                expect(modal).toHaveText(/@customdomain\.com/);
+
+                // The sender email field should keep the username part of the email address
+                await senderEmail.fill('harry@potter.com');
+                expect(await senderEmail.inputValue()).toBe('harry');
+
+                // The sender email field should keep the username part of the email address
+                await replyToEmail.fill('hermione@granger.com');
+                expect(await replyToEmail.inputValue()).toBe('hermione');
+
+                // The new username is saved without a confirmation popup
+                await modal.getByRole('button', {name: 'Save'}).click();
+                await expect(page.getByTestId('confirmation-modal')).toHaveCount(0);
+            });
+        });
     });
 
     test('Supports archiving newsletters', async ({page}) => {


### PR DESCRIPTION
refs GRO-59
refs GRO-56
refs GRO-52

- When email is managed without a custom domain, do not allow the Sender Email address to be changed, but allow Reply-to address to be changed to any address the publisher can verify
- When email is managed with a custom domain, allow both Sender and Reply-to addresses to be changed without verification, but not their domain names