### PR TITLE
Added metrics for measuring members importer

### DIFF
--- a/ghost/members-importer/package.json
+++ b/ghost/members-importer/package.json
@@ -28,6 +28,7 @@
     "@tryghost/errors": "1.2.26",
     "@tryghost/logging": "2.4.8",
     "@tryghost/members-csv": "0.0.0",
+    "@tryghost/metrics": "1.0.27",
     "@tryghost/tpl": "0.1.26",
     "moment-timezone": "0.5.23"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,7 +2670,7 @@
 
 "@elastic/elasticsearch@8.10.0", "@elastic/elasticsearch@8.5.0":
   version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-8.5.0.tgz#407aee0950a082ee76735a567f2571cf4301d4ea"
+  resolved "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.5.0.tgz#407aee0950a082ee76735a567f2571cf4301d4ea"
   integrity sha512-iOgr/3zQi84WmPhAplnK2W13R89VXD2oc6WhlQmH3bARQwmI+De23ZJKBEn7bvuG/AHMAqasPXX7uJIiJa2MqQ==
   dependencies:
     "@elastic/transport" "^8.2.0"
@@ -2678,7 +2678,7 @@
 
 "@elastic/transport@^8.2.0":
   version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.3.4.tgz#43c852e848dc8502bbd7f23f2d61bd5665cded99"
+  resolved "https://registry.npmjs.org/@elastic/transport/-/transport-8.3.4.tgz#43c852e848dc8502bbd7f23f2d61bd5665cded99"
   integrity sha512-+0o8o74sbzu3BO7oOZiP9ycjzzdOt4QwmMEjFc1zfO7M0Fh7QX1xrpKqZbSd8vBwihXNlSq/EnMPfgD2uFEmFg==
   dependencies:
     debug "^4.3.4"


### PR DESCRIPTION
fixes https://linear.app/tryghost/issue/PROD-199/add-metrics-for-members-importer

- we know the members importer is slow but we need metrics to prove it
- this should collect import count, error count + runtime for the members importer, so we can analyze the data