### PR TITLE
Added Sentry performance monitoring to Ghost Server

### DIFF
--- a/ghost/core/core/app.js
+++ b/ghost/core/core/app.js
@@ -30,8 +30,9 @@ const maintenanceMiddleware = (req, res, next) => {
 const rootApp = () => {
     const app = express('root');
     app.use(sentry.requestHandler);
-    app.use(sentry.tracingHandler);
-
+    if (config.get('sentry')?.tracing?.enabled === true) {
+        app.use(sentry.tracingHandler);
+    }
     app.enable('maintenance');
     app.use(maintenanceMiddleware);
 

--- a/ghost/core/core/app.js
+++ b/ghost/core/core/app.js
@@ -31,6 +31,8 @@ const rootApp = () => {
     const app = express('root');
     app.use(sentry.requestHandler);
 
+    app.use(sentry.tracingHandler)
+
     app.enable('maintenance');
     app.use(maintenanceMiddleware);
 

--- a/ghost/core/core/app.js
+++ b/ghost/core/core/app.js
@@ -30,8 +30,7 @@ const maintenanceMiddleware = (req, res, next) => {
 const rootApp = () => {
     const app = express('root');
     app.use(sentry.requestHandler);
-
-    app.use(sentry.tracingHandler)
+    app.use(sentry.tracingHandler);
 
     app.enable('maintenance');
     app.use(maintenanceMiddleware);

--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -59,17 +59,18 @@ if (sentryConfig && !sentryConfig.disabled) {
     const Sentry = require('@sentry/node');
     const version = require('@tryghost/version').full;
     const environment = config.get('env');
+    const tracesSampleRate = parseFloat(sentryConfig.tracesSampleRate) || 0.0;
     Sentry.init({
         dsn: sentryConfig.dsn,
         integrations: [
             new Sentry.Integrations.Http({tracing: true}),
             new Sentry.Integrations.Express()
         ],
-        tracesSampleRate: 1.0,
         release: 'ghost@' + version,
         environment: environment,
         maxValueLength: 1000,
-        beforeSend: beforeSend
+        beforeSend,
+        tracesSampleRate
     });
 
     module.exports = {

--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -61,6 +61,11 @@ if (sentryConfig && !sentryConfig.disabled) {
     const environment = config.get('env');
     Sentry.init({
         dsn: sentryConfig.dsn,
+        integrations: [
+            new Sentry.Integrations.Http({tracing: true}),
+            new Sentry.Integrations.Express()
+        ],
+        tracesSampleRate: 1.0,
         release: 'ghost@' + version,
         environment: environment,
         maxValueLength: 1000,
@@ -82,6 +87,7 @@ if (sentryConfig && !sentryConfig.disabled) {
                 return (error.statusCode === 500);
             }
         }),
+        tracingHandler: Sentry.Handlers.tracingHandler(),
         captureException: Sentry.captureException,
         beforeSend: beforeSend
     };
@@ -95,6 +101,7 @@ if (sentryConfig && !sentryConfig.disabled) {
     module.exports = {
         requestHandler: expressNoop,
         errorHandler: expressNoop,
+        tracingHandler: expressNoop,
         captureException: noop
     };
 }


### PR DESCRIPTION
refs ARCH-21

- We currently have NewRelic setup for a few of our largest customers for monitoring performance, but it is too expensive to enable across all sites
- Sentry has similar (but simpler) performance monitoring tools to keep track of response times that are available to us for free, but we just haven't configured them
- This PR sets up Sentry Performance monitoring for API requests so we can have one place for monitoring errors + performance so we can stay on top of response times more easily.
- Tracing is disabled by default, so there is no additional overhead unless `sentry.tracing.enabled` is set to `true` in the site's config. Additionally, `sentry.tracing.sampleRate` should be set to a decimal value between 0 and 1. This value defaults to 0 to avoid accidentally blowing through quota, and requires a value to explicitly be set in order to send the traces to Sentry.