### PR TITLE
🐛 Fixed hang in editor when back button is pressed whilst feature image caption is focused

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -415,7 +415,7 @@ export default class LexicalEditorController extends Controller {
 
     @action
     handleFeatureImageCaptionBlur() {
-        if (this.post.isDraft) {
+        if (this.post?.isDraft) {
             this.autosaveTask.perform();
         }
     }


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4228

- when leaving the editor via back button the feature image caption editor's blur handler was called by the React editor component after Ember had torn down the route resulting in an attempt to use `post.set()` when `post` doesn't exist
- the error also caused Lexical to re-render to try and recover which then triggered the blur handler again resulting in an infinite loop
- adding a check to ensure `this.post` exists was enough to fix the problem
