### PR TITLE
Enabled persistent filesystem caching for Ember builds

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -214,6 +214,14 @@ module.exports = function (defaults) {
                         fs: false
                     }
                 },
+                ...(isDevelopment && {
+                    cache: {
+                        type: 'filesystem',
+                        buildDependencies: {
+                            config: [__filename]
+                        }
+                    }
+                }),
                 plugins: [
                     new webpack.ProvidePlugin({
                         process: 'process/browser'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dev:admin": "node .github/scripts/dev.js --admin",
     "dev:ghost": "node .github/scripts/dev.js --ghost",
     "dev": "node .github/scripts/dev.js",
-    "fix": "yarn cache clean && rm -rf node_modules && yarn",
+    "fix": "yarn cache clean && rimraf -g '**/node_modules' && yarn",
     "knex-migrator": "yarn workspace ghost run knex-migrator",
     "setup": "yarn && git submodule update --init && NODE_ENV=development node .github/scripts/setup.js",
     "reset:data": "cd ghost/core && node index.js generate-data --clear-database --quantities members:100,posts:1 --seed 123",


### PR DESCRIPTION
fixes https://github.com/TryGhost/DevOps/issues/123

- ember-auto-import supports webpack v5 and v5 supports persistent file caching
- this stores a cache of built files across warm boots, so Admin built via `yarn dev` should be faster next time
- also ensures that recursive `node_modules` folders are emptied upon `yarn fix`, as the webpack cache is stored in `node_modules` under `ghost/admin`
- locally, this speeds up a warm build by 2x (!)
