### PR TITLE
Added "support email address" keywords

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/MembershipSettings.tsx
@@ -6,7 +6,7 @@ import SearchableSection from '../../SearchableSection';
 import Tiers from './Tiers';
 
 export const searchKeywords = {
-    portal: ['membership', 'portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership'],
+    portal: ['membership', 'portal', 'signup', 'sign up', 'signin', 'sign in', 'login', 'account', 'membership', 'support', 'email', 'address', 'support email address', 'support address'],
     access: ['membership', 'default', 'access', 'subscription', 'post', 'membership', 'comments', 'commenting'],
     tiers: ['membership', 'tiers', 'payment', 'paid', 'stripe'],
     analytics: ['membership', 'analytics', 'tracking', 'privacy', 'membership']


### PR DESCRIPTION
refs. https://linear.app/tryghost/issue/ADM-59/add-support-and-email-address-to-portal-keywords

Searching for "support email address" (or any combination of this) in Settings resulted in an empty screen. The setting is availble under Portal which is pretty hidden so it should at least be searchable. This PR sets up new search keywords for support email address in Settings.

