### PR TITLE
Configured Nx watch to run in an infinite loop

### DIFF
--- a/.github/scripts/dev.js
+++ b/.github/scripts/dev.js
@@ -45,7 +45,7 @@ const COMMAND_ADMIN = {
 
 const COMMAND_TYPESCRIPT = {
     name: 'ts',
-    command: 'nx watch --projects=ghost/collections,ghost/in-memory-repository,ghost/bookshelf-repository,ghost/mail-events,ghost/model-to-domain-event-interceptor,ghost/post-revisions,ghost/nql-filter-expansions,ghost/post-events,ghost/donations,ghost/recommendations,ghost/email-addresses -- nx run \\$NX_PROJECT_NAME:build:ts',
+    command: 'while [ 1 ]; do nx watch --projects=ghost/collections,ghost/in-memory-repository,ghost/bookshelf-repository,ghost/mail-events,ghost/model-to-domain-event-interceptor,ghost/post-revisions,ghost/nql-filter-expansions,ghost/post-events,ghost/donations,ghost/recommendations,ghost/email-addresses -- nx run \\$NX_PROJECT_NAME:build:ts; done',
     cwd: path.resolve(__dirname, '../../'),
     prefixColor: 'cyan',
     env: {}
@@ -55,7 +55,7 @@ const adminXApps = '@tryghost/admin-x-demo,@tryghost/admin-x-settings';
 
 const COMMANDS_ADMINX = [{
     name: 'adminXDeps',
-    command: 'nx watch --projects=apps/admin-x-design-system,apps/admin-x-framework -- nx run \\$NX_PROJECT_NAME:build --skip-nx-cache',
+    command: 'while [ 1 ]; do nx watch --projects=apps/admin-x-design-system,apps/admin-x-framework -- nx run \\$NX_PROJECT_NAME:build --skip-nx-cache; done',
     cwd: path.resolve(__dirname, '../..'),
     prefixColor: '#C35831',
     env: {}


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C02G9E68C/p1701939292474999?thread_ts=1701881060.000299&cid=C02G9E68C

- when you change branch or do a `git pull`, Nx will kill the watch command
- this becomes annoying when you're doing local development because it tears down the whole `yarn dev` command
- this puts the nx watch command in an infinite loop so it's just restart again and concurrently doesn't detect it as a failure
