### PR TITLE
Added [test] prefix to test emails

### DIFF
--- a/ghost/email-service/lib/EmailRenderer.js
+++ b/ghost/email-service/lib/EmailRenderer.js
@@ -167,8 +167,9 @@ class EmailRenderer {
         this.#models = models;
     }
 
-    getSubject(post) {
-        return post.related('posts_meta')?.get('email_subject') || post.get('title');
+    getSubject(post, isTestEmail = false) {
+        const subject = post.related('posts_meta')?.get('email_subject') || post.get('title');
+        return isTestEmail ? `[TEST] ${subject}` : subject;
     }
 
     #getRawFromAddress(post, newsletter) {

--- a/ghost/email-service/lib/EmailService.js
+++ b/ghost/email-service/lib/EmailService.js
@@ -301,7 +301,8 @@ class EmailService {
             emailId: null
         }, {
             clickTrackingEnabled: false,
-            openTrackingEnabled: false
+            openTrackingEnabled: false,
+            isTestEmail: true
         });
     }
 }

--- a/ghost/email-service/lib/SendingService.js
+++ b/ghost/email-service/lib/SendingService.js
@@ -88,6 +88,7 @@ class SendingService {
     */
     async send({post, newsletter, segment, members, emailId}, options) {
         const cacheId = emailId + '-' + (segment ?? 'null');
+        const isTestEmail = options.isTestEmail ?? false;
 
         /**
          * @type {EmailBody | null}
@@ -114,7 +115,7 @@ class SendingService {
 
         const recipients = this.buildRecipients(members, emailBody.replacements);
         return await this.#emailProvider.send({
-            subject: this.#emailRenderer.getSubject(post),
+            subject: this.#emailRenderer.getSubject(post, isTestEmail),
             from: this.#emailRenderer.getFromAddress(post, newsletter),
             replyTo: this.#emailRenderer.getReplyToAddress(post, newsletter) ?? undefined,
             html: emailBody.html,

--- a/ghost/email-service/test/email-renderer.test.js
+++ b/ghost/email-service/test/email-renderer.test.js
@@ -662,6 +662,18 @@ describe('Email renderer', function () {
             let response = emailRenderer.getSubject(post);
             response.should.equal('Sample Post');
         });
+
+        it('adds [TEST] prefix for test emails', function () {
+            const post = createModel({
+                posts_meta: createModel({
+                    email_subject: ''
+                }),
+                title: 'Sample Post',
+                loaded: ['posts_meta']
+            });
+            let response = emailRenderer.getSubject(post, true);
+            response.should.equal('[TEST] Sample Post');
+        });
     });
 
     describe('getFromAddress', function () {

--- a/ghost/email-service/test/email-service.test.js
+++ b/ghost/email-service/test/email-service.test.js
@@ -428,8 +428,10 @@ describe('Email Service', function () {
             await service.sendTestEmail(post, post.get('newsletter'), null, ['example@example.com']);
             sinon.assert.calledOnce(sendingService.send);
             const members = sendingService.send.firstCall.args[0].members;
+            const options = sendingService.send.firstCall.args[1];
             assert.equal(members.length, 1);
             assert.equal(members[0].email, 'example@example.com');
+            assert.equal(options.isTestEmail, true);
         });
     });
 });


### PR DESCRIPTION
fixes GRO-157

- the [TEST] prefix was removed unintentionally during the rewrite of the email sending service

