### PR TITLE
Added v-param to portal base URL

### DIFF
--- a/apps/admin-x-settings/src/utils/getOffersPortalPreviewUrl.ts
+++ b/apps/admin-x-settings/src/utils/getOffersPortalPreviewUrl.ts
@@ -35,6 +35,7 @@ export const getOfferPortalPreviewUrl = (overrides:offerPortalPreviewUrlTypes, b
     const portalBase = '/?v=modal-portal-offer#/portal/preview/offer';
     const settingsParam = new URLSearchParams();
 
+    settingsParam.append('disableBackground', 'false');
     settingsParam.append('name', encodeURIComponent(name));
     settingsParam.append('code', encodeURIComponent(code));
     settingsParam.append('display_title', encodeURIComponent(displayTitle));

--- a/apps/admin-x-settings/src/utils/getOffersPortalPreviewUrl.ts
+++ b/apps/admin-x-settings/src/utils/getOffersPortalPreviewUrl.ts
@@ -31,7 +31,8 @@ export const getOfferPortalPreviewUrl = (overrides:offerPortalPreviewUrlTypes, b
         tierId
     } = overrides;
 
-    const portalBase = '/#/portal/preview/offer';
+    baseUrl = baseUrl.replace(/\/$/, '');
+    const portalBase = '/?v=modal-portal-offer#/portal/preview/offer';
     const settingsParam = new URLSearchParams();
 
     settingsParam.append('name', encodeURIComponent(name));


### PR DESCRIPTION
no issue

- fixed the double `/` slash that's parsing the href url.
- also added a v-param.
