### PR TITLE
Indexed over members_newsletters(newsletter_id, member_id)

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
@@ -1,19 +1,16 @@
 const logging = require('@tryghost/logging');
 const {createNonTransactionalMigration} = require('../../utils');
+const {addIndex, dropIndex} = require('../../../schema/commands');
 
 module.exports = createNonTransactionalMigration(
     async function up(knex) {
         logging.info('Adding index over members_newsletters(newsletter_id, member_id)');
-        await knex.schema.alterTable('members_newsletters', function (table) {
-            table.index(['newsletter_id', 'member_id'], 'idx_members_newsletters_newsletter_id_member_id');
-        });
+        await addIndex('members_newsletters', ['newsletter_id', 'member_id'], knex);
     },
     async function down(knex) {
         logging.info('Dropping index over members_newsletters(newsletter_id, member_id)');
         try {
-            await knex.schema.alterTable('members_newsletters', function (table) {
-                table.dropIndex('idx_members_newsletters_newsletter_id_member_id');
-            });
+            await dropIndex('members_newsletters', ['newsletter_id', 'member_id'], knex);
         } catch (err) {
             logging.error({
                 err,
@@ -21,14 +18,10 @@ module.exports = createNonTransactionalMigration(
             });
 
             logging.info('Creating index over members_newsletters(newsletter_id)');
-            await knex.schema.alterTable('members_newsletters', function (table) {
-                table.index(['newsletter_id'], 'members_newsletters_newsletter_id_foreign');
-            });
+            await addIndex('members_newsletters', ['newsletter_id'], knex);
 
             logging.info('Dropping index over members_newsletters(newsletter_id, member_id)');
-            await knex.schema.alterTable('members_newsletters', function (table) {
-                table.dropIndex('idx_members_newsletters_newsletter_id_member_id');
-            });
+            await dropIndex('members_newsletters', ['newsletter_id', 'member_id'], knex);
         }
     }
 );

--- a/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
@@ -15,13 +15,12 @@ module.exports = createNonTransactionalMigration(
                     message: 'Error dropping index over members_newsletters(newsletter_id, member_id), re-adding index for newsletter_id'
                 });
 
-
                 await addIndex('members_newsletters', ['newsletter_id'], knex);
                 await dropIndex('members_newsletters', ['newsletter_id', 'member_id'], knex);
                 return;
-	         }
+             }
 	         
-	         throw err;
+             throw err;
         }
     }
 );

--- a/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
@@ -4,11 +4,9 @@ const {addIndex, dropIndex} = require('../../../schema/commands');
 
 module.exports = createNonTransactionalMigration(
     async function up(knex) {
-        logging.info('Adding index over members_newsletters(newsletter_id, member_id)');
         await addIndex('members_newsletters', ['newsletter_id', 'member_id'], knex);
     },
     async function down(knex) {
-        logging.info('Dropping index over members_newsletters(newsletter_id, member_id)');
         try {
             await dropIndex('members_newsletters', ['newsletter_id', 'member_id'], knex);
         } catch (err) {

--- a/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
@@ -20,6 +20,7 @@ module.exports = createNonTransactionalMigration(
 
                 await addIndex('members_newsletters', ['newsletter_id'], knex);
                 await dropIndex('members_newsletters', ['newsletter_id', 'member_id'], knex);
+                return;
 	         }
 	         
 	         throw err;

--- a/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
@@ -4,12 +4,16 @@ const {createNonTransactionalMigration} = require('../../utils');
 module.exports = createNonTransactionalMigration(
     async function up(knex) {
         logging.info('Adding index over members_newsletters(newsletter_id, member_id)');
-        await knex.raw(`CREATE INDEX idx_members_newsletters_newsletter_id_member_id ON members_newsletters(newsletter_id, member_id);`);
+        await knex.schema.alterTable('members_newsletters', function (table) {
+            table.index(['newsletter_id', 'member_id'], 'idx_members_newsletters_newsletter_id_member_id');
+        });
     },
     async function down(knex) {
         logging.info('Dropping index over members_newsletters(newsletter_id, member_id)');
         try {
-            await knex.raw(`ALTER TABLE members_newsletters DROP INDEX idx_members_newsletters_newsletter_id_member_id;`);
+            await knex.schema.alterTable('members_newsletters', function (table) {
+                table.dropIndex('idx_members_newsletters_newsletter_id_member_id');
+            });
         } catch (err) {
             logging.error({
                 err,
@@ -17,10 +21,14 @@ module.exports = createNonTransactionalMigration(
             });
 
             logging.info('Creating index over members_newsletters(newsletter_id)');
-            await knex.raw(`CREATE INDEX members_newsletters_newsletter_id_foreign ON members_newsletters(newsletter_id);`);
+            await knex.schema.alterTable('members_newsletters', function (table) {
+                table.index(['newsletter_id'], 'members_newsletters_newsletter_id_foreign');
+            });
 
             logging.info('Dropping index over members_newsletters(newsletter_id, member_id)');
-            await knex.raw(`ALTER TABLE members_newsletters DROP INDEX idx_members_newsletters_newsletter_id_member_id;`);
+            await knex.schema.alterTable('members_newsletters', function (table) {
+                table.dropIndex('idx_members_newsletters_newsletter_id_member_id');
+            });
         }
     }
 );

--- a/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
@@ -18,9 +18,9 @@ module.exports = createNonTransactionalMigration(
                 await addIndex('members_newsletters', ['newsletter_id'], knex);
                 await dropIndex('members_newsletters', ['newsletter_id', 'member_id'], knex);
                 return;
-             }
-	         
-             throw err;
+            }
+
+            throw err;
         }
     }
 );

--- a/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
+++ b/ghost/core/core/server/data/migrations/versions/5.75/2023-11-27-15-55-add-members-newsletters-index.js
@@ -1,0 +1,26 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info('Adding index over members_newsletters(newsletter_id, member_id)');
+        await knex.raw(`CREATE INDEX idx_members_newsletters_newsletter_id_member_id ON members_newsletters(newsletter_id, member_id);`);
+    },
+    async function down(knex) {
+        logging.info('Dropping index over members_newsletters(newsletter_id, member_id)');
+        try {
+            await knex.raw(`ALTER TABLE members_newsletters DROP INDEX idx_members_newsletters_newsletter_id_member_id;`);
+        } catch (err) {
+            logging.error({
+                err,
+                message: 'Error dropping index over members_newsletters(newsletter_id, member_id)'
+            });
+
+            logging.info('Creating index over members_newsletters(newsletter_id)');
+            await knex.raw(`CREATE INDEX members_newsletters_newsletter_id_foreign ON members_newsletters(newsletter_id);`);
+
+            logging.info('Dropping index over members_newsletters(newsletter_id, member_id)');
+            await knex.raw(`ALTER TABLE members_newsletters DROP INDEX idx_members_newsletters_newsletter_id_member_id;`);
+        }
+    }
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -938,7 +938,7 @@ module.exports = {
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
         newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true},
         '@@INDEXES@@': [
-            ['member_id', 'newsletter_id']
+            ['newsletter_id', 'member_id']
         ]
     },
     comments: {

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -936,7 +936,10 @@ module.exports = {
     members_newsletters: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-        newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true}
+        newsletter_id: {type: 'string', maxlength: 24, nullable: false, references: 'newsletters.id', cascadeDelete: true},
+        '@@INDEXES@@': [
+            ['member_id', 'newsletter_id']
+        ]
     },
     comments: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/core/server/models/newsletter.js
+++ b/ghost/core/core/server/models/newsletter.js
@@ -1,7 +1,6 @@
 const ghostBookshelf = require('./base');
 const ObjectID = require('bson-objectid').default;
 const uuid = require('uuid');
-const DatabaseInfo = require('@tryghost/database-info');
 const urlUtils = require('../../shared/url-utils');
 
 const Newsletter = ghostBookshelf.Model.extend({
@@ -156,17 +155,11 @@ const Newsletter = ghostBookshelf.Model.extend({
             active_members(modelOrCollection) {
                 modelOrCollection.query('columns', 'newsletters.*', (qb) => {
                     qb.count('members_newsletters.id')
+                        .from('members_newsletters')
                         .join('members', 'members.id', 'members_newsletters.member_id')
                         .whereRaw('members_newsletters.newsletter_id = newsletters.id')
                         .andWhere('members.email_disabled', false)
                         .as('count__active_members');
-
-                    // https://github.com/TryGhost/Product/issues/4181
-                    if (DatabaseInfo.isMySQL(ghostBookshelf.knex)) {
-                        qb.fromRaw('members_newsletters force index (members_newsletters_newsletter_id_foreign)');
-                    } else {
-                        qb.from('members_newsletters');
-                    }
                 });
             }
         };

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '84a241159b91dda673a22065f726e41f';
+    const currentSchemaHash = '34a9fa4dc1223ef6c45f8ed991d25de5';
     const currentFixturesHash = '4db87173699ad9c9d8a67ccab96dfd2d';
     const currentSettingsHash = '3128d4ec667a50049486b0c21f04be07';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '93dc3e803ab6d73462d59da699c46ed9';
+    const currentSchemaHash = '84a241159b91dda673a22065f726e41f';
     const currentFixturesHash = '4db87173699ad9c9d8a67ccab96dfd2d';
     const currentSettingsHash = '3128d4ec667a50049486b0c21f04be07';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
We were seeing slow queries when joining on this table, and the index speeds them up. The down migration is tricky because when we add the index MySQL can optimise away some `KEY` indexes on the `newsletter_id` column. When we then go to remove the newly created index, there is no index for the FK!