### PR TITLE
Fixed create offer API not returning created_at

### DIFF
--- a/ghost/core/test/e2e-api/admin/__snapshots__/offers.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/offers.test.js.snap
@@ -7,6 +7,7 @@ Object {
       "amount": 100,
       "cadence": "year",
       "code": "4th",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "currency": "USD",
       "currency_restriction": true,
       "display_description": "",
@@ -31,7 +32,7 @@ exports[`Offers API Can add a fixed offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "368",
+  "content-length": "408",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -49,6 +50,7 @@ Object {
       "amount": 12,
       "cadence": "year",
       "code": "black-friday",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "currency": null,
       "currency_restriction": false,
       "display_description": "10% off on yearly plan",
@@ -69,11 +71,26 @@ Object {
 }
 `;
 
+exports[`Offers API Can add a new offer 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "450",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "location": StringMatching /https\\?:\\\\/\\\\/\\.\\*\\?\\\\/offers\\\\/\\[a-f0-9\\]\\{24\\}\\\\//,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Offers API Can add a new offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "410",
+  "content-length": "450",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -91,6 +108,7 @@ Object {
       "amount": 50,
       "cadence": "month",
       "code": "easter",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "currency": null,
       "currency_restriction": false,
       "display_description": "",
@@ -115,7 +133,7 @@ exports[`Offers API Can add a new offer with minimal fields 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "365",
+  "content-length": "405",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -133,6 +151,7 @@ Object {
       "amount": 20,
       "cadence": "year",
       "code": "4th-trial",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "currency": null,
       "currency_restriction": false,
       "display_description": "",
@@ -157,7 +176,7 @@ exports[`Offers API Can add a trial offer 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "380",
+  "content-length": "420",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -959,6 +978,7 @@ Object {
       "amount": 20,
       "cadence": "year",
       "code": "summer-sale",
+      "created_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "currency": null,
       "currency_restriction": false,
       "display_description": "",
@@ -983,7 +1003,7 @@ exports[`Offers API Slugifies offer codes 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "368",
+  "content-length": "408",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/offers.test.js
+++ b/ghost/core/test/e2e-api/admin/offers.test.js
@@ -76,7 +76,8 @@ describe('Offers API', function () {
                     id: anyObjectId,
                     tier: {
                         id: anyObjectId
-                    }
+                    },
+                    created_at: anyISODateTime
                 }]
             });
         savedOffer = body.offers[0];
@@ -109,7 +110,8 @@ describe('Offers API', function () {
                     id: anyObjectId,
                     tier: {
                         id: anyObjectId
-                    }
+                    },
+                    created_at: anyISODateTime
                 }]
             });
     });
@@ -141,7 +143,8 @@ describe('Offers API', function () {
                     id: anyObjectId,
                     tier: {
                         id: anyObjectId
-                    }
+                    },
+                    created_at: anyISODateTime
                 }]
             })
             .expect(({body}) => {
@@ -177,7 +180,8 @@ describe('Offers API', function () {
                     id: anyObjectId,
                     tier: {
                         id: anyObjectId
-                    }
+                    },
+                    created_at: anyISODateTime
                 }]
             });
     });
@@ -210,7 +214,8 @@ describe('Offers API', function () {
                     id: anyObjectId,
                     tier: {
                         id: anyObjectId
-                    }
+                    },
+                    created_at: anyISODateTime
                 }]
             });
         trialOffer = body.offers[0];

--- a/ghost/offers/lib/domain/models/Offer.js
+++ b/ghost/offers/lib/domain/models/Offer.js
@@ -288,7 +288,7 @@ class Offer {
         const cadence = OfferCadence.create(data.cadence);
         const duration = OfferDuration.create(data.duration, data.duration_in_months);
         const status = OfferStatus.create(data.status || 'active');
-        const createdAt = isNew ? new Date().toISOString : OfferCreatedAt.create(data.created_at);
+        const createdAt = isNew ? new Date().toISOString() : OfferCreatedAt.create(data.created_at);
         const lastRedeemed = data.last_redeemed ? new Date(data.last_redeemed).toISOString() : null;
 
         if (isNew && data.redemptionCount !== undefined) {

--- a/ghost/offers/lib/domain/models/Offer.js
+++ b/ghost/offers/lib/domain/models/Offer.js
@@ -288,7 +288,7 @@ class Offer {
         const cadence = OfferCadence.create(data.cadence);
         const duration = OfferDuration.create(data.duration, data.duration_in_months);
         const status = OfferStatus.create(data.status || 'active');
-        const createdAt = isNew ? new Date().toISOString() : OfferCreatedAt.create(data.created_at);
+        const createdAt = isNew ? OfferCreatedAt.create() : OfferCreatedAt.create(data.created_at);
         const lastRedeemed = data.last_redeemed ? new Date(data.last_redeemed).toISOString() : null;
 
         if (isNew && data.redemptionCount !== undefined) {

--- a/ghost/offers/lib/domain/models/OfferCreatedAt.js
+++ b/ghost/offers/lib/domain/models/OfferCreatedAt.js
@@ -10,7 +10,7 @@ class OfferCreatedAt extends ValueObject {
 
     static create(createdAt) {
         if (createdAt === null || createdAt === undefined) {
-            return new Date().toISOString();
+            createdAt = new Date();
         }
 
         if (!(createdAt instanceof Date)) {
@@ -19,7 +19,10 @@ class OfferCreatedAt extends ValueObject {
             });
         }
 
-        return createdAt.toISOString();
+        const date = new Date(createdAt);
+        date.setMilliseconds(0);
+
+        return date.toISOString();
     }
 
     static InvalidOfferCreatedAt = InvalidOfferCreatedAt;

--- a/ghost/offers/lib/domain/models/OfferCreatedAt.js
+++ b/ghost/offers/lib/domain/models/OfferCreatedAt.js
@@ -10,7 +10,9 @@ class OfferCreatedAt extends ValueObject {
 
     static create(createdAt) {
         if (createdAt === null || createdAt === undefined) {
-            createdAt = new Date();
+            const now = new Date();
+            now.setMilliseconds(0);
+            return now.toISOString();
         }
 
         if (!(createdAt instanceof Date)) {
@@ -19,10 +21,7 @@ class OfferCreatedAt extends ValueObject {
             });
         }
 
-        const date = new Date(createdAt);
-        date.setMilliseconds(0);
-
-        return date.toISOString();
+        return createdAt.toISOString();
     }
 
     static InvalidOfferCreatedAt = InvalidOfferCreatedAt;

--- a/ghost/offers/test/lib/domain/models/Offer.test.js
+++ b/ghost/offers/test/lib/domain/models/Offer.test.js
@@ -259,6 +259,27 @@ describe('Offer', function () {
                 should.ok(err);
             });
         });
+
+        it('Sets createdAt for new Offers', async function () {
+            const data = {
+                name: 'My Offer',
+                code: 'offer-code',
+                display_title: 'My Offer Title',
+                display_description: 'My Offer Description',
+                cadence: 'month',
+                type: 'fixed',
+                amount: 1000,
+                duration: 'forever',
+                currency: 'USD',
+                tier: {
+                    id: ObjectID()
+                }
+            };
+
+            const offer = await Offer.create(data, mockUniqueChecker);
+
+            should.equal(typeof offer.createdAt, 'string');
+        });
     });
 
     describe('#updateCode', function () {


### PR DESCRIPTION
refs https://github.com/TryGhost/Product/issues/4196

The offers API basically returns the data you pass to it, rather than the created database record. It looks like this is how it was intended to work in the first place; the `setMilliseconds` is because the test helper expects `.000Z`, which I assume is because MySQL will strip off the milliseconds when it's saved.