### PR TITLE
Reduced amount of member count queries when opening the editor

### DIFF
--- a/ghost/admin/app/components/gh-members-segment-count.js
+++ b/ghost/admin/app/components/gh-members-segment-count.js
@@ -6,6 +6,7 @@ import {tracked} from '@glimmer/tracking';
 export default class GhMembersSegmentCountComponent extends Component {
     @service store;
     @service session;
+    @service membersCountCache;
 
     @tracked total = 0;
     @tracked segmentTotal = 0;
@@ -17,7 +18,7 @@ export default class GhMembersSegmentCountComponent extends Component {
         this.fetchSegmentTotalTask.perform();
 
         const filter = this.args.enforcedFilter || undefined;
-        this.total = yield this.membersStats.count({filter});
+        this.total = yield this.membersCountCache.count({filter});
     }
 
     @task({group: 'fetchTasks'})

--- a/ghost/admin/app/components/gh-members-segment-count.js
+++ b/ghost/admin/app/components/gh-members-segment-count.js
@@ -17,9 +17,7 @@ export default class GhMembersSegmentCountComponent extends Component {
         this.fetchSegmentTotalTask.perform();
 
         const filter = this.args.enforcedFilter || undefined;
-
-        const members = yield this.store.query('member', {limit: 1, filter});
-        this.total = members.meta.pagination.total;
+        this.total = yield this.membersStats.count({filter});
     }
 
     @task({group: 'fetchTasks'})

--- a/ghost/admin/app/helpers/publish-options.js
+++ b/ghost/admin/app/helpers/publish-options.js
@@ -9,6 +9,7 @@ export default class PublishOptionsResource extends Resource {
     @service session;
     @service settings;
     @service store;
+    @service membersCountCache;
 
     @inject config;
 
@@ -35,7 +36,7 @@ export default class PublishOptionsResource extends Resource {
     }
 
     _createPublishOptions(post) {
-        const {config, limit, settings, store} = this;
+        const {config, limit, settings, store, membersCountCache} = this;
 
         return new PublishOptions({
             config,
@@ -43,6 +44,7 @@ export default class PublishOptionsResource extends Resource {
             post,
             settings,
             store,
+            membersCountCache,
             user: this.session.user
         });
     }

--- a/ghost/admin/app/services/limit.js
+++ b/ghost/admin/app/services/limit.js
@@ -27,6 +27,7 @@ class HostLimitError extends LimitError {
 export default class LimitsService extends Service {
     @service store;
     @service membersStats;
+    @service membersCountCache;
 
     @inject config;
 
@@ -93,10 +94,7 @@ export default class LimitsService extends Service {
     }
 
     async getMembersCount() {
-        const members = await this.store.query('member', {limit: 1});
-        const total = members.meta.pagination.total;
-
-        return total;
+        return this.membersCountCache.count({});
     }
 
     async getNewslettersCount() {

--- a/ghost/admin/app/utils/publish-options.js
+++ b/ghost/admin/app/utils/publish-options.js
@@ -10,6 +10,7 @@ export default class PublishOptions {
     limit = null;
     settings = null;
     store = null;
+    membersCountCache = null;
 
     // passed in models
     post = null;
@@ -234,13 +235,14 @@ export default class PublishOptions {
 
     // setup -------------------------------------------------------------------
 
-    constructor({config, limit, post, settings, store, user} = {}) {
+    constructor({config, limit, post, settings, store, user, membersCountCache} = {}) {
         this.config = config;
         this.limit = limit;
         this.post = post;
         this.settings = settings;
         this.store = store;
         this.user = user;
+        this.membersCountCache = membersCountCache;
 
         // this needs to be set here rather than a class-level property because
         // unlike Ember-based classes the services are not injected so can't be
@@ -281,12 +283,14 @@ export default class PublishOptions {
     *fetchRequiredDataTask() {
         const promises = [];
 
+        console.log('fetchRequiredDataTask');
+
         // total # of members - used to enable/disable email
         // Only Admins/Owners have permission to browse members and get a count
         // for Editors/Authors set member count to 1 so email isn't disabled for not having any members
         if (this.user.isAdmin) {
-            promises.push(this.store.query('member', {limit: 1}).then((res) => {
-                this.totalMemberCount = res.meta.pagination.total;
+            promises.push(this.membersCountCache.count({}).then((res) => {
+                this.totalMemberCount = res;
             }));
         } else {
             this.totalMemberCount = 1;

--- a/ghost/admin/app/utils/publish-options.js
+++ b/ghost/admin/app/utils/publish-options.js
@@ -283,8 +283,6 @@ export default class PublishOptions {
     *fetchRequiredDataTask() {
         const promises = [];
 
-        console.log('fetchRequiredDataTask');
-
         // total # of members - used to enable/disable email
         // Only Admins/Owners have permission to browse members and get a count
         // for Editors/Authors set member count to 1 so email isn't disabled for not having any members


### PR DESCRIPTION
no issue

When we open the editor, we fire 4 requests to fetch member counts. This commit fixes this by replacing those calls with the members count cache service.