### PR TITLE
Removed Sentry Express integration

### DIFF
--- a/ghost/core/core/shared/sentry.js
+++ b/ghost/core/core/shared/sentry.js
@@ -73,7 +73,6 @@ if (sentryConfig && !sentryConfig.disabled) {
     // Enable tracing if sentry.tracing.enabled is true
     if (sentryConfig.tracing?.enabled === true) {
         sentryInitConfig.integrations.push(new Sentry.Integrations.Http({tracing: true}));
-        sentryInitConfig.integrations.push(new Sentry.Integrations.Express());
         sentryInitConfig.tracesSampleRate = parseFloat(sentryConfig.tracing.sampleRate) || 0.0;
         // Enable profiling, if configured, only if tracing is also configured
         if (sentryConfig.profiling?.enabled === true) {


### PR DESCRIPTION
no refs

Removed Sentry Express integration as it is not compatible with Ghost's use of Express