### PR TITLE
Enabled app build artifact caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ env:
     ${{ github.workspace }}/ghost/*/node_modules
     ~/.cache/ms-playwright/
   CACHED_BUILD_PATHS: |
+    ${{ github.workspace }}/apps/*/dist
+    ${{ github.workspace }}/apps/*/es
+    ${{ github.workspace }}/apps/*/umd
     ${{ github.workspace }}/ghost/*/build
   NX_CACHE_RESTORE_KEYS: |
     nx-Linux-${{ github.ref }}-${{ github.sha }}
@@ -183,7 +186,7 @@ jobs:
 
       - name: Build packages
         if: steps.cache_built_packages.outputs.cache-hit != 'true'
-        run: yarn nx run-many -t build:ts
+        run: yarn nx run-many -t build:ts && yarn nx run-many -t build -p apps/*
     outputs:
       dependency_cache_key: ${{ env.cachekey }}
 


### PR DESCRIPTION
fixes https://github.com/TryGhost/DevOps/issues/120

- we've seen errors in CI where the unit tests for the apps folder are being run concurrently, but the build assets are not present so multiple builds are happening for the same folder
- this leads to errors because Vite tries to cleanup or build folders at the same time
- this should fix that by eagerly building the apps and caching the output so unit tests run quicker
