### PR TITLE
Wired up Docker setup script and increased data generation performance

### DIFF
--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:8.0.35
     container_name: ghost-mysql
     ports:
-      - "3307:3306"
+      - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: ghost

--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:8.0.35
     container_name: ghost-mysql
     ports:
-      - "3306:3306"
+      - "3307:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: ghost

--- a/.github/scripts/docker-compose.yml
+++ b/.github/scripts/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   mysql:
     image: mysql:8.0.35
     container_name: ghost-mysql
+    # We'll need to look into how we can further fine tune the memory usage/performance here
+    command: --innodb-buffer-pool-size=1G --innodb-log-buffer-size=500M --innodb-change-buffer-max-size=50 --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT
     ports:
       - "3306:3306"
     environment:

--- a/.github/scripts/setup.js
+++ b/.github/scripts/setup.js
@@ -77,8 +77,7 @@ async function runAndStream(command, args, options) {
                     host: '127.0.0.1',
                     user: 'root',
                     password: 'root',
-                    database: 'ghost',
-                    port: 3307
+                    database: 'ghost'
                 }
             };
 

--- a/ghost/core/core/cli/generate-data.js
+++ b/ghost/core/core/cli/generate-data.js
@@ -32,6 +32,8 @@ module.exports = class DataGeneratorCommand extends Command {
     }
 
     async handle(argv = {}) {
+        // If we can't stream, throw an error while creating the connection
+        process.env.REQUIRE_INFILE_STREAM = '1';
         const knex = require('../server/data/db/connection');
 
         const tables = (argv.tables ? argv.tables.split(',') : []).map(table => ({

--- a/ghost/core/core/server/data/db/connection.js
+++ b/ghost/core/core/server/data/db/connection.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const knex = require('knex');
 const os = require('os');
+const fs = require('fs');
 
 const logging = require('@tryghost/logging');
 const config = require('../../../shared/config');
@@ -45,6 +46,10 @@ function configure(dbConfig) {
         dbConfig.connection.timezone = 'Z';
         dbConfig.connection.charset = 'utf8mb4';
         dbConfig.connection.decimalNumbers = true;
+
+        //if (dbConfig.connection.allowLocalInfile) {
+        dbConfig.connection.infileStreamFactory = path => fs.createReadStream(path);
+        //}
     }
 
     return dbConfig;

--- a/ghost/core/core/server/data/db/connection.js
+++ b/ghost/core/core/server/data/db/connection.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 
 const logging = require('@tryghost/logging');
 const config = require('../../../shared/config');
-let errors = require('@tryghost/errors');
+const errors = require('@tryghost/errors');
 let knexInstance;
 
 // @TODO:

--- a/ghost/core/core/server/data/db/connection.js
+++ b/ghost/core/core/server/data/db/connection.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 
 const logging = require('@tryghost/logging');
 const config = require('../../../shared/config');
+let errors = require('@tryghost/errors');
 let knexInstance;
 
 // @TODO:
@@ -47,9 +48,13 @@ function configure(dbConfig) {
         dbConfig.connection.charset = 'utf8mb4';
         dbConfig.connection.decimalNumbers = true;
 
-        //if (dbConfig.connection.allowLocalInfile) {
-        dbConfig.connection.infileStreamFactory = path => fs.createReadStream(path);
-        //}
+        if (process.env.REQUIRE_INFILE_STREAM) {
+            if (process.env.NODE_ENV === 'development' || process.env.ALLOW_INFILE_STREAM) {
+                dbConfig.connection.infileStreamFactory = path => fs.createReadStream(path);
+            } else {
+                throw new errors.InternalServerError({message: 'MySQL infile streaming is required to run the current process, but is not allowed. Run the script in development mode or set ALLOW_INFILE_STREAM=1.'});
+            }
+        }
     }
 
     return dbConfig;

--- a/ghost/data-generator/lib/DataGenerator.js
+++ b/ghost/data-generator/lib/DataGenerator.js
@@ -32,8 +32,7 @@ class DataGenerator {
         printDependencies,
         withDefault,
         seed,
-        quantities = {},
-        useCache = false
+        quantities = {}
     }) {
         this.knex = knex;
         this.tableList = tables || [];
@@ -46,7 +45,6 @@ class DataGenerator {
         this.printDependencies = printDependencies;
         this.seed = seed;
         this.quantities = quantities;
-        this.useCache = useCache;
     }
 
     sortTableList() {
@@ -240,9 +238,7 @@ class DataGenerator {
                     const amount = table.quantity ?? tableImporter.defaultQuantity;
                     this.logger.info('Importing content for table', table.name, amount ? `(${amount} records)` : '');
 
-                    if (!this.useCache || !(await tableImporter.reuseCacheIfPossible(table.quantity ?? undefined))) {
-                        await tableImporter.import(table.quantity ?? undefined);
-                    }
+                    await tableImporter.import(table.quantity ?? undefined);
                 }
             } finally {
                 if (this.seed) {

--- a/ghost/data-generator/lib/importers/BenefitsImporter.js
+++ b/ghost/data-generator/lib/importers/BenefitsImporter.js
@@ -17,7 +17,7 @@ class BenefitsImporter extends TableImporter {
         const sixMonthsLater = new Date(blogStartDate);
         sixMonthsLater.setMonth(sixMonthsLater.getMonth() + 6);
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             name: name,
             slug: `${slugify(name)}-${faker.random.numeric(3)}`,
             created_at: faker.date.between(blogStartDate, sixMonthsLater)

--- a/ghost/data-generator/lib/importers/EmailBatchesImporter.js
+++ b/ghost/data-generator/lib/importers/EmailBatchesImporter.js
@@ -25,7 +25,7 @@ class EmailBatchesImporter extends TableImporter {
         latestUpdatedDate.setHours(latestUpdatedDate.getHours() + 1);
 
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             email_id: this.model.id,
             provider_id: `${new Date().toISOString().split('.')[0].replace(/[^0-9]/g, '')}.${faker.datatype.hexadecimal({length: 16, prefix: '', case: 'lower'})}@m.example.com`,
             status: 'submitted', // TODO: introduce failures

--- a/ghost/data-generator/lib/importers/EmailRecipientFailuresImporter.js
+++ b/ghost/data-generator/lib/importers/EmailRecipientFailuresImporter.js
@@ -53,7 +53,7 @@ class EmailRecipientFailuresImporter extends TableImporter {
         const error = faker.helpers.arrayElement(errors);
 
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             email_id: this.model.email_id,
             member_id: this.model.member_id,
             email_recipient_id: this.model.id,

--- a/ghost/data-generator/lib/importers/EmailRecipientsImporter.js
+++ b/ghost/data-generator/lib/importers/EmailRecipientsImporter.js
@@ -154,10 +154,7 @@ class EmailRecipientsImporter extends TableImporter {
     }
 
     generate() {
-        let timestamp = this.events[this.eventIndex];
-        const memberId = this.membersList[this.eventIndex];
-        this.eventIndex += 1;
-
+        let timestamp = this.events.pop();
         if (!timestamp) {
             return;
         }
@@ -169,6 +166,7 @@ class EmailRecipientsImporter extends TableImporter {
             timestamp = new Date();
         }
 
+        const memberId = this.membersList[this.events.length];
         const member = this.members.get(memberId);
 
         let status = emailStatus.none;

--- a/ghost/data-generator/lib/importers/EmailRecipientsImporter.js
+++ b/ghost/data-generator/lib/importers/EmailRecipientsImporter.js
@@ -104,6 +104,11 @@ class EmailRecipientsImporter extends TableImporter {
             if (!this.membersSubscribeEventsCreatedAtsByNewsletterId.has(memberSubscribeEvent.newsletter_id)) {
                 this.membersSubscribeEventsCreatedAtsByNewsletterId.set(memberSubscribeEvent.newsletter_id, []);
             }
+
+            if (!(memberSubscribeEvent.created_at instanceof Date)) {
+                // SQLite fix
+                memberSubscribeEvent.created_at = new Date(memberSubscribeEvent.created_at);
+            }
             this.membersSubscribeEventsCreatedAtsByNewsletterId.get(memberSubscribeEvent.newsletter_id).push(memberSubscribeEvent.created_at.getTime());
         }
 

--- a/ghost/data-generator/lib/importers/EmailsImporter.js
+++ b/ghost/data-generator/lib/importers/EmailsImporter.js
@@ -13,15 +13,16 @@ class EmailsImporter extends TableImporter {
     }
 
     async import(quantity) {
-        const posts = await this.transaction.select('id', 'title', 'published_at').from('posts').where('type', 'post');
+        const posts = await this.transaction.select('id', 'title', 'published_at').from('posts').where('type', 'post').where('status', 'published').orderBy('published_at', 'desc');
         this.newsletters = await this.transaction.select('id').from('newsletters').orderBy('sort_order');
         this.membersSubscribeEvents = await this.transaction.select('id', 'newsletter_id', 'created_at').from('members_subscribe_events');
 
-        await this.importForEach(posts, quantity ? quantity / posts.length : 1);
+        // Only generate emails for last 25% of posts, and only generate emails for 50% of those
+        await this.importForEach(posts.slice(0, Math.ceil(posts.length / 4)), quantity ? quantity / posts.length : 0.5);
     }
 
     generate() {
-        const id = faker.database.mongodbObjectId();
+        const id = this.fastFakeObjectId();
 
         let newsletter;
         if (this.newsletters.length === 0) {

--- a/ghost/data-generator/lib/importers/LabelsImporter.js
+++ b/ghost/data-generator/lib/importers/LabelsImporter.js
@@ -27,7 +27,7 @@ class LabelsImporter extends TableImporter {
     generate() {
         const name = this.generateName();
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             name: name,
             slug: `${slugify(name)}`,
             created_at: dateToDatabaseString(blogStartDate),

--- a/ghost/data-generator/lib/importers/MembersClickEventsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersClickEventsImporter.js
@@ -12,10 +12,24 @@ class MembersClickEventsImporter extends TableImporter {
     }
 
     async import(quantity) {
-        const emailRecipients = await this.transaction.select('id', 'opened_at', 'email_id', 'member_id').from('email_recipients');
-        this.redirects = await this.transaction.select('id', 'post_id').from('redirects');
-        this.emails = await this.transaction.select('id', 'post_id').from('emails');
+        const emailRecipients = await this.transaction.select('id', 'opened_at', 'email_id', 'member_id').from('email_recipients').whereNotNull('opened_at');
+        const redirects = await this.transaction.select('id', 'post_id').from('redirects');
+        const emails = await this.transaction.select('id', 'post_id').from('emails');
         this.quantity = quantity ? quantity / emailRecipients.length : 2;
+
+        // Create maps for faster lookups (this does make a difference for large data generation)
+        this.emails = new Map();
+        for (const email of emails) {
+            this.emails.set(email.id, email);
+        }
+
+        this.redirects = new Map();
+        for (const redirect of redirects) {
+            if (!this.redirects.has(redirect.post_id)) {
+                this.redirects.set(redirect.post_id, []);
+            }
+            this.redirects.get(redirect.post_id).push(redirect);
+        }
 
         await this.importForEach(emailRecipients, this.quantity);
     }
@@ -26,28 +40,27 @@ class MembersClickEventsImporter extends TableImporter {
             min: 0,
             max: this.quantity
         }) : 0;
-        const email = this.emails.find(e => e.id === this.model.email_id);
-        this.redirectList = this.redirects.filter(redirect => redirect.post_id === email.post_id);
+        const email = this.emails.get(model.email_id);
+        this.redirectList = this.redirects.get(email.post_id) ?? [];
     }
 
     generate() {
-        if (this.amount <= 0 || this.redirectList.length === 0) {
+        if (this.amount <= 0 || this.redirectList.length === 0 || !this.model.opened_at) {
             return;
         }
         this.amount -= 1;
 
         const openedAt = new Date(this.model.opened_at);
-        const laterOn = new Date(this.model.opened_at);
-        laterOn.setMinutes(laterOn.getMinutes() + 15);
-        const clickTime = new Date(openedAt.valueOf() + (Math.random() * (laterOn.valueOf() - openedAt.valueOf())));
+        const laterOn = new Date(openedAt.getTime() + 1000 * 60 * 15);
+        const clickTime = faker.date.between(openedAt.getTime(), laterOn.getTime()); //added getTime here because it threw random errors
 
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             member_id: this.model.member_id,
-            redirect_id: this.redirectList[faker.datatype.number({
+            redirect_id: this.redirectList[this.redirectList.length === 1 ? 0 : (faker.datatype.number({
                 min: 0,
                 max: this.redirectList.length - 1
-            })].id,
+            }))].id,
             created_at: dateToDatabaseString(clickTime)
         };
     }

--- a/ghost/data-generator/lib/importers/MembersCreatedEventsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersCreatedEventsImporter.js
@@ -1,6 +1,7 @@
 const TableImporter = require('./TableImporter');
 const {faker} = require('@faker-js/faker');
 const {luck} = require('../utils/random');
+const dateToDatabaseString = require('../utils/database-date');
 
 class MembersCreatedEventsImporter extends TableImporter {
     static table = 'members_created_events';
@@ -79,8 +80,8 @@ class MembersCreatedEventsImporter extends TableImporter {
         }
 
         return {
-            id: faker.database.mongodbObjectId(),
-            created_at: this.model.created_at,
+            id: this.fastFakeObjectId(),
+            created_at: dateToDatabaseString(this.model.created_at),
             member_id: this.model.id,
             source,
             ...attribution,

--- a/ghost/data-generator/lib/importers/MembersCreatedEventsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersCreatedEventsImporter.js
@@ -33,8 +33,18 @@ class MembersCreatedEventsImporter extends TableImporter {
 
     generate() {
         const source = this.generateSource();
-        let attribution = {};
-        let referrer = {};
+
+        // We need to add all properties here already otherwise CSV imports won't know all the columns
+        let attribution = {
+            attribution_id: null,
+            attribution_type: null,
+            attribution_url: null
+        };
+        let referrer = {
+            referrer_source: null,
+            referrer_url: null,
+            referrer_medium: null
+        };
 
         if (source === 'member' && luck(30)) {
             const post = this.posts.find(p => p.visibility === 'public' && new Date(p.published_at) < new Date(this.model.created_at));

--- a/ghost/data-generator/lib/importers/MembersFeedbackImporter.js
+++ b/ghost/data-generator/lib/importers/MembersFeedbackImporter.js
@@ -28,11 +28,11 @@ class MembersFeedbackImporter extends TableImporter {
         const openedAt = new Date(this.model.opened_at);
         const laterOn = new Date(this.model.opened_at);
         laterOn.setMinutes(laterOn.getMinutes() + 60);
-        const feedbackTime = new Date(openedAt.valueOf() + (Math.random() * (laterOn.valueOf() - openedAt.valueOf())));
+        const feedbackTime = faker.date.between(openedAt, laterOn);
 
         const postId = this.emails.find(email => email.id === this.model.email_id).post_id;
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             score: luck(70) ? 1 : 0,
             member_id: this.model.member_id,
             post_id: postId,

--- a/ghost/data-generator/lib/importers/MembersImporter.js
+++ b/ghost/data-generator/lib/importers/MembersImporter.js
@@ -5,6 +5,7 @@ const {blogStartDate: startTime} = require('../utils/blog-info');
 const generateEvents = require('../utils/event-generator');
 const {luck} = require('../utils/random');
 const dateToDatabaseString = require('../utils/database-date');
+const debug = require('@tryghost/debug')('MembersImporter');
 
 class MembersImporter extends TableImporter {
     static table = 'members';
@@ -19,6 +20,8 @@ class MembersImporter extends TableImporter {
     }
 
     async import(quantity = this.defaultQuantity) {
+        const generateNow = Date.now();
+
         this.timestamps = generateEvents({
             shape: 'ease-in',
             trend: 'positive',
@@ -26,6 +29,7 @@ class MembersImporter extends TableImporter {
             startTime,
             endTime: new Date()
         }).sort();
+        debug(`${this.name} generated ${this.timestamps.length} timestamps in ${Date.now() - generateNow}ms`);
 
         await super.import(quantity);
     }
@@ -62,10 +66,10 @@ class MembersImporter extends TableImporter {
     }
 
     generate() {
-        const id = faker.database.mongodbObjectId();
+        const id = this.fastFakeObjectId();
         // Use name from American locale to reflect an English-speaking audience
         const name = `${americanFaker.name.firstName()} ${americanFaker.name.lastName()}`;
-        const timestamp = this.timestamps.shift();
+        const timestamp = this.timestamps.pop();
 
         return {
             id,

--- a/ghost/data-generator/lib/importers/MembersLabelsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersLabelsImporter.js
@@ -25,7 +25,7 @@ class MembersLabelsImporter extends TableImporter {
         }
         // TODO: Ensure we don't generate the same member label twice
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             member_id: this.model.id,
             label_id: this.labels[faker.datatype.number({
                 min: 0,

--- a/ghost/data-generator/lib/importers/MembersLoginEventsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersLoginEventsImporter.js
@@ -31,20 +31,20 @@ class MembersLoginEventsImporter extends TableImporter {
             trend: 'negative',
             // Steady readers login more, readers who lose interest read less overall.
             // ceil because members will all have logged in at least once
-            total: shape === 'flat' ? Math.ceil(daysBetween / 3) : Math.ceil(daysBetween / 7),
+            total: Math.min(5, shape === 'flat' ? Math.ceil(daysBetween / 3) : Math.ceil(daysBetween / 7)),
             startTime: new Date(model.created_at),
             endTime: endDate
         });
     }
 
     generate() {
-        const timestamp = this.timestamps.shift();
+        const timestamp = this.timestamps.pop();
         if (!timestamp) {
             // Out of events for this user
             return null;
         }
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             created_at: dateToDatabaseString(timestamp),
             member_id: this.model.id
         };

--- a/ghost/data-generator/lib/importers/MembersLoginEventsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersLoginEventsImporter.js
@@ -1,5 +1,4 @@
 const TableImporter = require('./TableImporter');
-const {faker} = require('@faker-js/faker');
 const {luck} = require('../utils/random');
 const generateEvents = require('../utils/event-generator');
 const dateToDatabaseString = require('../utils/database-date');

--- a/ghost/data-generator/lib/importers/MembersNewslettersImporter.js
+++ b/ghost/data-generator/lib/importers/MembersNewslettersImporter.js
@@ -17,7 +17,7 @@ class MembersNewslettersImporter extends TableImporter {
 
     generate() {
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             member_id: this.model.member_id,
             newsletter_id: this.model.newsletter_id
         };

--- a/ghost/data-generator/lib/importers/MembersNewslettersImporter.js
+++ b/ghost/data-generator/lib/importers/MembersNewslettersImporter.js
@@ -1,4 +1,3 @@
-const {faker} = require('@faker-js/faker');
 const TableImporter = require('./TableImporter');
 
 class MembersNewslettersImporter extends TableImporter {

--- a/ghost/data-generator/lib/importers/MembersPaidSubscriptionEventsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersPaidSubscriptionEventsImporter.js
@@ -1,5 +1,4 @@
 const TableImporter = require('./TableImporter');
-const {faker} = require('@faker-js/faker');
 
 class MembersPaidSubscriptionEventsImporter extends TableImporter {
     static table = 'members_paid_subscription_events';

--- a/ghost/data-generator/lib/importers/MembersPaidSubscriptionEventsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersPaidSubscriptionEventsImporter.js
@@ -11,8 +11,12 @@ class MembersPaidSubscriptionEventsImporter extends TableImporter {
 
     async import() {
         const subscriptions = await this.transaction.select('id', 'customer_id', 'plan_currency', 'plan_amount', 'created_at', 'plan_id', 'status', 'cancel_at_period_end', 'current_period_end').from('members_stripe_customers_subscriptions');
-        this.membersStripeCustomers = await this.transaction.select('id', 'member_id', 'customer_id').from('members_stripe_customers');
+        const membersStripeCustomers = await this.transaction.select('id', 'member_id', 'customer_id').from('members_stripe_customers');
 
+        this.membersStripeCustomers = new Map();
+        for (const customer of membersStripeCustomers) {
+            this.membersStripeCustomers.set(customer.customer_id, customer);
+        }
         await this.importForEach(subscriptions, 2);
     }
 
@@ -58,7 +62,7 @@ class MembersPaidSubscriptionEventsImporter extends TableImporter {
             return;
         }
 
-        const memberCustomer = this.membersStripeCustomers.find(c => c.customer_id === this.model.customer_id);
+        const memberCustomer = this.membersStripeCustomers.get(this.model.customer_id);
         const isMonthly = this.model.plan_interval === 'month';
 
         // Note that we need to recalculate the MRR, because it will be zero for inactive subscrptions
@@ -66,7 +70,7 @@ class MembersPaidSubscriptionEventsImporter extends TableImporter {
 
         // todo: implement + MRR and -MRR in case of inactive subscriptions
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             // TODO: Support expired / updated / cancelled events too
             type: this.count === 1 ? 'created' : this.getStatus(this.model),
             member_id: memberCustomer.member_id,

--- a/ghost/data-generator/lib/importers/MembersProductsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersProductsImporter.js
@@ -30,7 +30,7 @@ class MembersProductsImporter extends TableImporter {
 
     generate() {
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             member_id: this.model.id,
             product_id: this.getProduct().id,
             sort_order: 0,

--- a/ghost/data-generator/lib/importers/MembersStatusEventsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersStatusEventsImporter.js
@@ -18,15 +18,15 @@ class MembersStatusEventsImporter extends TableImporter {
 
     setReferencedModel(model) {
         this.events = [{
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             member_id: model.id,
             from_status: null,
             to_status: 'free',
-            created_at: model.created_at
+            created_at: dateToDatabaseString(model.created_at)
         }];
         if (model.status !== 'free') {
             this.events.push({
-                id: faker.database.mongodbObjectId(),
+                id: this.fastFakeObjectId(),
                 member_id: model.id,
                 from_status: 'free',
                 to_status: model.status,
@@ -36,7 +36,7 @@ class MembersStatusEventsImporter extends TableImporter {
     }
 
     generate() {
-        const event = this.events.shift();
+        const event = this.events.pop();
         if (!event) {
             return null;
         }

--- a/ghost/data-generator/lib/importers/MembersStripeCustomersImporter.js
+++ b/ghost/data-generator/lib/importers/MembersStripeCustomersImporter.js
@@ -29,7 +29,7 @@ class MembersStripeCustomersImporter extends TableImporter {
         }
 
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             member_id: this.model.id,
             customer_id: `cus_${faker.random.alphaNumeric(14, {
                 casing: 'mixed'

--- a/ghost/data-generator/lib/importers/MembersSubscribeEventsImporter.js
+++ b/ghost/data-generator/lib/importers/MembersSubscribeEventsImporter.js
@@ -41,10 +41,10 @@ class MembersSubscribeEventsImporter extends TableImporter {
         const newsletterId = this.newsletters[count % this.newsletters.length].id;
 
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             member_id: this.model.id,
             newsletter_id: newsletterId,
-            subscribed: true,
+            subscribed: 1,
             created_at: createdAt,
             source: 'member'
         };

--- a/ghost/data-generator/lib/importers/NewslettersImporter.js
+++ b/ghost/data-generator/lib/importers/NewslettersImporter.js
@@ -24,7 +24,7 @@ class NewslettersImporter extends TableImporter {
         weekAfter.setDate(weekAfter.getDate() + 7);
 
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             uuid: faker.datatype.uuid(),
             name: name,
             slug: `${slugify(name)}-${faker.random.numeric(3)}`,

--- a/ghost/data-generator/lib/importers/OffersImporter.js
+++ b/ghost/data-generator/lib/importers/OffersImporter.js
@@ -22,7 +22,7 @@ class OffersImporter extends TableImporter {
     }
 
     generate() {
-        const name = this.names.shift();
+        const name = this.names.pop();
 
         const product = this.products[faker.datatype.number({
             min: 0,
@@ -47,7 +47,7 @@ class OffersImporter extends TableImporter {
         // created_at: {type: 'dateTime', nullable: false},
         // updated_at: {type: 'dateTime', nullable: true}
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             active: true,
             name,
             code: slugify(name),

--- a/ghost/data-generator/lib/importers/PostsAuthorsImporter.js
+++ b/ghost/data-generator/lib/importers/PostsAuthorsImporter.js
@@ -21,7 +21,7 @@ class PostsAuthorsImporter extends TableImporter {
         const sortOrder = this.sortOrder;
         this.sortOrder = this.sortOrder + 1;
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             post_id: this.model.id,
             author_id: this.users[faker.datatype.number(this.users.length - 1)].id,
             sort_order: sortOrder

--- a/ghost/data-generator/lib/importers/PostsImporter.js
+++ b/ghost/data-generator/lib/importers/PostsImporter.js
@@ -51,7 +51,7 @@ class PostsImporter extends TableImporter {
         const visibility = luck(85) ? 'paid' : luck(10) ? 'members' : 'public';
 
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             created_at: dateToDatabaseString(timestamp),
             created_by: '1',
             updated_at: dateToDatabaseString(timestamp),

--- a/ghost/data-generator/lib/importers/PostsProductsImporter.js
+++ b/ghost/data-generator/lib/importers/PostsProductsImporter.js
@@ -25,7 +25,7 @@ class PostsProductsImporter extends TableImporter {
         const sortOrder = this.sortOrder;
         this.sortOrder = this.sortOrder + 1;
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             post_id: this.model.id,
             product_id: this.products[sortOrder].id,
             sort_order: this.sortOrder

--- a/ghost/data-generator/lib/importers/PostsProductsImporter.js
+++ b/ghost/data-generator/lib/importers/PostsProductsImporter.js
@@ -1,4 +1,3 @@
-const {faker} = require('@faker-js/faker');
 const TableImporter = require('./TableImporter');
 
 class PostsProductsImporter extends TableImporter {

--- a/ghost/data-generator/lib/importers/PostsTagsImporter.js
+++ b/ghost/data-generator/lib/importers/PostsTagsImporter.js
@@ -35,7 +35,7 @@ class PostsTagsImporter extends TableImporter {
         this.notIndex.push(tagIndex);
 
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             post_id: this.model.id,
             tag_id: this.tags[tagIndex].id,
             sort_order: sortOrder

--- a/ghost/data-generator/lib/importers/ProductsBenefitsImporter.js
+++ b/ghost/data-generator/lib/importers/ProductsBenefitsImporter.js
@@ -1,4 +1,3 @@
-const {faker} = require('@faker-js/faker');
 const TableImporter = require('./TableImporter');
 
 class ProductsBenefitsImporter extends TableImporter {

--- a/ghost/data-generator/lib/importers/ProductsBenefitsImporter.js
+++ b/ghost/data-generator/lib/importers/ProductsBenefitsImporter.js
@@ -44,7 +44,7 @@ class ProductsBenefitsImporter extends TableImporter {
         const sortOrder = this.sortOrder;
         this.sortOrder = this.sortOrder + 1;
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             product_id: this.model.id,
             benefit_id: this.benefits[sortOrder].id,
             sort_order: sortOrder

--- a/ghost/data-generator/lib/importers/ProductsImporter.js
+++ b/ghost/data-generator/lib/importers/ProductsImporter.js
@@ -61,7 +61,7 @@ class ProductsImporter extends TableImporter {
     }
 
     generate() {
-        const name = this.names.shift();
+        const name = this.names.pop();
         const count = this.count;
         this.count = this.count + 1;
         const sixMonthsLater = new Date(blogStartDate);
@@ -78,7 +78,7 @@ class ProductsImporter extends TableImporter {
             tierInfo.yearly_price = count * 5000;
         }
         return Object.assign({}, {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             name: name,
             slug: `${slugify(name)}-${faker.random.numeric(3)}`,
             visibility: 'public',

--- a/ghost/data-generator/lib/importers/ProductsImporter.js
+++ b/ghost/data-generator/lib/importers/ProductsImporter.js
@@ -14,7 +14,7 @@ class ProductsImporter extends TableImporter {
 
     async import(quantity = this.defaultQuantity) {
         // TODO: Add random products if quantity != 4
-        this.names = ['Free', 'Bronze', 'Silver', 'Gold'];
+        this.names = ['Free', 'Bronze', 'Silver', 'Gold'].reverse();
         this.count = 0;
 
         await super.import(quantity);

--- a/ghost/data-generator/lib/importers/RecommendationClickEventsImporter.js
+++ b/ghost/data-generator/lib/importers/RecommendationClickEventsImporter.js
@@ -21,7 +21,7 @@ class RecommendationClickEventsImporter extends TableImporter {
         // Not unique
         const member = luck(30) ? null : faker.helpers.arrayElement(this.members);
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             recommendation_id: this.model.id,
             member_id: member?.id ?? null,
             created_at: faker.date.past()

--- a/ghost/data-generator/lib/importers/RecommendationSubscribeEventsImporter.js
+++ b/ghost/data-generator/lib/importers/RecommendationSubscribeEventsImporter.js
@@ -21,7 +21,7 @@ class RecommendationSubscribeEventsImporter extends TableImporter {
         // Not unique
         const member = luck(1) ? null : faker.helpers.arrayElement(this.members);
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             recommendation_id: this.model.id,
             member_id: member?.id ?? null,
             created_at: faker.date.past()

--- a/ghost/data-generator/lib/importers/RecommendationsImporter.js
+++ b/ghost/data-generator/lib/importers/RecommendationsImporter.js
@@ -15,7 +15,7 @@ class RecommendationsImporter extends TableImporter {
     }
 
     generate() {
-        const id = faker.database.mongodbObjectId();
+        const id = this.fastFakeObjectId();
         return {
             id,
             url: faker.internet.url(),

--- a/ghost/data-generator/lib/importers/RedirectsImporter.js
+++ b/ghost/data-generator/lib/importers/RedirectsImporter.js
@@ -36,7 +36,7 @@ class RedirectsImporter extends TableImporter {
         }
         this.amount -= 1;
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             from: `/r/${faker.datatype.hexadecimal({length: 32, prefix: '', case: 'lower'})}`,
             to: `${faker.internet.url()}/${faker.helpers.slugify(`${faker.word.adjective()} ${faker.word.noun()}`).toLowerCase()}`,
             post_id: this.model.id,

--- a/ghost/data-generator/lib/importers/RolesUsersImporter.js
+++ b/ghost/data-generator/lib/importers/RolesUsersImporter.js
@@ -32,7 +32,7 @@ class RolesUsersImporter extends TableImporter {
             return;
         }
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             role_id: actualRole.id,
             user_id: this.model.id
         };

--- a/ghost/data-generator/lib/importers/StripePricesImporter.js
+++ b/ghost/data-generator/lib/importers/StripePricesImporter.js
@@ -54,7 +54,7 @@ class StripePricesImporter extends TableImporter {
         }
 
         return Object.assign({}, {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             stripe_price_id: faker.datatype.hexadecimal({
                 length: 64,
                 prefix: ''

--- a/ghost/data-generator/lib/importers/StripeProductsImporter.js
+++ b/ghost/data-generator/lib/importers/StripeProductsImporter.js
@@ -20,7 +20,7 @@ class StripeProductsImporter extends TableImporter {
 
     generate() {
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             product_id: this.model.id,
             stripe_product_id: faker.datatype.hexadecimal({
                 length: 64,

--- a/ghost/data-generator/lib/importers/SubscriptionsImporter.js
+++ b/ghost/data-generator/lib/importers/SubscriptionsImporter.js
@@ -58,7 +58,7 @@ class SubscriptionsImporter extends TableImporter {
             }
         }
         return Object.assign({}, {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             type: status,
             status: 'active',
             member_id: this.model.member_id,

--- a/ghost/data-generator/lib/importers/TableImporter.js
+++ b/ghost/data-generator/lib/importers/TableImporter.js
@@ -1,4 +1,12 @@
 const debug = require('@tryghost/debug')('TableImporter');
+const dateToDatabaseString = require('../utils/database-date');
+const path = require('path');
+const createCsvWriter = require('csv-writer').createObjectCsvWriter;
+const fs = require('fs');
+const {luck} = require('../utils/random');
+const os = require('os');
+const errors = require('@tryghost/errors');
+const ObjectID = require('bson-objectid').default;
 
 class TableImporter {
     /**
@@ -21,6 +29,13 @@ class TableImporter {
         this.name = name;
         this.knex = knex;
         this.transaction = transaction;
+        this.index = 0;
+    }
+
+    fastFakeObjectId() {
+        // using faker.database.mongodbObjectId() is too slow (slow generation + MySQL is faster for ascending PRIMARY keys)
+        this.index += 1;
+        return ObjectID.createFromTime(this.index).toHexString();
     }
 
     async #generateData(amount = this.defaultQuantity) {
@@ -42,10 +57,7 @@ class TableImporter {
         debug(`${this.name} generated ${data.length} records in ${Date.now() - generateNow}ms`);
 
         if (data.length > 0) {
-            debug (`Importing ${data.length} records into ${this.name}`);
-            const now = Date.now();
-            await this.knex.batchInsert(this.name, data).transacting(this.transaction);
-            debug(`${this.name} imported ${data.length} records in ${Date.now() - now}ms`);
+            await this.batchInsert(data);
         }
     }
 
@@ -58,12 +70,16 @@ class TableImporter {
 
         debug (`Generating data for ${models.length} models x ${amount} for ${this.name}`);
         const now = Date.now();
+        let settingReferenceModel = 0;
 
         for (const model of models) {
+            let s = Date.now();
             this.setReferencedModel(model);
+            settingReferenceModel += Date.now() - s;
+
             let currentAmount = (typeof amount === 'function') ? amount() : amount;
             if (!Number.isInteger(currentAmount)) {
-                currentAmount = Math.floor(currentAmount) + ((Math.random() < currentAmount % 1) ? 1 : 0);
+                currentAmount = Math.floor(currentAmount) + luck((currentAmount % 1) * 100);
             }
 
             const generatedData = await this.#generateData(currentAmount);
@@ -72,13 +88,72 @@ class TableImporter {
             }
         }
 
-        debug(`${this.name} generated ${data.length} records in ${Date.now() - now}ms`);
+        debug(`${this.name} generated ${data.length} records in ${Date.now() - now}ms (${settingReferenceModel}ms setting reference model)`);
 
         if (data.length > 0) {
-            const now2 = Date.now();
-            await this.knex.batchInsert(this.name, data).transacting(this.transaction);
-            debug(`${this.name} imported ${data.length} records in ${Date.now() - now2}ms`);
+            await this.batchInsert(data);
         }
+    }
+
+    async batchInsert(data) {
+        // Write to CSV file
+        const rootFolder = os.tmpdir();
+        const filePath = path.join(rootFolder, `${this.name}.csv`);
+        let now = Date.now();
+
+        if (data.length > 1000) {
+            try {
+                await fs.promises.unlink(filePath);
+            } catch (e) {
+                // Ignore: file doesn't exist
+            }
+
+            const csvWriter = createCsvWriter({
+                path: filePath,
+                header: Object.keys(data[0]).map((key) => {
+                    return {id: key, title: key};
+                })
+            });
+
+            // Loop the data in chunks of 50.000 items
+            const batchSize = 50000;
+
+            // Otherwise we get a out of range error because csvWriter tries to create a string that is too long
+            for (let i = 0; i < data.length; i += batchSize) {
+                const slicedData = data.slice(i, i + batchSize);
+
+                // Map data to what MySQL expects in the CSV for values like booleans, null and dates
+                for (let j = 0; j < slicedData.length; j++) {
+                    const obj = slicedData[j];
+
+                    for (const [key, value] of Object.entries(obj)) {
+                        if (typeof value === 'boolean') {
+                            obj[key] = value ? 1 : 0;
+                        } else if (value instanceof Date) {
+                            obj[key] = dateToDatabaseString(value);
+                        } else if (value === null) {
+                            obj[key] = '\\N';
+                        }
+                    }
+                }
+                await csvWriter.writeRecords(slicedData);
+            }
+
+            debug(`${this.name} saved CSV import file in ${Date.now() - now}ms`);
+            now = Date.now();
+
+            // Import from CSV file
+            const [result] = await this.transaction.raw(`LOAD DATA LOCAL INFILE '${filePath}' INTO TABLE \`${this.name}\` FIELDS TERMINATED BY ',' ENCLOSED BY '"' IGNORE 1 LINES (${Object.keys(data[0]).map(d => '`' + d + '`').join(',')});`);
+            if (result.affectedRows !== data.length) {
+                throw new errors.InternalServerError({
+                    message: `CSV import failed: expected ${data.length} imported rows, got ${result.affectedRows}`
+                });
+            }
+        } else {
+            await this.knex.batchInsert(this.name, data).transacting(this.transaction);
+        }
+
+        debug(`${this.name} imported ${data.length} records in ${Date.now() - now}ms`);
     }
 
     /**

--- a/ghost/data-generator/lib/importers/TableImporter.js
+++ b/ghost/data-generator/lib/importers/TableImporter.js
@@ -8,6 +8,8 @@ const os = require('os');
 const errors = require('@tryghost/errors');
 const ObjectID = require('bson-objectid').default;
 
+let idIndex = 0;
+
 class TableImporter {
     /**
      * @type {object|undefined} model Referenced model when generating data
@@ -29,13 +31,12 @@ class TableImporter {
         this.name = name;
         this.knex = knex;
         this.transaction = transaction;
-        this.index = 0;
     }
 
     fastFakeObjectId() {
         // using faker.database.mongodbObjectId() is too slow (slow generation + MySQL is faster for ascending PRIMARY keys)
-        this.index += 1;
-        return ObjectID.createFromTime(this.index).toHexString();
+        idIndex += 1;
+        return ObjectID.createFromTime(idIndex).toHexString();
     }
 
     async #generateData(amount = this.defaultQuantity) {

--- a/ghost/data-generator/lib/importers/TagsImporter.js
+++ b/ghost/data-generator/lib/importers/TagsImporter.js
@@ -28,7 +28,7 @@ class TagsImporter extends TableImporter {
         const twoYearsAgo = new Date();
         twoYearsAgo.setFullYear(twoYearsAgo.getFullYear() - 2);
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             name: name,
             slug: `${slugify(name)}-${faker.random.numeric(3)}`,
             description: faker.lorem.sentence(),

--- a/ghost/data-generator/lib/importers/UsersImporter.js
+++ b/ghost/data-generator/lib/importers/UsersImporter.js
@@ -16,7 +16,7 @@ class UsersImporter extends TableImporter {
     async generate() {
         const name = `${faker.name.firstName()} ${faker.name.lastName()}`;
         return {
-            id: faker.database.mongodbObjectId(),
+            id: this.fastFakeObjectId(),
             name: name,
             slug: slugify(name),
             password: await security.password.hash(faker.color.human()),

--- a/ghost/data-generator/lib/importers/WebMentionsImporter.js
+++ b/ghost/data-generator/lib/importers/WebMentionsImporter.js
@@ -14,7 +14,7 @@ class WebMentionsImporter extends TableImporter {
     }
 
     generate() {
-        const id = faker.database.mongodbObjectId();
+        const id = this.fastFakeObjectId();
 
         const author = `${faker.name.fullName()}`;
 

--- a/ghost/data-generator/lib/utils/JsonImporter.js
+++ b/ghost/data-generator/lib/utils/JsonImporter.js
@@ -1,5 +1,3 @@
-const {faker} = require('@faker-js/faker');
-
 class JsonImporter {
     constructor(knex, transaction) {
         this.knex = knex;

--- a/ghost/data-generator/lib/utils/JsonImporter.js
+++ b/ghost/data-generator/lib/utils/JsonImporter.js
@@ -25,7 +25,7 @@ class JsonImporter {
     }) {
         for (const obj of data) {
             if (!('id' in obj)) {
-                obj.id = faker.database.mongodbObjectId();
+                obj.id = this.fastFakeObjectId();
             }
         }
         if (rows.findIndex(row => row === 'id') === -1) {

--- a/ghost/data-generator/lib/utils/database-date.js
+++ b/ghost/data-generator/lib/utils/database-date.js
@@ -1,3 +1,7 @@
 module.exports = function dateToDatabaseString(date) {
+    if (typeof date === 'string') {
+        // SQLite fix when reusing other dates from the db
+        return date;
+    }
     return date.toISOString().replace('Z','').replace('T', ' ');
 };

--- a/ghost/data-generator/lib/utils/event-generator.js
+++ b/ghost/data-generator/lib/utils/event-generator.js
@@ -29,6 +29,7 @@ const generateEvents = ({
         beta = 1;
         break;
     }
+
     const data = probabilityDistributions.rbeta(total, alpha, beta, 0);
     const startTimeValue = startTime.valueOf();
     const timeDifference = endTime.valueOf() - startTimeValue;

--- a/ghost/data-generator/package.json
+++ b/ghost/data-generator/package.json
@@ -29,6 +29,7 @@
     "@faker-js/faker": "7.6.0",
     "@tryghost/root-utils": "0.3.24",
     "@tryghost/string": "0.2.10",
+    "csv-writer": "^1.6.0",
     "probability-distributions": "0.9.1"
   }
 }

--- a/ghost/data-generator/test/data-generator.test.js
+++ b/ghost/data-generator/test/data-generator.test.js
@@ -93,7 +93,6 @@ describe('Data Generator', function () {
         try {
             return await dataGenerator.importData();
         } catch (err) {
-            console.error(err);
             (false).should.eql(true, err.message);
         }
     });

--- a/ghost/data-generator/test/data-generator.test.js
+++ b/ghost/data-generator/test/data-generator.test.js
@@ -93,6 +93,7 @@ describe('Data Generator', function () {
         try {
             return await dataGenerator.importData();
         } catch (err) {
+            console.error(err);
             (false).should.eql(true, err.message);
         }
     });

--- a/ghost/recommendations/src/IncomingRecommendationService.ts
+++ b/ghost/recommendations/src/IncomingRecommendationService.ts
@@ -80,7 +80,7 @@ export class IncomingRecommendationService {
         // More importantly, we might have missed some deletes which we can detect.
         // So we do a slow revalidation of all incoming recommendations
         // This also prevents doing multiple external fetches when doing quick reboots of Ghost after each other (requires Ghost to be up for at least 15 seconds)
-        if (!process.env.NODE_ENV?.startsWith('test')) {
+        if (!process.env.NODE_ENV?.startsWith('test') && process.env.NODE_ENV !== 'development') {
             setTimeout(() => {
                 logging.info('Updating incoming recommendations on boot');
                 this.#updateIncomingRecommendations().catch((err) => {

--- a/ghost/recommendations/test/IncomingRecommendationService.test.ts
+++ b/ghost/recommendations/test/IncomingRecommendationService.test.ts
@@ -48,7 +48,7 @@ describe('IncomingRecommendationService', function () {
             // Sandbox time
             const saved = process.env.NODE_ENV;
             try {
-                process.env.NODE_ENV = 'development';
+                process.env.NODE_ENV = 'nottesting';
                 await service.init();
                 clock.tick(1000 * 60 * 60 * 24);
                 assert(refreshMentions.calledOnce);
@@ -61,7 +61,7 @@ describe('IncomingRecommendationService', function () {
             // Sandbox time
             const saved = process.env.NODE_ENV;
             try {
-                process.env.NODE_ENV = 'development';
+                process.env.NODE_ENV = 'nottesting';
 
                 refreshMentions.rejects(new Error('test'));
                 await service.init();

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fix": "yarn cache clean && rimraf -g '**/node_modules' && yarn",
     "knex-migrator": "yarn workspace ghost run knex-migrator",
     "setup": "yarn && git submodule update --init && NODE_ENV=development node .github/scripts/setup.js",
-    "reset:data": "cd ghost/core && node index.js generate-data --clear-database --quantities members:100,posts:1 --seed 123",
+    "reset:data": "cd ghost/core && node index.js generate-data --clear-database --quantities members:10000,posts:100 --seed 123",
     "docker:reset": "docker-compose -f .github/scripts/docker-compose.yml down -v && docker-compose -f .github/scripts/docker-compose.yml up -d --wait",
     "lint": "nx run-many -t lint",
     "test": "nx run-many -t test",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fix": "yarn cache clean && rimraf -g '**/node_modules' && yarn",
     "knex-migrator": "yarn workspace ghost run knex-migrator",
     "setup": "yarn && git submodule update --init && NODE_ENV=development node .github/scripts/setup.js",
-    "reset:data": "cd ghost/core && node index.js generate-data --clear-database --quantities members:10000,posts:100 --seed 123",
+    "reset:data": "cd ghost/core && node index.js generate-data --clear-database --quantities members:100000,posts:100 --seed 123",
     "docker:reset": "docker-compose -f .github/scripts/docker-compose.yml down -v && docker-compose -f .github/scripts/docker-compose.yml up -d --wait",
     "lint": "nx run-many -t lint",
     "test": "nx run-many -t test",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fix": "yarn cache clean && rimraf -g '**/node_modules' && yarn",
     "knex-migrator": "yarn workspace ghost run knex-migrator",
     "setup": "yarn && git submodule update --init && NODE_ENV=development node .github/scripts/setup.js",
-    "reset:data": "cd ghost/core && node index.js generate-data --clear-database --quantities members:100000,posts:100 --seed 123",
+    "reset:data": "cd ghost/core && node index.js generate-data --clear-database --quantities members:100000,posts:500 --seed 123",
     "docker:reset": "docker-compose -f .github/scripts/docker-compose.yml down -v && docker-compose -f .github/scripts/docker-compose.yml up -d --wait",
     "lint": "nx run-many -t lint",
     "test": "nx run-many -t test",
@@ -117,6 +117,7 @@
     "nx": "16.8.1",
     "rimraf": "5.0.5",
     "ts-node": "10.9.2",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "inquirer": "8.2.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2668,16 +2668,16 @@
 
 "@elastic/elasticsearch@8.10.0", "@elastic/elasticsearch@8.5.0":
   version "8.5.0"
-  resolved "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.5.0.tgz#407aee0950a082ee76735a567f2571cf4301d4ea"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-8.5.0.tgz#407aee0950a082ee76735a567f2571cf4301d4ea"
   integrity sha512-iOgr/3zQi84WmPhAplnK2W13R89VXD2oc6WhlQmH3bARQwmI+De23ZJKBEn7bvuG/AHMAqasPXX7uJIiJa2MqQ==
   dependencies:
     "@elastic/transport" "^8.2.0"
     tslib "^2.4.0"
 
 "@elastic/transport@^8.2.0":
-  version "8.3.4"
-  resolved "https://registry.npmjs.org/@elastic/transport/-/transport-8.3.4.tgz#43c852e848dc8502bbd7f23f2d61bd5665cded99"
-  integrity sha512-+0o8o74sbzu3BO7oOZiP9ycjzzdOt4QwmMEjFc1zfO7M0Fh7QX1xrpKqZbSd8vBwihXNlSq/EnMPfgD2uFEmFg==
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.4.0.tgz#e1ec05f7a2857162c161e2c97008f9b21301a673"
+  integrity sha512-Yb3fDa7yGD0ca3uMbL64M3vM1cE5h5uHmBcTjkdB4VpCasRNKSd09iDpwqX8zX1tbBtxcaKYLceKthWvPeIxTw==
   dependencies:
     debug "^4.3.4"
     hpagent "^1.0.0"
@@ -14197,6 +14197,11 @@ csstype@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
+
+csv-writer@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/csv-writer/-/csv-writer-1.6.0.tgz#d0cea44b6b4d7d3baa2ecc6f3f7209233514bcf9"
+  integrity sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==
 
 custom-error-instance@2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20005,6 +20005,27 @@ inline-source-map-comment@^1.0.5:
     sum-up "^1.0.1"
     xtend "^4.0.0"
 
+inquirer@8.2.4:
+  version "8.2.4"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.4.tgz#ddbfe86ca2f67649a67daa6f1051c128f684f0b4"
+  integrity sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^7.0.0"
+
 inquirer@8.2.6:
   version "8.2.6"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.6.tgz#733b74888195d8d400a67ac332011b5fae5ea562"


### PR DESCRIPTION
ref PROD-233

- Stored whether Docker is used in the config files
- When running `yarn setup`, any existing Docker container will be reset. Run with `-y` to skip the confirmation step.
- `yarn setup` will always init the database and generate fake data
- Increased amount of default generated data to 100,000 members + 500 posts.
- Made lots of performance improvements in the data generator so we can generate the default data in ±170s