### PR TITLE
Fixed generating fallback context unnecessarily

### DIFF
--- a/ghost/core/core/frontend/meta/context-object.js
+++ b/ghost/core/core/frontend/meta/context-object.js
@@ -2,15 +2,6 @@ const settingsCache = require('../../shared/settings-cache');
 const _ = require('lodash');
 
 function getContextObject(data, context) {
-    /**
-     * If the data object does not contain the requested context, we return the fallback object.
-     */
-    const blog = {
-        cover_image: settingsCache.get('cover_image'),
-        twitter: settingsCache.get('twitter'),
-        facebook: settingsCache.get('facebook')
-    };
-
     let chosenContext;
 
     // @TODO: meta layer is very broken, it's really hard to understand what it's doing
@@ -31,9 +22,13 @@ function getContextObject(data, context) {
         chosenContext = data[context];
     }
 
-    // Super fallback.
+    // If the data object does not contain the requested context, we return the fallback object.
     if (!chosenContext) {
-        chosenContext = blog;
+        chosenContext = {
+            cover_image: settingsCache.get('cover_image'),
+            twitter: settingsCache.get('twitter'),
+            facebook: settingsCache.get('facebook')
+        };
     }
 
     return chosenContext;


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/4216

When generating page/post metadata, we generate a "context object" from several meta helpers. In the event there is no context from the resource type, we generate a fallback object.

However... we generate this fallback object no matter what.

Now, the fallback object is just 3x settingsCache.get, which should be fast, but it's not. I've opened a separate issue for that: https://github.com/TryGhost/Product/issues/4217

In the mean time, we can switch this logic around to only do these calls when we have no other context.

From testing, this allows for 10% more throughput on a post 🤯
