### PR TITLE
Added calculated email address settings

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -79,9 +79,8 @@ export const isManagedEmail = (config: Config) => {
 };
 
 export const hasSendingDomain = (config: Config) => {
-    const isDomain = /[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
     const sendingDomain = config?.hostSettings?.managedEmail?.sendingDomain;
-    return typeof sendingDomain === 'string' && isDomain.test(sendingDomain);
+    return typeof sendingDomain === 'string' && sendingDomain.length > 0;
 };
 
 export const sendingDomain = (config: Config) => {

--- a/apps/admin-x-framework/src/api/site.ts
+++ b/apps/admin-x-framework/src/api/site.ts
@@ -1,4 +1,5 @@
 import {createQuery} from '../utils/api/hooks';
+import {Config, hasSendingDomain, isManagedEmail, sendingDomain} from './config';
 
 // Types
 
@@ -35,7 +36,11 @@ export function getHomepageUrl(siteData: SiteData): string {
     return `${url.origin}${subdir}`;
 }
 
-export function getEmailDomain(siteData: SiteData): string {
+export function getEmailDomain(siteData: SiteData, config: Config): string {
+    if (isManagedEmail(config) && hasSendingDomain(config)) {
+        return sendingDomain(config) || '';
+    }
+
     const domain = new URL(siteData.url).hostname || '';
     if (domain.startsWith('www.')) {
         return domain.replace(/^(www)\.(?=[^/]*\..{2,5})/, '');
@@ -43,7 +48,7 @@ export function getEmailDomain(siteData: SiteData): string {
     return domain;
 }
 
-export function fullEmailAddress(value: 'noreply' | string, siteData: SiteData) {
-    const emailDomain = getEmailDomain(siteData);
+export function fullEmailAddress(value: 'noreply' | string, siteData: SiteData, config: Config) {
+    const emailDomain = getEmailDomain(siteData, config);
     return value === 'noreply' ? `noreply@${emailDomain}` : value;
 }

--- a/apps/admin-x-framework/src/test/responses/settings.json
+++ b/apps/admin-x-framework/src/test/responses/settings.json
@@ -315,6 +315,14 @@
         {
             "key": "firstpromoter_account",
             "value": null
+        },
+        {
+            "key": "default_email_address",
+            "value": "default@example.com"
+        },
+        {
+            "key": "support_email_address",
+            "value": "support@example.com"
         }
     ],
     "meta": {

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/AlphaFeatures.tsx
@@ -63,6 +63,10 @@ const features = [{
     title: 'TK Reminders',
     description: 'Enables the TK Reminders feature in the editor',
     flag: 'tkReminders'
+},{
+    title: 'New email addresses',
+    description: 'For self hosters, forces the usage of the mail.from config as from address for all outgoing emails',
+    flag: 'newEmailAddresses'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterPreview.tsx
@@ -2,16 +2,15 @@ import NewsletterPreviewContent from './NewsletterPreviewContent';
 import React from 'react';
 import useFeatureFlag from '../../../../hooks/useFeatureFlag';
 import {Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
-import {fullEmailAddress} from '@tryghost/admin-x-framework/api/site';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
-import {hasSendingDomain, isManagedEmail, sendingDomain} from '@tryghost/admin-x-framework/api/config';
+import {hasSendingDomain, isManagedEmail} from '@tryghost/admin-x-framework/api/config';
 import {textColorForBackgroundColor} from '@tryghost/color-utils';
 import {useGlobalData} from '../../../providers/GlobalDataProvider';
 
 const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => {
     const hasEmailCustomization = useFeatureFlag('emailCustomization');
     const {currentUser, settings, siteData, config} = useGlobalData();
-    const [title, icon, commentsEnabled] = getSettingValues<string>(settings, ['title', 'icon', 'comments_enabled']);
+    const [title, icon, commentsEnabled, defaultEmailAddress] = getSettingValues<string>(settings, ['title', 'icon', 'comments_enabled', 'default_email_address']);
 
     let headerTitle: string | null = null;
     if (newsletter.show_header_title) {
@@ -94,12 +93,13 @@ const NewsletterPreview: React.FC<{newsletter: Newsletter}> = ({newsletter}) => 
 
     const renderSenderEmail = () => {
         if (isManagedEmail(config)) {
-            if (hasSendingDomain(config)) {
-                return newsletter.sender_email || 'noreply@' + sendingDomain(config);
+            if (!hasSendingDomain(config)) {
+                // Sender email is ignored
+                return defaultEmailAddress || '';
             }
         }
 
-        return fullEmailAddress(newsletter.sender_email || 'noreply', siteData);
+        return newsletter.sender_email || defaultEmailAddress || '';
     };
 
     return <NewsletterPreviewContent

--- a/apps/admin-x-settings/src/components/settings/membership/portal/AccountPage.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/AccountPage.tsx
@@ -7,11 +7,11 @@ import {useGlobalData} from '../../../providers/GlobalDataProvider';
 const AccountPage: React.FC<{
     updateSetting: (key: string, setting: SettingValue) => void
 }> = ({updateSetting}) => {
-    const {siteData, settings} = useGlobalData();
+    const {siteData, settings, config} = useGlobalData();
     const [membersSupportAddress] = getSettingValues(settings, ['members_support_address']);
-    const emailDomain = getEmailDomain(siteData!);
+    const emailDomain = getEmailDomain(siteData!, config);
 
-    const [value, setValue] = useState(fullEmailAddress(membersSupportAddress?.toString() || '', siteData!));
+    const [value, setValue] = useState(fullEmailAddress(membersSupportAddress?.toString() || '', siteData!, config));
 
     const updateSupportAddress: FocusEventHandler<HTMLInputElement> = (e) => {
         let supportAddress = e.target.value;
@@ -19,11 +19,11 @@ const AccountPage: React.FC<{
         let settingValue = emailDomain && supportAddress === `noreply@${emailDomain}` ? 'noreply' : supportAddress;
 
         updateSetting('members_support_address', settingValue);
-        setValue(fullEmailAddress(settingValue, siteData!));
+        setValue(fullEmailAddress(settingValue, siteData!, config));
     };
 
     useEffect(() => {
-        setValue(fullEmailAddress(membersSupportAddress?.toString() || '', siteData!));
+        setValue(fullEmailAddress(membersSupportAddress?.toString() || '', siteData!, config));
     }, [membersSupportAddress, siteData]);
 
     return <div className='mt-7'><Form>

--- a/apps/admin-x-settings/src/components/settings/membership/portal/PortalModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/PortalModal.tsx
@@ -66,7 +66,7 @@ const PortalModal: React.FC = () => {
     const [selectedPreviewTab, setSelectedPreviewTab] = useState('signup');
 
     const handleError = useHandleError();
-    const {settings, siteData} = useGlobalData();
+    const {settings, siteData, config} = useGlobalData();
     const {mutateAsync: editSettings} = useEditSettings();
     const {data: {tiers: allTiers} = {}} = useBrowseTiers();
     // const tiers = getPaidActiveTiers(allTiers || []);
@@ -141,7 +141,7 @@ const PortalModal: React.FC = () => {
                     title: 'Confirm email address',
                     prompt: <>
                         We&apos;ve sent a confirmation email to <strong>{newEmail}</strong>.
-                        Until verified, your support address will remain {fullEmailAddress(currentEmail?.toString() || 'noreply', siteData!)}.
+                        Until verified, your support address will remain {fullEmailAddress(currentEmail?.toString() || 'noreply', siteData!, config)}.
                     </>,
                     okLabel: 'Close',
                     cancelLabel: '',

--- a/apps/admin-x-settings/test/acceptance/email/newsletters.test.ts
+++ b/apps/admin-x-settings/test/acceptance/email/newsletters.test.ts
@@ -124,7 +124,7 @@ test.describe('Newsletter settings', async () => {
 
                 await expect(page.getByTestId('confirmation-modal')).toHaveCount(1);
                 await expect(page.getByTestId('confirmation-modal')).toHaveText(/Confirm newsletter email address/);
-                await expect(page.getByTestId('confirmation-modal')).toHaveText(/default email address \(noreply@test.com\)/);
+                await expect(page.getByTestId('confirmation-modal')).toHaveText(/default email address \(default@example.com\)/);
             });
 
             test('Displays the current email when changing sender address', async ({page}) => {
@@ -245,7 +245,7 @@ test.describe('Newsletter settings', async () => {
 
                 await expect(page.getByTestId('confirmation-modal')).toHaveCount(1);
                 await expect(page.getByTestId('confirmation-modal')).toHaveText(/Confirm reply-to address/);
-                await expect(page.getByTestId('confirmation-modal')).toHaveText(/previous reply-to address \(noreply@test.com\)/);
+                await expect(page.getByTestId('confirmation-modal')).toHaveText(/previous reply-to address \(support@example.com\)/);
             });
         });
 

--- a/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
+++ b/ghost/core/core/server/services/settings-helpers/SettingsHelpers.js
@@ -128,6 +128,10 @@ class SettingsHelpers {
      * @deprecated Use getDefaultEmail().address (without name) or EmailAddressParser.stringify(this.getDefaultEmail()) (with name) instead
      */
     getNoReplyAddress() {
+        return this.getDefaultEmailAddress();
+    }
+
+    getDefaultEmailAddress() {
         return this.getDefaultEmail().address;
     }
 

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -92,6 +92,10 @@ module.exports = {
         fields.push(new CalculatedField({key: 'firstpromoter_account', type: 'string', group: 'firstpromoter', fn: settingsHelpers.getFirstpromoterId.bind(settingsHelpers), dependents: ['firstpromoter', 'firstpromoter_id']}));
         fields.push(new CalculatedField({key: 'donations_enabled', type: 'boolean', group: 'donations', fn: settingsHelpers.areDonationsEnabled.bind(settingsHelpers), dependents: ['stripe_secret_key', 'stripe_publishable_key', 'stripe_connect_secret_key', 'stripe_connect_publishable_key']}));
 
+        // E-mail addresses
+        fields.push(new CalculatedField({key: 'default_email_address', type: 'string', group: 'email', fn: settingsHelpers.getDefaultEmailAddress.bind(settingsHelpers), dependents: ['labs']}));
+        fields.push(new CalculatedField({key: 'support_email_address', type: 'string', group: 'email', fn: settingsHelpers.getMembersSupportAddress.bind(settingsHelpers), dependents: ['labs', 'members_support_address']}));
+
         return fields;
     },
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -340,6 +340,14 @@ Object {
       "key": "donations_enabled",
       "value": true,
     },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "noreply@127.0.0.1",
+    },
   ],
 }
 `;
@@ -750,6 +758,14 @@ Object {
       "key": "donations_enabled",
       "value": true,
     },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "noreply@127.0.0.1",
+    },
   ],
 }
 `;
@@ -758,7 +774,7 @@ exports[`Settings API Edit Can edit a setting 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4367",
+  "content-length": "4487",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1107,6 +1123,14 @@ Object {
     Object {
       "key": "donations_enabled",
       "value": true,
+    },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "noreply@127.0.0.1",
     },
   ],
 }
@@ -1464,6 +1488,14 @@ Object {
     Object {
       "key": "donations_enabled",
       "value": true,
+    },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "support@example.com",
     },
   ],
 }
@@ -1826,6 +1858,14 @@ Object {
     Object {
       "key": "donations_enabled",
       "value": true,
+    },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "noreply@127.0.0.1",
     },
   ],
 }
@@ -2277,6 +2317,14 @@ Object {
       "key": "donations_enabled",
       "value": true,
     },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "noreply@127.0.0.1",
+    },
   ],
 }
 `;
@@ -2698,6 +2746,14 @@ Object {
     Object {
       "key": "donations_enabled",
       "value": true,
+    },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "support@example.com",
     },
   ],
 }

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -9,7 +9,7 @@ const models = require('../../../core/server/models');
 const {mockLabsDisabled} = require('../../utils/e2e-framework-mock-manager');
 const {anyErrorId} = matchers;
 
-const CURRENT_SETTINGS_COUNT = 84;
+const CURRENT_SETTINGS_COUNT = 86;
 
 const settingsMatcher = {};
 

--- a/ghost/email-addresses/src/EmailAddressService.ts
+++ b/ghost/email-addresses/src/EmailAddressService.ts
@@ -151,7 +151,7 @@ export class EmailAddressService {
             // Self hoster or legacy Ghost Pro
             return {
                 allowed: true,
-                verificationEmailRequired: type === 'from' && !this.useNewEmailAddresses
+                verificationEmailRequired: !this.useNewEmailAddresses // Self hosters don't need to verify email addresses
             };
         }
 


### PR DESCRIPTION
fixes GRO-73

We need to avoid duplicating the complex logic for determining the default email address and the support email address. So these are now exposed as calculated settings.