### PR TITLE
Set negative pricing in Offers index to 0

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
@@ -59,6 +59,11 @@ export const getOfferDiscount = (type: string, amount: number, cadence: string, 
         break;
     };
 
+    // Check if updatedPrice is negative, if so, set it to 0
+    if (updatedPrice < 0) {
+        updatedPrice = 0;
+    }
+
     const updatedPriceWithCurrency = getSymbol(currency) + numberWithCommas(formatToTwoDecimals(currencyToDecimal(updatedPrice)));
 
     return {


### PR DESCRIPTION
refs ADM-24

- sets a negative amount to 0
- this usually occurs if the tier amount was changed after the offer has been created.
