### PR TITLE
🐛 Fixed deleting members with email disabled

### DIFF
--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -223,8 +223,9 @@ export default class MembersController extends Controller {
             // If the provided filter param is a single filter related to newsletter subscription status
             // remove the surrounding brackets to prevent https://github.com/TryGhost/NQL/issues/16
             const BRACKETS_SURROUNDED_RE = /^\(.*\)$/;
+            const MULTIPLE_GROUPS_RE = /\).*\(/;
 
-            if (BRACKETS_SURROUNDED_RE.test(filterParam)) {
+            if (BRACKETS_SURROUNDED_RE.test(filterParam) && !MULTIPLE_GROUPS_RE.test(filterParam)) {
                 filterParam = filterParam.slice(1, -1);
             }
         }

--- a/ghost/admin/app/controllers/members.js
+++ b/ghost/admin/app/controllers/members.js
@@ -222,10 +222,9 @@ export default class MembersController extends Controller {
         if (filterParam) {
             // If the provided filter param is a single filter related to newsletter subscription status
             // remove the surrounding brackets to prevent https://github.com/TryGhost/NQL/issues/16
-            const NEWSLETTER_SUBSCRIPTION_STATUS_RE = /^\(subscribed:(?:true|false)[+,]email_disabled:[01]\)$/;
-            const SPECIFIC_NEWSLETTER_SUBSCRIPTION_STATUS_RE = /^\(newsletters\.slug:[^()]+[+,]email_disabled:[01]\)$/;
+            const BRACKETS_SURROUNDED_RE = /^\(.*\)$/;
 
-            if (NEWSLETTER_SUBSCRIPTION_STATUS_RE.test(filterParam) || SPECIFIC_NEWSLETTER_SUBSCRIPTION_STATUS_RE.test(filterParam)) {
+            if (BRACKETS_SURROUNDED_RE.test(filterParam)) {
                 filterParam = filterParam.slice(1, -1);
             }
         }


### PR DESCRIPTION
refs https://ghost.slack.com/archives/CTH5NDJMS/p1701688836406919

Deleting members with email disabled, results in deleting all members due to a broken NQL filter.

The filter `(email_disabled:1)` results in selecting all members because of the surrounding brackets, which cause a `yg` filter to be generated by NQL which is not supported by code that handles the Mongo filters.

This is a quick fix to reduce damage, this will need a proper fix in NQL / lower level.