### PR TITLE
Fixed displaying empty from address in newsletter preview

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -26,14 +26,14 @@ export const renderSenderEmail = (newsletter: Newsletter, config: Config, defaul
         if (newsletter.sender_email?.split('@')[1] === sendingDomain(config)) {
             return newsletter.sender_email;
         } else {
-            return '';
+            return defaultEmailAddress || '';
         }
     }
 
     return newsletter.sender_email || defaultEmailAddress || '';
 };
 
-export const renderReplyToEmail = (newsletter: Newsletter, config: Config, supportEmailAddress: string|undefined, defaultEmailAddress: string|undefined) => {   
+export const renderReplyToEmail = (newsletter: Newsletter, config: Config, supportEmailAddress: string|undefined, defaultEmailAddress: string|undefined) => {
     if (newsletter.sender_reply_to === 'newsletter') {
         return renderSenderEmail(newsletter, config, defaultEmailAddress);
     }
@@ -169,8 +169,15 @@ const Sidebar: React.FC<{
 
         // Pro users with custom sending domains
         if (hasSendingDomain(config)) {
-            const sendingEmail = renderSenderEmail(newsletter, config, defaultEmailAddress);
-            const sendingEmailUsername = sendingEmail?.split('@')[0];
+            let sendingEmail = newsletter.sender_email || ''; // Do not use the rendered address here, because this field is editable and we otherwise can't have an empty field
+
+            // It is possible we have an invalid saved email address, in that case it won't get used
+            // so we should display as if we are using the default = an empty address
+            if (sendingEmail && sendingEmail !== newsletterAddress) {
+                sendingEmail = '';
+            }
+
+            const sendingEmailUsername = sendingEmail?.split('@')[0] || '';
 
             return (
                 <TextField


### PR DESCRIPTION
no issue

When the from address of a newsletter is empty, and a custom sending domain is setup the preview would display 'From: Sitename ()' instead of 'From: Sitename (default@address)'.

When a custom sending domain was setup, but a different from address was saved, we'll also no longer display it in the input fields - as it will also be ignored IRL.