### PR TITLE
Add Lexical support to the external-media-inliner

### DIFF
--- a/ghost/external-media-inliner/lib/ExternalMediaInliner.js
+++ b/ghost/external-media-inliner/lib/ExternalMediaInliner.js
@@ -261,24 +261,24 @@ class ExternalMediaInliner {
                 const mobiledocContent = post.get('mobiledoc');
                 const lexicalContent = post.get('lexical');
 
-                let theContent;
-                let contentTarget;
-
-                if (mobiledocContent) {
-                    theContent = mobiledocContent;
-                    contentTarget = 'mobiledoc';
-                } else if (lexicalContent) {
-                    theContent = lexicalContent;
-                    contentTarget = 'lexical';
-                }
-
-                const inlinedContent = await this.inlineContent(theContent, domains);
-
                 const updatedFields = await this.inlineFields(post, postsInilingFields, domains);
 
-                // If content has changed, update the post
-                if (inlinedContent !== theContent) {
-                    updatedFields[contentTarget] = inlinedContent;
+                if (mobiledocContent) {
+                    const inlinedContent = await this.inlineContent(mobiledocContent, domains);
+
+                    // If content has changed, update the post
+                    if (inlinedContent !== mobiledocContent) {
+                        updatedFields.mobiledoc = inlinedContent;
+                    }
+                }
+
+                if (lexicalContent) {
+                    const inlinedContent = await this.inlineContent(lexicalContent, domains);
+
+                    // If content has changed, update the post
+                    if (inlinedContent !== lexicalContent) {
+                        updatedFields.lexical = inlinedContent;
+                    }
                 }
 
                 if (Object.keys(updatedFields).length > 0) {

--- a/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
+++ b/ghost/external-media-inliner/test/ExternalMediaInliner.test.js
@@ -267,6 +267,59 @@ describe('ExternalMediaInliner', function () {
             });
         });
 
+        it('inlines image in the post\'s mobiledoc & lexical content', async function () {
+            const imageURL = 'https://img.stockfresh.com/files/f/image.jpg';
+            const requestMock = nock('https://img.stockfresh.com')
+                .get('/files/f/image.jpg')
+                .reply(200, GIF1x1)
+                .get('/files/f/image.jpg')
+                .reply(200, GIF1x1);
+
+            const postStub = sinon.stub();
+            postStub.withArgs('mobiledoc').returns(`{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"${imageURL}"}]]}`);
+            postStub.withArgs('lexical').returns(`{"root":{"children":[{"type":"image","version":1,"src":"${imageURL}","width":1480,"height":486,"title":"","alt":"","caption":"","cardWidth":"regular","href":""}],"direction":null,"format":"","indent":0,"type":"root","version":1}}`);
+
+            const postModelInstanceStub = {
+                id: 'inlined-post-id',
+                get: postStub
+            };
+            postModelStub = {
+                findPage: sinon.stub().returns({
+                    data: [postModelInstanceStub]
+                }),
+                edit: sinon.stub().resolves()
+            };
+
+            sinon.stub(path, 'relative')
+                .withArgs('/content/images', '/content/images/unique-image.jpg')
+                .returns('unique-image.jpg');
+            const inliner = new ExternalMediaInliner({
+                PostModel: postModelStub,
+                PostMetaModel: postMetaModelStub,
+                TagModel: tagModelStub,
+                UserModel: userModelStub,
+                getMediaStorage: sinon.stub().withArgs('.jpg').returns({
+                    getTargetDir: () => '/content/images',
+                    getUniqueFileName: () => '/content/images/unique-image.jpg',
+                    saveRaw: () => '/content/images/unique-image.jpg'
+                })
+            });
+
+            await inliner.inline(['https://img.stockfresh.com']);
+
+            assert.ok(requestMock.isDone());
+            assert.ok(postModelStub.edit.calledOnce);
+            assert.ok(postModelStub.edit.calledWith({
+                mobiledoc: '{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"__GHOST_URL__/content/images/unique-image.jpg"}]]}',
+                lexical: '{"root":{"children":[{"type":"image","version":1,"src":"__GHOST_URL__/content/images/unique-image.jpg","width":1480,"height":486,"title":"","alt":"","caption":"","cardWidth":"regular","href":""}],"direction":null,"format":"","indent":0,"type":"root","version":1}}'
+            }, {
+                id: 'inlined-post-id',
+                context: {
+                    internal: true
+                }
+            }));
+        });
+
         it('logs an error when fetching an external media fails', async function () {
             const imageURL = 'https://img.stockfresh.com/files/f/image.jpg';
             const requestMock = nock('https://img.stockfresh.com')
@@ -368,11 +421,13 @@ describe('ExternalMediaInliner', function () {
                 .get('/files/f/image.jpg')
                 .reply(200, GIF1x1);
 
+            const postStub = sinon.stub();
+            postStub.withArgs('mobiledoc').returns(`{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"${imageURL}"}]]}`);
+            postStub.withArgs('lexical').returns(null);
+
             postModelStub = {
                 id: 'errored-post-id',
-                get: sinon.stub()
-                    .withArgs('mobiledoc')
-                    .returns(`{"version":"0.3.1","atoms":[],"cards":[["image",{"src":"${imageURL}"}]]}`)
+                get: postStub
             };
             postModelStub = {
                 findPage: sinon.stub().returns({


### PR DESCRIPTION
This adds Lexical support to the external media inliner package. 

The bulk of the changes here are determining what format of the content is available, which is then used to decide what post property to change & update.