### PR TITLE
Allowed custom/empty replyTo for newsletters with managed sending domain

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -189,35 +189,13 @@ const Sidebar: React.FC<{
             );
         }
 
-        // Pro users with custom sending domains
-        if (hasSendingDomain(config)) {
-            const replyToEmail = ['newsletter', 'support'].includes(newsletter.sender_reply_to) ? '' : renderReplyToEmail(newsletter, config, supportEmailAddress, defaultEmailAddress);
-            const replyToEmailUsername = replyToEmail?.split('@')[0] || '';
-
-            return (
-                <TextField
-                    error={Boolean(errors.sender_reply_to)}
-                    hint={errors.sender_reply_to}
-                    rightPlaceholder={`@${sendingDomain(config)}`}
-                    title="Reply-to address"
-                    value={replyToEmailUsername}
-                    onBlur={validate}
-                    onChange={(e) => {
-                        const username = e.target.value?.split('@')[0];
-                        const newEmail = username ? `${username}@${sendingDomain(config)}` : 'newsletter';
-                        updateNewsletter({sender_reply_to: newEmail});
-                    }}
-                    onKeyDown={() => clearError('sender_reply_to')}
-                />
-            );
-        }
-
+        const replyToRequired = !hasSendingDomain(config);
         // Pro users without custom sending domains
         return (
             <TextField
                 error={Boolean(errors.sender_reply_to)}
                 hint={errors.sender_reply_to}
-                placeholder={newsletterAddress || ''}
+                placeholder={replyToRequired ? (newsletterAddress || '') : ''}
                 title="Reply-to email"
                 value={renderReplyToEmail(newsletter, config, supportEmailAddress, defaultEmailAddress) || ''}
                 onBlur={validate}

--- a/apps/admin-x-settings/src/utils/newsletterEmails.ts
+++ b/apps/admin-x-settings/src/utils/newsletterEmails.ts
@@ -21,20 +21,16 @@ export const renderSenderEmail = (newsletter: Newsletter, config: Config, defaul
 
 export const renderReplyToEmail = (newsletter: Newsletter, config: Config, supportEmailAddress: string|undefined, defaultEmailAddress: string|undefined) => {
     if (newsletter.sender_reply_to === 'newsletter') {
+        if (isManagedEmail(config) && hasSendingDomain(config)) {
+            // No reply-to set
+            // sender_reply_to currently doesn't allow empty values, we need to set it to 'newsletter'
+            return '';
+        }
         return renderSenderEmail(newsletter, config, defaultEmailAddress);
     }
 
     if (newsletter.sender_reply_to === 'support') {
         return supportEmailAddress || defaultEmailAddress || '';
-    }
-
-    if (isManagedEmail(config) && hasSendingDomain(config)) {
-        // Only return sender_reply_to if the domain names match
-        if (newsletter.sender_reply_to.split('@')[1] === sendingDomain(config)) {
-            return newsletter.sender_reply_to;
-        } else {
-            return '';
-        }
     }
 
     return newsletter.sender_reply_to;

--- a/ghost/core/test/integration/services/q-email-addresses.test.js
+++ b/ghost/core/test/integration/services/q-email-addresses.test.js
@@ -269,7 +269,7 @@ describe('Email addresses', function () {
                 sender_reply_to: 'newsletter'
             });
             await sendNewsletter();
-            await assertFromAddressNewsletter('"Anything Possible" <default@sendingdomain.com>', '"Anything Possible" <default@sendingdomain.com>');
+            await assertFromAddressNewsletter('"Anything Possible" <default@sendingdomain.com>');
         });
 
         it('[NEWSLETTER] Does allow to send a newsletter from a custom sending domain', async function () {
@@ -279,7 +279,7 @@ describe('Email addresses', function () {
                 sender_reply_to: 'newsletter'
             });
             await sendNewsletter();
-            await assertFromAddressNewsletter('"Anything Possible" <anything@sendingdomain.com>', '"Anything Possible" <anything@sendingdomain.com>');
+            await assertFromAddressNewsletter('"Anything Possible" <anything@sendingdomain.com>');
         });
 
         it('[NEWSLETTER] Does allow to set the replyTo address to any address', async function () {
@@ -309,7 +309,7 @@ describe('Email addresses', function () {
                 sender_reply_to: 'newsletter'
             });
             await sendNewsletter();
-            await assertFromAddressNewsletter('"Example Site" <default@sendingdomain.com>', '"Example Site" <default@sendingdomain.com>');
+            await assertFromAddressNewsletter('"Example Site" <default@sendingdomain.com>');
         });
     });
 
@@ -365,7 +365,7 @@ describe('Email addresses', function () {
                 sender_reply_to: 'newsletter'
             });
             await sendNewsletter();
-            await assertFromAddressNewsletter('"Anything Possible" <default@sendingdomain.com>', '"Anything Possible" <default@sendingdomain.com>');
+            await assertFromAddressNewsletter('"Anything Possible" <default@sendingdomain.com>');
         });
 
         it('[NEWSLETTER] Does allow to set the replyTo address to any address', async function () {
@@ -395,7 +395,7 @@ describe('Email addresses', function () {
                 sender_reply_to: 'newsletter'
             });
             await sendNewsletter();
-            await assertFromAddressNewsletter('"Example Site" <default@sendingdomain.com>', '"Example Site" <default@sendingdomain.com>');
+            await assertFromAddressNewsletter('"Example Site" <default@sendingdomain.com>');
         });
     });
 

--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -215,6 +215,10 @@ class EmailRenderer {
             return this.#settingsHelpers.getMembersSupportAddress();
         }
         if (newsletter.get('sender_reply_to') === 'newsletter') {
+            if (this.#emailAddressService.managedEmailEnabled) {
+                // Don't duplicate the same replyTo addres if it already in the FROM address
+                return null;
+            }
             return this.getFromAddress(post, newsletter);
         }
 

--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -731,7 +731,8 @@ describe('Email renderer', function () {
         let emailAddressService = {
             getAddress(addresses) {
                 return addresses;
-            }
+            },
+            managedEmailEnabled: true
         };
         let emailRenderer = new EmailRenderer({
             settingsCache: {
@@ -765,14 +766,27 @@ describe('Email renderer', function () {
             response.should.equal('support@example.com');
         });
 
-        it('returns correct reply to address for newsletter', function () {
+        it('[legacy] returns correct reply to address for newsletter', function () {
+            emailAddressService.managedEmailEnabled = false;
             const newsletter = createModel({
                 sender_email: 'ghost@example.com',
                 sender_name: 'Ghost',
                 sender_reply_to: 'newsletter'
             });
             const response = emailRenderer.getReplyToAddress({}, newsletter);
-            response.should.equal(`"Ghost" <ghost@example.com>`);
+            assert.equal(response, `"Ghost" <ghost@example.com>`);
+            emailAddressService.managedEmailEnabled = true;
+        });
+
+        it('returns null when set to newsletter', function () {
+            emailAddressService.managedEmailEnabled = true;
+            const newsletter = createModel({
+                sender_email: 'ghost@example.com',
+                sender_name: 'Ghost',
+                sender_reply_to: 'newsletter'
+            });
+            const response = emailRenderer.getReplyToAddress({}, newsletter);
+            assert.equal(response, null);
         });
 
         it('returns correct custom reply to address', function () {


### PR DESCRIPTION
fixes GRO-75
fixes GRO-100

And allow them to be empty