### PR TITLE
Remove Toaster from AdminX demo

### DIFF
--- a/apps/admin-x-demo/src/ListPage.tsx
+++ b/apps/admin-x-demo/src/ListPage.tsx
@@ -1,5 +1,4 @@
 import {Avatar, Button, ButtonGroup, DynamicTable, DynamicTableColumn, DynamicTableRow, Heading, Hint, Page, SortMenu, Tooltip, ViewContainer, showToast} from '@tryghost/admin-x-design-system';
-import {Toaster} from 'react-hot-toast';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 import {useState} from 'react';
 
@@ -224,7 +223,6 @@ const ListPage = () => {
 
     const demoPage = (
         <Page>
-            <Toaster />
             <ViewContainer
                 actions={dummyActions}
                 primaryAction={{


### PR DESCRIPTION
no issue

It's already rendered by `DesignSystemApp` so we shouldn't need to add it explicitly.