### PR TITLE
🐛 Fixed error when loading editor in Safari versions earlier than 16.4

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -46,7 +46,7 @@
     "@tryghost/helpers": "1.1.88",
     "@tryghost/kg-clean-basic-html": "3.0.41",
     "@tryghost/kg-converters": "0.0.22",
-    "@tryghost/koenig-lexical": "0.5.23",
+    "@tryghost/koenig-lexical": "0.5.24",
     "@tryghost/limit-service": "1.2.12",
     "@tryghost/members-csv": "0.0.0",
     "@tryghost/nql": "0.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7932,10 +7932,10 @@
   dependencies:
     semver "^7.3.5"
 
-"@tryghost/koenig-lexical@0.5.23":
-  version "0.5.23"
-  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-0.5.23.tgz#6e6be97a364f3386181dd3a7c4e398eecaba1745"
-  integrity sha512-tUhu5cvQq8T6GvVHTi7CPFWGUELrMtO4GSgYVI3Rbb9u1NGN3uwWhuQjS0RI68fZIb5DlD81NmJbTK8eHV8ljw==
+"@tryghost/koenig-lexical@0.5.24":
+  version "0.5.24"
+  resolved "https://registry.yarnpkg.com/@tryghost/koenig-lexical/-/koenig-lexical-0.5.24.tgz#729cdae4b6c409bf0befa3259fb98b949706f82a"
+  integrity sha512-NmoxL3t2I5a+C1xkYmahAJnlBX+fjKXdLKpqBjZt5Jf8CkzShYdFI7L846RnU4ztxS7pYJEuBfn90ljKTnfSJQ==
 
 "@tryghost/limit-service@1.2.12", "@tryghost/limit-service@^1.2.10":
   version "1.2.12"


### PR DESCRIPTION
no issue

- bumped `@tryghost/koenig-lexical` to version that no longer uses negative lookbehind in a regex which wasn't supported in Safari until version 16.4