### PR TITLE
Added webmentions endpoint to robots.txt disallow

### DIFF
--- a/ghost/core/core/frontend/public/robots.txt
+++ b/ghost/core/core/frontend/public/robots.txt
@@ -4,4 +4,4 @@ Disallow: /ghost/
 Disallow: /p/
 Disallow: /email/
 Disallow: /r/
-Disallow: /webmentions/
+Disallow: /webmentions/receive/

--- a/ghost/core/core/frontend/public/robots.txt
+++ b/ghost/core/core/frontend/public/robots.txt
@@ -4,3 +4,4 @@ Disallow: /ghost/
 Disallow: /p/
 Disallow: /email/
 Disallow: /r/
+Disallow: /webmentions/

--- a/ghost/core/test/e2e-frontend/default_routes.test.js
+++ b/ghost/core/test/e2e-frontend/default_routes.test.js
@@ -326,7 +326,8 @@ describe('Default Frontend routing', function () {
                 'Sitemap: http://127.0.0.1:2369/sitemap.xml\nDisallow: /ghost/\n' +
                 'Disallow: /p/\n' +
                 'Disallow: /email/\n' +
-                'Disallow: /r/\n'
+                'Disallow: /r/\n' +
+                'Disallow: /webmentions/receive/\n'
             );
         });
 


### PR DESCRIPTION
fixes PROD-290
- in order to receive webmentions (e.g. recommendations), Ghost sites expose a /webmentions/receive endpoint. This endpoint is wrongly being indexed by Google as a regular page, and causes indexing errors in Google Search Console
