### PR TITLE
Added notice of upcoming removal of AMP

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/Integrations.tsx
@@ -109,7 +109,7 @@ const BuiltInIntegrations: React.FC = () => {
                     openModal('integrations/amp');
                 }}
                 active={ampEnabled}
-                detail='Google Accelerated Mobile Pages'
+                detail='Google AMP will be removed in Ghost 6.0'
                 icon={<AmpIcon className='h-8 w-8' />}
                 title='AMP' />
 

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/AmpModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/AmpModal.tsx
@@ -62,7 +62,7 @@ const AmpModal = NiceModal.create(() => {
                     <Toggle
                         checked={enabled}
                         direction='rtl'
-                        hint={<>Enable <a className='text-green' href="https://amp.dev" rel="noopener noreferrer" target='_blank'>Google Accelerated Mobile Pages</a> for your posts</>}
+                        hint={<>Google AMP is <a className='text-green' href="https://en.m.wikipedia.org/wiki/Accelerated_Mobile_Pages" rel="noopener noreferrer" target='_blank'>being retired</a> — this feature will be removed in Ghost 6.0</>}
                         label='Enable AMP'
                         onChange={(e) => {
                             setEnabled(e.target.checked);


### PR DESCRIPTION
Google AMP is on the way out. In Ghost 5.0 we changed the integration's default state to be `disabled`, and we have planned to remove it completely in Ghost 6.0 for a while — but we haven't shared this anywhere. 

@gergelyorosz bumped into this today:
https://twitter.com/GergelyOrosz/status/1729778093777100973

This PR is to start communicating our intent to remove AMP in the next major release of Ghost, by adding inline messaging to the integration settings in Ghost Admin