### PR TITLE
🐛 Fixed slash not working in Koenig link editor

### DIFF
--- a/apps/admin-x-settings/src/components/Sidebar.tsx
+++ b/apps/admin-x-settings/src/components/Sidebar.tsx
@@ -40,6 +40,11 @@ const Sidebar: React.FC = () => {
     // Focus in on search field when pressing "/"
     useEffect(() => {
         const handleKeyPress = (e: KeyboardEvent) => {
+            // ensures it doesn't fire when typing in a text field, particularly useful for the Koenig Editor.
+            if (e.target instanceof HTMLElement &&
+                (e.target.nodeName === 'INPUT' || e.target.nodeName === 'TEXTAREA' || e.target.isContentEditable)) {
+                return;
+            }
             if (e.key === '/' && !isAnyTextFieldFocused) {
                 e?.preventDefault();
                 if (searchInputRef.current) {


### PR DESCRIPTION
refs ADM-43 https://github.com/TryGhost/Product/issues/4213

- The slash '/' search was firing when it wasn't suppose to, eg via the URL editor inside the minimal koenig editors.
- this fix makes sure that if any input field has focus, that the slash search function doesn't get fired.