### PR TITLE
Fixed offers asc/desc sorting not updating in component

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
@@ -249,9 +249,9 @@ export const OffersIndexModal = () => {
                         <SortMenu
                             direction={sortDirection as 'asc' | 'desc'}
                             items={[
-                                {id: 'date-added', label: 'Date added', selected: sortOption === 'date-added', direction: 'desc'},
-                                {id: 'name', label: 'Name', selected: sortOption === 'name', direction: 'asc'},
-                                {id: 'redemptions', label: 'Redemptions', selected: sortOption === 'redemptions', direction: 'desc'}
+                                {id: 'date-added', label: 'Date added', selected: sortOption === 'date-added', direction: sortDirection as 'asc' | 'desc'},
+                                {id: 'name', label: 'Name', selected: sortOption === 'name', direction: sortDirection as 'asc' | 'desc'},
+                                {id: 'redemptions', label: 'Redemptions', selected: sortOption === 'redemptions', direction: sortDirection as 'asc' | 'desc'}
                             ]}
                             position='right'
                             onDirectionChange={(selectedDirection) => {

--- a/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/OffersIndex.tsx
@@ -247,7 +247,7 @@ export const OffersIndexModal = () => {
                     <h1 className='text-3xl'>{offersTabs.find(tab => tab.id === selectedTab)?.title} offers</h1>
                     <div className='-mr-3'>
                         <SortMenu
-                            direction='desc'
+                            direction={sortDirection as 'asc' | 'desc'}
                             items={[
                                 {id: 'date-added', label: 'Date added', selected: sortOption === 'date-added', direction: 'desc'},
                                 {id: 'name', label: 'Name', selected: sortOption === 'name', direction: 'asc'},


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/PROD-8/when-i-sort-by-name-→-click-into-an-offer-→-go-back-to-the-list-it
