### PR TITLE
🐛 Fixed links in signup terms

### DIFF
--- a/apps/portal/src/components/pages/OfferPage.js
+++ b/apps/portal/src/components/pages/OfferPage.js
@@ -6,6 +6,7 @@ import CloseButton from '../common/CloseButton';
 import InputForm from '../common/InputForm';
 import {getCurrencySymbol, getProductFromId, hasMultipleProductsFeature, isSameCurrency, formatNumber, hasMultipleNewsletters} from '../../utils/helpers';
 import {ValidateInputForm} from '../../utils/form';
+import {interceptAnchorClicks} from '../../utils/links';
 import NewsletterSelectionPage from './NewsletterSelectionPage';
 
 export const OfferPageStyles = () => {
@@ -251,13 +252,6 @@ export default class OfferPage extends React.Component {
         const errorClassName = this.state.errors?.checkbox ? 'gh-portal-error' : '';
 
         const className = `gh-portal-signup-terms ${errorClassName}`;
-
-        const interceptAnchorClicks = (e) => {
-            if (e.target.tagName === 'A') {
-                e.preventDefault();
-                window.open(e.target.href, '_blank');
-            }
-        };
 
         return (
             <div className={className} onClick={interceptAnchorClicks}>

--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -531,9 +531,13 @@ class SignupPage extends React.Component {
         const className = `gh-portal-signup-terms ${errorClassName}`;
 
         const interceptAnchorClicks = (e) => {
-            if (e.target.tagName === 'A') {
-                e.preventDefault();
-                window.open(e.target.href, '_blank');
+            if (e.currentTarget.contains(e.target)) {
+                const anchor = e.target.closest('a');
+
+                if (anchor) {
+                    e.preventDefault();
+                    window.open(anchor.href, '_blank');
+                }
             }
         };
 

--- a/apps/portal/src/components/pages/SignupPage.js
+++ b/apps/portal/src/components/pages/SignupPage.js
@@ -9,6 +9,7 @@ import InputForm from '../common/InputForm';
 import {ValidateInputForm} from '../../utils/form';
 import {getSiteProducts, getSitePrices, hasOnlyFreePlan, isInviteOnlySite, freeHasBenefitsOrDescription, hasOnlyFreeProduct, getFreeProductBenefits, getFreeTierDescription, hasMultipleNewsletters, hasFreeTrialTier, isSignupAllowed} from '../../utils/helpers';
 import {ReactComponent as InvitationIcon} from '../../images/icons/invitation.svg';
+import {interceptAnchorClicks} from '../../utils/links';
 
 export const SignupPageStyles = `
 .gh-portal-back-sitetitle {
@@ -529,17 +530,6 @@ class SignupPage extends React.Component {
         const errorClassName = this.state.errors?.checkbox ? 'gh-portal-error' : '';
 
         const className = `gh-portal-signup-terms ${errorClassName}`;
-
-        const interceptAnchorClicks = (e) => {
-            if (e.currentTarget.contains(e.target)) {
-                const anchor = e.target.closest('a');
-
-                if (anchor) {
-                    e.preventDefault();
-                    window.open(anchor.href, '_blank');
-                }
-            }
-        };
 
         return (
             <div className={className} onClick={interceptAnchorClicks}>

--- a/apps/portal/src/utils/links.js
+++ b/apps/portal/src/utils/links.js
@@ -1,0 +1,10 @@
+export const interceptAnchorClicks = (e) => {
+    if (e.currentTarget.contains(e.target)) {
+        const anchor = e.target.closest('a');
+
+        if (anchor) {
+            e.preventDefault();
+            window.open(anchor.href, '_blank');
+        }
+    }
+};


### PR DESCRIPTION
fixes https://github.com/TryGhost/Product/issues/4222
fixes PROD-197

- links in signup terms were not opening properly, as we open Portal within an iframe
- the previous fix in place did not work anymore, as the HTML structure of the signup terms has changed
