### PR TITLE
Fixed background click exiting CodeInjection modal

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/code/CodeModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/code/CodeModal.tsx
@@ -65,6 +65,7 @@ const CodeModal: React.FC<CodeModalProps> = ({afterClose}) => {
 
     return <Modal
         afterClose={afterClose}
+        backDropClick={false}
         cancelLabel='Close'
         footer={<></>}
         height='full'


### PR DESCRIPTION
no issue

- fixed a bug causing the full screen code injection to close when clicking out side of it, which could cause the loss of unsaved changes.