### PR TITLE
Fixed Portal's Ship command

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -26,7 +26,7 @@
     "test:unit": "yarn test:ci",
     "lint": "eslint src --ext .js --cache",
     "preship": "yarn lint",
-    "ship": "STATUS=$(git status --porcelain .); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version; else exit 1; fi",
+    "ship": "STATUS=$(git status --porcelain .); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version; else echo \"Uncommitted changes found.\" && exit 1; fi",
     "postship": "git push ${GHOST_UPSTREAM:-origin} --follow-tags && npm publish",
     "prepublishOnly": "yarn build"
   },

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -26,7 +26,7 @@
     "test:unit": "yarn test:ci",
     "lint": "eslint src --ext .js --cache",
     "preship": "yarn lint",
-    "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version; fi",
+    "ship": "STATUS=$(git status --porcelain .); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn version; else exit 1; fi",
     "postship": "git push ${GHOST_UPSTREAM:-origin} --follow-tags && npm publish",
     "prepublishOnly": "yarn build"
   },


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1701344186524289

- changed the ship command in portal to avoid checking the status of files in all of Ghost and just checks for the status of files inside Portal before publishing to NPM.