### PR TITLE
Updated newsletter email verification to render the verified address

### DIFF
--- a/apps/admin-x-framework/src/api/newsletters.ts
+++ b/apps/admin-x-framework/src/api/newsletters.ts
@@ -88,7 +88,7 @@ export interface NewslettersEditResponseType extends NewslettersResponseType {
 }
 
 export interface NewslettersVerifyResponseType extends NewslettersResponseType {
-    meta?: Meta & {email_verified: string[]}
+    meta?: Meta & {email_verified: string}
 }
 
 export const useEditNewsletter = createMutation<NewslettersEditResponseType, Newsletter>({

--- a/apps/admin-x-framework/src/api/newsletters.ts
+++ b/apps/admin-x-framework/src/api/newsletters.ts
@@ -87,6 +87,10 @@ export interface NewslettersEditResponseType extends NewslettersResponseType {
     meta?: Meta & {sent_email_verification: string[]}
 }
 
+export interface NewslettersVerifyResponseType extends NewslettersResponseType {
+    meta?: Meta & {email_verified: string[]}
+}
+
 export const useEditNewsletter = createMutation<NewslettersEditResponseType, Newsletter>({
     method: 'PUT',
     path: newsletter => `/newsletters/${newsletter.id}/`,
@@ -99,7 +103,7 @@ export const useEditNewsletter = createMutation<NewslettersEditResponseType, New
     }
 });
 
-export const useVerifyNewsletterEmail = createMutation<NewslettersResponseType, {token: string}>({
+export const useVerifyNewsletterEmail = createMutation<NewslettersVerifyResponseType, {token: string}>({
     method: 'PUT',
     path: () => '/newsletters/verifications/',
     body: ({token}) => ({token}),

--- a/apps/admin-x-settings/src/components/settings/email/Newsletters.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/Newsletters.tsx
@@ -48,7 +48,7 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
         const verify = async () => {
             try {
-                const {newsletters: [updatedNewsletter], meta: {email_verified: [emailVerified] = []} = {}} = await verifyEmail({token: verifyEmailToken});
+                const {newsletters: [updatedNewsletter], meta: {email_verified: emailVerified = []} = {}} = await verifyEmail({token: verifyEmailToken});
                 let title;
                 let prompt;
 

--- a/apps/admin-x-settings/src/components/settings/email/Newsletters.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/Newsletters.tsx
@@ -48,11 +48,24 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
         const verify = async () => {
             try {
-                const {newsletters: [updatedNewsletter]} = await verifyEmail({token: verifyEmailToken});
+                const {newsletters: [updatedNewsletter], meta: {email_verified: [emailVerified] = []} = {}} = await verifyEmail({token: verifyEmailToken});
+                let title;
+                let prompt;
+
+                if (emailVerified && emailVerified === 'sender_email') {
+                    title = 'Newsletter email verified';
+                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> will now be sent from <strong>{updatedNewsletter.sender_email}</strong>.</>;
+                } else if (emailVerified && emailVerified === 'sender_reply_to') {
+                    title = 'Reply-to address verified';
+                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> will now use <strong>{updatedNewsletter.sender_reply_to}</strong> as the reply-to address.</>;
+                } else {
+                    title = 'Email address verified';
+                    prompt = <>Email address for newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> has been changed.</>;
+                }
 
                 NiceModal.show(ConfirmationModal, {
-                    title: 'Email address verified',
-                    prompt: <>Success! Email address for newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> has been changed.</>,
+                    title,
+                    prompt,
                     okLabel: 'Close',
                     cancelLabel: '',
                     onOk: confirmModal => confirmModal?.remove()

--- a/ghost/core/core/server/services/newsletters/NewslettersService.js
+++ b/ghost/core/core/server/services/newsletters/NewslettersService.js
@@ -240,7 +240,7 @@ class NewslettersService {
         const updatedNewsletter = await this.NewsletterModel.edit(attrs, {id});
 
         updatedNewsletter.meta = updatedNewsletter.meta || {};
-        updatedNewsletter.meta.email_verified = [property];
+        updatedNewsletter.meta.email_verified = property;
 
         return updatedNewsletter;
     }

--- a/ghost/core/core/server/services/newsletters/NewslettersService.js
+++ b/ghost/core/core/server/services/newsletters/NewslettersService.js
@@ -237,7 +237,12 @@ class NewslettersService {
         const attrs = {};
         attrs[property] = value;
 
-        return this.NewsletterModel.edit(attrs, {id});
+        const updatedNewsletter = await this.NewsletterModel.edit(attrs, {id});
+
+        updatedNewsletter.meta = updatedNewsletter.meta || {};
+        updatedNewsletter.meta.email_verified = [property];
+
+        return updatedNewsletter;
     }
 
     /* Email verification Internals */

--- a/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/newsletters.test.js.snap
@@ -2331,6 +2331,9 @@ exports[`Newsletters API Can verify property updates 3: [text 1] 1`] = `
 
 exports[`Newsletters API Can verify property updates 4: [body] 1`] = `
 Object {
+  "meta": Object {
+    "email_verified": "sender_email",
+  },
   "newsletters": Array [
     Object {
       "background_color": "light",


### PR DESCRIPTION
fixes GRO-80
- added a new meta field "email_verified" to the /verification endpoint for newsletters. This meta field contains which email has been verified, "sender_email" or "sender_reply_to"
- updated copy in newsletter settings, based on which email has been verified
