### PR TITLE
🐛 Fixed Portal default page handling

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.36.2",
+  "version": "2.36.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/portal/src/App.js
+++ b/apps/portal/src/App.js
@@ -741,7 +741,11 @@ export default class App extends React.Component {
         const customOfferRegex = /^offers\/(\w+?)\/?$/;
         const site = useSite ?? this.state.site ?? {};
 
-        if (customOfferRegex.test(path)) {
+        if (path === undefined || path === '') {
+            return {
+                page: 'default'
+            };
+        } else if (customOfferRegex.test(path)) {
             return {
                 pageQuery: path
             };
@@ -822,7 +826,9 @@ export default class App extends React.Component {
                 }
             };
         }
-        return {};
+        return {
+            page: 'default'
+        };
     }
 
     /**Get Accent color from site data*/
@@ -834,7 +840,7 @@ export default class App extends React.Component {
     /**Get final page set in App context from state data*/
     getContextPage({site, page, member}) {
         /**Set default page based on logged-in status */
-        if (!page) {
+        if (!page || page === 'default') {
             const loggedOutPage = isInviteOnlySite({site}) ? 'signin' : 'signup';
             page = member ? 'accountHome' : loggedOutPage;
         }


### PR DESCRIPTION
fixes GRO-88

Instead of going to the previous page when visiting /#/portal, it will now go to the default page:
- Sign up if you are not signed in
- Account home if you are signed in

Previously, it had the same behaviour, with the difference that it would also go to the previous page if there was any.