### PR TITLE
Disabled backdrop click for offers modals

### DIFF
--- a/apps/admin-x-design-system/src/global/modal/PreviewModal.tsx
+++ b/apps/admin-x-design-system/src/global/modal/PreviewModal.tsx
@@ -44,6 +44,7 @@ export interface PreviewModalProps {
     sidebarPadding?: boolean;
     sidebarContentClasses?: string;
     enableCMDS?: boolean;
+    backDropClick?: boolean;
 
     onCancel?: () => void;
     onOk?: () => void;
@@ -83,6 +84,7 @@ export const PreviewModalContent: React.FC<PreviewModalProps> = ({
     sidebarPadding = true,
     sidebarContentClasses,
     enableCMDS = true,
+    backDropClick,
 
     onCancel,
     onOk,
@@ -262,6 +264,7 @@ export const PreviewModalContent: React.FC<PreviewModalProps> = ({
         <Modal
             afterClose={afterClose}
             animate={false}
+            backDropClick={backDropClick}
             footer={false}
             height={height}
             padding={false}

--- a/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/AddOfferModal.tsx
@@ -614,6 +614,7 @@ const AddOfferModal = () => {
         afterClose={() => {
             updateRoute('offers');
         }}
+        backDropClick={false}
         cancelLabel='Cancel'
         deviceSelector={false}
         dirty={saveState === 'unsaved'}

--- a/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/EditOfferModal.tsx
@@ -256,6 +256,7 @@ const EditOfferModal: React.FC<{id: string}> = ({id}) => {
         afterClose={() => {
             updateRoute('offers');
         }}
+        backDropClick={false}
         deviceSelector={false}
         dirty={saveState === 'unsaved'}
         height='full'

--- a/apps/admin-x-settings/src/components/settings/growth/offers/OfferSuccess.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/OfferSuccess.tsx
@@ -74,6 +74,7 @@ const OfferSuccess: React.FC<{id: string}> = ({id}) => {
             updateRoute('offers');
         }}
         animate={false}
+        backDropClick={false}
         footer={false}
         height='full'
         size='lg'

--- a/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
@@ -194,6 +194,7 @@ export const OffersIndexModal = () => {
             updateRoute('offers');
         }}
         animate={false}
+        backDropClick={false}
         cancelLabel=''
         header={false}
         height='full'


### PR DESCRIPTION
refs ADM-37

- backdrop click should be disabled for modals, especially when modals contain user editable fields
- to make things consistent, all offers related modals are not closeable by backdrop clicking


