### PR TITLE
Added retryStrategy to redis cache adapter with configurable retry delay

### DIFF
--- a/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
+++ b/ghost/adapter-cache-redis/lib/AdapterCacheRedis.js
@@ -43,6 +43,9 @@ class AdapterCacheRedis extends BaseCacheAdapter {
                 port: config.port,
                 username: config.username,
                 password: config.password,
+                retryStrategy: () => {
+                    return (config.storeConfig.retryConnectSeconds || 10) * 1000;
+                },
                 ...config.storeConfig,
                 clusterConfig: config.clusterConfig
             };


### PR DESCRIPTION
no-issue

A small patch to allow us to specify a number of seconds to wait between redisio connection retries.
