### PR TITLE
Fixed theme template picker state syncing with AdminX

### DIFF
--- a/ghost/admin/app/components/admin-x/admin-x-component.js
+++ b/ghost/admin/app/components/admin-x/admin-x-component.js
@@ -179,7 +179,12 @@ export default class AdminXComponent extends Component {
             const activated = response.themes.find(theme => theme.active);
 
             if (activated) {
-                this.themeManagement.activeTheme = this.store.peekAll('theme').filterBy('name', activated.name).firstObject;
+                const previouslyActive = this.store.peekAll('theme').find(theme => theme.active && theme.name !== activated.name);
+                previouslyActive?.set('active', false);
+
+                const newlyActive = this.store.peekAll('theme').filterBy('name', activated.name).firstObject;
+                newlyActive?.set('active', true);
+                this.themeManagement.activeTheme = newlyActive;
             }
         }
     };


### PR DESCRIPTION
refs PROD-235

Special case where we need to set the old theme to inactive after activating a new theme.