### PR TITLE
Removed duplicate member count queries in admin

### DIFF
--- a/ghost/admin/app/services/dashboard-stats.js
+++ b/ghost/admin/app/services/dashboard-stats.js
@@ -85,6 +85,7 @@ export default class DashboardStatsService extends Service {
     @service membersCountCache;
     @service settings;
     @service membersUtils;
+    @service membersStats;
 
     /**
      * @type {?SiteStatus} Contains information on what graphs need to be shown
@@ -523,9 +524,8 @@ export default class DashboardStatsService extends Service {
             this.memberCountStats = this.dashboardMocks.memberCountStats;
             return;
         }
-
-        let statsUrl = this.ghostPaths.url.api('stats/member_count');
-        let stats = yield this.ajax.request(statsUrl);
+        
+        const stats = yield this.membersStats.fetchMemberCounts();
         this.memberCountStats = stats.stats.map((d) => {
             return {
                 ...d,

--- a/ghost/admin/app/services/members-stats.js
+++ b/ghost/admin/app/services/members-stats.js
@@ -52,9 +52,13 @@ export default class MembersStatsService extends Service {
     }
 
     fetchMemberCount() {
-        let staleData = this._lastFetchedMemberCounts && (new Date() - this._lastFetchedMemberCounts) > ONE_MINUTE;
+        // if already running, return existing promise
+        if (this._fetchMemberCountsTask.isRunning) {
+            return this._fetchMemberCountsTask.last;
+        }
 
         // return existing stats unless data is > 1 min old
+        let staleData = this._lastFetchedMemberCounts && (new Date() - this._lastFetchedMemberCounts) > ONE_MINUTE;
         if (this.totalMemberCount && !this._forceRefresh && !staleData && this._fetchMemberCountsTask.last) {
             return this._fetchMemberCountsTask.last;
         }


### PR DESCRIPTION
no refs
- member_count endpoint was queried multiple times on load
- moved to collectively use the member stats service
- prevented multiple tasks from being queued up to return count