### PR TITLE
Added default build output folders to Nx config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -22,6 +22,13 @@
         ]
     },
     "targetDefaults": {
+        "build": {
+            "outputs": [
+                "{projectRoot}/dist",
+                "{projectRoot}/es",
+                "{projectRoot}/umd"
+            ]
+        },
         "build:ts": {
             "dependsOn": [
                 "^build:ts"


### PR DESCRIPTION
refs https://ghost.slack.com/archives/C0568LN2CGJ/p1702302128529339

- Nx doesn't know the what the output of these apps is, so it can't restore the cache
- this adds the 3 folders which we use to output the build assets