### PR TITLE
Disabled Codemirror searchKeymap in Admin X

### DIFF
--- a/apps/admin-x-design-system/src/global/form/CodeEditorView.tsx
+++ b/apps/admin-x-design-system/src/global/form/CodeEditorView.tsx
@@ -1,5 +1,5 @@
 import {Extension} from '@codemirror/state';
-import CodeMirror, {ReactCodeMirrorProps, ReactCodeMirrorRef} from '@uiw/react-codemirror';
+import CodeMirror, {ReactCodeMirrorProps, ReactCodeMirrorRef, BasicSetupOptions} from '@uiw/react-codemirror';
 import clsx from 'clsx';
 import React, {FocusEventHandler, forwardRef, useEffect, useId, useRef, useState} from 'react';
 import {useFocusContext} from '../../providers/DesignSystemProvider';
@@ -49,6 +49,9 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
     const sizeRef = useRef<HTMLDivElement>(null);
     const [width, setWidth] = useState(100);
     const [resolvedExtensions, setResolvedExtensions] = React.useState<Extension[] | null>(null);
+    const [basicSetup, setBasicSetup] = useState<BasicSetupOptions>({
+        crosshairCursor: false
+    });
     const {setFocusState} = useFocusContext();
 
     const handleFocus: FocusEventHandler<HTMLDivElement> = (e) => {
@@ -63,6 +66,7 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
 
     useEffect(() => {
         Promise.all(extensions).then(setResolvedExtensions);
+        setBasicSetup(setup => ({setup, searchKeymap: false}));
     }, [extensions]);
 
     useEffect(() => {
@@ -90,6 +94,7 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
         {resolvedExtensions && <div className={height === 'full' ? 'h-full' : ''} style={{width}}>
             <CodeMirror
                 ref={ref}
+                basicSetup={basicSetup}
                 className={styles}
                 extensions={resolvedExtensions}
                 height={height === 'full' ? '100%' : height}


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/PROD-287/cmdf-in-code-injection

- wired in the default basicSetup and then explicitly disable the search keymap to avoid cmd+f triggering the codemirror search and instead brings up the default browser finder.
