### PR TITLE
Refactored fetching schema tables in data generator

### DIFF
--- a/ghost/core/core/cli/generate-data.js
+++ b/ghost/core/core/cli/generate-data.js
@@ -3,6 +3,8 @@ const Command = require('./command');
 const DataGenerator = require('@tryghost/data-generator');
 const config = require('../shared/config');
 
+const schemaTables = require('../server/data/schema').tables;
+
 module.exports = class DataGeneratorCommand extends Command {
     setup() {
         this.help('Generates random data to populate the database for development & testing');
@@ -74,6 +76,7 @@ module.exports = class DataGeneratorCommand extends Command {
             baseUrl: config.getSiteUrl(),
             clearDatabase: argv['clear-database'],
             tables,
+            schemaTables,
             withDefault: argv['with-default'],
             printDependencies: argv['print-dependencies'],
             quantities,

--- a/ghost/data-generator/lib/DataGenerator.js
+++ b/ghost/data-generator/lib/DataGenerator.js
@@ -13,7 +13,6 @@ const importers = require('./importers').reduce((acc, val) => {
     acc[val.table] = val;
     return acc;
 }, {});
-const schema = require('../../core/core/server/data/schema').tables;
 
 class DataGenerator {
     /**
@@ -25,6 +24,7 @@ class DataGenerator {
     constructor({
         knex,
         tables,
+        schemaTables,
         clearDatabase = false,
         baseDataPack = '',
         baseUrl,
@@ -36,6 +36,7 @@ class DataGenerator {
     }) {
         this.knex = knex;
         this.tableList = tables || [];
+        this.schemaTables = schemaTables;
         this.willClearData = clearDatabase;
         this.useBaseDataPack = baseDataPack !== '';
         this.baseDataPack = baseDataPack;
@@ -53,7 +54,7 @@ class DataGenerator {
             table.importer = importers[table.name];
 
             // eslint-disable-next-line no-unused-vars
-            table.dependencies = Object.entries(schema[table.name]).reduce((acc, [_col, data]) => {
+            table.dependencies = Object.entries(this.schemaTables[table.name]).reduce((acc, [_col, data]) => {
                 if (data.references) {
                     const referencedTable = data.references.split('.')[0];
                     // The ghost_subscriptions_id property has a foreign key to the subscriptions table, but we don't use that table yet atm, so don't add it as a dependency

--- a/ghost/data-generator/test/data-generator.test.js
+++ b/ghost/data-generator/test/data-generator.test.js
@@ -13,6 +13,8 @@ const DataGenerator = require('../index');
 
 const schema = require('../../core/core/server/data/schema');
 
+const schemaTables = schema.tables;
+
 describe('Data Generator', function () {
     let db;
 
@@ -76,7 +78,8 @@ describe('Data Generator', function () {
         const dataGenerator = new DataGenerator({
             eventsOnly: false,
             knex: db,
-            schema: schema,
+            schema,
+            schemaTables,
             logger: {
                 info: () => { },
                 ok: () => { }


### PR DESCRIPTION
- we want to pass in the schema tables instead of cross requiring them from a different package because it means the package isn't standalone and moving the code structure around breaks the data generator