### PR TITLE
Fixed exit route on offers modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
@@ -536,6 +536,9 @@ const AddOfferModal = () => {
         href={href}
     />;
     return <PreviewModalContent
+        afterClose={() => {
+            updateRoute('offers');
+        }}
         cancelLabel='Cancel'
         deviceSelector={false}
         dirty={saveState === 'unsaved'}

--- a/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
@@ -259,6 +259,9 @@ const EditOfferModal: React.FC<{id: string}> = ({id}) => {
     />;
 
     return offerById ? <PreviewModalContent
+        afterClose={() => {
+            updateRoute('offers');
+        }}
         deviceSelector={false}
         dirty={saveState === 'unsaved'}
         height='full'


### PR DESCRIPTION
no issue

- when clicking outside the Edit or Add modal, it would clear the modal, but not the route. This modifies the route to clear as well.
