### PR TITLE
Added support for using the Admin URL in Recommendations

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/AddRecommendationModal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/AddRecommendationModal.tsx
@@ -78,18 +78,19 @@ const AddRecommendationModal: React.FC<RoutingModalProps & AddRecommendationModa
                 return;
             }
 
-            const existing = recommendations[0];
+            const metadata = recommendations[0];
 
-            if (existing.id) {
+            if (metadata.id) {
                 throw new AlreadyExistsError('A recommendation with this URL already exists.');
             }
 
             // Update metadata so we can preview it
-            updatedRecommendation.title = existing.title ?? defaultTitle;
-            updatedRecommendation.excerpt = existing.excerpt ?? updatedRecommendation.excerpt;
-            updatedRecommendation.featured_image = existing.featured_image ?? updatedRecommendation.featured_image ?? null;
-            updatedRecommendation.favicon = existing.favicon ?? updatedRecommendation.favicon ?? null;
-            updatedRecommendation.one_click_subscribe = existing.one_click_subscribe ?? updatedRecommendation.one_click_subscribe ?? false;
+            updatedRecommendation.url = metadata.url || validatedUrl.toString(); // Update URL in case the Admin URL was used instead of the site URL
+            updatedRecommendation.title = metadata.title ?? defaultTitle;
+            updatedRecommendation.excerpt = metadata.excerpt ?? updatedRecommendation.excerpt;
+            updatedRecommendation.featured_image = metadata.featured_image ?? updatedRecommendation.featured_image ?? null;
+            updatedRecommendation.favicon = metadata.favicon ?? updatedRecommendation.favicon ?? null;
+            updatedRecommendation.one_click_subscribe = metadata.one_click_subscribe ?? updatedRecommendation.one_click_subscribe ?? false;
 
             // Set a default description (excerpt)
             updatedRecommendation.description = updatedRecommendation.excerpt || null;

--- a/ghost/recommendations/src/RecommendationMetadataService.ts
+++ b/ghost/recommendations/src/RecommendationMetadataService.ts
@@ -23,6 +23,7 @@ type ExternalRequest = {
 }
 
 export type RecommendationMetadata = {
+    url: URL|null,
     title: string|null,
     excerpt: string|null,
     featuredImage: URL|null,
@@ -96,7 +97,16 @@ export class RecommendationMetadataService {
         if (ghostSiteData && typeof ghostSiteData === 'object' && ghostSiteData.site && typeof ghostSiteData.site === 'object') {
             // Check if the Ghost site returns allow_external_signup, otherwise it is an old Ghost version that returns unreliable data
             if (typeof ghostSiteData.site.allow_external_signup === 'boolean') {
+                // Fetch the site url from the metadata, in case the Admin URL was used instead of the site URL
+                let updatedUrl;
+                try {
+                    updatedUrl = new URL(ghostSiteData.site.url);
+                } catch (e) {
+                    updatedUrl = null;
+                }
+
                 return {
+                    url: updatedUrl,
                     title: ghostSiteData.site.title || null,
                     excerpt: ghostSiteData.site.description || null,
                     featuredImage: this.#castUrl(ghostSiteData.site.cover_image),
@@ -109,6 +119,7 @@ export class RecommendationMetadataService {
         // Use the oembed service to fetch metadata
         const oembed = await this.#oembedService.fetchOembedDataFromUrl(url.toString(), 'mention');
         return {
+            url: null,
             title: oembed?.metadata?.title || null,
             excerpt: oembed?.metadata?.description || null,
             featuredImage: this.#castUrl(oembed?.metadata?.thumbnail),

--- a/ghost/recommendations/test/RecommendationMetadataService.test.ts
+++ b/ghost/recommendations/test/RecommendationMetadataService.test.ts
@@ -39,6 +39,7 @@ describe('RecommendationMetadataService', function () {
             .get('/subdirectory/members/api/site')
             .reply(200, {
                 site: {
+                    url: 'https://exampleghostsite.com/',
                     title: 'Example Ghost Site',
                     description: 'Example Ghost Site Description',
                     cover_image: 'https://exampleghostsite.com/cover.png',
@@ -49,6 +50,7 @@ describe('RecommendationMetadataService', function () {
 
         const metadata = await service.fetch(new URL('https://exampleghostsite.com/subdirectory'));
         assert.deepEqual(metadata, {
+            url: new URL('https://exampleghostsite.com/'),
             title: 'Example Ghost Site',
             excerpt: 'Example Ghost Site Description',
             featuredImage: new URL('https://exampleghostsite.com/cover.png'),
@@ -62,6 +64,7 @@ describe('RecommendationMetadataService', function () {
             .get('/subdirectory/members/api/site')
             .reply(200, {
                 site: {
+                    url: '',
                     title: '',
                     description: '',
                     cover_image: '',
@@ -72,6 +75,7 @@ describe('RecommendationMetadataService', function () {
 
         const metadata = await service.fetch(new URL('https://exampleghostsite.com/subdirectory'));
         assert.deepEqual(metadata, {
+            url: null,
             title: null,
             excerpt: null,
             featuredImage: null,
@@ -95,6 +99,7 @@ describe('RecommendationMetadataService', function () {
         const metadata = await service.fetch(new URL('https://exampleghostsite.com'));
         assert.deepEqual(metadata, {
             // oembed
+            url: null,
             title: 'Oembed Site Title',
             excerpt: 'Oembed Site Description',
             featuredImage: new URL('https://example.com/oembed/thumbnail.png'),
@@ -112,6 +117,7 @@ describe('RecommendationMetadataService', function () {
             .get('/members/api/site')
             .reply(200, {
                 site: {
+                    url: 'https://exampleghostsite.com/',
                     title: 'Example Ghost Site',
                     description: 'Example Ghost Site Description',
                     cover_image: 'https://exampleghostsite.com/cover.png',
@@ -122,6 +128,7 @@ describe('RecommendationMetadataService', function () {
 
         const metadata = await service.fetch(new URL('https://exampleghostsite.com/subdirectory'));
         assert.deepEqual(metadata, {
+            url: new URL('https://exampleghostsite.com/'),
             title: 'Example Ghost Site',
             excerpt: 'Example Ghost Site Description',
             featuredImage: new URL('https://exampleghostsite.com/cover.png'),
@@ -141,6 +148,7 @@ describe('RecommendationMetadataService', function () {
 
         const metadata = await service.fetch(new URL('https://exampleghostsite.com/subdirectory'));
         assert.deepEqual(metadata, {
+            url: null,
             title: 'Oembed Site Title',
             excerpt: 'Oembed Site Description',
             featuredImage: new URL('https://example.com/oembed/thumbnail.png'),
@@ -173,6 +181,7 @@ describe('RecommendationMetadataService', function () {
 
         const metadata = await service.fetch(new URL('https://exampleghostsite.com/subdirectory'));
         assert.deepEqual(metadata, {
+            url: null,
             title: 'Oembed Site Title',
             excerpt: 'Oembed Site Description',
             featuredImage: null,
@@ -205,6 +214,7 @@ describe('RecommendationMetadataService', function () {
 
         const metadata = await service.fetch(new URL('https://exampleghostsite.com/subdirectory'));
         assert.deepEqual(metadata, {
+            url: null,
             title: null,
             excerpt: null,
             featuredImage: null,


### PR DESCRIPTION
fixes PROD-241
- when recommending a Ghost site, it's now possible to use either the Admin URL or the site URL
