### PR TITLE
Simplified offers modal navigation

### DIFF
--- a/apps/admin-x-design-system/src/global/ButtonGroup.tsx
+++ b/apps/admin-x-design-system/src/global/ButtonGroup.tsx
@@ -17,7 +17,7 @@ export interface ButtonGroupProps {
 const ButtonGroup: React.FC<ButtonGroupProps> = ({size = 'md', buttons, link, linkWithPadding, clearBg = true, outlineOnMobile, className}) => {
     let groupColorClasses = clsx(
         'flex items-center justify-start rounded',
-        link ? 'gap-4' : 'gap-5',
+        link ? 'gap-4' : 'gap-3',
         className
     );
 

--- a/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
@@ -621,17 +621,11 @@ const AddOfferModal = () => {
         okColor={okProps.color}
         okLabel='Publish'
         preview={iframe}
-        previewToolbarBreadcrumbs={[{label: 'Offers', onClick: () => {
-            updateRoute('offers/edit');
-        }}, {label: 'New offer'}]}
         sidebar={sidebar}
         size='lg'
         testId='add-offer-modal'
         title='Offer'
         width={1140}
-        onBreadcrumbsBack={() => {
-            updateRoute('offers/edit');
-        }}
         onCancel={cancelAddOffer}
         onOk={async () => {
             validate();

--- a/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
@@ -262,17 +262,11 @@ const EditOfferModal: React.FC<{id: string}> = ({id}) => {
         okColor={okProps.color}
         okLabel={okProps.label || 'Save'}
         preview={iframe}
-        previewToolbarBreadcrumbs={[{label: 'Offers', onClick: () => {
-            updateRoute('offers/edit');
-        }}, {label: offerById[0]?.name || ''}]}
         sidebar={sidebar}
         size='lg'
         testId='offer-update-modal'
         title='Offer'
         width={1140}
-        onBreadcrumbsBack={() => {
-            updateRoute('offers/edit');
-        }}
         onCancel={() => {
             updateRoute('offers/edit');
         }}


### PR DESCRIPTION
fixes ADM-36

- removed the breadcrumbs from the preview modals
- fixed spacing of button group


