### PR TITLE
Fixed error when deleting post

### DIFF
--- a/ghost/admin/app/controllers/lexical-editor.js
+++ b/ghost/admin/app/controllers/lexical-editor.js
@@ -415,7 +415,11 @@ export default class LexicalEditorController extends Controller {
 
     @action
     handleFeatureImageCaptionBlur() {
-        if (this.post?.isDraft) {
+        if (!this.post || this.post.isDestroyed || this.post.isDestroying) {
+            return;
+        }
+
+        if (this.post.isDraft) {
             this.autosaveTask.perform();
         }
     }
@@ -615,6 +619,10 @@ export default class LexicalEditorController extends Controller {
 
     @task
     *beforeSaveTask(options = {}) {
+        if (this.post?.isDestroyed || this.post?.isDestroying) {
+            return;
+        }
+
         // ensure we remove any blank cards when performing a full save
         if (!options.backgroundSave) {
             // TODO: not yet implemented in react editor


### PR DESCRIPTION
closes https://github.com/TryGhost/Product/issues/4230

- deleting a post could cause React components to trigger save tasks during teardown which then threw errors because they attempt to set properties on a deleted model instance
- added checks to the `beforeSaveTask()` to abort if the post object has been deleted
