### PR TITLE
Allow custom reply-to addresses for self-hosters and allow empty values

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/NewsletterDetailModal.tsx
@@ -99,7 +99,7 @@ const Sidebar: React.FC<{
     const {mutateAsync: editNewsletter} = useEditNewsletter();
     const limiter = useLimiter();
     const {settings, siteData, config} = useGlobalData();
-    const [icon, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(settings, ['icon', 'default_email_address', 'support_email_address']);
+    const [icon, defaultEmailAddress] = getSettingValues<string>(settings, ['icon', 'default_email_address', 'support_email_address']);
     const {mutateAsync: uploadImage} = useUploadImage();
     const [selectedTab, setSelectedTab] = useState('generalSettings');
     const hasEmailCustomization = useFeatureFlag('emailCustomization');

--- a/apps/admin-x-settings/src/utils/newsletterEmails.ts
+++ b/apps/admin-x-settings/src/utils/newsletterEmails.ts
@@ -21,7 +21,7 @@ export const renderSenderEmail = (newsletter: Newsletter, config: Config, defaul
 
 export const renderReplyToEmail = (newsletter: Newsletter, config: Config, supportEmailAddress: string|undefined, defaultEmailAddress: string|undefined) => {
     if (newsletter.sender_reply_to === 'newsletter') {
-        if (isManagedEmail(config) && hasSendingDomain(config)) {
+        if (isManagedEmail(config) || !!config.labs.newEmailAddresses) {
             // No reply-to set
             // sender_reply_to currently doesn't allow empty values, we need to set it to 'newsletter'
             return '';


### PR DESCRIPTION
fixes GRO-105

The newsletter value is mapped to an empty value when shown to the users, this matches the backend behaviour.

When entering an empty value, this is stored internally as 'newsletter'.

The replyToInput component now uses its own state for the input value. This avoids weird issues when the rendered value changes, e.g. when entering the text 'support' or 'newsletter' in the field.