### PR TITLE
🐛 Fixed about modal dev experiments info

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/About.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/About.tsx
@@ -17,11 +17,12 @@ const AboutModal = NiceModal.create<RoutingModalProps>(({}) => {
         return date.getFullYear();
     }
 
-    function hasDeveloperExperiments():string {
+    function hasDeveloperExperiments():boolean {
         if (config.enableDeveloperExperiments) {
-            return 'Enabled';
+            return true;
+        } else {
+            return false;
         }
-        return 'Disabled';
     }
 
     function showSystemInfo() : boolean {
@@ -73,7 +74,7 @@ const AboutModal = NiceModal.create<RoutingModalProps>(({}) => {
                     }
                     {
                         hasDeveloperExperiments() && (
-                            <div><strong>Developer experiments:</strong> {hasDeveloperExperiments()}</div>
+                            <div><strong>Developer experiments:</strong> Enabled</div>
                         )
                     }
 


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C0568LN2CGJ/p1700617587979039

- Fixes an issue where dev experiments data shows up in the settings About modal while it's disabled. Now it will only show when it's enabled.