### PR TITLE
Improved newsletters querying efficiency in admin-x

### DIFF
--- a/apps/admin-x-framework/src/api/newsletters.ts
+++ b/apps/admin-x-framework/src/api/newsletters.ts
@@ -49,10 +49,12 @@ export interface NewslettersResponseType {
 const dataType = 'NewslettersResponseType';
 export const newslettersDataType = dataType;
 
+export const browseNewslettersDefaultLimit = '50';
+
 export const useBrowseNewsletters = createInfiniteQuery<NewslettersResponseType & {isEnd: boolean}>({
     dataType,
     path: '/newsletters/',
-    defaultSearchParams: {include: 'count.active_members,count.posts', limit: '50'},
+    defaultSearchParams: {include: 'count.active_members,count.posts', limit: browseNewslettersDefaultLimit},
     defaultNextPageParams: (lastPage, otherParams) => ({
         ...otherParams,
         page: (lastPage.meta?.pagination.next || 1).toString()

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -8,7 +8,7 @@ import {Button, ButtonGroup, ColorPickerField, ConfirmationModal, Form, Heading,
 import {Config, hasSendingDomain, isManagedEmail, sendingDomain} from '@tryghost/admin-x-framework/api/config';
 import {ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {HostLimitError, useLimiter} from '../../../../hooks/useLimiter';
-import {Newsletter, useBrowseNewsletters, useEditNewsletter} from '@tryghost/admin-x-framework/api/newsletters';
+import {Newsletter, browseNewslettersDefaultLimit, useBrowseNewsletters, useEditNewsletter} from '@tryghost/admin-x-framework/api/newsletters';
 import {RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
@@ -640,7 +640,9 @@ const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: b
 };
 
 const NewsletterDetailModal: React.FC<RoutingModalProps> = ({params}) => {
-    const {data: {newsletters, isEnd} = {}, fetchNextPage} = useBrowseNewsletters();
+    const {data: {newsletters, isEnd} = {}, fetchNextPage} = useBrowseNewsletters({
+        searchParams: {limit: browseNewslettersDefaultLimit}
+    });
     const newsletter = newsletters?.find(({id}) => id === params?.id);
 
     useEffect(() => {


### PR DESCRIPTION
no refs

Improved newsletters querying efficiency in admin-x by only requesting member / post counts when explicitly required